### PR TITLE
[WIP] Fix flaky tests by improving wait conditions

### DIFF
--- a/mysql/tests/common.py
+++ b/mysql/tests/common.py
@@ -14,6 +14,8 @@ TESTS_HELPER_DIR = os.path.join(ROOT, 'datadog_checks_tests_helper')
 MYSQL_VERSION_PARSED = parse_version(os.getenv('MYSQL_VERSION'))
 
 CHECK_NAME = 'mysql'
+MASTER_CONTAINER_NAME = 'mysql-master'
+SLAVE_CONTAINER_NAME = 'mysql-slave'
 
 HOST = get_docker_hostname()
 PORT = 13306

--- a/mysql/tests/compose/mariadb.yaml
+++ b/mysql/tests/compose/mariadb.yaml
@@ -2,6 +2,7 @@ version: '3.5'
 
 services:
   mysql-master:
+    container_name: mysql-master
     image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
     environment:
       - ALLOW_EMPTY_PASSWORD=yes

--- a/mysql/tests/compose/mysql.yaml
+++ b/mysql/tests/compose/mysql.yaml
@@ -2,6 +2,7 @@ version: '3.5'
 
 services:
   mysql-master:
+    container_name: mysql-master
     image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=1

--- a/mysql/tests/compose/mysql8.yaml
+++ b/mysql/tests/compose/mysql8.yaml
@@ -2,6 +2,7 @@ version: '3.5'
 
 services:
   mysql-master:
+    container_name: mysql-master
     image: "${MYSQL_DOCKER_REPO}:${MYSQL_VERSION}"
     environment:
       - ALLOW_EMPTY_PASSWORD=yes


### PR DESCRIPTION
Sandbox PR: https://github.com/DataDog/integrations-core/pull/6432

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix flaky tests by improving wait conditions

### Motivation
<!-- What inspired you to submit this pull request? -->

```
E   RetryError: Result: None
E   Error: (1130, u"Host '172.21.0.1' is not allowed to connect to this MariaDB server")
E   Function: init_slave, Args: (), Kwargs: {}
```

Cases:
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13080&view=logs&jobId=d74967ea-228d-5634-fe5f-5bd874cd0575
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13459&view=logs&j=edee2339-3355-56ef-f286-7ebb52001393&t=a92ff1ac-93db-531d-d631-e388d588bd3d
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13459&view=logs&j=b07b42a6-4264-50a6-0efd-ee8d014c0218&t=8b7d1eea-399d-5dd2-09fb-0baf9d94f451

### Additional Notes
<!-- Anything else we should know when reviewing? -->


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
