### PR TITLE
Increase wait time

### DIFF
--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -59,7 +59,7 @@ def dd_environment():
             CheckEndpoints([common.URL]),
             lambda: generate_data(couch_version),
             WaitFor(send_replication, args=(couch_version,), wait=2, attempts=60),
-            WaitFor(get_replication, args=(couch_version,), wait=2, attempts=70),
+            WaitFor(get_replication, args=(couch_version,), wait=3, attempts=40),
         ],
     ):
         if couch_version == '1':


### PR DESCRIPTION
Seems even with the increased time it can fail some times: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13239&view=logs&j=c73aedc7-d1f1-5bee-93b6-629007590bd5&t=7b58fc00-c48d-5e79-d458-fcdf7976c98f&l=271

```
self = <datadog_checks.dev.conditions.WaitFor object at 0x7fd61db7a1c0>

    def __call__(self):
        last_result = None
        last_error = None
    
        for _ in range(self.attempts):
            try:
                result = self.func(*self.args, **self.kwargs)
            except Exception as e:
                last_error = str(e)
                time.sleep(self.wait)
                continue
            else:
                last_result = result
    
            if last_result is None or last_result is True:
                return True
    
            time.sleep(self.wait)
        else:
>           raise RetryError(
                'Result: {}\nError: {}\nFunction: {}, Args: {}, Kwargs: {}\n'.format(
                    repr(last_result), last_error, self.func.__name__, self.args, self.kwargs
                )
            )
E           datadog_checks.dev.errors.RetryError: Result: False
E           Error: None
E           Function: get_replication, Args: ('2',), Kwargs: {}

```