### PR TITLE
Add validation for per_unit_name and line numbers for all errors

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -276,7 +276,7 @@ def metadata(check, check_duplicates):
             if row['metric_name'] != normalized_metric_name:
                 errors = True
                 echo_failure(
-                    f"Metric name '{row['metric_name']}' is not valid,"
+                    f"{current_check}:{line} Metric name '{row['metric_name']}' is not valid,"
                     "it should be normalized as {normalized_metric_name}"
                 )
 
@@ -300,6 +300,11 @@ def metadata(check, check_duplicates):
             if row['unit_name'] and row['unit_name'] not in VALID_UNIT_NAMES:
                 errors = True
                 echo_failure(f"{current_check}:{line} `{row['unit_name']}` is an invalid unit_name.")
+
+            # per_unit_name header
+            if row['per_unit_name'] and row['per_unit_name'] not in VALID_UNIT_NAMES:
+                errors = True
+                echo_failure(f"{current_check}:{line} `{row['per_unit_name']}` is an invalid per_unit_name.")
 
             # orientation header
             if row['orientation'] and row['orientation'] not in VALID_ORIENTATION:
@@ -333,7 +338,7 @@ def metadata(check, check_duplicates):
                 )
             if row['interval'] and not row['interval'].isdigit():
                 errors = True
-                echo_failure(f"{current_check}: interval should be an int, found '{row['interval']}'")
+                echo_failure(f"{current_check}:{line} interval should be an int, found '{row['interval']}'")
 
         for header, count in empty_count.items():
             errors = True

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -338,7 +338,7 @@ def metadata(check, check_duplicates):
                 )
             if row['interval'] and not row['interval'].isdigit():
                 errors = True
-                echo_failure(f"{current_check}:{line} interval should be an int, found '{row['interval']}'")
+                echo_failure(f"{current_check}:{line} interval should be an int, found '{row['interval']}'.")
 
         for header, count in empty_count.items():
             errors = True

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -276,7 +276,7 @@ def metadata(check, check_duplicates):
             if row['metric_name'] != normalized_metric_name:
                 errors = True
                 echo_failure(
-                    f"{current_check}:{line} Metric name '{row['metric_name']}' is not valid,"
+                    f"{current_check}:{line} Metric name '{row['metric_name']}' is not valid, "
                     f"it should be normalized as {normalized_metric_name}"
                 )
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -277,7 +277,7 @@ def metadata(check, check_duplicates):
                 errors = True
                 echo_failure(
                     f"{current_check}:{line} Metric name '{row['metric_name']}' is not valid,"
-                    "it should be normalized as {normalized_metric_name}"
+                    f"it should be normalized as {normalized_metric_name}"
                 )
 
             # metric_name header
@@ -334,7 +334,7 @@ def metadata(check, check_duplicates):
                 errors = True
                 echo_failure(
                     f"{current_check}:{line} `{row['metric_name']}` exceeds the max length: "
-                    "{MAX_DESCRIPTION_LENGTH} for descriptions."
+                    f"{MAX_DESCRIPTION_LENGTH} for descriptions."
                 )
             if row['interval'] and not row['interval'].isdigit():
                 errors = True


### PR DESCRIPTION
### What does this PR do?

- Adds validation for per_unit_name
- Adds line number and check name for all errors

### Motivation

Working on aerospike metadata made me notice there was no validation for per_unit_name and interval errors did not have line numbers.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
