### PR TITLE
[DOCS-435] Adding AD instructions

### DIFF
--- a/kube_metrics_server/README.md
+++ b/kube_metrics_server/README.md
@@ -8,14 +8,27 @@ This check monitors [Kube_metrics_server][1] v0.3.0+, a component used by the Ku
 
 ### Installation
 
-The Kube_metrics_server check is included in the [Datadog Agent][2] package.
-No additional installation is needed on your server.
+The Kube_metrics_server check is included in the [Datadog Agent][2] package. No additional installation is needed on your server.
 
 ### Configuration
+
+#### Host
+
+Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
 
 1. Edit the `kube_metrics_server.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your kube_metrics_server performance data. See the [sample kube_metrics_server.d/conf.yaml][2] for all available configuration options.
 
 2. [Restart the Agent][3].
+
+#### Containerized
+
+For containerized environments, see the [Kubernetes Autodiscovery Integration Templates][4] for guidance on applying the parameters below.
+
+| Parameter            | Value                                                |
+| -------------------- | ---------------------------------------------------- |
+| `<INTEGRATION_NAME>` | `prometheus`                                         |
+| `<INIT_CONFIG>`      | blank or `{}`                                        |
+| `<INSTANCE_CONFIG>`  | `{"prometheus_url": "https://%%host%%:443/metrics"}` |
 
 #### SSL
 
@@ -25,17 +38,17 @@ If your endpoint is secured, additional configuration is required:
 
 2. Mount the related certificate file in the Agent pod.
 
-3. Apply your SSL configuration. Refer to the [default configuration file][7] for more information.
+3. Apply your SSL configuration. Refer to the [default configuration file][5] for more information.
 
 ### Validation
 
-[Run the Agent's status subcommand][4] and look for `kube_metrics_server` under the Checks section.
+[Run the Agent's status subcommand][6] and look for `kube_metrics_server` under the Checks section.
 
 ## Data Collected
 
 ### Metrics
 
-See [metadata.csv][5] for a list of metrics provided by this integration.
+See [metadata.csv][7] for a list of metrics provided by this integration.
 
 ### Service Checks
 
@@ -49,12 +62,13 @@ kube_metrics_server does not include any events.
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][6].
+Need help? Contact [Datadog support][8].
 
 [1]: https://github.com/kubernetes-incubator/metrics-server
 [2]: https://github.com/DataDog/integrations-core/blob/master/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
 [3]: https://docs.datadoghq.com/agent/guide/agent-commands/#restart-the-agent
-[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[5]: https://github.com/DataDog/integrations-core/blob/master/kube_metrics_server/metadata.csv
-[6]: https://docs.datadoghq.com/help
-[7]: https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+[4]: https://docs.datadoghq.com/agent/kubernetes/integrations
+[5]: https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+[6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[7]: https://github.com/DataDog/integrations-core/blob/master/kube_metrics_server/metadata.csv
+[8]: https://docs.datadoghq.com/help

--- a/kube_metrics_server/README.md
+++ b/kube_metrics_server/README.md
@@ -26,7 +26,7 @@ For containerized environments, see the [Kubernetes Autodiscovery Integration Te
 
 | Parameter            | Value                                                |
 | -------------------- | ---------------------------------------------------- |
-| `<INTEGRATION_NAME>` | `prometheus`                                         |
+| `<INTEGRATION_NAME>` | `kube_metrics_server `                                         |
 | `<INIT_CONFIG>`      | blank or `{}`                                        |
 | `<INSTANCE_CONFIG>`  | `{"prometheus_url": "https://%%host%%:443/metrics"}` |
 

--- a/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
@@ -10,7 +10,7 @@ instances:
     ## that is backed by more than one pod could lead to inaccurate metrics
     ## because of to the load balancing. In this case, it is recommended to
     ## enable endpoint checks alongside the service check and use autodiscovery
-    ## to get pod IP by setting up `prometheus_url` to https://%%host%%/metrics
+    ## to get pod IP by setting up `prometheus_url` to https://%%host%%:443/metrics
     #
   - prometheus_url: https://localhost:443/metrics
 


### PR DESCRIPTION
### What does this PR do?

* Adds AD instructions as it was missing.
* Updates the conf.yaml.example to match AD instructions.