### PR TITLE
[PROD] include openstack_controller docs as tab in OpenStack integration

### DIFF
--- a/openstack/README.md
+++ b/openstack/README.md
@@ -11,6 +11,103 @@ Get metrics from OpenStack service in real time to:
 
 ## Setup
 
+{{< tabs >}} 
+
+{{% tab "OpenStack v13 and Above" %}}
+### Installation
+
+OpenStack versions v13+ are covered by the OpenStack Controller check. This check is included in the [Datadog Agent][2] package, so you do not need to install anything else on your server.
+
+### Configuration
+
+The OpenStack Controller check is designed to collect information from all compute nodes and the servers running it. The integration should be run from a single Agent to monitor your OpenStack environment, and can be deployed on your controller node or an adjacent server that has access to the Keystone and Nova endpoints.
+
+<div class="alert alert-warning">
+In order to fully populate the Host Map, it is recommended to configure the OpenStack Controller check on each hypervisor. 
+</div>
+
+#### Prepare OpenStack
+
+Create a `datadog` user that is used in your `openstack_controller.d/conf.yaml` file. This user requires admin read-only permissions across your environment so that it can be run from a single node and read high level system information about all nodes and servers.
+
+#### Agent Configuration
+
+1. Edit the `openstack_controller.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your OpenStack Controller performance data. See the [sample openstack_controller.d/conf.yaml][2] for all available configuration options:
+
+   ```yaml
+   init_config:
+
+   instances:
+     ## @param name - string - required
+     ## Unique identifier for this instance.
+     #
+     - name: "<INSTANCE_NAME>"
+
+       ## @param user - object - required
+       ## Password authentication is the only auth method supported
+       ## User expects username, password, and user domain id
+       ## `user` should resolve to a structure like
+       ## {'password': '<PASSWORD>', 'name': '<USER_NAME>', 'domain': {'id': '<DOMAIN_ID>'}}
+       ## The check uses the Unscoped token method to collect information about
+       ## all available projects to the user.
+       #
+       user:
+         password: "<PASSWORD>"
+         name: "<USER_NAME>"
+         domain:
+           id: "<DOMAIN_ID>"
+   ```
+
+2. [Restart the Agent][3]
+
+### Validation
+
+[Run the Agent's `status` subcommand][4] and look for `openstack_controller` under the Checks section.
+
+## Data Collected
+
+### Metrics
+
+See [metadata.csv][5] for a list of metrics provided by this integration.
+
+### Service Checks
+
+**openstack.neutron.api.up**
+
+Returns `CRITICAL` if the Agent is unable to query the Neutron API, `UNKNOWN` if there is an issue with the Keystone API. Returns `OK` otherwise.
+
+**openstack.nova.api.up**
+
+Returns `CRITICAL` if the Agent is unable to query the Nova API, `UNKNOWN` if there is an issue with the Keystone API. Returns `OK` otherwise.
+
+**openstack.keystone.api.up**
+
+Returns `CRITICAL` if the Agent is unable to query the Keystone API. Returns `OK` otherwise.
+
+**openstack.nova.hypervisor.up**
+
+Returns `UNKNOWN` if the Agent is unable to get the Hypervisor state, `CRITICAL` if the Hypervisor is down. Returns `OK` otherwise.
+
+**openstack.neutron.network.up**
+
+Returns `CRITICAL` if the Network is down. Returns `OK` otherwise.
+
+### Events
+
+OpenStack Controller does not include any events.
+
+## Troubleshooting
+
+Need help? Contact [Datadog support][6].
+
+[1]: https://www.openstack.org
+[2]: https://github.com/DataDog/integrations-core/blob/master/openstack_controller/datadog_checks/openstack_controller/data/conf.yaml.example
+[3]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
+[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[5]: https://github.com/DataDog/integrations-core/blob/master/openstack_controller/metadata.csv
+[6]: https://docs.datadoghq.com/help
+{{% /tab %}}
+{{% tab "OpenStack v12 and Below" %}}
 ### Installation
 
 To capture your OpenStack metrics, [install the Agent][2] on your hosts running hypervisors.
@@ -171,3 +268,4 @@ See also these other Datadog blog posts:
 [9]: https://www.datadoghq.com/blog/openstack-monitoring-nova
 [10]: https://www.datadoghq.com/blog/install-openstack-in-two-commands
 [11]: https://www.datadoghq.com/blog/openstack-host-aggregates-flavors-availability-zones
+{{%/tab %}} {{< /tabs >}}

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -11,9 +11,8 @@ Get metrics from OpenStack service in real time to:
 
 ## Setup
 
-{{< tabs >}} 
-
-{{% tab "OpenStack v13 and Above" %}}
+<!-- xxx tabs xxx -->  
+<!-- xxx tab "OpenStack v13 and Above" --> 
 ### Installation
 
 OpenStack versions v13+ are covered by the OpenStack Controller check. This check is included in the [Datadog Agent][2] package, so you do not need to install anything else on your server.
@@ -106,8 +105,8 @@ Need help? Contact [Datadog support][6].
 [4]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [5]: https://github.com/DataDog/integrations-core/blob/master/openstack_controller/metadata.csv
 [6]: https://docs.datadoghq.com/help
-{{% /tab %}}
-{{% tab "OpenStack v12 and Below" %}}
+<!-- xxz tab xxx -->
+<!-- xxx tab "OpenStack v12 and Below" xxx -->
 ### Installation
 
 To capture your OpenStack metrics, [install the Agent][2] on your hosts running hypervisors.
@@ -268,4 +267,5 @@ See also these other Datadog blog posts:
 [9]: https://www.datadoghq.com/blog/openstack-monitoring-nova
 [10]: https://www.datadoghq.com/blog/install-openstack-in-two-commands
 [11]: https://www.datadoghq.com/blog/openstack-host-aggregates-flavors-availability-zones
-{{%/tab %}} {{< /tabs >}}
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx --> 


### PR DESCRIPTION
### What does this PR do?

The openstack_controller check collects the same information as the OpenStack integration, these should be consolidated into a single piece of documentation. 

I understand this probably isn't the ideal way to handle this PR, but until we can consolidate the openstack_controller check and the OpenStack integration into one repo; this will at least prevent this from being confusing to customers. 

The "OpenStack Integration" is actually outdated and only really applies to the "non-containerized" version of this technology v13 and below. v13 was end-of-lifed in 2018 and is no longer supported by Red Hat: https://docs.openstack.org/puppet-openstack-guide/latest/install/releases.html

### Motivation
Experienced a lot of confusion with Red Hat folks on this one as well as Ciena. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
