### PR TITLE
Ceph to capture Type errors as well as key errors for osd perf metrics

### DIFF
--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -94,8 +94,8 @@ class Ceph(AgentCheck):
                 local_tags = tags + ['ceph_osd:osd%s' % osdperf['id']]
                 self._publish(osdperf, self.gauge, ['perf_stats', 'apply_latency_ms'], local_tags)
                 self._publish(osdperf, self.gauge, ['perf_stats', 'commit_latency_ms'], local_tags)
-        except KeyError:
-            self.log.debug('Error retrieving osdperf metrics')
+        except (KeyError, TypeError):
+            self.log.debug('Error retrieving osdperf metrics. Received {}', raw.get('osd_perf', {}))
 
         try:
             health = {'num_near_full_osds': 0, 'num_full_osds': 0}

--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -87,14 +87,14 @@ class Ceph(AgentCheck):
             return
 
     def _extract_metrics(self, raw, tags):
-        try:
-            raw_osd_perf = raw.get('osd_perf', {}).get('osdstats', raw.get('osd_perf'))
+        raw_osd_perf = raw.get('osd_perf', {}).get('osdstats', raw.get('osd_perf', {}))
 
-            for osdperf in raw_osd_perf['osd_perf_infos']:
-                local_tags = tags + ['ceph_osd:osd%s' % osdperf['id']]
-                self._publish(osdperf, self.gauge, ['perf_stats', 'apply_latency_ms'], local_tags)
-                self._publish(osdperf, self.gauge, ['perf_stats', 'commit_latency_ms'], local_tags)
-        except (KeyError, TypeError):
+        for osdperf in raw_osd_perf.get('osd_perf_infos', []):
+            local_tags = tags + ['ceph_osd:osd%s' % osdperf['id']]
+            self._publish(osdperf, self.gauge, ['perf_stats', 'apply_latency_ms'], local_tags)
+            self._publish(osdperf, self.gauge, ['perf_stats', 'commit_latency_ms'], local_tags)
+
+        if not  raw_osd_perf.get('osd_perf_infos'):
             self.log.debug('Error retrieving osdperf metrics. Received {}', raw.get('osd_perf', {}))
 
         try:

--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -94,7 +94,7 @@ class Ceph(AgentCheck):
             self._publish(osdperf, self.gauge, ['perf_stats', 'apply_latency_ms'], local_tags)
             self._publish(osdperf, self.gauge, ['perf_stats', 'commit_latency_ms'], local_tags)
 
-        if not  raw_osd_perf.get('osd_perf_infos'):
+        if not raw_osd_perf.get('osd_perf_infos'):
             self.log.debug('Error retrieving osdperf metrics. Received {}', raw.get('osd_perf', {}))
 
         try:

--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -87,14 +87,14 @@ class Ceph(AgentCheck):
             return
 
     def _extract_metrics(self, raw, tags):
-        raw_osd_perf = raw.get('osd_perf', {}).get('osdstats', raw.get('osd_perf', {}))
+        try:
+            raw_osd_perf = raw.get('osd_perf', {}).get('osdstats', raw.get('osd_perf'))
 
-        for osdperf in raw_osd_perf.get('osd_perf_infos', []):
-            local_tags = tags + ['ceph_osd:osd%s' % osdperf['id']]
-            self._publish(osdperf, self.gauge, ['perf_stats', 'apply_latency_ms'], local_tags)
-            self._publish(osdperf, self.gauge, ['perf_stats', 'commit_latency_ms'], local_tags)
-
-        if not raw_osd_perf.get('osd_perf_infos'):
+            for osdperf in raw_osd_perf['osd_perf_infos']:
+                local_tags = tags + ['ceph_osd:osd%s' % osdperf['id']]
+                self._publish(osdperf, self.gauge, ['perf_stats', 'apply_latency_ms'], local_tags)
+                self._publish(osdperf, self.gauge, ['perf_stats', 'commit_latency_ms'], local_tags)
+        except (KeyError, TypeError):
             self.log.debug('Error retrieving osdperf metrics. Received {}', raw.get('osd_perf', {}))
 
         try:

--- a/ceph/tests/conftest.py
+++ b/ceph/tests/conftest.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import os
-import time
 
 import pytest
 
@@ -30,7 +29,7 @@ def dd_environment():
         compose_file=compose_file,
         conditions=[
             CheckDockerLogs(compose_file, 'spawning ceph --cluster ceph -w', wait=5),
-            CheckDockerLogs(compose_file, 'Running on http://0.0.0.0:5000/')
+            CheckDockerLogs(compose_file, 'Running on http://0.0.0.0:5000/'),
         ],
     ):
         # Clean the disk space warning

--- a/ceph/tests/conftest.py
+++ b/ceph/tests/conftest.py
@@ -26,16 +26,18 @@ E2E_METADATA = {
 def dd_environment():
     compose_file = os.path.join(HERE, 'compose', 'docker-compose.yaml')
     # We need a custom condition to wait a bit longer
-    condition = CheckDockerLogs(compose_file, 'spawning ceph --cluster ceph -w', wait=5)
     with docker_run(
         compose_file=compose_file,
-        conditions=[condition],
-        sleep=5,  # Let's wait just a little bit after ceph got spawned to remove flakyness
+        conditions=[
+            CheckDockerLogs(compose_file, 'spawning ceph --cluster ceph -w', wait=5),
+            CheckDockerLogs(compose_file, 'Running on http://0.0.0.0:5000/')
+        ],
     ):
         # Clean the disk space warning
         run_command(
             ['docker', 'exec', 'dd-test-ceph', 'ceph', 'tell', 'mon.*', 'injectargs', '--mon_data_avail_warn', '5']
         )
         # Wait a bit for the change to take effect
-        time.sleep(5)
+        condition = CheckDockerLogs(compose_file, 'Cluster is now healthy')
+        condition()
         yield BASIC_CONFIG, E2E_METADATA


### PR DESCRIPTION
Adds more logs checks and although it should not happen it captures this error:

```
tests/test_e2e.py:14: in test_check
    aggregator = dd_agent_check(BASIC_CONFIG, rate=True)
../datadog_checks_dev/datadog_checks/dev/plugin/pytest.py:197: in run_check
    replay_check_run(collector, aggregator)
../datadog_checks_dev/datadog_checks/dev/_env.py:118: in replay_check_run
    raise Exception("\n".join("Message: {}\n{}".format(err['message'], err['traceback']) for err in errors))
E   Exception: Message: 'NoneType' object has no attribute '__getitem__'
E   Traceback (most recent call last):
E     File "/home/datadog_checks_base/datadog_checks/base/checks/base.py", line 820, in run
E       self.check(instance)
E     File "/home/ceph/datadog_checks/ceph/ceph.py", line 291, in check
E       self._extract_metrics(raw, tags)
E     File "/home/ceph/datadog_checks/ceph/ceph.py", line 93, in _extract_metrics
E       for osdperf in raw_osd_perf['osd_perf_infos']:
E   TypeError: 'NoneType' object has no attribute '__getitem__'
```