### PR TITLE
Fix agent check and e2e with running env

### DIFF
--- a/tls/tests/conftest.py
+++ b/tls/tests/conftest.py
@@ -23,10 +23,10 @@ HOSTNAME_TO_PORT_MAPPING = {
 
 
 @pytest.fixture(scope='session', autouse=True)
-def dd_environment():
+def dd_environment(instance_e2e):
     with docker_run(os.path.join(HERE, 'compose', 'docker-compose.yml'), build=True, sleep=5):
         e2e_metadata = {'docker_volumes': ['{}:{}'.format(CA_CERT, CA_CERT)]}
-        yield {'server': 'valid.mock'}, e2e_metadata
+        yield instance_e2e, e2e_metadata
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -152,7 +152,7 @@ def instance_remote_ok():
     return {'server': 'https://valid.mock', 'ca_cert': CA_CERT}
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def instance_e2e():
     return {'server': 'https://localhost', 'port': 4443, 'server_hostname': 'valid.mock', 'ca_cert': CA_CERT}
 


### PR DESCRIPTION
### What does this PR do?
1) Adds support for `tls` agent check when active env started, via `ddev env check tls py38`
2) See #6306 for the PR which avoids breaking existing `--e2e` behavior when no env exists

### Motivation
For TLS, the agent check would fail to find the new `valid.mock` hostname as introduced in #6104 - this came down to an issue of not passing the appropriate instance configuration in order to properly connect to the hostnames.

While the changes to `conftest.py` in this PR addressed the workflow of `ddev env start tls py38` && `ddev env check tls py38`, it breaks the existing `e2e` workflow.  See #6306 for that solution.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
