### PR TITLE
Add vSphere version metadata

### DIFF
--- a/.stubs/pyVmomi/vim/__init__.pyi
+++ b/.stubs/pyVmomi/vim/__init__.pyi
@@ -34,6 +34,7 @@ class ServiceInstanceContent:
     viewManager: ViewManager
     perfManager: PerformanceManager
     eventManager: EventManager
+    about: AboutInfo
 
 class ServiceInstance:
     """
@@ -83,6 +84,14 @@ class PerformanceManager:
         value: Any
         entity: ManagedEntity
     def QueryPerf(self, querySpec: List[PerformanceManager.QuerySpec]) -> List[PerformanceManager.EntityMetricBase]: ...
+
+
+class AboutInfo:
+    apiType: str
+    apiVersion: str
+    version: str
+    build: str
+    fullName: str
 
 class VirtualMachine(ManagedEntity): ...
 class HostSystem(ManagedEntity): ...

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -510,12 +510,14 @@ class VSphereCheck(AgentCheck):
     def check(self, _):
         # type: (Any) -> None
         self._hostname = datadog_agent.get_hostname()
-        # Assert the health of the vCenter API and submit the service_check accordingly
+        # Assert the health of the vCenter API by getting the version, and submit the service_check accordingly
         try:
-            self.api.check_health()
+            version_info = self.api.get_version()
+            if self.is_metadata_collection_enabled():
+                self.set_metadata('version', version_info.version_str)
         except Exception:
             # Explicitly do not attach any host to the service checks.
-            self.log.error("The vCenter API is not responding. The check will not run.")
+            self.log.exception("The vCenter API is not responding. The check will not run. %s")
             self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=self.config.base_tags, hostname=None)
             raise
         else:

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -517,7 +517,7 @@ class VSphereCheck(AgentCheck):
                 self.set_metadata('version', version_info.version_str)
         except Exception:
             # Explicitly do not attach any host to the service checks.
-            self.log.exception("The vCenter API is not responding. The check will not run. %s")
+            self.log.exception("The vCenter API is not responding. The check will not run.")
             self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=self.config.base_tags, hostname=None)
             raise
         else:

--- a/vsphere/tests/mocked_api.py
+++ b/vsphere/tests/mocked_api.py
@@ -12,6 +12,8 @@ from requests import Response
 from six import iteritems
 from tests.common import HERE
 
+from datadog_checks.vsphere.api import VersionInfo
+
 
 class MockedCounter(object):
     def __init__(self, counter):
@@ -29,6 +31,15 @@ class MockedAPI(object):
 
     def check_health(self):
         return True
+
+    def get_version(self):
+        about = MagicMock(
+            version='6.7.0',
+            build='123456789',
+            fullName='VMware vCenter Server 6.7.0 build-14792544',
+            apiType='VirtualCenter',
+        )
+        return VersionInfo(about)
 
     def recursive_parse_topology(self, subtree, parent=None):
         current_mor = MagicMock(spec=getattr(vim, subtree['spec']), _moId=subtree['mo_id'])

--- a/vsphere/tests/test_api.py
+++ b/vsphere/tests/test_api.py
@@ -52,7 +52,7 @@ def test_connect_success(realtime_instance):
         connection = MagicMock()
         smart_connect = connect.SmartConnect
         smart_connect.return_value = connection
-        current_time = connection.CurrentTime
+        get_about_info = connection.content.about.version.__str__
 
         config = VSphereConfig(realtime_instance, MagicMock())
         api = VSphereAPI(config, MagicMock())
@@ -62,7 +62,7 @@ def test_connect_success(realtime_instance):
             pwd=realtime_instance['password'],
             sslContext=ANY,
         )
-        current_time.assert_called_once()
+        get_about_info.assert_called_once()
 
         assert api._conn == connection
 
@@ -72,8 +72,8 @@ def test_connect_failure(realtime_instance):
         connection = MagicMock()
         smart_connect = connect.SmartConnect
         smart_connect.return_value = connection
-        current_time = connection.CurrentTime
-        current_time.side_effect = Exception('foo')
+        version_info = connection.content.about.version.__str__
+        version_info.side_effect = Exception('foo')
 
         config = VSphereConfig(realtime_instance, MagicMock())
         with pytest.raises(APIConnectionError):
@@ -85,7 +85,7 @@ def test_connect_failure(realtime_instance):
             pwd=realtime_instance['password'],
             sslContext=ANY,
         )
-        current_time.assert_called_once()
+        version_info.assert_called_once()
 
 
 def test_get_infrastructure(realtime_instance):

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -306,3 +306,20 @@ def test_tags_filters_with_prefix_when_tags_are_not_yet_collected(aggregator, dd
     aggregator.assert_metric('vsphere.cpu.usage.avg', count=1)
     # Assert that the resource that was collected is the one with the correct tag
     aggregator.assert_metric('vsphere.cpu.usage.avg', tags=['vcenter_server:FAKE'], hostname='VM4-4')
+
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
+def test_version_metadata(aggregator, dd_run_check, realtime_instance, datadog_agent):
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
+    check.check_id = 'test:123'
+    dd_run_check(check)
+    version_metadata = {
+        'version.scheme': 'semver',
+        'version.major': '6',
+        'version.minor': '7',
+        'version.patch': '0',
+        'version.build': '123456789',
+        'version.raw': '6.7.0+123456789',
+    }
+
+    datadog_agent.assert_metadata('test:123', version_metadata)


### PR DESCRIPTION
### What does this PR do?
Collects and submit the vSphere version. Also uses version information to display an error message if the integration is connected to something that is not a vCenter instance (i.e an ESXi host directly)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
