### PR TITLE
[TEST/SANDBOX] mysql flaky (enough cases)

### DIFF
--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -1,6 +1,7 @@
 trigger: none
 
 pr:
+  autoCancel: false
   branches:
     include:
     - master
@@ -15,8 +16,8 @@ variables:
 jobs:
 - template: './templates/test-single-linux.yml'
   parameters:
-    job_name: Changed
-    display: Linux
+    job_name: Changed_0
+    display: Linux_0
     validate: true
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
@@ -24,11 +25,209 @@ jobs:
         pip | $(Agent.OS)
       path: $(PIP_CACHE_DIR)
 
-- template: './templates/test-single-windows.yml'
+- template: './templates/test-single-linux.yml'
   parameters:
-    job_name: Changed
-    check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dotnetclr exchange_server iis pdh_check sqlserver win32_event_log windows_service wmi_check'
-    display: Windows
+    job_name: Changed_1
+    display: Linux_1
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_2
+    display: Linux_2
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_3
+    display: Linux_3
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_4
+    display: Linux_4
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_5
+    display: Linux_5
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_6
+    display: Linux_6
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_7
+    display: Linux_7
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_8
+    display: Linux_8
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_9
+    display: Linux_9
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_10
+    display: Linux_10
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_11
+    display: Linux_11
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_12
+    display: Linux_12
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_13
+    display: Linux_13
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_14
+    display: Linux_14
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_15
+    display: Linux_15
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_16
+    display: Linux_16
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_17
+    display: Linux_17
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_18
+    display: Linux_18
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_19
+    display: Linux_19
+    validate: true
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
       restoreKeys: |

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -2,6 +2,7 @@
 # (C) Patrick Galbraith <patg@patg.net> 2013
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+# CHANGED
 from __future__ import division
 
 import re

--- a/mysql/tests/common.py
+++ b/mysql/tests/common.py
@@ -14,6 +14,8 @@ TESTS_HELPER_DIR = os.path.join(ROOT, 'datadog_checks_tests_helper')
 MYSQL_VERSION_PARSED = parse_version(os.getenv('MYSQL_VERSION'))
 
 CHECK_NAME = 'mysql'
+MASTER_CONTAINER_NAME = 'mysql-master'
+SLAVE_CONTAINER_NAME = 'mysql-slave'
 
 HOST = get_docker_hostname()
 PORT = 13306

--- a/mysql/tests/compose/mariadb.yaml
+++ b/mysql/tests/compose/mariadb.yaml
@@ -2,6 +2,7 @@ version: '3.5'
 
 services:
   mysql-master:
+    container_name: mysql-master
     image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
     environment:
       - ALLOW_EMPTY_PASSWORD=yes

--- a/mysql/tests/compose/mariadb.yaml
+++ b/mysql/tests/compose/mariadb.yaml
@@ -21,6 +21,7 @@ services:
   mysql-slave:
     container_name: mysql-slave
     image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
+    restart: on-failure
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
       - MASTER_HOST=mysql-master

--- a/mysql/tests/compose/mysql.yaml
+++ b/mysql/tests/compose/mysql.yaml
@@ -2,6 +2,7 @@ version: '3.5'
 
 services:
   mysql-master:
+    container_name: mysql-master
     image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=1

--- a/mysql/tests/compose/mysql.yaml
+++ b/mysql/tests/compose/mysql.yaml
@@ -16,6 +16,7 @@ services:
   mysql-slave:
     container_name: mysql-slave
     image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
+    restart: on-failure
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=1
       - MASTER_HOST=mysql-master

--- a/mysql/tests/compose/mysql8.yaml
+++ b/mysql/tests/compose/mysql8.yaml
@@ -2,6 +2,7 @@ version: '3.5'
 
 services:
   mysql-master:
+    container_name: mysql-master
     image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
     environment:
       - ALLOW_EMPTY_PASSWORD=yes

--- a/mysql/tests/compose/mysql8.yaml
+++ b/mysql/tests/compose/mysql8.yaml
@@ -21,6 +21,7 @@ services:
   mysql-slave:
     container_name: mysql-slave
     image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
+    restart: on-failure
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
       - MASTER_HOST=mysql-master

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -83,7 +83,7 @@ def build_wait_conditions():
         CheckDockerLogs(common.SLAVE_CONTAINER_NAME, ["ready for connections", "mariadb successfully initialized"])
     )
     conditions.append(WaitFor(init_master, wait=2))
-    conditions.append(WaitFor(init_slave, wait=2))
+    conditions.append(WaitFor(init_slave, wait=2, attempts=100))
     conditions.append(populate_database)
     return conditions
 

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -83,7 +83,7 @@ def build_wait_conditions():
         CheckDockerLogs(common.SLAVE_CONTAINER_NAME, ["ready for connections", "mariadb successfully initialized"])
     )
     conditions.append(WaitFor(init_master, wait=2))
-    conditions.append(WaitFor(init_slave, wait=2, attempts=100))
+    conditions.append(WaitFor(init_slave, wait=2, attempts=180))
     conditions.append(populate_database)
     return conditions
 

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -82,8 +82,8 @@ def build_wait_conditions():
     conditions.append(
         CheckDockerLogs(common.SLAVE_CONTAINER_NAME, ["ready for connections", "mariadb successfully initialized"])
     )
-    conditions.append(init_master)
-    conditions.append(init_slave)
+    conditions.append(WaitFor(init_master, wait=2))
+    conditions.append(WaitFor(init_slave, wait=2))
     conditions.append(populate_database)
     return conditions
 

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -233,10 +233,10 @@ def _mysql_docker_repo():
         # Warning: This image is a bit flaky on CI (it has been removed
         # https://github.com/DataDog/integrations-core/pull/4669)
         if MYSQL_VERSION in ('5.6', '5.7'):
-            return 'bergerx/mysql-replication'
+            return 'mysql'
         elif MYSQL_VERSION == '8.0':
-            return 'bitnami/mysql'
+            return 'mysql'
     elif MYSQL_FLAVOR == 'mariadb':
-        return 'bitnami/mariadb'
+        return 'mariadb'
     else:
         raise ValueError('Unsupported MySQL flavor: {}'.format(MYSQL_FLAVOR))

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -63,11 +63,6 @@ def dd_environment(config_e2e):
 
 
 def build_wait_conditions():
-    conditions = [
-        WaitFor(init_master, wait=2),
-        WaitFor(init_slave, wait=2),
-    ]
-
     master_logs = []
     # The order matters for log conditions
     if MYSQL_FLAVOR == 'mariadb':
@@ -81,11 +76,14 @@ def build_wait_conditions():
             master_logs.append("MySQL setup finished!")
             master_logs.append("Starting MySQL")
 
+    conditions = []
     for log in master_logs:
         conditions.append(CheckDockerLogs(common.MASTER_CONTAINER_NAME, [log]))
     conditions.append(
         CheckDockerLogs(common.SLAVE_CONTAINER_NAME, ["ready for connections", "mariadb successfully initialized"])
     )
+    conditions.append(init_master)
+    conditions.append(init_slave)
     conditions.append(populate_database)
     return conditions
 


### PR DESCRIPTION
[Pipeline Builds](https://dev.azure.com/datadoghq/integrations-core/_build?definitionId=6&_a=summary&branchFilter=2694)

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

```
E   RetryError: Result: None
E   Error: (1130, u"Host '172.21.0.1' is not allowed to connect to this MariaDB server")
E   Function: init_slave, Args: (), Kwargs: {}
```

Cases:
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13080&view=logs&jobId=d74967ea-228d-5634-fe5f-5bd874cd0575
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13459&view=logs&j=edee2339-3355-56ef-f286-7ebb52001393&t=a92ff1ac-93db-531d-d631-e388d588bd3d
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13459&view=logs&j=b07b42a6-4264-50a6-0efd-ee8d014c0218&t=8b7d1eea-399d-5dd2-09fb-0baf9d94f451

```
mysql-slave     | 2020-04-22T18:55:12.061942Z 4 [ERROR] [MY-013117] [Repl] Slave I/O for channel '': Fatal error: The slave I/O thread stops because master and slave have equal MySQL server ids; these ids must be different for replication to work (or the --replicate-same-server-id option must be used on slave but this does not always make sense; please check the manual before using it). Error_code: MY-013117
```
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13727&view=logs&j=2ea65d9a-1758-51ad-c2a6-509951bf54d0&t=ada8cbd9-646f-53e4-5919-215df53d3991

### Additional Notes
<!-- Anything else we should know when reviewing? -->


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
