### PR TITLE
Submit throughput as a rate

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/_generic-router-if.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-router-if.yaml
@@ -40,22 +40,33 @@ metrics:
     name: ifXTable
   forced_type: monotonic_count
   symbols:
-  - OID: 1.3.6.1.2.1.31.1.1.1.6
-    name: ifHCInOctets
   - OID: 1.3.6.1.2.1.31.1.1.1.7
     name: ifHCInUcastPkts
   - OID: 1.3.6.1.2.1.31.1.1.1.8
     name: ifHCInMulticastPkts
   - OID: 1.3.6.1.2.1.31.1.1.1.9
     name: ifHCInBroadcastPkts
-  - OID: 1.3.6.1.2.1.31.1.1.1.10
-    name: ifHCOutOctets
   - OID: 1.3.6.1.2.1.31.1.1.1.11
     name: ifHCOutUcastPkts
   - OID: 1.3.6.1.2.1.31.1.1.1.12
     name: ifHCOutMulticastPkts
   - OID: 1.3.6.1.2.1.31.1.1.1.13
     name: ifHCOutBroadcastPkts
+  metric_tags:
+  - column:
+      OID: 1.3.6.1.2.1.31.1.1.1.1
+      name: ifName
+    tag: interface
+- MIB: IF-MIB
+  table:
+    OID: 1.3.6.1.2.1.31.1.1
+    name: ifXTable
+  forced_type: monotonic_count_and_rate
+  symbols:
+  - OID: 1.3.6.1.2.1.31.1.1.1.6
+    name: ifHCInOctets
+  - OID: 1.3.6.1.2.1.31.1.1.1.10
+    name: ifHCOutOctets
   metric_tags:
   - column:
       OID: 1.3.6.1.2.1.31.1.1.1.1

--- a/snmp/datadog_checks/snmp/metrics.py
+++ b/snmp/datadog_checks/snmp/metrics.py
@@ -84,4 +84,7 @@ def as_metric_with_forced_type(value, forced_type):
     if forced_type == 'monotonic_count':
         return {'type': 'monotonic_count', 'value': int(value)}
 
+    if forced_type == 'monotonic_count_and_rate':
+        return {'type': 'monotonic_count_and_rate', 'value': int(value)}
+
     return None

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -495,6 +495,7 @@ class SnmpCheck(AgentCheck):
         return tags
 
     def monotonic_count_and_rate(self, metric, value, tags):
+        # type: (str, Any, List[str]) -> None
         """Specific submission method which sends a metric both as a monotonic cound and a rate."""
         self.monotonic_count(metric, value, tags=tags)
         self.rate("{}.rate".format(metric), value, tags=tags)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -494,6 +494,11 @@ class SnmpCheck(AgentCheck):
 
         return tags
 
+    def monotonic_count_and_rate(self, metric, value, tags):
+        """Specific submission method which sends a metric both as a monotonic cound and a rate."""
+        self.monotonic_count(metric, value, tags=tags)
+        self.rate("{}.rate".format(metric), value, tags=tags)
+
     def submit_metric(self, name, snmp_value, forced_type, tags):
         # type: (str, Any, Optional[ForceableMetricType], List[str]) -> None
         """
@@ -510,8 +515,7 @@ class SnmpCheck(AgentCheck):
         if forced_type is not None:
             metric = as_metric_with_forced_type(snmp_value, forced_type)
             if metric is None:
-                self.warning('Invalid forced-type specified: %s in %s', forced_type, name)
-                raise ConfigurationError('Invalid forced-type in config file: {}'.format(name))
+                raise ConfigurationError('Invalid forced-type {!r} for metric {!r}'.format(forced_type, name))
         else:
             metric = as_metric_with_inferred_type(snmp_value)
 

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -82,6 +82,10 @@ def test_f5(aggregator):
         'ifHCOutBroadcastPkts',
         'ifInDiscards',
     ]
+    if_rates = [
+        'ifHCInOctets.rate',
+        'ifHCOutOctets.rate',
+    ]
     interfaces = ['1.0', 'mgmt', '/Common/internal', '/Common/http-tunnel', '/Common/socks-tunnel']
     tags = ['snmp_profile:f5-big-ip', 'snmp_host:f5-big-ip-adc-good-byol-1-vm.c.datadog-integrations-lab.internal']
     tags += common.CHECK_TAGS
@@ -93,13 +97,15 @@ def test_f5(aggregator):
     for metric in cpu_rates:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=['cpu:0'] + tags, count=1)
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=['cpu:1'] + tags, count=1)
-    for metric in if_counts:
-        for interface in interfaces:
+    for interface in interfaces:
+        interface_tags = ['interface:{}'.format(interface)] + tags
+        for metric in if_counts:
             aggregator.assert_metric(
-                'snmp.{}'.format(metric),
-                metric_type=aggregator.MONOTONIC_COUNT,
-                tags=['interface:{}'.format(interface)] + tags,
-                count=1,
+                'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=interface_tags, count=1,
+            )
+        for metric in if_rates:
+            aggregator.assert_metric(
+                'snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=interface_tags, count=1
             )
     for metric in if_gauges:
         for interface in interfaces:
@@ -142,6 +148,10 @@ def test_router(aggregator):
         'ifHCOutUcastPkts',
         'ifHCOutMulticastPkts',
         'ifHCOutBroadcastPkts',
+    ]
+    if_rates = [
+        'ifHCInOctets.rate',
+        'ifHCOutOctets.rate',
     ]
     if_gauges = ['ifAdminStatus', 'ifOperStatus']
     ip_counts = [
@@ -211,6 +221,8 @@ def test_router(aggregator):
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
+        for metric in if_rates:
+            aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=tags, count=1)
         for metric in if_gauges:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
     for metric in tcp_counts:
@@ -264,6 +276,10 @@ def test_f5_router(aggregator):
         'ifHCOutMulticastPkts',
         'ifHCOutBroadcastPkts',
     ]
+    if_rates = [
+        'ifHCInOctets.rate',
+        'ifHCOutOctets.rate',
+    ]
     if_gauges = ['ifAdminStatus', 'ifOperStatus']
     # We only get a subset of metrics
     ip_counts = [
@@ -286,6 +302,8 @@ def test_f5_router(aggregator):
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
+        for metric in if_rates:
+            aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=tags, count=1)
         for metric in if_gauges:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
     for version in ['ipv4', 'ipv6']:
@@ -326,6 +344,10 @@ def test_3850(aggregator):
         'ifHCOutMulticastPkts',
         'ifHCOutBroadcastPkts',
     ]
+    if_rates = [
+        'ifHCInOctets.rate',
+        'ifHCOutOctets.rate',
+    ]
     if_gauges = ['ifAdminStatus', 'ifOperStatus']
     # We're not covering all interfaces
     interfaces = ["GigabitEthernet1/0/{}".format(i) for i in range(1, 48)]
@@ -345,6 +367,8 @@ def test_3850(aggregator):
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
+        for metric in if_rates:
+            aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=tags, count=1)
     for metric in tcp_counts:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=common_tags, count=1
@@ -490,6 +514,10 @@ def test_cisco_nexus(aggregator):
         'ifHCOutMulticastPkts',
         'ifHCOutBroadcastPkts',
     ]
+    if_rates = [
+        'ifHCInOctets.rate',
+        'ifHCOutOctets.rate',
+    ]
     if_gauges = ['ifAdminStatus', 'ifOperStatus']
 
     interfaces = ["GigabitEthernet1/0/{}".format(i) for i in range(1, 9)]
@@ -506,6 +534,8 @@ def test_cisco_nexus(aggregator):
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
+        for metric in if_rates:
+            aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=tags, count=1)
         for metric in if_gauges:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
 
@@ -887,6 +917,10 @@ def test_proliant(aggregator):
         'ifHCOutMulticastPkts',
         'ifHCOutBroadcastPkts',
     ]
+    if_rates = [
+        'ifHCInOctets.rate',
+        'ifHCOutOctets.rate',
+    ]
 
     for interface in ['eth0', 'eth1']:
         if_tags = ['interface:{}'.format(interface)] + common_tags
@@ -902,6 +936,8 @@ def test_proliant(aggregator):
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=if_tags, count=1
             )
+        for metric in if_rates:
+            aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=if_tags, count=1)
 
     aggregator.assert_all_metrics_covered()
 
@@ -998,6 +1034,10 @@ def test_cisco_asa_5525(aggregator):
         'ifHCOutMulticastPkts',
         'ifHCOutBroadcastPkts',
     ]
+    if_rates = [
+        'ifHCInOctets.rate',
+        'ifHCOutOctets.rate',
+    ]
     for metric in tcp_counts:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=common_tags, count=1
@@ -1025,6 +1065,8 @@ def test_cisco_asa_5525(aggregator):
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=hc_tags, count=1
         )
+    for metric in if_rates:
+        aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=hc_tags, count=1)
 
     aggregator.assert_metric('snmp.cieIfResetCount', metric_type=aggregator.MONOTONIC_COUNT, tags=common_tags, count=1)
 


### PR DESCRIPTION
This additional submits base bandwith stats as a rate with a suffix. We
can't change the existing submission as a monotonic count, so that's the
easiest fix for now.