### PR TITLE
Change mapreduce docker image

### DIFF
--- a/mapreduce/tests/compose/docker-compose.yaml
+++ b/mapreduce/tests/compose/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   hadoop-single-node:
-    image: sequenceiq/hadoop-docker:2.7.1
+    image: ouyi/hadoop-docker:latest
     hostname: ${HOSTNAME}
     container_name: dd-test-mapreduce
     environment:


### PR DESCRIPTION
Updates docker image to one that is less than 4 years old in an attempt to get rid of the `Unexpected EOF` errors when pulling 