### PR TITLE
[TEST/SANDBOX] couch flaky

### DIFF
--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -1,6 +1,7 @@
 trigger: none
 
 pr:
+  autoCancel: false
   branches:
     include:
     - master
@@ -15,8 +16,8 @@ variables:
 jobs:
 - template: './templates/test-single-linux.yml'
   parameters:
-    job_name: Changed
-    display: Linux
+    job_name: Changed_0
+    display: Linux_0
     validate: true
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
@@ -24,11 +25,209 @@ jobs:
         pip | $(Agent.OS)
       path: $(PIP_CACHE_DIR)
 
-- template: './templates/test-single-windows.yml'
+- template: './templates/test-single-linux.yml'
   parameters:
-    job_name: Changed
-    check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dotnetclr exchange_server iis pdh_check sqlserver win32_event_log windows_service wmi_check'
-    display: Windows
+    job_name: Changed_1
+    display: Linux_1
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_2
+    display: Linux_2
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_3
+    display: Linux_3
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_4
+    display: Linux_4
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_5
+    display: Linux_5
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_6
+    display: Linux_6
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_7
+    display: Linux_7
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_8
+    display: Linux_8
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_9
+    display: Linux_9
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_10
+    display: Linux_10
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_11
+    display: Linux_11
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_12
+    display: Linux_12
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_13
+    display: Linux_13
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_14
+    display: Linux_14
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_15
+    display: Linux_15
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_16
+    display: Linux_16
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_17
+    display: Linux_17
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_18
+    display: Linux_18
+    validate: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+
+- template: './templates/test-single-linux.yml'
+  parameters:
+    job_name: Changed_19
+    display: Linux_19
+    validate: true
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
       restoreKeys: |

--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -320,6 +320,7 @@ class CouchDB2:
             return []
 
         try:
+            print("membership nodes", nodes)
             idx = nodes.index(name)
         except ValueError:
             self.agent_check.log.error("Could not find node %r in %r", name, nodes)

--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -368,7 +368,6 @@ class CouchDB2:
         if stats is None:
             raise Exception("No stats could be retrieved from %s" % url)
 
-        print("url:", url, "/ stats:", stats)
         return stats
 
     def _get_system_stats(self, server, name, tags):

--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -1,3 +1,4 @@
+# CHANGED
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)

--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -368,7 +368,7 @@ class CouchDB2:
         if stats is None:
             raise Exception("No stats could be retrieved from %s" % url)
 
-        print("stats:", stats)
+        print("url:", url, "/ stats:", stats)
         return stats
 
     def _get_system_stats(self, server, name, tags):

--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -1,4 +1,3 @@
-# CHANGED
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
@@ -320,7 +319,6 @@ class CouchDB2:
             return []
 
         try:
-            print("membership nodes", nodes)
             idx = nodes.index(name)
         except ValueError:
             self.agent_check.log.error("Could not find node %r in %r", name, nodes)

--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -368,6 +368,7 @@ class CouchDB2:
         if stats is None:
             raise Exception("No stats could be retrieved from %s" % url)
 
+        print("stats:", stats)
         return stats
 
     def _get_system_stats(self, server, name, tags):

--- a/couch/tests/common.py
+++ b/couch/tests/common.py
@@ -52,8 +52,8 @@ BAD_CONFIG = {"server": "http://localhost:11111"}
 
 BAD_CONFIG_TAGS = ["instance:http://localhost:11111"]
 
-NODE1 = {"server": URL, "user": USER, "password": PASSWORD, "name": "node1@127.0.0.1"}
+NODE1 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-0.docker.com"}
 
-NODE2 = {"server": URL, "user": USER, "password": PASSWORD, "name": "node2@127.0.0.1"}
+NODE2 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-1.docker.com"}
 
-NODE3 = {"server": URL, "user": USER, "password": PASSWORD, "name": "node3@127.0.0.1"}
+NODE3 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-2.docker.com"}

--- a/couch/tests/common.py
+++ b/couch/tests/common.py
@@ -52,10 +52,10 @@ BAD_CONFIG = {"server": "http://localhost:11111"}
 
 BAD_CONFIG_TAGS = ["instance:http://localhost:11111"]
 
-NODE0 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-0.example.com"}
-
 NODE1 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-1.example.com"}
 
 NODE2 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-2.example.com"}
 
-ALL_NODES = [NODE0, NODE1, NODE2]
+NODE3 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-3.example.com"}
+
+ALL_NODES = [NODE1, NODE2, NODE3]

--- a/couch/tests/common.py
+++ b/couch/tests/common.py
@@ -52,10 +52,10 @@ BAD_CONFIG = {"server": "http://localhost:11111"}
 
 BAD_CONFIG_TAGS = ["instance:http://localhost:11111"]
 
-NODE1 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-0.example.com"}
+NODE0 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-0.example.com"}
 
-NODE2 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-1.example.com"}
+NODE1 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-1.example.com"}
 
-NODE3 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-2.example.com"}
+NODE2 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-2.example.com"}
 
-ALL_NODES = [NODE1, NODE2, NODE3]
+ALL_NODES = [NODE0, NODE1, NODE2]

--- a/couch/tests/common.py
+++ b/couch/tests/common.py
@@ -52,10 +52,10 @@ BAD_CONFIG = {"server": "http://localhost:11111"}
 
 BAD_CONFIG_TAGS = ["instance:http://localhost:11111"]
 
-NODE1 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-0.docker.com"}
+NODE1 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-0.example.com"}
 
-NODE2 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-1.docker.com"}
+NODE2 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-1.example.com"}
 
-NODE3 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-2.docker.com"}
+NODE3 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-2.example.com"}
 
 ALL_NODES = [NODE1, NODE2, NODE3]

--- a/couch/tests/common.py
+++ b/couch/tests/common.py
@@ -57,3 +57,5 @@ NODE1 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@cou
 NODE2 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-1.docker.com"}
 
 NODE3 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-2.docker.com"}
+
+ALL_NODES = [NODE1, NODE2, NODE3]

--- a/couch/tests/compose/compose_v1.yaml
+++ b/couch/tests/compose/compose_v1.yaml
@@ -2,6 +2,7 @@ version: '3.5'
 
 services:
   couch:
+    container_name: server-0
     image: couchdb:${COUCH_VERSION}
     ports:
       - ${COUCH_PORT}:5984

--- a/couch/tests/compose/compose_v1.yaml
+++ b/couch/tests/compose/compose_v1.yaml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   couch:
-    container_name: server-0
+    container_name: couchdb-0
     image: couchdb:${COUCH_VERSION}
     ports:
       - ${COUCH_PORT}:5984

--- a/couch/tests/compose/compose_v1.yaml
+++ b/couch/tests/compose/compose_v1.yaml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   couch:
-    container_name: couchdb-0
+    container_name: couchdb-1
     image: couchdb:${COUCH_VERSION}
     ports:
       - ${COUCH_PORT}:5984

--- a/couch/tests/compose/compose_v2.yaml
+++ b/couch/tests/compose/compose_v2.yaml
@@ -4,20 +4,6 @@ networks:
   network:
 
 services:
-  couchdb-0:
-    container_name: couchdb-0
-    image: couchdb:${COUCH_VERSION}
-    environment:
-      NODENAME: couchdb-0.example.com
-      COUCHDB_USER: ${COUCH_USER}
-      COUCHDB_PASSWORD: ${COUCH_PASSWORD}
-    networks:
-      network:
-        aliases:
-          - couchdb-0.example.com
-    ports:
-      - "${COUCH_PORT}:5984"
-      - "5986:5986"
   couchdb-1:
     container_name: couchdb-1
     image: couchdb:${COUCH_VERSION}
@@ -30,8 +16,8 @@ services:
         aliases:
           - couchdb-1.example.com
     ports:
-      - "15984:5984"
-      - "15986:5986"
+      - "${COUCH_PORT}:5984"
+      - "5986:5986"
   couchdb-2:
     container_name: couchdb-2
     image: couchdb:${COUCH_VERSION}
@@ -43,6 +29,20 @@ services:
       network:
         aliases:
           - couchdb-2.example.com
+    ports:
+      - "15984:5984"
+      - "15986:5986"
+  couchdb-3:
+    container_name: couchdb-3
+    image: couchdb:${COUCH_VERSION}
+    environment:
+      NODENAME: couchdb-3.example.com
+      COUCHDB_USER: ${COUCH_USER}
+      COUCHDB_PASSWORD: ${COUCH_PASSWORD}
+    networks:
+      network:
+        aliases:
+          - couchdb-3.example.com
     ports:
       - "25984:5984"
       - "25986:5986"

--- a/couch/tests/compose/compose_v2.yaml
+++ b/couch/tests/compose/compose_v2.yaml
@@ -15,6 +15,7 @@ networks:
 
 services:
   server-0:
+    container_name: server-0
     environment:
       COUCHDB_PASSWORD: pawprint
       COUCHDB_SECRET: 0123456789abcdef0123456789abcdef
@@ -31,6 +32,7 @@ services:
     volumes:
       - "volume-0:/opt/couchdb/data"
   server-1:
+    container_name: server-1
     environment:
       COUCHDB_PASSWORD: pawprint
       COUCHDB_SECRET: 0123456789abcdef0123456789abcdef
@@ -47,6 +49,7 @@ services:
     volumes:
       - "volume-1:/opt/couchdb/data"
   server-2:
+    container_name: server-2
     environment:
       COUCHDB_PASSWORD: pawprint
       COUCHDB_SECRET: 0123456789abcdef0123456789abcdef

--- a/couch/tests/compose/compose_v2.yaml
+++ b/couch/tests/compose/compose_v2.yaml
@@ -1,8 +1,69 @@
-version: '3.5'
+#version: '3.5'
+#
+#services:
+#  couch:
+#    image: datadog/docker-library:couch_${COUCH_VERSION}
+#    ports:
+#      - ${COUCH_PORT}:5984
+#    command: --admin=dduser:pawprint --with-haproxy
+#
+
+version: "3.5"
+
+networks:
+  network:
 
 services:
-  couch:
-    image: datadog/docker-library:couch_${COUCH_VERSION}
+  server-0:
+    environment:
+      COUCHDB_PASSWORD: pawprint
+      COUCHDB_SECRET: 0123456789abcdef0123456789abcdef
+      COUCHDB_USER: dduser
+      NODENAME: couchdb-0.docker.com
+    image: couchdb:2.3.1
+    networks:
+      network:
+        aliases:
+          - couchdb-0.docker.com
     ports:
-      - ${COUCH_PORT}:5984
-    command: --admin=dduser:pawprint --with-haproxy
+      - "5984:5984"
+      - "5986:5986"
+    volumes:
+      - "volume-0:/opt/couchdb/data"
+  server-1:
+    environment:
+      COUCHDB_PASSWORD: pawprint
+      COUCHDB_SECRET: 0123456789abcdef0123456789abcdef
+      COUCHDB_USER: dduser
+      NODENAME: couchdb-1.docker.com
+    image: couchdb:2.3.1
+    networks:
+      network:
+        aliases:
+          - couchdb-1.docker.com
+    ports:
+      - "15984:5984"
+      - "15986:5986"
+    volumes:
+      - "volume-1:/opt/couchdb/data"
+  server-2:
+    environment:
+      COUCHDB_PASSWORD: pawprint
+      COUCHDB_SECRET: 0123456789abcdef0123456789abcdef
+      COUCHDB_USER: dduser
+      NODENAME: couchdb-2.docker.com
+    image: couchdb:2.3.1
+    networks:
+      network:
+        aliases:
+          - couchdb-2.docker.com
+    ports:
+      - "25984:5984"
+      - "25986:5986"
+    volumes:
+      - "volume-2:/opt/couchdb/data"
+
+volumes:
+  volume-0:
+  volume-1:
+  volume-2:

--- a/couch/tests/compose/compose_v2.yaml
+++ b/couch/tests/compose/compose_v2.yaml
@@ -29,8 +29,6 @@ services:
     ports:
       - "5984:5984"
       - "5986:5986"
-    volumes:
-      - "volume-0:/opt/couchdb/data"
   server-1:
     container_name: server-1
     environment:
@@ -46,8 +44,6 @@ services:
     ports:
       - "15984:5984"
       - "15986:5986"
-    volumes:
-      - "volume-1:/opt/couchdb/data"
   server-2:
     container_name: server-2
     environment:
@@ -63,10 +59,3 @@ services:
     ports:
       - "25984:5984"
       - "25986:5986"
-    volumes:
-      - "volume-2:/opt/couchdb/data"
-
-volumes:
-  volume-0:
-  volume-1:
-  volume-2:

--- a/couch/tests/compose/compose_v2.yaml
+++ b/couch/tests/compose/compose_v2.yaml
@@ -1,61 +1,48 @@
-#version: '3.5'
-#
-#services:
-#  couch:
-#    image: datadog/docker-library:couch_${COUCH_VERSION}
-#    ports:
-#      - ${COUCH_PORT}:5984
-#    command: --admin=dduser:pawprint --with-haproxy
-#
-
 version: "3.5"
 
 networks:
   network:
 
 services:
-  server-0:
-    container_name: server-0
+  couchdb-0:
+    container_name: couchdb-0
+    image: couchdb:${COUCH_VERSION}
     environment:
-      COUCHDB_PASSWORD: pawprint
-      COUCHDB_SECRET: 0123456789abcdef0123456789abcdef
-      COUCHDB_USER: dduser
-      NODENAME: couchdb-0.docker.com
-    image: couchdb:2.3.1
+      NODENAME: couchdb-0.example.com
+      COUCHDB_USER: ${COUCH_USER}
+      COUCHDB_PASSWORD: ${COUCH_PASSWORD}
     networks:
       network:
         aliases:
-          - couchdb-0.docker.com
+          - couchdb-0.example.com
     ports:
-      - "5984:5984"
+      - "${COUCH_PORT}:5984"
       - "5986:5986"
-  server-1:
-    container_name: server-1
+  couchdb-1:
+    container_name: couchdb-1
+    image: couchdb:${COUCH_VERSION}
     environment:
-      COUCHDB_PASSWORD: pawprint
-      COUCHDB_SECRET: 0123456789abcdef0123456789abcdef
-      COUCHDB_USER: dduser
-      NODENAME: couchdb-1.docker.com
-    image: couchdb:2.3.1
+      NODENAME: couchdb-1.example.com
+      COUCHDB_USER: ${COUCH_USER}
+      COUCHDB_PASSWORD: ${COUCH_PASSWORD}
     networks:
       network:
         aliases:
-          - couchdb-1.docker.com
+          - couchdb-1.example.com
     ports:
       - "15984:5984"
       - "15986:5986"
-  server-2:
-    container_name: server-2
+  couchdb-2:
+    container_name: couchdb-2
+    image: couchdb:${COUCH_VERSION}
     environment:
-      COUCHDB_PASSWORD: pawprint
-      COUCHDB_SECRET: 0123456789abcdef0123456789abcdef
-      COUCHDB_USER: dduser
-      NODENAME: couchdb-2.docker.com
-    image: couchdb:2.3.1
+      NODENAME: couchdb-2.example.com
+      COUCHDB_USER: ${COUCH_USER}
+      COUCHDB_PASSWORD: ${COUCH_PASSWORD}
     networks:
       network:
         aliases:
-          - couchdb-2.docker.com
+          - couchdb-2.example.com
     ports:
       - "25984:5984"
       - "25986:5986"

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -88,7 +88,8 @@ def generate_data(couch_version):
 
     # Generate a test database
     requests.put("{}/kennel".format(common.URL), auth=auth, headers=headers)
-    requests.put("{}/foo_document".format(common.URL), auth=auth, headers=headers)
+    for i in range(10):
+        requests.put("{}/db{}".format(common.URL, i), auth=auth, headers=headers)
 
     # Populate the database
     data = {

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -117,13 +117,14 @@ def send_replication():
     }
     for i in range(10):
         print("Create Replication task {}".format(i))
-        replication_body['_id'] = 'my_replication_id_{}'.format(i)
-        replication_body['target'] = replication_body['target'] + str(i)
+        body = replication_body.copy()
+        body['_id'] = 'my_replication_id_{}'.format(i)
+        body['target'] = body['target'] + str(i)
         r = requests.post(
             replicator_url,
             auth=(common.NODE1['user'], common.NODE1['password']),
             headers={'Content-Type': 'application/json'},
-            json=replication_body,
+            json=body,
         )
         r.raise_for_status()
         print("Replication task created:", r.json())

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -72,7 +72,7 @@ def dd_environment():
                 WaitFor(generate_data, args=(couch_version,)),
                 WaitFor(check_node_stats),
                 WaitFor(send_replication),
-                WaitFor(get_replication),
+                # WaitFor(get_replication),
             ],
         ):
             yield common.BASIC_CONFIG_V2

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -72,8 +72,8 @@ def dd_environment():
                 WaitFor(enable_cluster),
                 WaitFor(generate_data, args=(couch_version,)),
                 WaitFor(check_node_stats),
-                # WaitFor(send_replication, args=(couch_version,), wait=2, attempts=60),
-                # WaitFor(get_replication, args=(couch_version,), wait=3, attempts=40),
+                WaitFor(send_replication),
+                WaitFor(get_replication),
             ],
         ):
             yield common.BASIC_CONFIG_V2
@@ -101,13 +101,10 @@ def generate_data(couch_version):
     requests.put("{}/kennel/_design/dummy".format(common.URL), json=data, auth=auth, headers=headers)
 
 
-def send_replication(couch_version):
+def send_replication():
     """
     Send replication task to trigger tasks
     """
-    if couch_version == '1':
-        return
-
     replicator_url = "{}/_replicate".format(common.NODE1['server'])
 
     replication_body = {
@@ -117,8 +114,8 @@ def send_replication(couch_version):
         'create_target': True,
         'continuous': True,
     }
-    for i in range(100):
-        print("Create Replication task")
+    for i in range(3):
+        print("Create Replication task {}".format(i))
         replication_body['_id'] = 'my_replication_id_{}'.format(i)
         r = requests.post(
             replicator_url,
@@ -194,5 +191,4 @@ def check_node_stats():
         print("[INFO] url", url)
         res = requests.get(url, auth=auth, headers=headers)
         data = res.json()
-        print("[INFO] node data", data)
         assert "global_changes" in data

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -115,7 +115,7 @@ def send_replication():
         'create_target': True,
         'continuous': True,
     }
-    for i in range(10):
+    for i in range(5):
         print("Create Replication task {}".format(i))
         body = replication_body.copy()
         body['_id'] = 'my_replication_id_{}'.format(i)

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -88,7 +88,7 @@ def generate_data(couch_version):
 
     # Generate a test database
     requests.put("{}/kennel".format(common.URL), auth=auth, headers=headers)
-    for i in range(10):
+    for i in range(5):
         requests.put("{}/db{}".format(common.URL, i), auth=auth, headers=headers)
 
     # Populate the database

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -3,9 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
 import os
-from collections import defaultdict
 from copy import deepcopy
-from time import sleep
 
 import pytest
 import requests

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -116,7 +116,7 @@ def send_replication():
         'continuous': True,
     }
     for i in range(5):
-        print("Create Replication task {}".format(i))
+        print("[INFO] create replication task {}".format(i))
         body = replication_body.copy()
         body['_id'] = 'my_replication_id_{}'.format(i)
         body['target'] = body['target'] + str(i)
@@ -127,7 +127,7 @@ def send_replication():
             json=body,
         )
         r.raise_for_status()
-        print("Replication task created:", r.json())
+        print("[INFO] replication task created:", r.json())
 
 
 def get_replication():
@@ -139,7 +139,7 @@ def get_replication():
     r = requests.get(task_url, auth=(common.NODE1['user'], common.NODE1['password']))
     r.raise_for_status()
     active_tasks = r.json()
-    print("active_tasks:", active_tasks)
+    print("[INFO] active_tasks response:", active_tasks)
     count = len(active_tasks)
     return count > 0
 
@@ -181,7 +181,7 @@ def enable_cluster():
 
     resp = requests.get("{}/_membership".format(common.URL), auth=auth, headers=headers)
     membership = resp.json()
-    print("[INFO] membership", membership)
+    print("[INFO] membership response:", membership)
     assert len(membership['cluster_nodes']) == 3
 
 
@@ -191,7 +191,7 @@ def check_node_stats():
     # Check all nodes have stats
     for node in common.ALL_NODES:
         url = "{}/_node/{}/_stats".format(common.URL, node['name'])
-        print("[INFO] url", url)
+        print("[INFO] get stats url:", url)
         res = requests.get(url, auth=auth, headers=headers)
         data = res.json()
         assert "global_changes" in data

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -152,13 +152,19 @@ def enable_cluster(couch_version):
             }
         )
 
-    for data in enumerate(requests_data):
+    for data in requests_data:
         for i in range(10):
-            r = requests.post("{}/_cluster_setup".format(common.URL), json=data, auth=auth, headers=headers)
-            if r.status_code == 200:
+            print('cluster_setup make request ({}) {}: {}'.format(i, common.URL, data))
+            resp = requests.post("{}/_cluster_setup".format(common.URL), json=data, auth=auth, headers=headers)
+            resp_data = resp.json()
+            if resp_data.get('ok', False):
                 break
-            print('cluster_setup request error: ', r.json())
-            sleep(1)
+            print('cluster_setup request error ({}): {}'.format(i, resp_data))
+            sleep(3)
+        else:
+            resp.raise_for_status()
+
+    # for node in ["couchdb-1.docker.com", "couchdb-2.docker.com"]:
 
 
 def generate_data(couch_version):

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -128,30 +128,37 @@ def enable_cluster(couch_version):
 
     requests_data = []
     for node in ["couchdb-1.docker.com", "couchdb-2.docker.com"]:
-        requests_data.append({
-            "action": "enable_cluster",
-            "username": common.USER,
-            "password": common.PASSWORD,
-            "bind_address": "0.0.0.0",
-            "port": 5984,
-            "node_count": 3,
-            "remote_node": node,
-            "remote_current_user": common.USER,
-            "remote_current_password": common.PASSWORD,
-        })
-        requests_data.append({
-            "action": "add_node",
-            "username": common.USER,
-            "password": common.PASSWORD,
-            "host": node,
-            "port": 5984,
-            "singlenode": False,
-        })
+        requests_data.append(
+            {
+                "action": "enable_cluster",
+                "username": common.USER,
+                "password": common.PASSWORD,
+                "bind_address": "0.0.0.0",
+                "port": 5984,
+                "node_count": 3,
+                "remote_node": node,
+                "remote_current_user": common.USER,
+                "remote_current_password": common.PASSWORD,
+            }
+        )
+        requests_data.append(
+            {
+                "action": "add_node",
+                "username": common.USER,
+                "password": common.PASSWORD,
+                "host": node,
+                "port": 5984,
+                "singlenode": False,
+            }
+        )
 
-    for idx, data in enumerate(requests_data):
-        r = requests.post("{}/_cluster_setup?rev={}".format(common.URL, idx), json=data, auth=auth, headers=headers)
-        print("cluster_setup query resp for %s %s:".format(common.URL, idx), r.json())
-        r.raise_for_status()
+    for data in enumerate(requests_data):
+        for i in range(10):
+            r = requests.post("{}/_cluster_setup".format(common.URL), json=data, auth=auth, headers=headers)
+            if r.status_code == 200:
+                break
+            print('cluster_setup request error: ', r.json())
+            sleep(1)
 
 
 def generate_data(couch_version):

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -72,6 +72,7 @@ def dd_environment():
                 WaitFor(generate_data, args=(couch_version,)),
                 WaitFor(check_node_stats),
                 WaitFor(send_replication),
+                WaitFor(get_replication),
             ],
         ):
             yield common.BASIC_CONFIG_V2
@@ -117,6 +118,7 @@ def send_replication():
     for i in range(10):
         print("Create Replication task {}".format(i))
         replication_body['_id'] = 'my_replication_id_{}'.format(i)
+        replication_body['target'] = replication_body['target'] + str(i)
         r = requests.post(
             replicator_url,
             auth=(common.NODE1['user'], common.NODE1['password']),
@@ -125,8 +127,6 @@ def send_replication():
         )
         r.raise_for_status()
         print("Replication task created:", r.json())
-
-    return get_replication()
 
 
 def get_replication():

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -84,13 +84,15 @@ def send_replication(couch_version):
         'create_target': True,
         'continuous': True,
     }
-    r = requests.post(
-        replicator_url,
-        auth=(common.NODE1['user'], common.NODE1['password']),
-        headers={'Content-Type': 'application/json'},
-        json=replication_body,
-    )
-    r.raise_for_status()
+    for _ in range(100):
+        r = requests.post(
+            replicator_url,
+            auth=(common.NODE1['user'], common.NODE1['password']),
+            headers={'Content-Type': 'application/json'},
+            json=replication_body,
+        )
+        r.raise_for_status()
+        print("Replication task created:", r.json())
 
 
 def get_replication(couch_version):
@@ -160,6 +162,7 @@ def generate_data(couch_version):
         try:
             res = requests.get(doc_url, auth=auth, headers=headers)
             data = res.json()
+            print("_replicator/_all_docs", data)
             if data.get('rows'):
                 break
         except Exception:

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -51,13 +51,17 @@ def dd_environment():
     up.
     """
     couch_version = os.environ["COUCH_VERSION"][0]
+    if couch_version == "1":
+        startup_msg = 'CouchDB has started'
+    else:
+        startup_msg = 'Started replicator db changes listener'
 
     with docker_run(
         compose_file=os.path.join(common.HERE, 'compose', 'compose_v{}.yaml'.format(couch_version)),
         env_vars={'COUCH_PORT': common.PORT},
         conditions=[
             CheckEndpoints([common.URL]),
-            CheckDockerLogs('server-0', ["Started replicator db changes listener"]),
+            CheckDockerLogs('server-0', [startup_msg]),
             lambda: enable_cluster(couch_version),
             lambda: generate_data(couch_version),
             # WaitFor(send_replication, args=(couch_version,), wait=2, attempts=60),

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -83,7 +83,7 @@ def enable_cluster():
     headers = {'Accept': 'text/json'}
 
     requests_data = []
-    for node in ["couchdb-1.example.com", "couchdb-2.example.com"]:
+    for node in [common.NODE1, common.NODE2]:
         requests_data.append(
             {
                 "action": "enable_cluster",

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -135,7 +135,10 @@ def enable_cluster(couch_version):
             "remote_current_password": common.PASSWORD,
         }
         r = requests.post("{}/_cluster_setup".format(common.URL), json=cluster_setup, auth=auth, headers=headers)
+        print("_cluster_setup enable cluster: ", r.json())
         r.raise_for_status()
+
+        sleep(1)
 
         add_node = {
             "action": "add_node",
@@ -146,7 +149,11 @@ def enable_cluster(couch_version):
             "singlenode": False,
         }
         r = requests.post("{}/_cluster_setup".format(common.URL), json=add_node, auth=auth, headers=headers)
+        print("_cluster_setup add node: ", r.json())
         r.raise_for_status()
+
+        sleep(1)
+
 
 
 def generate_data(couch_version):

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -89,6 +89,7 @@ def generate_data(couch_version):
 
     # Generate a test database
     requests.put("{}/kennel".format(common.URL), auth=auth, headers=headers)
+    requests.put("{}/foo_document".format(common.URL), auth=auth, headers=headers)
 
     # Populate the database
     data = {

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -58,8 +58,8 @@ def dd_environment():
         conditions=[
             CheckEndpoints([common.URL]),
             lambda: generate_data(couch_version),
-            WaitFor(send_replication, args=(couch_version,), wait=2, attempts=60),
-            WaitFor(get_replication, args=(couch_version,), wait=3, attempts=40),
+            # WaitFor(send_replication, args=(couch_version,), wait=2, attempts=60),
+            # WaitFor(get_replication, args=(couch_version,), wait=3, attempts=40),
         ],
     ):
         if couch_version == '1':
@@ -75,7 +75,7 @@ def send_replication(couch_version):
     if couch_version == '1':
         return
 
-    replicator_url = "{}/_replicator".format(common.NODE1['server'])
+    replicator_url = "{}/_replicate".format(common.NODE1['server'])
 
     replication_body = {
         '_id': 'my_replication_id',
@@ -123,7 +123,8 @@ def generate_data(couch_version):
     headers = {'Accept': 'text/json'}
 
     # Generate a test database
-    requests.put("{}/kennel".format(common.URL), auth=auth, headers=headers)
+    r = requests.put("{}/kennel".format(common.URL), auth=auth, headers=headers)
+    r.raise_for_status()
 
     # Populate the database
     data = {
@@ -133,7 +134,8 @@ def generate_data(couch_version):
             "by_data": {"map": "function(doc) { emit(doc.data, doc); }"},
         },
     }
-    requests.put("{}/kennel/_design/dummy".format(common.URL), json=data, auth=auth, headers=headers)
+    r = requests.put("{}/kennel/_design/dummy".format(common.URL), json=data, auth=auth, headers=headers)
+    r.raise_for_status()
 
     urls = [
         "{}/_node/node1@127.0.0.1/_stats".format(common.URL),

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -72,7 +72,6 @@ def dd_environment():
                 WaitFor(generate_data, args=(couch_version,)),
                 WaitFor(check_node_stats),
                 WaitFor(send_replication),
-                # WaitFor(get_replication),
             ],
         ):
             yield common.BASIC_CONFIG_V2
@@ -126,6 +125,8 @@ def send_replication():
         )
         r.raise_for_status()
         print("Replication task created:", r.json())
+
+    return get_replication()
 
 
 def get_replication():

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -114,7 +114,7 @@ def send_replication():
         'create_target': True,
         'continuous': True,
     }
-    for i in range(3):
+    for i in range(10):
         print("Create Replication task {}".format(i))
         replication_body['_id'] = 'my_replication_id_{}'.format(i)
         r = requests.post(

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -104,7 +104,9 @@ def get_replication(couch_version):
 
     r = requests.get(task_url, auth=(common.NODE1['user'], common.NODE1['password']))
     r.raise_for_status()
-    count = len(r.json())
+    active_tasks = r.json()
+    print("active_tasks:", active_tasks)
+    count = len(active_tasks)
     return count > 0
 
 

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -126,8 +126,9 @@ def enable_cluster(couch_version):
     auth = (common.USER, common.PASSWORD)
     headers = {'Accept': 'text/json'}
 
+    requests_data = []
     for node in ["couchdb-1.docker.com", "couchdb-2.docker.com"]:
-        cluster_setup = {
+        requests_data.append({
             "action": "enable_cluster",
             "username": common.USER,
             "password": common.PASSWORD,
@@ -137,26 +138,20 @@ def enable_cluster(couch_version):
             "remote_node": node,
             "remote_current_user": common.USER,
             "remote_current_password": common.PASSWORD,
-        }
-        r = requests.post("{}/_cluster_setup".format(common.URL), json=cluster_setup, auth=auth, headers=headers)
-        print("_cluster_setup enable cluster: ", r.json())
-        r.raise_for_status()
-
-        sleep(1)
-
-        add_node = {
+        })
+        requests_data.append({
             "action": "add_node",
             "username": common.USER,
             "password": common.PASSWORD,
             "host": node,
             "port": 5984,
             "singlenode": False,
-        }
-        r = requests.post("{}/_cluster_setup".format(common.URL), json=add_node, auth=auth, headers=headers)
-        print("_cluster_setup add node: ", r.json())
-        r.raise_for_status()
+        })
 
-        sleep(1)
+    for idx, data in enumerate(requests_data):
+        r = requests.post("{}/_cluster_setup?rev={}".format(common.URL, idx), json=data, auth=auth, headers=headers)
+        print("cluster_setup query resp for %s %s:".format(common.URL, idx), r.json())
+        r.raise_for_status()
 
 
 def generate_data(couch_version):

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -55,7 +55,7 @@ def dd_environment():
             env_vars={'COUCH_PORT': common.PORT},
             conditions=[
                 CheckEndpoints([common.URL]),
-                CheckDockerLogs('server-0', ['CouchDB has started']),
+                CheckDockerLogs('couchdb-0', ['CouchDB has started']),
                 WaitFor(generate_data, args=(couch_version,)),
             ],
         ):
@@ -64,10 +64,14 @@ def dd_environment():
     else:
         with docker_run(
             compose_file=os.path.join(common.HERE, 'compose', 'compose_v2.yaml'),
-            env_vars={'COUCH_PORT': common.PORT},
+            env_vars={
+                'COUCH_PORT': common.PORT,
+                'COUCH_USER': common.USER,
+                'COUCH_PASSWORD': common.PASSWORD,
+            },
             conditions=[
                 CheckEndpoints([common.URL]),
-                CheckDockerLogs('server-0', ['Started replicator db changes listener']),
+                CheckDockerLogs('couchdb-0', ['Started replicator db changes listener']),
                 WaitFor(enable_cluster),
                 WaitFor(generate_data, args=(couch_version,)),
                 WaitFor(check_node_stats),
@@ -149,7 +153,7 @@ def enable_cluster():
     headers = {'Accept': 'text/json'}
 
     requests_data = []
-    for node in ["couchdb-1.docker.com", "couchdb-2.docker.com"]:
+    for node in ["couchdb-1.example.com", "couchdb-2.example.com"]:
         requests_data.append(
             {
                 "action": "enable_cluster",

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -64,11 +64,7 @@ def dd_environment():
     else:
         with docker_run(
             compose_file=os.path.join(common.HERE, 'compose', 'compose_v2.yaml'),
-            env_vars={
-                'COUCH_PORT': common.PORT,
-                'COUCH_USER': common.USER,
-                'COUCH_PASSWORD': common.PASSWORD,
-            },
+            env_vars={'COUCH_PORT': common.PORT, 'COUCH_USER': common.USER, 'COUCH_PASSWORD': common.PASSWORD},
             conditions=[
                 CheckEndpoints([common.URL]),
                 CheckDockerLogs('couchdb-0', ['Started replicator db changes listener']),

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -84,7 +84,9 @@ def send_replication(couch_version):
         'create_target': True,
         'continuous': True,
     }
-    for _ in range(100):
+    for i in range(100):
+        print("Create Replication task")
+        replication_body['_id'] = 'my_replication_id_{}'.format(i)
         r = requests.post(
             replicator_url,
             auth=(common.NODE1['user'], common.NODE1['password']),

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -185,7 +185,9 @@ def generate_data(couch_version):
             for url in urls:
                 if not ready[url]:
                     res = requests.get(url, auth=auth, headers=headers)
-                    if res.json():
+                    data = res.json()
+                    print("node data", data)
+                    if data:
                         ready[url] = True
             if len(ready) and all(ready.values()):
                 break

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -57,7 +57,6 @@ def dd_environment():
                 CheckEndpoints([common.URL]),
                 CheckDockerLogs('server-0', ['CouchDB has started']),
                 WaitFor(generate_data, args=(couch_version,)),
-                WaitFor(check_node_stats),
             ],
         ):
             yield common.BASIC_CONFIG

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -55,7 +55,7 @@ def dd_environment():
             env_vars={'COUCH_PORT': common.PORT},
             conditions=[
                 CheckEndpoints([common.URL]),
-                CheckDockerLogs('couchdb-0', ['CouchDB has started']),
+                CheckDockerLogs('couchdb-1', ['CouchDB has started']),
                 WaitFor(generate_data, args=(couch_version,)),
             ],
         ):
@@ -67,7 +67,7 @@ def dd_environment():
             env_vars={'COUCH_PORT': common.PORT, 'COUCH_USER': common.USER, 'COUCH_PASSWORD': common.PASSWORD},
             conditions=[
                 CheckEndpoints([common.URL]),
-                CheckDockerLogs('couchdb-0', ['Started replicator db changes listener']),
+                CheckDockerLogs('couchdb-1', ['Started replicator db changes listener']),
                 WaitFor(enable_cluster),
                 WaitFor(generate_data, args=(couch_version,)),
                 WaitFor(check_node_stats),
@@ -83,7 +83,7 @@ def enable_cluster():
     headers = {'Accept': 'text/json'}
 
     requests_data = []
-    for node in [common.NODE1, common.NODE2]:
+    for node in [common.NODE2, common.NODE3]:
         _, node_name = node['name'].split('@')
         requests_data.append(
             {
@@ -166,7 +166,7 @@ def send_replication():
     """
     Send replication task to trigger tasks
     """
-    replicator_url = "{}/_replicate".format(common.NODE0['server'])
+    replicator_url = "{}/_replicate".format(common.NODE1['server'])
 
     replication_body = {
         '_id': 'my_replication_id',
@@ -181,7 +181,7 @@ def send_replication():
         body['target'] = body['target'] + str(i)
         r = requests.post(
             replicator_url,
-            auth=(common.NODE0['user'], common.NODE0['password']),
+            auth=(common.NODE1['user'], common.NODE1['password']),
             headers={'Content-Type': 'application/json'},
             json=body,
         )
@@ -192,9 +192,9 @@ def get_replication():
     """
     Attempt to get active replication tasks
     """
-    task_url = "{}/_active_tasks".format(common.NODE0['server'])
+    task_url = "{}/_active_tasks".format(common.NODE1['server'])
 
-    r = requests.get(task_url, auth=(common.NODE0['user'], common.NODE0['password']))
+    r = requests.get(task_url, auth=(common.NODE1['user'], common.NODE1['password']))
     r.raise_for_status()
     active_tasks = r.json()
     count = len(active_tasks)

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -159,7 +159,6 @@ def enable_cluster(couch_version):
         sleep(1)
 
 
-
 def generate_data(couch_version):
     """
     Generate data on the couch cluster to test metrics.

--- a/couch/tests/fixtures/_active_tasks.json
+++ b/couch/tests/fixtures/_active_tasks.json
@@ -1,6 +1,6 @@
 [
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.docker.com",
       "pid": "<0.10672.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -12,7 +12,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.docker.com",
       "pid": "<0.10674.0>",
       "changes_done": 0,
       "database": "shards/c0000000-dfffffff/kennel.1525771285",
@@ -24,7 +24,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.docker.com",
       "pid": "<0.10676.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -36,7 +36,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.docker.com",
       "pid": "<0.10678.0>",
       "changes_done": 0,
       "database": "shards/20000000-3fffffff/kennel.1525771285",
@@ -48,7 +48,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.docker.com",
       "pid": "<0.10680.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -60,7 +60,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.docker.com",
       "pid": "<0.10682.0>",
       "changes_done": 0,
       "database": "shards/60000000-7fffffff/kennel.1525771285",
@@ -72,7 +72,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node2@127.0.0.1",
+      "node": "couchdb@couchdb-1.docker.com",
       "pid": "<0.11052.0>",
       "changes_done": 0,
       "database": "shards/00000000-1fffffff/kennel.1525771285",
@@ -84,7 +84,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node2@127.0.0.1",
+      "node": "couchdb@couchdb-1.docker.com",
       "pid": "<0.11079.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -96,7 +96,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node2@127.0.0.1",
+      "node": "couchdb@couchdb-1.docker.com",
       "pid": "<0.11081.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -108,7 +108,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node2@127.0.0.1",
+      "node": "couchdb@couchdb-1.docker.com",
       "pid": "<0.11083.0>",
       "changes_done": 0,
       "database": "shards/40000000-5fffffff/kennel.1525771285",
@@ -120,7 +120,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node2@127.0.0.1",
+      "node": "couchdb@couchdb-1.docker.com",
       "pid": "<0.11087.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -132,7 +132,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node2@127.0.0.1",
+      "node": "couchdb@couchdb-1.docker.com",
       "pid": "<0.11089.0>",
       "changes_done": 0,
       "database": "shards/c0000000-dfffffff/kennel.1525771285",
@@ -144,7 +144,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node3@127.0.0.1",
+      "node": "couchdb@couchdb-2.docker.com",
       "pid": "<0.10439.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -156,7 +156,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node3@127.0.0.1",
+      "node": "couchdb@couchdb-2.docker.com",
       "pid": "<0.10445.0>",
       "changes_done": 0,
       "database": "shards/40000000-5fffffff/kennel.1525771285",
@@ -168,7 +168,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node3@127.0.0.1",
+      "node": "couchdb@couchdb-2.docker.com",
       "pid": "<0.10453.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -180,7 +180,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node3@127.0.0.1",
+      "node": "couchdb@couchdb-2.docker.com",
       "pid": "<0.10455.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -192,7 +192,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node3@127.0.0.1",
+      "node": "couchdb@couchdb-2.docker.com",
       "pid": "<0.10457.0>",
       "changes_done": 0,
       "database": "shards/60000000-7fffffff/kennel.1525771285",
@@ -204,7 +204,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.docker.com",
       "changes_done": 44461,
       "database": "my_db",
       "pid": "<0.218.0>",

--- a/couch/tests/fixtures/_active_tasks.json
+++ b/couch/tests/fixtures/_active_tasks.json
@@ -1,6 +1,6 @@
 [
     {
-      "node": "couchdb@couchdb-0.docker.com",
+      "node": "couchdb@couchdb-0.example.com",
       "pid": "<0.10672.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -12,7 +12,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.docker.com",
+      "node": "couchdb@couchdb-0.example.com",
       "pid": "<0.10674.0>",
       "changes_done": 0,
       "database": "shards/c0000000-dfffffff/kennel.1525771285",
@@ -24,7 +24,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.docker.com",
+      "node": "couchdb@couchdb-0.example.com",
       "pid": "<0.10676.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -36,7 +36,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.docker.com",
+      "node": "couchdb@couchdb-0.example.com",
       "pid": "<0.10678.0>",
       "changes_done": 0,
       "database": "shards/20000000-3fffffff/kennel.1525771285",
@@ -48,7 +48,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.docker.com",
+      "node": "couchdb@couchdb-0.example.com",
       "pid": "<0.10680.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -60,7 +60,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.docker.com",
+      "node": "couchdb@couchdb-0.example.com",
       "pid": "<0.10682.0>",
       "changes_done": 0,
       "database": "shards/60000000-7fffffff/kennel.1525771285",
@@ -72,7 +72,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.docker.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.11052.0>",
       "changes_done": 0,
       "database": "shards/00000000-1fffffff/kennel.1525771285",
@@ -84,7 +84,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.docker.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.11079.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -96,7 +96,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.docker.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.11081.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -108,7 +108,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.docker.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.11083.0>",
       "changes_done": 0,
       "database": "shards/40000000-5fffffff/kennel.1525771285",
@@ -120,7 +120,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.docker.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.11087.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -132,7 +132,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.docker.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.11089.0>",
       "changes_done": 0,
       "database": "shards/c0000000-dfffffff/kennel.1525771285",
@@ -144,7 +144,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.docker.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.10439.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -156,7 +156,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.docker.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.10445.0>",
       "changes_done": 0,
       "database": "shards/40000000-5fffffff/kennel.1525771285",
@@ -168,7 +168,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.docker.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.10453.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -180,7 +180,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.docker.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.10455.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -192,7 +192,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.docker.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.10457.0>",
       "changes_done": 0,
       "database": "shards/60000000-7fffffff/kennel.1525771285",
@@ -204,7 +204,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.docker.com",
+      "node": "couchdb@couchdb-0.example.com",
       "changes_done": 44461,
       "database": "my_db",
       "pid": "<0.218.0>",

--- a/couch/tests/fixtures/_active_tasks.json
+++ b/couch/tests/fixtures/_active_tasks.json
@@ -1,6 +1,6 @@
 [
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.10672.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -12,7 +12,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.10674.0>",
       "changes_done": 0,
       "database": "shards/c0000000-dfffffff/kennel.1525771285",
@@ -24,7 +24,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.10676.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -36,7 +36,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.10678.0>",
       "changes_done": 0,
       "database": "shards/20000000-3fffffff/kennel.1525771285",
@@ -48,7 +48,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.10680.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -60,7 +60,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.10682.0>",
       "changes_done": 0,
       "database": "shards/60000000-7fffffff/kennel.1525771285",
@@ -72,7 +72,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.example.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.11052.0>",
       "changes_done": 0,
       "database": "shards/00000000-1fffffff/kennel.1525771285",
@@ -84,7 +84,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.example.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.11079.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -96,7 +96,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.example.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.11081.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -108,7 +108,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.example.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.11083.0>",
       "changes_done": 0,
       "database": "shards/40000000-5fffffff/kennel.1525771285",
@@ -120,7 +120,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.example.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.11087.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -132,7 +132,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.example.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.11089.0>",
       "changes_done": 0,
       "database": "shards/c0000000-dfffffff/kennel.1525771285",
@@ -144,7 +144,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.example.com",
+      "node": "couchdb@couchdb-3.example.com",
       "pid": "<0.10439.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -156,7 +156,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.example.com",
+      "node": "couchdb@couchdb-3.example.com",
       "pid": "<0.10445.0>",
       "changes_done": 0,
       "database": "shards/40000000-5fffffff/kennel.1525771285",
@@ -168,7 +168,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.example.com",
+      "node": "couchdb@couchdb-3.example.com",
       "pid": "<0.10453.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -180,7 +180,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.example.com",
+      "node": "couchdb@couchdb-3.example.com",
       "pid": "<0.10455.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -192,7 +192,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.example.com",
+      "node": "couchdb@couchdb-3.example.com",
       "pid": "<0.10457.0>",
       "changes_done": 0,
       "database": "shards/60000000-7fffffff/kennel.1525771285",
@@ -204,7 +204,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "changes_done": 44461,
       "database": "my_db",
       "pid": "<0.218.0>",

--- a/couch/tests/test_couch.py
+++ b/couch/tests/test_couch.py
@@ -7,8 +7,6 @@ from datadog_checks.couch import CouchDb
 
 from . import common
 
-COUCHDB2_VERSIONS = {'2_3': '2.3.1'}
-
 
 @pytest.mark.usefixtures("dd_environment")
 def test_collect_metadata_instance(aggregator, datadog_agent, instance):
@@ -16,10 +14,6 @@ def test_collect_metadata_instance(aggregator, datadog_agent, instance):
     check.check_id = common.CHECK_ID
     check.check(instance)
     version = common.COUCH_RAW_VERSION
-
-    # CouchDB2 version is formatted differently for the datadog hosted image
-    if common.COUCH_MAJOR_VERSION == 2:
-        version = COUCHDB2_VERSIONS[common.COUCH_RAW_VERSION]
 
     major, minor, patch = version.split('.')
     version_metadata = {
@@ -32,3 +26,4 @@ def test_collect_metadata_instance(aggregator, datadog_agent, instance):
 
     datadog_agent.assert_metadata(common.CHECK_ID, version_metadata)
     datadog_agent.assert_metadata_count(5)
+

--- a/couch/tests/test_couch.py
+++ b/couch/tests/test_couch.py
@@ -26,4 +26,3 @@ def test_collect_metadata_instance(aggregator, datadog_agent, instance):
 
     datadog_agent.assert_metadata(common.CHECK_ID, version_metadata)
     datadog_agent.assert_metadata_count(5)
-

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -126,7 +126,7 @@ def test_db_whitelisting(aggregator, gauges):
 
     for n in [common.NODE1, common.NODE2, common.NODE3]:
         node = deepcopy(n)
-        node['db_whitelist'] = ['db0', 'db2', 'db4']
+        node['db_whitelist'] = ['db0']
         configs.append(node)
 
     for config in configs:
@@ -134,12 +134,12 @@ def test_db_whitelisting(aggregator, gauges):
         check.check(config)
 
     for _ in configs:
-        for db in ['db0', 'db2', 'db4']:
+        for db in ['db0']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags)
 
-        for db in ['db1', 'db3']:
+        for db in ['db1']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags, count=0)
@@ -152,7 +152,7 @@ def test_db_blacklisting(aggregator, gauges):
 
     for node in [common.NODE1, common.NODE2, common.NODE3]:
         config = deepcopy(node)
-        config['db_blacklist'] = ['db0', 'db2', 'db4']
+        config['db_blacklist'] = ['db0']
         configs.append(config)
 
     for config in configs:
@@ -160,12 +160,12 @@ def test_db_blacklisting(aggregator, gauges):
         check.check(config)
 
     for _ in configs:
-        for db in ['db1', 'db3']:
+        for db in ['db1']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags)
 
-        for db in ['db0', 'db2', 'db4']:
+        for db in ['db0']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags, count=0)

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -126,7 +126,7 @@ def test_db_whitelisting(aggregator, gauges):
 
     for n in [common.NODE1, common.NODE2, common.NODE3]:
         node = deepcopy(n)
-        node['db_whitelist'] = ['kennel']
+        node['db_whitelist'] = ['db0', 'db2', 'db4']
         configs.append(node)
 
     for config in configs:
@@ -134,14 +134,15 @@ def test_db_whitelisting(aggregator, gauges):
         check.check(config)
 
     for _ in configs:
-        for db in ['kennel_replica0']:
+        for db in ['db0', 'db2', 'db4']:
+            expected_tags = ["db:{}".format(db)]
+            for gauge in gauges["by_db_gauges"]:
+                aggregator.assert_metric(gauge, tags=expected_tags)
+
+        for db in ['db1', 'db3']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags, count=0)
-
-        for gauge in gauges["by_db_gauges"]:
-            expected_tags = ["db:kennel"]
-            aggregator.assert_metric(gauge, tags=expected_tags)
 
 
 @pytest.mark.usefixtures('dd_environment')
@@ -151,7 +152,7 @@ def test_db_blacklisting(aggregator, gauges):
 
     for node in [common.NODE1, common.NODE2, common.NODE3]:
         config = deepcopy(node)
-        config['db_blacklist'] = ['db1']
+        config['db_blacklist'] = ['db0', 'db2', 'db4']
         configs.append(config)
 
     for config in configs:
@@ -159,14 +160,15 @@ def test_db_blacklisting(aggregator, gauges):
         check.check(config)
 
     for _ in configs:
-        for db in ['db2']:
+        for db in ['db1', 'db3']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags)
 
-        for gauge in gauges["by_db_gauges"]:
-            expected_tags = ["db:db1"]
-            aggregator.assert_metric(gauge, tags=expected_tags, count=0)
+        for db in ['db0', 'db2', 'db4']:
+            expected_tags = ["db:{}".format(db)]
+            for gauge in gauges["by_db_gauges"]:
+                aggregator.assert_metric(gauge, tags=expected_tags, count=0)
 
 
 @pytest.mark.usefixtures('dd_environment')

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -34,12 +34,6 @@ def gauges():
     with open("{}/../metadata.csv".format(common.HERE), mode) as csvfile:
         reader = csv.reader(csvfile)
         for row in reader:
-            # if row[0] in [
-            #     'couchdb.active_tasks.indexer.changes_done',
-            #     'couchdb.active_tasks.indexer.progress',
-            #     'couchdb.active_tasks.indexer.total_changes',
-            # ]:
-            #     continue
             if row[0] == 'metric_name':
                 # skip the header
                 continue

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -98,7 +98,7 @@ def _assert_check(aggregator, gauges):
             expected_tags = ["design_document:{}".format(dd), "language:javascript", "db:{}".format(db)]
             aggregator.assert_metric(gauge, tags=expected_tags)
 
-    for db in ["kennel"]:
+    for db in ["kennel", "kennel_replica0"]:
         for gauge in gauges["by_db_gauges"]:
             expected_tags = ["db:{}".format(db)]
             aggregator.assert_metric(gauge, tags=expected_tags)
@@ -151,7 +151,7 @@ def test_db_blacklisting(aggregator, gauges):
 
     for node in [common.NODE1, common.NODE2, common.NODE3]:
         config = deepcopy(node)
-        config['db_blacklist'] = ['kennel_replica0']
+        config['db_blacklist'] = ['kennel']
         configs.append(config)
 
     for config in configs:
@@ -159,13 +159,13 @@ def test_db_blacklisting(aggregator, gauges):
         check.check(config)
 
     for _ in configs:
-        for db in ['kennel']:
+        for db in ['kennel_replica0']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags)
 
         for gauge in gauges["by_db_gauges"]:
-            expected_tags = ["db:kennel_replica0"]
+            expected_tags = ["db:kennel"]
             aggregator.assert_metric(gauge, tags=expected_tags, count=0)
 
 

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -134,7 +134,7 @@ def test_db_whitelisting(aggregator, gauges):
         check.check(config)
 
     for _ in configs:
-        for db in ['kennel_replica']:
+        for db in ['kennel_replica0']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags, count=0)
@@ -151,7 +151,7 @@ def test_db_blacklisting(aggregator, gauges):
 
     for node in [common.NODE1, common.NODE2, common.NODE3]:
         config = deepcopy(node)
-        config['db_blacklist'] = ['kennel_replica']
+        config['db_blacklist'] = ['kennel_replica0']
         configs.append(config)
 
     for config in configs:
@@ -165,7 +165,7 @@ def test_db_blacklisting(aggregator, gauges):
                 aggregator.assert_metric(gauge, tags=expected_tags)
 
         for gauge in gauges["by_db_gauges"]:
-            expected_tags = ["db:kennel_replica"]
+            expected_tags = ["db:kennel_replica0"]
             aggregator.assert_metric(gauge, tags=expected_tags, count=0)
 
 

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -20,7 +20,7 @@ from . import common
 
 pytestmark = pytest.mark.skipif(common.COUCH_MAJOR_VERSION != 2, reason='Test for version Couch v2')
 
-INSTANCES = [common.NODE0, common.NODE1, common.NODE2]
+INSTANCES = [common.NODE1, common.NODE2, common.NODE3]
 
 
 @pytest.fixture(scope="module")
@@ -103,11 +103,11 @@ def _assert_check(aggregator, gauges):
             expected_tags = ["db:{}".format(db)]
             aggregator.assert_metric(gauge, tags=expected_tags)
 
-    expected_tags = ["instance:{}".format(common.NODE0["name"])]
+    expected_tags = ["instance:{}".format(common.NODE1["name"])]
     # One for the version, one for the server stats
     aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=2)
 
-    for node in [common.NODE1, common.NODE2]:
+    for node in [common.NODE2, common.NODE3]:
         expected_tags = ["instance:{}".format(node["name"])]
         # One for the server stats, the version is already loaded
         aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=2)
@@ -124,7 +124,7 @@ def _assert_check(aggregator, gauges):
 def test_db_whitelisting(aggregator, gauges):
     configs = []
 
-    for n in [common.NODE0, common.NODE1, common.NODE2]:
+    for n in [common.NODE1, common.NODE2, common.NODE3]:
         node = deepcopy(n)
         node['db_whitelist'] = ['db0']
         configs.append(node)
@@ -150,7 +150,7 @@ def test_db_whitelisting(aggregator, gauges):
 def test_db_blacklisting(aggregator, gauges):
     configs = []
 
-    for node in [common.NODE0, common.NODE1, common.NODE2]:
+    for node in [common.NODE1, common.NODE2, common.NODE3]:
         config = deepcopy(node)
         config['db_blacklist'] = ['db0']
         configs.append(config)
@@ -174,12 +174,12 @@ def test_db_blacklisting(aggregator, gauges):
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
 def test_check_without_names(aggregator, gauges):
-    config = deepcopy(common.NODE0)
+    config = deepcopy(common.NODE1)
     config.pop('name')
     check = CouchDb(common.CHECK_NAME, {}, [config])
     check.check(config)
 
-    configs = [common.NODE0, common.NODE1, common.NODE2]
+    configs = [common.NODE1, common.NODE2, common.NODE3]
 
     for config in configs:
         expected_tags = ["instance:{}".format(config["name"])]
@@ -206,7 +206,7 @@ def test_check_without_names(aggregator, gauges):
     # One for the version, one for the server stats
     aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=1)
 
-    for node in [common.NODE1, common.NODE2]:
+    for node in [common.NODE2, common.NODE3]:
         expected_tags = ["instance:{}".format(node["name"])]
         # One for the server stats, the version is already loaded
         aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=1)
@@ -218,7 +218,7 @@ def test_check_without_names(aggregator, gauges):
 @pytest.mark.integration
 @pytest.mark.parametrize('number_nodes', [1, 2, 3])
 def test_only_max_nodes_are_scanned(aggregator, gauges, number_nodes):
-    config = deepcopy(common.NODE0)
+    config = deepcopy(common.NODE1)
     config.pop("name")
     config['max_nodes_per_check'] = number_nodes
 
@@ -242,7 +242,7 @@ def test_only_max_nodes_are_scanned(aggregator, gauges, number_nodes):
 @pytest.mark.integration
 @pytest.mark.parametrize('number_db', [1, 2, 3])
 def test_only_max_dbs_are_scanned(aggregator, gauges, number_db):
-    config = deepcopy(common.NODE0)
+    config = deepcopy(common.NODE1)
     config["max_dbs_per_check"] = number_db
 
     check = CouchDb(common.CHECK_NAME, {}, [config])
@@ -264,7 +264,7 @@ def test_only_max_dbs_are_scanned(aggregator, gauges, number_db):
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
 def test_replication_metrics(aggregator, gauges):
-    for config in [common.NODE0, common.NODE1, common.NODE2]:
+    for config in [common.NODE1, common.NODE2, common.NODE3]:
         check = CouchDb(common.CHECK_NAME, {}, [config])
         check.check(config)
 
@@ -284,10 +284,10 @@ def test_compaction_metrics(aggregator, gauges, active_tasks):
     def _get_active_tasks(server, name, tags):
         return active_tasks
 
-    check = CouchDb(common.CHECK_NAME, {}, [common.NODE0])
+    check = CouchDb(common.CHECK_NAME, {}, [common.NODE1])
     check.checker = couch.CouchDB2(check)
     check.checker._get_active_tasks = _get_active_tasks
-    check.check(common.NODE0)
+    check.check(common.NODE1)
 
     for gauge in gauges["compaction_tasks_gauges"]:
         aggregator.assert_metric(gauge)
@@ -308,13 +308,13 @@ def test_indexing_metrics(aggregator, gauges, active_tasks):
         return {}
 
     # run the check on all instances
-    for config in [common.NODE0, common.NODE1, common.NODE2]:
+    for config in [common.NODE1, common.NODE2, common.NODE3]:
         check = CouchDb(common.CHECK_NAME, {}, [config])
         check.checker = couch.CouchDB2(check)
         check.get = _get
         check.check(config)
 
-    for node in [common.NODE0, common.NODE1, common.NODE2]:
+    for node in [common.NODE1, common.NODE2, common.NODE3]:
         expected_tags = ['database:kennel', 'design_document:dummy', 'instance:{}'.format(node['name'])]
         for gauge in gauges["indexing_tasks_gauges"]:
             aggregator.assert_metric(gauge, tags=expected_tags)
@@ -384,7 +384,7 @@ def test_view_compaction_metrics(aggregator, gauges):
 
     threads = []
     for _ in range(40):
-        t = LoadGenerator(common.NODE0['server'], (common.NODE0['user'], common.NODE0['password']))
+        t = LoadGenerator(common.NODE1['server'], (common.NODE1['user'], common.NODE1['password']))
         t.start()
         threads.append(t)
 
@@ -395,7 +395,7 @@ def test_view_compaction_metrics(aggregator, gauges):
             tries += 1
 
             try:
-                for config in [common.NODE0, common.NODE1, common.NODE2]:
+                for config in [common.NODE1, common.NODE2, common.NODE3]:
                     check = CouchDb(common.CHECK_NAME, {}, [config])
                     check.check(config)
             except Exception:
@@ -423,7 +423,7 @@ def test_view_compaction_metrics(aggregator, gauges):
 @pytest.mark.integration
 def test_config_tags(aggregator, gauges):
     TEST_TAG = "test_tag:test"
-    config = deepcopy(common.NODE0)
+    config = deepcopy(common.NODE1)
     config['tags'] = [TEST_TAG]
 
     check = CouchDb(common.CHECK_NAME, {}, [config])

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -98,7 +98,7 @@ def _assert_check(aggregator, gauges):
             expected_tags = ["design_document:{}".format(dd), "language:javascript", "db:{}".format(db)]
             aggregator.assert_metric(gauge, tags=expected_tags)
 
-    for db in ["kennel", "kennel_replica0"]:
+    for db in ["kennel", "db1"]:
         for gauge in gauges["by_db_gauges"]:
             expected_tags = ["db:{}".format(db)]
             aggregator.assert_metric(gauge, tags=expected_tags)
@@ -151,7 +151,7 @@ def test_db_blacklisting(aggregator, gauges):
 
     for node in [common.NODE1, common.NODE2, common.NODE3]:
         config = deepcopy(node)
-        config['db_blacklist'] = ['kennel']
+        config['db_blacklist'] = ['db1']
         configs.append(config)
 
     for config in configs:
@@ -159,13 +159,13 @@ def test_db_blacklisting(aggregator, gauges):
         check.check(config)
 
     for _ in configs:
-        for db in ['kennel_replica0']:
+        for db in ['db2']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags)
 
         for gauge in gauges["by_db_gauges"]:
-            expected_tags = ["db:kennel"]
+            expected_tags = ["db:db1"]
             aggregator.assert_metric(gauge, tags=expected_tags, count=0)
 
 

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -43,12 +43,12 @@ def gauges():
                 'couchdb.active_tasks.indexer.changes_done',
                 'couchdb.active_tasks.indexer.progress',
                 'couchdb.active_tasks.indexer.total_changes',
-                'couchdb.active_tasks.replication.changes_pending',
-                'couchdb.active_tasks.replication.doc_write_failures',
-                'couchdb.active_tasks.replication.docs_read',
-                'couchdb.active_tasks.replication.docs_written',
-                'couchdb.active_tasks.replication.missing_revisions_found',
-                'couchdb.active_tasks.replication.revisions_checked',
+                # 'couchdb.active_tasks.replication.changes_pending',
+                # 'couchdb.active_tasks.replication.doc_write_failures',
+                # 'couchdb.active_tasks.replication.docs_read',
+                # 'couchdb.active_tasks.replication.docs_written',
+                # 'couchdb.active_tasks.replication.missing_revisions_found',
+                # 'couchdb.active_tasks.replication.revisions_checked',
             ]:
                 continue
             print("row[0]", row[0])
@@ -243,8 +243,8 @@ def test_only_max_nodes_are_scanned(aggregator, gauges):
     for gauge in gauges["erlang_gauges"]:
         aggregator.assert_metric(gauge)
 
-    for gauge in gauges["replication_tasks_gauges"]:
-        aggregator.assert_metric(gauge)
+    # for gauge in gauges["replication_tasks_gauges"]:
+    #     aggregator.assert_metric(gauge)
 
     for config in [common.NODE1, common.NODE2]:
         expected_tags = ["instance:{}".format(config["name"])]

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -231,9 +231,6 @@ def test_only_max_nodes_are_scanned(aggregator, gauges):
     for gauge in gauges["erlang_gauges"]:
         aggregator.assert_metric(gauge)
 
-    for gauge in gauges["replication_tasks_gauges"]:
-        aggregator.assert_metric(gauge)
-
     for config in [common.NODE1, common.NODE2]:
         expected_tags = ["instance:{}".format(config["name"])]
         for gauge in gauges["cluster_gauges"]:

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -34,24 +34,12 @@ def gauges():
     with open("{}/../metadata.csv".format(common.HERE), mode) as csvfile:
         reader = csv.reader(csvfile)
         for row in reader:
-            if row[0] in [
-                # 'couchdb.couchdb.document_purges.failure',
-                # 'couchdb.couchdb.document_purges.success',
-                # 'couchdb.couchdb.document_purges.total',
-                # 'couchdb.couchdb.database_purges',
-                # 'couchdb.couchdb.httpd.purge_requests',
-                'couchdb.active_tasks.indexer.changes_done',
-                'couchdb.active_tasks.indexer.progress',
-                'couchdb.active_tasks.indexer.total_changes',
-                # 'couchdb.active_tasks.replication.changes_pending',
-                # 'couchdb.active_tasks.replication.doc_write_failures',
-                # 'couchdb.active_tasks.replication.docs_read',
-                # 'couchdb.active_tasks.replication.docs_written',
-                # 'couchdb.active_tasks.replication.missing_revisions_found',
-                # 'couchdb.active_tasks.replication.revisions_checked',
-            ]:
-                continue
-            print("row[0]", row[0])
+            # if row[0] in [
+            #     'couchdb.active_tasks.indexer.changes_done',
+            #     'couchdb.active_tasks.indexer.progress',
+            #     'couchdb.active_tasks.indexer.total_changes',
+            # ]:
+            #     continue
             if row[0] == 'metric_name':
                 # skip the header
                 continue
@@ -243,8 +231,8 @@ def test_only_max_nodes_are_scanned(aggregator, gauges):
     for gauge in gauges["erlang_gauges"]:
         aggregator.assert_metric(gauge)
 
-    # for gauge in gauges["replication_tasks_gauges"]:
-    #     aggregator.assert_metric(gauge)
+    for gauge in gauges["replication_tasks_gauges"]:
+        aggregator.assert_metric(gauge)
 
     for config in [common.NODE1, common.NODE2]:
         expected_tags = ["instance:{}".format(config["name"])]

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -227,8 +227,7 @@ def test_only_max_nodes_are_scanned(aggregator, gauges, number_nodes):
 
     metrics = []
     for metric_list in aggregator._metrics.values():
-        for m in metric_list:
-            metrics.append(m)
+        metrics.extend(metric_list)
 
     instance_tags = set()
     for m in metrics:
@@ -251,8 +250,7 @@ def test_only_max_dbs_are_scanned(aggregator, gauges, number_db):
 
     metrics = []
     for metric_list in aggregator._metrics.values():
-        for m in metric_list:
-            metrics.append(m)
+        metrics.extend(metric_list)
 
     db_tags = set()
     for m in metrics:

--- a/couch/tox.ini
+++ b/couch/tox.ini
@@ -18,7 +18,7 @@ passenv =
     DOCKER*
 setenv =
     1.6: COUCH_VERSION=1.6.1
-    2.3: COUCH_VERSION=2_3
+    2.3: COUCH_VERSION=2.3.1
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
Fix PR: https://github.com/DataDog/integrations-core/pull/6467
[Pipeline Builds](https://dev.azure.com/datadoghq/integrations-core/_build?definitionId=6&_a=summary&branchFilter=2703)

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

The issue seems only present for couch version `2.3`

120 successful builds
![image](https://user-images.githubusercontent.com/49917914/80200784-713caa80-8623-11ea-9299-afe1230a9d6a.png)


### Motivation
<!-- What inspired you to submit this pull request? -->

```

            time.sleep(self.wait)
        else:
>           raise RetryError(
                'Result: {}\nError: {}\nFunction: {}, Args: {}, Kwargs: {}\n'.format(
                    repr(last_result), last_error, self.func.__name__, self.args, self.kwargs
                )
            )
E           datadog_checks.dev.errors.RetryError: Result: False
E           Error: None
E           Function: get_replication, Args: ('2',), Kwargs: {}

../datadog_checks_dev/datadog_checks/dev/conditions.py:48: RetryError
---------------------------- Captured stdout setup -----------------------------
Waiting for stats to be generated on the nodes...
Waiting for stats to be generated on the nodes...
Waiting for stats to be generated on the nodes...
Waiting for stats to be generated on the nodes...
Attaching to compose_couch_1
couch_1  | [ * ] Setup environment ... ok
couch_1  | [ * ] Ensure CouchDB is built ... ok
couch_1  | [ * ] Prepare configuration files ... ok
couch_1  | [ * ] Start node node1 ... ok
couch_1  | [ * ] Start node node2 ... ok
couch_1  | [ * ] Start node node3 ... ok
couch_1  | [ * ] Check node at http://127.0.0.1:15984/ ... ok
couch_1  | [ * ] Check node at http://127.0.0.1:25984/ ... ok
couch_1  | [ * ] Check node at http://127.0.0.1:35984/ ... ok
couch_1  | [ * ] Running cluster setup ... ok
couch_1  | [ * ] Developers cluster is set up at http://127.0.0.1:15984.
couch_1  | Admin username: dduser
couch_1  | Password: pawprint

```

- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13542&view=logs&jobId=c73aedc7-d1f1-5bee-93b6-629007590bd5&j=c73aedc7-d1f1-5bee-93b6-629007590bd5&t=7b58fc00-c48d-5e79-d458-fcdf7976c98f
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13546&view=logs&j=2ab1c2a9-b99d-5635-db6c-1df7fa16203c&t=b9844dff-51dd-556e-cad6-453479ddb360
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13546&view=logs&j=b07b42a6-4264-50a6-0efd-ee8d014c0218&t=8b7d1eea-399d-5dd2-09fb-0baf9d94f451
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13550&view=logs&j=965095b0-692a-5c14-24f4-254c6ac3a9cb&t=31e59c68-b6a9-5840-4ea0-b0fde12615d7

Envs:
- ERROR:   py27-2.3: commands failed
- ERROR:   py38-2.3: commands failed


```
___________________________________ test_e2e ___________________________________
tests/test_couchv2.py:80: in test_e2e
    aggregator = dd_agent_check({'init_config': {}, 'instances': deepcopy(INSTANCES)})
../datadog_checks_dev/datadog_checks/dev/plugin/pytest.py:197: in run_check
    replay_check_run(collector, aggregator)
../datadog_checks_dev/datadog_checks/dev/_env.py:118: in replay_check_run
    raise Exception("\n".join("Message: {}\n{}".format(err['message'], err['traceback']) for err in errors))
E   Exception: Message: 'node1@127.0.0.1' is not in list
E   Traceback (most recent call last):
E     File "/home/datadog_checks_base/datadog_checks/base/checks/base.py", line 820, in run
E       self.check(instance)
E     File "/home/couch/datadog_checks/couch/couch.py", line 87, in check
E       self.checker.check(instance)
E     File "/home/couch/datadog_checks/couch/couch.py", line 345, in check
E       for db in self._get_dbs_to_scan(server, name, tags):
E     File "/home/couch/datadog_checks/couch/couch.py", line 323, in _get_dbs_to_scan
E       idx = nodes.index(name)
E   ValueError: 'node1@127.0.0.1' is not in list

```
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13546&view=logs&j=a32153be-4ddf-5c50-bd9d-a859be4ee754&t=22372c57-d01c-544b-f5b4-80fd98fd8696

Envs:
- py27-2.3
- ERROR:   py38-2.3: commands failed



```
../datadog_checks_dev/datadog_checks/dev/conditions.py:84: in __call__
    raise RetryError('Endpoint: {}\n' 'Error: {}'.format(last_endpoint, last_error))
E   RetryError: Endpoint: http://localhost:5984
E   Error: <urlopen error [Errno 111] Connection refused>
```
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13702&view=logs&j=cc5abc9e-0189-58d8-da2a-d33663c307d9&t=cebab5d0-cca0-5dee-159e-852a6fe6d123

Envs:
- ERROR:   py27-2.3: commands failed


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
