### PR TITLE
Update fluentd tests to not use instance

### DIFF
--- a/fluentd/tests/test_integration.py
+++ b/fluentd/tests/test_integration.py
@@ -17,7 +17,7 @@ def test_fluentd_exception(aggregator):
     instance = {"monitor_agent_url": BAD_URL, "plugin_ids": ["plg2"], "tags": ["test"]}
     check = Fluentd(CHECK_NAME, {}, [instance])
     with pytest.raises(Exception):
-        check.check({})
+        check.check(None)
 
     sc_tags = ['fluentd_host:{}'.format(HOST), 'fluentd_port:{}'.format(BAD_PORT), 'test']
     aggregator.assert_service_check(check.SERVICE_CHECK_NAME, status=Fluentd.CRITICAL, tags=sc_tags, count=1)
@@ -29,7 +29,7 @@ def test_fluentd_with_tag_by_type(aggregator):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     instance["tag_by"] = "type"
     check = Fluentd(CHECK_NAME, {}, [instance])
-    check.check({})
+    check.check(None)
 
     for m in EXPECTED_GAUGES:
         metric_name = '{0}.{1}'.format(CHECK_NAME, m)
@@ -48,7 +48,7 @@ def test_fluentd_with_tag_by_plugin_id(aggregator):
     instance["tag_by"] = "plugin_id"
 
     check = Fluentd(CHECK_NAME, {}, [instance])
-    check.check({})
+    check.check(None)
 
     for m in EXPECTED_GAUGES:
         metric_name = '{0}.{1}'.format(CHECK_NAME, m)
@@ -67,7 +67,7 @@ def test_fluentd_with_custom_tags(aggregator):
     instance["tags"] = custom_tags
     check = Fluentd(CHECK_NAME, {}, [instance])
 
-    check.check({})
+    check.check(None)
 
     for m in EXPECTED_GAUGES:
         metric_name = '{0}.{1}'.format(CHECK_NAME, m)

--- a/fluentd/tests/test_integration.py
+++ b/fluentd/tests/test_integration.py
@@ -17,7 +17,7 @@ def test_fluentd_exception(aggregator):
     instance = {"monitor_agent_url": BAD_URL, "plugin_ids": ["plg2"], "tags": ["test"]}
     check = Fluentd(CHECK_NAME, {}, [instance])
     with pytest.raises(Exception):
-        check.check(instance)
+        check.check({})
 
     sc_tags = ['fluentd_host:{}'.format(HOST), 'fluentd_port:{}'.format(BAD_PORT), 'test']
     aggregator.assert_service_check(check.SERVICE_CHECK_NAME, status=Fluentd.CRITICAL, tags=sc_tags, count=1)
@@ -29,7 +29,7 @@ def test_fluentd_with_tag_by_type(aggregator):
     instance = copy.deepcopy(DEFAULT_INSTANCE)
     instance["tag_by"] = "type"
     check = Fluentd(CHECK_NAME, {}, [instance])
-    check.check(instance)
+    check.check({})
 
     for m in EXPECTED_GAUGES:
         metric_name = '{0}.{1}'.format(CHECK_NAME, m)
@@ -48,7 +48,7 @@ def test_fluentd_with_tag_by_plugin_id(aggregator):
     instance["tag_by"] = "plugin_id"
 
     check = Fluentd(CHECK_NAME, {}, [instance])
-    check.check(instance)
+    check.check({})
 
     for m in EXPECTED_GAUGES:
         metric_name = '{0}.{1}'.format(CHECK_NAME, m)
@@ -67,7 +67,7 @@ def test_fluentd_with_custom_tags(aggregator):
     instance["tags"] = custom_tags
     check = Fluentd(CHECK_NAME, {}, [instance])
 
-    check.check(instance)
+    check.check({})
 
     for m in EXPECTED_GAUGES:
         metric_name = '{0}.{1}'.format(CHECK_NAME, m)

--- a/fluentd/tests/test_integration_and_e2e.py
+++ b/fluentd/tests/test_integration_and_e2e.py
@@ -27,8 +27,8 @@ def assert_basic_case(aggregator):
 def test_basic_case_integration(aggregator):
     instance = copy.deepcopy(INSTANCE_WITH_PLUGIN)
     check = Fluentd(CHECK_NAME, {}, [instance])
-    check.check({})
-    check.check({})
+    check.check(None)
+    check.check(None)
 
     assert_basic_case(aggregator)
 

--- a/fluentd/tests/test_integration_and_e2e.py
+++ b/fluentd/tests/test_integration_and_e2e.py
@@ -27,8 +27,8 @@ def assert_basic_case(aggregator):
 def test_basic_case_integration(aggregator):
     instance = copy.deepcopy(INSTANCE_WITH_PLUGIN)
     check = Fluentd(CHECK_NAME, {}, [instance])
-    check.check(instance)
-    check.check(instance)
+    check.check({})
+    check.check({})
 
     assert_basic_case(aggregator)
 

--- a/fluentd/tests/test_metadata.py
+++ b/fluentd/tests/test_metadata.py
@@ -21,7 +21,7 @@ def test_collect_metadata_instance(aggregator, datadog_agent, instance):
 
     check = Fluentd(CHECK_NAME, {}, [instance])
     check.check_id = CHECK_ID
-    check.check({})
+    check.check(None)
 
     major, minor, patch = FLUENTD_VERSION.split('.')
     version_metadata = {
@@ -42,7 +42,7 @@ def test_collect_metadata_missing_version(aggregator, datadog_agent, instance):
 
     check = Fluentd(CHECK_NAME, {}, [instance])
     check.check_id = CHECK_ID
-    check.check({})
+    check.check(None)
 
     datadog_agent.assert_metadata(CHECK_ID, {})
     datadog_agent.assert_metadata_count(0)
@@ -54,7 +54,7 @@ def test_collect_metadata_invalid_binary(datadog_agent, instance):
 
     check = Fluentd(CHECK_NAME, {}, [instance])
     check.check_id = CHECK_ID
-    check.check({})
+    check.check(None)
 
     datadog_agent.assert_metadata(CHECK_ID, {})
     datadog_agent.assert_metadata_count(0)
@@ -66,7 +66,7 @@ def test_collect_metadata_invalid_binary_with_endpoint(datadog_agent, instance):
 
     check = Fluentd(CHECK_NAME, {}, [instance])
     check.check_id = CHECK_ID
-    check.check({})
+    check.check(None)
 
     major, minor, patch = FLUENTD_VERSION.split('.')
     version_metadata = {

--- a/fluentd/tests/test_metadata.py
+++ b/fluentd/tests/test_metadata.py
@@ -21,7 +21,7 @@ def test_collect_metadata_instance(aggregator, datadog_agent, instance):
 
     check = Fluentd(CHECK_NAME, {}, [instance])
     check.check_id = CHECK_ID
-    check.check(instance)
+    check.check({})
 
     major, minor, patch = FLUENTD_VERSION.split('.')
     version_metadata = {
@@ -42,7 +42,7 @@ def test_collect_metadata_missing_version(aggregator, datadog_agent, instance):
 
     check = Fluentd(CHECK_NAME, {}, [instance])
     check.check_id = CHECK_ID
-    check.check(instance)
+    check.check({})
 
     datadog_agent.assert_metadata(CHECK_ID, {})
     datadog_agent.assert_metadata_count(0)
@@ -54,7 +54,7 @@ def test_collect_metadata_invalid_binary(datadog_agent, instance):
 
     check = Fluentd(CHECK_NAME, {}, [instance])
     check.check_id = CHECK_ID
-    check.check(instance)
+    check.check({})
 
     datadog_agent.assert_metadata(CHECK_ID, {})
     datadog_agent.assert_metadata_count(0)
@@ -66,7 +66,7 @@ def test_collect_metadata_invalid_binary_with_endpoint(datadog_agent, instance):
 
     check = Fluentd(CHECK_NAME, {}, [instance])
     check.check_id = CHECK_ID
-    check.check(instance)
+    check.check({})
 
     major, minor, patch = FLUENTD_VERSION.split('.')
     version_metadata = {

--- a/fluentd/tests/test_unit.py
+++ b/fluentd/tests/test_unit.py
@@ -9,7 +9,7 @@ from .common import CHECK_NAME
 def test_default_timeout(instance):
     # test default timeout
     check = Fluentd(CHECK_NAME, {}, [instance])
-    check.check({})
+    check.check(None)
 
     assert check.http.options['timeout'] == (5, 5)
 
@@ -17,14 +17,14 @@ def test_default_timeout(instance):
 def test_init_config_old_timeout(instance):
     # test init_config timeout
     check = Fluentd(CHECK_NAME, {'default_timeout': 2}, [instance])
-    check.check({})
+    check.check(None)
     assert check.http.options['timeout'] == (2, 2)
 
 
 def test_init_config_timeout(instance):
     # test init_config timeout
     check = Fluentd(CHECK_NAME, {'timeout': 7}, [instance])
-    check.check({})
+    check.check(None)
 
     assert check.http.options['timeout'] == (7, 7)
 
@@ -33,7 +33,7 @@ def test_instance_old_timeout(instance):
     # test instance default_timeout
     instance['default_timeout'] = 13
     check = Fluentd(CHECK_NAME, {'default_timeout': 9}, [instance])
-    check.check({})
+    check.check(None)
 
     assert check.http.options['timeout'] == (13, 13)
 
@@ -42,6 +42,6 @@ def test_instance_timeout(instance):
     # test instance timeout
     instance['timeout'] = 15
     check = Fluentd(CHECK_NAME, {}, [instance])
-    check.check({})
+    check.check(None)
 
     assert check.http.options['timeout'] == (15, 15)

--- a/fluentd/tests/test_unit.py
+++ b/fluentd/tests/test_unit.py
@@ -9,7 +9,7 @@ from .common import CHECK_NAME
 def test_default_timeout(instance):
     # test default timeout
     check = Fluentd(CHECK_NAME, {}, [instance])
-    check.check(instance)
+    check.check({})
 
     assert check.http.options['timeout'] == (5, 5)
 
@@ -17,14 +17,14 @@ def test_default_timeout(instance):
 def test_init_config_old_timeout(instance):
     # test init_config timeout
     check = Fluentd(CHECK_NAME, {'default_timeout': 2}, [instance])
-    check.check(instance)
+    check.check({})
     assert check.http.options['timeout'] == (2, 2)
 
 
 def test_init_config_timeout(instance):
     # test init_config timeout
     check = Fluentd(CHECK_NAME, {'timeout': 7}, [instance])
-    check.check(instance)
+    check.check({})
 
     assert check.http.options['timeout'] == (7, 7)
 
@@ -33,7 +33,7 @@ def test_instance_old_timeout(instance):
     # test instance default_timeout
     instance['default_timeout'] = 13
     check = Fluentd(CHECK_NAME, {'default_timeout': 9}, [instance])
-    check.check(instance)
+    check.check({})
 
     assert check.http.options['timeout'] == (13, 13)
 
@@ -42,6 +42,6 @@ def test_instance_timeout(instance):
     # test instance timeout
     instance['timeout'] = 15
     check = Fluentd(CHECK_NAME, {}, [instance])
-    check.check(instance)
+    check.check({})
 
     assert check.http.options['timeout'] == (15, 15)


### PR DESCRIPTION
### What does this PR do?
QA for https://github.com/DataDog/integrations-core/pull/6063 to ensure fluentd does not rely on the `instance` parameter in `check()`.

### Motivation
I'm not sure if this is the cleanest way to do it, but passing in empty instances in the tests does verify that instance is not being used in `check()`

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
