### PR TITLE
Fix release-manual pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ release-manual:
     - /.*-\d+\.\d+\.\d+(-(rc|pre|alpha|beta)\.\d+)?$/
   script:
     # Get tagger info
-    - tagger=$(git show "$CI_COMMIT_TAG" | head -2 | tail -1)
+    - tagger=$(git show "$CI_COMMIT_TAG" | grep '^Tagger:')
     # The automatic release builder will trigger this job as a side-effect of
     # tagging releases. To prevent multiple redundant builds we don't trigger
     # the pipeline unless the tag was applied manually.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Replacing filtering logic.

For some reason `git show "$CI_COMMIT_TAG" | head -2` fails on CI. Investigating.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
