### PR TITLE
Fix misleading `metric_tags` naming on `ParsedMetric`

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -31,18 +31,18 @@ from .types import ForceableMetricType
 
 class ParsedMetric(object):
 
-    __slots__ = ('name', 'metric_tags', 'forced_type', 'enforce_scalar')
+    __slots__ = ('name', 'tags', 'forced_type', 'enforce_scalar')
 
     def __init__(
         self,
         name,  # type: str
-        metric_tags,  # type: List[Dict[str, Any]]
+        tags=None,  # type: List[str]
         forced_type=None,  # type: ForceableMetricType
         enforce_scalar=True,  # type: bool
     ):
         # type: (...) -> None
         self.name = name
-        self.metric_tags = metric_tags
+        self.tags = tags or []
         self.forced_type = forced_type
         self.enforce_scalar = enforce_scalar
 
@@ -399,7 +399,7 @@ class InstanceConfig:
                     except Exception as e:
                         warning("Can't generate MIB object for variable : %s\nException: %s", metric, e)
                     else:
-                        parsed_metric = ParsedMetric(parsed_metric_name, metric_tags, forced_type)
+                        parsed_metric = ParsedMetric(parsed_metric_name, tags=metric_tags, forced_type=forced_type)
                         parsed_metrics.append(parsed_metric)
 
                     continue
@@ -462,7 +462,9 @@ class InstanceConfig:
                 table_oids[metric['OID']] = (oid, [])
                 self._resolver.register(oid.as_tuple(), metric['name'])
 
-                parsed_metric = ParsedMetric(metric['name'], metric_tags, forced_type, enforce_scalar=False)
+                parsed_metric = ParsedMetric(
+                    metric['name'], tags=metric_tags, forced_type=forced_type, enforce_scalar=False
+                )
                 parsed_metrics.append(parsed_metric)
 
             else:
@@ -543,6 +545,6 @@ class InstanceConfig:
         self.all_oids.append(uptime_oid)
         self._resolver.register(uptime_oid.as_tuple(), 'sysUpTimeInstance')
 
-        parsed_metric = ParsedMetric('sysUpTimeInstance', [], 'gauge')
+        parsed_metric = ParsedMetric('sysUpTimeInstance', forced_type='gauge')
         self.parsed_metrics.append(parsed_metric)
         self._uptime_metric_added = True

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -448,7 +448,7 @@ class SnmpCheck(AgentCheck):
                         # For backward compatibility reason, we publish the first value for OID.
                         continue
                 val = result[0][1]
-                metric_tags = tags + metric.metric_tags
+                metric_tags = tags + metric.tags
                 self.submit_metric(name, val, metric.forced_type, metric_tags)
 
     def get_index_tags(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Rename `.metric_tags` to `.tags` on `ParsedMetric`, and fix its type hint.

### Motivation
<!-- What inspired you to submit this pull request? -->
The `.metric_tags` naming for regular metrics was misleading, because in that case it refers to a list of tags (instead of a list of "metric tag definitions" for table metrics).

Example:

```yaml
metrics:
- OID: ...
  name: ...
  metric_tags:
    - my:tag
```

We don't use this API in profiles, but it's tested:

```python
# tests/common.py
SCALAR_OBJECTS_WITH_TAGS = [
    {'OID': "1.3.6.1.2.1.7.1.0", 'name': "udpDatagrams", 'metric_tags': ['udpdgrams', 'UDP']},
    {'OID': "1.3.6.1.2.1.6.10.0", 'name': "tcpInSegs", 'metric_tags': ['tcpinsegs', 'TCP']},
    {'MIB': "TCP-MIB", 'symbol': "tcpCurrEstab", 'metric_tags': ['MIB', 'TCP', 'estab']},
]
```

This ambiguity originally led me to add an incorrect type hint in that case, so this PR fixes it too.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Discovered because mypy was raising an error on this line — it thought we were adding a list of strings to a list of dicts:

https://github.com/DataDog/integrations-core/blob/df7ad91a50ecbddb24d918661d0152dea6c1447c/snmp/datadog_checks/snmp/snmp.py#L451

After looking at the actual data, everything was actually strings. So the type hint was wrong, and I realized that in that case `.metric_tags` really just contained a list of `name:value` tags, hence what I call here "misleading naming".

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
