### PR TITLE
Fix paths

### DIFF
--- a/ibm_db2/README.md
+++ b/ibm_db2/README.md
@@ -27,13 +27,13 @@ The [ibm_db][4] client library is required. To install it, ensure you have a wor
 For Agent versions <= 6.11:
 
 ```text
-"C:\Program Files\Datadog\Datadog Agent\embedded\Scripts\python.exe" -m pip install ibm_db==3.0.1
+"C:\Program Files\Datadog\Datadog Agent\embedded\python.exe" -m pip install ibm_db==3.0.1
 ```
 
 For Agent versions >= 6.12:
 
 ```text
-"C:\Program Files\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\Scripts\python.exe" -m pip install ibm_db==3.0.1
+"C:\Program Files\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe" -m pip install ibm_db==3.0.1
 ```
 
 On Linux there may be need for XML functionality. If you encounter errors during


### PR DESCRIPTION
### What does this PR do?
Fixes the paths for the embedded python exe in Windows

### Motivation
A customer pointed out a mistake with our documented paths

### Additional Notes
I've checked that the .exe file for Windows is nested under embedded instead of embedded/Scripts in Agent version >= 6.12. I have not checked this for Agent version <= 6.11.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
