### PR TITLE
Drop outdated `warning` parameter in `parse_metrics`

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -334,8 +334,7 @@ class InstanceConfig:
             yield host
 
     def parse_metrics(
-        self,
-        metrics,  # type: List[Dict[str, Any]]
+        self, metrics,  # type: List[Dict[str, Any]]
     ):
         # type: (...) -> Tuple[List[OID], List[OID], List[Union[ParsedMetric, ParsedTableMetric]]]
         """Parse configuration and returns data to be used for SNMP queries.

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -111,7 +111,6 @@ class SnmpCheck(AgentCheck):
         # type: (dict) -> InstanceConfig
         return InstanceConfig(
             instance,
-            warning=self.warning,
             global_metrics=self.init_config.get('global_metrics', []),
             mibs_path=self.mibs_path,
             profiles=self.profiles,
@@ -160,7 +159,7 @@ class SnmpCheck(AgentCheck):
                         self.log.warning("Host %s didn't match a profile for sysObjectID %s", host, sys_object_oid)
                         continue
                 else:
-                    host_config.refresh_with_profile(self.profiles[profile], self.warning)
+                    host_config.refresh_with_profile(self.profiles[profile])
                     host_config.add_profile_tag(profile)
 
                 config.discovered_instances[host] = host_config
@@ -374,7 +373,7 @@ class SnmpCheck(AgentCheck):
             if not (config.all_oids or config.bulk_oids):
                 sys_object_oid = self.fetch_sysobject_oid(config)
                 profile = self._profile_for_sysobject_oid(sys_object_oid)
-                config.refresh_with_profile(self.profiles[profile], self.warning)
+                config.refresh_with_profile(self.profiles[profile])
                 config.add_profile_tag(profile)
 
             if config.all_oids or config.bulk_oids:

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -28,21 +28,19 @@ pytestmark = pytest.mark.unit
 def test_parse_metrics(lcd_mock):
     # type: (Any) -> None
     lcd_mock.configure.return_value = ('addr', None)
-    instance = common.generate_instance_config(common.SUPPORTED_METRIC_TYPES)
-    check = SnmpCheck('snmp', {}, [instance])
+
     # Unsupported metric
     metrics = [{"foo": "bar"}]  # type: list
     config = InstanceConfig(
-        {"ip_address": "127.0.0.1", "community_string": "public", "metrics": [{"OID": "1.2.3", "name": "foo"}]},
-        warning=check.warning,
+        {"ip_address": "127.0.0.1", "community_string": "public", "metrics": [{"OID": "1.2.3", "name": "foo"}]}
     )
 
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, check.warning)
+        config.parse_metrics(metrics)
 
     # Simple OID
     metrics = [{"OID": "1.2.3", "name": "foo"}]
-    oids, _, parsed_metrics = config.parse_metrics(metrics, check.warning)
+    oids, _, parsed_metrics = config.parse_metrics(metrics)
     assert len(oids) == 1
     assert len(parsed_metrics) == 1
     foo = parsed_metrics[0]
@@ -52,11 +50,11 @@ def test_parse_metrics(lcd_mock):
     # MIB with no symbol or table
     metrics = [{"MIB": "foo_mib"}]
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, check.warning)
+        config.parse_metrics(metrics)
 
     # MIB with symbol
     metrics = [{"MIB": "foo_mib", "symbol": "foo"}]
-    oids, _, parsed_metrics = config.parse_metrics(metrics, check.warning)
+    oids, _, parsed_metrics = config.parse_metrics(metrics)
     assert len(oids) == 1
     assert len(parsed_metrics) == 1
     foo = parsed_metrics[0]
@@ -66,11 +64,11 @@ def test_parse_metrics(lcd_mock):
     # MIB with table, no symbols
     metrics = [{"MIB": "foo_mib", "table": "foo"}]
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, check.warning)
+        config.parse_metrics(metrics)
 
     # MIB with table and symbols
     metrics = [{"MIB": "foo_mib", "table": "foo_table", "symbols": ["foo", "bar"]}]
-    oids, _, parsed_metrics = config.parse_metrics(metrics, check.warning)
+    oids, _, parsed_metrics = config.parse_metrics(metrics)
     assert len(oids) == 2
     assert len(parsed_metrics) == 2
     foo, bar = parsed_metrics
@@ -82,16 +80,16 @@ def test_parse_metrics(lcd_mock):
     # MIB with table, symbols, bad metrics_tags
     metrics = [{"MIB": "foo_mib", "table": "foo_table", "symbols": ["foo", "bar"], "metric_tags": [{}]}]
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, check.warning)
+        config.parse_metrics(metrics)
 
     # MIB with table, symbols, bad metrics_tags
     metrics = [{"MIB": "foo_mib", "table": "foo_table", "symbols": ["foo", "bar"], "metric_tags": [{"tag": "test"}]}]
     with pytest.raises(Exception):
-        config.parse_metrics(metrics, check.warning)
+        config.parse_metrics(metrics)
 
     # Table with manual OID
     metrics = [{"MIB": "foo_mib", "table": "foo_table", "symbols": [{"OID": "1.2.3", "name": "foo"}]}]
-    oids, _, parsed_metrics = config.parse_metrics(metrics, check.warning)
+    oids, _, parsed_metrics = config.parse_metrics(metrics)
     assert len(oids) == 1
     assert len(parsed_metrics) == 1
     foo = parsed_metrics[0]
@@ -107,7 +105,7 @@ def test_parse_metrics(lcd_mock):
             "metric_tags": [{"tag": "test", "index": "1"}],
         },
     ]
-    oids, _, parsed_metrics = config.parse_metrics(metrics, check.warning)
+    oids, _, parsed_metrics = config.parse_metrics(metrics)
     assert len(oids) == 2
     assert len(parsed_metrics) == 2
     foo, bar = parsed_metrics
@@ -127,7 +125,7 @@ def test_parse_metrics(lcd_mock):
             "metric_tags": [{"tag": "test", "column": "baz"}],
         }
     ]
-    oids, _, parsed_metrics = config.parse_metrics(metrics, check.warning)
+    oids, _, parsed_metrics = config.parse_metrics(metrics)
     assert len(oids) == 3
     assert len(parsed_metrics) == 2
     foo, bar = parsed_metrics
@@ -147,7 +145,7 @@ def test_parse_metrics(lcd_mock):
             "metric_tags": [{"tag": "test", "column": {"name": "baz", "OID": "1.5.6"}}],
         }
     ]
-    oids, _, parsed_metrics = config.parse_metrics(metrics, check.warning)
+    oids, _, parsed_metrics = config.parse_metrics(metrics)
     assert len(oids) == 3
     assert len(parsed_metrics) == 2
     foo, bar = parsed_metrics


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Drop the `warnings` parameter passed across the `InstanceConfig`.

### Motivation
<!-- What inspired you to submit this pull request? -->
It's only used in a single location, and it actually seems to me that the exception handling there is outdated.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Prep work for `parse_metrics()` refactor.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
