### PR TITLE
Add retry to fix env setup

### DIFF
--- a/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
+++ b/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
@@ -38,13 +38,21 @@ sudo apt-get install -y --no-install-recommends \
 
 mkdir -p $TMP_DIR
 pushd $TMP_DIR
-  curl --retry 20 --retry-delay 5 -LO $MQ_URL
+
+  # Retry necessary due to flaky download that might trigger:
+  # curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110
+  for i in 2 4 8 16 32; do
+    curl --verbose -LO $MQ_URL && break
+    sleep $i
+  done
+
   tar -zxvf ./*.tar.gz
   pushd MQServer
     sudo ./mqlicense.sh -text_only -accept
     sudo rpm -ivh --force-debian *.rpm
     sudo /opt/mqm/bin/setmqinst -p /opt/mqm -i
   popd
+
 popd
 
 ls /opt/mqm

--- a/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
+++ b/.azure-pipelines/scripts/ibm_mq/linux/55_install_client.sh
@@ -43,6 +43,7 @@ pushd $TMP_DIR
   # curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110
   for i in 2 4 8 16 32; do
     curl --verbose -LO $MQ_URL && break
+    echo "[INFO] Wait $i seconds and retry curl download"
     sleep $i
   done
 

--- a/ibm_mq/tests/common.py
+++ b/ibm_mq/tests/common.py
@@ -96,15 +96,8 @@ INSTANCE_QUEUE_REGEX_TAG = {
 }
 
 E2E_METADATA = {
-    # This script makes the necessary setup to be able to compile pymqi on the agent machine
-    'start_commands': [
-        'apt-get update',
-        'apt-get install gcc -y',
-        'mkdir /opt/mqm',
-        'curl -L -o /opt/mqm/mq-client.tar.gz '
-        'https://ddintegrations.blob.core.windows.net/ibm-mq/9.1.0.4-IBM-MQC-Redist-LinuxX64.tar.gz',
-        'tar -C /opt/mqm -xf /opt/mqm/mq-client.tar.gz',
-    ],
+    'docker_volumes': ['{}/scripts/start_commands.sh:/tmp/start_commands.sh'.format(HERE)],
+    'start_commands': ['bash /tmp/start_commands.sh'],
     'env_vars': {'LD_LIBRARY_PATH': '/opt/mqm/lib64:/opt/mqm/lib', 'C_INCLUDE_PATH': '/opt/mqm/inc'},
 }
 

--- a/ibm_mq/tests/scripts/start_commands.sh
+++ b/ibm_mq/tests/scripts/start_commands.sh
@@ -1,0 +1,17 @@
+# This script makes the necessary setup to be able to compile pymqi on the agent machine
+
+MQ_URL=https://ddintegrations.blob.core.windows.net/ibm-mq/9.1.0.4-IBM-MQC-Redist-LinuxX64.tar.gz
+
+apt-get update
+apt-get install gcc -y
+
+mkdir /opt/mqm
+
+# Retry necessary due to flaky download that might trigger:
+# curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110
+for i in 2 4 8 16 32; do
+  curl -L -o /opt/mqm/mq-client.tar.gz $MQ_URL && break
+  sleep $i
+done
+
+tar -C /opt/mqm -xf /opt/mqm/mq-client.tar.gz


### PR DESCRIPTION
## What this PR does

Fix flaky download by using retry with exponential backoff.

Retry demo on CI: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13352&view=logs&j=cc5abc9e-0189-58d8-da2a-d33663c307d9&t=1a86c5c0-5052-5a2b-f4e0-7f5a07d3dca8

## Motivation

### CI Setup failure:

```
curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110
```

https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=12632&view=logs&jobId=f3774450-0a68-5b0d-a279-93c033634772&j=f3774450-0a68-5b0d-a279-93c033634772&t=c900b11a-1940-55cc-15eb-97387e3df1eb

### E2E Setup failure:

https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13352&view=logs&j=4f1addd7-da00-5424-0c3e-2425923a6810&t=c70250f9-5dff-5d4e-5e8d-2c849d063cfc
## Additional Info

Sandbox PR: https://github.com/DataDog/integrations-core/pull/6418