### PR TITLE
Add RabbitMQ integration saved views

### DIFF
--- a/rabbitmq/assets/saved_views/rabbitmq_pattern.json
+++ b/rabbitmq/assets/saved_views/rabbitmq_pattern.json
@@ -1,0 +1,9 @@
+{ 
+  "name": "RabbitMQ patterns",
+  "type": "logs",
+  "page": "patterns",
+  "query": "source:rabbitmq",
+  "timerange": {
+    "interval_ms": 3600000
+  }
+}

--- a/rabbitmq/assets/saved_views/status_overview.json
+++ b/rabbitmq/assets/saved_views/status_overview.json
@@ -1,0 +1,21 @@
+{ 
+  "name": "Rabbit MQ status overview",
+  "type": "logs",
+  "page": "analytics",
+  "query": "source:rabbitmq",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "host", "service", "status"],
+  "options": {
+    "group_bys": [
+      { "facet": "status" }
+    ],
+    "aggregations": [
+      { "metric": "count", "type": "count" }
+    ],
+    "step_ms": "30000",
+    "limit": "50",
+    "widget": "timeseries"
+  }
+}

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -31,7 +31,7 @@
     "dashboards": {},
     "saved_views": {
       "pid_overview": "assets/saved_views/status_overview.json",
-      "rabbitmq_patern": "assets/saved_views/rabbitmq_patern.json"
+      "rabbitmq_pattern": "assets/saved_views/rabbitmq_pattern.json"
     },
     "service_checks": "assets/service_checks.json"
   }

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -29,6 +29,10 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
+    "saved_views": {
+      "pid_overview": "assets/saved_views/status_overview.json",
+      "rabbitmq_patern": "assets/saved_views/rabbitmq_patern.json"
+    },
     "service_checks": "assets/service_checks.json"
   }
 }


### PR DESCRIPTION
### What does this PR do?
Add saved views for the RabbitMQ integration

### Motivation
Saved views are now included in integrations

### Additional Notes

- https://github.com/DataDog/integrations-core/pull/6386
- https://github.com/DataDog/integrations-core/pull/5873
- https://github.com/DataDog/integrations-core/pull/5713
- https://github.com/DataDog/integrations-core/pull/5865
- https://github.com/DataDog/integrations-core/pull/5866
- https://github.com/DataDog/integrations-core/pull/5870
- https://github.com/DataDog/integrations-core/pull/5871
- https://github.com/DataDog/integrations-core/pull/5872
- https://github.com/DataDog/integrations-core/pull/6393

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
