### PR TITLE
Add default template to openmetrics & jmx config

### DIFF
--- a/activemq/assets/configuration/spec.yaml
+++ b/activemq/assets/configuration/spec.yaml
@@ -5,14 +5,12 @@ files:
   - template: init_config
     options:
       - template: init_config/jmx
-      - template: init_config/default
   - template: instances
     options:
     - template: instances/jmx
       overrides:
         host.value.example: localhost
         port.value.example: 1616
-    - template: instances/default
   - template: logs
     example:
     - type: file

--- a/confluent_platform/assets/configuration/spec.yaml
+++ b/confluent_platform/assets/configuration/spec.yaml
@@ -10,7 +10,6 @@ files:
         service_check_prefix.value.example: confluent
         service_check_prefix.description: |
           Service check prefix to use.
-    - template: init_config/default
   - template: instances
     overrides:
       description: |
@@ -29,7 +28,6 @@ files:
         The list of metrics collected by default are listed in `metrics.yaml`.
     options:
     - template: instances/jmx
-    - template: instances/default
   - template: logs
     example:
     - type: file

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
@@ -33,3 +33,4 @@
     type: array
     items:
       type: object
+- template: init_config/default

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/openmetrics.yaml
@@ -1,1 +1,2 @@
 - template: init_config/http
+- template: init_config/default

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
@@ -90,3 +90,5 @@
   value:
     example: false
     type: boolean
+
+- template: instances/default

--- a/hive/assets/configuration/spec.yaml
+++ b/hive/assets/configuration/spec.yaml
@@ -5,7 +5,6 @@ files:
   - template: init_config
     options:
     - template: init_config/jmx
-    - template: init_config/default
   - template: instances
     options:
     - template: instances/jmx
@@ -13,7 +12,6 @@ files:
         host.description: HiveServer2 or Hive Metastore JMX host to connect to.
         port.value.example: 8809
         port.description: HiveServer2 or Hive Metastore JMX port to connect to.
-    - template: instances/default
   - template: logs
     example:
     - type: file

--- a/jboss_wildfly/assets/configuration/spec.yaml
+++ b/jboss_wildfly/assets/configuration/spec.yaml
@@ -9,7 +9,6 @@ files:
         service_check_prefix.required: true
         service_check_prefix.value.example: jboss
         service_check_prefix.description: Service check prefix to use.
-    - template: init_config/default
   - template: instances
     options:
     - template: instances/jmx
@@ -21,7 +20,6 @@ files:
         jmx_url.display_priority: 10
         host.required: false
         port.required: false
-    - template: instances/default
   - template: logs
     example:
     - type: file

--- a/openmetrics/assets/configuration/spec.yaml
+++ b/openmetrics/assets/configuration/spec.yaml
@@ -4,7 +4,6 @@ files:
     options:
     - template: init_config
       options:
-        - template: init_config/default
         - template: init_config/openmetrics
     - template: instances
       options:

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -2,13 +2,6 @@
 #
 init_config:
 
-    ## @param service - string - optional
-    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
-    ##
-    ## Additionally, this sets the default `service` for every log source.
-    #
-    # service: <SERVICE>
-
     ## @param proxy - mapping - optional
     ## Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
     ## to specify hosts that must bypass proxies.
@@ -40,6 +33,13 @@ init_config:
     ## The timeout for connecting to services.
     #
     # timeout: 10
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Additionally, this sets the default `service` for every log source.
+    #
+    # service: <SERVICE>
 
 ## Every instance is scheduled independent of the others.
 #


### PR DESCRIPTION
Add `init_config/default` to openmetrics spec template