### PR TITLE
Add metric_to_check for new etcd version

### DIFF
--- a/etcd/manifest.json
+++ b/etcd/manifest.json
@@ -13,7 +13,10 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "etcd.",
-  "metric_to_check": "etcd.store.watchers",
+  "metric_to_check": [
+    "etcd.store.watchers",
+    "etcd.server.has_leader"
+  ],
   "name": "etcd",
   "process_signatures": [
     "etcd"


### PR DESCRIPTION
We currently only support `metric_to_check` for legacy etcd check. The integration tile is not automatically installed when running preview version of check for post v3 etcd.