### PR TITLE
Refactor CI release-manual job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,12 +32,12 @@ release-manual:
     - /.*-\d+\.\d+\.\d+(-(rc|pre|alpha|beta)\.\d+)?$/
   script:
     # Get tagger info
-    - tagger=$(git show "$CI_COMMIT_TAG" | grep '^Tagger:')
+    - tagger=$(git for-each-ref refs/tags/$CI_COMMIT_TAG  --format='%(taggername) %(taggeremail)')
     # The automatic release builder will trigger this job as a side-effect of
     # tagging releases. To prevent multiple redundant builds we don't trigger
     # the pipeline unless the tag was applied manually.
     - |
-      if [[ "$tagger" =~ "Tagger: $TAGGER_NAME <$TAGGER_EMAIL>" ]]; then
+      if [[ "$tagger" =~ "$TAGGER_NAME <$TAGGER_EMAIL>" ]]; then
           echo "Skipping, packages have already been built"
       else
           ./.gitlab/tagger/build-packages.sh


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Refactor CI release-manual job to use `git for-each-ref` instead of `git show`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
