### PR TITLE
[TEST/SANDBOX] apache flaky (enough cases, fix merged)

### DIFF
--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -1,6 +1,7 @@
 trigger: none
 
 pr:
+  autoCancel: false
   branches:
     include:
     - master
@@ -15,8 +16,8 @@ variables:
 jobs:
 - template: './templates/test-single-linux.yml'
   parameters:
-    job_name: Changed
-    display: Linux
+    job_name: Changed_0
+    display: Linux_0
     validate: true
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
@@ -24,11 +25,209 @@ jobs:
         pip | $(Agent.OS)
       path: $(PIP_CACHE_DIR)
 
-- template: './templates/test-single-windows.yml'
+- template: './templates/test-single-linux.yml'
   parameters:
-    job_name: Changed
-    check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dotnetclr exchange_server iis pdh_check sqlserver win32_event_log windows_service wmi_check'
-    display: Windows
+    job_name: Changed_1
+    display: Linux_1
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_2
+    display: Linux_2
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_3
+    display: Linux_3
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_4
+    display: Linux_4
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_5
+    display: Linux_5
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_6
+    display: Linux_6
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_7
+    display: Linux_7
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_8
+    display: Linux_8
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_9
+    display: Linux_9
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_10
+    display: Linux_10
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_11
+    display: Linux_11
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_12
+    display: Linux_12
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_13
+    display: Linux_13
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_14
+    display: Linux_14
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_15
+    display: Linux_15
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_16
+    display: Linux_16
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_17
+    display: Linux_17
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_18
+    display: Linux_18
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_19
+    display: Linux_19
+    validate: true
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
       restoreKeys: |

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -1,3 +1,4 @@
+# CHANGED
 # (C) Datadog, Inc. 2010-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)

--- a/apache/tests/conftest.py
+++ b/apache/tests/conftest.py
@@ -37,8 +37,14 @@ def generate_metrics():
 
 
 def check_status_page_ready():
+    """
+    Some status info we need for metrics do not appear immediately.
+    This check help waiting for the full status page.
+    """
     resp = requests.get(AUTO_STATUS_URL)
-    assert 'ReqPerSec: ' in resp.content.decode('utf-8')
+    data = resp.content.decode('utf-8')
+    assert 'ReqPerSec: ' in data
+    assert 'CPULoad: ' in data
 
 
 @pytest.fixture


### PR DESCRIPTION
Fix PR: https://github.com/DataDog/integrations-core/pull/6453
[Pipeline Builds](https://dev.azure.com/datadoghq/integrations-core/_build?definitionId=6&_a=summary&branchFilter=2700
)

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

All `status` data used for metrics may not appear right away. This PR adds some new wait conditions for that.

160 successful builds:

![image](https://user-images.githubusercontent.com/49917914/80012036-fb262f80-84cc-11ea-9fb8-baa1819cb33a.png)


### Motivation
<!-- What inspired you to submit this pull request? -->

```

------------------------------ Captured log call -------------------------------
WARNING  datadog_checks.base.checks.base.apache:base.py:709 Assuming url was not correct. Trying to add ?auto suffix to the url
_______________________________ test_check_auto ________________________________
tests/test_apache.py:76: in test_check_auto
    aggregator.assert_metric(mname, tags=tags, count=1)
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:249: in assert_metric
    self._assert(condition, msg=msg, expected_stub=expected_metric, submitted_elements=self._metrics)
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:291: in _assert
    assert condition, new_msg
E   AssertionError: Needed exactly 1 candidates for 'apache.performance.cpu_load', got 0
E     Expected:
E             MetricStub(name='apache.performance.cpu_load', type=None, value=None, tags=['instance:second'], hostname=None, device=None)
E     Similar submitted:
E     Score   Most similar
E     0.83    MetricStub(name='apache.performance.uptime', type=0, value=20.0, tags=['instance:second'], hostname='', device=None)
E     0.82    MetricStub(name='apache.performance.busy_workers', type=0, value=1.0, tags=['instance:second'], hostname='', device=None)
E     0.79    MetricStub(name='apache.performance.idle_workers', type=0, value=74.0, tags=['instance:second'], hostname='', device=None)
E     0.65    MetricStub(name='apache.conns_async_keep_alive', type=0, value=0.0, tags=['instance:second'], hostname='', device=None)
E     0.65    MetricStub(name='apache.conns_async_closing', type=0, value=0.0, tags=['instance:second'], hostname='', device=None)
E     0.59    MetricStub(name='apache.conns_async_writing', type=0, value=0.0, tags=['instance:second'], hostname='', device=None)
E     0.59    MetricStub(name='apache.net.bytes_per_s', type=1, value=28672.0, tags=['instance:second'], hostname='', device=None)
E     0.58    MetricStub(name='apache.conns_total', type=0, value=1.0, tags=['instance:second'], hostname='', device=None)
E     0.57    MetricStub(name='apache.net.request_per_s', type=1, value=105.0, tags=['instance:second'], hostname='', device=None)
E     0.57    MetricStub(name='apache.net.hits', type=0, value=105.0, tags=['instance:second'], hostname='', device=None)
E     0.56    MetricStub(name='apache.net.bytes', type=0, value=28672.0, tags=['instance:second'], hostname='', device=None)
E   assert False
```
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=12232&view=logs&jobId=82f604ee-2edd-5639-6463-dbdc7756af1f&j=82f604ee-2edd-5639-6463-dbdc7756af1f&t=ada7998a-3567-597e-9d15-4048d1fa5689
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13489&view=logs&j=f61083d9-c0c7-55f1-3a43-9bca1617a6f3&t=7143fcfe-f1bc-5392-6ee4-83ffa27f5c1a
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13514&view=logs&j=2ab1c2a9-b99d-5635-db6c-1df7fa16203c&t=2570cc18-24e0-54cc-3f82-0f8793114684

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
