### PR TITLE
Set locale for tagger docker image

### DIFF
--- a/.gitlab/tagger/Dockerfile
+++ b/.gitlab/tagger/Dockerfile
@@ -28,6 +28,9 @@ RUN mkdir -p ~/.ssh \
 
 # Environment
 ENV DDEV_ROOT ~/datadog_checks_dev
+# Locales are required to be set to use click
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
 # Assumes the build context is `integrations-core/datadog_checks_dev`
 COPY . ${DDEV_ROOT}


### PR DESCRIPTION
Updating the ubuntu version in https://github.com/DataDog/integrations-core/pull/6365 apparently breaks click in the CI.

Let's set the locales to make click happy.

I was able to run `ddev --version` manually in that container.
