### PR TITLE
Remove `dd_check_types` from check template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tox.ini
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tox.ini
@@ -7,8 +7,6 @@ envlist =
 
 [testenv]
 dd_check_style = true
-dd_check_types = true
-dd_mypy_args = --py2 datadog_checks/ tests/
 usedevelop = true
 platform = linux|darwin|win32
 deps =


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove type checking-related options in the `tox.ini` file generated by `$ ddev create`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Most users won't use mypy and type checking, so this option is adding unecessary burden for them when building new checks. Eg see: https://github.com/DataDog/integrations-internal/pull/59

Users that do want to use type checking can still do it by adding these options back - although they're still undocumented (would need updating the [mypy](https://datadoghq.dev/integrations-core/guidelines/style/#mypy) section in the WIP docs).

At this point it's unclear whether we want to encourage type checking by default in official integrations (it should probably just be at the appreciation of the implementer), so it's another argument in favor of disabling it by default.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
