### PR TITLE
Hide openmetrics template options that are typically overridden

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -5,12 +5,14 @@
     type: string
 - name: namespace
   required: true
+  hidden: true
   description: The namespace to be prepended to all metrics.
   value:
     type: string
     example: service
 - name: metrics
   required: true
+  hidden: true
   description: |
     List of metrics to be fetched from the prometheus endpoint, if there's a
     value it'll be renamed. This list should contain at least one metric.

--- a/openmetrics/assets/configuration/spec.yaml
+++ b/openmetrics/assets/configuration/spec.yaml
@@ -8,6 +8,6 @@ files:
     - template: instances
       options:
         - template: instances/openmetrics
-          override:
+          overrides:
             namespace.hidden: false
             metrics.hidden: false

--- a/openmetrics/assets/configuration/spec.yaml
+++ b/openmetrics/assets/configuration/spec.yaml
@@ -8,3 +8,6 @@ files:
     - template: instances
       options:
         - template: instances/openmetrics
+          override:
+            namespace.hidden: false
+            metrics.hidden: false

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -50,6 +50,20 @@ instances:
     #
   - prometheus_url: <PROMETHEUS_URL>
 
+    ## @param namespace - string - required
+    ## The namespace to be prepended to all metrics.
+    #
+    namespace: service
+
+    ## @param metrics - list of strings - required
+    ## List of metrics to be fetched from the prometheus endpoint, if there's a
+    ## value it'll be renamed. This list should contain at least one metric.
+    #
+    metrics:
+      - processor:cpu
+      - memory:mem
+      - io
+
     ## @param prometheus_metrics_prefix - string - optional
     ## <PREFIX> for exposed Prometheus metrics.
     #

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -50,20 +50,6 @@ instances:
     #
   - prometheus_url: <PROMETHEUS_URL>
 
-    ## @param namespace - string - required
-    ## The namespace to be prepended to all metrics.
-    #
-    namespace: service
-
-    ## @param metrics - list of strings - required
-    ## List of metrics to be fetched from the prometheus endpoint, if there's a
-    ## value it'll be renamed. This list should contain at least one metric.
-    #
-    metrics:
-      - processor:cpu
-      - memory:mem
-      - io
-
     ## @param prometheus_metrics_prefix - string - optional
     ## <PREFIX> for exposed Prometheus metrics.
     #


### PR DESCRIPTION
`namespace` and `metrics` options are typically set in openmetrics-based integrations that do not use config values. Hiding these options by default as it is not valid/used in other integrations.