### PR TITLE
Use LTS ubuntu in tagger image

### DIFF
--- a/.gitlab/tagger/Dockerfile
+++ b/.gitlab/tagger/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.04
+FROM ubuntu:18.04
 
 # Update sources and install required packages
 RUN apt-get update \


### PR DESCRIPTION
The tagger image used in CI is based on ubuntu 19.04 and fails when running `apt-get update`.
The PR updates the base image to ubuntu:18.04 (LTS)

19.04 is now EOL and the respositories don't exist anymore:

```
$ docker run -it ubuntu:19.04 apt-get update

Ign:1 http://archive.ubuntu.com/ubuntu disco InRelease
Ign:2 http://archive.ubuntu.com/ubuntu disco-updates InRelease
Ign:3 http://archive.ubuntu.com/ubuntu disco-backports InRelease
Err:4 http://archive.ubuntu.com/ubuntu disco Release
  404  Not Found [IP: 91.189.88.142 80]
Err:5 http://archive.ubuntu.com/ubuntu disco-updates Release
  404  Not Found [IP: 91.189.88.142 80]
Err:6 http://archive.ubuntu.com/ubuntu disco-backports Release
  404  Not Found [IP: 91.189.88.142 80]
Ign:7 http://security.ubuntu.com/ubuntu disco-security InRelease
Err:8 http://security.ubuntu.com/ubuntu disco-security Release
  404  Not Found [IP: 91.189.91.39 80]
Reading package lists... Done
E: The repository 'http://archive.ubuntu.com/ubuntu disco Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://archive.ubuntu.com/ubuntu disco-updates Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://archive.ubuntu.com/ubuntu disco-backports Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://security.ubuntu.com/ubuntu disco-security Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.

```