### PR TITLE
[TEST/SANDBOX] ibm mq flaky setup (fixed with #6425)

### DIFF
--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -1,6 +1,7 @@
 trigger: none
 
 pr:
+  autoCancel: false
   branches:
     include:
     - master
@@ -15,8 +16,8 @@ variables:
 jobs:
 - template: './templates/test-single-linux.yml'
   parameters:
-    job_name: Changed
-    display: Linux
+    job_name: Changed_0
+    display: Linux_0
     validate: true
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
@@ -24,11 +25,209 @@ jobs:
         pip | $(Agent.OS)
       path: $(PIP_CACHE_DIR)
 
-- template: './templates/test-single-windows.yml'
+- template: './templates/test-single-linux.yml'
   parameters:
-    job_name: Changed
-    check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dotnetclr exchange_server iis pdh_check sqlserver win32_event_log windows_service wmi_check'
-    display: Windows
+    job_name: Changed_1
+    display: Linux_1
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_2
+    display: Linux_2
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_3
+    display: Linux_3
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_4
+    display: Linux_4
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_5
+    display: Linux_5
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_6
+    display: Linux_6
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_7
+    display: Linux_7
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_8
+    display: Linux_8
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_9
+    display: Linux_9
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_10
+    display: Linux_10
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_11
+    display: Linux_11
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_12
+    display: Linux_12
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_13
+    display: Linux_13
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_14
+    display: Linux_14
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_15
+    display: Linux_15
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_16
+    display: Linux_16
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_17
+    display: Linux_17
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_18
+    display: Linux_18
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_19
+    display: Linux_19
+    validate: true
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
       restoreKeys: |

--- a/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
+++ b/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
@@ -39,12 +39,9 @@ sudo apt-get install -y --no-install-recommends \
 mkdir -p $TMP_DIR
 pushd $TMP_DIR
 
-  n=0
-  until [ $n -ge 10 ]
-  do
-     curl -LO $MQ_URL && break
-     n=$((n+1))
-     sleep 10
+  for i in 2 4 8 16 32; do
+    curl -LO $MQ_URL && break
+    sleep $i
   done
 
   tar -zxvf ./*.tar.gz

--- a/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
+++ b/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
@@ -40,11 +40,11 @@ mkdir -p $TMP_DIR
 pushd $TMP_DIR
 
   n=0
-  until [ $n -ge 20 ]
+  until [ $n -ge 10 ]
   do
      curl -LO $MQ_URL && break
      n=$((n+1))
-     sleep 5
+     sleep 10
   done
 
   tar -zxvf ./*.tar.gz

--- a/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
+++ b/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
@@ -39,6 +39,8 @@ sudo apt-get install -y --no-install-recommends \
 mkdir -p $TMP_DIR
 pushd $TMP_DIR
 
+  # Retry necessary due to flaky download that might trigger:
+  # curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110
   for i in 2 4 8 16 32; do
     curl --verbose -LO $MQ_URL && break
     sleep $i

--- a/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
+++ b/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
@@ -40,7 +40,7 @@ mkdir -p $TMP_DIR
 pushd $TMP_DIR
 
   for i in 2 4 8 16 32; do
-    curl -LO $MQ_URL && break
+    curl --verbose -LO $MQ_URL && break
     sleep $i
   done
 

--- a/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
+++ b/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
@@ -38,13 +38,22 @@ sudo apt-get install -y --no-install-recommends \
 
 mkdir -p $TMP_DIR
 pushd $TMP_DIR
-  curl --retry 20 --retry-delay 5 -LO $MQ_URL
+
+  n=0
+  until [ $n -ge 20 ]
+  do
+     curl -LO $MQ_URL && break
+     n=$((n+1))
+     sleep 5
+  done
+
   tar -zxvf ./*.tar.gz
   pushd MQServer
     sudo ./mqlicense.sh -text_only -accept
     sudo rpm -ivh --force-debian *.rpm
     sudo /opt/mqm/bin/setmqinst -p /opt/mqm -i
   popd
+
 popd
 
 ls /opt/mqm

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+# CHANGED
 
 import logging
 from typing import Any

--- a/ibm_mq/tests/common.py
+++ b/ibm_mq/tests/common.py
@@ -96,14 +96,11 @@ INSTANCE_QUEUE_REGEX_TAG = {
 }
 
 E2E_METADATA = {
-    # This script makes the necessary setup to be able to compile pymqi on the agent machine
+    'docker_volumes': [
+        '{}/scripts/start_commands.sh:/tmp/start_commands.sh'.format(HERE),
+    ],
     'start_commands': [
-        'apt-get update',
-        'apt-get install gcc -y',
-        'mkdir /opt/mqm',
-        'curl -L -o /opt/mqm/mq-client.tar.gz '
-        'https://ddintegrations.blob.core.windows.net/ibm-mq/9.1.0.4-IBM-MQC-Redist-LinuxX64.tar.gz',
-        'tar -C /opt/mqm -xf /opt/mqm/mq-client.tar.gz',
+        'bash /tmp/start_commands.sh',
     ],
     'env_vars': {'LD_LIBRARY_PATH': '/opt/mqm/lib64:/opt/mqm/lib', 'C_INCLUDE_PATH': '/opt/mqm/inc'},
 }

--- a/ibm_mq/tests/common.py
+++ b/ibm_mq/tests/common.py
@@ -96,12 +96,8 @@ INSTANCE_QUEUE_REGEX_TAG = {
 }
 
 E2E_METADATA = {
-    'docker_volumes': [
-        '{}/scripts/start_commands.sh:/tmp/start_commands.sh'.format(HERE),
-    ],
-    'start_commands': [
-        'bash /tmp/start_commands.sh',
-    ],
+    'docker_volumes': ['{}/scripts/start_commands.sh:/tmp/start_commands.sh'.format(HERE)],
+    'start_commands': ['bash /tmp/start_commands.sh'],
     'env_vars': {'LD_LIBRARY_PATH': '/opt/mqm/lib64:/opt/mqm/lib', 'C_INCLUDE_PATH': '/opt/mqm/inc'},
 }
 

--- a/ibm_mq/tests/scripts/start_commands.sh
+++ b/ibm_mq/tests/scripts/start_commands.sh
@@ -1,0 +1,14 @@
+# This script makes the necessary setup to be able to compile pymqi on the agent machine
+apt-get update
+apt-get install gcc -y
+
+mkdir /opt/mqm
+
+# Retry necessary due to flaky download that might trigger:
+# curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110
+for i in 2 4 8 16 32; do
+  curl -L -o /opt/mqm/mq-client.tar.gz https://ddintegrations.blob.core.windows.net/ibm-mq/9.1.0.4-IBM-MQC-Redist-LinuxX64.tar.gz && break
+  sleep $i
+done
+
+tar -C /opt/mqm -xf /opt/mqm/mq-client.tar.gz

--- a/ibm_mq/tests/scripts/start_commands.sh
+++ b/ibm_mq/tests/scripts/start_commands.sh
@@ -1,4 +1,7 @@
 # This script makes the necessary setup to be able to compile pymqi on the agent machine
+
+MQ_URL=https://ddintegrations.blob.core.windows.net/ibm-mq/mqadv_dev90_linux_x86-64.tar.gz
+
 apt-get update
 apt-get install gcc -y
 
@@ -7,7 +10,7 @@ mkdir /opt/mqm
 # Retry necessary due to flaky download that might trigger:
 # curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110
 for i in 2 4 8 16 32; do
-  curl -L -o /opt/mqm/mq-client.tar.gz https://ddintegrations.blob.core.windows.net/ibm-mq/9.1.0.4-IBM-MQC-Redist-LinuxX64.tar.gz && break
+  curl -L -o $MQ_URL && break
   sleep $i
 done
 

--- a/ibm_mq/tests/scripts/start_commands.sh
+++ b/ibm_mq/tests/scripts/start_commands.sh
@@ -1,6 +1,6 @@
 # This script makes the necessary setup to be able to compile pymqi on the agent machine
 
-MQ_URL=https://ddintegrations.blob.core.windows.net/ibm-mq/mqadv_dev90_linux_x86-64.tar.gz
+MQ_URL=https://ddintegrations.blob.core.windows.net/ibm-mq/9.1.0.4-IBM-MQC-Redist-LinuxX64.tar.gz
 
 apt-get update
 apt-get install gcc -y

--- a/ibm_mq/tests/scripts/start_commands.sh
+++ b/ibm_mq/tests/scripts/start_commands.sh
@@ -10,7 +10,7 @@ mkdir /opt/mqm
 # Retry necessary due to flaky download that might trigger:
 # curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110
 for i in 2 4 8 16 32; do
-  curl -L -o $MQ_URL && break
+  curl -L -o /opt/mqm/mq-client.tar.gz $MQ_URL && break
   sleep $i
 done
 


### PR DESCRIPTION
PR for review: https://github.com/DataDog/integrations-core/pull/6425

## What this PR does

Fix flaky download by using retry with exponential backoff.

Retry demo on CI: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13352&view=logs&j=cc5abc9e-0189-58d8-da2a-d33663c307d9&t=1a86c5c0-5052-5a2b-f4e0-7f5a07d3dca8

## Motivation

Flaky CI:

```
curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110
```

https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=12632&view=logs&jobId=f3774450-0a68-5b0d-a279-93c033634772&j=f3774450-0a68-5b0d-a279-93c033634772&t=c900b11a-1940-55cc-15eb-97387e3df1eb

https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13353&view=logs&j=4f1addd7-da00-5424-0c3e-2425923a6810&t=c70250f9-5dff-5d4e-5e8d-2c849d063cfc