### PR TITLE
Add rmi_connection_timeout & rmi_client_timeout to config spec

### DIFF
--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -121,6 +121,18 @@ instances:
     #
     # rmi_registry_ssl: false
 
+    ## @param rmi_connection_timeout - number - optional - default: 30
+    ## The connection timeout, in seconds, when connecting to a remote JVM.
+    #
+    # rmi_connection_timeout: 30
+
+    ## @param rmi_client_timeout - number - optional - default: 30
+    ## The timeout to consider a remote connection, already successfully established, as lost.
+    ## If a connected remote JVM does not reply after `rmi_client_timeout` seconds jmxfetch
+    ## will give up on that connection and retry.
+    #
+    # rmi_client_timeout: 30
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+++ b/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
@@ -132,6 +132,18 @@ instances:
     #
     # rmi_registry_ssl: false
 
+    ## @param rmi_connection_timeout - number - optional - default: 30
+    ## The connection timeout, in seconds, when connecting to a remote JVM.
+    #
+    # rmi_connection_timeout: 30
+
+    ## @param rmi_client_timeout - number - optional - default: 30
+    ## The timeout to consider a remote connection, already successfully established, as lost.
+    ## If a connected remote JVM does not reply after `rmi_client_timeout` seconds jmxfetch
+    ## will give up on that connection and retry.
+    #
+    # rmi_client_timeout: 30
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
@@ -91,4 +91,19 @@
     example: false
     type: boolean
 
+- name: rmi_connection_timeout
+  description: The connection timeout, in seconds, when connecting to a remote JVM.
+  value:
+    example: 30
+    type: number
+
+- name: rmi_client_timeout
+  description: |
+    The timeout to consider a remote connection, already successfully established, as lost.
+    If a connected remote JVM does not reply after `rmi_client_timeout` seconds jmxfetch
+    will give up on that connection and retry.
+  value:
+    example: 30
+    type: number
+
 - template: instances/default

--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -121,6 +121,18 @@ instances:
     #
     # rmi_registry_ssl: false
 
+    ## @param rmi_connection_timeout - number - optional - default: 30
+    ## The connection timeout, in seconds, when connecting to a remote JVM.
+    #
+    # rmi_connection_timeout: 30
+
+    ## @param rmi_client_timeout - number - optional - default: 30
+    ## The timeout to consider a remote connection, already successfully established, as lost.
+    ## If a connected remote JVM does not reply after `rmi_client_timeout` seconds jmxfetch
+    ## will give up on that connection and retry.
+    #
+    # rmi_client_timeout: 30
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/ignite/datadog_checks/ignite/data/conf.yaml.example
+++ b/ignite/datadog_checks/ignite/data/conf.yaml.example
@@ -121,6 +121,18 @@ instances:
     #
     # rmi_registry_ssl: false
 
+    ## @param rmi_connection_timeout - number - optional - default: 30
+    ## The connection timeout, in seconds, when connecting to a remote JVM.
+    #
+    # rmi_connection_timeout: 30
+
+    ## @param rmi_client_timeout - number - optional - default: 30
+    ## The timeout to consider a remote connection, already successfully established, as lost.
+    ## If a connected remote JVM does not reply after `rmi_client_timeout` seconds jmxfetch
+    ## will give up on that connection and retry.
+    #
+    # rmi_client_timeout: 30
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -127,6 +127,18 @@ instances:
     #
     # rmi_registry_ssl: false
 
+    ## @param rmi_connection_timeout - number - optional - default: 30
+    ## The connection timeout, in seconds, when connecting to a remote JVM.
+    #
+    # rmi_connection_timeout: 30
+
+    ## @param rmi_client_timeout - number - optional - default: 30
+    ## The timeout to consider a remote connection, already successfully established, as lost.
+    ## If a connected remote JVM does not reply after `rmi_client_timeout` seconds jmxfetch
+    ## will give up on that connection and retry.
+    #
+    # rmi_client_timeout: 30
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/tomcat/datadog_checks/tomcat/data/conf.yaml.example
+++ b/tomcat/datadog_checks/tomcat/data/conf.yaml.example
@@ -121,6 +121,18 @@ instances:
     #
     # rmi_registry_ssl: false
 
+    ## @param rmi_connection_timeout - number - optional - default: 30
+    ## The connection timeout, in seconds, when connecting to a remote JVM.
+    #
+    # rmi_connection_timeout: 30
+
+    ## @param rmi_client_timeout - number - optional - default: 30
+    ## The timeout to consider a remote connection, already successfully established, as lost.
+    ## If a connected remote JVM does not reply after `rmi_client_timeout` seconds jmxfetch
+    ## will give up on that connection and retry.
+    #
+    # rmi_client_timeout: 30
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##


### PR DESCRIPTION
### What does this PR do?
Add rmi_connection_timeout & rmi_client_timeout to config spec

### Motivation
Missing jmxfetch settings

### Additional Notes
N/A

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
