### PR TITLE
add jmx url for Wildfly 9 and below

### DIFF
--- a/jboss_wildfly/README.md
+++ b/jboss_wildfly/README.md
@@ -8,7 +8,7 @@ This check monitors [JBoss][1] and [WildFly][2] applications.
 
 ### Installation
 
-The JBoss/WildFly check is included in the [Datadog Agent][3] package.
+The JBoss/WildFly check is included in the [Datadog Agent][3] package so you don’t need to install anything else on your JBoss/WildFly host.
 
 ### Configuration
 

--- a/jboss_wildfly/README.md
+++ b/jboss_wildfly/README.md
@@ -24,7 +24,7 @@ Place the JAR on the same machine as your Agent, and add the path to the `custom
 
    `service:jmx:remote+http://<HOST>:<PORT>`
 
-Please refer to the [WildFly JMX subsystem configuration page](https://docs.jboss.org/author/display/WFLY9/JMX%20subsystem%20configuration.html) for more information
+Refer to the [WildFly JMX subsystem configuration page](https://docs.jboss.org/author/display/WFLY9/JMX%20subsystem%20configuration.html) for more information.
 
 ### Configuration
 

--- a/jboss_wildfly/README.md
+++ b/jboss_wildfly/README.md
@@ -8,7 +8,21 @@ This check monitors [JBoss][1] and [WildFly][2] applications.
 
 ### Installation
 
-The JBoss/WildFly check is included in the [Datadog Agent][3] package. Depending on your server setup (particularly when using the `remote+http` JMX scheme), you may need to specify a custom JAR to connect to the server. Place the JAR on the same machine as your Agent, and add the path to the `custom_jar_paths` option.
+The JBoss/WildFly check is included in the [Datadog Agent][3] package. 
+
+Depending on your server setup (particularly when using the `remote+http` JMX scheme), you may need to specify a custom JAR to connect to the server. 
+
+Place the JAR on the same machine as your Agent, and add the path to the `custom_jar_paths` option.
+
+   **Note**: The JMX url scheme is different according to your WildFly version.
+
+   For Wildfly 9 and older:
+
+   `service:jmx:http-remoting-jmx://" + host + ":" + port `
+
+   For Wildfly 10+:
+
+   `service:jmx:remote+http://" + host + ":" + port`
 
 ### Configuration
 

--- a/jboss_wildfly/README.md
+++ b/jboss_wildfly/README.md
@@ -8,25 +8,11 @@ This check monitors [JBoss][1] and [WildFly][2] applications.
 
 ### Installation
 
-The JBoss/WildFly check is included in the [Datadog Agent][3] package. 
-
-Depending on your server setup (particularly when using the `remote+http` JMX scheme), you may need to specify a custom JAR to connect to the server. 
-
-Place the JAR on the same machine as your Agent, and add the path to the `custom_jar_paths` option.
-
-**Note**: The JMX url scheme is different according to your WildFly version: 
-
-- For Wildfly 9 and older:
-
-   `service:jmx:http-remoting-jmx://<HOST>:<PORT> `
-   
-- For Wildfly 10+:
-
-   `service:jmx:remote+http://<HOST>:<PORT>`
-
-Refer to the [WildFly JMX subsystem configuration page](https://docs.jboss.org/author/display/WFLY9/JMX%20subsystem%20configuration.html) for more information.
+The JBoss/WildFly check is included in the [Datadog Agent][3] package.
 
 ### Configuration
+
+This check has a limit of 350 metrics per instance. The number of returned metrics is indicated in the info page. You can specify the metrics you are interested in by editing the configuration below. To learn how to customize the collected metrics, visit the [JMX Checks documentation][4] for more detailed instructions. If you need to monitor more metrics, contact [Datadog support][5].
 
 #### Host
 
@@ -34,11 +20,18 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 ##### Metric collection
 
-1. Edit the `jboss_wildfly.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your JBoss or WildFly application server's performance data. See the [sample jboss_wildfly.d/conf.yaml][4] for all available configuration options.
+1. Edit the `jboss_wildfly.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your JBoss or WildFly application server's performance data. See the [sample jboss_wildfly.d/conf.yaml][6] for all available configuration options.
 
-    **Note**:This check has a limit of 350 metrics per instance. The number of returned metrics is indicated in the info page. You can specify the metrics you are interested in by editing the configuration below. To learn how to customize the collected metrics, visit the [JMX Checks documentation][5] for more detailed instructions. If you need to monitor more metrics, contact [Datadog support][6].
+    Depending on your server setup (particularly when using the `remote+http` JMX scheme), you may need to specify a custom JAR to connect to the server. Place the JAR on the same machine as your Agent, and add its path to the `custom_jar_paths` option in your `jboss_wildfly.d/conf.yaml` file.
 
-2. [Restart the Agent][7].
+    **Note**: The JMX url scheme is different according to your WildFly version:
+
+   - For Wildfly 9 and older: `service:jmx:http-remoting-jmx://<HOST>:<PORT> `
+   - For Wildfly 10+: `service:jmx:remote+http://<HOST>:<PORT>`
+
+    Refer to the [WildFly JMX subsystem configuration page][7] for more information.
+
+2. [Restart the Agent][8].
 
 ##### Log collection
 
@@ -60,19 +53,19 @@ _Available for Agent versions >6.0_
        service: '<APPLICATION_NAME>'
    ```
 
-3. [Restart the Agent][7].
+3. [Restart the Agent][8].
 
 #### Containerized
 
 ##### Metric collection
 
-For containerized environments, see the [Autodiscovery with JMX][8] guide.
+For containerized environments, see the [Autodiscovery with JMX][9] guide.
 
 ##### Log collection
 
 _Available for Agent versions >6.0_
 
-Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][9].
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Docker log collection][10].
 
 | Parameter      | Value                                                      |
 | -------------- | ---------------------------------------------------------- |
@@ -80,13 +73,13 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 ### Validation
 
-[Run the Agent's status subcommand][10] and look for `jboss_wildfly` under the Checks section.
+[Run the Agent's status subcommand][11] and look for `jboss_wildfly` under the Checks section.
 
 ## Data Collected
 
 ### Metrics
 
-See [metadata.csv][11] for a list of metrics provided by this integration.
+See [metadata.csv][12] for a list of metrics provided by this integration.
 
 ### Events
 
@@ -99,16 +92,17 @@ Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][6].
+Need help? Contact [Datadog support][5].
 
 [1]: https://developers.redhat.com/products/eap/overview
 [2]: http://wildfly.org
 [3]: https://app.datadoghq.com/account/settings#agent
-[4]: https://github.com/DataDog/integrations-core/blob/master/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
-[5]: https://docs.datadoghq.com/integrations/java
-[6]: https://docs.datadoghq.com/help
-[7]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-restart-the-agent
-[8]: https://docs.datadoghq.com/agent/guide/autodiscovery-with-jmx/?tab=containerizedagent
-[9]: https://docs.datadoghq.com/agent/docker/log/
-[10]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[11]: https://github.com/DataDog/integrations-core/blob/master/jboss_wildfly/metadata.csv
+[4]: https://docs.datadoghq.com/integrations/java
+[5]: https://docs.datadoghq.com/help
+[6]: https://github.com/DataDog/integrations-core/blob/master/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+[7]: https://docs.jboss.org/author/display/WFLY9/JMX%20subsystem%20configuration.html
+[8]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-restart-the-agent
+[9]: https://docs.datadoghq.com/agent/guide/autodiscovery-with-jmx/?tab=containerizedagent
+[10]: https://docs.datadoghq.com/agent/docker/log/
+[11]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[12]: https://github.com/DataDog/integrations-core/blob/master/jboss_wildfly/metadata.csv

--- a/jboss_wildfly/README.md
+++ b/jboss_wildfly/README.md
@@ -18,11 +18,13 @@ Place the JAR on the same machine as your Agent, and add the path to the `custom
 
    For Wildfly 9 and older:
 
-   `service:jmx:http-remoting-jmx://" + host + ":" + port `
-
+   `service:jmx:http-remoting-jmx://<host>:<port> `
+   
    For Wildfly 10+:
 
-   `service:jmx:remote+http://" + host + ":" + port`
+   `service:jmx:remote+http://<host>:<port>`
+
+Please refer to the [WildFly JMX subsystem configuration page](https://docs.jboss.org/author/display/WFLY9/JMX%20subsystem%20configuration.html) for more information
 
 ### Configuration
 

--- a/jboss_wildfly/README.md
+++ b/jboss_wildfly/README.md
@@ -14,15 +14,15 @@ Depending on your server setup (particularly when using the `remote+http` JMX sc
 
 Place the JAR on the same machine as your Agent, and add the path to the `custom_jar_paths` option.
 
-   **Note**: The JMX url scheme is different according to your WildFly version.
+**Note**: The JMX url scheme is different according to your WildFly version: 
 
-   For Wildfly 9 and older:
+- For Wildfly 9 and older:
 
-   `service:jmx:http-remoting-jmx://<host>:<port> `
+   `service:jmx:http-remoting-jmx://<HOST>:<PORT> `
    
-   For Wildfly 10+:
+- For Wildfly 10+:
 
-   `service:jmx:remote+http://<host>:<port>`
+   `service:jmx:remote+http://<HOST>:<PORT>`
 
 Please refer to the [WildFly JMX subsystem configuration page](https://docs.jboss.org/author/display/WFLY9/JMX%20subsystem%20configuration.html) for more information
 

--- a/jboss_wildfly/assets/configuration/spec.yaml
+++ b/jboss_wildfly/assets/configuration/spec.yaml
@@ -16,7 +16,10 @@ files:
       overrides:
         jmx_url.required: true
         jmx_url.hidden: false
-        jmx_url.description: JBoss/WildFly URL to connect to.
+        jmx_url.description: |-
+          JBoss/WildFly URL to connect to:
+          - For Wildfly 9 and older use: `jmx_url: service:jmx:http-remoting-jmx://<HOST>:<PORT>`
+          - For Wildfly 10+ use: `jmx_url: service:jmx:remote+http://<HOST>:<PORT>`
         jmx_url.value.example: "service:jmx:remote+http://localhost:9990"
         jmx_url.display_priority: 10
         host.required: false

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -44,9 +44,12 @@ instances:
 
     ## @param jmx_url - string - required
     ## JBoss/WildFly URL to connect to.
-    #
+    ## for Wildfly 10 and above: 
   - jmx_url: service:jmx:remote+http://localhost:9990
 
+    ## for older WildFly:
+    # jmx_url: service:jmx:http-remoting-jmx://localhost:9990
+    
     ## @param host - string - optional
     ## JMX hostname to connect to.
     #

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -44,9 +44,6 @@ instances:
 
     ## @param jmx_url - string - required
     ## JBoss/WildFly URL to connect to.
-    ##
-    ## For Wildfly 9 and older use: `jmx_url: service:jmx:http-remoting-jmx://<HOST>:<PORT>`
-    ## For Wildfly 10+ use: `jmx_url: service:jmx:remote+http://<HOST>:<PORT>`
     #
   - jmx_url: service:jmx:remote+http://localhost:9990
 

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -45,9 +45,11 @@ instances:
     ## @param jmx_url - string - required
     ## JBoss/WildFly URL to connect to.
     ## for Wildfly 10 and above: 
+    #
   - jmx_url: service:jmx:remote+http://localhost:9990
 
     ## for older WildFly:
+    #
     # jmx_url: service:jmx:http-remoting-jmx://localhost:9990
     
     ## @param host - string - optional

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -50,8 +50,6 @@ instances:
     #
   - jmx_url: service:jmx:remote+http://localhost:9990
 
-    
-    
     ## @param host - string - optional
     ## JMX hostname to connect to.
     #

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -43,7 +43,9 @@ init_config:
 instances:
 
     ## @param jmx_url - string - required
-    ## JBoss/WildFly URL to connect to.
+    ## JBoss/WildFly URL to connect to:
+    ## - For Wildfly 9 and older use: `jmx_url: service:jmx:http-remoting-jmx://<HOST>:<PORT>`
+    ## - For Wildfly 10+ use: `jmx_url: service:jmx:remote+http://<HOST>:<PORT>`
     #
   - jmx_url: service:jmx:remote+http://localhost:9990
 

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -44,13 +44,13 @@ instances:
 
     ## @param jmx_url - string - required
     ## JBoss/WildFly URL to connect to.
-    ## for Wildfly 10 and above: 
+    ##
+    ## For Wildfly 9 and older use: `jmx_url: service:jmx:http-remoting-jmx://<HOST>:<PORT>`
+    ## For Wildfly 10+ use: `jmx_url: service:jmx:remote+http://<HOST>:<PORT>`
     #
   - jmx_url: service:jmx:remote+http://localhost:9990
 
-    ## for older WildFly:
-    #
-    # jmx_url: service:jmx:http-remoting-jmx://localhost:9990
+    
     
     ## @param host - string - optional
     ## JMX hostname to connect to.


### PR DESCRIPTION
### What does this PR do?
Add jmx url for Wildfly 9 and below in public facing doc and the sample jboss/wildfly config

### Motivation
Many clients are still using WildFly 8 or 9 which does not support the jmx url that we put in our docs, adding those option and making users aware of the jmx url scheme change between version 9 and 10 may help them config their integration correctly and reduce support cases.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
