### PR TITLE
Fix new option name in config sample

### DIFF
--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -341,9 +341,7 @@ instances:
     #   X-Auth-Token: <AUTH_TOKEN>
 
     ## @param tls_use_host_header - boolean - optional - default: false
-    ## If set to true, the Host header is used to match 
-    ## against the SSL Certificate CN or SAN.
-    ## Requires persist_connections set to true.
+    ## If a `Host` header is set, this enables its use for SNI (matching against the TLS certificate CN or SAN).
     #
     # tls_use_host_header: false
 

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -340,12 +340,12 @@ instances:
     #   Host: <ALTERNATIVE_HOSTNAME>
     #   X-Auth-Token: <AUTH_TOKEN>
 
-    ## @param host_header_ssl - boolean - optional - default: false
+    ## @param tls_use_host_header - boolean - optional - default: false
     ## If set to true, the Host header is used to match 
     ## against the SSL Certificate CN or SAN.
     ## Requires persist_connections set to true.
     #
-    # host_header_ssl: false
+    # tls_use_host_header: false
 
     ## @param timeout - integer - optional - default: 10
     ## The timeout for connecting to services.


### PR DESCRIPTION
 The option was renamed during the PR, but the config sample wasn't changed. This fixes it. See #5833