### PR TITLE
Batch requests for most endpoints

### DIFF
--- a/twistlock/datadog_checks/twistlock/config.py
+++ b/twistlock/datadog_checks/twistlock/config.py
@@ -18,3 +18,5 @@ class Config:
         self.project = instance.get('project')
         if self.project:
             self.tags.append("project:{}".format(self.project))
+
+        self.batch_size = instance.get('batch_size', 50)

--- a/twistlock/datadog_checks/twistlock/data/conf.yaml.example
+++ b/twistlock/datadog_checks/twistlock/data/conf.yaml.example
@@ -193,3 +193,8 @@ instances:
     ## Whether or not to persist cookies and use connection pooling for increased performance.
     #
     # persist_connections: false
+
+    ## @param batch_size - integer - optional - default: 50
+    ## The number of objects requested for each API calls.
+    #
+    # batch_size: 50

--- a/twistlock/tests/test_twistlock.py
+++ b/twistlock/tests/test_twistlock.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import json
 import os
 
 import mock
@@ -51,9 +50,6 @@ class MockResponse:
     @property
     def content(self):
         return ensure_bytes(self._json)
-
-    def json(self):
-        return json.loads(self._json)
 
 
 def mock_get_factory(fixture_group):


### PR DESCRIPTION
Various API endpoints can return a lot of data. To reduce the loading to a reasonable level, this adds a batch capability so that those APIs return less data at a time.