### PR TITLE
Pin envoy version to fix tests

### DIFF
--- a/envoy/tests/docker/default/Dockerfile-service
+++ b/envoy/tests/docker/default/Dockerfile-service
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy-alpine:latest
+FROM envoyproxy/envoy-alpine:v1.14.1
 
 RUN apk update && apk add python3 bash
 RUN python3 --version && pip3 --version

--- a/envoy/tox.ini
+++ b/envoy/tox.ini
@@ -20,7 +20,7 @@ passenv =
     COMPOSE*
 setenv =
     FLAVOR=default
-    ENVOY_VERSION=latest
+    ENVOY_VERSION=v1.14.1
 commands =
     pip install -r requirements.in
     pytest -v {posargs} --benchmark-skip


### PR DESCRIPTION
Seems `latest` tag has been removed:

```
Creating network "default_envoymesh" with the default driver
Pulling front-envoy (envoyproxy/envoy:latest)...
manifest for envoyproxy/envoy:latest not found: manifest unknown: manifest unknown
Removing network default_envoymesh
```
Also
```
Service 'service1' failed to build: manifest for envoyproxy/envoy-alpine:latest not found: manifest unknown: manifest unknown
```