### PR TITLE
Fix namespace tagging for latency metrics

### DIFF
--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -292,7 +292,7 @@ class AerospikeCheck(AgentCheck):
                     latency = metric_name + '_over_' + latency
                     metric_names.append(latency)
 
-            ns_latencies[ns]["metric_names"] = ns_latencies[ns].get("metric_names", []) + list(metric_names)
+            ns_latencies[ns].setdefault("metric_names", []).extend(metric_names)
 
         for ns, v in iteritems(ns_latencies):
             metric_names = v.get("metric_names", [])

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -270,7 +270,7 @@ class AerospikeCheck(AgentCheck):
             timestamp = re.match(r'(\d+:\d+:\d+)', line)
             if timestamp:
                 metric_values = line.split(",")[1:]
-                ns_latencies[ns]["metric_values"] = ns_latencies[ns].get("metric_values", []) + list(metric_values)
+                ns_latencies[ns].setdefault("metric_values", []).extend(metric_values)
                 continue
 
             # match only works at the beginning

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import
 
 import re
+from collections import defaultdict
 
 from six import iteritems
 
@@ -254,12 +255,11 @@ class AerospikeCheck(AgentCheck):
 
         ns = None
 
-        metric_names = []
-
-        metric_values = []
+        ns_latencies = defaultdict(dict)
 
         while data:
             line = data.pop(0)
+            metric_names = []
 
             if line.startswith("error-"):
                 continue
@@ -269,7 +269,8 @@ class AerospikeCheck(AgentCheck):
 
             timestamp = re.match(r'(\d+:\d+:\d+)', line)
             if timestamp:
-                metric_values += line.split(",")[1:]
+                metric_values = line.split(",")[1:]
+                ns_latencies[ns]["metric_values"] = ns_latencies[ns].get("metric_values", []) + list(metric_values)
                 continue
 
             # match only works at the beginning
@@ -291,12 +292,16 @@ class AerospikeCheck(AgentCheck):
                     latency = metric_name + '_over_' + latency
                     metric_names.append(latency)
 
+            ns_latencies[ns]["metric_names"] = ns_latencies[ns].get("metric_names", []) + list(metric_names)
+
+        for ns, v in iteritems(ns_latencies):
+            metric_names = v.get("metric_names", [])
+            metric_values = v.get("metric_values", [])
             namespace_tags = ['namespace:{}'.format(ns)]
             namespace_tags.extend(self._tags)
-
-        if len(metric_names) == len(metric_values):
-            for i in range(len(metric_names)):
-                self.send(NAMESPACE_LATENCY_METRIC_TYPE, metric_names[i], metric_values[i], namespace_tags)
+            if len(metric_names) == len(metric_values):
+                for i in range(len(metric_names)):
+                    self.send(NAMESPACE_LATENCY_METRIC_TYPE, metric_names[i], metric_values[i], namespace_tags)
 
     def collect_throughput(self, namespaces):
         data = self.get_info('throughput:')


### PR DESCRIPTION
### What does this PR do?
Fix namespace tagging for latency metrics. All latency metrics are tagged with the last namespace processed

### Motivation
- 2050-wayfair-aerospike-latency-metrics-shows-n-a-for-0-values


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
