### PR TITLE
Disable collect_default_metrics for tests

### DIFF
--- a/confluent_platform/tests/common.py
+++ b/confluent_platform/tests/common.py
@@ -49,3 +49,4 @@ INSTANCES = [
 
 CHECK_CONFIG = load_jmx_config()
 CHECK_CONFIG['instances'] = INSTANCES
+CHECK_CONFIG['init_config']['collect_default_metrics'] = False

--- a/confluent_platform/tests/test_e2e.py
+++ b/confluent_platform/tests/test_e2e.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.stubs.aggregator import AggregatorStub
 
 from .common import CHECK_CONFIG
@@ -25,11 +26,6 @@ def test_e2e(dd_agent_check):
     # type: (Any) -> None
     aggregator = dd_agent_check(CHECK_CONFIG, rate=True)  # type: AggregatorStub
 
-    # Skip default `jvm.*` metrics by marking them as asserted
-    for metric_name in aggregator._metrics:
-        if metric_name.startswith('jvm.'):
-            aggregator.assert_metric(metric_name)
-
     for metric in ALWAYS_PRESENT_METRICS:
         aggregator.assert_metric(metric)
 
@@ -40,8 +36,4 @@ def test_e2e(dd_agent_check):
 
     for instance in CHECK_CONFIG['instances']:
         tags = ['instance:confluent_platform-localhost-{}'.format(instance['port']), 'jmx_server:localhost']
-        # TODO: Assert the status "status=AgentCheck.OK"
-        # JMXFetch is currently sending the service check status as string, but should be number.
-        # Add "status=AgentCheck.OK" once that's fixed
-        # See https://github.com/DataDog/jmxfetch/pull/287
-        aggregator.assert_service_check('confluent.can_connect', tags=tags)
+        aggregator.assert_service_check('confluent.can_connect', status=AgentCheck.OK, tags=tags)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Disable collect_default_metrics for tests

### Motivation
<!-- What inspired you to submit this pull request? -->

Make tests focused on testing integration own metrics.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
