### PR TITLE
Isolate PySNMP inspection hacks

### DIFF
--- a/snmp/datadog_checks/snmp/metrics.py
+++ b/snmp/datadog_checks/snmp/metrics.py
@@ -9,8 +9,8 @@ from typing import Any, Optional
 
 from pyasn1.codec.ber.decoder import decode as pyasn1_decode
 
-from .pysnmp_inspect import is_gauge, is_counter, is_opaque
 from .compat import total_time_to_temporal_percent
+from .pysnmp_inspect import is_counter, is_gauge, is_opaque
 from .types import MetricDefinition
 
 

--- a/snmp/datadog_checks/snmp/metrics.py
+++ b/snmp/datadog_checks/snmp/metrics.py
@@ -5,52 +5,24 @@
 Helpers for deriving metrics from SNMP values.
 """
 
-from typing import Any, Optional, Set
+from typing import Any, Optional
 
 from pyasn1.codec.ber.decoder import decode as pyasn1_decode
 
+from .pysnmp_inspect import is_gauge, is_counter, is_opaque
 from .compat import total_time_to_temporal_percent
 from .types import MetricDefinition
-
-# SNMP value types that we explicitly support.
-SNMP_COUNTER_CLASSES = {
-    'Counter32',
-    'Counter64',
-    # Additional types that are not part of the SNMP protocol (see RFC 2856).
-    'ZeroBasedCounter64',
-}  # type: Set[str]
-SNMP_GAUGE_CLASSES = {
-    'Gauge32',
-    'Integer',
-    'Integer32',
-    'Unsigned32',
-    # Additional types that are not part of the SNMP protocol (see RFC 2856).
-    'CounterBasedGauge64',
-}  # type: Set[str]
 
 
 def as_metric_with_inferred_type(value):
     # type: (Any) -> Optional[MetricDefinition]
-
-    # Ugly hack but couldn't find a cleaner way. Proper way would be to use the ASN.1
-    # method `.isSameTypeWith()`, or at least `isinstance()`.
-    # But these wrongfully return `True` in some cases, eg:
-    # ```python
-    # >>> from pysnmp.proto.rfc1902 import Counter64
-    # >>> from datadog_checks.snmp.pysnmp_types import CounterBasedGauge64
-    # >>> issubclass(CounterBasedGauge64, Counter64)
-    # True  # <-- WRONG! (CounterBasedGauge64 values are gauges, not counters.)
-    # ````
-
-    pysnmp_class_name = value.__class__.__name__
-
-    if pysnmp_class_name in SNMP_COUNTER_CLASSES:
+    if is_counter(value):
         return {'type': 'rate', 'value': int(value)}
 
-    if pysnmp_class_name in SNMP_GAUGE_CLASSES:
+    if is_gauge(value):
         return {'type': 'gauge', 'value': int(value)}
 
-    if pysnmp_class_name == 'Opaque':
+    if is_opaque(value):
         # Arbitrary ASN.1 syntax encoded as an octet string. Let's try to decode it as a float.
         # See: http://snmplabs.com/pysnmp/docs/api-reference.html#opaque-type
         try:

--- a/snmp/datadog_checks/snmp/models.py
+++ b/snmp/datadog_checks/snmp/models.py
@@ -8,6 +8,7 @@ Define our own models and interfaces for dealing with SNMP data.
 from typing import Optional, Sequence, Tuple, Union
 
 from .exceptions import CouldNotDecodeOID, SmiError, UnresolvedOID
+from .pysnmp_inspect import object_identity_from_object_type, parts_from_object_identity
 from .pysnmp_types import MibViewController, ObjectIdentity, ObjectName, ObjectType
 from .types import MIBSymbol
 from .utils import format_as_oid_string, parse_as_oid_tuple
@@ -23,46 +24,29 @@ class OID(object):
     def __init__(self, value):
         # type: (Union[Sequence[int], str, ObjectName, ObjectIdentity, ObjectType]) -> None
         parts = None  # type: Optional[Tuple[int, ...]]
+        object_identity = None  # type: Optional[ObjectIdentity]
 
         try:
             parts = parse_as_oid_tuple(value)
         except CouldNotDecodeOID:
             raise  # Invalid input.
         except UnresolvedOID:
+            # `value` must be a PySNMP object, let's inspect it.
             if isinstance(value, ObjectType):
-                # An unresolved `ObjectType(ObjectIdentity('<MIB>', '<symbol>'))`.
-                parts = None
+                object_identity = object_identity_from_object_type(value)
             elif isinstance(value, ObjectIdentity):
-                # An unresolved `ObjectIdentity('<MIB>', '<symbol>')`.
-                parts = None
+                object_identity = value
             else:  # pragma: no cover
                 raise RuntimeError('Unexpectedly treated {!r} as an unresolved OID'.format(value))
-
-        # Resolve the `ObjectIdentity` which we can use to resolve the MIB name of the OID (for metric naming).
-        # PySNMP objects may contain MIB information already, so check for them in priority.
-        if isinstance(value, ObjectType):
-            # No other choice than to use private API here.
-            object_identity = value._ObjectType__args[0]
-            if not isinstance(object_identity, ObjectIdentity):  # pragma: no cover
-                raise RuntimeError('Expected {!r} to be an `ObjectIdentity` instance'.format(object_identity))
-        elif isinstance(value, ObjectIdentity):
-            object_identity = value
+            parts = parts_from_object_identity(object_identity)
         else:
-            # Fallback.
-            if parts is None:  # pragma: no cover
-                raise RuntimeError('`parts` should have been set')
             object_identity = ObjectIdentity(parts)
 
         self._parts = parts
-        self._object_identity = object_identity  # type: ObjectIdentity
+        self._object_identity = object_identity
 
     def resolve(self, mib_view_controller):
         # type: (MibViewController) -> None
-        if self._parts is not None:
-            # Client code should only call this if they're certain the
-            # underlying OID isn't resolved yet.
-            raise RuntimeError('Already resolved as {}'.format(self._parts))
-
         self._object_identity.resolveWithMib(mib_view_controller)
         self._parts = parse_as_oid_tuple(self._object_identity)
 

--- a/snmp/datadog_checks/snmp/pysnmp_inspect.py
+++ b/snmp/datadog_checks/snmp/pysnmp_inspect.py
@@ -1,0 +1,81 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+"""
+Helpers for inspecting PySNMP objects.
+"""
+from typing import Any, Optional, Tuple
+
+from .exceptions import CouldNotDecodeOID, UnresolvedOID
+from .pysnmp_types import ObjectIdentity, ObjectType
+from .utils import parse_as_oid_tuple
+
+
+def _get_constructor_arguments(obj):
+    # type: (Any) -> tuple
+    # Several PySNMP objects store their `__init__` arguments into a private `__args` attribute, and their
+    # public API prevents accessing that data until MIB resolution has occurred.
+    # HACK: If the data we care about is in those arguments (eg the OID string in `ObjectIdentity('1.2.3...')`),
+    # then we reach into private API to get it.
+    attr_name = '_{}__args'.format(obj.__class__.__name__)
+    return getattr(obj, attr_name)
+
+
+def object_identity_from_object_type(object_type):
+    # type: (ObjectType) -> ObjectIdentity
+    # Assume `ObjectType(<object_identity>[, ...])`.
+    args = _get_constructor_arguments(object_type)
+    return args[0]
+
+
+def parts_from_object_identity(object_identity):
+    # type: (ObjectIdentity) -> Optional[Tuple[int, ...]]
+    # Aim for `ObjectIdentity('1.2.3...')`.
+    args = _get_constructor_arguments(object_identity)
+
+    try:
+        oid_str = args[0]
+    except IndexError:
+        return None
+
+    try:
+        return parse_as_oid_tuple(oid_str)
+    except (CouldNotDecodeOID, UnresolvedOID):
+        return None
+
+
+# HACK: we infer the types of SNMP values from their class names.
+# Proper way would be to use the ASN.1 method `.isSameTypeWith()`, or at least `isinstance()`, but these
+# wrongfully return `True` in some cases.
+# For example, `CounterBasedGauge64` would be interpreted as a `Counter64` instead of a gauge.
+
+SNMP_COUNTER_CLASSES = {
+    'Counter32',
+    'Counter64',
+    # Additional types that are not part of the SNMP protocol (see RFC 2856).
+    'ZeroBasedCounter64',
+}
+
+SNMP_GAUGE_CLASSES = {
+    'Gauge32',
+    'Integer',
+    'Integer32',
+    'Unsigned32',
+    # Additional types that are not part of the SNMP protocol (see RFC 2856).
+    'CounterBasedGauge64',
+}
+
+
+def is_counter(obj):
+    # type: (Any) -> bool
+    return obj.__class__.__name__ in SNMP_COUNTER_CLASSES
+
+
+def is_gauge(obj):
+    # type: (Any) -> bool
+    return obj.__class__.__name__ in SNMP_GAUGE_CLASSES
+
+
+def is_opaque(obj):
+    # type: (Any) -> bool
+    return obj.__class__.__name__ == 'Opaque'

--- a/snmp/datadog_checks/snmp/pysnmp_inspect.py
+++ b/snmp/datadog_checks/snmp/pysnmp_inspect.py
@@ -32,11 +32,7 @@ def parts_from_object_identity(object_identity):
     # type: (ObjectIdentity) -> Optional[Tuple[int, ...]]
     # Aim for `ObjectIdentity('1.2.3...')`.
     args = _get_constructor_arguments(object_identity)
-
-    try:
-        oid_str = args[0]
-    except IndexError:
-        return None
+    oid_str = args[0]
 
     try:
         return parse_as_oid_tuple(oid_str)

--- a/snmp/tests/test_utils.py
+++ b/snmp/tests/test_utils.py
@@ -50,6 +50,8 @@ def test_oid_from_unresolved_symbol():
         oid.as_tuple()
     with pytest.raises(UnresolvedOID):
         str(oid)
+    with pytest.raises(UnresolvedOID):
+        oid.get_mib_symbol()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We have a few necessary `HACK` to introspect PySNMP values, so this PR centralizes them in a dedicated module.

This allows us to simplify the `OID` constructor — tests also adjusted and simplified.

### Motivation
<!-- What inspired you to submit this pull request? -->
More easily keep track track of our hacks, and keep the main logic clean.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
