### PR TITLE
Renew REST API session on failure

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -10,7 +10,7 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from typing import Any, Dict, Generator, Iterable, List, Set, Type, cast
 
 from pyVmomi import vim, vmodl
-from six import iteritems, iterkeys
+from six import iteritems
 
 from datadog_checks.base import AgentCheck, is_affirmative, to_string
 from datadog_checks.base.checks.libs.timer import Timer
@@ -160,9 +160,9 @@ class VSphereCheck(AgentCheck):
         }
 
         t0 = Timer()
-        mors_iterator = iterkeys(filtered_infra_data)
+        mors_list = list(filtered_infra_data.keys())
         try:
-            mor_tags = self.api_rest.get_resource_tags_for_mors(mors_iterator)
+            mor_tags = self.api_rest.get_resource_tags_for_mors(mors_list)
         except Exception as e:
             self.log.error("Failed to collect tags: %s", e)
             return {}

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -261,6 +261,21 @@ def test_refresh_tags_cache_should_not_raise_exception(aggregator, dd_run_check,
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
+def test_renew_rest_api_session_on_failure(aggregator, dd_run_check, realtime_instance):
+    realtime_instance.update({'collect_tags': True})
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
+    config = VSphereConfig(realtime_instance, MagicMock())
+    check.api_rest = VSphereRestAPI(config, MagicMock())
+    check.api_rest.make_batch = MagicMock(side_effect=[Exception, []])
+    check.api_rest.smart_connect = MagicMock()
+
+    tags = check.collect_tags({})
+    assert tags
+    assert check.api_rest.make_batch.call_count == 2
+    assert check.api_rest.smart_connect.call_count == 1
+
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
 def test_tags_filters_when_tags_are_not_yet_collected(aggregator, dd_run_check, realtime_instance):
     realtime_instance['collect_tags'] = True
     realtime_instance['resource_filters'] = [


### PR DESCRIPTION
### What does this PR do?
Adds the `@smart_retry` decorator to `get_resource_tags_for_mors` in the rest api.
Even though the REST API don't persist connections and uses an username + password, the session token has to be renewed every now and then.


### Motivation
Found on the lab running overnight.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
