### PR TITLE
Drop `ForceableMetricType` type

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -26,7 +26,6 @@ from .pysnmp_types import (
     usmHMACMD5AuthProtocol,
 )
 from .resolver import OIDResolver
-from .types import ForceableMetricType
 
 
 class ParsedMetric(object):
@@ -37,7 +36,7 @@ class ParsedMetric(object):
         self,
         name,  # type: str
         tags=None,  # type: List[str]
-        forced_type=None,  # type: ForceableMetricType
+        forced_type=None,  # type: str
         enforce_scalar=True,  # type: bool
     ):
         # type: (...) -> None
@@ -56,7 +55,7 @@ class ParsedTableMetric(object):
         name,  # type: str
         index_tags,  # type: List[Tuple[str, int]]
         column_tags,  # type: List[Tuple[str, str]]
-        forced_type=None,  # type: ForceableMetricType
+        forced_type=None,  # type: str
     ):
         # type: (...) -> None
         self.name = name

--- a/snmp/datadog_checks/snmp/metrics.py
+++ b/snmp/datadog_checks/snmp/metrics.py
@@ -10,7 +10,7 @@ from typing import Any, Optional, Set
 from pyasn1.codec.ber.decoder import decode as pyasn1_decode
 
 from .compat import total_time_to_temporal_percent
-from .types import ForceableMetricType, MetricDefinition
+from .types import MetricDefinition
 
 # SNMP value types that we explicitly support.
 SNMP_COUNTER_CLASSES = {
@@ -71,7 +71,7 @@ def as_metric_with_inferred_type(value):
 
 
 def as_metric_with_forced_type(value, forced_type):
-    # type: (Any, ForceableMetricType) -> Optional[MetricDefinition]
+    # type: (Any, str) -> Optional[MetricDefinition]
     if forced_type == 'gauge':
         return {'type': 'gauge', 'value': int(value)}
 

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -25,7 +25,6 @@ from .exceptions import PySnmpError
 from .metrics import as_metric_with_forced_type, as_metric_with_inferred_type
 from .models import OID
 from .pysnmp_types import ObjectIdentity, ObjectType, noSuchInstance, noSuchObject
-from .types import ForceableMetricType
 from .utils import (
     OIDPrinter,
     get_default_profiles,
@@ -495,7 +494,7 @@ class SnmpCheck(AgentCheck):
         return tags
 
     def submit_metric(self, name, snmp_value, forced_type, tags):
-        # type: (str, Any, Optional[ForceableMetricType], List[str]) -> None
+        # type: (str, Any, Optional[str], List[str]) -> None
         """
         Convert the values reported as pysnmp-Managed Objects to values and
         report them to the aggregator.

--- a/snmp/datadog_checks/snmp/types.py
+++ b/snmp/datadog_checks/snmp/types.py
@@ -6,7 +6,6 @@ Type declarations, for type checking purposes only.
 """
 from typing import Literal, NamedTuple, Tuple, TypedDict
 
-ForceableMetricType = Literal['gauge', 'percent']
 MetricDefinition = TypedDict(
     'MetricDefinition', {'type': Literal['gauge', 'rate', 'counter', 'monotonic_count'], 'value': float}
 )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove the `ForceableMetricType` type alias.

### Motivation
<!-- What inspired you to submit this pull request? -->
It's not useful: it's redundant with the logic inside `as_metric_with_forced_type()`, which is the only place where we process `forced_type`. Updating this function (as in #6384) would result in the type hint getting out of date with no actual benefit, so we should as well just drop it.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
