### PR TITLE
Bump python requirement

### DIFF
--- a/docs/datadog_checks_dev.cli.rst
+++ b/docs/datadog_checks_dev.cli.rst
@@ -6,7 +6,7 @@ The Developer Toolkit
 Prerequisites
 ^^^^^^^^^^^^^
 
-* Python 3.7+ needs to be available on your system. Python 2.7 is optional.
+* Python 3.8+ needs to be available on your system. Python 2.7 is optional.
 * Docker to run the full test suite.
 
 Using a virtual environment is recommended.

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -20,7 +20,7 @@ These requirements are used during the code review process as a checklist. This 
 
 ## Prerequisites
 
-* Python 3.7+ needs to be available on your system; Python 2.7 is optional but recommended.
+* Python 3.8+ needs to be available on your system; Python 2.7 is optional but recommended.
 * Docker to run the full test suite.
 
 In general, creating and activating [Python virtual environments][1] to isolate the development environment is good practice; however, it is not mandatory. For more information, see the [Python Environment documentation][2].


### PR DESCRIPTION
The agent ships 3.8 now and it's the one we rely on.