### PR TITLE
ActiveMQ Artemis metrics configuration file

### DIFF
--- a/activemq/datadog_checks/activemq/data/artemis-metrics.yaml
+++ b/activemq/datadog_checks/activemq/data/artemis-metrics.yaml
@@ -1,0 +1,111 @@
+jmx_metrics:
+  - include:
+      domain: org.apache.activemq.artemis
+      bean_regex:
+        - org.apache.activemq.artemis:broker="broker01"
+      tags:
+        broker: broker01
+      attribute:
+        ConnectionCount:
+          alias: activemq.broker.ConnectionCount
+          metric_type: gauge
+        TotalConnectionCount:
+          alias: activemq.broker.TotalConnectionCount
+          metric_type: gauge
+        TotalConsumerCount:
+          alias: activemq.broker.TotalConsumerCount
+          metric_type: gauge
+        TotalMessageCount:
+          alias: activemq.broker.TotalMessageCount
+          metric_type: gauge
+        TotalMessagesAcknowledged:
+          alias: activemq.broker.TotalMessagesAcknowledged
+          metric_type: gauge
+        TotalMessagesAdded:
+          alias: activemq.broker.TotalMessagesAdded
+          metric_type: gauge
+
+  - include:
+      domain: org.apache.activemq.artemis
+      bean_regex:
+        - org.apache.activemq.artemis:broker="(.*)",component=addresses,address="(.*)"
+      tags:
+        broker: $1
+        address: $2
+      attribute:
+        MessageCount:
+          alias: activemq.address.MessageCount
+          metric_type: gauge
+        NumberOfMessages:
+          alias: activemq.address.MessageCount
+          metric_type: gauge
+        UnRoutedMessageCount:
+          alias: activemq.address.MessageCount
+          metric_type: gauge
+
+  - include:
+      domain: org.apache.activemq.artemis
+      bean_regex:
+      - org.apache.activemq.artemis:broker="(.*)",component=addresses,address="(.*)",subcomponent=queues,routing-type="anycast",queue="(.*)"
+      tags:
+        broker: $1
+        address: $2
+        queue: $3
+      attribute:
+        ConsumerCount:
+          alias: activemq.queue.ConsumerCount
+          metric_type: gauge
+        DeliveringCount:
+          alias: activemq.queue.DeliveringCount
+          metric_type: gauge
+        DeliveringSize:
+          alias: activemq.queue.DeliveringSize
+          metric_type: gauge
+        DurableDeliveringCount:
+          alias: activemq.queue.DurableDeliveringCount
+          metric_type: gauge
+        DurableDeliveringSize:
+          alias: activemq.queue.DurableDeliveringSize
+          metric_type: gauge
+        DurableMessageCount:
+          alias: activemq.queue.DurableMessageCount
+          metric_type: gauge
+        DurablePersistentSize:
+          alias: activemq.queue.DurablePersistentSize
+          metric_type: gauge
+        DurableScheduledCount:
+          alias: activemq.queue.DurableScheduledCount
+          metric_type: gauge
+        DurableScheduledSize:
+          alias: activemq.queue.DurableScheduledSize
+          metric_type: gauge
+        MaxConsumers:
+          alias: activemq.queue.MaxConsumers
+          metric_type: gauge
+        MessageCount:
+          alias: activemq.queue.MessageCount
+          metric_type: gauge
+        MessagesAcknowledged:
+          alias: activemq.queue.MessagesAcknowledged
+          metric_type: gauge
+        MessagesAdded:
+          alias: activemq.queue.MessagesAdded
+          metric_type: gauge
+        MessagesExpired:
+          alias: activemq.queue.MessagesExpired
+          metric_type: gauge
+        MessagesKilled:
+          alias: activemq.queue.MessagesKilled
+          metric_type: gauge
+        ProducedRate:
+          alias: activemq.queue.ProducedRate
+          metric_type: gauge
+        RingSize:
+          alias: activemq.queue.RingSize
+          metric_type: gauge
+        ScheduledCount:
+          alias: activemq.queue.ScheduledCount
+          metric_type: gauge
+        ScheduledSize:
+          alias: activemq.queue.ScheduledSize
+          metric_type: gauge

--- a/activemq/datadog_checks/activemq/data/artemis-metrics.yaml
+++ b/activemq/datadog_checks/activemq/data/artemis-metrics.yaml
@@ -2,9 +2,9 @@ jmx_metrics:
   - include:
       domain: org.apache.activemq.artemis
       bean_regex:
-        - org.apache.activemq.artemis:broker="broker01"
+        - org.apache.activemq.artemis:broker="(.*)"
       tags:
-        broker: broker01
+        broker: $1
       attribute:
         ConnectionCount:
           alias: activemq.broker.ConnectionCount
@@ -37,20 +37,21 @@ jmx_metrics:
           alias: activemq.address.MessageCount
           metric_type: gauge
         NumberOfMessages:
-          alias: activemq.address.MessageCount
+          alias: activemq.address.NumberOfMessages
           metric_type: gauge
         UnRoutedMessageCount:
-          alias: activemq.address.MessageCount
+          alias: activemq.address.UnRoutedMessageCount
           metric_type: gauge
 
   - include:
       domain: org.apache.activemq.artemis
       bean_regex:
-      - org.apache.activemq.artemis:broker="(.*)",component=addresses,address="(.*)",subcomponent=queues,routing-type="anycast",queue="(.*)"
+      - org.apache.activemq.artemis:broker="(.*)",component=addresses,address="(.*)",subcomponent=queues,routing-type="(.*)",queue="(.*)"
       tags:
         broker: $1
         address: $2
-        queue: $3
+        routing: $3
+        queue: $4
       attribute:
         ConsumerCount:
           alias: activemq.queue.ConsumerCount

--- a/activemq/datadog_checks/activemq/data/artemis-metrics.yaml
+++ b/activemq/datadog_checks/activemq/data/artemis-metrics.yaml
@@ -47,11 +47,17 @@ jmx_metrics:
       domain: org.apache.activemq.artemis
       bean_regex:
       - org.apache.activemq.artemis:broker="(.*)",component=addresses,address="(.*)",subcomponent=queues,routing-type="(.*)",queue="(.*)"
+      #- org.apache.activemq.artemis:broker="(.*)",component=addresses,address="(.*)",subcomponent=(queue|topic)s,routing-type="(.*)",(queue|topic)="(.*)"
       tags:
         broker: $1
         address: $2
         routing: $3
         queue: $4
+        #broker: $1
+        #address: $2
+        #subcomponent: $3
+        #routing: $4
+        #"$5": $6
       attribute:
         ConsumerCount:
           alias: activemq.queue.ConsumerCount


### PR DESCRIPTION
### What does this PR do?
This PR introduces a new YAML template file to gather metrics from Apache ActiveMQ Artemis broker, exposed via JMX. It uses `bean_regex` to access MBeans objects and attributes.

### Motivation
Apache ActiveMQ is still very popular, however, years ago two distinct community projects HornetQ and ActiveMQ were merged together under a new project called Apache ActiveMQ Artemis, which tries to get best out of both projects.
Red Hat AMQ 7+ is based on that, and many enterprise customers rely on such vendor technology.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
