### PR TITLE
Introduce join_standard_tags setting

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -371,64 +371,38 @@ class KubernetesState(OpenMetricsBaseCheck):
                 }
             )
 
+        labels_to_get = [
+            "label_tags_datadoghq_com_env",
+            "label_tags_datadoghq_com_service",
+            "label_tags_datadoghq_com_version"
+        ]
+
         if join_standard_tags:
             ksm_instance['label_joins'].update(
                 {
                     "kube_pod_labels": {
                         "labels_to_match": ["pod", "namespace"],
-                        "labels_to_get": [
-                            "label_tags_datadoghq_com_env",
-                            "label_tags_datadoghq_com_service",
-                            "label_tags_datadoghq_com_version"
-                        ]
+                        "labels_to_get": labels_to_get
                     },
                     "kube_deployment_labels": {
                         "labels_to_match": ["deployment", "namespace"],
-                        "labels_to_get": [
-                            "label_tags_datadoghq_com_env",
-                            "label_tags_datadoghq_com_service",
-                            "label_tags_datadoghq_com_version"
-                        ]
+                        "labels_to_get": labels_to_get
                     },
                     "kube_replicaset_labels": {
                         "labels_to_match": ["replicaset", "namespace"],
-                        "labels_to_get": [
-                            "label_tags_datadoghq_com_env",
-                            "label_tags_datadoghq_com_service",
-                            "label_tags_datadoghq_com_version"
-                        ]
+                        "labels_to_get": labels_to_get
                     },
                     "kube_daemonset_labels": {
                         "labels_to_match": ["daemonset", "namespace"],
-                        "labels_to_get": [
-                            "label_tags_datadoghq_com_env",
-                            "label_tags_datadoghq_com_service",
-                            "label_tags_datadoghq_com_version"
-                        ]
+                        "labels_to_get": labels_to_get
                     },
                     "kube_statefulset_labels": {
                         "labels_to_match": ["statefulset", "namespace"],
-                        "labels_to_get": [
-                            "label_tags_datadoghq_com_env",
-                            "label_tags_datadoghq_com_service",
-                            "label_tags_datadoghq_com_version"
-                        ]
+                        "labels_to_get": labels_to_get
                     },
                     "kube_job_labels": {
-                        "labels_to_match": ["job", "namespace"],
-                        "labels_to_get": [
-                            "label_tags_datadoghq_com_env",
-                            "label_tags_datadoghq_com_service",
-                            "label_tags_datadoghq_com_version"
-                        ]
-                    },
-                    "kube_cronjob_labels": {
-                        "labels_to_match": ["cronjob", "namespace"],
-                        "labels_to_get": [
-                            "label_tags_datadoghq_com_env",
-                            "label_tags_datadoghq_com_service",
-                            "label_tags_datadoghq_com_version"
-                        ]
+                        "labels_to_match": ["job_name", "namespace"],
+                        "labels_to_get": labels_to_get
                     },
                 }
             )

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -374,36 +374,30 @@ class KubernetesState(OpenMetricsBaseCheck):
         labels_to_get = [
             "label_tags_datadoghq_com_env",
             "label_tags_datadoghq_com_service",
-            "label_tags_datadoghq_com_version"
+            "label_tags_datadoghq_com_version",
         ]
 
         if join_standard_tags:
             ksm_instance['label_joins'].update(
                 {
-                    "kube_pod_labels": {
-                        "labels_to_match": ["pod", "namespace"],
-                        "labels_to_get": labels_to_get
-                    },
+                    "kube_pod_labels": {"labels_to_match": ["pod", "namespace"], "labels_to_get": labels_to_get},
                     "kube_deployment_labels": {
                         "labels_to_match": ["deployment", "namespace"],
-                        "labels_to_get": labels_to_get
+                        "labels_to_get": labels_to_get,
                     },
                     "kube_replicaset_labels": {
                         "labels_to_match": ["replicaset", "namespace"],
-                        "labels_to_get": labels_to_get
+                        "labels_to_get": labels_to_get,
                     },
                     "kube_daemonset_labels": {
                         "labels_to_match": ["daemonset", "namespace"],
-                        "labels_to_get": labels_to_get
+                        "labels_to_get": labels_to_get,
                     },
                     "kube_statefulset_labels": {
                         "labels_to_match": ["statefulset", "namespace"],
-                        "labels_to_get": labels_to_get
+                        "labels_to_get": labels_to_get,
                     },
-                    "kube_job_labels": {
-                        "labels_to_match": ["job_name", "namespace"],
-                        "labels_to_get": labels_to_get
-                    },
+                    "kube_job_labels": {"labels_to_match": ["job_name", "namespace"], "labels_to_get": labels_to_get},
                 }
             )
 
@@ -411,7 +405,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                 {
                     "label_tags_datadoghq_com_env": "env",
                     "label_tags_datadoghq_com_service": "service",
-                    "label_tags_datadoghq_com_version": "version"
+                    "label_tags_datadoghq_com_version": "version",
                 }
             )
 

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -178,6 +178,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         extra_labels = ksm_instance.get('label_joins', {})
         hostname_override = is_affirmative(ksm_instance.get('hostname_override', True))
         join_kube_labels = is_affirmative(ksm_instance.get('join_kube_labels', False))
+        join_standard_tags = is_affirmative(ksm_instance.get('join_standard_tags', False))
 
         ksm_instance.update(
             {
@@ -367,6 +368,76 @@ class KubernetesState(OpenMetricsBaseCheck):
                     'kube_pod_labels': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['*']},
                     'kube_deployment_labels': {'labels_to_match': ['deployment', 'namespace'], 'labels_to_get': ['*']},
                     'kube_daemonset_labels': {'labels_to_match': ['daemonset', 'namespace'], 'labels_to_get': ['*']},
+                }
+            )
+
+        if join_standard_tags:
+            ksm_instance['label_joins'].update(
+                {
+                    "kube_pod_labels": {
+                        "labels_to_match": ["pod", "namespace"],
+                        "labels_to_get": [
+                            "label_tags_datadoghq_com_env",
+                            "label_tags_datadoghq_com_service",
+                            "label_tags_datadoghq_com_version"
+                        ]
+                    },
+                    "kube_deployment_labels": {
+                        "labels_to_match": ["deployment", "namespace"],
+                        "labels_to_get": [
+                            "label_tags_datadoghq_com_env",
+                            "label_tags_datadoghq_com_service",
+                            "label_tags_datadoghq_com_version"
+                        ]
+                    },
+                    "kube_replicaset_labels": {
+                        "labels_to_match": ["replicaset", "namespace"],
+                        "labels_to_get": [
+                            "label_tags_datadoghq_com_env",
+                            "label_tags_datadoghq_com_service",
+                            "label_tags_datadoghq_com_version"
+                        ]
+                    },
+                    "kube_daemonset_labels": {
+                        "labels_to_match": ["daemonset", "namespace"],
+                        "labels_to_get": [
+                            "label_tags_datadoghq_com_env",
+                            "label_tags_datadoghq_com_service",
+                            "label_tags_datadoghq_com_version"
+                        ]
+                    },
+                    "kube_statefulset_labels": {
+                        "labels_to_match": ["statefulset", "namespace"],
+                        "labels_to_get": [
+                            "label_tags_datadoghq_com_env",
+                            "label_tags_datadoghq_com_service",
+                            "label_tags_datadoghq_com_version"
+                        ]
+                    },
+                    "kube_job_labels": {
+                        "labels_to_match": ["job", "namespace"],
+                        "labels_to_get": [
+                            "label_tags_datadoghq_com_env",
+                            "label_tags_datadoghq_com_service",
+                            "label_tags_datadoghq_com_version"
+                        ]
+                    },
+                    "kube_cronjob_labels": {
+                        "labels_to_match": ["cronjob", "namespace"],
+                        "labels_to_get": [
+                            "label_tags_datadoghq_com_env",
+                            "label_tags_datadoghq_com_service",
+                            "label_tags_datadoghq_com_version"
+                        ]
+                    },
+                }
+            )
+
+            ksm_instance.setdefault("labels_mapper", {}).update(
+                {
+                    "label_tags_datadoghq_com_env": "env",
+                    "label_tags_datadoghq_com_service": "service",
+                    "label_tags_datadoghq_com_version": "version"
                 }
             )
 

--- a/kubernetes_state/tests/fixtures/ksm-standard-tags-gke.txt
+++ b/kubernetes_state/tests/fixtures/ksm-standard-tags-gke.txt
@@ -1,0 +1,3724 @@
+# HELP kube_certificatesigningrequest_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_certificatesigningrequest_labels gauge
+# HELP kube_certificatesigningrequest_created Unix creation timestamp
+# TYPE kube_certificatesigningrequest_created gauge
+# HELP kube_certificatesigningrequest_condition The number of each certificatesigningrequest condition
+# TYPE kube_certificatesigningrequest_condition gauge
+# HELP kube_certificatesigningrequest_cert_length Length of the issued cert
+# TYPE kube_certificatesigningrequest_cert_length gauge
+# HELP kube_configmap_info Information about configmap.
+# TYPE kube_configmap_info gauge
+kube_configmap_info{namespace="kube-system",configmap="metrics-server-config"} 1
+kube_configmap_info{namespace="default",configmap="datadog-custom-metrics"} 1
+kube_configmap_info{namespace="default",configmap="datadog-leader-election"} 1
+kube_configmap_info{namespace="kube-system",configmap="kube-dns"} 1
+kube_configmap_info{namespace="kube-system",configmap="kube-dns-autoscaler"} 1
+kube_configmap_info{namespace="kube-system",configmap="ingress-gce-lock"} 1
+kube_configmap_info{namespace="kube-system",configmap="ingress-uid"} 1
+kube_configmap_info{namespace="kube-system",configmap="metadata-agent-config"} 1
+kube_configmap_info{namespace="kube-system",configmap="extension-apiserver-authentication"} 1
+kube_configmap_info{namespace="kube-system",configmap="fluentd-gcp-config-v1.2.6"} 1
+kube_configmap_info{namespace="kube-system",configmap="gke-common-webhook-lock"} 1
+kube_configmap_info{namespace="kube-system",configmap="heapster-config"} 1
+# HELP kube_configmap_created Unix creation timestamp
+# TYPE kube_configmap_created gauge
+kube_configmap_created{namespace="kube-system",configmap="ingress-uid"} 1.580242918e+09
+kube_configmap_created{namespace="kube-system",configmap="metadata-agent-config"} 1.585686064e+09
+kube_configmap_created{namespace="kube-system",configmap="extension-apiserver-authentication"} 1.580242883e+09
+kube_configmap_created{namespace="kube-system",configmap="fluentd-gcp-config-v1.2.6"} 1.580242912e+09
+kube_configmap_created{namespace="kube-system",configmap="gke-common-webhook-lock"} 1.580242914e+09
+kube_configmap_created{namespace="kube-system",configmap="heapster-config"} 1.580242903e+09
+kube_configmap_created{namespace="kube-system",configmap="ingress-gce-lock"} 1.580242921e+09
+kube_configmap_created{namespace="default",configmap="datadog-custom-metrics"} 1.58024358e+09
+kube_configmap_created{namespace="default",configmap="datadog-leader-election"} 1.58024358e+09
+kube_configmap_created{namespace="kube-system",configmap="kube-dns"} 1.580242903e+09
+kube_configmap_created{namespace="kube-system",configmap="kube-dns-autoscaler"} 1.580242922e+09
+kube_configmap_created{namespace="kube-system",configmap="metrics-server-config"} 1.580242903e+09
+# HELP kube_configmap_metadata_resource_version Resource version representing a specific version of the configmap.
+# TYPE kube_configmap_metadata_resource_version gauge
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="heapster-config"} 265
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="ingress-gce-lock"} 2.4026112e+07
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="ingress-uid"} 601
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="metadata-agent-config"} 2.2035277e+07
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="extension-apiserver-authentication"} 37
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="fluentd-gcp-config-v1.2.6"} 481
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="gke-common-webhook-lock"} 2.4026119e+07
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="kube-dns-autoscaler"} 651
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="metrics-server-config"} 266
+kube_configmap_metadata_resource_version{namespace="default",configmap="datadog-custom-metrics"} 3818
+kube_configmap_metadata_resource_version{namespace="default",configmap="datadog-leader-election"} 2.4026058e+07
+kube_configmap_metadata_resource_version{namespace="kube-system",configmap="kube-dns"} 264
+# HELP kube_cronjob_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_cronjob_labels gauge
+kube_cronjob_labels{namespace="default",cronjob="curl-cron-job",label_tags_datadoghq_com_env="dev",label_tags_datadoghq_com_service="web",label_tags_datadoghq_com_version="v1"} 1
+# HELP kube_cronjob_info Info about cronjob.
+# TYPE kube_cronjob_info gauge
+kube_cronjob_info{namespace="default",cronjob="curl-cron-job",schedule="*/1 * * * *",concurrency_policy="Allow"} 1
+# HELP kube_cronjob_created Unix creation timestamp
+# TYPE kube_cronjob_created gauge
+kube_cronjob_created{namespace="default",cronjob="curl-cron-job"} 1.586187636e+09
+# HELP kube_cronjob_status_active Active holds pointers to currently running jobs.
+# TYPE kube_cronjob_status_active gauge
+kube_cronjob_status_active{namespace="default",cronjob="curl-cron-job"} 0
+# HELP kube_cronjob_status_last_schedule_time LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
+# TYPE kube_cronjob_status_last_schedule_time gauge
+kube_cronjob_status_last_schedule_time{namespace="default",cronjob="curl-cron-job"} 1.58619648e+09
+# HELP kube_cronjob_spec_suspend Suspend flag tells the controller to suspend subsequent executions.
+# TYPE kube_cronjob_spec_suspend gauge
+kube_cronjob_spec_suspend{namespace="default",cronjob="curl-cron-job"} 0
+# HELP kube_cronjob_spec_starting_deadline_seconds Deadline in seconds for starting the job if it misses scheduled time for any reason.
+# TYPE kube_cronjob_spec_starting_deadline_seconds gauge
+# HELP kube_cronjob_next_schedule_time Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.
+# TYPE kube_cronjob_next_schedule_time gauge
+kube_cronjob_next_schedule_time{namespace="default",cronjob="curl-cron-job"} 1.58619654e+09
+# HELP kube_daemonset_created Unix creation timestamp
+# TYPE kube_daemonset_created gauge
+kube_daemonset_created{namespace="kube-system",daemonset="prometheus-to-sd"} 1.580242906e+09
+kube_daemonset_created{namespace="default",daemonset="datadog-monitoring"} 1.584562061e+09
+kube_daemonset_created{namespace="kube-system",daemonset="fluentd-gcp-v3.1.1"} 1.580242906e+09
+kube_daemonset_created{namespace="kube-system",daemonset="metadata-proxy-v0.1"} 1.580242906e+09
+kube_daemonset_created{namespace="kube-system",daemonset="nvidia-gpu-device-plugin"} 1.580242911e+09
+# HELP kube_daemonset_status_current_number_scheduled The number of nodes running at least one daemon pod and are supposed to.
+# TYPE kube_daemonset_status_current_number_scheduled gauge
+kube_daemonset_status_current_number_scheduled{namespace="kube-system",daemonset="fluentd-gcp-v3.1.1"} 3
+kube_daemonset_status_current_number_scheduled{namespace="kube-system",daemonset="metadata-proxy-v0.1"} 0
+kube_daemonset_status_current_number_scheduled{namespace="kube-system",daemonset="nvidia-gpu-device-plugin"} 0
+kube_daemonset_status_current_number_scheduled{namespace="kube-system",daemonset="prometheus-to-sd"} 3
+kube_daemonset_status_current_number_scheduled{namespace="default",daemonset="datadog-monitoring"} 3
+# HELP kube_daemonset_status_desired_number_scheduled The number of nodes that should be running the daemon pod.
+# TYPE kube_daemonset_status_desired_number_scheduled gauge
+kube_daemonset_status_desired_number_scheduled{namespace="kube-system",daemonset="prometheus-to-sd"} 3
+kube_daemonset_status_desired_number_scheduled{namespace="default",daemonset="datadog-monitoring"} 3
+kube_daemonset_status_desired_number_scheduled{namespace="kube-system",daemonset="fluentd-gcp-v3.1.1"} 3
+kube_daemonset_status_desired_number_scheduled{namespace="kube-system",daemonset="metadata-proxy-v0.1"} 0
+kube_daemonset_status_desired_number_scheduled{namespace="kube-system",daemonset="nvidia-gpu-device-plugin"} 0
+# HELP kube_daemonset_status_number_available The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available
+# TYPE kube_daemonset_status_number_available gauge
+kube_daemonset_status_number_available{namespace="kube-system",daemonset="nvidia-gpu-device-plugin"} 0
+kube_daemonset_status_number_available{namespace="kube-system",daemonset="prometheus-to-sd"} 3
+kube_daemonset_status_number_available{namespace="default",daemonset="datadog-monitoring"} 3
+kube_daemonset_status_number_available{namespace="kube-system",daemonset="fluentd-gcp-v3.1.1"} 3
+kube_daemonset_status_number_available{namespace="kube-system",daemonset="metadata-proxy-v0.1"} 0
+# HELP kube_daemonset_status_number_misscheduled The number of nodes running a daemon pod but are not supposed to.
+# TYPE kube_daemonset_status_number_misscheduled gauge
+kube_daemonset_status_number_misscheduled{namespace="default",daemonset="datadog-monitoring"} 0
+kube_daemonset_status_number_misscheduled{namespace="kube-system",daemonset="fluentd-gcp-v3.1.1"} 0
+kube_daemonset_status_number_misscheduled{namespace="kube-system",daemonset="metadata-proxy-v0.1"} 0
+kube_daemonset_status_number_misscheduled{namespace="kube-system",daemonset="nvidia-gpu-device-plugin"} 0
+kube_daemonset_status_number_misscheduled{namespace="kube-system",daemonset="prometheus-to-sd"} 0
+# HELP kube_daemonset_status_number_ready The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
+# TYPE kube_daemonset_status_number_ready gauge
+kube_daemonset_status_number_ready{namespace="default",daemonset="datadog-monitoring"} 3
+kube_daemonset_status_number_ready{namespace="kube-system",daemonset="fluentd-gcp-v3.1.1"} 3
+kube_daemonset_status_number_ready{namespace="kube-system",daemonset="metadata-proxy-v0.1"} 0
+kube_daemonset_status_number_ready{namespace="kube-system",daemonset="nvidia-gpu-device-plugin"} 0
+kube_daemonset_status_number_ready{namespace="kube-system",daemonset="prometheus-to-sd"} 3
+# HELP kube_daemonset_status_number_unavailable The number of nodes that should be running the daemon pod and have none of the daemon pod running and available
+# TYPE kube_daemonset_status_number_unavailable gauge
+kube_daemonset_status_number_unavailable{namespace="kube-system",daemonset="prometheus-to-sd"} 0
+kube_daemonset_status_number_unavailable{namespace="default",daemonset="datadog-monitoring"} 0
+kube_daemonset_status_number_unavailable{namespace="kube-system",daemonset="fluentd-gcp-v3.1.1"} 0
+kube_daemonset_status_number_unavailable{namespace="kube-system",daemonset="metadata-proxy-v0.1"} 0
+kube_daemonset_status_number_unavailable{namespace="kube-system",daemonset="nvidia-gpu-device-plugin"} 0
+# HELP kube_daemonset_updated_number_scheduled The total number of nodes that are running updated daemon pod
+# TYPE kube_daemonset_updated_number_scheduled gauge
+kube_daemonset_updated_number_scheduled{namespace="default",daemonset="datadog-monitoring"} 3
+kube_daemonset_updated_number_scheduled{namespace="kube-system",daemonset="fluentd-gcp-v3.1.1"} 3
+kube_daemonset_updated_number_scheduled{namespace="kube-system",daemonset="metadata-proxy-v0.1"} 0
+kube_daemonset_updated_number_scheduled{namespace="kube-system",daemonset="nvidia-gpu-device-plugin"} 0
+kube_daemonset_updated_number_scheduled{namespace="kube-system",daemonset="prometheus-to-sd"} 3
+# HELP kube_daemonset_metadata_generation Sequence number representing a specific generation of the desired state.
+# TYPE kube_daemonset_metadata_generation gauge
+kube_daemonset_metadata_generation{namespace="default",daemonset="datadog-monitoring"} 5
+kube_daemonset_metadata_generation{namespace="kube-system",daemonset="fluentd-gcp-v3.1.1"} 3
+kube_daemonset_metadata_generation{namespace="kube-system",daemonset="metadata-proxy-v0.1"} 1
+kube_daemonset_metadata_generation{namespace="kube-system",daemonset="nvidia-gpu-device-plugin"} 1
+kube_daemonset_metadata_generation{namespace="kube-system",daemonset="prometheus-to-sd"} 2
+# HELP kube_daemonset_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_daemonset_labels gauge
+kube_daemonset_labels{namespace="default",daemonset="datadog-monitoring",label_app_kubernetes_io_instance="datadog-monitoring",label_app_kubernetes_io_managed_by="Helm",label_app_kubernetes_io_name="datadog-monitoring",label_app_kubernetes_io_version="7",label_helm_sh_chart="datadog-2.0.12",label_tags_datadoghq_com_env="dev",label_tags_datadoghq_com_service="datadog-agent",label_tags_datadoghq_com_version="7"} 1
+kube_daemonset_labels{namespace="kube-system",daemonset="fluentd-gcp-v3.1.1",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="fluentd-gcp",label_kubernetes_io_cluster_service="true",label_version="v3.1.1"} 1
+kube_daemonset_labels{namespace="kube-system",daemonset="metadata-proxy-v0.1",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="metadata-proxy",label_kubernetes_io_cluster_service="true",label_version="v0.1"} 1
+kube_daemonset_labels{namespace="kube-system",daemonset="nvidia-gpu-device-plugin",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="nvidia-gpu-device-plugin"} 1
+kube_daemonset_labels{namespace="kube-system",daemonset="prometheus-to-sd",label_addonmanager_kubernetes_io_mode="Reconcile",label_kubernetes_io_cluster_service="true"} 1
+# HELP kube_deployment_created Unix creation timestamp
+# TYPE kube_deployment_created gauge
+kube_deployment_created{namespace="kube-system",deployment="fluentd-gcp-scaler"} 1.580242911e+09
+kube_deployment_created{namespace="kube-system",deployment="l7-default-backend"} 1.580242904e+09
+kube_deployment_created{namespace="kube-system",deployment="metrics-server-v0.3.3"} 1.580242908e+09
+kube_deployment_created{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level"} 1.580242905e+09
+kube_deployment_created{namespace="default",deployment="redis"} 1.584734676e+09
+kube_deployment_created{namespace="kube-system",deployment="event-exporter-v0.3.0"} 1.580242906e+09
+kube_deployment_created{namespace="kube-system",deployment="heapster-gke"} 1.580242905e+09
+kube_deployment_created{namespace="kube-system",deployment="kube-dns"} 1.580242904e+09
+kube_deployment_created{namespace="kube-system",deployment="kube-dns-autoscaler"} 1.580242904e+09
+kube_deployment_created{namespace="default",deployment="datadog-monitoring-cluster-agent"} 1.584562061e+09
+kube_deployment_created{namespace="default",deployment="kube-state-metrics"} 1.582669594e+09
+# HELP kube_deployment_status_replicas The number of replicas per deployment.
+# TYPE kube_deployment_status_replicas gauge
+kube_deployment_status_replicas{namespace="kube-system",deployment="fluentd-gcp-scaler"} 1
+kube_deployment_status_replicas{namespace="kube-system",deployment="l7-default-backend"} 1
+kube_deployment_status_replicas{namespace="kube-system",deployment="metrics-server-v0.3.3"} 1
+kube_deployment_status_replicas{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level"} 1
+kube_deployment_status_replicas{namespace="default",deployment="redis"} 1
+kube_deployment_status_replicas{namespace="kube-system",deployment="event-exporter-v0.3.0"} 1
+kube_deployment_status_replicas{namespace="kube-system",deployment="heapster-gke"} 1
+kube_deployment_status_replicas{namespace="kube-system",deployment="kube-dns"} 2
+kube_deployment_status_replicas{namespace="kube-system",deployment="kube-dns-autoscaler"} 1
+kube_deployment_status_replicas{namespace="default",deployment="datadog-monitoring-cluster-agent"} 1
+kube_deployment_status_replicas{namespace="default",deployment="kube-state-metrics"} 1
+# HELP kube_deployment_status_replicas_available The number of available replicas per deployment.
+# TYPE kube_deployment_status_replicas_available gauge
+kube_deployment_status_replicas_available{namespace="kube-system",deployment="l7-default-backend"} 1
+kube_deployment_status_replicas_available{namespace="kube-system",deployment="metrics-server-v0.3.3"} 1
+kube_deployment_status_replicas_available{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level"} 1
+kube_deployment_status_replicas_available{namespace="default",deployment="redis"} 1
+kube_deployment_status_replicas_available{namespace="kube-system",deployment="event-exporter-v0.3.0"} 1
+kube_deployment_status_replicas_available{namespace="kube-system",deployment="fluentd-gcp-scaler"} 1
+kube_deployment_status_replicas_available{namespace="kube-system",deployment="kube-dns"} 2
+kube_deployment_status_replicas_available{namespace="kube-system",deployment="kube-dns-autoscaler"} 1
+kube_deployment_status_replicas_available{namespace="default",deployment="datadog-monitoring-cluster-agent"} 1
+kube_deployment_status_replicas_available{namespace="default",deployment="kube-state-metrics"} 1
+kube_deployment_status_replicas_available{namespace="kube-system",deployment="heapster-gke"} 1
+# HELP kube_deployment_status_replicas_unavailable The number of unavailable replicas per deployment.
+# TYPE kube_deployment_status_replicas_unavailable gauge
+kube_deployment_status_replicas_unavailable{namespace="kube-system",deployment="kube-dns"} 0
+kube_deployment_status_replicas_unavailable{namespace="kube-system",deployment="kube-dns-autoscaler"} 0
+kube_deployment_status_replicas_unavailable{namespace="default",deployment="datadog-monitoring-cluster-agent"} 0
+kube_deployment_status_replicas_unavailable{namespace="default",deployment="kube-state-metrics"} 0
+kube_deployment_status_replicas_unavailable{namespace="kube-system",deployment="heapster-gke"} 0
+kube_deployment_status_replicas_unavailable{namespace="kube-system",deployment="l7-default-backend"} 0
+kube_deployment_status_replicas_unavailable{namespace="kube-system",deployment="metrics-server-v0.3.3"} 0
+kube_deployment_status_replicas_unavailable{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level"} 0
+kube_deployment_status_replicas_unavailable{namespace="default",deployment="redis"} 0
+kube_deployment_status_replicas_unavailable{namespace="kube-system",deployment="event-exporter-v0.3.0"} 0
+kube_deployment_status_replicas_unavailable{namespace="kube-system",deployment="fluentd-gcp-scaler"} 0
+# HELP kube_deployment_status_replicas_updated The number of updated replicas per deployment.
+# TYPE kube_deployment_status_replicas_updated gauge
+kube_deployment_status_replicas_updated{namespace="kube-system",deployment="event-exporter-v0.3.0"} 1
+kube_deployment_status_replicas_updated{namespace="kube-system",deployment="fluentd-gcp-scaler"} 1
+kube_deployment_status_replicas_updated{namespace="kube-system",deployment="l7-default-backend"} 1
+kube_deployment_status_replicas_updated{namespace="kube-system",deployment="metrics-server-v0.3.3"} 1
+kube_deployment_status_replicas_updated{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level"} 1
+kube_deployment_status_replicas_updated{namespace="default",deployment="redis"} 1
+kube_deployment_status_replicas_updated{namespace="default",deployment="kube-state-metrics"} 1
+kube_deployment_status_replicas_updated{namespace="kube-system",deployment="heapster-gke"} 1
+kube_deployment_status_replicas_updated{namespace="kube-system",deployment="kube-dns"} 2
+kube_deployment_status_replicas_updated{namespace="kube-system",deployment="kube-dns-autoscaler"} 1
+kube_deployment_status_replicas_updated{namespace="default",deployment="datadog-monitoring-cluster-agent"} 1
+# HELP kube_deployment_status_observed_generation The generation observed by the deployment controller.
+# TYPE kube_deployment_status_observed_generation gauge
+kube_deployment_status_observed_generation{namespace="default",deployment="datadog-monitoring-cluster-agent"} 1
+kube_deployment_status_observed_generation{namespace="default",deployment="kube-state-metrics"} 1
+kube_deployment_status_observed_generation{namespace="kube-system",deployment="heapster-gke"} 2
+kube_deployment_status_observed_generation{namespace="kube-system",deployment="kube-dns"} 2
+kube_deployment_status_observed_generation{namespace="kube-system",deployment="kube-dns-autoscaler"} 1
+kube_deployment_status_observed_generation{namespace="default",deployment="redis"} 3
+kube_deployment_status_observed_generation{namespace="kube-system",deployment="event-exporter-v0.3.0"} 1
+kube_deployment_status_observed_generation{namespace="kube-system",deployment="fluentd-gcp-scaler"} 1
+kube_deployment_status_observed_generation{namespace="kube-system",deployment="l7-default-backend"} 1
+kube_deployment_status_observed_generation{namespace="kube-system",deployment="metrics-server-v0.3.3"} 2
+kube_deployment_status_observed_generation{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level"} 3
+# HELP kube_deployment_status_condition The current status conditions of a deployment.
+# TYPE kube_deployment_status_condition gauge
+kube_deployment_status_condition{namespace="kube-system",deployment="l7-default-backend",condition="Progressing",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="l7-default-backend",condition="Progressing",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="l7-default-backend",condition="Progressing",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="l7-default-backend",condition="Available",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="l7-default-backend",condition="Available",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="l7-default-backend",condition="Available",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="metrics-server-v0.3.3",condition="Progressing",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="metrics-server-v0.3.3",condition="Progressing",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="metrics-server-v0.3.3",condition="Progressing",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="metrics-server-v0.3.3",condition="Available",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="metrics-server-v0.3.3",condition="Available",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="metrics-server-v0.3.3",condition="Available",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level",condition="Available",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level",condition="Available",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level",condition="Available",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level",condition="Progressing",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level",condition="Progressing",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level",condition="Progressing",status="unknown"} 0
+kube_deployment_status_condition{namespace="default",deployment="redis",condition="Available",status="true"} 1
+kube_deployment_status_condition{namespace="default",deployment="redis",condition="Available",status="false"} 0
+kube_deployment_status_condition{namespace="default",deployment="redis",condition="Available",status="unknown"} 0
+kube_deployment_status_condition{namespace="default",deployment="redis",condition="Progressing",status="true"} 1
+kube_deployment_status_condition{namespace="default",deployment="redis",condition="Progressing",status="false"} 0
+kube_deployment_status_condition{namespace="default",deployment="redis",condition="Progressing",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="event-exporter-v0.3.0",condition="Progressing",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="event-exporter-v0.3.0",condition="Progressing",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="event-exporter-v0.3.0",condition="Progressing",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="event-exporter-v0.3.0",condition="Available",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="event-exporter-v0.3.0",condition="Available",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="event-exporter-v0.3.0",condition="Available",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="fluentd-gcp-scaler",condition="Progressing",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="fluentd-gcp-scaler",condition="Progressing",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="fluentd-gcp-scaler",condition="Progressing",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="fluentd-gcp-scaler",condition="Available",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="fluentd-gcp-scaler",condition="Available",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="fluentd-gcp-scaler",condition="Available",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="kube-dns",condition="Progressing",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="kube-dns",condition="Progressing",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="kube-dns",condition="Progressing",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="kube-dns",condition="Available",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="kube-dns",condition="Available",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="kube-dns",condition="Available",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="kube-dns-autoscaler",condition="Progressing",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="kube-dns-autoscaler",condition="Progressing",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="kube-dns-autoscaler",condition="Progressing",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="kube-dns-autoscaler",condition="Available",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="kube-dns-autoscaler",condition="Available",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="kube-dns-autoscaler",condition="Available",status="unknown"} 0
+kube_deployment_status_condition{namespace="default",deployment="datadog-monitoring-cluster-agent",condition="Available",status="true"} 1
+kube_deployment_status_condition{namespace="default",deployment="datadog-monitoring-cluster-agent",condition="Available",status="false"} 0
+kube_deployment_status_condition{namespace="default",deployment="datadog-monitoring-cluster-agent",condition="Available",status="unknown"} 0
+kube_deployment_status_condition{namespace="default",deployment="datadog-monitoring-cluster-agent",condition="Progressing",status="true"} 1
+kube_deployment_status_condition{namespace="default",deployment="datadog-monitoring-cluster-agent",condition="Progressing",status="false"} 0
+kube_deployment_status_condition{namespace="default",deployment="datadog-monitoring-cluster-agent",condition="Progressing",status="unknown"} 0
+kube_deployment_status_condition{namespace="default",deployment="kube-state-metrics",condition="Progressing",status="true"} 1
+kube_deployment_status_condition{namespace="default",deployment="kube-state-metrics",condition="Progressing",status="false"} 0
+kube_deployment_status_condition{namespace="default",deployment="kube-state-metrics",condition="Progressing",status="unknown"} 0
+kube_deployment_status_condition{namespace="default",deployment="kube-state-metrics",condition="Available",status="true"} 1
+kube_deployment_status_condition{namespace="default",deployment="kube-state-metrics",condition="Available",status="false"} 0
+kube_deployment_status_condition{namespace="default",deployment="kube-state-metrics",condition="Available",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="heapster-gke",condition="Progressing",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="heapster-gke",condition="Progressing",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="heapster-gke",condition="Progressing",status="unknown"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="heapster-gke",condition="Available",status="true"} 1
+kube_deployment_status_condition{namespace="kube-system",deployment="heapster-gke",condition="Available",status="false"} 0
+kube_deployment_status_condition{namespace="kube-system",deployment="heapster-gke",condition="Available",status="unknown"} 0
+# HELP kube_deployment_spec_replicas Number of desired pods for a deployment.
+# TYPE kube_deployment_spec_replicas gauge
+kube_deployment_spec_replicas{namespace="kube-system",deployment="l7-default-backend"} 1
+kube_deployment_spec_replicas{namespace="kube-system",deployment="metrics-server-v0.3.3"} 1
+kube_deployment_spec_replicas{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level"} 1
+kube_deployment_spec_replicas{namespace="default",deployment="redis"} 1
+kube_deployment_spec_replicas{namespace="kube-system",deployment="event-exporter-v0.3.0"} 1
+kube_deployment_spec_replicas{namespace="kube-system",deployment="fluentd-gcp-scaler"} 1
+kube_deployment_spec_replicas{namespace="kube-system",deployment="kube-dns"} 2
+kube_deployment_spec_replicas{namespace="kube-system",deployment="kube-dns-autoscaler"} 1
+kube_deployment_spec_replicas{namespace="default",deployment="datadog-monitoring-cluster-agent"} 1
+kube_deployment_spec_replicas{namespace="default",deployment="kube-state-metrics"} 1
+kube_deployment_spec_replicas{namespace="kube-system",deployment="heapster-gke"} 1
+# HELP kube_deployment_spec_paused Whether the deployment is paused and will not be processed by the deployment controller.
+# TYPE kube_deployment_spec_paused gauge
+kube_deployment_spec_paused{namespace="default",deployment="kube-state-metrics"} 0
+kube_deployment_spec_paused{namespace="kube-system",deployment="heapster-gke"} 0
+kube_deployment_spec_paused{namespace="kube-system",deployment="kube-dns"} 0
+kube_deployment_spec_paused{namespace="kube-system",deployment="kube-dns-autoscaler"} 0
+kube_deployment_spec_paused{namespace="default",deployment="datadog-monitoring-cluster-agent"} 0
+kube_deployment_spec_paused{namespace="kube-system",deployment="event-exporter-v0.3.0"} 0
+kube_deployment_spec_paused{namespace="kube-system",deployment="fluentd-gcp-scaler"} 0
+kube_deployment_spec_paused{namespace="kube-system",deployment="l7-default-backend"} 0
+kube_deployment_spec_paused{namespace="kube-system",deployment="metrics-server-v0.3.3"} 0
+kube_deployment_spec_paused{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level"} 0
+kube_deployment_spec_paused{namespace="default",deployment="redis"} 0
+# HELP kube_deployment_spec_strategy_rollingupdate_max_unavailable Maximum number of unavailable replicas during a rolling update of a deployment.
+# TYPE kube_deployment_spec_strategy_rollingupdate_max_unavailable gauge
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="default",deployment="redis"} 1
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="kube-system",deployment="event-exporter-v0.3.0"} 1
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="kube-system",deployment="fluentd-gcp-scaler"} 1
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="kube-system",deployment="l7-default-backend"} 1
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="kube-system",deployment="metrics-server-v0.3.3"} 1
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level"} 1
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="default",deployment="datadog-monitoring-cluster-agent"} 0
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="default",deployment="kube-state-metrics"} 1
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="kube-system",deployment="heapster-gke"} 1
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="kube-system",deployment="kube-dns"} 0
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{namespace="kube-system",deployment="kube-dns-autoscaler"} 1
+# HELP kube_deployment_spec_strategy_rollingupdate_max_surge Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a deployment.
+# TYPE kube_deployment_spec_strategy_rollingupdate_max_surge gauge
+kube_deployment_spec_strategy_rollingupdate_max_surge{namespace="default",deployment="redis"} 1
+kube_deployment_spec_strategy_rollingupdate_max_surge{namespace="kube-system",deployment="event-exporter-v0.3.0"} 1
+kube_deployment_spec_strategy_rollingupdate_max_surge{namespace="kube-system",deployment="fluentd-gcp-scaler"} 1
+kube_deployment_spec_strategy_rollingupdate_max_surge{namespace="kube-system",deployment="l7-default-backend"} 1
+kube_deployment_spec_strategy_rollingupdate_max_surge{namespace="kube-system",deployment="metrics-server-v0.3.3"} 1
+kube_deployment_spec_strategy_rollingupdate_max_surge{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level"} 1
+kube_deployment_spec_strategy_rollingupdate_max_surge{namespace="default",deployment="datadog-monitoring-cluster-agent"} 1
+kube_deployment_spec_strategy_rollingupdate_max_surge{namespace="default",deployment="kube-state-metrics"} 1
+kube_deployment_spec_strategy_rollingupdate_max_surge{namespace="kube-system",deployment="heapster-gke"} 1
+kube_deployment_spec_strategy_rollingupdate_max_surge{namespace="kube-system",deployment="kube-dns"} 1
+kube_deployment_spec_strategy_rollingupdate_max_surge{namespace="kube-system",deployment="kube-dns-autoscaler"} 1
+# HELP kube_deployment_metadata_generation Sequence number representing a specific generation of the desired state.
+# TYPE kube_deployment_metadata_generation gauge
+kube_deployment_metadata_generation{namespace="default",deployment="kube-state-metrics"} 1
+kube_deployment_metadata_generation{namespace="kube-system",deployment="heapster-gke"} 2
+kube_deployment_metadata_generation{namespace="kube-system",deployment="kube-dns"} 2
+kube_deployment_metadata_generation{namespace="kube-system",deployment="kube-dns-autoscaler"} 1
+kube_deployment_metadata_generation{namespace="default",deployment="datadog-monitoring-cluster-agent"} 1
+kube_deployment_metadata_generation{namespace="kube-system",deployment="event-exporter-v0.3.0"} 1
+kube_deployment_metadata_generation{namespace="kube-system",deployment="fluentd-gcp-scaler"} 1
+kube_deployment_metadata_generation{namespace="kube-system",deployment="l7-default-backend"} 1
+kube_deployment_metadata_generation{namespace="kube-system",deployment="metrics-server-v0.3.3"} 2
+kube_deployment_metadata_generation{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level"} 3
+kube_deployment_metadata_generation{namespace="default",deployment="redis"} 3
+# HELP kube_deployment_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_deployment_labels gauge
+kube_deployment_labels{namespace="default",deployment="datadog-monitoring-cluster-agent",label_app_kubernetes_io_instance="datadog-monitoring",label_app_kubernetes_io_managed_by="Helm",label_app_kubernetes_io_name="datadog-monitoring",label_app_kubernetes_io_version="7",label_helm_sh_chart="datadog-2.0.12"} 1
+kube_deployment_labels{namespace="default",deployment="kube-state-metrics",label_app_kubernetes_io_instance="kube-state-metrics",label_app_kubernetes_io_managed_by="Helm",label_app_kubernetes_io_name="kube-state-metrics",label_helm_sh_chart="kube-state-metrics-2.6.2"} 1
+kube_deployment_labels{namespace="kube-system",deployment="heapster-gke",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="heapster",label_kubernetes_io_cluster_service="true",label_version="v1.7.2"} 1
+kube_deployment_labels{namespace="kube-system",deployment="kube-dns",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="kube-dns",label_kubernetes_io_cluster_service="true"} 1
+kube_deployment_labels{namespace="kube-system",deployment="kube-dns-autoscaler",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="kube-dns-autoscaler",label_kubernetes_io_cluster_service="true"} 1
+kube_deployment_labels{namespace="default",deployment="redis",label_tags_datadoghq_com_env="dev",label_tags_datadoghq_com_service="redis",label_tags_datadoghq_com_version="v1"} 1
+kube_deployment_labels{namespace="kube-system",deployment="event-exporter-v0.3.0",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="event-exporter",label_kubernetes_io_cluster_service="true",label_version="v0.3.0"} 1
+kube_deployment_labels{namespace="kube-system",deployment="fluentd-gcp-scaler",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="fluentd-gcp-scaler",label_version="v0.5.1"} 1
+kube_deployment_labels{namespace="kube-system",deployment="l7-default-backend",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="glbc",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="GLBC"} 1
+kube_deployment_labels{namespace="kube-system",deployment="metrics-server-v0.3.3",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="metrics-server",label_kubernetes_io_cluster_service="true",label_version="v0.3.3"} 1
+kube_deployment_labels{namespace="kube-system",deployment="stackdriver-metadata-agent-cluster-level",label_addonmanager_kubernetes_io_mode="Reconcile",label_app="stackdriver-metadata-agent",label_kubernetes_io_cluster_service="true"} 1
+# HELP kube_endpoint_info Information about endpoint.
+# TYPE kube_endpoint_info gauge
+kube_endpoint_info{namespace="kube-system",endpoint="kube-scheduler"} 1
+kube_endpoint_info{namespace="kube-system",endpoint="vpa-recommender"} 1
+kube_endpoint_info{namespace="default",endpoint="kube-state-metrics"} 1
+kube_endpoint_info{namespace="kube-system",endpoint="default-http-backend"} 1
+kube_endpoint_info{namespace="kube-system",endpoint="gcp-controller-manager"} 1
+kube_endpoint_info{namespace="kube-system",endpoint="heapster"} 1
+kube_endpoint_info{namespace="kube-system",endpoint="kube-controller-manager"} 1
+kube_endpoint_info{namespace="default",endpoint="nginx"} 1
+kube_endpoint_info{namespace="default",endpoint="datadog-monitoring-cluster-agent"} 1
+kube_endpoint_info{namespace="default",endpoint="datadog-monitoring-cluster-agent-metrics-api"} 1
+kube_endpoint_info{namespace="kube-system",endpoint="managed-certificate-controller"} 1
+kube_endpoint_info{namespace="kube-system",endpoint="metrics-server"} 1
+kube_endpoint_info{namespace="default",endpoint="kubernetes"} 1
+kube_endpoint_info{namespace="kube-system",endpoint="kube-dns"} 1
+# HELP kube_endpoint_created Unix creation timestamp
+# TYPE kube_endpoint_created gauge
+kube_endpoint_created{namespace="default",endpoint="datadog-monitoring-cluster-agent-metrics-api"} 1.584562061e+09
+kube_endpoint_created{namespace="kube-system",endpoint="gcp-controller-manager"} 1.580242911e+09
+kube_endpoint_created{namespace="kube-system",endpoint="heapster"} 1.580242905e+09
+kube_endpoint_created{namespace="kube-system",endpoint="kube-controller-manager"} 1.580242885e+09
+kube_endpoint_created{namespace="default",endpoint="nginx"} 1.586188625e+09
+kube_endpoint_created{namespace="default",endpoint="datadog-monitoring-cluster-agent"} 1.584562061e+09
+kube_endpoint_created{namespace="kube-system",endpoint="kube-dns"} 1.580242904e+09
+kube_endpoint_created{namespace="kube-system",endpoint="managed-certificate-controller"} 1.580242912e+09
+kube_endpoint_created{namespace="kube-system",endpoint="metrics-server"} 1.580242908e+09
+kube_endpoint_created{namespace="default",endpoint="kubernetes"} 1.580242886e+09
+kube_endpoint_created{namespace="kube-system",endpoint="default-http-backend"} 1.580242904e+09
+kube_endpoint_created{namespace="kube-system",endpoint="kube-scheduler"} 1.580242886e+09
+kube_endpoint_created{namespace="kube-system",endpoint="vpa-recommender"} 1.580242918e+09
+kube_endpoint_created{namespace="default",endpoint="kube-state-metrics"} 1.582669594e+09
+# HELP kube_endpoint_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_endpoint_labels gauge
+kube_endpoint_labels{namespace="default",endpoint="kubernetes"} 1
+kube_endpoint_labels{namespace="kube-system",endpoint="kube-dns",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="kube-dns",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="KubeDNS"} 1
+kube_endpoint_labels{namespace="kube-system",endpoint="managed-certificate-controller"} 1
+kube_endpoint_labels{namespace="kube-system",endpoint="metrics-server",label_addonmanager_kubernetes_io_mode="Reconcile",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="Metrics-server"} 1
+kube_endpoint_labels{namespace="default",endpoint="kube-state-metrics",label_app_kubernetes_io_instance="kube-state-metrics",label_app_kubernetes_io_managed_by="Helm",label_app_kubernetes_io_name="kube-state-metrics",label_helm_sh_chart="kube-state-metrics-2.6.2"} 1
+kube_endpoint_labels{namespace="kube-system",endpoint="default-http-backend",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="glbc",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="GLBCDefaultBackend"} 1
+kube_endpoint_labels{namespace="kube-system",endpoint="kube-scheduler"} 1
+kube_endpoint_labels{namespace="kube-system",endpoint="vpa-recommender"} 1
+kube_endpoint_labels{namespace="default",endpoint="nginx",label_app="nginx"} 1
+kube_endpoint_labels{namespace="default",endpoint="datadog-monitoring-cluster-agent",label_app_kubernetes_io_instance="datadog-monitoring",label_app_kubernetes_io_managed_by="Helm",label_app_kubernetes_io_name="datadog-monitoring",label_app_kubernetes_io_version="7",label_helm_sh_chart="datadog-2.0.12"} 1
+kube_endpoint_labels{namespace="default",endpoint="datadog-monitoring-cluster-agent-metrics-api",label_app="datadog-monitoring",label_app_kubernetes_io_instance="datadog-monitoring",label_app_kubernetes_io_managed_by="Helm",label_app_kubernetes_io_name="datadog-monitoring",label_app_kubernetes_io_version="7",label_chart="datadog-2.0.12",label_helm_sh_chart="datadog-2.0.12",label_heritage="Helm",label_release="datadog-monitoring"} 1
+kube_endpoint_labels{namespace="kube-system",endpoint="gcp-controller-manager"} 1
+kube_endpoint_labels{namespace="kube-system",endpoint="heapster",label_addonmanager_kubernetes_io_mode="Reconcile",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="Heapster"} 1
+kube_endpoint_labels{namespace="kube-system",endpoint="kube-controller-manager"} 1
+# HELP kube_endpoint_address_available Number of addresses available in endpoint.
+# TYPE kube_endpoint_address_available gauge
+kube_endpoint_address_available{namespace="default",endpoint="kube-state-metrics"} 1
+kube_endpoint_address_available{namespace="kube-system",endpoint="default-http-backend"} 1
+kube_endpoint_address_available{namespace="kube-system",endpoint="kube-scheduler"} 0
+kube_endpoint_address_available{namespace="kube-system",endpoint="vpa-recommender"} 0
+kube_endpoint_address_available{namespace="default",endpoint="datadog-monitoring-cluster-agent"} 1
+kube_endpoint_address_available{namespace="default",endpoint="datadog-monitoring-cluster-agent-metrics-api"} 1
+kube_endpoint_address_available{namespace="kube-system",endpoint="gcp-controller-manager"} 0
+kube_endpoint_address_available{namespace="kube-system",endpoint="heapster"} 1
+kube_endpoint_address_available{namespace="kube-system",endpoint="kube-controller-manager"} 0
+kube_endpoint_address_available{namespace="default",endpoint="nginx"} 2
+kube_endpoint_address_available{namespace="default",endpoint="kubernetes"} 1
+kube_endpoint_address_available{namespace="kube-system",endpoint="kube-dns"} 4
+kube_endpoint_address_available{namespace="kube-system",endpoint="managed-certificate-controller"} 0
+kube_endpoint_address_available{namespace="kube-system",endpoint="metrics-server"} 1
+# HELP kube_endpoint_address_not_ready Number of addresses not ready in endpoint
+# TYPE kube_endpoint_address_not_ready gauge
+kube_endpoint_address_not_ready{namespace="default",endpoint="kubernetes"} 0
+kube_endpoint_address_not_ready{namespace="kube-system",endpoint="kube-dns"} 0
+kube_endpoint_address_not_ready{namespace="kube-system",endpoint="managed-certificate-controller"} 0
+kube_endpoint_address_not_ready{namespace="kube-system",endpoint="metrics-server"} 0
+kube_endpoint_address_not_ready{namespace="default",endpoint="kube-state-metrics"} 0
+kube_endpoint_address_not_ready{namespace="kube-system",endpoint="default-http-backend"} 0
+kube_endpoint_address_not_ready{namespace="kube-system",endpoint="kube-scheduler"} 0
+kube_endpoint_address_not_ready{namespace="kube-system",endpoint="vpa-recommender"} 0
+kube_endpoint_address_not_ready{namespace="default",endpoint="datadog-monitoring-cluster-agent"} 0
+kube_endpoint_address_not_ready{namespace="default",endpoint="datadog-monitoring-cluster-agent-metrics-api"} 0
+kube_endpoint_address_not_ready{namespace="kube-system",endpoint="gcp-controller-manager"} 0
+kube_endpoint_address_not_ready{namespace="kube-system",endpoint="heapster"} 0
+kube_endpoint_address_not_ready{namespace="kube-system",endpoint="kube-controller-manager"} 0
+kube_endpoint_address_not_ready{namespace="default",endpoint="nginx"} 0
+# HELP kube_hpa_metadata_generation The generation observed by the HorizontalPodAutoscaler controller.
+# TYPE kube_hpa_metadata_generation gauge
+# HELP kube_hpa_spec_max_replicas Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+# TYPE kube_hpa_spec_max_replicas gauge
+# HELP kube_hpa_spec_min_replicas Lower limit for the number of pods that can be set by the autoscaler, default 1.
+# TYPE kube_hpa_spec_min_replicas gauge
+# HELP kube_hpa_spec_target_metric The metric specifications used by this autoscaler when calculating the desired replica count.
+# TYPE kube_hpa_spec_target_metric gauge
+# HELP kube_hpa_status_current_replicas Current number of replicas of pods managed by this autoscaler.
+# TYPE kube_hpa_status_current_replicas gauge
+# HELP kube_hpa_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
+# TYPE kube_hpa_status_desired_replicas gauge
+# HELP kube_hpa_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_hpa_labels gauge
+# HELP kube_hpa_status_condition The condition of this autoscaler.
+# TYPE kube_hpa_status_condition gauge
+# HELP kube_hpa_status_current_metrics_average_value Average metric value observed by the autoscaler.
+# TYPE kube_hpa_status_current_metrics_average_value gauge
+# HELP kube_hpa_status_current_metrics_average_utilization Average metric utilization observed by the autoscaler.
+# TYPE kube_hpa_status_current_metrics_average_utilization gauge
+# HELP kube_ingress_info Information about ingress.
+# TYPE kube_ingress_info gauge
+# HELP kube_ingress_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_ingress_labels gauge
+# HELP kube_ingress_created Unix creation timestamp
+# TYPE kube_ingress_created gauge
+# HELP kube_ingress_metadata_resource_version Resource version representing a specific version of ingress.
+# TYPE kube_ingress_metadata_resource_version gauge
+# HELP kube_ingress_path Ingress host, paths and backend service information.
+# TYPE kube_ingress_path gauge
+# HELP kube_ingress_tls Ingress TLS host and secret information.
+# TYPE kube_ingress_tls gauge
+# HELP kube_job_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_job_labels gauge
+kube_job_labels{namespace="default",job_name="curl-cron-job-1586205240",label_tags_datadoghq_com_env="dev",label_tags_datadoghq_com_service="curl-cron-job",label_tags_datadoghq_com_version="v1"} 1
+kube_job_labels{namespace="default",job_name="curl-job",label_controller_uid="efb6e033-4827-4c24-92fe-c6e306cf4d8f",label_job_name="curl-job",label_tags_datadoghq_com_env="dev",label_tags_datadoghq_com_service="curl-job",label_tags_datadoghq_com_version="v1"} 1
+# HELP kube_job_info Information about job.
+# TYPE kube_job_info gauge
+kube_job_info{namespace="default",job_name="curl-cron-job-1586205240"} 1
+kube_job_info{namespace="default",job_name="curl-job"} 1
+# HELP kube_job_created Unix creation timestamp
+# TYPE kube_job_created gauge
+kube_job_created{namespace="default",job_name="curl-cron-job-1586205240"} 1.586205249e+09
+kube_job_created{namespace="default",job_name="curl-job"} 1.58618763e+09
+# HELP kube_job_spec_parallelism The maximum desired number of pods the job should run at any given time.
+# TYPE kube_job_spec_parallelism gauge
+kube_job_spec_parallelism{namespace="default",job_name="curl-cron-job-1586205240"} 1
+kube_job_spec_parallelism{namespace="default",job_name="curl-job"} 1
+# HELP kube_job_spec_completions The desired number of successfully finished pods the job should be run with.
+# TYPE kube_job_spec_completions gauge
+kube_job_spec_completions{namespace="default",job_name="curl-cron-job-1586205240"} 1
+kube_job_spec_completions{namespace="default",job_name="curl-job"} 1
+# HELP kube_job_spec_active_deadline_seconds The duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.
+# TYPE kube_job_spec_active_deadline_seconds gauge
+# HELP kube_job_status_succeeded The number of pods which reached Phase Succeeded.
+# TYPE kube_job_status_succeeded gauge
+kube_job_status_succeeded{namespace="default",job_name="curl-job"} 1
+kube_job_status_succeeded{namespace="default",job_name="curl-cron-job-1586205240"} 1
+# HELP kube_job_status_failed The number of pods which reached Phase Failed.
+# TYPE kube_job_status_failed gauge
+kube_job_status_failed{namespace="default",job_name="curl-cron-job-1586205240"} 0
+# HELP kube_job_status_active The number of actively running pods.
+# TYPE kube_job_status_active gauge
+kube_job_status_active{namespace="default",job_name="curl-cron-job-1586205240"} 0
+# HELP kube_job_complete The job has completed its execution.
+# TYPE kube_job_complete gauge
+kube_job_complete{namespace="default",job_name="curl-cron-job-1586205240",condition="true"} 1
+kube_job_complete{namespace="default",job_name="curl-cron-job-1586205240",condition="false"} 0
+kube_job_complete{namespace="default",job_name="curl-cron-job-1586205240",condition="unknown"} 0
+kube_job_complete{namespace="default",job_name="curl-job",condition="true"} 1
+kube_job_complete{namespace="default",job_name="curl-job",condition="false"} 0
+kube_job_complete{namespace="default",job_name="curl-job",condition="unknown"} 0
+# HELP kube_job_failed The job has failed its execution.
+# TYPE kube_job_failed gauge
+# HELP kube_job_status_start_time StartTime represents time when the job was acknowledged by the Job Manager.
+# TYPE kube_job_status_start_time gauge
+kube_job_status_start_time{namespace="default",job_name="curl-cron-job-1586205240"} 1.586205249e+09
+kube_job_status_start_time{namespace="default",job_name="curl-job"} 1.58618763e+09
+# HELP kube_job_status_completion_time CompletionTime represents time when the job was completed.
+# TYPE kube_job_status_completion_time gauge
+kube_job_status_completion_time{namespace="default",job_name="curl-cron-job-1586205240"} 1.586205251e+09
+kube_job_status_completion_time{namespace="default",job_name="curl-job"} 1.586187643e+09
+# HELP kube_job_owner Information about the Job's owner.
+# TYPE kube_job_owner gauge
+kube_job_owner{namespace="default",job_name="curl-cron-job-1586205240",owner_kind="CronJob",owner_name="curl-cron-job",owner_is_controller="true"} 1
+kube_job_owner{namespace="default",job_name="curl-job",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+# HELP kube_limitrange Information about limit range.
+# TYPE kube_limitrange gauge
+kube_limitrange{namespace="default",limitrange="limits",resource="cpu",type="Container",constraint="defaultRequest"} 0.1
+# HELP kube_limitrange_created Unix creation timestamp
+# TYPE kube_limitrange_created gauge
+kube_limitrange_created{namespace="default",limitrange="limits"} 1.580242903e+09
+# HELP kube_namespace_created Unix creation timestamp
+# TYPE kube_namespace_created gauge
+kube_namespace_created{namespace="default"} 1.580242886e+09
+kube_namespace_created{namespace="kube-node-lease"} 1.580242883e+09
+kube_namespace_created{namespace="kube-public"} 1.580242883e+09
+kube_namespace_created{namespace="kube-system"} 1.580242883e+09
+# HELP kube_namespace_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_namespace_labels gauge
+kube_namespace_labels{namespace="default"} 1
+kube_namespace_labels{namespace="kube-node-lease"} 1
+kube_namespace_labels{namespace="kube-public"} 1
+kube_namespace_labels{namespace="kube-system"} 1
+# HELP kube_namespace_status_phase kubernetes namespace status phase.
+# TYPE kube_namespace_status_phase gauge
+kube_namespace_status_phase{namespace="kube-public",phase="Active"} 1
+kube_namespace_status_phase{namespace="kube-public",phase="Terminating"} 0
+kube_namespace_status_phase{namespace="kube-system",phase="Active"} 1
+kube_namespace_status_phase{namespace="kube-system",phase="Terminating"} 0
+kube_namespace_status_phase{namespace="default",phase="Active"} 1
+kube_namespace_status_phase{namespace="default",phase="Terminating"} 0
+kube_namespace_status_phase{namespace="kube-node-lease",phase="Active"} 1
+kube_namespace_status_phase{namespace="kube-node-lease",phase="Terminating"} 0
+# HELP kube_namespace_status_condition The condition of a namespace.
+# TYPE kube_namespace_status_condition gauge
+# HELP kube_node_info Information about a cluster node.
+# TYPE kube_node_info gauge
+kube_node_info{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",kernel_version="4.19.76+",os_image="Container-Optimized OS from Google",container_runtime_version="docker://19.3.1",kubelet_version="v1.15.8-gke.3",kubeproxy_version="v1.15.8-gke.3",provider_id="gce://something/us-central1-a/gke-abcdef-cluster-default-pool-53c8a4ea-95lc",pod_cidr="192.168.0.0/24"} 1
+kube_node_info{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",kernel_version="4.19.76+",os_image="Container-Optimized OS from Google",container_runtime_version="docker://19.3.1",kubelet_version="v1.15.8-gke.3",kubeproxy_version="v1.15.8-gke.3",provider_id="gce://something/us-central1-a/gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",pod_cidr="192.168.2.0/24"} 1
+kube_node_info{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",kernel_version="4.19.76+",os_image="Container-Optimized OS from Google",container_runtime_version="docker://19.3.1",kubelet_version="v1.15.8-gke.3",kubeproxy_version="v1.15.8-gke.3",provider_id="gce://something/us-central1-a/gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",pod_cidr="192.168.1.0/24"} 1
+# HELP kube_node_created Unix creation timestamp
+# TYPE kube_node_created gauge
+kube_node_created{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 1.584058483e+09
+kube_node_created{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 1.58024292e+09
+kube_node_created{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 1.580242912e+09
+# HELP kube_node_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_node_labels gauge
+kube_node_labels{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",label_beta_kubernetes_io_arch="amd64",label_beta_kubernetes_io_fluentd_ds_ready="true",label_beta_kubernetes_io_instance_type="n1-standard-1",label_beta_kubernetes_io_os="linux",label_cloud_google_com_gke_nodepool="default-pool",label_cloud_google_com_gke_os_distribution="cos",label_user="marcus_aurelius",label_failure_domain_beta_kubernetes_io_region="us-central1",label_failure_domain_beta_kubernetes_io_zone="us-central1-a",label_kubernetes_io_arch="amd64",label_kubernetes_io_hostname="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",label_kubernetes_io_os="linux",label_team="stoics"} 1
+kube_node_labels{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",label_beta_kubernetes_io_arch="amd64",label_beta_kubernetes_io_fluentd_ds_ready="true",label_beta_kubernetes_io_instance_type="n1-standard-1",label_beta_kubernetes_io_os="linux",label_cloud_google_com_gke_nodepool="default-pool",label_cloud_google_com_gke_os_distribution="cos",label_user="marcus_aurelius",label_failure_domain_beta_kubernetes_io_region="us-central1",label_failure_domain_beta_kubernetes_io_zone="us-central1-a",label_kubernetes_io_arch="amd64",label_kubernetes_io_hostname="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",label_kubernetes_io_os="linux",label_team="stoics"} 1
+kube_node_labels{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",label_beta_kubernetes_io_arch="amd64",label_beta_kubernetes_io_fluentd_ds_ready="true",label_beta_kubernetes_io_instance_type="n1-standard-1",label_beta_kubernetes_io_os="linux",label_cloud_google_com_gke_nodepool="default-pool",label_cloud_google_com_gke_os_distribution="cos",label_user="marcus_aurelius",label_failure_domain_beta_kubernetes_io_region="us-central1",label_failure_domain_beta_kubernetes_io_zone="us-central1-a",label_kubernetes_io_arch="amd64",label_kubernetes_io_hostname="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",label_kubernetes_io_os="linux",label_team="stoics"} 1
+# HELP kube_node_role The role of a cluster node.
+# TYPE kube_node_role gauge
+# HELP kube_node_spec_unschedulable Whether a node can schedule new pods.
+# TYPE kube_node_spec_unschedulable gauge
+kube_node_spec_unschedulable{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0
+kube_node_spec_unschedulable{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0
+kube_node_spec_unschedulable{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0
+# HELP kube_node_spec_taint The taint of a cluster node.
+# TYPE kube_node_spec_taint gauge
+# HELP kube_node_status_condition The condition of a cluster node.
+# TYPE kube_node_status_condition gauge
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="CorruptDockerOverlay2",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="CorruptDockerOverlay2",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="CorruptDockerOverlay2",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="FrequentUnregisterNetDevice",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="FrequentUnregisterNetDevice",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="FrequentUnregisterNetDevice",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="FrequentKubeletRestart",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="FrequentKubeletRestart",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="FrequentKubeletRestart",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="FrequentDockerRestart",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="FrequentDockerRestart",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="FrequentDockerRestart",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="FrequentContainerdRestart",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="FrequentContainerdRestart",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="FrequentContainerdRestart",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="KernelDeadlock",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="KernelDeadlock",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="KernelDeadlock",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="ReadonlyFilesystem",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="ReadonlyFilesystem",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="ReadonlyFilesystem",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="NetworkUnavailable",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="NetworkUnavailable",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="NetworkUnavailable",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="MemoryPressure",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="MemoryPressure",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="MemoryPressure",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="DiskPressure",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="DiskPressure",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="DiskPressure",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="PIDPressure",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="PIDPressure",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="PIDPressure",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="Ready",status="true"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="Ready",status="false"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="Ready",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="FrequentContainerdRestart",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="FrequentContainerdRestart",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="FrequentContainerdRestart",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="CorruptDockerOverlay2",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="CorruptDockerOverlay2",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="CorruptDockerOverlay2",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="FrequentUnregisterNetDevice",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="FrequentUnregisterNetDevice",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="FrequentUnregisterNetDevice",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="KernelDeadlock",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="KernelDeadlock",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="KernelDeadlock",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="ReadonlyFilesystem",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="ReadonlyFilesystem",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="ReadonlyFilesystem",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="FrequentKubeletRestart",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="FrequentKubeletRestart",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="FrequentKubeletRestart",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="FrequentDockerRestart",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="FrequentDockerRestart",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="FrequentDockerRestart",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="NetworkUnavailable",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="NetworkUnavailable",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="NetworkUnavailable",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="MemoryPressure",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="MemoryPressure",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="MemoryPressure",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="DiskPressure",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="DiskPressure",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="DiskPressure",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="PIDPressure",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="PIDPressure",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="PIDPressure",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="Ready",status="true"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="Ready",status="false"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="Ready",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="FrequentKubeletRestart",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="FrequentKubeletRestart",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="FrequentKubeletRestart",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="FrequentDockerRestart",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="FrequentDockerRestart",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="FrequentDockerRestart",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="FrequentContainerdRestart",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="FrequentContainerdRestart",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="FrequentContainerdRestart",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="KernelDeadlock",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="KernelDeadlock",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="KernelDeadlock",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="ReadonlyFilesystem",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="ReadonlyFilesystem",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="ReadonlyFilesystem",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="CorruptDockerOverlay2",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="CorruptDockerOverlay2",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="CorruptDockerOverlay2",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="FrequentUnregisterNetDevice",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="FrequentUnregisterNetDevice",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="FrequentUnregisterNetDevice",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="NetworkUnavailable",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="NetworkUnavailable",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="NetworkUnavailable",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="MemoryPressure",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="MemoryPressure",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="MemoryPressure",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="DiskPressure",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="DiskPressure",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="DiskPressure",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="PIDPressure",status="true"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="PIDPressure",status="false"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="PIDPressure",status="unknown"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="Ready",status="true"} 1
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="Ready",status="false"} 0
+kube_node_status_condition{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="Ready",status="unknown"} 0
+# HELP kube_node_status_phase The phase the node is currently in.
+# TYPE kube_node_status_phase gauge
+# HELP kube_node_status_capacity The capacity for different resources of a node.
+# TYPE kube_node_status_capacity gauge
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="ephemeral_storage",unit="byte"} 1.01241290752e+11
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="hugepages_2Mi",unit="byte"} 0
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 3.876859904e+09
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="pods",unit="integer"} 110
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="attachable_volumes_gce_pd",unit="byte"} 127
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 1
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="ephemeral_storage",unit="byte"} 1.01241290752e+11
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="hugepages_2Mi",unit="byte"} 0
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 3.87680256e+09
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="pods",unit="integer"} 110
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="attachable_volumes_gce_pd",unit="byte"} 127
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 1
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="hugepages_2Mi",unit="byte"} 0
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="memory",unit="byte"} 3.876818944e+09
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="pods",unit="integer"} 110
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="attachable_volumes_gce_pd",unit="byte"} 127
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 1
+kube_node_status_capacity{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="ephemeral_storage",unit="byte"} 1.01241290752e+11
+# HELP kube_node_status_capacity_pods The total pod resources of the node.
+# TYPE kube_node_status_capacity_pods gauge
+kube_node_status_capacity_pods{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 110
+kube_node_status_capacity_pods{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 110
+kube_node_status_capacity_pods{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 110
+# HELP kube_node_status_capacity_cpu_cores The total CPU resources of the node.
+# TYPE kube_node_status_capacity_cpu_cores gauge
+kube_node_status_capacity_cpu_cores{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 1
+kube_node_status_capacity_cpu_cores{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 1
+kube_node_status_capacity_cpu_cores{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 1
+# HELP kube_node_status_capacity_memory_bytes The total memory resources of the node.
+# TYPE kube_node_status_capacity_memory_bytes gauge
+kube_node_status_capacity_memory_bytes{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 3.876859904e+09
+kube_node_status_capacity_memory_bytes{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 3.87680256e+09
+kube_node_status_capacity_memory_bytes{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 3.876818944e+09
+# HELP kube_node_status_allocatable The allocatable for different resources of a node that are available for scheduling.
+# TYPE kube_node_status_allocatable gauge
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="ephemeral_storage",unit="byte"} 4.7093746742e+10
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="hugepages_2Mi",unit="byte"} 0
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 2.765312e+09
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="pods",unit="integer"} 110
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="attachable_volumes_gce_pd",unit="byte"} 127
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.94
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="ephemeral_storage",unit="byte"} 4.7093746742e+10
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="hugepages_2Mi",unit="byte"} 0
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="memory",unit="byte"} 2.765328384e+09
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="pods",unit="integer"} 110
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="attachable_volumes_gce_pd",unit="byte"} 127
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.94
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 2.765369344e+09
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="pods",unit="integer"} 110
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="attachable_volumes_gce_pd",unit="byte"} 127
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.94
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="ephemeral_storage",unit="byte"} 4.7093746742e+10
+kube_node_status_allocatable{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="hugepages_2Mi",unit="byte"} 0
+# HELP kube_node_status_allocatable_pods The pod resources of a node that are available for scheduling.
+# TYPE kube_node_status_allocatable_pods gauge
+kube_node_status_allocatable_pods{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 110
+kube_node_status_allocatable_pods{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 110
+kube_node_status_allocatable_pods{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 110
+# HELP kube_node_status_allocatable_cpu_cores The CPU resources of a node that are available for scheduling.
+# TYPE kube_node_status_allocatable_cpu_cores gauge
+kube_node_status_allocatable_cpu_cores{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.94
+kube_node_status_allocatable_cpu_cores{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.94
+kube_node_status_allocatable_cpu_cores{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.94
+# HELP kube_node_status_allocatable_memory_bytes The memory resources of a node that are available for scheduling.
+# TYPE kube_node_status_allocatable_memory_bytes gauge
+kube_node_status_allocatable_memory_bytes{node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 2.765369344e+09
+kube_node_status_allocatable_memory_bytes{node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 2.765312e+09
+kube_node_status_allocatable_memory_bytes{node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 2.765328384e+09
+# HELP kube_persistentvolumeclaim_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_persistentvolumeclaim_labels gauge
+kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="www-web-0",label_app="nginx"} 1
+kube_persistentvolumeclaim_labels{namespace="default",persistentvolumeclaim="www-web-1",label_app="nginx"} 1
+# HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
+# TYPE kube_persistentvolumeclaim_info gauge
+kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="www-web-0",storageclass="standard",volumename="pvc-4f890d22-5039-4caf-b681-984873fb14bf"} 1
+kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="www-web-1",storageclass="standard",volumename="pvc-ea59bf1e-011a-4c06-b110-69c6e2e13cf4"} 1
+# HELP kube_persistentvolumeclaim_status_phase The phase the persistent volume claim is currently in.
+# TYPE kube_persistentvolumeclaim_status_phase gauge
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="www-web-0",phase="Lost"} 0
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="www-web-0",phase="Bound"} 1
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="www-web-0",phase="Pending"} 0
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="www-web-1",phase="Lost"} 0
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="www-web-1",phase="Bound"} 1
+kube_persistentvolumeclaim_status_phase{namespace="default",persistentvolumeclaim="www-web-1",phase="Pending"} 0
+# HELP kube_persistentvolumeclaim_resource_requests_storage_bytes The capacity of storage requested by the persistent volume claim.
+# TYPE kube_persistentvolumeclaim_resource_requests_storage_bytes gauge
+kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="www-web-0"} 1.073741824e+09
+kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="default",persistentvolumeclaim="www-web-1"} 1.073741824e+09
+# HELP kube_persistentvolumeclaim_access_mode The access mode(s) specified by the persistent volume claim.
+# TYPE kube_persistentvolumeclaim_access_mode gauge
+kube_persistentvolumeclaim_access_mode{namespace="default",persistentvolumeclaim="www-web-0",access_mode="ReadWriteOnce"} 1
+kube_persistentvolumeclaim_access_mode{namespace="default",persistentvolumeclaim="www-web-1",access_mode="ReadWriteOnce"} 1
+# HELP kube_persistentvolumeclaim_status_condition Information about status of different conditions of persistent volume claim.
+# TYPE kube_persistentvolumeclaim_status_condition gauge
+# HELP kube_persistentvolume_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_persistentvolume_labels gauge
+kube_persistentvolume_labels{persistentvolume="pvc-4f890d22-5039-4caf-b681-984873fb14bf",label_failure_domain_beta_kubernetes_io_region="us-central1",label_failure_domain_beta_kubernetes_io_zone="us-central1-a"} 1
+kube_persistentvolume_labels{persistentvolume="pvc-ea59bf1e-011a-4c06-b110-69c6e2e13cf4",label_failure_domain_beta_kubernetes_io_region="us-central1",label_failure_domain_beta_kubernetes_io_zone="us-central1-a"} 1
+# HELP kube_persistentvolume_status_phase The phase indicates if a volume is available, bound to a claim, or released by a claim.
+# TYPE kube_persistentvolume_status_phase gauge
+kube_persistentvolume_status_phase{persistentvolume="pvc-4f890d22-5039-4caf-b681-984873fb14bf",phase="Pending"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-4f890d22-5039-4caf-b681-984873fb14bf",phase="Available"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-4f890d22-5039-4caf-b681-984873fb14bf",phase="Bound"} 1
+kube_persistentvolume_status_phase{persistentvolume="pvc-4f890d22-5039-4caf-b681-984873fb14bf",phase="Released"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-4f890d22-5039-4caf-b681-984873fb14bf",phase="Failed"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-ea59bf1e-011a-4c06-b110-69c6e2e13cf4",phase="Pending"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-ea59bf1e-011a-4c06-b110-69c6e2e13cf4",phase="Available"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-ea59bf1e-011a-4c06-b110-69c6e2e13cf4",phase="Bound"} 1
+kube_persistentvolume_status_phase{persistentvolume="pvc-ea59bf1e-011a-4c06-b110-69c6e2e13cf4",phase="Released"} 0
+kube_persistentvolume_status_phase{persistentvolume="pvc-ea59bf1e-011a-4c06-b110-69c6e2e13cf4",phase="Failed"} 0
+# HELP kube_persistentvolume_info Information about persistentvolume.
+# TYPE kube_persistentvolume_info gauge
+kube_persistentvolume_info{persistentvolume="pvc-4f890d22-5039-4caf-b681-984873fb14bf",storageclass="standard"} 1
+kube_persistentvolume_info{persistentvolume="pvc-ea59bf1e-011a-4c06-b110-69c6e2e13cf4",storageclass="standard"} 1
+# HELP kube_persistentvolume_capacity_bytes Persistentvolume capacity in bytes.
+# TYPE kube_persistentvolume_capacity_bytes gauge
+kube_persistentvolume_capacity_bytes{persistentvolume="pvc-ea59bf1e-011a-4c06-b110-69c6e2e13cf4"} 1.073741824e+09
+kube_persistentvolume_capacity_bytes{persistentvolume="pvc-4f890d22-5039-4caf-b681-984873fb14bf"} 1.073741824e+09
+# HELP kube_poddisruptionbudget_created Unix creation timestamp
+# TYPE kube_poddisruptionbudget_created gauge
+# HELP kube_poddisruptionbudget_status_current_healthy Current number of healthy pods
+# TYPE kube_poddisruptionbudget_status_current_healthy gauge
+# HELP kube_poddisruptionbudget_status_desired_healthy Minimum desired number of healthy pods
+# TYPE kube_poddisruptionbudget_status_desired_healthy gauge
+# HELP kube_poddisruptionbudget_status_pod_disruptions_allowed Number of pod disruptions that are currently allowed
+# TYPE kube_poddisruptionbudget_status_pod_disruptions_allowed gauge
+# HELP kube_poddisruptionbudget_status_expected_pods Total number of pods counted by this disruption budget
+# TYPE kube_poddisruptionbudget_status_expected_pods gauge
+# HELP kube_poddisruptionbudget_status_observed_generation Most recent generation observed when updating this PDB status
+# TYPE kube_poddisruptionbudget_status_observed_generation gauge
+# HELP kube_pod_info Information about pod.
+# TYPE kube_pod_info gauge
+kube_pod_info{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",host_ip="192.250.0.62",pod_ip="192.250.0.62",uid="d50a60ae-8cbd-4a15-9d84-1830d232f25a",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",created_by_kind="DaemonSet",created_by_name="fluentd-gcp-v3.1.1",priority_class="system-node-critical"} 1
+kube_pod_info{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",host_ip="192.250.0.78",pod_ip="192.250.0.78",uid="cd479fb1-07e7-43ac-9c6f-2505e2c1038a",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",created_by_kind="DaemonSet",created_by_name="fluentd-gcp-v3.1.1",priority_class="system-node-critical"} 1
+kube_pod_info{namespace="kube-system",pod="prometheus-to-sd-nh249",host_ip="192.250.0.78",pod_ip="192.250.0.78",uid="eb61c1fc-b385-4c4a-9354-a930e45c90a5",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",created_by_kind="DaemonSet",created_by_name="prometheus-to-sd",priority_class="system-node-critical"} 1
+kube_pod_info{namespace="default",pod="web-0",host_ip="192.250.0.134",pod_ip="192.168.1.47",uid="cf5b4368-ff79-432c-bafa-3f428be25bef",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",created_by_kind="StatefulSet",created_by_name="web",priority_class=""} 1
+kube_pod_info{namespace="default",pod="datadog-monitoring-ftwqn",host_ip="192.250.0.78",pod_ip="192.168.0.13",uid="fb3af553-0cd6-46de-9b9e-10f85844cb9c",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",created_by_kind="DaemonSet",created_by_name="datadog-monitoring",priority_class=""} 1
+kube_pod_info{namespace="default",pod="datadog-monitoring-hgrnm",host_ip="192.250.0.62",pod_ip="192.168.2.15",uid="597f0014-c2cf-4209-a0ab-f728719ac74f",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",created_by_kind="DaemonSet",created_by_name="datadog-monitoring",priority_class=""} 1
+kube_pod_info{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",host_ip="192.250.0.78",pod_ip="192.168.0.4",uid="0b64f15c-113a-4cf6-bc8a-721c5497fcaa",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",created_by_kind="ReplicaSet",created_by_name="kube-state-metrics-868bf6f59d",priority_class=""} 1
+kube_pod_info{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",host_ip="192.250.0.62",pod_ip="192.168.2.4",uid="a61e45ee-2fa9-4f83-bcd0-a477097937a8",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",created_by_kind="ReplicaSet",created_by_name="event-exporter-v0.3.0-74bf544f8b",priority_class=""} 1
+kube_pod_info{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",host_ip="192.250.0.78",pod_ip="192.168.0.8",uid="57c85d7b-618c-4141-88e9-7deab7f7e279",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",created_by_kind="ReplicaSet",created_by_name="l7-default-backend-84c9fcfbb",priority_class=""} 1
+kube_pod_info{namespace="kube-system",pod="prometheus-to-sd-lzbh6",host_ip="192.250.0.62",pod_ip="192.250.0.62",uid="23f7c6c9-1c19-40fa-86dd-52ef86d47789",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",created_by_kind="DaemonSet",created_by_name="prometheus-to-sd",priority_class="system-node-critical"} 1
+kube_pod_info{namespace="default",pod="curl-cron-job-1586196480-nxtk6",host_ip="192.250.0.134",pod_ip="192.168.1.21",uid="79b85fea-8046-47f3-9f38-2963cffbac09",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",created_by_kind="Job",created_by_name="curl-cron-job-1586196480",priority_class=""} 1
+kube_pod_info{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",host_ip="192.250.0.134",pod_ip="192.168.1.3",uid="2e2ab2d7-ffbf-4f9c-b281-30e5d8f176fc",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",created_by_kind="ReplicaSet",created_by_name="datadog-monitoring-cluster-agent-5447d77668",priority_class=""} 1
+kube_pod_info{namespace="default",pod="datadog-monitoring-tk746",host_ip="192.250.0.134",pod_ip="192.168.1.8",uid="f660743d-004d-473a-8974-5cc046dc4725",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",created_by_kind="DaemonSet",created_by_name="datadog-monitoring",priority_class=""} 1
+kube_pod_info{namespace="default",pod="redis-599d64fcb9-c654j",host_ip="192.250.0.134",pod_ip="192.168.1.12",uid="e5d5400c-b336-4af3-b630-debdf6b57667",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",created_by_kind="ReplicaSet",created_by_name="redis-599d64fcb9",priority_class=""} 1
+kube_pod_info{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",host_ip="192.250.0.62",pod_ip="192.168.2.5",uid="f2761d91-9751-46c1-a38e-b4ea1aac8efb",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",created_by_kind="ReplicaSet",created_by_name="metrics-server-v0.3.3-6d96fcc55",priority_class="system-cluster-critical"} 1
+kube_pod_info{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",host_ip="192.250.0.62",pod_ip="192.168.2.9",uid="e2de1031-31ea-4fdc-ad01-ecc884a0a038",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",created_by_kind="ReplicaSet",created_by_name="fluentd-gcp-scaler-dd489f778",priority_class=""} 1
+kube_pod_info{namespace="default",pod="curl-job-xbchd",host_ip="192.250.0.134",pod_ip="192.168.1.15",uid="3d957cb7-2811-4e46-b470-6b726cfd6e52",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",created_by_kind="Job",created_by_name="curl-job",priority_class=""} 1
+kube_pod_info{namespace="default",pod="curl-cron-job-1586196360-qmvmq",host_ip="192.250.0.134",pod_ip="192.168.1.18",uid="82975dd9-d934-4362-aa98-5fbe83d518e8",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",created_by_kind="Job",created_by_name="curl-cron-job-1586196360",priority_class=""} 1
+kube_pod_info{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",host_ip="192.250.0.78",pod_ip="192.168.0.5",uid="8f7a580a-ac54-477d-a3b0-de9cba1ae557",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",created_by_kind="ReplicaSet",created_by_name="kube-dns-5dbbd9cc58",priority_class="system-cluster-critical"} 1
+kube_pod_info{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",host_ip="192.250.0.62",pod_ip="192.168.2.7",uid="38a07903-33d8-4c06-8255-e0f2d90e6601",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",created_by_kind="ReplicaSet",created_by_name="kube-dns-5dbbd9cc58",priority_class="system-cluster-critical"} 1
+kube_pod_info{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",host_ip="192.250.0.62",pod_ip="192.168.2.8",uid="3f989464-1f1a-42e6-b540-8d8020e7c31c",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",created_by_kind="ReplicaSet",created_by_name="kube-dns-autoscaler-6b7f784798",priority_class="system-cluster-critical"} 1
+kube_pod_info{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",host_ip="192.250.0.78",pod_ip="192.250.0.78",uid="d5c4b2e8-1059-484d-a43e-974bb0a8d3ed",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",created_by_kind="<none>",created_by_name="<none>",priority_class="system-node-critical"} 1
+kube_pod_info{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",host_ip="192.250.0.134",pod_ip="192.250.0.134",uid="ac4815eb-3a2f-4332-b5d9-e23db9c9361c",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",created_by_kind="<none>",created_by_name="<none>",priority_class="system-node-critical"} 1
+kube_pod_info{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",host_ip="192.250.0.134",pod_ip="192.250.0.134",uid="9c9ad68b-e9f6-4c93-b727-8356c9651284",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",created_by_kind="DaemonSet",created_by_name="fluentd-gcp-v3.1.1",priority_class="system-node-critical"} 1
+kube_pod_info{namespace="kube-system",pod="prometheus-to-sd-rfzfg",host_ip="192.250.0.134",pod_ip="192.250.0.134",uid="42b06fea-bced-440c-97c2-7d3e360800b9",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",created_by_kind="DaemonSet",created_by_name="prometheus-to-sd",priority_class="system-node-critical"} 1
+kube_pod_info{namespace="default",pod="curl-cron-job-1586196420-tlq52",host_ip="192.250.0.134",pod_ip="192.168.1.19",uid="75222e81-8743-48fc-a6d8-cbb23b11b3f5",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",created_by_kind="Job",created_by_name="curl-cron-job-1586196420",priority_class=""} 1
+kube_pod_info{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",host_ip="192.250.0.78",pod_ip="192.168.0.6",uid="7d321ac9-8256-4992-ad93-9efa2dbcdd23",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",created_by_kind="ReplicaSet",created_by_name="heapster-gke-84994c444b",priority_class="system-cluster-critical"} 1
+kube_pod_info{namespace="default",pod="curl-cron-job-1586196300-sn78l",host_ip="192.250.0.134",pod_ip="192.168.1.17",uid="071a53ab-a7d0-4df0-8a4e-f49e1b484454",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",created_by_kind="Job",created_by_name="curl-cron-job-1586196300",priority_class=""} 1
+kube_pod_info{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",host_ip="192.250.0.134",pod_ip="192.168.1.14",uid="ad49d610-7830-4e24-b9fc-d8270722261d",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",created_by_kind="ReplicaSet",created_by_name="stackdriver-metadata-agent-cluster-level-54779d5c66",priority_class="system-cluster-critical"} 1
+kube_pod_info{namespace="default",pod="dogstatsdclienttest",host_ip="192.250.0.62",pod_ip="192.168.2.3",uid="6fa571dc-f876-448f-93fa-14ae43247ca7",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",created_by_kind="<none>",created_by_name="<none>",priority_class=""} 1
+kube_pod_info{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",host_ip="192.250.0.62",pod_ip="192.250.0.62",uid="f57f4180-a4d6-4149-a756-af89f5860e29",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",created_by_kind="<none>",created_by_name="<none>",priority_class="system-node-critical"} 1
+kube_pod_info{namespace="default",pod="web-1",host_ip="192.250.0.62",pod_ip="192.168.2.16",uid="6cc29382-973f-4081-b0d2-adae4a2818e9",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",created_by_kind="StatefulSet",created_by_name="web",priority_class=""} 1
+# HELP kube_pod_start_time Start time in unix timestamp for a pod.
+# TYPE kube_pod_start_time gauge
+kube_pod_start_time{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst"} 1.584058498e+09
+kube_pod_start_time{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg"} 1.584058813e+09
+kube_pod_start_time{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9"} 1.584058813e+09
+kube_pod_start_time{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 1.584058483e+09
+kube_pod_start_time{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 1.584062689e+09
+kube_pod_start_time{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96"} 1.585686099e+09
+kube_pod_start_time{namespace="kube-system",pod="prometheus-to-sd-rfzfg"} 1.585686183e+09
+kube_pod_start_time{namespace="default",pod="curl-cron-job-1586196420-tlq52"} 1.58619642e+09
+kube_pod_start_time{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm"} 1.584058497e+09
+kube_pod_start_time{namespace="default",pod="curl-cron-job-1586196300-sn78l"} 1.586196309e+09
+kube_pod_start_time{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr"} 1.585686072e+09
+kube_pod_start_time{namespace="default",pod="dogstatsdclienttest"} 1.58273121e+09
+kube_pod_start_time{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 1.584058801e+09
+kube_pod_start_time{namespace="default",pod="web-1"} 1.586188661e+09
+kube_pod_start_time{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55"} 1.585686069e+09
+kube_pod_start_time{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk"} 1.585686083e+09
+kube_pod_start_time{namespace="kube-system",pod="prometheus-to-sd-nh249"} 1.585686143e+09
+kube_pod_start_time{namespace="default",pod="web-0"} 1.586188631e+09
+kube_pod_start_time{namespace="default",pod="datadog-monitoring-ftwqn"} 1.584733823e+09
+kube_pod_start_time{namespace="default",pod="datadog-monitoring-hgrnm"} 1.584733782e+09
+kube_pod_start_time{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh"} 1.584058495e+09
+kube_pod_start_time{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74"} 1.584058813e+09
+kube_pod_start_time{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp"} 1.584058813e+09
+kube_pod_start_time{namespace="kube-system",pod="prometheus-to-sd-lzbh6"} 1.585686101e+09
+kube_pod_start_time{namespace="default",pod="curl-cron-job-1586196480-nxtk6"} 1.58619648e+09
+kube_pod_start_time{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d"} 1.584562061e+09
+kube_pod_start_time{namespace="default",pod="datadog-monitoring-tk746"} 1.584733749e+09
+kube_pod_start_time{namespace="default",pod="redis-599d64fcb9-c654j"} 1.584735714e+09
+kube_pod_start_time{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql"} 1.584058815e+09
+kube_pod_start_time{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24"} 1.584058813e+09
+kube_pod_start_time{namespace="default",pod="curl-job-xbchd"} 1.58618763e+09
+kube_pod_start_time{namespace="default",pod="curl-cron-job-1586196360-qmvmq"} 1.586196369e+09
+# HELP kube_pod_completion_time Completion time in unix timestamp for a pod.
+# TYPE kube_pod_completion_time gauge
+kube_pod_completion_time{namespace="default",pod="curl-cron-job-1586196300-sn78l"} 1.586196311e+09
+kube_pod_completion_time{namespace="default",pod="curl-cron-job-1586196480-nxtk6"} 1.586196481e+09
+kube_pod_completion_time{namespace="default",pod="curl-job-xbchd"} 1.586187643e+09
+kube_pod_completion_time{namespace="default",pod="curl-cron-job-1586196360-qmvmq"} 1.586196371e+09
+kube_pod_completion_time{namespace="default",pod="curl-cron-job-1586196420-tlq52"} 1.586196421e+09
+# HELP kube_pod_owner Information about the Pod's owner.
+# TYPE kube_pod_owner gauge
+kube_pod_owner{namespace="default",pod="web-0",owner_kind="StatefulSet",owner_name="web",owner_is_controller="true"} 1
+kube_pod_owner{namespace="default",pod="datadog-monitoring-ftwqn",owner_kind="DaemonSet",owner_name="datadog-monitoring",owner_is_controller="true"} 1
+kube_pod_owner{namespace="default",pod="datadog-monitoring-hgrnm",owner_kind="DaemonSet",owner_name="datadog-monitoring",owner_is_controller="true"} 1
+kube_pod_owner{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",owner_kind="ReplicaSet",owner_name="kube-state-metrics-868bf6f59d",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",owner_kind="ReplicaSet",owner_name="event-exporter-v0.3.0-74bf544f8b",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",owner_kind="ReplicaSet",owner_name="l7-default-backend-84c9fcfbb",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="prometheus-to-sd-lzbh6",owner_kind="DaemonSet",owner_name="prometheus-to-sd",owner_is_controller="true"} 1
+kube_pod_owner{namespace="default",pod="curl-cron-job-1586196480-nxtk6",owner_kind="Job",owner_name="curl-cron-job-1586196480",owner_is_controller="true"} 1
+kube_pod_owner{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",owner_kind="ReplicaSet",owner_name="datadog-monitoring-cluster-agent-5447d77668",owner_is_controller="true"} 1
+kube_pod_owner{namespace="default",pod="datadog-monitoring-tk746",owner_kind="DaemonSet",owner_name="datadog-monitoring",owner_is_controller="true"} 1
+kube_pod_owner{namespace="default",pod="redis-599d64fcb9-c654j",owner_kind="ReplicaSet",owner_name="redis-599d64fcb9",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",owner_kind="ReplicaSet",owner_name="metrics-server-v0.3.3-6d96fcc55",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",owner_kind="ReplicaSet",owner_name="fluentd-gcp-scaler-dd489f778",owner_is_controller="true"} 1
+kube_pod_owner{namespace="default",pod="curl-job-xbchd",owner_kind="Job",owner_name="curl-job",owner_is_controller="true"} 1
+kube_pod_owner{namespace="default",pod="curl-cron-job-1586196360-qmvmq",owner_kind="Job",owner_name="curl-cron-job-1586196360",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",owner_kind="ReplicaSet",owner_name="kube-dns-5dbbd9cc58",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",owner_kind="ReplicaSet",owner_name="kube-dns-5dbbd9cc58",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",owner_kind="ReplicaSet",owner_name="kube-dns-autoscaler-6b7f784798",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+kube_pod_owner{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+kube_pod_owner{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",owner_kind="DaemonSet",owner_name="fluentd-gcp-v3.1.1",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="prometheus-to-sd-rfzfg",owner_kind="DaemonSet",owner_name="prometheus-to-sd",owner_is_controller="true"} 1
+kube_pod_owner{namespace="default",pod="curl-cron-job-1586196420-tlq52",owner_kind="Job",owner_name="curl-cron-job-1586196420",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",owner_kind="ReplicaSet",owner_name="heapster-gke-84994c444b",owner_is_controller="true"} 1
+kube_pod_owner{namespace="default",pod="curl-cron-job-1586196300-sn78l",owner_kind="Job",owner_name="curl-cron-job-1586196300",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",owner_kind="ReplicaSet",owner_name="stackdriver-metadata-agent-cluster-level-54779d5c66",owner_is_controller="true"} 1
+kube_pod_owner{namespace="default",pod="dogstatsdclienttest",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+kube_pod_owner{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",owner_kind="<none>",owner_name="<none>",owner_is_controller="<none>"} 1
+kube_pod_owner{namespace="default",pod="web-1",owner_kind="StatefulSet",owner_name="web",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",owner_kind="DaemonSet",owner_name="fluentd-gcp-v3.1.1",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",owner_kind="DaemonSet",owner_name="fluentd-gcp-v3.1.1",owner_is_controller="true"} 1
+kube_pod_owner{namespace="kube-system",pod="prometheus-to-sd-nh249",owner_kind="DaemonSet",owner_name="prometheus-to-sd",owner_is_controller="true"} 1
+# HELP kube_pod_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_pod_labels gauge
+kube_pod_labels{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",label_k8s_app="heapster",label_pod_template_hash="84994c444b",label_version="v1.7.2"} 1
+kube_pod_labels{namespace="default",pod="curl-cron-job-1586196300-sn78l",label_controller_uid="9875e61a-be44-469a-b590-33e823bdec30",label_job_name="curl-cron-job-1586196300"} 1
+kube_pod_labels{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",label_app="stackdriver-metadata-agent",label_cluster_level="true",label_pod_template_hash="54779d5c66"} 1
+kube_pod_labels{namespace="default",pod="dogstatsdclienttest",label_name="dogstatsdclienttest"} 1
+kube_pod_labels{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",label_component="kube-proxy",label_tier="node"} 1
+kube_pod_labels{namespace="default",pod="web-1",label_app="nginx",label_controller_revision_hash="web-b46f789c4",label_statefulset_kubernetes_io_pod_name="web-1"} 1
+kube_pod_labels{namespace="kube-system",pod="prometheus-to-sd-nh249",label_controller_revision_hash="76645d989",label_k8s_app="prometheus-to-sd",label_pod_template_generation="2"} 1
+kube_pod_labels{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",label_controller_revision_hash="6d7f97d977",label_k8s_app="fluentd-gcp",label_kubernetes_io_cluster_service="true",label_pod_template_generation="3",label_version="v3.1.1"} 1
+kube_pod_labels{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",label_controller_revision_hash="6d7f97d977",label_k8s_app="fluentd-gcp",label_kubernetes_io_cluster_service="true",label_pod_template_generation="3",label_version="v3.1.1"} 1
+kube_pod_labels{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",label_k8s_app="event-exporter",label_pod_template_hash="74bf544f8b",label_version="v0.3.0"} 1
+kube_pod_labels{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",label_k8s_app="glbc",label_name="glbc",label_pod_template_hash="84c9fcfbb"} 1
+kube_pod_labels{namespace="kube-system",pod="prometheus-to-sd-lzbh6",label_controller_revision_hash="76645d989",label_k8s_app="prometheus-to-sd",label_pod_template_generation="2"} 1
+kube_pod_labels{namespace="default",pod="curl-cron-job-1586196480-nxtk6",label_controller_uid="6db9c035-cada-40f8-ae97-910b42f11590",label_job_name="curl-cron-job-1586196480"} 1
+kube_pod_labels{namespace="default",pod="web-0",label_app="nginx",label_controller_revision_hash="web-b46f789c4",label_statefulset_kubernetes_io_pod_name="web-0"} 1
+kube_pod_labels{namespace="default",pod="datadog-monitoring-ftwqn",label_app="datadog-monitoring",label_controller_revision_hash="549ffb667b",label_pod_template_generation="5"} 1
+kube_pod_labels{namespace="default",pod="datadog-monitoring-hgrnm",label_app="datadog-monitoring",label_controller_revision_hash="549ffb667b",label_pod_template_generation="5"} 1
+kube_pod_labels{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",label_app_kubernetes_io_instance="kube-state-metrics",label_app_kubernetes_io_name="kube-state-metrics",label_pod_template_hash="868bf6f59d"} 1
+kube_pod_labels{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",label_k8s_app="metrics-server",label_pod_template_hash="6d96fcc55",label_version="v0.3.3"} 1
+kube_pod_labels{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",label_app="datadog-monitoring-cluster-agent",label_pod_template_hash="5447d77668"} 1
+kube_pod_labels{namespace="default",pod="datadog-monitoring-tk746",label_app="datadog-monitoring",label_controller_revision_hash="549ffb667b",label_pod_template_generation="5"} 1
+kube_pod_labels{namespace="default",pod="redis-599d64fcb9-c654j",label_app="redis",label_pod_template_hash="599d64fcb9",label_tags_datadoghq_com_env="dev",label_tags_datadoghq_com_service="redis",label_tags_datadoghq_com_version="v1"} 1
+kube_pod_labels{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",label_k8s_app="fluentd-gcp-scaler",label_pod_template_hash="dd489f778"} 1
+kube_pod_labels{namespace="default",pod="curl-job-xbchd",label_controller_uid="efb6e033-4827-4c24-92fe-c6e306cf4d8f",label_job_name="curl-job"} 1
+kube_pod_labels{namespace="default",pod="curl-cron-job-1586196360-qmvmq",label_controller_uid="a117ce3c-b952-4368-931a-2d07bef27b1e",label_job_name="curl-cron-job-1586196360"} 1
+kube_pod_labels{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",label_k8s_app="kube-dns",label_pod_template_hash="5dbbd9cc58"} 1
+kube_pod_labels{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",label_k8s_app="kube-dns",label_pod_template_hash="5dbbd9cc58"} 1
+kube_pod_labels{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",label_controller_revision_hash="6d7f97d977",label_k8s_app="fluentd-gcp",label_kubernetes_io_cluster_service="true",label_pod_template_generation="3",label_version="v3.1.1"} 1
+kube_pod_labels{namespace="kube-system",pod="prometheus-to-sd-rfzfg",label_controller_revision_hash="76645d989",label_k8s_app="prometheus-to-sd",label_pod_template_generation="2"} 1
+kube_pod_labels{namespace="default",pod="curl-cron-job-1586196420-tlq52",label_controller_uid="d13172e6-3035-448e-beb7-8baf4e0263ea",label_job_name="curl-cron-job-1586196420"} 1
+kube_pod_labels{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",label_k8s_app="kube-dns-autoscaler",label_pod_template_hash="6b7f784798"} 1
+kube_pod_labels{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",label_component="kube-proxy",label_tier="node"} 1
+kube_pod_labels{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",label_component="kube-proxy",label_tier="node"} 1
+# HELP kube_pod_created Unix creation timestamp
+# TYPE kube_pod_created gauge
+kube_pod_created{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 1.584062693e+09
+kube_pod_created{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96"} 1.585686099e+09
+kube_pod_created{namespace="kube-system",pod="prometheus-to-sd-rfzfg"} 1.585686183e+09
+kube_pod_created{namespace="default",pod="curl-cron-job-1586196420-tlq52"} 1.58619642e+09
+kube_pod_created{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9"} 1.584058813e+09
+kube_pod_created{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 1.584058483e+09
+kube_pod_created{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr"} 1.585686071e+09
+kube_pod_created{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm"} 1.584058494e+09
+kube_pod_created{namespace="default",pod="curl-cron-job-1586196300-sn78l"} 1.586196309e+09
+kube_pod_created{namespace="default",pod="web-1"} 1.586188656e+09
+kube_pod_created{namespace="default",pod="dogstatsdclienttest"} 1.582731209e+09
+kube_pod_created{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 1.584058806e+09
+kube_pod_created{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk"} 1.585686083e+09
+kube_pod_created{namespace="kube-system",pod="prometheus-to-sd-nh249"} 1.585686143e+09
+kube_pod_created{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55"} 1.585686069e+09
+kube_pod_created{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh"} 1.584058494e+09
+kube_pod_created{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74"} 1.584058813e+09
+kube_pod_created{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp"} 1.584058813e+09
+kube_pod_created{namespace="kube-system",pod="prometheus-to-sd-lzbh6"} 1.585686101e+09
+kube_pod_created{namespace="default",pod="curl-cron-job-1586196480-nxtk6"} 1.58619648e+09
+kube_pod_created{namespace="default",pod="web-0"} 1.586188625e+09
+kube_pod_created{namespace="default",pod="datadog-monitoring-ftwqn"} 1.584733823e+09
+kube_pod_created{namespace="default",pod="datadog-monitoring-hgrnm"} 1.584733781e+09
+kube_pod_created{namespace="default",pod="redis-599d64fcb9-c654j"} 1.584735714e+09
+kube_pod_created{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql"} 1.584058813e+09
+kube_pod_created{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d"} 1.584562061e+09
+kube_pod_created{namespace="default",pod="datadog-monitoring-tk746"} 1.584733749e+09
+kube_pod_created{namespace="default",pod="curl-cron-job-1586196360-qmvmq"} 1.586196369e+09
+kube_pod_created{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24"} 1.584058813e+09
+kube_pod_created{namespace="default",pod="curl-job-xbchd"} 1.58618763e+09
+kube_pod_created{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst"} 1.584058495e+09
+kube_pod_created{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg"} 1.584058813e+09
+# HELP kube_pod_restart_policy Describes the restart policy in use by this pod.
+# TYPE kube_pod_restart_policy gauge
+kube_pod_restart_policy{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",type="Always"} 1
+kube_pod_restart_policy{namespace="default",pod="curl-cron-job-1586196300-sn78l",type="OnFailure"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",type="Always"} 1
+kube_pod_restart_policy{namespace="default",pod="dogstatsdclienttest",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",type="Always"} 1
+kube_pod_restart_policy{namespace="default",pod="web-1",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="prometheus-to-sd-nh249",type="Always"} 1
+kube_pod_restart_policy{namespace="default",pod="web-0",type="Always"} 1
+kube_pod_restart_policy{namespace="default",pod="datadog-monitoring-ftwqn",type="Always"} 1
+kube_pod_restart_policy{namespace="default",pod="datadog-monitoring-hgrnm",type="Always"} 1
+kube_pod_restart_policy{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="prometheus-to-sd-lzbh6",type="Always"} 1
+kube_pod_restart_policy{namespace="default",pod="curl-cron-job-1586196480-nxtk6",type="OnFailure"} 1
+kube_pod_restart_policy{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",type="Always"} 1
+kube_pod_restart_policy{namespace="default",pod="datadog-monitoring-tk746",type="Always"} 1
+kube_pod_restart_policy{namespace="default",pod="redis-599d64fcb9-c654j",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",type="Always"} 1
+kube_pod_restart_policy{namespace="default",pod="curl-job-xbchd",type="Never"} 1
+kube_pod_restart_policy{namespace="default",pod="curl-cron-job-1586196360-qmvmq",type="OnFailure"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",type="Always"} 1
+kube_pod_restart_policy{namespace="kube-system",pod="prometheus-to-sd-rfzfg",type="Always"} 1
+kube_pod_restart_policy{namespace="default",pod="curl-cron-job-1586196420-tlq52",type="OnFailure"} 1
+# HELP kube_pod_status_scheduled_time Unix timestamp when pod moved into scheduled status
+# TYPE kube_pod_status_scheduled_time gauge
+kube_pod_status_scheduled_time{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24"} 1.584058813e+09
+kube_pod_status_scheduled_time{namespace="default",pod="curl-job-xbchd"} 1.58618763e+09
+kube_pod_status_scheduled_time{namespace="default",pod="curl-cron-job-1586196360-qmvmq"} 1.586196369e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst"} 1.584058495e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg"} 1.584058813e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9"} 1.584058813e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 1.584058483e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 1.584062689e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96"} 1.585686099e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="prometheus-to-sd-rfzfg"} 1.585686183e+09
+kube_pod_status_scheduled_time{namespace="default",pod="curl-cron-job-1586196420-tlq52"} 1.58619642e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm"} 1.584058495e+09
+kube_pod_status_scheduled_time{namespace="default",pod="curl-cron-job-1586196300-sn78l"} 1.586196309e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr"} 1.585686071e+09
+kube_pod_status_scheduled_time{namespace="default",pod="dogstatsdclienttest"} 1.58273121e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 1.584058801e+09
+kube_pod_status_scheduled_time{namespace="default",pod="web-1"} 1.586188661e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55"} 1.585686069e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk"} 1.585686083e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="prometheus-to-sd-nh249"} 1.585686143e+09
+kube_pod_status_scheduled_time{namespace="default",pod="web-0"} 1.586188631e+09
+kube_pod_status_scheduled_time{namespace="default",pod="datadog-monitoring-ftwqn"} 1.584733823e+09
+kube_pod_status_scheduled_time{namespace="default",pod="datadog-monitoring-hgrnm"} 1.584733781e+09
+kube_pod_status_scheduled_time{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh"} 1.584058494e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74"} 1.584058813e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp"} 1.584058813e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="prometheus-to-sd-lzbh6"} 1.585686101e+09
+kube_pod_status_scheduled_time{namespace="default",pod="curl-cron-job-1586196480-nxtk6"} 1.58619648e+09
+kube_pod_status_scheduled_time{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d"} 1.584562061e+09
+kube_pod_status_scheduled_time{namespace="default",pod="datadog-monitoring-tk746"} 1.584733749e+09
+kube_pod_status_scheduled_time{namespace="default",pod="redis-599d64fcb9-c654j"} 1.584735714e+09
+kube_pod_status_scheduled_time{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql"} 1.584058814e+09
+# HELP kube_pod_status_unschedulable Describes the unschedulable status for the pod.
+# TYPE kube_pod_status_unschedulable gauge
+# HELP kube_pod_status_phase The pods current phase.
+# TYPE kube_pod_status_phase gauge
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196420-tlq52",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196420-tlq52",phase="Succeeded"} 1
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196420-tlq52",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196420-tlq52",phase="Running"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196420-tlq52",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-rfzfg",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-rfzfg",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-rfzfg",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-rfzfg",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-rfzfg",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196300-sn78l",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196300-sn78l",phase="Succeeded"} 1
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196300-sn78l",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196300-sn78l",phase="Running"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196300-sn78l",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="dogstatsdclienttest",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="dogstatsdclienttest",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="default",pod="dogstatsdclienttest",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="dogstatsdclienttest",phase="Running"} 1
+kube_pod_status_phase{namespace="default",pod="dogstatsdclienttest",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="web-1",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="web-1",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="default",pod="web-1",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="web-1",phase="Running"} 1
+kube_pod_status_phase{namespace="default",pod="web-1",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-nh249",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-nh249",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-nh249",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-nh249",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-nh249",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-lzbh6",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-lzbh6",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-lzbh6",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-lzbh6",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="prometheus-to-sd-lzbh6",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196480-nxtk6",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196480-nxtk6",phase="Succeeded"} 1
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196480-nxtk6",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196480-nxtk6",phase="Running"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196480-nxtk6",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="web-0",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="web-0",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="default",pod="web-0",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="web-0",phase="Running"} 1
+kube_pod_status_phase{namespace="default",pod="web-0",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-ftwqn",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-ftwqn",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-ftwqn",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-ftwqn",phase="Running"} 1
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-ftwqn",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-hgrnm",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-hgrnm",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-hgrnm",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-hgrnm",phase="Running"} 1
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-hgrnm",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",phase="Running"} 1
+kube_pod_status_phase{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",phase="Running"} 1
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-tk746",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-tk746",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-tk746",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-tk746",phase="Running"} 1
+kube_pod_status_phase{namespace="default",pod="datadog-monitoring-tk746",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="redis-599d64fcb9-c654j",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="redis-599d64fcb9-c654j",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="default",pod="redis-599d64fcb9-c654j",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="redis-599d64fcb9-c654j",phase="Running"} 1
+kube_pod_status_phase{namespace="default",pod="redis-599d64fcb9-c654j",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="curl-job-xbchd",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="curl-job-xbchd",phase="Succeeded"} 1
+kube_pod_status_phase{namespace="default",pod="curl-job-xbchd",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="curl-job-xbchd",phase="Running"} 0
+kube_pod_status_phase{namespace="default",pod="curl-job-xbchd",phase="Unknown"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196360-qmvmq",phase="Pending"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196360-qmvmq",phase="Succeeded"} 1
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196360-qmvmq",phase="Failed"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196360-qmvmq",phase="Running"} 0
+kube_pod_status_phase{namespace="default",pod="curl-cron-job-1586196360-qmvmq",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",phase="Unknown"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",phase="Pending"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",phase="Succeeded"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",phase="Failed"} 0
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",phase="Running"} 1
+kube_pod_status_phase{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",phase="Unknown"} 0
+# HELP kube_pod_status_ready Describes whether the pod is ready to serve requests.
+# TYPE kube_pod_status_ready gauge
+kube_pod_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="prometheus-to-sd-rfzfg",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="prometheus-to-sd-rfzfg",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="prometheus-to-sd-rfzfg",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="curl-cron-job-1586196420-tlq52",condition="true"} 0
+kube_pod_status_ready{namespace="default",pod="curl-cron-job-1586196420-tlq52",condition="false"} 1
+kube_pod_status_ready{namespace="default",pod="curl-cron-job-1586196420-tlq52",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="curl-cron-job-1586196300-sn78l",condition="true"} 0
+kube_pod_status_ready{namespace="default",pod="curl-cron-job-1586196300-sn78l",condition="false"} 1
+kube_pod_status_ready{namespace="default",pod="curl-cron-job-1586196300-sn78l",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="dogstatsdclienttest",condition="true"} 1
+kube_pod_status_ready{namespace="default",pod="dogstatsdclienttest",condition="false"} 0
+kube_pod_status_ready{namespace="default",pod="dogstatsdclienttest",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="web-1",condition="true"} 1
+kube_pod_status_ready{namespace="default",pod="web-1",condition="false"} 0
+kube_pod_status_ready{namespace="default",pod="web-1",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="prometheus-to-sd-nh249",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="prometheus-to-sd-nh249",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="prometheus-to-sd-nh249",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="prometheus-to-sd-lzbh6",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="prometheus-to-sd-lzbh6",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="prometheus-to-sd-lzbh6",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="curl-cron-job-1586196480-nxtk6",condition="true"} 0
+kube_pod_status_ready{namespace="default",pod="curl-cron-job-1586196480-nxtk6",condition="false"} 1
+kube_pod_status_ready{namespace="default",pod="curl-cron-job-1586196480-nxtk6",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="web-0",condition="true"} 1
+kube_pod_status_ready{namespace="default",pod="web-0",condition="false"} 0
+kube_pod_status_ready{namespace="default",pod="web-0",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="datadog-monitoring-ftwqn",condition="true"} 1
+kube_pod_status_ready{namespace="default",pod="datadog-monitoring-ftwqn",condition="false"} 0
+kube_pod_status_ready{namespace="default",pod="datadog-monitoring-ftwqn",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="datadog-monitoring-hgrnm",condition="true"} 1
+kube_pod_status_ready{namespace="default",pod="datadog-monitoring-hgrnm",condition="false"} 0
+kube_pod_status_ready{namespace="default",pod="datadog-monitoring-hgrnm",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",condition="true"} 1
+kube_pod_status_ready{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",condition="false"} 0
+kube_pod_status_ready{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",condition="true"} 1
+kube_pod_status_ready{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",condition="false"} 0
+kube_pod_status_ready{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="datadog-monitoring-tk746",condition="true"} 1
+kube_pod_status_ready{namespace="default",pod="datadog-monitoring-tk746",condition="false"} 0
+kube_pod_status_ready{namespace="default",pod="datadog-monitoring-tk746",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="redis-599d64fcb9-c654j",condition="true"} 1
+kube_pod_status_ready{namespace="default",pod="redis-599d64fcb9-c654j",condition="false"} 0
+kube_pod_status_ready{namespace="default",pod="redis-599d64fcb9-c654j",condition="unknown"} 0
+kube_pod_status_ready{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",condition="true"} 1
+kube_pod_status_ready{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",condition="false"} 0
+kube_pod_status_ready{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="curl-job-xbchd",condition="true"} 0
+kube_pod_status_ready{namespace="default",pod="curl-job-xbchd",condition="false"} 1
+kube_pod_status_ready{namespace="default",pod="curl-job-xbchd",condition="unknown"} 0
+kube_pod_status_ready{namespace="default",pod="curl-cron-job-1586196360-qmvmq",condition="true"} 0
+kube_pod_status_ready{namespace="default",pod="curl-cron-job-1586196360-qmvmq",condition="false"} 1
+kube_pod_status_ready{namespace="default",pod="curl-cron-job-1586196360-qmvmq",condition="unknown"} 0
+# HELP kube_pod_status_scheduled Describes the status of the scheduling process for the pod.
+# TYPE kube_pod_status_scheduled gauge
+kube_pod_status_scheduled{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="datadog-monitoring-tk746",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="datadog-monitoring-tk746",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="datadog-monitoring-tk746",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="redis-599d64fcb9-c654j",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="redis-599d64fcb9-c654j",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="redis-599d64fcb9-c654j",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="curl-job-xbchd",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="curl-job-xbchd",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="curl-job-xbchd",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="curl-cron-job-1586196360-qmvmq",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="curl-cron-job-1586196360-qmvmq",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="curl-cron-job-1586196360-qmvmq",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="curl-cron-job-1586196420-tlq52",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="curl-cron-job-1586196420-tlq52",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="curl-cron-job-1586196420-tlq52",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="prometheus-to-sd-rfzfg",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="prometheus-to-sd-rfzfg",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="prometheus-to-sd-rfzfg",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="curl-cron-job-1586196300-sn78l",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="curl-cron-job-1586196300-sn78l",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="curl-cron-job-1586196300-sn78l",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="dogstatsdclienttest",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="dogstatsdclienttest",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="dogstatsdclienttest",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="web-1",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="web-1",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="web-1",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="prometheus-to-sd-nh249",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="prometheus-to-sd-nh249",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="prometheus-to-sd-nh249",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="prometheus-to-sd-lzbh6",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="prometheus-to-sd-lzbh6",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="prometheus-to-sd-lzbh6",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="curl-cron-job-1586196480-nxtk6",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="curl-cron-job-1586196480-nxtk6",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="curl-cron-job-1586196480-nxtk6",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="web-0",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="web-0",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="web-0",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="datadog-monitoring-ftwqn",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="datadog-monitoring-ftwqn",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="datadog-monitoring-ftwqn",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="datadog-monitoring-hgrnm",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="datadog-monitoring-hgrnm",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="datadog-monitoring-hgrnm",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",condition="true"} 1
+kube_pod_status_scheduled{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",condition="false"} 0
+kube_pod_status_scheduled{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",condition="unknown"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",condition="true"} 1
+kube_pod_status_scheduled{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",condition="false"} 0
+kube_pod_status_scheduled{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",condition="unknown"} 0
+# HELP kube_pod_container_info Information about a container in a pod.
+# TYPE kube_pod_container_info gauge
+kube_pod_container_info{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",image="gcr.io/stackdriver-agents/stackdriver-logging-agent:1.6.17-16060",image_id="docker-pullable://gcr.io/stackdriver-agents/stackdriver-logging-agent@sha256:79ddc530f0e558da80c3857c2e02d8b6dcce64c4c875fb94e3a420f53c502492",container_id="docker://5d9b66e83cc7ae0f5ec94e02a0a98a7b8de648dc3b573730e082652b8af03bba"} 1
+kube_pod_container_info{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",image="k8s.gcr.io/prometheus-to-sd:v0.5.0",image_id="docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:14666989f40bb7c896c3e775a93c6873e2b791d65bc65579f58a078b7f9a764e",container_id="docker://fc68d223f8f1a86b39997d80665567998adb9d63775d911f163dc295694f3a2e"} 1
+kube_pod_container_info{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",image="k8s.gcr.io/prometheus-to-sd:v0.8.2",image_id="docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:3216dd0e94d6911f6dc04f4258c0bf5cb1fff088ee2d3ce742ada490cbd5ca5c",container_id="docker://0a0962a757ebabb657100e7b212c23a8e7a8687ff11e568321b91204ddcfd9cf"} 1
+kube_pod_container_info{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",image="k8s.gcr.io/prometheus-to-sd:v0.8.2",image_id="docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:3216dd0e94d6911f6dc04f4258c0bf5cb1fff088ee2d3ce742ada490cbd5ca5c",container_id="docker://6b03980108bfe06647a2dc037abf0b5aca8a308370d610f5273fcd1bc0f6ff2f"} 1
+kube_pod_container_info{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",image="gcr.io/stackdriver-agents/stackdriver-logging-agent:1.6.17-16060",image_id="docker-pullable://gcr.io/stackdriver-agents/stackdriver-logging-agent@sha256:79ddc530f0e558da80c3857c2e02d8b6dcce64c4c875fb94e3a420f53c502492",container_id="docker://4568d8d798f63cf15660d0bc869ca85d693253706567bbd97d4be18375b0baf9"} 1
+kube_pod_container_info{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",image="k8s.gcr.io/prometheus-to-sd:v0.5.0",image_id="docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:14666989f40bb7c896c3e775a93c6873e2b791d65bc65579f58a078b7f9a764e",container_id="docker://3ec9949dc19ee3c7dc6a3bf1724ae44137b20d23e1a2037eb5114fe3e81a21e6"} 1
+kube_pod_container_info{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",image="datadog/agent:latest",image_id="docker-pullable://datadog/agent@sha256:debda90785408f0efba3997836ce7d86c47b778c78b2af0d74dfe17f2f59c926",container_id="docker://290b6f3c3da6b154dd757c50018667d7c5330aef62d6b4ef27c7bdc51bf58de7"} 1
+kube_pod_container_info{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",image="datadog/agent:latest",image_id="docker-pullable://datadog/agent@sha256:debda90785408f0efba3997836ce7d86c47b778c78b2af0d74dfe17f2f59c926",container_id="docker://55a7fc3cf47a41d9607b4fef8081719497873cb446ef3abead6a582145a02117"} 1
+kube_pod_container_info{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",image="quay.io/coreos/kube-state-metrics:v1.9.2",image_id="docker-pullable://quay.io/coreos/kube-state-metrics@sha256:99e18bb3ca7344cb8ece2b5ced2599d561d2de2306531366e8198364d17b0f22",container_id="docker://634f53f640248be619349655e83201ef58f44b1c74f79cf4540fce02b7e497ca"} 1
+kube_pod_container_info{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",image="k8s.gcr.io/event-exporter:v0.3.0",image_id="docker-pullable://k8s.gcr.io/event-exporter@sha256:529ba8eb0637d9e1d2386a3b9ad10803f92b82b85d2cf6d54da27deac696967f",container_id="docker://336d4cdfe87b2b98530393668889a38f6a33311165ebe3c73ea8d5a9e084e43d"} 1
+kube_pod_container_info{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",image="k8s.gcr.io/prometheus-to-sd:v0.5.0",image_id="docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:14666989f40bb7c896c3e775a93c6873e2b791d65bc65579f58a078b7f9a764e",container_id="docker://92079385f8df271ee3a7b0ab3f13775fa11a0f62f58f8340bc567249dc2865f8"} 1
+kube_pod_container_info{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",image="k8s.gcr.io/defaultbackend-amd64:1.5",image_id="docker-pullable://k8s.gcr.io/defaultbackend-amd64@sha256:4dc5e07c8ca4e23bddb3153737d7b8c556e5fb2f29c4558b7cd6e6df99c512c7",container_id="docker://80cddafe3171812c0d10864c1057eada405239b651bee2e42e256a5fa27fad1e"} 1
+kube_pod_container_info{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",image="k8s.gcr.io/prometheus-to-sd:v0.8.2",image_id="docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:3216dd0e94d6911f6dc04f4258c0bf5cb1fff088ee2d3ce742ada490cbd5ca5c",container_id="docker://6572ce705944b45fa45ecad8689abf3d6671000f6bae7cbb34b4a92ad3b45b27"} 1
+kube_pod_container_info{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",image="k8s.gcr.io/prometheus-to-sd:v0.8.2",image_id="docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:3216dd0e94d6911f6dc04f4258c0bf5cb1fff088ee2d3ce742ada490cbd5ca5c",container_id="docker://0753f4ae8253ed237cd98659eddea92fbbd73b7772414b909ee6081e8fb2c06b"} 1
+kube_pod_container_info{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",image="tutum/curl:latest",image_id="docker-pullable://tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f",container_id="docker://e1436d0eb2c78a7e71df740e0cf40bd2c8d4f69fffb17e0bf17bebd9ae9992a7"} 1
+kube_pod_container_info{namespace="default",pod="web-0",container="nginx",image="k8s.gcr.io/nginx-slim:0.8",image_id="docker-pullable://k8s.gcr.io/nginx-slim@sha256:8b4501fe0fe221df663c22e16539f399e89594552f400408303c42f3dd8d0e52",container_id="docker://a1c20ca23db6cd22725b5d124966b61d3f8b6e1533ab53e4f37a9eb360393471"} 1
+kube_pod_container_info{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",image="datadog/agent:latest",image_id="docker-pullable://datadog/agent@sha256:debda90785408f0efba3997836ce7d86c47b778c78b2af0d74dfe17f2f59c926",container_id="docker://fd5ff208abe14f5f05594fcd11585fbf3dce71cf3188a35206ed3c03d2095e0e"} 1
+kube_pod_container_info{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",image="datadog/agent:latest",image_id="docker-pullable://datadog/agent@sha256:debda90785408f0efba3997836ce7d86c47b778c78b2af0d74dfe17f2f59c926",container_id="docker://4d75d96077e7183fb9847fa3dcc65fac2b52f4dbd4cd61fefd3a2964a050ab96"} 1
+kube_pod_container_info{namespace="default",pod="datadog-monitoring-tk746",container="agent",image="datadog/agent:latest",image_id="docker-pullable://datadog/agent@sha256:debda90785408f0efba3997836ce7d86c47b778c78b2af0d74dfe17f2f59c926",container_id="docker://b755b8716ab025c03e4d9fc1ebbca513b5ece40043b36e4d0b5190fbc65a64e1"} 1
+kube_pod_container_info{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",image="datadog/agent:latest",image_id="docker-pullable://datadog/agent@sha256:debda90785408f0efba3997836ce7d86c47b778c78b2af0d74dfe17f2f59c926",container_id="docker://a1e9c64b73e3f478f0770416fe30dc09f7e4c69a0a9ec90ddda77e41e43401a1"} 1
+kube_pod_container_info{namespace="default",pod="redis-599d64fcb9-c654j",container="master",image="redis:latest",image_id="docker-pullable://redis@sha256:780f7dacdc133e899fba9ff09c099828b469030acefe6f3bbc16197b55800cfd",container_id="docker://8d20768a061a0e7808bd2ff5e8247d05c79a59964be89f73e55e31160afeaaf1"} 1
+kube_pod_container_info{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",image="k8s.gcr.io/metrics-server-amd64:v0.3.3",image_id="docker-pullable://k8s.gcr.io/metrics-server-amd64@sha256:4ca116565ff6a46e582bada50ba3550f95b368db1d2415829241a565a6c38e2a",container_id="docker://16a50fa0cc3b5d1a37898e7255e16d0fc771232851d7b1f45e03bd1c3ab24cbb"} 1
+kube_pod_container_info{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",image="asia.gcr.io/gke-release-staging/addon-resizer:1.8.5-gke.0",image_id="docker-pullable://asia.gcr.io/gke-release-staging/addon-resizer@sha256:637bd7337bcddd0477987818b902c846a48923f3d7b7061cdcfc7721601558b8",container_id="docker://25da95966b4d487be8101b970fe19fc4163fa7d066ba4f58cd9fdf35bf162533"} 1
+kube_pod_container_info{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",image="datadog/cluster-agent:1.5.0-rc3",image_id="docker-pullable://datadog/cluster-agent@sha256:40d27958b22ec7459ba964fc7895384129c2fd8dc1e88e9bc9f428eb304be481",container_id="docker://7d01fc838640f44d8dd52685c9761a2e4050c22b739ece2204f37d1f965a9949"} 1
+kube_pod_container_info{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",image="tutum/curl:latest",image_id="docker-pullable://tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f",container_id="docker://cf5ff1122e2f55da9e3e6bf4d72b8728b0676da9de1b0bfb184d1530774780a2"} 1
+kube_pod_container_info{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",image="tutum/curl:latest",image_id="docker-pullable://tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f",container_id="docker://0da1bb828096be45023366b0a65683a892e6fe1688717471fddda9ddbb2fd86b"} 1
+kube_pod_container_info{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",image="k8s.gcr.io/fluentd-gcp-scaler:0.5.2",image_id="docker-pullable://k8s.gcr.io/fluentd-gcp-scaler@sha256:4f28f10fb89506768910b858f7a18ffb996824a16d70d5ac895e49687df9ff58",container_id="docker://b43a54d05a7ab4956eaf70111d2ad6d28dfeda370bc6d631e172dc612ed25d06"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",image="k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.8",image_id="docker-pullable://k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64@sha256:3f0c30decd8f1b81242e8ec23dece40ae078a6fdd4d579840ca40f25783b3f7e",container_id="docker://1522343095f8c034e9683f740f57bfd68d484d312e9685969504f67af734e618"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",image="k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.8",image_id="docker-pullable://k8s.gcr.io/k8s-dns-kube-dns-amd64@sha256:8f8ba87c4ac94aff38d5668da225918c91557591c156cf5f0df4f7f64f16c464",container_id="docker://c808a5ca6eb4a506de193a3db5afa0d7fbaf65fffbae9417a7e0d42907be62de"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",image="k8s.gcr.io/prometheus-to-sd:v0.4.2",image_id="docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:aca8ef83a7fae83f1f8583e978dd4d1ff655b9f2ca0a76bda5edce6d8965bdf2",container_id="docker://fcb3b37f004d5e21f7f4f6b46a136334301ec69f1f3dfe0482a4286c638b6094"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",image="k8s.gcr.io/k8s-dns-sidecar-amd64:1.15.8",image_id="docker-pullable://k8s.gcr.io/k8s-dns-sidecar-amd64@sha256:b9efdbaeca0031e1405c173bb942d429d2f0c2d7e8ec1888c45cb8277dcfcf5d",container_id="docker://3784f8249ae8ee9e70b2e2d5cdc0898dddc05275660c9a939ccfee86894d750a"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",image="k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.8",image_id="docker-pullable://k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64@sha256:3f0c30decd8f1b81242e8ec23dece40ae078a6fdd4d579840ca40f25783b3f7e",container_id="docker://dd6e7090a9065a7d01af0e78bf07cd2257237f0e36a956fb4542fce7129d425a"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",image="k8s.gcr.io/k8s-dns-kube-dns-amd64:1.15.8",image_id="docker-pullable://k8s.gcr.io/k8s-dns-kube-dns-amd64@sha256:8f8ba87c4ac94aff38d5668da225918c91557591c156cf5f0df4f7f64f16c464",container_id="docker://b6cc1f70dbd5b1bd1745cad13bc4a17fcf04b017d29f8b3db5672ab54d6540ac"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",image="k8s.gcr.io/prometheus-to-sd:v0.4.2",image_id="docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:aca8ef83a7fae83f1f8583e978dd4d1ff655b9f2ca0a76bda5edce6d8965bdf2",container_id="docker://debad999becc3df36a75b2faaed48eb51024ea52f5fa4e0c7b518de5d246b490"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",image="k8s.gcr.io/k8s-dns-sidecar-amd64:1.15.8",image_id="docker-pullable://k8s.gcr.io/k8s-dns-sidecar-amd64@sha256:b9efdbaeca0031e1405c173bb942d429d2f0c2d7e8ec1888c45cb8277dcfcf5d",container_id="docker://4f3ca55c174de828d7949d8721e366b3b1d84374b8cbcad2f6f60d1e0c9dad27"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",image="gke.gcr.io/kube-proxy:v1.15.8-gke.3",image_id="docker://sha256:a4f6a58438ac325467696e37cdc8fa2cd8429d4c1006ff22f04cbf6580071253",container_id="docker://dd1de44176da52612d319ba92a2e6f9933c8ca74f61995d8658a6a20b358c250"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",image="gke.gcr.io/kube-proxy:v1.15.8-gke.3",image_id="docker://sha256:a4f6a58438ac325467696e37cdc8fa2cd8429d4c1006ff22f04cbf6580071253",container_id="docker://1285f7eaa9436db922fa1bd755f6ab51cbdb2d804359ed8bf82cead775242fa9"} 1
+kube_pod_container_info{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",image="gcr.io/stackdriver-agents/stackdriver-logging-agent:1.6.17-16060",image_id="docker-pullable://gcr.io/stackdriver-agents/stackdriver-logging-agent@sha256:79ddc530f0e558da80c3857c2e02d8b6dcce64c4c875fb94e3a420f53c502492",container_id="docker://3596bff87c08359fab19057bc7e11439b1033eaf2cf9a925328edda71eba612d"} 1
+kube_pod_container_info{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",image="k8s.gcr.io/prometheus-to-sd:v0.5.0",image_id="docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:14666989f40bb7c896c3e775a93c6873e2b791d65bc65579f58a078b7f9a764e",container_id="docker://25b57d8d938e525d387e091e8c0788ad42126ecd7fb8889136ad77a1370ca149"} 1
+kube_pod_container_info{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",image="k8s.gcr.io/prometheus-to-sd:v0.8.2",image_id="docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:3216dd0e94d6911f6dc04f4258c0bf5cb1fff088ee2d3ce742ada490cbd5ca5c",container_id="docker://1353aaa18ba238c4ac9205f6366bbff3650285df612e33bf85819b1a321a1d36"} 1
+kube_pod_container_info{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",image="k8s.gcr.io/prometheus-to-sd:v0.8.2",image_id="docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:3216dd0e94d6911f6dc04f4258c0bf5cb1fff088ee2d3ce742ada490cbd5ca5c",container_id="docker://de5fde1d69015b597bf3c7755f9ccb047a32560d7ecead3d85bc4004279e80ce"} 1
+kube_pod_container_info{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",image="tutum/curl:latest",image_id="docker-pullable://tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f",container_id="docker://47ce08b7915faf6717419ffc6dc3a9a1de57e44268e5950686fc7514104b6b43"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",image="asia.gcr.io/gke-release-staging/cluster-proportional-autoscaler-amd64:1.7.1-gke.0",image_id="docker-pullable://asia.gcr.io/gke-release-staging/cluster-proportional-autoscaler-amd64@sha256:e3f48b3d1e49cfa3e7f002020769c9cd01cd0e77bbc99dc133c7ab0f8097e989",container_id="docker://f6a63016585df4bf0ce0374ea5c7baf767e4fdbb41eb34c049c07d534151e596"} 1
+kube_pod_container_info{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",image="tutum/curl:latest",image_id="docker-pullable://tutum/curl@sha256:b6f16e88387acd4e6326176b212b3dae63f5b2134e69560d0b0673cfb0fb976f",container_id="docker://a3ff8e4f63977855a4ae3a713f09b9c70fef63d282c67f0f55efa6eada3ce1d0"} 1
+kube_pod_container_info{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",image="gcr.io/stackdriver-agents/metadata-agent-go:1.0.5",image_id="docker-pullable://gcr.io/stackdriver-agents/metadata-agent-go@sha256:ca13ec92f6e41befff6ca2a578ee7951edb1e49a566430f816f9a8acf631a62a",container_id="docker://36b4d97a6b6b923e59fe6617109ea5cc7285162ddbef9a893b6fd34417bea29e"} 1
+kube_pod_container_info{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",image="k8s.gcr.io/addon-resizer:1.8.7",image_id="docker-pullable://k8s.gcr.io/addon-resizer@sha256:30b3b12e471c534949e12d2da958fdf33848d153f2a0a88565bdef7ca999b5ad",container_id="docker://8700c68d348028c14266e53aad7163c9c9320446d6a29d1a3e28acc5623712b5"} 1
+kube_pod_container_info{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",image="gke.gcr.io/heapster:v1.7.2",image_id="docker-pullable://gke.gcr.io/heapster@sha256:26891d2f8c22407a772b911aed912993e1c530128ebb2d3561b49fc16a52d765",container_id="docker://223804f321ece70aac9a8ed8e08248ab286d7b83ca7487a82638de96cad508b7"} 1
+kube_pod_container_info{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",image="k8s.gcr.io/addon-resizer:1.8.3",image_id="docker-pullable://k8s.gcr.io/addon-resizer@sha256:07353f7b26327f0d933515a22b1de587b040d3d85c464ea299c1b9f242529326",container_id="docker://916e8f00e9205f4a514067e17be118cb67d302e2a15828595d03c6ef54e798ce"} 1
+kube_pod_container_info{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",image="k8s.gcr.io/prometheus-to-sd:v0.5.0",image_id="docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:14666989f40bb7c896c3e775a93c6873e2b791d65bc65579f58a078b7f9a764e",container_id="docker://401457cca403fc5370dd7e25d9bd80757cd767c53215ed610e9fb7ad0933a7bf"} 1
+kube_pod_container_info{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",image="gke.gcr.io/kube-proxy:v1.15.8-gke.3",image_id="docker://sha256:a4f6a58438ac325467696e37cdc8fa2cd8429d4c1006ff22f04cbf6580071253",container_id="docker://c2eeea0fb6cbf5850d958fcf52973428884945419356f4585daa5736cbb8b4dc"} 1
+kube_pod_container_info{namespace="default",pod="web-1",container="nginx",image="k8s.gcr.io/nginx-slim:0.8",image_id="docker-pullable://k8s.gcr.io/nginx-slim@sha256:8b4501fe0fe221df663c22e16539f399e89594552f400408303c42f3dd8d0e52",container_id="docker://aa6d241729402ad5739780d60688788b33f51ac6f5c23af0da3e5ea8dec3e329"} 1
+kube_pod_container_info{namespace="default",pod="dogstatsdclienttest",container="myapp",image="cedriclamoriniere/dogstatdclienttest:udp",image_id="docker-pullable://cedriclamoriniere/dogstatdclienttest@sha256:5fa72ca6f63fc8c25e97e16918144d0422254a348bae5431a4e833cf6af43b36",container_id="docker://f1a5cae86cd9bc9aa1478b3bcff5e3aaa99ca636f336cf5c35acee0c8fbbf3a5"} 1
+# HELP kube_pod_init_container_info Information about an init container in a pod.
+# TYPE kube_pod_init_container_info gauge
+kube_pod_init_container_info{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",image="datadog/agent:latest",image_id="docker-pullable://datadog/agent@sha256:debda90785408f0efba3997836ce7d86c47b778c78b2af0d74dfe17f2f59c926",container_id="docker://5a2b6435d16e2af12562ba1f7ea64355d56b7edf53f2ba09da09d25f710bde30"} 1
+kube_pod_init_container_info{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",image="datadog/agent:latest",image_id="docker-pullable://datadog/agent@sha256:debda90785408f0efba3997836ce7d86c47b778c78b2af0d74dfe17f2f59c926",container_id="docker://0b07bdbb7c658474c59afda7cc6f6313f7fcea11f4b9a292d4655122dd4ce207"} 1
+kube_pod_init_container_info{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",image="datadog/agent:latest",image_id="docker-pullable://datadog/agent@sha256:debda90785408f0efba3997836ce7d86c47b778c78b2af0d74dfe17f2f59c926",container_id="docker://547a20a4e624d3aba237401a3ebdd4abdcc22090fd382a7f95a97ac20f874bfe"} 1
+kube_pod_init_container_info{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",image="datadog/agent:latest",image_id="docker-pullable://datadog/agent@sha256:debda90785408f0efba3997836ce7d86c47b778c78b2af0d74dfe17f2f59c926",container_id="docker://67a35d5599bf5f3f382507436dd8fc7fc7050def1510e85695e90ba84b94af95"} 1
+kube_pod_init_container_info{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",image="datadog/agent:latest",image_id="docker-pullable://datadog/agent@sha256:debda90785408f0efba3997836ce7d86c47b778c78b2af0d74dfe17f2f59c926",container_id="docker://d09cbc52ad28793b35d510e6ebe89dc54c01db335a4bcf9b04dde34117e523b6"} 1
+kube_pod_init_container_info{namespace="default",pod="datadog-monitoring-tk746",container="init-config",image="datadog/agent:latest",image_id="docker-pullable://datadog/agent@sha256:debda90785408f0efba3997836ce7d86c47b778c78b2af0d74dfe17f2f59c926",container_id="docker://98ed203867ba6e1d820b09e7bb3f502b3a91ae06eaa30b4de115163a074ccd93"} 1
+# HELP kube_pod_container_status_waiting Describes whether the container is currently in waiting state.
+# TYPE kube_pod_container_status_waiting gauge
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model"} 0
+kube_pod_container_status_waiting{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd"} 0
+kube_pod_container_status_waiting{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny"} 0
+kube_pod_container_status_waiting{namespace="default",pod="dogstatsdclienttest",container="myapp"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy"} 0
+kube_pod_container_status_waiting{namespace="default",pod="web-1",container="nginx"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model"} 0
+kube_pod_container_status_waiting{namespace="default",pod="datadog-monitoring-ftwqn",container="agent"} 0
+kube_pod_container_status_waiting{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent"} 0
+kube_pod_container_status_waiting{namespace="default",pod="datadog-monitoring-hgrnm",container="agent"} 0
+kube_pod_container_status_waiting{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent"} 0
+kube_pod_container_status_waiting{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model"} 0
+kube_pod_container_status_waiting{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron"} 0
+kube_pod_container_status_waiting{namespace="default",pod="web-0",container="nginx"} 0
+kube_pod_container_status_waiting{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent"} 0
+kube_pod_container_status_waiting{namespace="default",pod="datadog-monitoring-tk746",container="agent"} 0
+kube_pod_container_status_waiting{namespace="default",pod="datadog-monitoring-tk746",container="process-agent"} 0
+kube_pod_container_status_waiting{namespace="default",pod="redis-599d64fcb9-c654j",container="master"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler"} 0
+kube_pod_container_status_waiting{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron"} 0
+kube_pod_container_status_waiting{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd"} 0
+kube_pod_container_status_waiting{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar"} 0
+# HELP kube_pod_init_container_status_waiting Describes whether the init container is currently in waiting state.
+# TYPE kube_pod_init_container_status_waiting gauge
+kube_pod_init_container_status_waiting{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume"} 0
+kube_pod_init_container_status_waiting{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config"} 0
+kube_pod_init_container_status_waiting{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume"} 0
+kube_pod_init_container_status_waiting{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config"} 0
+kube_pod_init_container_status_waiting{namespace="default",pod="datadog-monitoring-tk746",container="init-volume"} 0
+kube_pod_init_container_status_waiting{namespace="default",pod="datadog-monitoring-tk746",container="init-config"} 0
+# HELP kube_pod_container_status_waiting_reason Describes the reason the container is currently in waiting state.
+# TYPE kube_pod_container_status_waiting_reason gauge
+kube_pod_container_status_waiting_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-1",container="nginx",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-1",container="nginx",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-1",container="nginx",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-1",container="nginx",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-1",container="nginx",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-1",container="nginx",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-1",container="nginx",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-0",container="nginx",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-0",container="nginx",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-0",container="nginx",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-0",container="nginx",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-0",container="nginx",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-0",container="nginx",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="web-0",container="nginx",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="InvalidImageName"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="ContainerCreating"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="CrashLoopBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="CreateContainerConfigError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="ErrImagePull"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="ImagePullBackOff"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="CreateContainerError"} 0
+kube_pod_container_status_waiting_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="InvalidImageName"} 0
+# HELP kube_pod_init_container_status_waiting_reason Describes the reason the init container is currently in waiting state.
+# TYPE kube_pod_init_container_status_waiting_reason gauge
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="ContainerCreating"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="CrashLoopBackOff"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="CreateContainerConfigError"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="ErrImagePull"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="ImagePullBackOff"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="CreateContainerError"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="InvalidImageName"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="ContainerCreating"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="CrashLoopBackOff"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="CreateContainerConfigError"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="ErrImagePull"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="ImagePullBackOff"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="CreateContainerError"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="InvalidImageName"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="ContainerCreating"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="CrashLoopBackOff"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="CreateContainerConfigError"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="ErrImagePull"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="ImagePullBackOff"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="CreateContainerError"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="InvalidImageName"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="ContainerCreating"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="CrashLoopBackOff"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="CreateContainerConfigError"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="ErrImagePull"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="ImagePullBackOff"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="CreateContainerError"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="InvalidImageName"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="ContainerCreating"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="CrashLoopBackOff"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="CreateContainerConfigError"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="ErrImagePull"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="ImagePullBackOff"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="CreateContainerError"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="InvalidImageName"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="ContainerCreating"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="CrashLoopBackOff"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="CreateContainerConfigError"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="ErrImagePull"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="ImagePullBackOff"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="CreateContainerError"} 0
+kube_pod_init_container_status_waiting_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="InvalidImageName"} 0
+# HELP kube_pod_container_status_running Describes whether the container is currently in running state.
+# TYPE kube_pod_container_status_running gauge
+kube_pod_container_status_running{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model"} 1
+kube_pod_container_status_running{namespace="default",pod="web-0",container="nginx"} 1
+kube_pod_container_status_running{namespace="default",pod="datadog-monitoring-ftwqn",container="agent"} 1
+kube_pod_container_status_running{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent"} 1
+kube_pod_container_status_running{namespace="default",pod="datadog-monitoring-hgrnm",container="agent"} 1
+kube_pod_container_status_running{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent"} 1
+kube_pod_container_status_running{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model"} 1
+kube_pod_container_status_running{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron"} 0
+kube_pod_container_status_running{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent"} 1
+kube_pod_container_status_running{namespace="default",pod="datadog-monitoring-tk746",container="agent"} 1
+kube_pod_container_status_running{namespace="default",pod="datadog-monitoring-tk746",container="process-agent"} 1
+kube_pod_container_status_running{namespace="default",pod="redis-599d64fcb9-c654j",container="master"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler"} 1
+kube_pod_container_status_running{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron"} 0
+kube_pod_container_status_running{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron"} 0
+kube_pod_container_status_running{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model"} 1
+kube_pod_container_status_running{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron"} 0
+kube_pod_container_status_running{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd"} 1
+kube_pod_container_status_running{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron"} 0
+kube_pod_container_status_running{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny"} 1
+kube_pod_container_status_running{namespace="default",pod="dogstatsdclienttest",container="myapp"} 1
+kube_pod_container_status_running{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy"} 1
+kube_pod_container_status_running{namespace="default",pod="web-1",container="nginx"} 1
+# HELP kube_pod_init_container_status_running Describes whether the init container is currently in running state.
+# TYPE kube_pod_init_container_status_running gauge
+kube_pod_init_container_status_running{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume"} 0
+kube_pod_init_container_status_running{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config"} 0
+kube_pod_init_container_status_running{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume"} 0
+kube_pod_init_container_status_running{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config"} 0
+kube_pod_init_container_status_running{namespace="default",pod="datadog-monitoring-tk746",container="init-volume"} 0
+kube_pod_init_container_status_running{namespace="default",pod="datadog-monitoring-tk746",container="init-config"} 0
+# HELP kube_pod_container_status_terminated Describes whether the container is currently in terminated state.
+# TYPE kube_pod_container_status_terminated gauge
+kube_pod_container_status_terminated{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler"} 0
+kube_pod_container_status_terminated{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron"} 1
+kube_pod_container_status_terminated{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron"} 1
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model"} 0
+kube_pod_container_status_terminated{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron"} 1
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd"} 0
+kube_pod_container_status_terminated{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron"} 1
+kube_pod_container_status_terminated{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny"} 0
+kube_pod_container_status_terminated{namespace="default",pod="dogstatsdclienttest",container="myapp"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy"} 0
+kube_pod_container_status_terminated{namespace="default",pod="web-1",container="nginx"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model"} 0
+kube_pod_container_status_terminated{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron"} 1
+kube_pod_container_status_terminated{namespace="default",pod="web-0",container="nginx"} 0
+kube_pod_container_status_terminated{namespace="default",pod="datadog-monitoring-ftwqn",container="agent"} 0
+kube_pod_container_status_terminated{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent"} 0
+kube_pod_container_status_terminated{namespace="default",pod="datadog-monitoring-hgrnm",container="agent"} 0
+kube_pod_container_status_terminated{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent"} 0
+kube_pod_container_status_terminated{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter"} 0
+kube_pod_container_status_terminated{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent"} 0
+kube_pod_container_status_terminated{namespace="default",pod="datadog-monitoring-tk746",container="agent"} 0
+kube_pod_container_status_terminated{namespace="default",pod="datadog-monitoring-tk746",container="process-agent"} 0
+kube_pod_container_status_terminated{namespace="default",pod="redis-599d64fcb9-c654j",container="master"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server"} 0
+kube_pod_container_status_terminated{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny"} 0
+# HELP kube_pod_init_container_status_terminated Describes whether the init container is currently in terminated state.
+# TYPE kube_pod_init_container_status_terminated gauge
+kube_pod_init_container_status_terminated{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume"} 1
+kube_pod_init_container_status_terminated{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config"} 1
+kube_pod_init_container_status_terminated{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume"} 1
+kube_pod_init_container_status_terminated{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config"} 1
+kube_pod_init_container_status_terminated{namespace="default",pod="datadog-monitoring-tk746",container="init-volume"} 1
+kube_pod_init_container_status_terminated{namespace="default",pod="datadog-monitoring-tk746",container="init-config"} 1
+# HELP kube_pod_container_status_terminated_reason Describes the reason the container is currently in terminated state.
+# TYPE kube_pod_container_status_terminated_reason gauge
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="Completed"} 1
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="Completed"} 1
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="web-1",container="nginx",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="web-1",container="nginx",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="web-1",container="nginx",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="web-1",container="nginx",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="web-1",container="nginx",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="web-1",container="nginx",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="Completed"} 1
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="web-0",container="nginx",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="web-0",container="nginx",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="web-0",container="nginx",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="web-0",container="nginx",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="web-0",container="nginx",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="web-0",container="nginx",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="Completed"} 1
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="Completed"} 1
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="Evicted"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="OOMKilled"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="Completed"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="Error"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="ContainerCannotRun"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="DeadlineExceeded"} 0
+kube_pod_container_status_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="Evicted"} 0
+# HELP kube_pod_init_container_status_terminated_reason Describes the reason the init container is currently in terminated state.
+# TYPE kube_pod_init_container_status_terminated_reason gauge
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="OOMKilled"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="Completed"} 1
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="Error"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="ContainerCannotRun"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="DeadlineExceeded"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="Evicted"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="OOMKilled"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="Completed"} 1
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="Error"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="ContainerCannotRun"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="DeadlineExceeded"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="Evicted"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="OOMKilled"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="Completed"} 1
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="Error"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="ContainerCannotRun"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="DeadlineExceeded"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="Evicted"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="OOMKilled"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="Completed"} 1
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="Error"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="ContainerCannotRun"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="DeadlineExceeded"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="Evicted"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="OOMKilled"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="Completed"} 1
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="Error"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="ContainerCannotRun"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="DeadlineExceeded"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="Evicted"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="OOMKilled"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="Completed"} 1
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="Error"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="ContainerCannotRun"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="DeadlineExceeded"} 0
+kube_pod_init_container_status_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="Evicted"} 0
+# HELP kube_pod_container_status_last_terminated_reason Describes the last reason the container was in terminated state.
+# TYPE kube_pod_container_status_last_terminated_reason gauge
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="dogstatsdclienttest",container="myapp",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="web-1",container="nginx",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="web-1",container="nginx",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="web-1",container="nginx",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="web-1",container="nginx",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="web-1",container="nginx",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="web-1",container="nginx",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="web-0",container="nginx",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="web-0",container="nginx",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="web-0",container="nginx",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="web-0",container="nginx",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="web-0",container="nginx",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="web-0",container="nginx",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="agent",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="redis-599d64fcb9-c654j",container="master",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",reason="Evicted"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="OOMKilled"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="Completed"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="Error"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="ContainerCannotRun"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="DeadlineExceeded"} 0
+kube_pod_container_status_last_terminated_reason{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",reason="Evicted"} 0
+# HELP kube_pod_init_container_status_last_terminated_reason Describes the last reason the init container was in terminated state.
+# TYPE kube_pod_init_container_status_last_terminated_reason gauge
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="OOMKilled"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="Completed"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="Error"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="ContainerCannotRun"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="DeadlineExceeded"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-volume",reason="Evicted"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="OOMKilled"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="Completed"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="Error"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="ContainerCannotRun"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="DeadlineExceeded"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-tk746",container="init-config",reason="Evicted"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="OOMKilled"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="Completed"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="Error"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="ContainerCannotRun"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="DeadlineExceeded"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume",reason="Evicted"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="OOMKilled"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="Completed"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="Error"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="ContainerCannotRun"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="DeadlineExceeded"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config",reason="Evicted"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="OOMKilled"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="Completed"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="Error"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="ContainerCannotRun"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="DeadlineExceeded"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume",reason="Evicted"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="OOMKilled"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="Completed"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="Error"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="ContainerCannotRun"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="DeadlineExceeded"} 0
+kube_pod_init_container_status_last_terminated_reason{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config",reason="Evicted"} 0
+# HELP kube_pod_container_status_ready Describes whether the containers readiness check succeeded.
+# TYPE kube_pod_container_status_ready gauge
+kube_pod_container_status_ready{namespace="default",pod="dogstatsdclienttest",container="myapp"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy"} 1
+kube_pod_container_status_ready{namespace="default",pod="web-1",container="nginx"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model"} 1
+kube_pod_container_status_ready{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron"} 0
+kube_pod_container_status_ready{namespace="default",pod="web-0",container="nginx"} 1
+kube_pod_container_status_ready{namespace="default",pod="datadog-monitoring-ftwqn",container="agent"} 1
+kube_pod_container_status_ready{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent"} 1
+kube_pod_container_status_ready{namespace="default",pod="datadog-monitoring-hgrnm",container="agent"} 1
+kube_pod_container_status_ready{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent"} 1
+kube_pod_container_status_ready{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend"} 1
+kube_pod_container_status_ready{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent"} 1
+kube_pod_container_status_ready{namespace="default",pod="datadog-monitoring-tk746",container="agent"} 1
+kube_pod_container_status_ready{namespace="default",pod="datadog-monitoring-tk746",container="process-agent"} 1
+kube_pod_container_status_ready{namespace="default",pod="redis-599d64fcb9-c654j",container="master"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler"} 1
+kube_pod_container_status_ready{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron"} 0
+kube_pod_container_status_ready{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron"} 0
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar"} 1
+kube_pod_container_status_ready{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron"} 0
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd"} 1
+kube_pod_container_status_ready{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron"} 0
+kube_pod_container_status_ready{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent"} 1
+kube_pod_container_status_ready{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny"} 1
+# HELP kube_pod_init_container_status_ready Describes whether the init containers readiness check succeeded.
+# TYPE kube_pod_init_container_status_ready gauge
+kube_pod_init_container_status_ready{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume"} 1
+kube_pod_init_container_status_ready{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config"} 1
+kube_pod_init_container_status_ready{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume"} 1
+kube_pod_init_container_status_ready{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config"} 1
+kube_pod_init_container_status_ready{namespace="default",pod="datadog-monitoring-tk746",container="init-volume"} 1
+kube_pod_init_container_status_ready{namespace="default",pod="datadog-monitoring-tk746",container="init-config"} 1
+# HELP kube_pod_container_status_restarts_total The number of container restarts per container.
+# TYPE kube_pod_container_status_restarts_total counter
+kube_pod_container_status_restarts_total{namespace="default",pod="datadog-monitoring-tk746",container="agent"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="datadog-monitoring-tk746",container="process-agent"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="redis-599d64fcb9-c654j",container="master"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="fluentd-gcp-scaler-dd489f778-nll24",container="fluentd-gcp-scaler"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="prometheus-to-sd"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="prometheus-to-sd"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="prometheus-to-sd-exporter"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="prom-to-sd"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="web-1",container="nginx"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="dogstatsdclienttest",container="myapp"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="prometheus-to-sd-exporter"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="prometheus-to-sd-exporter"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="datadog-monitoring-hgrnm",container="agent"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="event-exporter"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="event-exporter-v0.3.0-74bf544f8b-6qj74",container="prometheus-to-sd-exporter"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd"} 0
+kube_pod_container_status_restarts_total{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="web-0",container="nginx"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="datadog-monitoring-ftwqn",container="agent"} 0
+kube_pod_container_status_restarts_total{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent"} 0
+# HELP kube_pod_init_container_status_restarts_total The number of restarts for the init container.
+# TYPE kube_pod_init_container_status_restarts_total counter
+kube_pod_init_container_status_restarts_total{namespace="default",pod="datadog-monitoring-hgrnm",container="init-volume"} 0
+kube_pod_init_container_status_restarts_total{namespace="default",pod="datadog-monitoring-hgrnm",container="init-config"} 0
+kube_pod_init_container_status_restarts_total{namespace="default",pod="datadog-monitoring-ftwqn",container="init-volume"} 0
+kube_pod_init_container_status_restarts_total{namespace="default",pod="datadog-monitoring-ftwqn",container="init-config"} 0
+kube_pod_init_container_status_restarts_total{namespace="default",pod="datadog-monitoring-tk746",container="init-volume"} 0
+kube_pod_init_container_status_restarts_total{namespace="default",pod="datadog-monitoring-tk746",container="init-config"} 0
+# HELP kube_pod_container_resource_requests The number of requested request resource by a container.
+# TYPE kube_pod_container_resource_requests gauge
+kube_pod_container_resource_requests{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.013
+kube_pod_container_resource_requests{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 1.2582912e+08
+kube_pod_container_resource_requests{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.05
+kube_pod_container_resource_requests{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 9.519104e+07
+kube_pod_container_resource_requests{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.043
+kube_pod_container_resource_requests{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="memory",unit="byte"} 4.718592e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.05
+kube_pod_container_resource_requests{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="memory",unit="byte"} 9.519104e+07
+kube_pod_container_resource_requests{namespace="default",pod="dogstatsdclienttest",container="myapp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.01
+kube_pod_container_resource_requests{namespace="default",pod="dogstatsdclienttest",container="myapp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 1.34217728e+08
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="default",pod="web-1",container="nginx",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.001
+kube_pod_container_resource_requests{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 2.097152e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 2.097152e+08
+kube_pod_container_resource_requests{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 2.097152e+08
+kube_pod_container_resource_requests{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.01
+kube_pod_container_resource_requests{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 2.097152e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.001
+kube_pod_container_resource_requests{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 2.097152e+07
+kube_pod_container_resource_requests{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="default",pod="web-0",container="nginx",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.043
+kube_pod_container_resource_requests{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 5.767168e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.005
+kube_pod_container_resource_requests{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 5.24288e+07
+kube_pod_container_resource_requests{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="default",pod="datadog-monitoring-tk746",container="agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="default",pod="redis-599d64fcb9-c654j",container="master",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="default",pod="redis-599d64fcb9-c654j",container="master",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="memory",unit="byte"} 1.048576e+08
+kube_pod_container_resource_requests{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 7.340032e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.15
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 2.097152e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.01
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 2.097152e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 7.340032e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.15
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 2.097152e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.01
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 2.097152e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="memory",unit="byte"} 2.097152e+08
+kube_pod_container_resource_requests{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.001
+kube_pod_container_resource_requests{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="memory",unit="byte"} 2.097152e+07
+kube_pod_container_resource_requests{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.02
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 1.048576e+07
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_requests{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.1
+# HELP kube_pod_container_resource_limits The number of requested limit resource by a container.
+# TYPE kube_pod_container_resource_limits gauge
+kube_pod_container_resource_limits{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.01
+kube_pod_container_resource_limits{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 2.097152e+07
+kube_pod_container_resource_limits{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.003
+kube_pod_container_resource_limits{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 2.097152e+07
+kube_pod_container_resource_limits{namespace="default",pod="redis-599d64fcb9-c654j",container="master",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.4
+kube_pod_container_resource_limits{namespace="default",pod="redis-599d64fcb9-c654j",container="master",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="memory",unit="byte"} 4.194304e+08
+kube_pod_container_resource_limits{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.043
+kube_pod_container_resource_limits{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 5.767168e+07
+kube_pod_container_resource_limits{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.1
+kube_pod_container_resource_limits{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 3.145728e+08
+kube_pod_container_resource_limits{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 1.7825792e+08
+kube_pod_container_resource_limits{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 1.7825792e+08
+kube_pod_container_resource_limits{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 1
+kube_pod_container_resource_limits{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="memory",unit="byte"} 5.24288e+08
+kube_pod_container_resource_limits{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.003
+kube_pod_container_resource_limits{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="memory",unit="byte"} 2.097152e+07
+kube_pod_container_resource_limits{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 1.2582912e+08
+kube_pod_container_resource_limits{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.013
+kube_pod_container_resource_limits{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.05
+kube_pod_container_resource_limits{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 9.519104e+07
+kube_pod_container_resource_limits{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.043
+kube_pod_container_resource_limits{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="memory",unit="byte"} 4.718592e+07
+kube_pod_container_resource_limits{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="cpu",unit="core"} 0.05
+kube_pod_container_resource_limits{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",resource="memory",unit="byte"} 9.519104e+07
+kube_pod_container_resource_limits{namespace="default",pod="dogstatsdclienttest",container="myapp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 0.01
+kube_pod_container_resource_limits{namespace="default",pod="dogstatsdclienttest",container="myapp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 1.34217728e+08
+kube_pod_container_resource_limits{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="cpu",unit="core"} 1
+kube_pod_container_resource_limits{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",resource="memory",unit="byte"} 5.24288e+08
+kube_pod_container_resource_limits{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 1
+kube_pod_container_resource_limits{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 5.24288e+08
+kube_pod_container_resource_limits{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="cpu",unit="core"} 0.003
+kube_pod_container_resource_limits{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc",resource="memory",unit="byte"} 2.097152e+07
+# HELP kube_pod_init_container_resource_limits The number of requested limit resource by the init container.
+# TYPE kube_pod_init_container_resource_limits gauge
+# HELP kube_pod_container_resource_requests_cpu_cores The number of requested cpu cores by a container.
+# TYPE kube_pod_container_resource_requests_cpu_cores gauge
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.01
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.001
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="curl-cron-job-1586196480-nxtk6",container="notifsender-sms-cron",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="web-0",container="nginx",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="datadog-monitoring-ftwqn",container="agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="datadog-monitoring-ftwqn",container="process-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="datadog-monitoring-hgrnm",container="agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="datadog-monitoring-hgrnm",container="process-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="kube-state-metrics-868bf6f59d-ztwjh",container="kube-state-metrics",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.043
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.005
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="datadog-monitoring-cluster-agent-5447d77668-tgw5d",container="cluster-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="datadog-monitoring-tk746",container="agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="datadog-monitoring-tk746",container="process-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="redis-599d64fcb9-c654j",container="master",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="curl-job-xbchd",container="notifsender-sms-cron",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="curl-cron-job-1586196360-qmvmq",container="notifsender-sms-cron",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.15
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.01
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.15
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.01
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.001
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="curl-cron-job-1586196420-tlq52",container="notifsender-sms-cron",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.02
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-95lc",container="kube-proxy",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-z9rw",container="kube-proxy",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.013
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.05
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="curl-cron-job-1586196300-sn78l",container="notifsender-sms-cron",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.043
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.05
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="dogstatsdclienttest",container="myapp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.01
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="kube-proxy-gke-abcdef-cluster-default-pool-53c8a4ea-wj4k",container="kube-proxy",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="default",pod="web-1",container="nginx",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.001
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.1
+kube_pod_container_resource_requests_cpu_cores{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.1
+# HELP kube_pod_container_resource_requests_memory_bytes The number of requested memory bytes by a container.
+# TYPE kube_pod_container_resource_requests_memory_bytes gauge
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 2.097152e+08
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 2.097152e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="kube-dns-autoscaler-6b7f784798-qrxd9",container="autoscaler",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 1.048576e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 1.2582912e+08
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 9.519104e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 4.718592e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 9.519104e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="default",pod="dogstatsdclienttest",container="myapp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 1.34217728e+08
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 2.097152e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 2.097152e+08
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 2.097152e+08
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 2.097152e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 2.097152e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 5.767168e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 5.24288e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="default",pod="redis-599d64fcb9-c654j",container="master",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 1.048576e+08
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 7.340032e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="dnsmasq",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 2.097152e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="sidecar",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 2.097152e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 7.340032e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="dnsmasq",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 2.097152e+07
+kube_pod_container_resource_requests_memory_bytes{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="sidecar",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 2.097152e+07
+# HELP kube_pod_container_resource_limits_cpu_cores The limit on cpu cores to be used by a container.
+# TYPE kube_pod_container_resource_limits_cpu_cores gauge
+kube_pod_container_resource_limits_cpu_cores{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 1
+kube_pod_container_resource_limits_cpu_cores{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.003
+kube_pod_container_resource_limits_cpu_cores{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.043
+kube_pod_container_resource_limits_cpu_cores{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.05
+kube_pod_container_resource_limits_cpu_cores{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.013
+kube_pod_container_resource_limits_cpu_cores{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.05
+kube_pod_container_resource_limits_cpu_cores{namespace="default",pod="dogstatsdclienttest",container="myapp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.01
+kube_pod_container_resource_limits_cpu_cores{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 1
+kube_pod_container_resource_limits_cpu_cores{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.003
+kube_pod_container_resource_limits_cpu_cores{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 1
+kube_pod_container_resource_limits_cpu_cores{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 0.01
+kube_pod_container_resource_limits_cpu_cores{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.003
+kube_pod_container_resource_limits_cpu_cores{namespace="default",pod="redis-599d64fcb9-c654j",container="master",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 0.4
+kube_pod_container_resource_limits_cpu_cores{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.043
+kube_pod_container_resource_limits_cpu_cores{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 0.1
+# HELP kube_pod_container_resource_limits_memory_bytes The limit on memory to be used by a container in bytes.
+# TYPE kube_pod_container_resource_limits_memory_bytes gauge
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="fluentd-gcp-v3.1.1-bcj96",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 5.24288e+08
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="prometheus-to-sd-rfzfg",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 2.097152e+07
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 1.2582912e+08
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="heapster-gke-84994c444b-6xdcm",container="heapster-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 9.519104e+07
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 4.718592e+07
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="stackdriver-metadata-agent-cluster-level-54779d5c66-5z7jr",container="metadata-agent-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 9.519104e+07
+kube_pod_container_resource_limits_memory_bytes{namespace="default",pod="dogstatsdclienttest",container="myapp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 1.34217728e+08
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="fluentd-gcp-v3.1.1-fms55",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 5.24288e+08
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="fluentd-gcp-v3.1.1-wdntk",container="fluentd-gcp",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 5.24288e+08
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="prometheus-to-sd-nh249",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 2.097152e+07
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="l7-default-backend-84c9fcfbb-jhvcp",container="default-http-backend",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 2.097152e+07
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="prometheus-to-sd-lzbh6",container="prometheus-to-sd-new-model",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 2.097152e+07
+kube_pod_container_resource_limits_memory_bytes{namespace="default",pod="redis-599d64fcb9-c654j",container="master",node="gke-abcdef-cluster-default-pool-53c8a4ea-z9rw"} 4.194304e+08
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 5.767168e+07
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="metrics-server-v0.3.3-6d96fcc55-29rql",container="metrics-server-nanny",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 3.145728e+08
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="kube-dns-5dbbd9cc58-gcqst",container="kubedns",node="gke-abcdef-cluster-default-pool-53c8a4ea-95lc"} 1.7825792e+08
+kube_pod_container_resource_limits_memory_bytes{namespace="kube-system",pod="kube-dns-5dbbd9cc58-lkkxg",container="kubedns",node="gke-abcdef-cluster-default-pool-53c8a4ea-wj4k"} 1.7825792e+08
+# HELP kube_pod_spec_volumes_persistentvolumeclaims_info Information about persistentvolumeclaim volumes in a pod.
+# TYPE kube_pod_spec_volumes_persistentvolumeclaims_info gauge
+kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="default",pod="web-1",volume="www",persistentvolumeclaim="www-web-1"} 1
+kube_pod_spec_volumes_persistentvolumeclaims_info{namespace="default",pod="web-0",volume="www",persistentvolumeclaim="www-web-0"} 1
+# HELP kube_pod_spec_volumes_persistentvolumeclaims_readonly Describes whether a persistentvolumeclaim is mounted read only.
+# TYPE kube_pod_spec_volumes_persistentvolumeclaims_readonly gauge
+kube_pod_spec_volumes_persistentvolumeclaims_readonly{namespace="default",pod="web-1",volume="www",persistentvolumeclaim="www-web-1"} 0
+kube_pod_spec_volumes_persistentvolumeclaims_readonly{namespace="default",pod="web-0",volume="www",persistentvolumeclaim="www-web-0"} 0
+# HELP kube_replicaset_created Unix creation timestamp
+# TYPE kube_replicaset_created gauge
+kube_replicaset_created{namespace="default",replicaset="redis-599d64fcb9"} 1.584735714e+09
+kube_replicaset_created{namespace="kube-system",replicaset="event-exporter-v0.3.0-74bf544f8b"} 1.580242906e+09
+kube_replicaset_created{namespace="kube-system",replicaset="metrics-server-v0.3.3-6d96fcc55"} 1.580242923e+09
+kube_replicaset_created{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-54779d5c66"} 1.585686071e+09
+kube_replicaset_created{namespace="default",replicaset="datadog-monitoring-cluster-agent-5447d77668"} 1.584562061e+09
+kube_replicaset_created{namespace="default",replicaset="redis-c5c49b48d"} 1.584735424e+09
+kube_replicaset_created{namespace="default",replicaset="redis-db5b8b6b5"} 1.584734676e+09
+kube_replicaset_created{namespace="kube-system",replicaset="fluentd-gcp-scaler-dd489f778"} 1.580242911e+09
+kube_replicaset_created{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-595d87cbc7"} 1.580242905e+09
+kube_replicaset_created{namespace="default",replicaset="kube-state-metrics-868bf6f59d"} 1.582669594e+09
+kube_replicaset_created{namespace="kube-system",replicaset="heapster-gke-84994c444b"} 1.580242957e+09
+kube_replicaset_created{namespace="kube-system",replicaset="kube-dns-5dbbd9cc58"} 1.580242904e+09
+kube_replicaset_created{namespace="kube-system",replicaset="l7-default-backend-84c9fcfbb"} 1.580242904e+09
+kube_replicaset_created{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-57b5b7c7fb"} 1.585686064e+09
+kube_replicaset_created{namespace="kube-system",replicaset="heapster-gke-c6d577fc4"} 1.580242905e+09
+kube_replicaset_created{namespace="kube-system",replicaset="kube-dns-autoscaler-6b7f784798"} 1.580242904e+09
+kube_replicaset_created{namespace="kube-system",replicaset="metrics-server-v0.3.3-66cbb7c9f9"} 1.580242908e+09
+# HELP kube_replicaset_status_replicas The number of replicas per ReplicaSet.
+# TYPE kube_replicaset_status_replicas gauge
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="heapster-gke-c6d577fc4"} 0
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="kube-dns-autoscaler-6b7f784798"} 1
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="metrics-server-v0.3.3-66cbb7c9f9"} 0
+kube_replicaset_status_replicas{namespace="default",replicaset="redis-599d64fcb9"} 1
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="event-exporter-v0.3.0-74bf544f8b"} 1
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="metrics-server-v0.3.3-6d96fcc55"} 1
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-54779d5c66"} 1
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-595d87cbc7"} 0
+kube_replicaset_status_replicas{namespace="default",replicaset="datadog-monitoring-cluster-agent-5447d77668"} 1
+kube_replicaset_status_replicas{namespace="default",replicaset="redis-c5c49b48d"} 0
+kube_replicaset_status_replicas{namespace="default",replicaset="redis-db5b8b6b5"} 0
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="fluentd-gcp-scaler-dd489f778"} 1
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-57b5b7c7fb"} 0
+kube_replicaset_status_replicas{namespace="default",replicaset="kube-state-metrics-868bf6f59d"} 1
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="heapster-gke-84994c444b"} 1
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="kube-dns-5dbbd9cc58"} 2
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="l7-default-backend-84c9fcfbb"} 1
+# HELP kube_replicaset_status_fully_labeled_replicas The number of fully labeled replicas per ReplicaSet.
+# TYPE kube_replicaset_status_fully_labeled_replicas gauge
+kube_replicaset_status_fully_labeled_replicas{namespace="default",replicaset="redis-599d64fcb9"} 1
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="event-exporter-v0.3.0-74bf544f8b"} 1
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="metrics-server-v0.3.3-6d96fcc55"} 1
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-54779d5c66"} 1
+kube_replicaset_status_fully_labeled_replicas{namespace="default",replicaset="datadog-monitoring-cluster-agent-5447d77668"} 1
+kube_replicaset_status_fully_labeled_replicas{namespace="default",replicaset="redis-c5c49b48d"} 0
+kube_replicaset_status_fully_labeled_replicas{namespace="default",replicaset="redis-db5b8b6b5"} 0
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="fluentd-gcp-scaler-dd489f778"} 1
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-595d87cbc7"} 0
+kube_replicaset_status_fully_labeled_replicas{namespace="default",replicaset="kube-state-metrics-868bf6f59d"} 1
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="heapster-gke-84994c444b"} 1
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="kube-dns-5dbbd9cc58"} 2
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="l7-default-backend-84c9fcfbb"} 1
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-57b5b7c7fb"} 0
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="heapster-gke-c6d577fc4"} 0
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="kube-dns-autoscaler-6b7f784798"} 1
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="metrics-server-v0.3.3-66cbb7c9f9"} 0
+# HELP kube_replicaset_status_ready_replicas The number of ready replicas per ReplicaSet.
+# TYPE kube_replicaset_status_ready_replicas gauge
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="l7-default-backend-84c9fcfbb"} 1
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-57b5b7c7fb"} 0
+kube_replicaset_status_ready_replicas{namespace="default",replicaset="kube-state-metrics-868bf6f59d"} 1
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="heapster-gke-84994c444b"} 1
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="kube-dns-5dbbd9cc58"} 2
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="heapster-gke-c6d577fc4"} 0
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="kube-dns-autoscaler-6b7f784798"} 1
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="metrics-server-v0.3.3-66cbb7c9f9"} 0
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-54779d5c66"} 1
+kube_replicaset_status_ready_replicas{namespace="default",replicaset="redis-599d64fcb9"} 1
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="event-exporter-v0.3.0-74bf544f8b"} 1
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="metrics-server-v0.3.3-6d96fcc55"} 1
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="fluentd-gcp-scaler-dd489f778"} 1
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-595d87cbc7"} 0
+kube_replicaset_status_ready_replicas{namespace="default",replicaset="datadog-monitoring-cluster-agent-5447d77668"} 1
+kube_replicaset_status_ready_replicas{namespace="default",replicaset="redis-c5c49b48d"} 0
+kube_replicaset_status_ready_replicas{namespace="default",replicaset="redis-db5b8b6b5"} 0
+# HELP kube_replicaset_status_observed_generation The generation observed by the ReplicaSet controller.
+# TYPE kube_replicaset_status_observed_generation gauge
+kube_replicaset_status_observed_generation{namespace="default",replicaset="redis-599d64fcb9"} 1
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="event-exporter-v0.3.0-74bf544f8b"} 1
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="metrics-server-v0.3.3-6d96fcc55"} 1
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-54779d5c66"} 1
+kube_replicaset_status_observed_generation{namespace="default",replicaset="datadog-monitoring-cluster-agent-5447d77668"} 1
+kube_replicaset_status_observed_generation{namespace="default",replicaset="redis-c5c49b48d"} 2
+kube_replicaset_status_observed_generation{namespace="default",replicaset="redis-db5b8b6b5"} 2
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="fluentd-gcp-scaler-dd489f778"} 1
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-595d87cbc7"} 2
+kube_replicaset_status_observed_generation{namespace="default",replicaset="kube-state-metrics-868bf6f59d"} 1
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="heapster-gke-84994c444b"} 1
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="kube-dns-5dbbd9cc58"} 2
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="l7-default-backend-84c9fcfbb"} 1
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-57b5b7c7fb"} 2
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="heapster-gke-c6d577fc4"} 2
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="kube-dns-autoscaler-6b7f784798"} 1
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="metrics-server-v0.3.3-66cbb7c9f9"} 2
+# HELP kube_replicaset_spec_replicas Number of desired pods for a ReplicaSet.
+# TYPE kube_replicaset_spec_replicas gauge
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="heapster-gke-c6d577fc4"} 0
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="kube-dns-autoscaler-6b7f784798"} 1
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="metrics-server-v0.3.3-66cbb7c9f9"} 0
+kube_replicaset_spec_replicas{namespace="default",replicaset="redis-599d64fcb9"} 1
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="event-exporter-v0.3.0-74bf544f8b"} 1
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="metrics-server-v0.3.3-6d96fcc55"} 1
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-54779d5c66"} 1
+kube_replicaset_spec_replicas{namespace="default",replicaset="datadog-monitoring-cluster-agent-5447d77668"} 1
+kube_replicaset_spec_replicas{namespace="default",replicaset="redis-c5c49b48d"} 0
+kube_replicaset_spec_replicas{namespace="default",replicaset="redis-db5b8b6b5"} 0
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="fluentd-gcp-scaler-dd489f778"} 1
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-595d87cbc7"} 0
+kube_replicaset_spec_replicas{namespace="default",replicaset="kube-state-metrics-868bf6f59d"} 1
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="heapster-gke-84994c444b"} 1
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="kube-dns-5dbbd9cc58"} 2
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="l7-default-backend-84c9fcfbb"} 1
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-57b5b7c7fb"} 0
+# HELP kube_replicaset_metadata_generation Sequence number representing a specific generation of the desired state.
+# TYPE kube_replicaset_metadata_generation gauge
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="heapster-gke-c6d577fc4"} 2
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="kube-dns-autoscaler-6b7f784798"} 1
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="metrics-server-v0.3.3-66cbb7c9f9"} 2
+kube_replicaset_metadata_generation{namespace="default",replicaset="redis-599d64fcb9"} 1
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="event-exporter-v0.3.0-74bf544f8b"} 1
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="metrics-server-v0.3.3-6d96fcc55"} 1
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-54779d5c66"} 1
+kube_replicaset_metadata_generation{namespace="default",replicaset="datadog-monitoring-cluster-agent-5447d77668"} 1
+kube_replicaset_metadata_generation{namespace="default",replicaset="redis-c5c49b48d"} 2
+kube_replicaset_metadata_generation{namespace="default",replicaset="redis-db5b8b6b5"} 2
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="fluentd-gcp-scaler-dd489f778"} 1
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-595d87cbc7"} 2
+kube_replicaset_metadata_generation{namespace="default",replicaset="kube-state-metrics-868bf6f59d"} 1
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="heapster-gke-84994c444b"} 1
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="kube-dns-5dbbd9cc58"} 2
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="l7-default-backend-84c9fcfbb"} 1
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-57b5b7c7fb"} 2
+# HELP kube_replicaset_owner Information about the ReplicaSet's owner.
+# TYPE kube_replicaset_owner gauge
+kube_replicaset_owner{namespace="kube-system",replicaset="heapster-gke-c6d577fc4",owner_kind="Deployment",owner_name="heapster-gke",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="kube-system",replicaset="kube-dns-autoscaler-6b7f784798",owner_kind="Deployment",owner_name="kube-dns-autoscaler",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="kube-system",replicaset="metrics-server-v0.3.3-66cbb7c9f9",owner_kind="Deployment",owner_name="metrics-server-v0.3.3",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="default",replicaset="redis-599d64fcb9",owner_kind="Deployment",owner_name="redis",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="kube-system",replicaset="event-exporter-v0.3.0-74bf544f8b",owner_kind="Deployment",owner_name="event-exporter-v0.3.0",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="kube-system",replicaset="metrics-server-v0.3.3-6d96fcc55",owner_kind="Deployment",owner_name="metrics-server-v0.3.3",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-54779d5c66",owner_kind="Deployment",owner_name="stackdriver-metadata-agent-cluster-level",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="default",replicaset="datadog-monitoring-cluster-agent-5447d77668",owner_kind="Deployment",owner_name="datadog-monitoring-cluster-agent",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="default",replicaset="redis-c5c49b48d",owner_kind="Deployment",owner_name="redis",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="default",replicaset="redis-db5b8b6b5",owner_kind="Deployment",owner_name="redis",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="kube-system",replicaset="fluentd-gcp-scaler-dd489f778",owner_kind="Deployment",owner_name="fluentd-gcp-scaler",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-595d87cbc7",owner_kind="Deployment",owner_name="stackdriver-metadata-agent-cluster-level",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="default",replicaset="kube-state-metrics-868bf6f59d",owner_kind="Deployment",owner_name="kube-state-metrics",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="kube-system",replicaset="heapster-gke-84994c444b",owner_kind="Deployment",owner_name="heapster-gke",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="kube-system",replicaset="kube-dns-5dbbd9cc58",owner_kind="Deployment",owner_name="kube-dns",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="kube-system",replicaset="l7-default-backend-84c9fcfbb",owner_kind="Deployment",owner_name="l7-default-backend",owner_is_controller="true"} 1
+kube_replicaset_owner{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-57b5b7c7fb",owner_kind="Deployment",owner_name="stackdriver-metadata-agent-cluster-level",owner_is_controller="true"} 1
+# HELP kube_replicaset_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_replicaset_labels gauge
+kube_replicaset_labels{namespace="default",replicaset="redis-599d64fcb9",label_app="redis",label_pod_template_hash="599d64fcb9", label_tags_datadoghq_com_env="dev",label_tags_datadoghq_com_service="redis",label_tags_datadoghq_com_version="v1"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="event-exporter-v0.3.0-74bf544f8b",label_k8s_app="event-exporter",label_pod_template_hash="74bf544f8b",label_version="v0.3.0"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="metrics-server-v0.3.3-6d96fcc55",label_k8s_app="metrics-server",label_pod_template_hash="6d96fcc55",label_version="v0.3.3"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-54779d5c66",label_app="stackdriver-metadata-agent",label_cluster_level="true",label_pod_template_hash="54779d5c66"} 1
+kube_replicaset_labels{namespace="default",replicaset="datadog-monitoring-cluster-agent-5447d77668",label_app="datadog-monitoring-cluster-agent",label_pod_template_hash="5447d77668"} 1
+kube_replicaset_labels{namespace="default",replicaset="redis-c5c49b48d",label_ad_datadoghq_com_master_env="dev",label_ad_datadoghq_com_master_service="redis",label_ad_datadoghq_com_master_version="1.0",label_app="redis",label_pod_template_hash="c5c49b48d"} 1
+kube_replicaset_labels{namespace="default",replicaset="redis-db5b8b6b5",label_app="redis",label_pod_template_hash="db5b8b6b5"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="fluentd-gcp-scaler-dd489f778",label_k8s_app="fluentd-gcp-scaler",label_pod_template_hash="dd489f778"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-595d87cbc7",label_app="stackdriver-metadata-agent",label_cluster_level="true",label_pod_template_hash="595d87cbc7"} 1
+kube_replicaset_labels{namespace="default",replicaset="kube-state-metrics-868bf6f59d",label_app_kubernetes_io_instance="kube-state-metrics",label_app_kubernetes_io_name="kube-state-metrics",label_pod_template_hash="868bf6f59d"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="heapster-gke-84994c444b",label_k8s_app="heapster",label_pod_template_hash="84994c444b",label_version="v1.7.2"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="kube-dns-5dbbd9cc58",label_k8s_app="kube-dns",label_pod_template_hash="5dbbd9cc58"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="l7-default-backend-84c9fcfbb",label_k8s_app="glbc",label_name="glbc",label_pod_template_hash="84c9fcfbb"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="stackdriver-metadata-agent-cluster-level-57b5b7c7fb",label_app="stackdriver-metadata-agent",label_cluster_level="true",label_pod_template_hash="57b5b7c7fb"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="heapster-gke-c6d577fc4",label_k8s_app="heapster",label_pod_template_hash="c6d577fc4",label_version="v1.7.2"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="kube-dns-autoscaler-6b7f784798",label_k8s_app="kube-dns-autoscaler",label_pod_template_hash="6b7f784798"} 1
+kube_replicaset_labels{namespace="kube-system",replicaset="metrics-server-v0.3.3-66cbb7c9f9",label_k8s_app="metrics-server",label_pod_template_hash="66cbb7c9f9",label_version="v0.3.3"} 1
+# HELP kube_replicationcontroller_created Unix creation timestamp
+# TYPE kube_replicationcontroller_created gauge
+# HELP kube_replicationcontroller_status_replicas The number of replicas per ReplicationController.
+# TYPE kube_replicationcontroller_status_replicas gauge
+# HELP kube_replicationcontroller_status_fully_labeled_replicas The number of fully labeled replicas per ReplicationController.
+# TYPE kube_replicationcontroller_status_fully_labeled_replicas gauge
+# HELP kube_replicationcontroller_status_ready_replicas The number of ready replicas per ReplicationController.
+# TYPE kube_replicationcontroller_status_ready_replicas gauge
+# HELP kube_replicationcontroller_status_available_replicas The number of available replicas per ReplicationController.
+# TYPE kube_replicationcontroller_status_available_replicas gauge
+# HELP kube_replicationcontroller_status_observed_generation The generation observed by the ReplicationController controller.
+# TYPE kube_replicationcontroller_status_observed_generation gauge
+# HELP kube_replicationcontroller_spec_replicas Number of desired pods for a ReplicationController.
+# TYPE kube_replicationcontroller_spec_replicas gauge
+# HELP kube_replicationcontroller_metadata_generation Sequence number representing a specific generation of the desired state.
+# TYPE kube_replicationcontroller_metadata_generation gauge
+# HELP kube_resourcequota_created Unix creation timestamp
+# TYPE kube_resourcequota_created gauge
+kube_resourcequota_created{namespace="default",resourcequota="gke-resource-quotas"} 1.580243285e+09
+kube_resourcequota_created{namespace="kube-node-lease",resourcequota="gke-resource-quotas"} 1.580243285e+09
+kube_resourcequota_created{namespace="kube-public",resourcequota="gke-resource-quotas"} 1.580243286e+09
+kube_resourcequota_created{namespace="kube-system",resourcequota="gke-resource-quotas"} 1.580243287e+09
+# HELP kube_resourcequota Information about resource quota.
+# TYPE kube_resourcequota gauge
+kube_resourcequota{namespace="default",resourcequota="gke-resource-quotas",resource="count/ingresses.extensions",type="hard"} 100
+kube_resourcequota{namespace="default",resourcequota="gke-resource-quotas",resource="count/jobs.batch",type="hard"} 5000
+kube_resourcequota{namespace="default",resourcequota="gke-resource-quotas",resource="pods",type="hard"} 1500
+kube_resourcequota{namespace="default",resourcequota="gke-resource-quotas",resource="services",type="hard"} 500
+kube_resourcequota{namespace="default",resourcequota="gke-resource-quotas",resource="count/jobs.batch",type="used"} 6
+kube_resourcequota{namespace="default",resourcequota="gke-resource-quotas",resource="pods",type="used"} 9
+kube_resourcequota{namespace="default",resourcequota="gke-resource-quotas",resource="services",type="used"} 5
+kube_resourcequota{namespace="default",resourcequota="gke-resource-quotas",resource="count/ingresses.extensions",type="used"} 0
+kube_resourcequota{namespace="kube-node-lease",resourcequota="gke-resource-quotas",resource="services",type="hard"} 500
+kube_resourcequota{namespace="kube-node-lease",resourcequota="gke-resource-quotas",resource="count/ingresses.extensions",type="hard"} 100
+kube_resourcequota{namespace="kube-node-lease",resourcequota="gke-resource-quotas",resource="count/jobs.batch",type="hard"} 5000
+kube_resourcequota{namespace="kube-node-lease",resourcequota="gke-resource-quotas",resource="pods",type="hard"} 1500
+kube_resourcequota{namespace="kube-node-lease",resourcequota="gke-resource-quotas",resource="count/jobs.batch",type="used"} 0
+kube_resourcequota{namespace="kube-node-lease",resourcequota="gke-resource-quotas",resource="pods",type="used"} 0
+kube_resourcequota{namespace="kube-node-lease",resourcequota="gke-resource-quotas",resource="services",type="used"} 0
+kube_resourcequota{namespace="kube-node-lease",resourcequota="gke-resource-quotas",resource="count/ingresses.extensions",type="used"} 0
+kube_resourcequota{namespace="kube-public",resourcequota="gke-resource-quotas",resource="pods",type="hard"} 1500
+kube_resourcequota{namespace="kube-public",resourcequota="gke-resource-quotas",resource="services",type="hard"} 500
+kube_resourcequota{namespace="kube-public",resourcequota="gke-resource-quotas",resource="count/ingresses.extensions",type="hard"} 100
+kube_resourcequota{namespace="kube-public",resourcequota="gke-resource-quotas",resource="count/jobs.batch",type="hard"} 5000
+kube_resourcequota{namespace="kube-public",resourcequota="gke-resource-quotas",resource="count/ingresses.extensions",type="used"} 0
+kube_resourcequota{namespace="kube-public",resourcequota="gke-resource-quotas",resource="count/jobs.batch",type="used"} 0
+kube_resourcequota{namespace="kube-public",resourcequota="gke-resource-quotas",resource="pods",type="used"} 0
+kube_resourcequota{namespace="kube-public",resourcequota="gke-resource-quotas",resource="services",type="used"} 0
+kube_resourcequota{namespace="kube-system",resourcequota="gke-resource-quotas",resource="count/jobs.batch",type="hard"} 5000
+kube_resourcequota{namespace="kube-system",resourcequota="gke-resource-quotas",resource="pods",type="hard"} 1500
+kube_resourcequota{namespace="kube-system",resourcequota="gke-resource-quotas",resource="services",type="hard"} 500
+kube_resourcequota{namespace="kube-system",resourcequota="gke-resource-quotas",resource="count/ingresses.extensions",type="hard"} 100
+kube_resourcequota{namespace="kube-system",resourcequota="gke-resource-quotas",resource="count/ingresses.extensions",type="used"} 0
+kube_resourcequota{namespace="kube-system",resourcequota="gke-resource-quotas",resource="count/jobs.batch",type="used"} 0
+kube_resourcequota{namespace="kube-system",resourcequota="gke-resource-quotas",resource="pods",type="used"} 18
+kube_resourcequota{namespace="kube-system",resourcequota="gke-resource-quotas",resource="services",type="used"} 4
+# HELP kube_secret_info Information about secret.
+# TYPE kube_secret_info gauge
+kube_secret_info{namespace="kube-system",secret="expand-controller-token-fv7nr"} 1
+kube_secret_info{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v1"} 1
+kube_secret_info{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v5"} 1
+kube_secret_info{namespace="default",secret="sh.helm.release.v1.kube-state-metrics.v1"} 1
+kube_secret_info{namespace="kube-system",secret="default-token-qjvgq"} 1
+kube_secret_info{namespace="kube-system",secret="namespace-controller-token-xw22r"} 1
+kube_secret_info{namespace="kube-system",secret="ttl-controller-token-s2wsx"} 1
+kube_secret_info{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v4"} 1
+kube_secret_info{namespace="kube-system",secret="cloud-provider-token-skqf9"} 1
+kube_secret_info{namespace="kube-system",secret="fluentd-gcp-scaler-token-nk4z6"} 1
+kube_secret_info{namespace="kube-system",secret="metadata-agent-token-tbw5p"} 1
+kube_secret_info{namespace="default",secret="kube-state-metrics-token-t2trh"} 1
+kube_secret_info{namespace="kube-system",secret="pv-protection-controller-token-6pm4s"} 1
+kube_secret_info{namespace="kube-system",secret="heapster-token-qqs78"} 1
+kube_secret_info{namespace="kube-system",secret="kube-dns-token-gzf68"} 1
+kube_secret_info{namespace="kube-node-lease",secret="default-token-w9jrx"} 1
+kube_secret_info{namespace="kube-system",secret="clusterrole-aggregation-controller-token-6rr54"} 1
+kube_secret_info{namespace="kube-system",secret="disruption-controller-token-2rt2n"} 1
+kube_secret_info{namespace="kube-system",secret="event-exporter-sa-token-mp5lw"} 1
+kube_secret_info{namespace="kube-system",secret="node-controller-token-v8m6l"} 1
+kube_secret_info{namespace="default",secret="datadog-monitoring-cluster-agent-token-9q26n"} 1
+kube_secret_info{namespace="default",secret="datadog-monitoring-token-lqldn"} 1
+kube_secret_info{namespace="kube-system",secret="prometheus-to-sd-token-wntrn"} 1
+kube_secret_info{namespace="kube-system",secret="service-account-controller-token-9dzfv"} 1
+kube_secret_info{namespace="default",secret="default-token-l9w57"} 1
+kube_secret_info{namespace="kube-system",secret="fluentd-gcp-token-msqp2"} 1
+kube_secret_info{namespace="kube-system",secret="attachdetach-controller-token-4mbdk"} 1
+kube_secret_info{namespace="kube-system",secret="cronjob-controller-token-b2cqs"} 1
+kube_secret_info{namespace="kube-system",secret="daemon-set-controller-token-k5lr7"} 1
+kube_secret_info{namespace="kube-system",secret="statefulset-controller-token-849np"} 1
+kube_secret_info{namespace="kube-system",secret="certificate-controller-token-cbcst"} 1
+kube_secret_info{namespace="kube-system",secret="replication-controller-token-748lh"} 1
+kube_secret_info{namespace="kube-system",secret="replicaset-controller-token-62d4g"} 1
+kube_secret_info{namespace="kube-system",secret="resourcequota-controller-token-g6fml"} 1
+kube_secret_info{namespace="kube-system",secret="deployment-controller-token-fth7q"} 1
+kube_secret_info{namespace="kube-system",secret="generic-garbage-collector-token-zvlhm"} 1
+kube_secret_info{namespace="kube-system",secret="horizontal-pod-autoscaler-token-9bzgq"} 1
+kube_secret_info{namespace="kube-system",secret="metrics-server-token-bcnpz"} 1
+kube_secret_info{namespace="default",secret="datadog-monitoring-cluster-agent"} 1
+kube_secret_info{namespace="kube-system",secret="pod-garbage-collector-token-9kj7f"} 1
+kube_secret_info{namespace="kube-system",secret="pvc-protection-controller-token-qwbx9"} 1
+kube_secret_info{namespace="kube-system",secret="persistent-volume-binder-token-srsqx"} 1
+kube_secret_info{namespace="kube-system",secret="service-controller-token-v97cz"} 1
+kube_secret_info{namespace="kube-public",secret="default-token-vp8jd"} 1
+kube_secret_info{namespace="kube-system",secret="job-controller-token-45xv2"} 1
+kube_secret_info{namespace="kube-system",secret="metadata-proxy-token-jcw8x"} 1
+kube_secret_info{namespace="default",secret="datadog-monitoring"} 1
+kube_secret_info{namespace="default",secret="datadog-monitoring-appkey"} 1
+kube_secret_info{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v2"} 1
+kube_secret_info{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v3"} 1
+kube_secret_info{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v6"} 1
+kube_secret_info{namespace="kube-system",secret="endpoint-controller-token-6nrxj"} 1
+kube_secret_info{namespace="kube-system",secret="kube-dns-autoscaler-token-mthtq"} 1
+# HELP kube_secret_type Type about secret.
+# TYPE kube_secret_type gauge
+kube_secret_type{namespace="kube-system",secret="default-token-qjvgq",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="namespace-controller-token-xw22r",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="ttl-controller-token-s2wsx",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="metadata-agent-token-tbw5p",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v4",type="helm.sh/release.v1"} 1
+kube_secret_type{namespace="kube-system",secret="cloud-provider-token-skqf9",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="fluentd-gcp-scaler-token-nk4z6",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="pv-protection-controller-token-6pm4s",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="kube-state-metrics-token-t2trh",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="disruption-controller-token-2rt2n",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="event-exporter-sa-token-mp5lw",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="heapster-token-qqs78",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="kube-dns-token-gzf68",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-node-lease",secret="default-token-w9jrx",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="clusterrole-aggregation-controller-token-6rr54",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="node-controller-token-v8m6l",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="datadog-monitoring-cluster-agent-token-9q26n",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="datadog-monitoring-token-lqldn",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="prometheus-to-sd-token-wntrn",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="service-account-controller-token-9dzfv",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="default-token-l9w57",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="attachdetach-controller-token-4mbdk",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="cronjob-controller-token-b2cqs",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="fluentd-gcp-token-msqp2",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="daemon-set-controller-token-k5lr7",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="statefulset-controller-token-849np",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="certificate-controller-token-cbcst",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="replication-controller-token-748lh",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="horizontal-pod-autoscaler-token-9bzgq",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="replicaset-controller-token-62d4g",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="resourcequota-controller-token-g6fml",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="deployment-controller-token-fth7q",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="generic-garbage-collector-token-zvlhm",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="metrics-server-token-bcnpz",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="datadog-monitoring-cluster-agent",type="Opaque"} 1
+kube_secret_type{namespace="kube-system",secret="pod-garbage-collector-token-9kj7f",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="pvc-protection-controller-token-qwbx9",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="job-controller-token-45xv2",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="metadata-proxy-token-jcw8x",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="persistent-volume-binder-token-srsqx",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="service-controller-token-v97cz",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-public",secret="default-token-vp8jd",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="datadog-monitoring",type="Opaque"} 1
+kube_secret_type{namespace="default",secret="datadog-monitoring-appkey",type="Opaque"} 1
+kube_secret_type{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v2",type="helm.sh/release.v1"} 1
+kube_secret_type{namespace="kube-system",secret="endpoint-controller-token-6nrxj",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="kube-system",secret="kube-dns-autoscaler-token-mthtq",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v3",type="helm.sh/release.v1"} 1
+kube_secret_type{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v6",type="helm.sh/release.v1"} 1
+kube_secret_type{namespace="kube-system",secret="expand-controller-token-fv7nr",type="kubernetes.io/service-account-token"} 1
+kube_secret_type{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v1",type="helm.sh/release.v1"} 1
+kube_secret_type{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v5",type="helm.sh/release.v1"} 1
+kube_secret_type{namespace="default",secret="sh.helm.release.v1.kube-state-metrics.v1",type="helm.sh/release.v1"} 1
+# HELP kube_secret_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_secret_labels gauge
+kube_secret_labels{namespace="kube-system",secret="heapster-token-qqs78"} 1
+kube_secret_labels{namespace="kube-system",secret="kube-dns-token-gzf68"} 1
+kube_secret_labels{namespace="kube-node-lease",secret="default-token-w9jrx"} 1
+kube_secret_labels{namespace="kube-system",secret="clusterrole-aggregation-controller-token-6rr54"} 1
+kube_secret_labels{namespace="kube-system",secret="disruption-controller-token-2rt2n"} 1
+kube_secret_labels{namespace="kube-system",secret="event-exporter-sa-token-mp5lw"} 1
+kube_secret_labels{namespace="kube-system",secret="node-controller-token-v8m6l"} 1
+kube_secret_labels{namespace="default",secret="datadog-monitoring-cluster-agent-token-9q26n"} 1
+kube_secret_labels{namespace="default",secret="datadog-monitoring-token-lqldn"} 1
+kube_secret_labels{namespace="kube-system",secret="prometheus-to-sd-token-wntrn"} 1
+kube_secret_labels{namespace="kube-system",secret="service-account-controller-token-9dzfv"} 1
+kube_secret_labels{namespace="default",secret="default-token-l9w57"} 1
+kube_secret_labels{namespace="kube-system",secret="fluentd-gcp-token-msqp2"} 1
+kube_secret_labels{namespace="kube-system",secret="attachdetach-controller-token-4mbdk"} 1
+kube_secret_labels{namespace="kube-system",secret="cronjob-controller-token-b2cqs"} 1
+kube_secret_labels{namespace="kube-system",secret="daemon-set-controller-token-k5lr7"} 1
+kube_secret_labels{namespace="kube-system",secret="statefulset-controller-token-849np"} 1
+kube_secret_labels{namespace="kube-system",secret="certificate-controller-token-cbcst"} 1
+kube_secret_labels{namespace="kube-system",secret="replication-controller-token-748lh"} 1
+kube_secret_labels{namespace="kube-system",secret="replicaset-controller-token-62d4g"} 1
+kube_secret_labels{namespace="kube-system",secret="resourcequota-controller-token-g6fml"} 1
+kube_secret_labels{namespace="kube-system",secret="deployment-controller-token-fth7q"} 1
+kube_secret_labels{namespace="kube-system",secret="generic-garbage-collector-token-zvlhm"} 1
+kube_secret_labels{namespace="kube-system",secret="horizontal-pod-autoscaler-token-9bzgq"} 1
+kube_secret_labels{namespace="kube-system",secret="metrics-server-token-bcnpz"} 1
+kube_secret_labels{namespace="default",secret="datadog-monitoring-cluster-agent",label_app_kubernetes_io_instance="datadog-monitoring",label_app_kubernetes_io_managed_by="Helm",label_app_kubernetes_io_name="datadog-monitoring",label_app_kubernetes_io_version="7",label_helm_sh_chart="datadog-2.0.12"} 1
+kube_secret_labels{namespace="kube-system",secret="pod-garbage-collector-token-9kj7f"} 1
+kube_secret_labels{namespace="kube-system",secret="pvc-protection-controller-token-qwbx9"} 1
+kube_secret_labels{namespace="kube-system",secret="persistent-volume-binder-token-srsqx"} 1
+kube_secret_labels{namespace="kube-system",secret="service-controller-token-v97cz"} 1
+kube_secret_labels{namespace="kube-public",secret="default-token-vp8jd"} 1
+kube_secret_labels{namespace="kube-system",secret="job-controller-token-45xv2"} 1
+kube_secret_labels{namespace="kube-system",secret="metadata-proxy-token-jcw8x"} 1
+kube_secret_labels{namespace="default",secret="datadog-monitoring",label_app_kubernetes_io_instance="datadog-monitoring",label_app_kubernetes_io_managed_by="Helm",label_app_kubernetes_io_name="datadog-monitoring",label_app_kubernetes_io_version="7",label_helm_sh_chart="datadog-2.0.12"} 1
+kube_secret_labels{namespace="default",secret="datadog-monitoring-appkey",label_app_kubernetes_io_instance="datadog-monitoring",label_app_kubernetes_io_managed_by="Helm",label_app_kubernetes_io_name="datadog-monitoring",label_app_kubernetes_io_version="7",label_helm_sh_chart="datadog-2.0.12"} 1
+kube_secret_labels{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v2",label_modifiedAt="1584562355",label_name="datadog-monitoring",label_owner="helm",label_status="superseded",label_version="2"} 1
+kube_secret_labels{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v3",label_modifiedAt="1584562327",label_name="datadog-monitoring",label_owner="helm",label_status="failed",label_version="3"} 1
+kube_secret_labels{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v6",label_modifiedAt="1584733743",label_name="datadog-monitoring",label_owner="helm",label_status="deployed",label_version="6"} 1
+kube_secret_labels{namespace="kube-system",secret="endpoint-controller-token-6nrxj"} 1
+kube_secret_labels{namespace="kube-system",secret="kube-dns-autoscaler-token-mthtq"} 1
+kube_secret_labels{namespace="kube-system",secret="expand-controller-token-fv7nr"} 1
+kube_secret_labels{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v1",label_modifiedAt="1584562236",label_name="datadog-monitoring",label_owner="helm",label_status="superseded",label_version="1"} 1
+kube_secret_labels{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v5",label_modifiedAt="1584733743",label_name="datadog-monitoring",label_owner="helm",label_status="superseded",label_version="5"} 1
+kube_secret_labels{namespace="default",secret="sh.helm.release.v1.kube-state-metrics.v1",label_modifiedAt="1582669594",label_name="kube-state-metrics",label_owner="helm",label_status="deployed",label_version="1"} 1
+kube_secret_labels{namespace="kube-system",secret="default-token-qjvgq"} 1
+kube_secret_labels{namespace="kube-system",secret="namespace-controller-token-xw22r"} 1
+kube_secret_labels{namespace="kube-system",secret="ttl-controller-token-s2wsx"} 1
+kube_secret_labels{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v4",label_modifiedAt="1584562464",label_name="datadog-monitoring",label_owner="helm",label_status="superseded",label_version="4"} 1
+kube_secret_labels{namespace="kube-system",secret="cloud-provider-token-skqf9"} 1
+kube_secret_labels{namespace="kube-system",secret="fluentd-gcp-scaler-token-nk4z6"} 1
+kube_secret_labels{namespace="kube-system",secret="metadata-agent-token-tbw5p"} 1
+kube_secret_labels{namespace="default",secret="kube-state-metrics-token-t2trh"} 1
+kube_secret_labels{namespace="kube-system",secret="pv-protection-controller-token-6pm4s"} 1
+# HELP kube_secret_created Unix creation timestamp
+# TYPE kube_secret_created gauge
+kube_secret_created{namespace="kube-system",secret="expand-controller-token-fv7nr"} 1.580242899e+09
+kube_secret_created{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v1"} 1.58456206e+09
+kube_secret_created{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v5"} 1.584562461e+09
+kube_secret_created{namespace="default",secret="sh.helm.release.v1.kube-state-metrics.v1"} 1.582669592e+09
+kube_secret_created{namespace="kube-system",secret="default-token-qjvgq"} 1.580242901e+09
+kube_secret_created{namespace="kube-system",secret="namespace-controller-token-xw22r"} 1.580242899e+09
+kube_secret_created{namespace="kube-system",secret="ttl-controller-token-s2wsx"} 1.580242899e+09
+kube_secret_created{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v4"} 1.584562353e+09
+kube_secret_created{namespace="kube-system",secret="cloud-provider-token-skqf9"} 1.580242888e+09
+kube_secret_created{namespace="kube-system",secret="fluentd-gcp-scaler-token-nk4z6"} 1.580242905e+09
+kube_secret_created{namespace="kube-system",secret="metadata-agent-token-tbw5p"} 1.580242905e+09
+kube_secret_created{namespace="kube-system",secret="pv-protection-controller-token-6pm4s"} 1.580242889e+09
+kube_secret_created{namespace="default",secret="kube-state-metrics-token-t2trh"} 1.582669594e+09
+kube_secret_created{namespace="kube-system",secret="event-exporter-sa-token-mp5lw"} 1.580242906e+09
+kube_secret_created{namespace="kube-system",secret="heapster-token-qqs78"} 1.580242905e+09
+kube_secret_created{namespace="kube-system",secret="kube-dns-token-gzf68"} 1.580242904e+09
+kube_secret_created{namespace="kube-node-lease",secret="default-token-w9jrx"} 1.580242901e+09
+kube_secret_created{namespace="kube-system",secret="clusterrole-aggregation-controller-token-6rr54"} 1.580242899e+09
+kube_secret_created{namespace="kube-system",secret="disruption-controller-token-2rt2n"} 1.5802429e+09
+kube_secret_created{namespace="kube-system",secret="node-controller-token-v8m6l"} 1.580242888e+09
+kube_secret_created{namespace="default",secret="datadog-monitoring-cluster-agent-token-9q26n"} 1.58456206e+09
+kube_secret_created{namespace="default",secret="datadog-monitoring-token-lqldn"} 1.58456206e+09
+kube_secret_created{namespace="kube-system",secret="service-account-controller-token-9dzfv"} 1.580242899e+09
+kube_secret_created{namespace="kube-system",secret="prometheus-to-sd-token-wntrn"} 1.580242906e+09
+kube_secret_created{namespace="default",secret="default-token-l9w57"} 1.580242901e+09
+kube_secret_created{namespace="kube-system",secret="cronjob-controller-token-b2cqs"} 1.580242889e+09
+kube_secret_created{namespace="kube-system",secret="fluentd-gcp-token-msqp2"} 1.580242905e+09
+kube_secret_created{namespace="kube-system",secret="attachdetach-controller-token-4mbdk"} 1.5802429e+09
+kube_secret_created{namespace="kube-system",secret="daemon-set-controller-token-k5lr7"} 1.5802429e+09
+kube_secret_created{namespace="kube-system",secret="statefulset-controller-token-849np"} 1.580242899e+09
+kube_secret_created{namespace="kube-system",secret="certificate-controller-token-cbcst"} 1.580242888e+09
+kube_secret_created{namespace="kube-system",secret="replication-controller-token-748lh"} 1.580242899e+09
+kube_secret_created{namespace="kube-system",secret="replicaset-controller-token-62d4g"} 1.580242899e+09
+kube_secret_created{namespace="kube-system",secret="resourcequota-controller-token-g6fml"} 1.5802429e+09
+kube_secret_created{namespace="kube-system",secret="deployment-controller-token-fth7q"} 1.580242899e+09
+kube_secret_created{namespace="kube-system",secret="generic-garbage-collector-token-zvlhm"} 1.580242888e+09
+kube_secret_created{namespace="kube-system",secret="horizontal-pod-autoscaler-token-9bzgq"} 1.580242889e+09
+kube_secret_created{namespace="kube-system",secret="metrics-server-token-bcnpz"} 1.580242907e+09
+kube_secret_created{namespace="default",secret="datadog-monitoring-cluster-agent"} 1.58456206e+09
+kube_secret_created{namespace="kube-system",secret="pod-garbage-collector-token-9kj7f"} 1.580242889e+09
+kube_secret_created{namespace="kube-system",secret="pvc-protection-controller-token-qwbx9"} 1.580242899e+09
+kube_secret_created{namespace="kube-system",secret="metadata-proxy-token-jcw8x"} 1.580242906e+09
+kube_secret_created{namespace="kube-system",secret="persistent-volume-binder-token-srsqx"} 1.580242899e+09
+kube_secret_created{namespace="kube-system",secret="service-controller-token-v97cz"} 1.5802429e+09
+kube_secret_created{namespace="kube-public",secret="default-token-vp8jd"} 1.580242901e+09
+kube_secret_created{namespace="kube-system",secret="job-controller-token-45xv2"} 1.580242899e+09
+kube_secret_created{namespace="default",secret="datadog-monitoring"} 1.58456206e+09
+kube_secret_created{namespace="default",secret="datadog-monitoring-appkey"} 1.58456206e+09
+kube_secret_created{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v2"} 1.584562233e+09
+kube_secret_created{namespace="kube-system",secret="kube-dns-autoscaler-token-mthtq"} 1.580242911e+09
+kube_secret_created{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v3"} 1.584562324e+09
+kube_secret_created{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v6"} 1.584733739e+09
+kube_secret_created{namespace="kube-system",secret="endpoint-controller-token-6nrxj"} 1.5802429e+09
+# HELP kube_secret_metadata_resource_version Resource version representing a specific version of secret.
+# TYPE kube_secret_metadata_resource_version gauge
+kube_secret_metadata_resource_version{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v1"} 1.7664037e+07
+kube_secret_metadata_resource_version{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v5"} 1.8330649e+07
+kube_secret_metadata_resource_version{namespace="default",secret="sh.helm.release.v1.kube-state-metrics.v1"} 9.923565e+06
+kube_secret_metadata_resource_version{namespace="kube-system",secret="expand-controller-token-fv7nr"} 215
+kube_secret_metadata_resource_version{namespace="kube-system",secret="default-token-qjvgq"} 247
+kube_secret_metadata_resource_version{namespace="kube-system",secret="namespace-controller-token-xw22r"} 206
+kube_secret_metadata_resource_version{namespace="kube-system",secret="ttl-controller-token-s2wsx"} 200
+kube_secret_metadata_resource_version{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v4"} 1.7665013e+07
+kube_secret_metadata_resource_version{namespace="kube-system",secret="cloud-provider-token-skqf9"} 152
+kube_secret_metadata_resource_version{namespace="kube-system",secret="fluentd-gcp-scaler-token-nk4z6"} 343
+kube_secret_metadata_resource_version{namespace="kube-system",secret="metadata-agent-token-tbw5p"} 326
+kube_secret_metadata_resource_version{namespace="default",secret="kube-state-metrics-token-t2trh"} 9.923567e+06
+kube_secret_metadata_resource_version{namespace="kube-system",secret="pv-protection-controller-token-6pm4s"} 168
+kube_secret_metadata_resource_version{namespace="kube-node-lease",secret="default-token-w9jrx"} 256
+kube_secret_metadata_resource_version{namespace="kube-system",secret="clusterrole-aggregation-controller-token-6rr54"} 194
+kube_secret_metadata_resource_version{namespace="kube-system",secret="disruption-controller-token-2rt2n"} 240
+kube_secret_metadata_resource_version{namespace="kube-system",secret="event-exporter-sa-token-mp5lw"} 351
+kube_secret_metadata_resource_version{namespace="kube-system",secret="heapster-token-qqs78"} 309
+kube_secret_metadata_resource_version{namespace="kube-system",secret="kube-dns-token-gzf68"} 274
+kube_secret_metadata_resource_version{namespace="kube-system",secret="node-controller-token-v8m6l"} 158
+kube_secret_metadata_resource_version{namespace="default",secret="datadog-monitoring-cluster-agent-token-9q26n"} 1.7663176e+07
+kube_secret_metadata_resource_version{namespace="default",secret="datadog-monitoring-token-lqldn"} 1.7663175e+07
+kube_secret_metadata_resource_version{namespace="kube-system",secret="prometheus-to-sd-token-wntrn"} 367
+kube_secret_metadata_resource_version{namespace="kube-system",secret="service-account-controller-token-9dzfv"} 191
+kube_secret_metadata_resource_version{namespace="default",secret="default-token-l9w57"} 246
+kube_secret_metadata_resource_version{namespace="kube-system",secret="attachdetach-controller-token-4mbdk"} 227
+kube_secret_metadata_resource_version{namespace="kube-system",secret="cronjob-controller-token-b2cqs"} 174
+kube_secret_metadata_resource_version{namespace="kube-system",secret="fluentd-gcp-token-msqp2"} 338
+kube_secret_metadata_resource_version{namespace="kube-system",secret="daemon-set-controller-token-k5lr7"} 237
+kube_secret_metadata_resource_version{namespace="kube-system",secret="statefulset-controller-token-849np"} 212
+kube_secret_metadata_resource_version{namespace="kube-system",secret="certificate-controller-token-cbcst"} 154
+kube_secret_metadata_resource_version{namespace="kube-system",secret="replication-controller-token-748lh"} 218
+kube_secret_metadata_resource_version{namespace="kube-system",secret="deployment-controller-token-fth7q"} 210
+kube_secret_metadata_resource_version{namespace="kube-system",secret="generic-garbage-collector-token-zvlhm"} 161
+kube_secret_metadata_resource_version{namespace="kube-system",secret="horizontal-pod-autoscaler-token-9bzgq"} 165
+kube_secret_metadata_resource_version{namespace="kube-system",secret="replicaset-controller-token-62d4g"} 189
+kube_secret_metadata_resource_version{namespace="kube-system",secret="resourcequota-controller-token-g6fml"} 234
+kube_secret_metadata_resource_version{namespace="kube-system",secret="metrics-server-token-bcnpz"} 385
+kube_secret_metadata_resource_version{namespace="default",secret="datadog-monitoring-cluster-agent"} 1.8330614e+07
+kube_secret_metadata_resource_version{namespace="kube-system",secret="pod-garbage-collector-token-9kj7f"} 171
+kube_secret_metadata_resource_version{namespace="kube-system",secret="pvc-protection-controller-token-qwbx9"} 221
+kube_secret_metadata_resource_version{namespace="kube-public",secret="default-token-vp8jd"} 250
+kube_secret_metadata_resource_version{namespace="kube-system",secret="job-controller-token-45xv2"} 198
+kube_secret_metadata_resource_version{namespace="kube-system",secret="metadata-proxy-token-jcw8x"} 374
+kube_secret_metadata_resource_version{namespace="kube-system",secret="persistent-volume-binder-token-srsqx"} 203
+kube_secret_metadata_resource_version{namespace="kube-system",secret="service-controller-token-v97cz"} 224
+kube_secret_metadata_resource_version{namespace="default",secret="datadog-monitoring"} 1.8330615e+07
+kube_secret_metadata_resource_version{namespace="default",secret="datadog-monitoring-appkey"} 1.8330616e+07
+kube_secret_metadata_resource_version{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v2"} 1.7664545e+07
+kube_secret_metadata_resource_version{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v3"} 1.7664429e+07
+kube_secret_metadata_resource_version{namespace="default",secret="sh.helm.release.v1.datadog-monitoring.v6"} 1.833065e+07
+kube_secret_metadata_resource_version{namespace="kube-system",secret="endpoint-controller-token-6nrxj"} 231
+kube_secret_metadata_resource_version{namespace="kube-system",secret="kube-dns-autoscaler-token-mthtq"} 420
+# HELP kube_service_info Information about service.
+# TYPE kube_service_info gauge
+kube_service_info{namespace="default",service="nginx",cluster_ip="None",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="default",service="datadog-monitoring-cluster-agent-metrics-api",cluster_ip="10.8.41.80",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="default",service="kube-state-metrics",cluster_ip="10.8.44.112",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="kube-system",service="kube-dns",cluster_ip="10.8.32.10",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="kube-system",service="heapster",cluster_ip="10.8.35.123",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="kube-system",service="metrics-server",cluster_ip="10.8.41.98",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="default",service="datadog-monitoring-cluster-agent",cluster_ip="10.8.47.177",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="default",service="kubernetes",cluster_ip="10.8.32.1",external_name="",load_balancer_ip=""} 1
+kube_service_info{namespace="kube-system",service="default-http-backend",cluster_ip="10.8.43.49",external_name="",load_balancer_ip=""} 1
+# HELP kube_service_created Unix creation timestamp
+# TYPE kube_service_created gauge
+kube_service_created{namespace="default",service="datadog-monitoring-cluster-agent"} 1.584562061e+09
+kube_service_created{namespace="default",service="kubernetes"} 1.580242886e+09
+kube_service_created{namespace="kube-system",service="default-http-backend"} 1.580242904e+09
+kube_service_created{namespace="kube-system",service="heapster"} 1.580242905e+09
+kube_service_created{namespace="kube-system",service="metrics-server"} 1.580242908e+09
+kube_service_created{namespace="default",service="datadog-monitoring-cluster-agent-metrics-api"} 1.584562061e+09
+kube_service_created{namespace="default",service="kube-state-metrics"} 1.582669593e+09
+kube_service_created{namespace="kube-system",service="kube-dns"} 1.580242904e+09
+kube_service_created{namespace="default",service="nginx"} 1.586188625e+09
+# HELP kube_service_spec_type Type about service.
+# TYPE kube_service_spec_type gauge
+kube_service_spec_type{namespace="default",service="datadog-monitoring-cluster-agent",type="ClusterIP"} 1
+kube_service_spec_type{namespace="default",service="kubernetes",type="ClusterIP"} 1
+kube_service_spec_type{namespace="kube-system",service="default-http-backend",type="NodePort"} 1
+kube_service_spec_type{namespace="kube-system",service="heapster",type="ClusterIP"} 1
+kube_service_spec_type{namespace="kube-system",service="metrics-server",type="ClusterIP"} 1
+kube_service_spec_type{namespace="default",service="datadog-monitoring-cluster-agent-metrics-api",type="ClusterIP"} 1
+kube_service_spec_type{namespace="default",service="kube-state-metrics",type="ClusterIP"} 1
+kube_service_spec_type{namespace="kube-system",service="kube-dns",type="ClusterIP"} 1
+kube_service_spec_type{namespace="default",service="nginx",type="ClusterIP"} 1
+# HELP kube_service_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_service_labels gauge
+kube_service_labels{namespace="kube-system",service="metrics-server",label_addonmanager_kubernetes_io_mode="Reconcile",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="Metrics-server"} 1
+kube_service_labels{namespace="default",service="datadog-monitoring-cluster-agent",label_app_kubernetes_io_instance="datadog-monitoring",label_app_kubernetes_io_managed_by="Helm",label_app_kubernetes_io_name="datadog-monitoring",label_app_kubernetes_io_version="7",label_helm_sh_chart="datadog-2.0.12"} 1
+kube_service_labels{namespace="default",service="kubernetes",label_component="apiserver",label_provider="kubernetes"} 1
+kube_service_labels{namespace="kube-system",service="default-http-backend",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="glbc",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="GLBCDefaultBackend"} 1
+kube_service_labels{namespace="kube-system",service="heapster",label_addonmanager_kubernetes_io_mode="Reconcile",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="Heapster"} 1
+kube_service_labels{namespace="default",service="datadog-monitoring-cluster-agent-metrics-api",label_app="datadog-monitoring",label_app_kubernetes_io_instance="datadog-monitoring",label_app_kubernetes_io_managed_by="Helm",label_app_kubernetes_io_name="datadog-monitoring",label_app_kubernetes_io_version="7",label_chart="datadog-2.0.12",label_helm_sh_chart="datadog-2.0.12",label_heritage="Helm",label_release="datadog-monitoring"} 1
+kube_service_labels{namespace="default",service="kube-state-metrics",label_app_kubernetes_io_instance="kube-state-metrics",label_app_kubernetes_io_managed_by="Helm",label_app_kubernetes_io_name="kube-state-metrics",label_helm_sh_chart="kube-state-metrics-2.6.2"} 1
+kube_service_labels{namespace="kube-system",service="kube-dns",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="kube-dns",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="KubeDNS"} 1
+kube_service_labels{namespace="default",service="nginx",label_app="nginx"} 1
+# HELP kube_service_spec_external_ip Service external ips. One series for each ip
+# TYPE kube_service_spec_external_ip gauge
+# HELP kube_service_status_load_balancer_ingress Service load balancer ingress status
+# TYPE kube_service_status_load_balancer_ingress gauge
+# HELP kube_statefulset_created Unix creation timestamp
+# TYPE kube_statefulset_created gauge
+kube_statefulset_created{namespace="default",statefulset="web"} 1.586188625e+09
+# HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
+# TYPE kube_statefulset_status_replicas gauge
+kube_statefulset_status_replicas{namespace="default",statefulset="web"} 2
+# HELP kube_statefulset_status_replicas_current The number of current replicas per StatefulSet.
+# TYPE kube_statefulset_status_replicas_current gauge
+kube_statefulset_status_replicas_current{namespace="default",statefulset="web"} 2
+# HELP kube_statefulset_status_replicas_ready The number of ready replicas per StatefulSet.
+# TYPE kube_statefulset_status_replicas_ready gauge
+kube_statefulset_status_replicas_ready{namespace="default",statefulset="web"} 2
+# HELP kube_statefulset_status_replicas_updated The number of updated replicas per StatefulSet.
+# TYPE kube_statefulset_status_replicas_updated gauge
+kube_statefulset_status_replicas_updated{namespace="default",statefulset="web"} 2
+# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
+# TYPE kube_statefulset_status_observed_generation gauge
+kube_statefulset_status_observed_generation{namespace="default",statefulset="web"} 1
+# HELP kube_statefulset_replicas Number of desired pods for a StatefulSet.
+# TYPE kube_statefulset_replicas gauge
+kube_statefulset_replicas{namespace="default",statefulset="web"} 2
+# HELP kube_statefulset_metadata_generation Sequence number representing a specific generation of the desired state for the StatefulSet.
+# TYPE kube_statefulset_metadata_generation gauge
+kube_statefulset_metadata_generation{namespace="default",statefulset="web"} 1
+# HELP kube_statefulset_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_statefulset_labels gauge
+kube_statefulset_labels{namespace="default",statefulset="web",label_tags_datadoghq_com_env="dev",label_tags_datadoghq_com_service="web",label_tags_datadoghq_com_version="v1"} 1
+# HELP kube_statefulset_status_current_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+# TYPE kube_statefulset_status_current_revision gauge
+kube_statefulset_status_current_revision{namespace="default",statefulset="web",revision="web-b46f789c4"} 1
+# HELP kube_statefulset_status_update_revision Indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+# TYPE kube_statefulset_status_update_revision gauge
+kube_statefulset_status_update_revision{namespace="default",statefulset="web",revision="web-b46f789c4"} 1
+# HELP kube_storageclass_info Information about storageclass.
+# TYPE kube_storageclass_info gauge
+kube_storageclass_info{storageclass="standard",provisioner="kubernetes.io/gce-pd",reclaimPolicy="Delete",volumeBindingMode="Immediate"} 1
+# HELP kube_storageclass_created Unix creation timestamp
+# TYPE kube_storageclass_created gauge
+kube_storageclass_created{storageclass="standard"} 1.580242904e+09
+# HELP kube_storageclass_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_storageclass_labels gauge
+kube_storageclass_labels{storageclass="standard",label_addonmanager_kubernetes_io_mode="EnsureExists",label_kubernetes_io_cluster_service="true"} 1

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -70,7 +70,7 @@ kube_deployment_created{deployment="tiller-deploy",namespace="kube-system"} 1.50
 # HELP kube_deployment_labels Kubernetes labels converted to Prometheus labels.
 # TYPE kube_deployment_labels gauge
 kube_deployment_labels{deployment="failingtest",label_app="failingtest",namespace="default"} 1
-kube_deployment_labels{deployment="tiller-deploy",label_app="helm",label_name="tiller",namespace="kube-system"} 1
+kube_deployment_labels{deployment="tiller-deploy",label_tags_datadoghq_com_env="dev",label_tags_datadoghq_com_service="tiller",label_tags_datadoghq_com_version="xyz",label_app="helm",label_name="tiller",namespace="kube-system"} 1
 kube_deployment_labels{deployment="kube-dns",label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="kube-dns",label_version="v20",namespace="kube-system"} 1
 kube_deployment_labels{deployment="jaundiced-numbat-kube-state-metrics",label_app="kube-state-metrics",label_chart="kube-state-metrics-0.3.1",label_heritage="Tiller",label_release="jaundiced-numbat",namespace="default"} 1
 # HELP kube_deployment_metadata_generation Sequence number representing a specific generation of the desired state.
@@ -526,7 +526,7 @@ kube_pod_labels{label_controller_uid="f2d4c3f7-c32c-11e7-a7e7-080027bdd864",labe
 kube_pod_labels{label_app="failingtest",label_pod_template_hash="91416680",namespace="default",pod="failingtest-f585bbd4-2fsml"} 1
 kube_pod_labels{label_k8s_app="kube-dns",label_pod_template_hash="1326421443",namespace="kube-system",pod="kube-dns-1326421443-hj4hx"} 1
 kube_pod_labels{label_addonmanager_kubernetes_io_mode="Reconcile",label_app="kubernetes-dashboard",label_version="v1.6.3",namespace="kube-system",pod="kubernetes-dashboard-zhtjl"} 1
-kube_pod_labels{label_addonmanager_kubernetes_io_mode="Reconcile",label_name="registry-creds",label_version="v1.8",namespace="kube-system",pod="registry-creds-hq249"} 1
+kube_pod_labels{label_addonmanager_kubernetes_io_mode="Reconcile",label_tags_datadoghq_com_env="dev",label_tags_datadoghq_com_service="registry-creds",label_tags_datadoghq_com_version="v1.8",label_name="registry-creds",label_version="v1.8",namespace="kube-system",pod="registry-creds-hq249"} 1
 kube_pod_labels{label_app="helm",label_name="tiller",label_pod_template_hash="1651615695",namespace="kube-system",pod="tiller-deploy-1651615695-dcphn"} 1
 kube_pod_labels{label_app="jaundiced-numbat-dd-k8state",label_controller_revision_hash="3690254688",label_pod_template_generation="1",namespace="default",pod="jaundiced-numbat-dd-k8state-b6s77"} 1
 kube_pod_labels{label_component="kube-addon-manager",label_kubernetes_io_minikube_addons="addon-manager",label_version="v6.4",namespace="kube-system",pod="kube-addon-manager-minikube"} 1

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -239,7 +239,7 @@ def instance():
     }
 
 
-def _check(instance,mock_file="prometheus.txt"):
+def _check(instance, mock_file="prometheus.txt"):
     check = KubernetesState(CHECK_NAME, {}, {}, [instance])
     check.poll = mock.MagicMock(return_value=MockResponse(mock_from_file(mock_file), 'text/plain'))
     return check

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -239,9 +239,9 @@ def instance():
     }
 
 
-def _check(instance):
+def _check(instance,mock_file="prometheus.txt"):
     check = KubernetesState(CHECK_NAME, {}, {}, [instance])
-    check.poll = mock.MagicMock(return_value=MockResponse(mock_from_file("prometheus.txt"), 'text/plain'))
+    check.poll = mock.MagicMock(return_value=MockResponse(mock_from_file(mock_file), 'text/plain'))
     return check
 
 
@@ -257,9 +257,9 @@ def check_with_join_kube_labels(instance):
 
 
 @pytest.fixture
-def check_with_join_standard_tag_labels(instance):
+def check_with_join_standard_tag_labels(instance, ):
     instance['join_standard_tags'] = True
-    return _check(instance)
+    return _check(instance=instance, mock_file="ksm-standard-tags-gke.txt")
 
 
 def assert_not_all_zeroes(aggregator, metric_name):
@@ -428,37 +428,116 @@ def test_join_standard_tags_labels(aggregator, instance, check_with_join_standar
     for _ in range(2):
         check_with_join_standard_tag_labels.check(instance)
 
+    # Pod standard tags
     aggregator.assert_metric(
-        NAMESPACE + '.container.waiting',
+        NAMESPACE + '.container.ready',
         tags=[
-            'container:registry-creds',
-            'kube_container_name:registry-creds',
-            'kube_namespace:kube-system',
-            'namespace:kube-system',
-            'node:minikube',
+            'container:master',
+            'kube_container_name:master',
+            'kube_namespace:default',
+            'namespace:default',
             'optional:tag1',
-            'phase:pending',
-            'pod:registry-creds-hq249',
-            'pod_name:registry-creds-hq249',
-            'pod_phase:pending',
+            'node:gke-abcdef-cluster-default-pool-53c8a4ea-z9rw',
+            'phase:running',
+            'pod:redis-599d64fcb9-c654j',
+            'pod_name:redis-599d64fcb9-c654j',
+            'pod_phase:running',
             "env:dev",
-            "service:registry-creds",
-            "version:v1.8"
+            "service:redis",
+            "version:v1"
         ],
         value=1,
     )
 
+    # Deployment standard tags
     aggregator.assert_metric(
         NAMESPACE + '.deployment.replicas',
         tags=[
-            'deployment:tiller-deploy',
-            'kube_deployment:tiller-deploy',
-            'kube_namespace:kube-system',
-            'namespace:kube-system',
+            'deployment:redis',
+            'kube_deployment:redis',
+            'kube_namespace:default',
+            'namespace:default',
             'optional:tag1',
             "env:dev",
-            "service:tiller",
-            "version:xyz"
+            "service:redis",
+            "version:v1"
+        ],
+        value=1,
+    )
+
+    # ReplicaSet standard tags
+    aggregator.assert_metric(
+        NAMESPACE + '.replicaset.replicas_ready',
+        tags=[
+            'replicaset:redis-599d64fcb9',
+            'kube_replica_set:redis-599d64fcb9',
+            'kube_namespace:default',
+            'namespace:default',
+            'optional:tag1',
+            "env:dev",
+            "service:redis",
+            "version:v1"
+        ],
+        value=1,
+    )
+
+    # Daemonset standard tags
+    aggregator.assert_metric(
+        NAMESPACE + '.daemonset.desired',
+        tags=[
+            'daemonset:datadog-monitoring',
+            'kube_daemon_set:datadog-monitoring',
+            'kube_namespace:default',
+            'namespace:default',
+            'optional:tag1',
+            "env:dev",
+            "service:datadog-agent",
+            "version:7"
+        ],
+        value=3,
+    )
+
+    # StatefulSet standard tags
+    aggregator.assert_metric(
+        NAMESPACE + '.statefulset.replicas_ready',
+        tags=[
+            'statefulset:web',
+            'kube_namespace:default',
+            'namespace:default',
+            'optional:tag1',
+            "env:dev",
+            "service:web",
+            "version:v1"
+        ],
+        value=2,
+    )
+
+    # Job standard tags
+    aggregator.assert_metric(
+        NAMESPACE + '.job.succeeded',
+        tags=[
+            'job_name:curl-job',
+            'kube_namespace:default',
+            'namespace:default',
+            'optional:tag1',
+            "env:dev",
+            "service:curl-job",
+            "version:v1"
+        ],
+        value=1,
+    )
+
+    # CronJob standard tags
+    aggregator.assert_metric(
+        NAMESPACE + '.job.succeeded',
+        tags=[
+            'job_name:curl-cron-job',
+            'kube_namespace:default',
+            'namespace:default',
+            'optional:tag1',
+            "env:dev",
+            "service:curl-cron-job",
+            "version:v1"
         ],
         value=1,
     )

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -257,7 +257,7 @@ def check_with_join_kube_labels(instance):
 
 
 @pytest.fixture
-def check_with_join_standard_tag_labels(instance, ):
+def check_with_join_standard_tag_labels(instance,):
     instance['join_standard_tags'] = True
     return _check(instance=instance, mock_file="ksm-standard-tags-gke.txt")
 
@@ -444,7 +444,7 @@ def test_join_standard_tags_labels(aggregator, instance, check_with_join_standar
             'pod_phase:running',
             "env:dev",
             "service:redis",
-            "version:v1"
+            "version:v1",
         ],
         value=1,
     )
@@ -460,7 +460,7 @@ def test_join_standard_tags_labels(aggregator, instance, check_with_join_standar
             'optional:tag1',
             "env:dev",
             "service:redis",
-            "version:v1"
+            "version:v1",
         ],
         value=1,
     )
@@ -476,7 +476,7 @@ def test_join_standard_tags_labels(aggregator, instance, check_with_join_standar
             'optional:tag1',
             "env:dev",
             "service:redis",
-            "version:v1"
+            "version:v1",
         ],
         value=1,
     )
@@ -492,7 +492,7 @@ def test_join_standard_tags_labels(aggregator, instance, check_with_join_standar
             'optional:tag1',
             "env:dev",
             "service:datadog-agent",
-            "version:7"
+            "version:7",
         ],
         value=3,
     )
@@ -507,7 +507,7 @@ def test_join_standard_tags_labels(aggregator, instance, check_with_join_standar
             'optional:tag1',
             "env:dev",
             "service:web",
-            "version:v1"
+            "version:v1",
         ],
         value=2,
     )
@@ -522,7 +522,7 @@ def test_join_standard_tags_labels(aggregator, instance, check_with_join_standar
             'optional:tag1',
             "env:dev",
             "service:curl-job",
-            "version:v1"
+            "version:v1",
         ],
         value=1,
     )
@@ -537,7 +537,7 @@ def test_join_standard_tags_labels(aggregator, instance, check_with_join_standar
             'optional:tag1',
             "env:dev",
             "service:curl-cron-job",
-            "version:v1"
+            "version:v1",
         ],
         value=1,
     )


### PR DESCRIPTION
### What does this PR do?

`join_standard_tags` enables label joins for standard tags captured from the following labels:
- `tags.datadoghq.com/version`
- `tags.datadoghq.com/env`
- `tags.datadoghq.com/service`

Metrics are being enriched for the following objects: Pod, Deployment, ReplicaSet, DaemonSet, StatefulSet, Job, CronJob.

### Motivation
Unified tagging in KSM integration.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
