### PR TITLE
Handle missing role metrics for mesos_master

### DIFF
--- a/mesos_master/datadog_checks/mesos_master/mesos_master.py
+++ b/mesos_master/datadog_checks/mesos_master/mesos_master.py
@@ -275,7 +275,12 @@ class MesosMaster(AgentCheck):
                         self.GAUGE('mesos.role.frameworks.count', len(role['frameworks']), tags=role_tags)
                         self.GAUGE('mesos.role.weight', role['weight'], tags=role_tags)
                         for key_name, (metric_name, metric_func) in iteritems(self.ROLE_RESOURCES_METRICS):
-                            metric_func(self, metric_name, role['resources'][key_name], tags=role_tags)
+                            try:
+                                metric_func(self, metric_name, role['resources'][key_name], tags=role_tags)
+                            except KeyError:
+                                self.log.debug(
+                                    'Unable to access metrics for master role resource: {}.  Skipping.', key_name
+                                )
 
             stats_metrics = self._get_master_stats(url, instance_tags)
             if stats_metrics is not None:


### PR DESCRIPTION
### What does this PR do?
This gracefully handles the case when mesos does not manage disks, thus that field doesn't appear in the `/roles` endpoint output.

Currently, a missing value in that output causes the whole check to fail.

This change logs a note to `debug`, since any condition where this occurs will happen for every check, so shouldn't pollute the log in normal operations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
