### PR TITLE
Fix flacky docker login

### DIFF
--- a/.azure-pipelines/scripts/oracle/linux/55_docker_login.sh
+++ b/.azure-pipelines/scripts/oracle/linux/55_docker_login.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 set +x
 
-echo "$ORACLE_DOCKER_PASSWORD" | docker login container-registry.oracle.com --username "$ORACLE_DOCKER_USERNAME" --password-stdin
+echo "[INFO] Docker login"
+for i in 2 4 8 16 32; do
+  echo "$ORACLE_DOCKER_PASSWORD" | docker login container-registry.oracle.com --username "$ORACLE_DOCKER_USERNAME" --password-stdin && break
+  echo "[INFO] Wait $i seconds and retry docker login"
+  sleep $i
+done
 
 set -x


### PR DESCRIPTION
# What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Retry oracle docker login.

### Motivation
<!-- What inspired you to submit this pull request? -->

```
subprocess.CalledProcessError: Command '['/home/vsts/work/1/s/.azure-pipelines/scripts/oracle/linux/55_docker_login.sh']' returned non-zero exit status 1.

```

https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13290&view=logs&jobId=c3a06451-088b-587c-b2b9-012b146267bb&j=c3a06451-088b-587c-b2b9-012b146267bb&t=2bafb84b-8462-569e-008d-81bcd7799f67

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Success builds with the retry:
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13373&view=results
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13374&view=results
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13375&view=results
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13376&view=results

Sandbox PR https://github.com/DataDog/integrations-core/pull/6419

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
