### PR TITLE
Add Postgres integration saved views

### DIFF
--- a/postgres/assets/saved_views/operations.json
+++ b/postgres/assets/saved_views/operations.json
@@ -1,0 +1,17 @@
+{ 
+  "name": "Postgres operations",
+  "type": "logs",
+  "page": "stream",
+  "query": "source:postgresql @db.operation:*",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "host", "service", "status", "@db.instance", "@db.operation", "@db.user", "@postgres.session_id", "@duration"],
+  "options": {
+    "columns": ["status", "host", "@db.operation", "@db.instance"],
+    "show_date_column": true,
+    "show_message_column": true,
+    "message_display": "inline",
+    "show_timeline": true
+  }
+}

--- a/postgres/assets/saved_views/postgres_pattern.json
+++ b/postgres/assets/saved_views/postgres_pattern.json
@@ -1,0 +1,9 @@
+{ 
+  "name": "Postgres patterns",
+  "type": "logs",
+  "page": "patterns",
+  "query": "source:postgresql",
+  "timerange": {
+    "interval_ms": 3600000
+  }
+}

--- a/postgres/assets/saved_views/sessions_by_host.json
+++ b/postgres/assets/saved_views/sessions_by_host.json
@@ -1,0 +1,21 @@
+{ 
+  "name": "Postgres sessions by Host",
+  "type": "logs",
+  "page": "analytics",
+  "query": "source:postgresql",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "host", "service", "status", "@db.instance", "@db.operation", "@db.user", "@postgres.session_id", "@duration"],
+  "options": {
+    "group_bys": [
+      { "facet": "host" }
+    ],
+    "aggregations": [
+      { "metric": "@postgres.session_id", "type": "cardinality" }
+    ],
+    "step_ms": "30000",
+    "limit": "50",
+    "widget": "timeseries"
+  }
+}

--- a/postgres/assets/saved_views/slow_operations.json
+++ b/postgres/assets/saved_views/slow_operations.json
@@ -1,0 +1,17 @@
+{ 
+  "name": "Postgres slow operations",
+  "type": "logs",
+  "page": "stream",
+  "query": "source:postgresql @db.operation:* @duration:>1s",
+  "timerange": {
+    "interval_ms": 3600000
+  },
+  "visible_facets": ["source", "host", "service", "status", "@db.instance", "@db.operation", "@db.user", "@postgres.session_id", "@duration"],
+  "options": {
+    "columns": ["status", "host", "@db.operation", "@db.instance"],
+    "show_date_column": true,
+    "show_message_column": true,
+    "message_display": "inline",
+    "show_timeline": true
+  }
+}

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -37,6 +37,12 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
+    "saved_views": {
+      "operations": "assets/saved_views/operations.json",
+      "slow_operations": "assets/saved_views/slow_operations.json",
+      "postgres_pattern": "assets/saved_views/postgres_pattern.json",
+      "sessions_by_host": "assets/saved_views/sessions_by_host.json"
+    },
     "service_checks": "assets/service_checks.json"
   }
 }


### PR DESCRIPTION
### What does this PR do?
Add saved views for the Postgres integration

### Motivation
Saved views are now included in integrations

### Additional Notes

- https://github.com/DataDog/integrations-core/pull/5713
- https://github.com/DataDog/integrations-core/pull/5865
- https://github.com/DataDog/integrations-core/pull/5866
- https://github.com/DataDog/integrations-core/pull/5870
- https://github.com/DataDog/integrations-core/pull/5871
- https://github.com/DataDog/integrations-core/pull/5872
- https://github.com/DataDog/integrations-core/pull/5873
- https://github.com/DataDog/integrations-core/pull/6386
- https://github.com/DataDog/integrations-core/pull/6393
- https://github.com/DataDog/integrations-core/pull/6401

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
