### PR TITLE
Ignore flags to ddev test

### DIFF
--- a/datadog_checks_dev/tests/tooling/commands/test_create.py
+++ b/datadog_checks_dev/tests/tooling/commands/test_create.py
@@ -24,7 +24,7 @@ def test_new_check_test():
         run_command([sys.executable, '-m', 'pip', 'install', check_path], capture=True, check=True)
 
         with chdir(check_path):
-            ignored_env_vars = [TESTING_PLUGIN]
+            ignored_env_vars = [TESTING_PLUGIN, 'PYTEST_ADDOPTS']
             ignored_env_vars.extend(ev for ev in os.environ if ev.startswith(E2E_PREFIX))
 
             with EnvVars(ignore=ignored_env_vars):


### PR DESCRIPTION
### Motivation

`test_new_check_test` fails if you pass `-k` b/c then it gets passed to pytest