### PR TITLE
Fix flaky integration/e2e tests

### DIFF
--- a/clickhouse/tests/conftest.py
+++ b/clickhouse/tests/conftest.py
@@ -6,16 +6,23 @@ from copy import deepcopy
 import pytest
 
 from datadog_checks.dev import docker_run
+from datadog_checks.dev.conditions import CheckDockerLogs, CheckEndpoints
 
 from . import common
 
 
 @pytest.fixture(scope='session')
 def dd_environment():
+    conditions = []
+    for i in range(6):
+        conditions.append(CheckEndpoints(['http://{}:{}'.format(common.HOST, common.HTTP_START_PORT + i)]))
+        conditions.append(
+            CheckDockerLogs(
+                'clickhouse-0{}'.format(i + 1), 'Logging errors to /var/log/clickhouse-server/clickhouse-server.err.log'
+            )
+        )
     with docker_run(
-        common.COMPOSE_FILE,
-        endpoints=['http://{}:{}'.format(common.HOST, common.HTTP_START_PORT + i) for i in range(6)],
-        sleep=10,
+        common.COMPOSE_FILE, conditions=conditions, sleep=10,
     ):
         yield common.CONFIG
 

--- a/clickhouse/tests/docker/docker-compose.yaml
+++ b/clickhouse/tests/docker/docker-compose.yaml
@@ -156,7 +156,11 @@ services:
       - clickhouse-network
 
   clickhouse-zookeeper:
-    image: zookeeper:latest
+    # Using zookeeper `3.6.0` is raising this error:
+    #   Connection request from old client /172.30.0.7:51646; will be dropped if server is in r-o mode
+    # For now, we use zookeeper `3.5.7` instead
+    # Similar case: https://stackoverflow.com/a/22884698
+    image: zookeeper:3.5.7
     hostname: clickhouse-zookeeper
     container_name: clickhouse-zookeeper
     ports:
@@ -164,7 +168,14 @@ services:
       - "2182:2182"
     networks:
       - clickhouse-network
-
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      # "You need to set advertised.listeners (or KAFKA_ADVERTISED_LISTENERS if you’re using Docker images) to
+      # the external address (host/IP) so that clients can correctly connect to it. Otherwise they’ll try to
+      # connect to the internal host address–and if that’s not reachable then problems ensue."
+      # Source: https://rmoff.net/2018/08/02/kafka-listeners-explained/
+      KAFKA_ADVERTISED_LISTENERS: CLICKHOUSE01://127.0.0.1:8124,CLICKHOUSE02://127.0.0.1:8125,CLICKHOUSE03://127.0.0.1:8126,CLICKHOUSE04://127.0.0.1:8127,CLICKHOUSE05://127.0.0.1:8128,CLICKHOUSE06://127.0.0.1:8129
+      ALLOW_PLAINTEXT_LISTENER: "yes"
   # The client is useful for debugging or running arbitrary commands.
   #
   # clickhouse-client:


### PR DESCRIPTION
Sandbox PR: https://github.com/DataDog/integrations-core/pull/6431
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix flaky integration/e2e tests

120 successful builds:
![image](https://user-images.githubusercontent.com/49917914/79983246-c2c02a80-84a7-11ea-9009-cd79d484d617.png)

https://dev.azure.com/datadoghq/integrations-core/_build?definitionId=6&_a=summary&view=runs&branchFilter=2693

### Motivation
<!-- What inspired you to submit this pull request? -->

```
__________________________________ test_check __________________________________
tests/test_clickhouse.py:27: in test_check
    aggregator.assert_metric('clickhouse.table.replicated.total', 2)
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:249: in assert_metric
    self._assert(condition, msg=msg, expected_stub=expected_metric, submitted_elements=self._metrics)
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:291: in _assert
    assert condition, new_msg
E   AssertionError: Needed at least 1 candidates for 'clickhouse.table.replicated.total', got 0
E     Expected:
E             MetricStub(name='clickhouse.table.replicated.total', type=None, value=2, tags=None, hostname=None, device=None)
E     Similar submitted:
E     Score   Most similar
E     0.91    MetricStub(name='clickhouse.table.replicated.log.max', type=0, value=2.0, tags=['database:default', 'db:default', 'foo:bar', 'is_leader:true', 'is_readonly:false', 'is_session_expired:false', 'port:9001', 'server:localhost', 'table:tableau'], hostname='', device=None)
E     0.79    MetricStub(name='clickhouse.database.total', type=0, value=2.0, tags=['db:default', 'foo:bar', 'port:9001', 'server:localhost'], hostname='', device=None)
E     0.77    MetricStub(name='clickhouse.query.total', type=0, value=2.0, tags=['db:default', 'foo:bar', 'port:9001', 'server:localhost'], hostname='', device=None)
E     0.76    MetricStub(name='clickhouse.query.select.total', type=0, value=2.0, tags=['db:default', 'foo:bar', 'port:9001', 'server:localhost'], hostname='', device=None)
E     0.75    MetricStub(name='clickhouse.table.replicated.total', type=0, value=1.0, tags=['database:default', 'db:default', 'foo:bar', 'is_leader:true', 'is_readonly:false', 'is_session_expired:false', 'port:9001', 'server:localhost', 'table:tableau'], hostname='', device=None)
E     0.73    MetricStub(name='clickhouse.syscall.read', type=0, value=2.0, tags=['db:default', 'foo:bar', 'port:9001', 'server:localhost'], hostname='', device=None)
E     0.71    MetricStub(name='clickhouse.table.mergetree.part.current', type=0, value=2.0, tags=['database:system', 'db:default', 'foo:bar', 'port:9001', 'server:localhost', 'table:metric_log'], hostname='', device=None)
E     0.69    MetricStub(name='clickhouse.zk.node.ephemeral', type=0, value=2.0, tags=['db:default', 'foo:bar', 'port:9001', 'server:localhost'], hostname='', device=None)
E     0.65    MetricStub(name='clickhouse.table.replicated.readonly', type=0, value=0.0, tags=['db:default', 'foo:bar', 'port:9001', 'server:localhost'], hostname='', device=None)
E     0.65    MetricStub(name='clickhouse.table.replicated.leader', type=0, value=1.0, tags=['db:default', 'foo:bar', 'port:9001', 'server:localhost'], hostname='', device=None)
E     0.65    MetricStub(name='clickhouse.table.replicated.active', type=0, value=1.0, tags=['database:default', 'db:default', 'foo:bar', 'is_leader:true', 'is_readonly:false', 'is_session_expired:false', 'port:9001', 'server:localhost', 'table:tableau'], hostname='', device=None)
E     0.64    MetricStub(name='clickhouse.table.replicated.version', type=0, value=-1.0, tags=['database:default', 'db:default', 'foo:bar', 'is_leader:true', 'is_readonly:false', 'is_session_expired:false', 'port:9001', 'server:localhost', 'table:tableau'], hostname='', device=None)
E     0.64    MetricStub(name='clickhouse.query.select.count', type=3, value=2.0, tags=['db:default', 'foo:bar', 'port:9001', 'server:localhost'], hostname='', device=None)
E     0.63    MetricStub(name='clickhouse.table.replicated.part.fetch', type=0, value=0.0, tags=['db:default', 'foo:bar', 'port:9001', 'server:localhost'], hostname='', device=None)
E     0.62    MetricStub(name='clickhouse.table.replicated.part.future', type=0, value=0.0, tags=['database:default', 'db:default', 'foo:bar', 'is_leader:true', 'is_readonly:false', 'is_session_expired:false', 'port:9001', 'server:localhost', 'table:tableau'], hostname='', device=None)
E   assert False

```
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13462&view=logs&j=ea99e374-0f57-5d59-1e65-753fbb562759&t=94b52232-1f93-5c55-e3aa-252b9fe79c5d
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13468&view=logs&j=11311303-ad7e-5883-9499-8fc9a3639c10&t=1e6409ce-84e2-5079-5e65-b54652aa619a

```
__________________________________ test_check __________________________________
tests/test_e2e.py:18: in test_check
    aggregator.assert_metric_has_tag(metric, server_tag)
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:157: in assert_metric_has_tag
    assert len(candidates) >= at_least, msg
E   AssertionError: Candidates size assertion for `clickhouse.table.replicated.active`, count: None, at_least: 1) failed
E   assert 0 >= 1
E    +  where 0 = len([])
- generated xml file: /home/vsts/work/1/s/clickhouse/.junit/test-e2e-py27-latest.xml -
=================== 1 failed, 11 deselected in 5.08 seconds ====================
ERROR: InvocationError for command /home/vsts/work/1/s/clickhouse/.tox/py27-latest/bin/pytest -v (exited with code 1)
```

- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13458&view=logs&j=36b044ca-10ac-53cf-9b38-72da67a73916&t=2a6215e6-d760-5164-807b-5ed88cf8b56c
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13462&view=logs&j=edee2339-3355-56ef-f286-7ebb52001393&t=7cda71ad-4b50-5929-c87b-ba799c4488d4
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13468&view=logs&j=a32153be-4ddf-5c50-bd9d-a859be4ee754&t=c712125a-d13e-579e-d2a2-7de8b57c0841




```
__________________________________ test_check __________________________________
tests/test_e2e.py:13: in test_check
    aggregator = dd_agent_check(instance, rate=True)
../datadog_checks_dev/datadog_checks/dev/plugin/pytest.py:187: in run_check
    result.stdout, result.stderr, AGENT_COLLECTOR_SEPARATOR
E   ValueError: 
E   Could not find `=== JSON ===` in the output
- generated xml file: /home/vsts/work/1/s/clickhouse/.junit/test-e2e-py27-18.xml
```

- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13284&view=logs&jobId=8e96ab15-72b0-549c-5ab8-f9fece94b017&j=8e96ab15-72b0-549c-5ab8-f9fece94b017&t=c7a08f9e-1bc8-50f0-be66-4a54fd3d5050


### Additional Notes
<!-- Anything else we should know when reviewing? -->
