### PR TITLE
Drop unused `OID.__eq__()` implementation

### DIFF
--- a/snmp/datadog_checks/snmp/models.py
+++ b/snmp/datadog_checks/snmp/models.py
@@ -5,7 +5,7 @@
 Define our own models and interfaces for dealing with SNMP data.
 """
 
-from typing import Any, Optional, Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, Union
 
 from .exceptions import CouldNotDecodeOID, SmiError, UnresolvedOID
 from .pysnmp_types import MibViewController, ObjectIdentity, ObjectName, ObjectType
@@ -87,10 +87,6 @@ class OID(object):
         prefix = tuple(index.prettyPrint() for index in indexes)
 
         return MIBSymbol(name, prefix)
-
-    def __eq__(self, other):
-        # type: (Any) -> bool
-        return isinstance(other, OID) and self.as_tuple() == other.as_tuple()
 
     def __str__(self):
         # type: () -> str

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -15,7 +15,6 @@ from datadog_checks.base import ConfigurationError
 from datadog_checks.dev import temp_dir
 from datadog_checks.snmp import SnmpCheck
 from datadog_checks.snmp.config import InstanceConfig, ParsedMetric, ParsedTableMetric
-from datadog_checks.snmp.models import OID
 from datadog_checks.snmp.resolver import OIDTrie
 from datadog_checks.snmp.utils import _load_default_profiles, oid_pattern_specificity, recursively_expand_base_profiles
 
@@ -44,7 +43,7 @@ def test_parse_metrics(lcd_mock):
     # Simple OID
     metrics = [{"OID": "1.2.3", "name": "foo"}]
     oids, _, parsed_metrics = config.parse_metrics(metrics, check.warning)
-    assert oids == [OID('1.2.3')]
+    assert len(oids) == 1
     assert len(parsed_metrics) == 1
     foo = parsed_metrics[0]
     assert isinstance(foo, ParsedMetric)
@@ -93,7 +92,7 @@ def test_parse_metrics(lcd_mock):
     # Table with manual OID
     metrics = [{"MIB": "foo_mib", "table": "foo_table", "symbols": [{"OID": "1.2.3", "name": "foo"}]}]
     oids, _, parsed_metrics = config.parse_metrics(metrics, check.warning)
-    assert oids == [OID('1.2.3')]
+    assert len(oids) == 1
     assert len(parsed_metrics) == 1
     foo = parsed_metrics[0]
     assert isinstance(foo, ParsedTableMetric)
@@ -150,7 +149,6 @@ def test_parse_metrics(lcd_mock):
     ]
     oids, _, parsed_metrics = config.parse_metrics(metrics, check.warning)
     assert len(oids) == 3
-    assert OID('1.5.6') in oids
     assert len(parsed_metrics) == 2
     foo, bar = parsed_metrics
     assert isinstance(foo, ParsedTableMetric)

--- a/snmp/tests/test_utils.py
+++ b/snmp/tests/test_utils.py
@@ -12,8 +12,6 @@ def test_oid():
     # type: () -> None
     oid = OID((1, 3, 6, 1, 2, 1, 0))
     assert oid.as_tuple() == (1, 3, 6, 1, 2, 1, 0)
-    assert oid == OID((1, 3, 6, 1, 2, 1, 0))
-    assert oid != OID((1, 3, 6, 1, 4, 0))
     assert repr(oid) == "OID('1.3.6.1.2.1.0')"
     assert str(oid) == '1.3.6.1.2.1.0'
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Drop the `__eq__()` override on the `OID` model.

### Motivation
<!-- What inspired you to submit this pull request? -->
We don't use it in the check. It was only used in tests, and even then it was not absolutely necessary.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
