### PR TITLE
Add device_name tag

### DIFF
--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -105,6 +105,7 @@ class Disk(AgentCheck):
                 device_name = device_name.strip('\\').lower()
 
             tags.append('device:{}'.format(device_name))
+            tags.append('device_name:{}'.format(os.path.basename(part.device)))
             for metric_name, metric_value in iteritems(self._collect_part_metrics(part, disk_usage)):
                 self.gauge(metric_name, metric_value, tags=tags)
 
@@ -250,6 +251,7 @@ class Disk(AgentCheck):
                 write_time_pct = disk.write_time * 100 / 1000
                 metric_tags = [] if self._custom_tags is None else self._custom_tags[:]
                 metric_tags.append('device:{}'.format(disk_name))
+                metric_tags.append('device_name:{}'.format(os.path.basename(disk_name)))
                 if self.devices_label.get(disk_name):
                     metric_tags.append(self.devices_label.get(disk_name))
                 self.rate(self.METRIC_DISK.format('read_time_pct'), read_time_pct, tags=metric_tags)

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -20,6 +20,13 @@ from datadog_checks.base.utils.timeout import TimeoutException, timeout
 IGNORE_CASE = re.I if platform.system() == 'Windows' else 0
 
 
+def _base_device_name(device):
+    if Platform.is_win32():
+        return device.strip('\\').lower()
+    else:
+        return os.path.basename(device)
+
+
 class Disk(AgentCheck):
     """ Collects metrics about the machine's disks. """
 
@@ -105,7 +112,7 @@ class Disk(AgentCheck):
                 device_name = device_name.strip('\\').lower()
 
             tags.append('device:{}'.format(device_name))
-            tags.append('device_name:{}'.format(os.path.basename(part.device)))
+            tags.append('device_name:{}'.format(_base_device_name(part.device)))
             for metric_name, metric_value in iteritems(self._collect_part_metrics(part, disk_usage)):
                 self.gauge(metric_name, metric_value, tags=tags)
 
@@ -251,7 +258,7 @@ class Disk(AgentCheck):
                 write_time_pct = disk.write_time * 100 / 1000
                 metric_tags = [] if self._custom_tags is None else self._custom_tags[:]
                 metric_tags.append('device:{}'.format(disk_name))
-                metric_tags.append('device_name:{}'.format(os.path.basename(disk_name)))
+                metric_tags.append('device_name:{}'.format(_base_device_name(disk_name)))
                 if self.devices_label.get(disk_name):
                     metric_tags.append(self.devices_label.get(disk_name))
                 self.rate(self.METRIC_DISK.format('read_time_pct'), read_time_pct, tags=metric_tags)

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -16,14 +16,18 @@ from datadog_checks.base.utils.platform import Platform
 from datadog_checks.base.utils.subprocess_output import SubprocessOutputEmptyError, get_subprocess_output
 from datadog_checks.base.utils.timeout import TimeoutException, timeout
 
-# See: https://github.com/DataDog/integrations-core/pull/1109#discussion_r167133580
-IGNORE_CASE = re.I if platform.system() == 'Windows' else 0
+if platform.system() == 'Windows':
+    # See: https://github.com/DataDog/integrations-core/pull/1109#discussion_r167133580
+    IGNORE_CASE = re.I
 
-
-def _base_device_name(device):
-    if Platform.is_win32():
+    def _base_device_name(device):
         return device.strip('\\').lower()
-    else:
+
+
+else:
+    IGNORE_CASE = 0
+
+    def _base_device_name(device):
         return os.path.basename(device)
 
 

--- a/disk/tests/common.py
+++ b/disk/tests/common.py
@@ -9,10 +9,12 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 
 if ON_WINDOWS:
     DEFAULT_DEVICE_NAME = 'c:'
+    DEFAULT_DEVICE_BASE_NAME = 'c:'
     DEFAULT_FILE_SYSTEM = 'ntfs'
     DEFAULT_MOUNT_POINT = 'c:'
 else:
     DEFAULT_DEVICE_NAME = '/dev/sda1'
+    DEFAULT_DEVICE_BASE_NAME = 'sda1'
     DEFAULT_FILE_SYSTEM = 'ext4'
     DEFAULT_MOUNT_POINT = '/'
 

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -11,7 +11,7 @@ from six import iteritems
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.disk import Disk
 
-from .common import DEFAULT_DEVICE_NAME, DEFAULT_FILE_SYSTEM, DEFAULT_MOUNT_POINT
+from .common import DEFAULT_DEVICE_BASE_NAME, DEFAULT_DEVICE_NAME, DEFAULT_FILE_SYSTEM, DEFAULT_MOUNT_POINT
 from .mocks import MockDiskMetrics, mock_blkid_output
 
 
@@ -56,6 +56,7 @@ def test_default(aggregator, gauge_metrics, rate_metrics):
                 DEFAULT_FILE_SYSTEM,
                 'filesystem:{}'.format(DEFAULT_FILE_SYSTEM),
                 'device:{}'.format(DEFAULT_DEVICE_NAME),
+                'device_name:{}'.format(DEFAULT_DEVICE_BASE_NAME),
             ]
         else:
             tags = []
@@ -64,7 +65,11 @@ def test_default(aggregator, gauge_metrics, rate_metrics):
             aggregator.assert_metric(name, value=value, tags=tags)
 
         for name, value in iteritems(rate_metrics):
-            aggregator.assert_metric(name, value=value, tags=['device:{}'.format(DEFAULT_DEVICE_NAME)])
+            aggregator.assert_metric(
+                name,
+                value=value,
+                tags=['device:{}'.format(DEFAULT_DEVICE_NAME), 'device_name:{}'.format(DEFAULT_DEVICE_BASE_NAME)],
+            )
 
     aggregator.assert_all_metrics_covered()
 
@@ -90,10 +95,18 @@ def test_use_mount(aggregator, instance_basic_mount, gauge_metrics, rate_metrics
     c.check(instance_basic_mount)
 
     for name, value in iteritems(gauge_metrics):
-        aggregator.assert_metric(name, value=value, tags=['device:{}'.format(DEFAULT_MOUNT_POINT)])
+        aggregator.assert_metric(
+            name,
+            value=value,
+            tags=['device:{}'.format(DEFAULT_MOUNT_POINT), 'device_name:{}'.format(DEFAULT_DEVICE_BASE_NAME)],
+        )
 
     for name, value in iteritems(rate_metrics):
-        aggregator.assert_metric(name, value=value, tags=['device:{}'.format(DEFAULT_DEVICE_NAME)])
+        aggregator.assert_metric(
+            name,
+            value=value,
+            tags=['device:{}'.format(DEFAULT_DEVICE_NAME), 'device_name:{}'.format(DEFAULT_DEVICE_BASE_NAME)],
+        )
 
     aggregator.assert_all_metrics_covered()
 
@@ -115,14 +128,28 @@ def test_device_tagging(aggregator, gauge_metrics, rate_metrics):
         c.check(instance)
 
     # Assert metrics
-    tags = ['type:dev', 'tag:two', 'device:{}'.format(DEFAULT_DEVICE_NAME), 'optional:tags1', 'label:mylab']
+    tags = [
+        'type:dev',
+        'tag:two',
+        'device:{}'.format(DEFAULT_DEVICE_NAME),
+        'device_name:{}'.format(DEFAULT_DEVICE_BASE_NAME),
+        'optional:tags1',
+        'label:mylab',
+    ]
 
     for name, value in iteritems(gauge_metrics):
         aggregator.assert_metric(name, value=value, tags=tags)
 
     for name, value in iteritems(rate_metrics):
         aggregator.assert_metric(
-            name, value=value, tags=['device:{}'.format(DEFAULT_DEVICE_NAME), 'optional:tags1', 'label:mylab']
+            name,
+            value=value,
+            tags=[
+                'device:{}'.format(DEFAULT_DEVICE_NAME),
+                'device_name:{}'.format(DEFAULT_DEVICE_BASE_NAME),
+                'optional:tags1',
+                'label:mylab',
+            ],
         )
 
     aggregator.assert_all_metrics_covered()
@@ -155,6 +182,7 @@ def test_min_disk_size(aggregator, gauge_metrics, rate_metrics):
 
     for name in rate_metrics:
         aggregator.assert_metric_has_tag(name, 'device:{}'.format(DEFAULT_DEVICE_NAME))
+        aggregator.assert_metric_has_tag(name, 'device_name:{}'.format(DEFAULT_DEVICE_BASE_NAME))
 
     aggregator.assert_all_metrics_covered()
 

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -196,7 +196,7 @@ def test_labels_from_blkid_cache_file(aggregator, instance_blkid_cache_file, gau
     c = Disk('disk', {}, [instance_blkid_cache_file])
     c.check(instance_blkid_cache_file)
     for metric in chain(gauge_metrics, rate_metrics):
-        aggregator.assert_metric(metric, tags=['device:/dev/sda1', 'label:MYLABEL'])
+        aggregator.assert_metric(metric, tags=['device:/dev/sda1', 'device_name:sda1', 'label:MYLABEL'])
 
 
 @pytest.mark.skipif(not Platform.is_linux(), reason='disk labels are only available on Linux')
@@ -210,4 +210,4 @@ def test_blkid_cache_file_contains_no_labels(
     c = Disk('disk', {}, [instance_blkid_cache_file_no_label])
     c.check(instance_blkid_cache_file_no_label)
     for metric in chain(gauge_metrics, rate_metrics):
-        aggregator.assert_metric(metric, tags=['device:/dev/sda1'])
+        aggregator.assert_metric(metric, tags=['device:/dev/sda1', 'device_name:sda1'])


### PR DESCRIPTION
This adds a new tag which only contains the base part of the device, for
compatibility with iostats check.