### PR TITLE
Update Oracle Readme for supported Java versions

### DIFF
--- a/oracle/README.md
+++ b/oracle/README.md
@@ -18,7 +18,6 @@ To use the Oracle integration, either install the Oracle Instant Client librarie
 - Java 8 onwards 
 - [Microsoft Visual C++ Runtime 2015][13]
 
-Please make sure to have these runtimes installed on your system.
 
 ##### JDBC Driver
 

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -16,7 +16,7 @@ To use the Oracle integration, either install the Oracle Instant Client librarie
 
 **Note**: The following runtimes are required on your system for JPype, one of the libraries used by the Agent when using JDBC Driver:
 
-- Java 8 onwards 
+- Java 8 or higher 
 - [Microsoft Visual C++ Runtime 2015][13]
 
 

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -14,7 +14,8 @@ Get metrics from Oracle Database servers in real time to visualize and monitor a
 
 To use the Oracle integration, either install the Oracle Instant Client libraries, or download the Oracle JDBC Driver. Due to licensing restrictions, these libraries are not included in the Datadog Agent, but can be downloaded directly from Oracle.
 
-**Note**: JPype, one of the libraries used by the Agent when using JDBC Driver, has the following minimum requirements:
+**Note**: The following runtimes are required on your system for JPype, one of the libraries used by the Agent when using JDBC Driver:
+
 - Java 8 onwards 
 - [Microsoft Visual C++ Runtime 2015][13]
 

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -14,7 +14,11 @@ Get metrics from Oracle Database servers in real time to visualize and monitor a
 
 To use the Oracle integration, either install the Oracle Instant Client libraries, or download the Oracle JDBC Driver. Due to licensing restrictions, these libraries are not included in the Datadog Agent, but can be downloaded directly from Oracle.
 
-**Note**: JPype, one of the libraries used by the Agent, depends specifically on the [Microsoft Visual C++ Runtime 2015][13]. Make sure this runtime is installed on your system.
+**Note**: JPype, one of the libraries used by the Agent, has the following minimum requirements:
+- Java 8 onwards 
+- [Microsoft Visual C++ Runtime 2015][13]
+
+Please make sure to have these runtimes installed on your system.
 
 ##### JDBC Driver
 

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -14,7 +14,7 @@ Get metrics from Oracle Database servers in real time to visualize and monitor a
 
 To use the Oracle integration, either install the Oracle Instant Client libraries, or download the Oracle JDBC Driver. Due to licensing restrictions, these libraries are not included in the Datadog Agent, but can be downloaded directly from Oracle.
 
-**Note**: JPype, one of the libraries used by the Agent, has the following minimum requirements:
+**Note**: JPype, one of the libraries used by the Agent when using JDBC Driver, has the following minimum requirements:
 - Java 8 onwards 
 - [Microsoft Visual C++ Runtime 2015][13]
 


### PR DESCRIPTION
### What does this PR do?
Updates the Oracle readme to highlight Jpype's requirement of supported Java versions (Java 8+)
