### PR TITLE
Clarify default port of 8126 must be set for APM and Fargate

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -265,7 +265,7 @@ Monitor Fargate logs by using the `awslogs` log driver and a Lambda function to 
 
 ### Trace Collection
 
-1. Follow the [instructions above](#installation) to add the Datadog Agent container to your task definition with the additional environment variable `DD_APM_ENABLED` set to `true`.
+1. Follow the [instructions above](#installation) to add the Datadog Agent container to your task definition with the additional environment variable `DD_APM_ENABLED` set to `true` and set up a host port that uses **8126** with **tcp** protocol under port mappings.
 
 2. [Instrument your application][32] based on your setup.
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Clarify default tcp port of 8126 must be set for APM and Fargate.

### Motivation
<!-- What inspired you to submit this pull request? -->

If you follow our Fargate docs and don't specifically set up port **8126** with **tcp** protocol where the Datadog Agent is, the application will not be able to submit its traces to the Datadog Agent.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

It is possible to change the default receiver port to another port, but if you do this, then your tracing client must also match, so let me know if the wording should be more general about the port number. Note that 8126 is the default.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
