### PR TITLE
Update logo url

### DIFF
--- a/ecs_fargate/assets/dashboards/amazon_fargate_overview.json
+++ b/ecs_fargate/assets/dashboards/amazon_fargate_overview.json
@@ -38,7 +38,7 @@
             "sizing": "zoom", 
             "title": false, 
             "type": "image", 
-            "url": "https://static.datadoghq.com/static/images/saas_logos/bot/amazon_fargate@2x.png", 
+            "url": "/static/images/saas_logos/bot/amazon_fargate@2x.png", 
             "width": 11, 
             "x": 1, 
             "y": 1

--- a/ecs_fargate/assets/dashboards/amazon_fargate_overview.json
+++ b/ecs_fargate/assets/dashboards/amazon_fargate_overview.json
@@ -38,7 +38,7 @@
             "sizing": "zoom", 
             "title": false, 
             "type": "image", 
-            "url": "https://static.datadoghq.com/static/v/35.2101155/images/saas_logos/bot/amazon_fargate@2x.png", 
+            "url": "https://static.datadoghq.com/static/images/saas_logos/bot/amazon_fargate@2x.png", 
             "width": 11, 
             "x": 1, 
             "y": 1


### PR DESCRIPTION
Amazon Fargate logo is not loading on preset dashboard. The original URL is 403 error. This PR updates that logo url
https://app.datadoghq.com/screen/integration/30311/amazon-fargate-overview