### PR TITLE
Update PyYAML to 5.3.1

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -56,7 +56,7 @@ python3-gearman==0.1.0; sys_platform != 'win32' and python_version > '3.0'
 pytz==2019.3
 pyvmomi==v6.5.0.2017.5-1
 pywin32==227; sys_platform == 'win32'
-pyyaml==5.3
+pyyaml==5.3.1
 redis==3.3.11
 requests==2.22.0
 requests-kerberos==0.12.0

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -12,7 +12,7 @@ protobuf==3.7.0
 pysocks==1.7.0
 pytz==2019.3
 pywin32==227; sys_platform == 'win32'
-pyyaml==5.3
+pyyaml==5.3.1
 requests==2.22.0
 requests-kerberos==0.12.0
 requests_ntlm==1.1.0


### PR DESCRIPTION
This PR updates the PyYAML dependency from 5.3.0 to 5.3.1 to include a patch for [CVE-2020-1747](https://nvd.nist.gov/vuln/detail/CVE-2020-1747)

This CVE allows arbitrary code execution when using the `full_load` method but because the Datadog Agent loads yaml safely the impact is minimal. For more details: https://github.com/DataDog/integrations-core/pull/3089 

As documented [here](https://github.com/yaml/pyyaml/blob/master/CHANGES), the CVE patch is the only change between those two PyYAML versions.

