### PR TITLE
Fix flaky by using zk 3.4.11 for kafka 0.9

### DIFF
--- a/kafka_consumer/tests/docker/docker-compose.yaml
+++ b/kafka_consumer/tests/docker/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   zookeeper:
-    image: zookeeper:3.6.0
+    image: wurstmeister/zookeeper
     ports:
       - 2181:2181
 

--- a/kafka_consumer/tests/docker/docker-compose.yaml
+++ b/kafka_consumer/tests/docker/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: zookeeper:${ZK_VERSION}
     ports:
       - 2181:2181
 

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -28,7 +28,7 @@ setenv =
     0.11: KAFKA_VERSION=0.11.0.1
     1.1: KAFKA_VERSION=1.1.0
     2.3: KAFKA_VERSION=2.12-2.3.0
-    # Using Kafka 0.9 + with ZK 3.4 due to flakiness of Kafka 0.9 + 3.6
+    # Using Kafka 0.9 + with ZK 3.4 due to flakiness of Kafka 0.9 + ZK 3.6
     0.9: ZK_VERSION=3.4.11
     0.11,1.1,2.3,latest: ZK_VERSION=3.6.0
     latest: KAFKA_VERSION=latest

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -28,6 +28,7 @@ setenv =
     0.11: KAFKA_VERSION=0.11.0.1
     1.1: KAFKA_VERSION=1.1.0
     2.3: KAFKA_VERSION=2.12-2.3.0
+    # Using Kafka 0.9 + with ZK 3.4 due to flakiness of Kafka 0.9 + 3.6
     0.9: ZK_VERSION=3.4.11
     0.11,1.1,2.3,latest: ZK_VERSION=3.6.0
     latest: KAFKA_VERSION=latest

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -28,4 +28,6 @@ setenv =
     0.11: KAFKA_VERSION=0.11.0.1
     1.1: KAFKA_VERSION=1.1.0
     2.3: KAFKA_VERSION=2.12-2.3.0
+    0.9: ZK_VERSION=3.4.11
+    0.11,1.1,2.3,latest: ZK_VERSION=3.6.0
     latest: KAFKA_VERSION=latest


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix flaky zookeeper by using `wurstmeister/zookeeper` image

Before:
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13176&view=results
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13177

Use zk 3.4.11 for kafka 0.9
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13277&view=results
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13276&view=results


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Kafka 0.9.0.x aka Confluent Platform 2.0.x end of support is December 7, 2017. 

https://docs.confluent.io/current/installation/versions-interoperability.html



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
