### PR TITLE
Allow arbitrary repos in CLI config

### DIFF
--- a/.azure-pipelines/templates/install-deps.yml
+++ b/.azure-pipelines/templates/install-deps.yml
@@ -50,5 +50,5 @@ steps:
   - script: pip install datadog-checks-dev[cli]
     displayName: 'Install ddev from PyPI'
 
-- script: ddev config set ${{ parameters.repo }} . && ddev config set repo ${{ parameters.repo }}
+- script: ddev config set repos.${{ parameters.repo }} . && ddev config set repo ${{ parameters.repo }}
   displayName: 'Configure ddev'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
@@ -35,9 +35,7 @@ def ddev(ctx, core, extras, agent, here, color, quiet, debug):
         try:
             restore_config()
             echo_success('Success! Please see `ddev config`.')
-        # TODO: Remove IOError (and noqa: B014) when Python 2 is removed
-        # In Python 3, IOError have been merged into OSError
-        except (IOError, OSError, PermissionError):  # noqa: B014
+        except OSError:
             echo_warning(f'Unable to create config file located at `{CONFIG_FILE}`. Please check your permissions.')
 
     # Load and store configuration for sub-commands.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/config.py
@@ -98,7 +98,7 @@ def set_value(ctx, key, value):
         scrubbing = any(fnmatch(key, pattern) for pattern in SECRET_KEYS)
         value = click.prompt(f'Value for `{key}`', hide_input=scrubbing)
 
-    if key in ('core', 'extras', 'agent') and not value.startswith('~'):
+    if key in ('repos.core', 'repos.extras', 'repos.agent') and not value.startswith('~'):
         value = os.path.abspath(value)
 
     user_config = new_config = ctx.obj

--- a/datadog_checks_dev/datadog_checks/dev/tooling/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/config.py
@@ -26,9 +26,6 @@ SECRET_KEYS = {
 }
 
 DEFAULT_CONFIG = {
-    'core': os.path.join('~', 'dd', 'integrations-core'),
-    'extras': os.path.join('~', 'dd', 'integrations-extras'),
-    'agent': os.path.join('~', 'dd', 'datadog-agent'),
     'repo': 'core',
     'color': bool(int(os.environ['DDEV_COLOR'])) if 'DDEV_COLOR' in os.environ else None,
     'dd_api_key': os.getenv('DD_API_KEY'),
@@ -39,6 +36,11 @@ DEFAULT_CONFIG = {
     'github': {'user': '', 'token': ''},
     'pypi': {'user': '', 'pass': ''},
     'trello': {'key': '', 'token': ''},
+    'repos': {
+        'core': os.path.join('~', 'dd', 'integrations-core'),
+        'extras': os.path.join('~', 'dd', 'integrations-extras'),
+        'agent': os.path.join('~', 'dd', 'datadog-agent'),
+    },
     'orgs': {
         'default': {
             'api_key': os.getenv('DD_API_KEY'),

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -95,7 +95,7 @@ def initialize_root(config, agent=False, core=False, extras=False, here=False):
     config['repo_name'] = REPO_CHOICES[repo_choice]
 
     message = None
-    root = os.path.expanduser(config.get(repo_choice, ''))
+    root = os.path.expanduser(config.get(repo_choice) or config.get('repos', {}).get(repo_choice, ''))
     if here or not dir_exists(root):
         if not here:
             repo = 'datadog-agent' if repo_choice == 'agent' else f'integrations-{repo_choice}'


### PR DESCRIPTION
### Motivation

During the process of documenting, I realized the repos at the root was weird so now we do it like `orgs` https://github.com/DataDog/integrations-core/pull/5197

Backward compatible though