### PR TITLE
Allow `dd_environment` fixtures to accept arbitrary arguments

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -78,7 +78,7 @@ def dd_environment_runner(request):
         fixture_def = request._fixturemanager._arg2fixturedefs[E2E_FIXTURE_NAME][0]
 
         # Make the underlying function a no-op
-        fixture_def.func = lambda: None
+        fixture_def.func = lambda *args, **kwargs: None
         return
 
     try:


### PR DESCRIPTION
With #6303 implemented, this PR avoids breaking existing `--e2e` behavior when no env exists

### Motivation
In #6303, the agent check would fail to find the new `valid.mock` hostname as introduced in #6104 - this came down to an issue of not passing the appropriate instance configuration in order to properly connect to the hostnames.

While the changes to `conftest.py` in this PR addressed the workflow of `ddev env start tls py38` && `ddev env check tls py38`, it broke the existing `e2e` workflow.  Passing in the `instance_e2e` fixture now raised an error, when the following steps take place:

```
$ ddev env start tls py38
...
success!
Updating `datadog/agent:7.19.0-rc.2`... success!
Detecting the major version... Agent 7 detected
Writing configuration for `py38`... success!
Starting the Agent... success!

Config file (copied to your clipboard): /Users/mike.garabedian/Library/Application Support/dd-checks-dev/envs/tls/py38/config/tls.yaml
To run this check, do: ddev env check tls py38
To stop this check, do: ddev env stop tls py38

$ ddev test --e2e tls:py38
...
E   TypeError: <lambda>() got an unexpected keyword argument 'instance_e2e'
======================================================================= short test summary info ========================================================================
ERROR tests/test_e2e.py::test_e2e - TypeError: <lambda>() got an unexpected keyword argument 'instance_e2e'
=================================================================== 47 deselected, 1 error in 0.29s ====================================================================
ERROR: InvocationError for command /Users/mike.garabedian/src/integrations-core/tls/.tox/py38/bin/pytest -v (exited with code 1)
_______________________________________________________________________________ summary ________________________________________________________________________________
ERROR:   py38: commands failed

Failed!
```

This led to the change in the lambda function found in the `pytest.py` file, which addressed that issue, while keeping the previous fix solved.
