### PR TITLE
Submit server tags with a namespace

### DIFF
--- a/rethinkdb/datadog_checks/rethinkdb/operations.py
+++ b/rethinkdb/datadog_checks/rethinkdb/operations.py
@@ -37,6 +37,11 @@ r = rethinkdb.r
 system = r.db('rethinkdb')
 
 
+def _format_server_tags(tags):
+    # type: (List[str]) -> List[str]
+    return ['server_tag:{}'.format(tag) for tag in tags]
+
+
 def get_connected_server_raw_version(conn, **kwargs):
     # type: (rethinkdb.net.Connection, **Any) -> Optional[str]
     """
@@ -116,7 +121,7 @@ def get_servers_statistics(conn, **kwargs):
         server_stats = row['left']  # type: ServerStats
         server = row['right']  # type: Server
         tags = ['server:{}'.format(server['name'])]
-        tags.extend(server['tags'])
+        tags.extend(_format_server_tags(server['tags']))
         yield server_stats, tags
 
 
@@ -207,7 +212,7 @@ def get_replicas_statistics(conn, **kwargs):
             'server:{}'.format(server['name']),
             'state:{}'.format(replica['state']),
         ]
-        tags.extend(server['tags'])
+        tags.extend(_format_server_tags(server['tags']))
 
         yield replica_stats, tags
 

--- a/rethinkdb/tests/assertions.py
+++ b/rethinkdb/tests/assertions.py
@@ -14,6 +14,7 @@ from .common import (
     CURRENT_ISSUE_TYPES_SUBMITTED_IF_DISCONNECTED_SERVERS,
     CURRENT_ISSUES_METRICS,
     DATABASE,
+    FORMATTED_SERVER_TAGS,
     HEROES_TABLE,
     HEROES_TABLE_PRIMARY_REPLICA,
     HEROES_TABLE_REPLICAS_BY_SHARD,
@@ -23,7 +24,6 @@ from .common import (
     REPLICA_STATISTICS_METRICS,
     SERVER_STATISTICS_METRICS,
     SERVER_STATUS_METRICS,
-    SERVER_TAGS,
     SERVERS,
     TABLE_STATISTICS_METRICS,
     TABLE_STATUS_METRICS,
@@ -79,7 +79,7 @@ def _assert_statistics_metrics(aggregator, disconnected_servers):
         aggregator.assert_metric(metric, metric_type=typ, count=1, tags=TAGS)
 
     for server in SERVERS:
-        tags = TAGS + ['server:{}'.format(server)] + SERVER_TAGS[server]
+        tags = TAGS + ['server:{}'.format(server)] + FORMATTED_SERVER_TAGS[server]
         for metric, typ in SERVER_STATISTICS_METRICS:
             count = 0 if server in disconnected_servers else 1
             aggregator.assert_metric(metric, metric_type=typ, count=count, tags=tags)
@@ -92,7 +92,7 @@ def _assert_statistics_metrics(aggregator, disconnected_servers):
         tags = (
             TAGS
             + ['table:{}'.format(HEROES_TABLE), 'database:{}'.format(DATABASE), 'server:{}'.format(server)]
-            + SERVER_TAGS[server]
+            + FORMATTED_SERVER_TAGS[server]
         )
 
         for metric, typ in REPLICA_STATISTICS_METRICS:

--- a/rethinkdb/tests/common.py
+++ b/rethinkdb/tests/common.py
@@ -27,10 +27,10 @@ TAGS = ['env:testing']
 SERVERS = {'server0', 'server1', 'server2'}  # type: Set[ServerName]
 BOOTSTRAP_SERVER = 'server0'  # type: ServerName
 SERVER_PORTS = {'server0': 28015, 'server1': 28016, 'server2': 28017, 'proxy': 28018}  # type: Dict[ServerName, int]
-SERVER_TAGS = {
-    'server0': ['default', 'us'],
-    'server1': ['default', 'us', 'primary'],
-    'server2': ['default', 'eu'],
+FORMATTED_SERVER_TAGS = {
+    'server0': ['server_tag:default', 'server_tag:us'],
+    'server1': ['server_tag:default', 'server_tag:us', 'server_tag:primary'],
+    'server2': ['server_tag:default', 'server_tag:eu'],
 }  # type: Dict[ServerName, List[str]]
 
 # Users.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add `server_tag:` namespace to server tags submitted with server-related metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->
RethinkDB server tags were forwarded as-is, eg `['default', 'primary', 'us']`, but such unnamed tags are hard to use in Datadog (the recommended format is `name:value`).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
