### PR TITLE
Add MySQL integration saved views

### DIFF
--- a/mysql/assets/saved_views/operations.json
+++ b/mysql/assets/saved_views/operations.json
@@ -1,0 +1,17 @@
+{ 
+  "name": "MySQL operations",
+  "type": "logs",
+  "page": "stream",
+  "query": "source:mysql @db.operation:*",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "host", "service", "status", "@db.operation","@duration"],
+  "options": {
+    "columns": ["status", "host", "@db.operation"],
+    "show_date_column": true,
+    "show_message_column": true,
+    "message_display": "inline",
+    "show_timeline": true
+  }
+}

--- a/mysql/assets/saved_views/operations_overview.json
+++ b/mysql/assets/saved_views/operations_overview.json
@@ -1,0 +1,21 @@
+{ 
+  "name": "MySQL operations overview",
+  "type": "logs",
+  "page": "analytics",
+  "query": "source:mysql @db.operation:*",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "host", "service", "status", "@db.operation","@duration"],
+  "options": {
+    "group_bys": [
+      { "facet": "@db.operation" }
+    ],
+    "aggregations": [
+      { "metric": "count", "type": "count" }
+    ],
+    "step_ms": "30000",
+    "limit": "50",
+    "widget": "timeseries"
+  }
+}

--- a/mysql/assets/saved_views/slow_operations.json
+++ b/mysql/assets/saved_views/slow_operations.json
@@ -1,5 +1,5 @@
 { 
-  "name": "MySQL operations",
+  "name": "MySQL slow operations",
   "type": "logs",
   "page": "stream",
   "query": "source:mysql @db.operation:* @duration:>1s",

--- a/mysql/assets/saved_views/slow_operations.json
+++ b/mysql/assets/saved_views/slow_operations.json
@@ -1,0 +1,17 @@
+{ 
+  "name": "MySQL operations",
+  "type": "logs",
+  "page": "stream",
+  "query": "source:mysql @db.operation:* @duration:>1s",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "host", "service", "status", "@db.operation","@duration"],
+  "options": {
+    "columns": ["status", "host", "@db.operation"],
+    "show_date_column": true,
+    "show_message_column": true,
+    "message_display": "inline",
+    "show_timeline": true
+  }
+}

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -29,6 +29,11 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
+    "saved_views": {
+      "operations": "assets/saved_views/operations.json",
+      "operations_overview": "assets/saved_views/operations_overview.json",
+      "slow_operations": "assets/saved_views/slow_operations.json"
+    },
     "service_checks": "assets/service_checks.json"
   }
 }


### PR DESCRIPTION
### What does this PR do?
Add saved views for the MySQL integration

### Motivation
Saved views are now included in integrations

### Additional Notes

- https://github.com/DataDog/integrations-core/pull/5873
- https://github.com/DataDog/integrations-core/pull/5713
- https://github.com/DataDog/integrations-core/pull/5865
- https://github.com/DataDog/integrations-core/pull/5866
- https://github.com/DataDog/integrations-core/pull/5870
- https://github.com/DataDog/integrations-core/pull/5871
- https://github.com/DataDog/integrations-core/pull/5872

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
