### PR TITLE
Update release make to avoid commiting new files

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
@@ -155,7 +155,7 @@ def make(ctx, checks, version, initial_release, skip_sign, sign_only, exclude):
         # commit the changes.
         # do not use [ci skip] so releases get built https://docs.gitlab.com/ee/ci/yaml/#skipping-jobs
         msg = f'[Release] Bumped {check} version to {version}'
-        git_commit(commit_targets, msg)
+        git_commit(commit_targets, msg, update=True)
 
         if not initial_release:
             # Reset version

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -75,9 +75,15 @@ def git_show_file(path, ref):
         return run_command(command, capture=True).stdout
 
 
-def git_commit(targets, message, force=False, sign=False):
+def git_commit(targets, message, force=False, sign=False, update=False):
     """
     Commit the changes for the given targets.
+
+    `targets` - be files or directiries
+    `message` - the commit message
+    `force` - (optional) force the commit
+    `sign` - sign with `-S` option
+    `update` - only commit updated files already tracked by git, via `-u`
     """
     root = get_root()
     target_paths = []
@@ -85,7 +91,10 @@ def git_commit(targets, message, force=False, sign=False):
         target_paths.append(os.path.join(root, t))
 
     with chdir(root):
-        result = run_command(f"git add{' -f' if force else ''} {' '.join(target_paths)}")
+        if updated:
+            result = run_command(f"git add{' -f' if force else ''} -u {' '.join(target_paths)}")
+        else:
+            result = run_command(f"git add{' -f' if force else ''} {' '.join(target_paths)}")
         if result.code != 0:
             return result
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -91,7 +91,7 @@ def git_commit(targets, message, force=False, sign=False, update=False):
         target_paths.append(os.path.join(root, t))
 
     with chdir(root):
-        if updated:
+        if update:
             result = run_command(f"git add{' -f' if force else ''} -u {' '.join(target_paths)}")
         else:
             result = run_command(f"git add{' -f' if force else ''} {' '.join(target_paths)}")


### PR DESCRIPTION
### What does this PR do?
Updates the commit operation during `ddev release make` to only commit updated files via the `git add -u` operation instead of every file in the check directory.

### Motivation
When performing a release, that command picked up some temporary files that aren't in `.gitignore` but were used during testing operations and shouldn't have been committed.  This caused an issue because the signing operation then was invalid once those files were properly removed from the PR.

### Additional notes

This should work since the only files being changed by the operation are existing files of `CHANGELOG.md`, `__about__.py`, `requirements-agent-release.txt`, and the in-toto metadata.

There might be edge cases that need to be considered, however.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
