### PR TITLE
Remove useless else clause

### DIFF
--- a/vsphere/datadog_checks/vsphere/api_rest.py
+++ b/vsphere/datadog_checks/vsphere/api_rest.py
@@ -55,9 +55,8 @@ class VSphereRestAPI(object):
                 yield batch
                 batch = []
             batch.append(mor)
-        else:
-            if batch:
-                yield batch
+        if batch:
+            yield batch
 
     # Don't retry, mors is an iterator and will be consumed during the function call.
     def get_resource_tags_for_mors(self, mors):


### PR DESCRIPTION
On hold during the freeze, not a blocker.
Opening the PR so that we don't forget about it.