### PR TITLE
Mark `instance` as non-`Optional`

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -174,7 +174,7 @@ class AgentCheck(object):
         self.name = name  # type: str
         self.init_config = init_config  # type: InitConfigType
         self.agentConfig = agentConfig  # type: AgentConfigType
-        self.instance = instance  # type: Optional[InstanceType]
+        self.instance = instance  # type: InstanceType
         self.instances = instances  # type: List[InstanceType]
         self.warnings = []  # type: List[str]
         self.metrics = defaultdict(list)  # type: DefaultDict[str, List[str]]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Convince IDEs and type checkers that `self.instance` always refers to a well-defined instance dict, although it is not technically enforced at runtime yet.

### Motivation
<!-- What inspired you to submit this pull request? -->
Currently, mypy always complains (as it should) when we're trying to access anything on `self.instance`, because it's marked as `Optional`.

This is _technically correct_, because some tests still use the legacy signature without passing an instance.

But _in practice_ (i.e. when an Agent is running a check in the wild) the `instance` is always set, so it makes better sense to mark it as a non-optional dict.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
