### PR TITLE
Add string cache and web cache metrics

### DIFF
--- a/tomcat/datadog_checks/tomcat/data/metrics.yaml
+++ b/tomcat/datadog_checks/tomcat/data/metrics.yaml
@@ -46,6 +46,17 @@ jmx_metrics:
             alias: tomcat.servlet.request_count
             metric_type: counter
     - include:
+        # Deprecated metric available in Tomcat 7
+        # https://github.com/apache/tomcat/blob/7.0.x/java/org/apache/catalina/core/StandardContext.java#L5293-L5297
+        type: Cache
+        attribute:
+          accessCount:
+            alias: tomcat.cache.access_count
+            metric_type: counter
+          hitsCounts:
+            alias: tomcat.cache.hits_count
+            metric_type: counter
+    - include:
         type: StringCache
         attribute:
           accessCount:

--- a/tomcat/datadog_checks/tomcat/data/metrics.yaml
+++ b/tomcat/datadog_checks/tomcat/data/metrics.yaml
@@ -46,13 +46,22 @@ jmx_metrics:
             alias: tomcat.servlet.request_count
             metric_type: counter
     - include:
-        type: Cache
+        type: StringCache
         attribute:
           accessCount:
-            alias: tomcat.cache.access_count
+            alias: tomcat.string_cache.access_count
             metric_type: counter
-          hitsCounts:
-            alias: tomcat.cache.hits_count
+          hitCount:
+            alias: tomcat.string_cache.hit_count
+            metric_type: counter
+    - include:
+        bean_regex: Catalina:type=WebResourceRoot,host=.*,context=.*,name=Cache
+        attribute:
+          hitCount:
+            alias: tomcat.web.cache.hit_count
+            metric_type: counter
+          lookupCount:
+            alias: tomcat.web.cache.lookup_count
             metric_type: counter
     - include:
         type: JspMonitor

--- a/tomcat/datadog_checks/tomcat/data/metrics.yaml
+++ b/tomcat/datadog_checks/tomcat/data/metrics.yaml
@@ -55,7 +55,9 @@ jmx_metrics:
             alias: tomcat.string_cache.hit_count
             metric_type: counter
     - include:
-        bean_regex: Catalina:type=WebResourceRoot,host=.*,context=.*,name=Cache
+        # Example Bean: `Catalina:type=WebResourceRoot,host=localhost,context=/docs,name=Cache`
+        type: WebResourceRoot
+        name: Cache
         attribute:
           hitCount:
             alias: tomcat.web.cache.hit_count

--- a/tomcat/metadata.csv
+++ b/tomcat/metadata.csv
@@ -11,7 +11,9 @@ tomcat.processing_time,gauge,10,,,The sum of request processing times across all
 tomcat.servlet.processing_time,gauge,10,,,The sum of request processing times across all requests to the servlet (in milliseconds) per second.,0,tomcat,servlet proc time
 tomcat.servlet.error_count,gauge,10,error,second,The number of erroneous requests received by the servlet per second.,-1,tomcat,servlet err count
 tomcat.servlet.request_count,gauge,10,request,second,The number of requests received by the servlet per second.,0,tomcat,servlet requests
-tomcat.cache.access_count,gauge,10,get,second,The number of accesses to the cache per second.,0,tomcat,cache accesses
-tomcat.cache.hits_count,gauge,10,hit,second,The number of cache hits per second.,0,tomcat,cache hits
+tomcat.string_cache.access_count,gauge,10,get,second,The number of accesses to the string cache per second.,0,tomcat,string cache accesses
+tomcat.string_cache.hit_count,gauge,10,hit,second,The number of string cache hits per second.,0,tomcat,string cache hits
+tomcat.web.cache.lookup_count,gauge,10,hit,second,The number of lookups for web resources.,0,tomcat,web cache lookups
+tomcat.web.cache.hit_count,gauge,10,get,second,The number of requests for web resources that were served from the cache.,0,tomcat,web cache accesses
 tomcat.jsp.count,gauge,10,page,second,The number of JSPs per second that have been loaded in the web module.,0,tomcat,jsp count
 tomcat.jsp.reload_count,gauge,10,page,second,The number of JSPs per second that have been reloaded in the web module.,0,tomcat,jsp reloads

--- a/tomcat/metadata.csv
+++ b/tomcat/metadata.csv
@@ -13,7 +13,7 @@ tomcat.servlet.error_count,gauge,10,error,second,The number of erroneous request
 tomcat.servlet.request_count,gauge,10,request,second,The number of requests received by the servlet per second.,0,tomcat,servlet requests
 tomcat.string_cache.access_count,gauge,10,get,second,The number of accesses to the string cache per second.,0,tomcat,string cache accesses
 tomcat.string_cache.hit_count,gauge,10,hit,second,The number of string cache hits per second.,0,tomcat,string cache hits
-tomcat.web.cache.lookup_count,gauge,10,hit,second,The number of lookups for web resources.,0,tomcat,web cache lookups
-tomcat.web.cache.hit_count,gauge,10,get,second,The number of requests for web resources that were served from the cache.,0,tomcat,web cache accesses
+tomcat.web.cache.lookup_count,gauge,10,hit,second,The number of lookups for web resources per second.,0,tomcat,web cache lookups
+tomcat.web.cache.hit_count,gauge,10,get,second,The number of requests for web resources that were served from the cache per second.,0,tomcat,web cache accesses
 tomcat.jsp.count,gauge,10,page,second,The number of JSPs per second that have been loaded in the web module.,0,tomcat,jsp count
 tomcat.jsp.reload_count,gauge,10,page,second,The number of JSPs per second that have been reloaded in the web module.,0,tomcat,jsp reloads

--- a/tomcat/metadata.csv
+++ b/tomcat/metadata.csv
@@ -11,9 +11,11 @@ tomcat.processing_time,gauge,10,,,The sum of request processing times across all
 tomcat.servlet.processing_time,gauge,10,,,The sum of request processing times across all requests to the servlet (in milliseconds) per second.,0,tomcat,servlet proc time
 tomcat.servlet.error_count,gauge,10,error,second,The number of erroneous requests received by the servlet per second.,-1,tomcat,servlet err count
 tomcat.servlet.request_count,gauge,10,request,second,The number of requests received by the servlet per second.,0,tomcat,servlet requests
+tomcat.cache.access_count,gauge,10,get,second,The number of accesses to the cache per second.,0,tomcat,cache accesses
+tomcat.cache.hits_count,gauge,10,hit,second,The number of cache hits per second.,0,tomcat,cache hits
 tomcat.string_cache.access_count,gauge,10,get,second,The number of accesses to the string cache per second.,0,tomcat,string cache accesses
 tomcat.string_cache.hit_count,gauge,10,hit,second,The number of string cache hits per second.,0,tomcat,string cache hits
-tomcat.web.cache.lookup_count,gauge,10,get,second,The number of lookups for web resources per second.,0,tomcat,web cache lookups
-tomcat.web.cache.hit_count,gauge,10,hit,second,The number of requests for web resources that were served from the cache per second.,0,tomcat,web cache accesses
+tomcat.web.cache.lookup_count,gauge,10,get,second,The number of lookups to the web resource cache per second.,0,tomcat,web cache lookups
+tomcat.web.cache.hit_count,gauge,10,hit,second,The number of web resource cache hits per second.,0,tomcat,web cache hits
 tomcat.jsp.count,gauge,10,page,second,The number of JSPs per second that have been loaded in the web module.,0,tomcat,jsp count
 tomcat.jsp.reload_count,gauge,10,page,second,The number of JSPs per second that have been reloaded in the web module.,0,tomcat,jsp reloads

--- a/tomcat/metadata.csv
+++ b/tomcat/metadata.csv
@@ -13,7 +13,7 @@ tomcat.servlet.error_count,gauge,10,error,second,The number of erroneous request
 tomcat.servlet.request_count,gauge,10,request,second,The number of requests received by the servlet per second.,0,tomcat,servlet requests
 tomcat.string_cache.access_count,gauge,10,get,second,The number of accesses to the string cache per second.,0,tomcat,string cache accesses
 tomcat.string_cache.hit_count,gauge,10,hit,second,The number of string cache hits per second.,0,tomcat,string cache hits
-tomcat.web.cache.lookup_count,gauge,10,hit,second,The number of lookups for web resources per second.,0,tomcat,web cache lookups
+tomcat.web.cache.lookup_count,gauge,10,get,second,The number of lookups for web resources per second.,0,tomcat,web cache lookups
 tomcat.web.cache.hit_count,gauge,10,get,second,The number of requests for web resources that were served from the cache per second.,0,tomcat,web cache accesses
 tomcat.jsp.count,gauge,10,page,second,The number of JSPs per second that have been loaded in the web module.,0,tomcat,jsp count
 tomcat.jsp.reload_count,gauge,10,page,second,The number of JSPs per second that have been reloaded in the web module.,0,tomcat,jsp reloads

--- a/tomcat/metadata.csv
+++ b/tomcat/metadata.csv
@@ -14,6 +14,6 @@ tomcat.servlet.request_count,gauge,10,request,second,The number of requests rece
 tomcat.string_cache.access_count,gauge,10,get,second,The number of accesses to the string cache per second.,0,tomcat,string cache accesses
 tomcat.string_cache.hit_count,gauge,10,hit,second,The number of string cache hits per second.,0,tomcat,string cache hits
 tomcat.web.cache.lookup_count,gauge,10,get,second,The number of lookups for web resources per second.,0,tomcat,web cache lookups
-tomcat.web.cache.hit_count,gauge,10,get,second,The number of requests for web resources that were served from the cache per second.,0,tomcat,web cache accesses
+tomcat.web.cache.hit_count,gauge,10,hit,second,The number of requests for web resources that were served from the cache per second.,0,tomcat,web cache accesses
 tomcat.jsp.count,gauge,10,page,second,The number of JSPs per second that have been loaded in the web module.,0,tomcat,jsp count
 tomcat.jsp.reload_count,gauge,10,page,second,The number of JSPs per second that have been reloaded in the web module.,0,tomcat,jsp reloads

--- a/tomcat/tests/common.py
+++ b/tomcat/tests/common.py
@@ -7,13 +7,6 @@ CHECK_NAME = "tomcat"
 
 HERE = get_here()
 
-"""
-Metrics that are not produced by our e2e tests:
-    "tomcat.cache.access_count",
-    "tomcat.cache.hits_count",
-"""
-
-
 TOMCAT_E2E_METRICS = [
     # Tomcat
     "tomcat.max_time",
@@ -31,6 +24,10 @@ TOMCAT_E2E_METRICS = [
     "tomcat.servlet.request_count",
     "tomcat.jsp.count",
     "tomcat.jsp.reload_count",
+    "tomcat.string_cache.access_count",
+    "tomcat.string_cache.hit_count",
+    "tomcat.web.cache.hit_count",
+    "tomcat.web.cache.lookup_count",
     # JVM
     "jvm.buffer_pool.direct.capacity",
     "jvm.buffer_pool.direct.count",

--- a/tomcat/tests/compose/docker-compose.yml
+++ b/tomcat/tests/compose/docker-compose.yml
@@ -6,5 +6,14 @@ services:
     ports:
       - 8080:8080
       - 9012:9012 # JMX
-    environment: 
-      - JAVA_OPTS=-Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9012 -Dcom.sun.management.jmxremote.rmi.port=9012 -Djava.rmi.server.hostname=0.0.0.0
+    environment:
+      # Use low `StringCache.trainThreshold` to make it easier to get StringCache metrics
+      JAVA_OPTS: >-
+        -Dcom.sun.management.jmxremote.authenticate=false
+        -Dcom.sun.management.jmxremote.ssl=false
+        -Dcom.sun.management.jmxremote.port=9012
+        -Dcom.sun.management.jmxremote.rmi.port=9012
+        -Djava.rmi.server.hostname=0.0.0.0
+        -Dtomcat.util.buf.StringCache.byte.enabled=true
+        -Dtomcat.util.buf.StringCache.char.enabled=true
+        -Dtomcat.util.buf.StringCache.trainThreshold=100

--- a/tomcat/tests/test_check.py
+++ b/tomcat/tests/test_check.py
@@ -6,6 +6,51 @@ import pytest
 
 from .common import TOMCAT_E2E_METRICS
 
+JVM_METRICS = [
+    'jvm.buffer_pool.direct.capacity',
+    'jvm.buffer_pool.direct.count',
+    'jvm.buffer_pool.direct.used',
+    'jvm.buffer_pool.mapped.capacity',
+    'jvm.buffer_pool.mapped.count',
+    'jvm.buffer_pool.mapped.used',
+    'jvm.cpu_load.process',
+    'jvm.cpu_load.system',
+    'jvm.gc.cms.count',
+    'jvm.gc.eden_size',
+    'jvm.gc.old_gen_size',
+    'jvm.gc.parnew.time',
+    'jvm.gc.survivor_size',
+    'jvm.heap_memory_committed',
+    'jvm.heap_memory_init',
+    'jvm.heap_memory_max',
+    'jvm.heap_memory',
+    'jvm.loaded_classes',
+    'jvm.non_heap_memory_committed',
+    'jvm.non_heap_memory_init',
+    'jvm.non_heap_memory_max',
+    'jvm.non_heap_memory',
+    'jvm.os.open_file_descriptors',
+    'jvm.thread_count',
+]
+
+COUNTER_METRICS = [
+    # TODO: JMXFetch `counter` is reporter the wrong type.
+    'tomcat.bytes_rcvd',
+    'tomcat.bytes_sent',
+    'tomcat.error_count',
+    'tomcat.jsp.count',
+    'tomcat.jsp.reload_count',
+    'tomcat.processing_time',
+    'tomcat.request_count',
+    'tomcat.servlet.error_count',
+    'tomcat.servlet.processing_time',
+    'tomcat.servlet.request_count',
+    'tomcat.string_cache.access_count',
+    'tomcat.string_cache.hit_count',
+    'tomcat.web.cache.hit_count',
+    'tomcat.web.cache.lookup_count',
+]
+
 
 @pytest.mark.e2e
 def test(dd_agent_check):
@@ -16,3 +61,6 @@ def test(dd_agent_check):
         aggregator.assert_metric(metric)
 
     aggregator.assert_all_metrics_covered()
+
+    from datadog_checks.dev.utils import get_metadata_metrics
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=JVM_METRICS + COUNTER_METRICS)

--- a/tomcat/tests/test_check.py
+++ b/tomcat/tests/test_check.py
@@ -36,7 +36,8 @@ JVM_METRICS = [
 ]
 
 COUNTER_METRICS = [
-    # TODO: JMXFetch is not reporting in-app type for JMX `counter` type
+    # TODO: JMXFetch is not reporting in-app type for JMX `counter` type.
+    #       Remove this exclusion list when fixed.
     'tomcat.bytes_rcvd',
     'tomcat.bytes_sent',
     'tomcat.error_count',

--- a/tomcat/tests/test_check.py
+++ b/tomcat/tests/test_check.py
@@ -4,6 +4,8 @@
 
 import pytest
 
+from datadog_checks.dev.utils import get_metadata_metrics
+
 from .common import TOMCAT_E2E_METRICS
 
 JVM_METRICS = [
@@ -34,7 +36,7 @@ JVM_METRICS = [
 ]
 
 COUNTER_METRICS = [
-    # TODO: JMXFetch `counter` is reporter the wrong type.
+    # TODO: JMXFetch is not reporting in-app type for JMX `counter` type
     'tomcat.bytes_rcvd',
     'tomcat.bytes_sent',
     'tomcat.error_count',
@@ -62,5 +64,4 @@ def test(dd_agent_check):
 
     aggregator.assert_all_metrics_covered()
 
-    from datadog_checks.dev.utils import get_metadata_metrics
     aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=JVM_METRICS + COUNTER_METRICS)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add string cache and web cache metrics.

`StringCache` metrics might be useful to investigate performance cases like this one:
- https://issues.redhat.com/browse/JBPAPP-4752?attachmentViewMode=list&_sscc=t

### Motivation
<!-- What inspired you to submit this pull request? -->

`type: Cache` removed, it does not exist.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
