### PR TITLE
Fix flaky tests and use official docker image

### DIFF
--- a/couch/tests/common.py
+++ b/couch/tests/common.py
@@ -52,10 +52,10 @@ BAD_CONFIG = {"server": "http://localhost:11111"}
 
 BAD_CONFIG_TAGS = ["instance:http://localhost:11111"]
 
-NODE0 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-0.example.com"}
-
 NODE1 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-1.example.com"}
 
 NODE2 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-2.example.com"}
 
-ALL_NODES = [NODE0, NODE1, NODE2]
+NODE3 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-3.example.com"}
+
+ALL_NODES = [NODE1, NODE2, NODE3]

--- a/couch/tests/common.py
+++ b/couch/tests/common.py
@@ -52,10 +52,10 @@ BAD_CONFIG = {"server": "http://localhost:11111"}
 
 BAD_CONFIG_TAGS = ["instance:http://localhost:11111"]
 
-NODE1 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-0.example.com"}
+NODE0 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-0.example.com"}
 
-NODE2 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-1.example.com"}
+NODE1 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-1.example.com"}
 
-NODE3 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-2.example.com"}
+NODE2 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-2.example.com"}
 
-ALL_NODES = [NODE1, NODE2, NODE3]
+ALL_NODES = [NODE0, NODE1, NODE2]

--- a/couch/tests/common.py
+++ b/couch/tests/common.py
@@ -52,8 +52,10 @@ BAD_CONFIG = {"server": "http://localhost:11111"}
 
 BAD_CONFIG_TAGS = ["instance:http://localhost:11111"]
 
-NODE1 = {"server": URL, "user": USER, "password": PASSWORD, "name": "node1@127.0.0.1"}
+NODE1 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-0.example.com"}
 
-NODE2 = {"server": URL, "user": USER, "password": PASSWORD, "name": "node2@127.0.0.1"}
+NODE2 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-1.example.com"}
 
-NODE3 = {"server": URL, "user": USER, "password": PASSWORD, "name": "node3@127.0.0.1"}
+NODE3 = {"server": URL, "user": USER, "password": PASSWORD, "name": "couchdb@couchdb-2.example.com"}
+
+ALL_NODES = [NODE1, NODE2, NODE3]

--- a/couch/tests/compose/compose_v1.yaml
+++ b/couch/tests/compose/compose_v1.yaml
@@ -2,6 +2,7 @@ version: '3.5'
 
 services:
   couch:
+    container_name: couchdb-0
     image: couchdb:${COUCH_VERSION}
     ports:
       - ${COUCH_PORT}:5984

--- a/couch/tests/compose/compose_v1.yaml
+++ b/couch/tests/compose/compose_v1.yaml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   couch:
-    container_name: couchdb-0
+    container_name: couchdb-1
     image: couchdb:${COUCH_VERSION}
     ports:
       - ${COUCH_PORT}:5984

--- a/couch/tests/compose/compose_v2.yaml
+++ b/couch/tests/compose/compose_v2.yaml
@@ -4,20 +4,6 @@ networks:
   network:
 
 services:
-  couchdb-0:
-    container_name: couchdb-0
-    image: couchdb:${COUCH_VERSION}
-    environment:
-      NODENAME: couchdb-0.example.com
-      COUCHDB_USER: ${COUCH_USER}
-      COUCHDB_PASSWORD: ${COUCH_PASSWORD}
-    networks:
-      network:
-        aliases:
-          - couchdb-0.example.com
-    ports:
-      - "${COUCH_PORT}:5984"
-      - "5986:5986"
   couchdb-1:
     container_name: couchdb-1
     image: couchdb:${COUCH_VERSION}
@@ -30,8 +16,8 @@ services:
         aliases:
           - couchdb-1.example.com
     ports:
-      - "15984:5984"
-      - "15986:5986"
+      - "${COUCH_PORT}:5984"
+      - "5986:5986"
   couchdb-2:
     container_name: couchdb-2
     image: couchdb:${COUCH_VERSION}
@@ -43,6 +29,20 @@ services:
       network:
         aliases:
           - couchdb-2.example.com
+    ports:
+      - "15984:5984"
+      - "15986:5986"
+  couchdb-3:
+    container_name: couchdb-3
+    image: couchdb:${COUCH_VERSION}
+    environment:
+      NODENAME: couchdb-3.example.com
+      COUCHDB_USER: ${COUCH_USER}
+      COUCHDB_PASSWORD: ${COUCH_PASSWORD}
+    networks:
+      network:
+        aliases:
+          - couchdb-3.example.com
     ports:
       - "25984:5984"
       - "25986:5986"

--- a/couch/tests/compose/compose_v2.yaml
+++ b/couch/tests/compose/compose_v2.yaml
@@ -1,8 +1,48 @@
-version: '3.5'
+version: "3.5"
+
+networks:
+  network:
 
 services:
-  couch:
-    image: datadog/docker-library:couch_${COUCH_VERSION}
+  couchdb-0:
+    container_name: couchdb-0
+    image: couchdb:${COUCH_VERSION}
+    environment:
+      NODENAME: couchdb-0.example.com
+      COUCHDB_USER: ${COUCH_USER}
+      COUCHDB_PASSWORD: ${COUCH_PASSWORD}
+    networks:
+      network:
+        aliases:
+          - couchdb-0.example.com
     ports:
-      - ${COUCH_PORT}:5984
-    command: --admin=dduser:pawprint --with-haproxy
+      - "${COUCH_PORT}:5984"
+      - "5986:5986"
+  couchdb-1:
+    container_name: couchdb-1
+    image: couchdb:${COUCH_VERSION}
+    environment:
+      NODENAME: couchdb-1.example.com
+      COUCHDB_USER: ${COUCH_USER}
+      COUCHDB_PASSWORD: ${COUCH_PASSWORD}
+    networks:
+      network:
+        aliases:
+          - couchdb-1.example.com
+    ports:
+      - "15984:5984"
+      - "15986:5986"
+  couchdb-2:
+    container_name: couchdb-2
+    image: couchdb:${COUCH_VERSION}
+    environment:
+      NODENAME: couchdb-2.example.com
+      COUCHDB_USER: ${COUCH_USER}
+      COUCHDB_PASSWORD: ${COUCH_PASSWORD}
+    networks:
+      network:
+        aliases:
+          - couchdb-2.example.com
+    ports:
+      - "25984:5984"
+      - "25986:5986"

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -3,16 +3,14 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
 import os
-from collections import defaultdict
 from copy import deepcopy
-from time import sleep
 
 import pytest
 import requests
 
 from datadog_checks.couch import CouchDb
-from datadog_checks.dev import WaitFor, docker_run
-from datadog_checks.dev.conditions import CheckEndpoints
+from datadog_checks.dev import docker_run
+from datadog_checks.dev.conditions import CheckDockerLogs, CheckEndpoints, WaitFor
 
 from . import common
 
@@ -51,61 +49,33 @@ def dd_environment():
     up.
     """
     couch_version = os.environ["COUCH_VERSION"][0]
-
-    with docker_run(
-        compose_file=os.path.join(common.HERE, 'compose', 'compose_v{}.yaml'.format(couch_version)),
-        env_vars={'COUCH_PORT': common.PORT},
-        conditions=[
-            CheckEndpoints([common.URL]),
-            lambda: generate_data(couch_version),
-            WaitFor(send_replication, args=(couch_version,), wait=2, attempts=60),
-            WaitFor(get_replication, args=(couch_version,), wait=3, attempts=40),
-        ],
-    ):
-        if couch_version == '1':
+    if couch_version == "1":
+        with docker_run(
+            compose_file=os.path.join(common.HERE, 'compose', 'compose_v1.yaml'),
+            env_vars={'COUCH_PORT': common.PORT},
+            conditions=[
+                CheckEndpoints([common.URL]),
+                CheckDockerLogs('couchdb-0', ['CouchDB has started']),
+                WaitFor(generate_data, args=(couch_version,)),
+            ],
+        ):
             yield common.BASIC_CONFIG
-        elif couch_version == '2':
+
+    else:
+        with docker_run(
+            compose_file=os.path.join(common.HERE, 'compose', 'compose_v2.yaml'),
+            env_vars={'COUCH_PORT': common.PORT, 'COUCH_USER': common.USER, 'COUCH_PASSWORD': common.PASSWORD},
+            conditions=[
+                CheckEndpoints([common.URL]),
+                CheckDockerLogs('couchdb-0', ['Started replicator db changes listener']),
+                WaitFor(enable_cluster),
+                WaitFor(generate_data, args=(couch_version,)),
+                WaitFor(check_node_stats),
+                WaitFor(send_replication),
+                WaitFor(get_replication),
+            ],
+        ):
             yield common.BASIC_CONFIG_V2
-
-
-def send_replication(couch_version):
-    """
-    Send replication task to trigger tasks
-    """
-    if couch_version == '1':
-        return
-
-    replicator_url = "{}/_replicator".format(common.NODE1['server'])
-
-    replication_body = {
-        '_id': 'my_replication_id',
-        'source': 'http://dduser:pawprint@127.0.0.1:5984/kennel',
-        'target': 'http://dduser:pawprint@127.0.0.1:5984/kennel_replica',
-        'create_target': True,
-        'continuous': True,
-    }
-    r = requests.post(
-        replicator_url,
-        auth=(common.NODE1['user'], common.NODE1['password']),
-        headers={'Content-Type': 'application/json'},
-        json=replication_body,
-    )
-    r.raise_for_status()
-
-
-def get_replication(couch_version):
-    """
-    Attempt to get active replication tasks
-    """
-    if couch_version == '1':
-        return
-
-    task_url = "{}/_active_tasks".format(common.NODE1['server'])
-
-    r = requests.get(task_url, auth=(common.NODE1['user'], common.NODE1['password']))
-    r.raise_for_status()
-    count = len(r.json())
-    return count > 0
 
 
 def generate_data(couch_version):
@@ -118,6 +88,8 @@ def generate_data(couch_version):
 
     # Generate a test database
     requests.put("{}/kennel".format(common.URL), auth=auth, headers=headers)
+    for i in range(5):
+        requests.put("{}/db{}".format(common.URL, i), auth=auth, headers=headers)
 
     # Populate the database
     data = {
@@ -129,37 +101,97 @@ def generate_data(couch_version):
     }
     requests.put("{}/kennel/_design/dummy".format(common.URL), json=data, auth=auth, headers=headers)
 
-    urls = [
-        "{}/_node/node1@127.0.0.1/_stats".format(common.URL),
-        "{}/_node/node2@127.0.0.1/_stats".format(common.URL),
-        "{}/_node/node3@127.0.0.1/_stats".format(common.URL),
-    ]
 
-    ready = defaultdict(bool)
-    for _ in range(120):
-        print("Waiting for stats to be generated on the nodes...")
-        try:
-            for url in urls:
-                if not ready[url]:
-                    res = requests.get(url, auth=auth, headers=headers)
-                    if res.json():
-                        ready[url] = True
-            if len(ready) and all(ready.values()):
-                break
-        except Exception:
-            pass
-        sleep(1)
+def send_replication():
+    """
+    Send replication task to trigger tasks
+    """
+    replicator_url = "{}/_replicate".format(common.NODE1['server'])
 
-    if couch_version == "1":
-        return
+    replication_body = {
+        '_id': 'my_replication_id',
+        'source': 'http://dduser:pawprint@127.0.0.1:5984/kennel',
+        'target': 'http://dduser:pawprint@127.0.0.1:5984/kennel_replica',
+        'create_target': True,
+        'continuous': True,
+    }
+    for i in range(5):
+        print("[INFO] create replication task {}".format(i))
+        body = replication_body.copy()
+        body['_id'] = 'my_replication_id_{}'.format(i)
+        body['target'] = body['target'] + str(i)
+        r = requests.post(
+            replicator_url,
+            auth=(common.NODE1['user'], common.NODE1['password']),
+            headers={'Content-Type': 'application/json'},
+            json=body,
+        )
+        r.raise_for_status()
+        print("[INFO] replication task created:", r.json())
 
-    doc_url = "{}/_replicator/_all_docs".format(common.URL)
-    for _ in range(120):
-        try:
-            res = requests.get(doc_url, auth=auth, headers=headers)
-            data = res.json()
-            if data.get('rows'):
-                break
-        except Exception:
-            pass
-        sleep(1)
+
+def get_replication():
+    """
+    Attempt to get active replication tasks
+    """
+    task_url = "{}/_active_tasks".format(common.NODE1['server'])
+
+    r = requests.get(task_url, auth=(common.NODE1['user'], common.NODE1['password']))
+    r.raise_for_status()
+    active_tasks = r.json()
+    print("[INFO] active_tasks response:", active_tasks)
+    count = len(active_tasks)
+    return count > 0
+
+
+def enable_cluster():
+    auth = (common.USER, common.PASSWORD)
+    headers = {'Accept': 'text/json'}
+
+    requests_data = []
+    for node in ["couchdb-1.example.com", "couchdb-2.example.com"]:
+        requests_data.append(
+            {
+                "action": "enable_cluster",
+                "username": common.USER,
+                "password": common.PASSWORD,
+                "bind_address": "0.0.0.0",
+                "port": 5984,
+                "node_count": 3,
+                "remote_node": node,
+                "remote_current_user": common.USER,
+                "remote_current_password": common.PASSWORD,
+            }
+        )
+        requests_data.append(
+            {
+                "action": "add_node",
+                "username": common.USER,
+                "password": common.PASSWORD,
+                "host": node,
+                "port": 5984,
+                "singlenode": False,
+            }
+        )
+
+    for data in requests_data:
+        resp = requests.post("{}/_cluster_setup".format(common.URL), json=data, auth=auth, headers=headers)
+        resp_data = resp.json()
+        print('[INFO] cluster setup resp', resp_data)
+
+    resp = requests.get("{}/_membership".format(common.URL), auth=auth, headers=headers)
+    membership = resp.json()
+    print("[INFO] membership response:", membership)
+    assert len(membership['cluster_nodes']) == 3
+
+
+def check_node_stats():
+    auth = (common.USER, common.PASSWORD)
+    headers = {'Accept': 'text/json'}
+    # Check all nodes have stats
+    for node in common.ALL_NODES:
+        url = "{}/_node/{}/_stats".format(common.URL, node['name'])
+        print("[INFO] get stats url:", url)
+        res = requests.get(url, auth=auth, headers=headers)
+        data = res.json()
+        assert "global_changes" in data

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -83,7 +83,7 @@ def enable_cluster():
     headers = {'Accept': 'text/json'}
 
     requests_data = []
-    for node in ["couchdb-1.example.com", "couchdb-2.example.com"]:
+    for node in [common.NODE1, common.NODE2]:
         requests_data.append(
             {
                 "action": "enable_cluster",

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -55,7 +55,7 @@ def dd_environment():
             env_vars={'COUCH_PORT': common.PORT},
             conditions=[
                 CheckEndpoints([common.URL]),
-                CheckDockerLogs('couchdb-0', ['CouchDB has started']),
+                CheckDockerLogs('couchdb-1', ['CouchDB has started']),
                 WaitFor(generate_data, args=(couch_version,)),
             ],
         ):
@@ -67,7 +67,7 @@ def dd_environment():
             env_vars={'COUCH_PORT': common.PORT, 'COUCH_USER': common.USER, 'COUCH_PASSWORD': common.PASSWORD},
             conditions=[
                 CheckEndpoints([common.URL]),
-                CheckDockerLogs('couchdb-0', ['Started replicator db changes listener']),
+                CheckDockerLogs('couchdb-1', ['Started replicator db changes listener']),
                 WaitFor(enable_cluster),
                 WaitFor(generate_data, args=(couch_version,)),
                 WaitFor(check_node_stats),
@@ -83,7 +83,7 @@ def enable_cluster():
     headers = {'Accept': 'text/json'}
 
     requests_data = []
-    for node in [common.NODE1, common.NODE2]:
+    for node in [common.NODE2, common.NODE3]:
         _, node_name = node['name'].split('@')
         requests_data.append(
             {
@@ -166,7 +166,7 @@ def send_replication():
     """
     Send replication task to trigger tasks
     """
-    replicator_url = "{}/_replicate".format(common.NODE0['server'])
+    replicator_url = "{}/_replicate".format(common.NODE1['server'])
 
     replication_body = {
         '_id': 'my_replication_id',
@@ -181,7 +181,7 @@ def send_replication():
         body['target'] = body['target'] + str(i)
         r = requests.post(
             replicator_url,
-            auth=(common.NODE0['user'], common.NODE0['password']),
+            auth=(common.NODE1['user'], common.NODE1['password']),
             headers={'Content-Type': 'application/json'},
             json=body,
         )
@@ -192,9 +192,9 @@ def get_replication():
     """
     Attempt to get active replication tasks
     """
-    task_url = "{}/_active_tasks".format(common.NODE0['server'])
+    task_url = "{}/_active_tasks".format(common.NODE1['server'])
 
-    r = requests.get(task_url, auth=(common.NODE0['user'], common.NODE0['password']))
+    r = requests.get(task_url, auth=(common.NODE1['user'], common.NODE1['password']))
     r.raise_for_status()
     active_tasks = r.json()
     count = len(active_tasks)

--- a/couch/tests/fixtures/_active_tasks.json
+++ b/couch/tests/fixtures/_active_tasks.json
@@ -1,6 +1,6 @@
 [
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.example.com",
       "pid": "<0.10672.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -12,7 +12,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.example.com",
       "pid": "<0.10674.0>",
       "changes_done": 0,
       "database": "shards/c0000000-dfffffff/kennel.1525771285",
@@ -24,7 +24,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.example.com",
       "pid": "<0.10676.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -36,7 +36,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.example.com",
       "pid": "<0.10678.0>",
       "changes_done": 0,
       "database": "shards/20000000-3fffffff/kennel.1525771285",
@@ -48,7 +48,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.example.com",
       "pid": "<0.10680.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -60,7 +60,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.example.com",
       "pid": "<0.10682.0>",
       "changes_done": 0,
       "database": "shards/60000000-7fffffff/kennel.1525771285",
@@ -72,7 +72,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node2@127.0.0.1",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.11052.0>",
       "changes_done": 0,
       "database": "shards/00000000-1fffffff/kennel.1525771285",
@@ -84,7 +84,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node2@127.0.0.1",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.11079.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -96,7 +96,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node2@127.0.0.1",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.11081.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -108,7 +108,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node2@127.0.0.1",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.11083.0>",
       "changes_done": 0,
       "database": "shards/40000000-5fffffff/kennel.1525771285",
@@ -120,7 +120,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node2@127.0.0.1",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.11087.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -132,7 +132,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node2@127.0.0.1",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.11089.0>",
       "changes_done": 0,
       "database": "shards/c0000000-dfffffff/kennel.1525771285",
@@ -144,7 +144,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node3@127.0.0.1",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.10439.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -156,7 +156,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node3@127.0.0.1",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.10445.0>",
       "changes_done": 0,
       "database": "shards/40000000-5fffffff/kennel.1525771285",
@@ -168,7 +168,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node3@127.0.0.1",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.10453.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -180,7 +180,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node3@127.0.0.1",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.10455.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -192,7 +192,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node3@127.0.0.1",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.10457.0>",
       "changes_done": 0,
       "database": "shards/60000000-7fffffff/kennel.1525771285",
@@ -204,7 +204,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "node1@127.0.0.1",
+      "node": "couchdb@couchdb-0.example.com",
       "changes_done": 44461,
       "database": "my_db",
       "pid": "<0.218.0>",

--- a/couch/tests/fixtures/_active_tasks.json
+++ b/couch/tests/fixtures/_active_tasks.json
@@ -1,6 +1,6 @@
 [
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.10672.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -12,7 +12,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.10674.0>",
       "changes_done": 0,
       "database": "shards/c0000000-dfffffff/kennel.1525771285",
@@ -24,7 +24,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.10676.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -36,7 +36,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.10678.0>",
       "changes_done": 0,
       "database": "shards/20000000-3fffffff/kennel.1525771285",
@@ -48,7 +48,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.10680.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -60,7 +60,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "pid": "<0.10682.0>",
       "changes_done": 0,
       "database": "shards/60000000-7fffffff/kennel.1525771285",
@@ -72,7 +72,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.example.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.11052.0>",
       "changes_done": 0,
       "database": "shards/00000000-1fffffff/kennel.1525771285",
@@ -84,7 +84,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.example.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.11079.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -96,7 +96,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.example.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.11081.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -108,7 +108,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.example.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.11083.0>",
       "changes_done": 0,
       "database": "shards/40000000-5fffffff/kennel.1525771285",
@@ -120,7 +120,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.example.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.11087.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -132,7 +132,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-1.example.com",
+      "node": "couchdb@couchdb-2.example.com",
       "pid": "<0.11089.0>",
       "changes_done": 0,
       "database": "shards/c0000000-dfffffff/kennel.1525771285",
@@ -144,7 +144,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.example.com",
+      "node": "couchdb@couchdb-3.example.com",
       "pid": "<0.10439.0>",
       "changes_done": 0,
       "database": "shards/e0000000-ffffffff/kennel.1525771285",
@@ -156,7 +156,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.example.com",
+      "node": "couchdb@couchdb-3.example.com",
       "pid": "<0.10445.0>",
       "changes_done": 0,
       "database": "shards/40000000-5fffffff/kennel.1525771285",
@@ -168,7 +168,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.example.com",
+      "node": "couchdb@couchdb-3.example.com",
       "pid": "<0.10453.0>",
       "changes_done": 0,
       "database": "shards/a0000000-bfffffff/kennel.1525771285",
@@ -180,7 +180,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.example.com",
+      "node": "couchdb@couchdb-3.example.com",
       "pid": "<0.10455.0>",
       "changes_done": 0,
       "database": "shards/80000000-9fffffff/kennel.1525771285",
@@ -192,7 +192,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-2.example.com",
+      "node": "couchdb@couchdb-3.example.com",
       "pid": "<0.10457.0>",
       "changes_done": 0,
       "database": "shards/60000000-7fffffff/kennel.1525771285",
@@ -204,7 +204,7 @@
       "updated_on": 1525771365
     },
     {
-      "node": "couchdb@couchdb-0.example.com",
+      "node": "couchdb@couchdb-1.example.com",
       "changes_done": 44461,
       "database": "my_db",
       "pid": "<0.218.0>",

--- a/couch/tests/test_couch.py
+++ b/couch/tests/test_couch.py
@@ -7,8 +7,6 @@ from datadog_checks.couch import CouchDb
 
 from . import common
 
-COUCHDB2_VERSIONS = {'2_3': '2.3.1'}
-
 
 @pytest.mark.usefixtures("dd_environment")
 def test_collect_metadata_instance(aggregator, datadog_agent, instance):
@@ -16,10 +14,6 @@ def test_collect_metadata_instance(aggregator, datadog_agent, instance):
     check.check_id = common.CHECK_ID
     check.check(instance)
     version = common.COUCH_RAW_VERSION
-
-    # CouchDB2 version is formatted differently for the datadog hosted image
-    if common.COUCH_MAJOR_VERSION == 2:
-        version = COUCHDB2_VERSIONS[common.COUCH_RAW_VERSION]
 
     major, minor, patch = version.split('.')
     version_metadata = {

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -126,7 +126,7 @@ def test_db_whitelisting(aggregator, gauges):
 
     for n in [common.NODE1, common.NODE2, common.NODE3]:
         node = deepcopy(n)
-        node['db_whitelist'] = ['db0', 'db2', 'db4']
+        node['db_whitelist'] = ['db0']
         configs.append(node)
 
     for config in configs:
@@ -134,12 +134,12 @@ def test_db_whitelisting(aggregator, gauges):
         check.check(config)
 
     for _ in configs:
-        for db in ['db0', 'db2', 'db4']:
+        for db in ['db0']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags)
 
-        for db in ['db1', 'db3']:
+        for db in ['db1']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags, count=0)
@@ -152,7 +152,7 @@ def test_db_blacklisting(aggregator, gauges):
 
     for node in [common.NODE1, common.NODE2, common.NODE3]:
         config = deepcopy(node)
-        config['db_blacklist'] = ['db0', 'db2', 'db4']
+        config['db_blacklist'] = ['db0']
         configs.append(config)
 
     for config in configs:
@@ -160,12 +160,12 @@ def test_db_blacklisting(aggregator, gauges):
         check.check(config)
 
     for _ in configs:
-        for db in ['db1', 'db3']:
+        for db in ['db1']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags)
 
-        for db in ['db0', 'db2', 'db4']:
+        for db in ['db0']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags, count=0)

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -126,7 +126,7 @@ def test_db_whitelisting(aggregator, gauges):
 
     for n in [common.NODE1, common.NODE2, common.NODE3]:
         node = deepcopy(n)
-        node['db_whitelist'] = ['kennel']
+        node['db_whitelist'] = ['db0', 'db2', 'db4']
         configs.append(node)
 
     for config in configs:
@@ -134,14 +134,15 @@ def test_db_whitelisting(aggregator, gauges):
         check.check(config)
 
     for _ in configs:
-        for db in ['kennel_replica0']:
+        for db in ['db0', 'db2', 'db4']:
+            expected_tags = ["db:{}".format(db)]
+            for gauge in gauges["by_db_gauges"]:
+                aggregator.assert_metric(gauge, tags=expected_tags)
+
+        for db in ['db1', 'db3']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags, count=0)
-
-        for gauge in gauges["by_db_gauges"]:
-            expected_tags = ["db:kennel"]
-            aggregator.assert_metric(gauge, tags=expected_tags)
 
 
 @pytest.mark.usefixtures('dd_environment')
@@ -151,7 +152,7 @@ def test_db_blacklisting(aggregator, gauges):
 
     for node in [common.NODE1, common.NODE2, common.NODE3]:
         config = deepcopy(node)
-        config['db_blacklist'] = ['db1']
+        config['db_blacklist'] = ['db0', 'db2', 'db4']
         configs.append(config)
 
     for config in configs:
@@ -159,14 +160,15 @@ def test_db_blacklisting(aggregator, gauges):
         check.check(config)
 
     for _ in configs:
-        for db in ['db2']:
+        for db in ['db1', 'db3']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags)
 
-        for gauge in gauges["by_db_gauges"]:
-            expected_tags = ["db:db1"]
-            aggregator.assert_metric(gauge, tags=expected_tags, count=0)
+        for db in ['db0', 'db2', 'db4']:
+            expected_tags = ["db:{}".format(db)]
+            for gauge in gauges["by_db_gauges"]:
+                aggregator.assert_metric(gauge, tags=expected_tags, count=0)
 
 
 @pytest.mark.usefixtures('dd_environment')

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -20,7 +20,7 @@ from . import common
 
 pytestmark = pytest.mark.skipif(common.COUCH_MAJOR_VERSION != 2, reason='Test for version Couch v2')
 
-INSTANCES = [common.NODE0, common.NODE1, common.NODE2]
+INSTANCES = [common.NODE1, common.NODE2, common.NODE3]
 
 
 @pytest.fixture(scope="module")
@@ -103,11 +103,11 @@ def _assert_check(aggregator, gauges):
             expected_tags = ["db:{}".format(db)]
             aggregator.assert_metric(gauge, tags=expected_tags)
 
-    expected_tags = ["instance:{}".format(common.NODE0["name"])]
+    expected_tags = ["instance:{}".format(common.NODE1["name"])]
     # One for the version, one for the server stats
     aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=2)
 
-    for node in [common.NODE1, common.NODE2]:
+    for node in [common.NODE2, common.NODE3]:
         expected_tags = ["instance:{}".format(node["name"])]
         # One for the server stats, the version is already loaded
         aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=2)
@@ -124,7 +124,7 @@ def _assert_check(aggregator, gauges):
 def test_db_whitelisting(aggregator, gauges):
     configs = []
 
-    for n in [common.NODE0, common.NODE1, common.NODE2]:
+    for n in [common.NODE1, common.NODE2, common.NODE3]:
         node = deepcopy(n)
         node['db_whitelist'] = ['db0']
         configs.append(node)
@@ -150,7 +150,7 @@ def test_db_whitelisting(aggregator, gauges):
 def test_db_blacklisting(aggregator, gauges):
     configs = []
 
-    for node in [common.NODE0, common.NODE1, common.NODE2]:
+    for node in [common.NODE1, common.NODE2, common.NODE3]:
         config = deepcopy(node)
         config['db_blacklist'] = ['db0']
         configs.append(config)
@@ -174,12 +174,12 @@ def test_db_blacklisting(aggregator, gauges):
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
 def test_check_without_names(aggregator, gauges):
-    config = deepcopy(common.NODE0)
+    config = deepcopy(common.NODE1)
     config.pop('name')
     check = CouchDb(common.CHECK_NAME, {}, [config])
     check.check(config)
 
-    configs = [common.NODE0, common.NODE1, common.NODE2]
+    configs = [common.NODE1, common.NODE2, common.NODE3]
 
     for config in configs:
         expected_tags = ["instance:{}".format(config["name"])]
@@ -206,7 +206,7 @@ def test_check_without_names(aggregator, gauges):
     # One for the version, one for the server stats
     aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=1)
 
-    for node in [common.NODE1, common.NODE2]:
+    for node in [common.NODE2, common.NODE3]:
         expected_tags = ["instance:{}".format(node["name"])]
         # One for the server stats, the version is already loaded
         aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=1)
@@ -218,7 +218,7 @@ def test_check_without_names(aggregator, gauges):
 @pytest.mark.integration
 @pytest.mark.parametrize('number_nodes', [1, 2, 3])
 def test_only_max_nodes_are_scanned(aggregator, gauges, number_nodes):
-    config = deepcopy(common.NODE0)
+    config = deepcopy(common.NODE1)
     config.pop("name")
     config['max_nodes_per_check'] = number_nodes
 
@@ -242,7 +242,7 @@ def test_only_max_nodes_are_scanned(aggregator, gauges, number_nodes):
 @pytest.mark.integration
 @pytest.mark.parametrize('number_db', [1, 2, 3])
 def test_only_max_dbs_are_scanned(aggregator, gauges, number_db):
-    config = deepcopy(common.NODE0)
+    config = deepcopy(common.NODE1)
     config["max_dbs_per_check"] = number_db
 
     check = CouchDb(common.CHECK_NAME, {}, [config])
@@ -264,7 +264,7 @@ def test_only_max_dbs_are_scanned(aggregator, gauges, number_db):
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
 def test_replication_metrics(aggregator, gauges):
-    for config in [common.NODE0, common.NODE1, common.NODE2]:
+    for config in [common.NODE1, common.NODE2, common.NODE3]:
         check = CouchDb(common.CHECK_NAME, {}, [config])
         check.check(config)
 
@@ -284,10 +284,10 @@ def test_compaction_metrics(aggregator, gauges, active_tasks):
     def _get_active_tasks(server, name, tags):
         return active_tasks
 
-    check = CouchDb(common.CHECK_NAME, {}, [common.NODE0])
+    check = CouchDb(common.CHECK_NAME, {}, [common.NODE1])
     check.checker = couch.CouchDB2(check)
     check.checker._get_active_tasks = _get_active_tasks
-    check.check(common.NODE0)
+    check.check(common.NODE1)
 
     for gauge in gauges["compaction_tasks_gauges"]:
         aggregator.assert_metric(gauge)
@@ -308,13 +308,13 @@ def test_indexing_metrics(aggregator, gauges, active_tasks):
         return {}
 
     # run the check on all instances
-    for config in [common.NODE0, common.NODE1, common.NODE2]:
+    for config in [common.NODE1, common.NODE2, common.NODE3]:
         check = CouchDb(common.CHECK_NAME, {}, [config])
         check.checker = couch.CouchDB2(check)
         check.get = _get
         check.check(config)
 
-    for node in [common.NODE0, common.NODE1, common.NODE2]:
+    for node in [common.NODE1, common.NODE2, common.NODE3]:
         expected_tags = ['database:kennel', 'design_document:dummy', 'instance:{}'.format(node['name'])]
         for gauge in gauges["indexing_tasks_gauges"]:
             aggregator.assert_metric(gauge, tags=expected_tags)
@@ -384,7 +384,7 @@ def test_view_compaction_metrics(aggregator, gauges):
 
     threads = []
     for _ in range(40):
-        t = LoadGenerator(common.NODE0['server'], (common.NODE0['user'], common.NODE0['password']))
+        t = LoadGenerator(common.NODE1['server'], (common.NODE1['user'], common.NODE1['password']))
         t.start()
         threads.append(t)
 
@@ -395,7 +395,7 @@ def test_view_compaction_metrics(aggregator, gauges):
             tries += 1
 
             try:
-                for config in [common.NODE0, common.NODE1, common.NODE2]:
+                for config in [common.NODE1, common.NODE2, common.NODE3]:
                     check = CouchDb(common.CHECK_NAME, {}, [config])
                     check.check(config)
             except Exception:
@@ -423,7 +423,7 @@ def test_view_compaction_metrics(aggregator, gauges):
 @pytest.mark.integration
 def test_config_tags(aggregator, gauges):
     TEST_TAG = "test_tag:test"
-    config = deepcopy(common.NODE0)
+    config = deepcopy(common.NODE1)
     config['tags'] = [TEST_TAG]
 
     check = CouchDb(common.CHECK_NAME, {}, [config])

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -227,8 +227,7 @@ def test_only_max_nodes_are_scanned(aggregator, gauges, number_nodes):
 
     metrics = []
     for metric_list in aggregator._metrics.values():
-        for m in metric_list:
-            metrics.append(m)
+        metrics.extend(metric_list)
 
     instance_tags = set()
     for m in metrics:
@@ -251,8 +250,7 @@ def test_only_max_dbs_are_scanned(aggregator, gauges, number_db):
 
     metrics = []
     for metric_list in aggregator._metrics.values():
-        for m in metric_list:
-            metrics.append(m)
+        metrics.extend(metric_list)
 
     db_tags = set()
     for m in metrics:

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -93,12 +93,12 @@ def _assert_check(aggregator, gauges):
         for gauge in gauges["erlang_gauges"]:
             aggregator.assert_metric(gauge)
 
-    for db, dd in {"kennel": "dummy", "_replicator": "_replicator", "_users": "_auth"}.items():
+    for db, dd in {"kennel": "dummy"}.items():
         for gauge in gauges["by_dd_gauges"]:
             expected_tags = ["design_document:{}".format(dd), "language:javascript", "db:{}".format(db)]
             aggregator.assert_metric(gauge, tags=expected_tags)
 
-    for db in ["_users", "_global_changes", "_replicator", "kennel"]:
+    for db in ["kennel", "db1"]:
         for gauge in gauges["by_db_gauges"]:
             expected_tags = ["db:{}".format(db)]
             aggregator.assert_metric(gauge, tags=expected_tags)
@@ -134,7 +134,7 @@ def test_db_whitelisting(aggregator, gauges):
         check.check(config)
 
     for _ in configs:
-        for db in ['_users', '_global_changes', '_replicator']:
+        for db in ['kennel_replica0']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags, count=0)
@@ -151,7 +151,7 @@ def test_db_blacklisting(aggregator, gauges):
 
     for node in [common.NODE1, common.NODE2, common.NODE3]:
         config = deepcopy(node)
-        config['db_blacklist'] = ['kennel']
+        config['db_blacklist'] = ['db1']
         configs.append(config)
 
     for config in configs:
@@ -159,13 +159,13 @@ def test_db_blacklisting(aggregator, gauges):
         check.check(config)
 
     for _ in configs:
-        for db in ['_users', '_global_changes', '_replicator']:
+        for db in ['db2']:
             expected_tags = ["db:{}".format(db)]
             for gauge in gauges["by_db_gauges"]:
                 aggregator.assert_metric(gauge, tags=expected_tags)
 
         for gauge in gauges["by_db_gauges"]:
-            expected_tags = ["db:kennel"]
+            expected_tags = ["db:db1"]
             aggregator.assert_metric(gauge, tags=expected_tags, count=0)
 
 
@@ -190,12 +190,12 @@ def test_check_without_names(aggregator, gauges):
         for gauge in gauges["replication_tasks_gauges"]:
             aggregator.assert_metric(gauge)
 
-    for db, dd in {"kennel": "dummy", "_replicator": "_replicator", "_users": "_auth"}.items():
+    for db, dd in {"kennel": "dummy"}.items():
         expected_tags = ["design_document:{}".format(dd), "language:javascript", "db:{}".format(db)]
         for gauge in gauges["by_dd_gauges"]:
             aggregator.assert_metric(gauge, tags=expected_tags)
 
-    for db in ["_users", "_global_changes", "_replicator", "kennel"]:
+    for db in ["kennel"]:
         expected_tags = ["db:{}".format(db)]
         for gauge in gauges["by_db_gauges"]:
             aggregator.assert_metric(gauge, tags=expected_tags)
@@ -214,81 +214,51 @@ def test_check_without_names(aggregator, gauges):
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_only_max_nodes_are_scanned(aggregator, gauges):
+@pytest.mark.parametrize('number_nodes', [1, 2, 3])
+def test_only_max_nodes_are_scanned(aggregator, gauges, number_nodes):
     config = deepcopy(common.NODE1)
     config.pop("name")
-    config['max_nodes_per_check'] = 2
+    config['max_nodes_per_check'] = number_nodes
 
     check = CouchDb(common.CHECK_NAME, {}, [config])
     check.check(config)
 
-    for gauge in gauges["erlang_gauges"]:
-        aggregator.assert_metric(gauge)
+    metrics = []
+    for metric_list in aggregator._metrics.values():
+        for m in metric_list:
+            metrics.append(m)
 
-    for gauge in gauges["replication_tasks_gauges"]:
-        aggregator.assert_metric(gauge)
+    instance_tags = set()
+    for m in metrics:
+        for tag in m.tags:
+            if tag.startswith('instance:'):
+                instance_tags.add(tag)
 
-    for config in [common.NODE1, common.NODE2]:
-        expected_tags = ["instance:{}".format(config["name"])]
-        for gauge in gauges["cluster_gauges"]:
-            aggregator.assert_metric(gauge, tags=expected_tags)
-
-    for db in ["_users", "_global_changes", "_replicator"]:
-        expected_tags = ["db:{}".format(db)]
-        for gauge in gauges["by_db_gauges"]:
-            aggregator.assert_metric(gauge, tags=expected_tags)
-
-    for db, dd in {"_replicator": "_replicator", "_users": "_auth"}.items():
-        expected_tags = ["design_document:{}".format(dd), "language:javascript", "db:{}".format(db)]
-        for gauge in gauges["by_dd_gauges"]:
-            aggregator.assert_metric(gauge, tags=expected_tags)
-
-    expected_tags = ["instance:{}".format(config["server"])]
-    # One for the version as we don't have any names to begin with
-    aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=1)
-
-    for node in [common.NODE1, common.NODE2]:
-        expected_tags = ["instance:{}".format(node["name"])]
-        # One for the server stats, the version is already loaded
-        aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=1)
-
-    expected_tags = ["instance:{}".format(common.NODE3["name"])]
-    for gauge in gauges["cluster_gauges"]:
-        aggregator.assert_metric(gauge, tags=expected_tags, count=0)
-
-    for db in ['_users', '_global_changes', '_replicator', 'kennel']:
-        expected_tags = [expected_tags[0], "db:{}".format(db)]
-        for gauge in gauges["by_db_gauges"]:
-            aggregator.assert_metric(gauge, tags=expected_tags, count=0)
-
-    expected_tags = ["instance:{}".format(common.NODE3["name"])]
-    aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=0)
-
-    aggregator.assert_all_metrics_covered()
+    assert len(instance_tags) == number_nodes
 
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_only_max_dbs_are_scanned(aggregator, gauges):
-    configs = []
-    for node in [common.NODE1, common.NODE2, common.NODE3]:
-        config = deepcopy(node)
-        config["max_dbs_per_check"] = 1
-        configs.append(config)
+@pytest.mark.parametrize('number_db', [1, 2, 3])
+def test_only_max_dbs_are_scanned(aggregator, gauges, number_db):
+    config = deepcopy(common.NODE1)
+    config["max_dbs_per_check"] = number_db
 
-    for config in configs:
-        check = CouchDb(common.CHECK_NAME, {}, [config])
-        check.check(config)
+    check = CouchDb(common.CHECK_NAME, {}, [config])
+    check.check(config)
 
-    for db in ['kennel', '_replicator']:
-        expected_tags = ["db:{}".format(db)]
-        for gauge in gauges["by_db_gauges"]:
-            aggregator.assert_metric(gauge, tags=expected_tags, count=0)
+    metrics = []
+    for metric_list in aggregator._metrics.values():
+        for m in metric_list:
+            metrics.append(m)
 
-    for db in ['_global_changes', '_users']:
-        expected_tags = ["db:{}".format(db)]
-        for gauge in gauges["by_db_gauges"]:
-            aggregator.assert_metric(gauge, tags=expected_tags, count=1)
+    db_tags = set()
+    for m in metrics:
+        for tag in m.tags:
+            if tag.startswith('db:'):
+                db_tags.add(tag)
+
+    assert len(db_tags) == number_db
 
 
 @pytest.mark.usefixtures('dd_environment')

--- a/couch/tox.ini
+++ b/couch/tox.ini
@@ -18,7 +18,7 @@ passenv =
     DOCKER*
 setenv =
     1.6: COUCH_VERSION=1.6.1
-    2.3: COUCH_VERSION=2_3
+    2.3: COUCH_VERSION=2.3.1
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
Sandbox PR: https://github.com/DataDog/integrations-core/pull/6440

[Pipeline Builds](https://dev.azure.com/datadoghq/integrations-core/_build?definitionId=6&_a=summary&branchFilter=2703)

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix flaky tests and use official docker image


120 successful builds
![image](https://user-images.githubusercontent.com/49917914/80200784-713caa80-8623-11ea-9299-afe1230a9d6a.png)


### Motivation
<!-- What inspired you to submit this pull request? -->

```

            time.sleep(self.wait)
        else:
>           raise RetryError(
                'Result: {}\nError: {}\nFunction: {}, Args: {}, Kwargs: {}\n'.format(
                    repr(last_result), last_error, self.func.__name__, self.args, self.kwargs
                )
            )
E           datadog_checks.dev.errors.RetryError: Result: False
E           Error: None
E           Function: get_replication, Args: ('2',), Kwargs: {}

../datadog_checks_dev/datadog_checks/dev/conditions.py:48: RetryError
---------------------------- Captured stdout setup -----------------------------
Waiting for stats to be generated on the nodes...
Waiting for stats to be generated on the nodes...
Waiting for stats to be generated on the nodes...
Waiting for stats to be generated on the nodes...
Attaching to compose_couch_1
couch_1  | [ * ] Setup environment ... ok
couch_1  | [ * ] Ensure CouchDB is built ... ok
couch_1  | [ * ] Prepare configuration files ... ok
couch_1  | [ * ] Start node node1 ... ok
couch_1  | [ * ] Start node node2 ... ok
couch_1  | [ * ] Start node node3 ... ok
couch_1  | [ * ] Check node at http://127.0.0.1:15984/ ... ok
couch_1  | [ * ] Check node at http://127.0.0.1:25984/ ... ok
couch_1  | [ * ] Check node at http://127.0.0.1:35984/ ... ok
couch_1  | [ * ] Running cluster setup ... ok
couch_1  | [ * ] Developers cluster is set up at http://127.0.0.1:15984.
couch_1  | Admin username: dduser
couch_1  | Password: pawprint

```

- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13542&view=logs&jobId=c73aedc7-d1f1-5bee-93b6-629007590bd5&j=c73aedc7-d1f1-5bee-93b6-629007590bd5&t=7b58fc00-c48d-5e79-d458-fcdf7976c98f
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13546&view=logs&j=2ab1c2a9-b99d-5635-db6c-1df7fa16203c&t=b9844dff-51dd-556e-cad6-453479ddb360
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13546&view=logs&j=b07b42a6-4264-50a6-0efd-ee8d014c0218&t=8b7d1eea-399d-5dd2-09fb-0baf9d94f451
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13550&view=logs&j=965095b0-692a-5c14-24f4-254c6ac3a9cb&t=31e59c68-b6a9-5840-4ea0-b0fde12615d7

Envs:
- ERROR:   py27-2.3: commands failed
- ERROR:   py38-2.3: commands failed


```
___________________________________ test_e2e ___________________________________
tests/test_couchv2.py:80: in test_e2e
    aggregator = dd_agent_check({'init_config': {}, 'instances': deepcopy(INSTANCES)})
../datadog_checks_dev/datadog_checks/dev/plugin/pytest.py:197: in run_check
    replay_check_run(collector, aggregator)
../datadog_checks_dev/datadog_checks/dev/_env.py:118: in replay_check_run
    raise Exception("\n".join("Message: {}\n{}".format(err['message'], err['traceback']) for err in errors))
E   Exception: Message: 'node1@127.0.0.1' is not in list
E   Traceback (most recent call last):
E     File "/home/datadog_checks_base/datadog_checks/base/checks/base.py", line 820, in run
E       self.check(instance)
E     File "/home/couch/datadog_checks/couch/couch.py", line 87, in check
E       self.checker.check(instance)
E     File "/home/couch/datadog_checks/couch/couch.py", line 345, in check
E       for db in self._get_dbs_to_scan(server, name, tags):
E     File "/home/couch/datadog_checks/couch/couch.py", line 323, in _get_dbs_to_scan
E       idx = nodes.index(name)
E   ValueError: 'node1@127.0.0.1' is not in list

```
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13546&view=logs&j=a32153be-4ddf-5c50-bd9d-a859be4ee754&t=22372c57-d01c-544b-f5b4-80fd98fd8696

Envs:
- py27-2.3
- ERROR:   py38-2.3: commands failed



```
../datadog_checks_dev/datadog_checks/dev/conditions.py:84: in __call__
    raise RetryError('Endpoint: {}\n' 'Error: {}'.format(last_endpoint, last_error))
E   RetryError: Endpoint: http://localhost:5984
E   Error: <urlopen error [Errno 111] Connection refused>
```
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13702&view=logs&j=cc5abc9e-0189-58d8-da2a-d33663c307d9&t=cebab5d0-cca0-5dee-159e-852a6fe6d123

Envs:
- ERROR:   py27-2.3: commands failed


### Additional Notes
<!-- Anything else we should know when reviewing? -->

I suspect that some instability is caused by db selection algorithm:

https://github.com/DataDog/integrations-core/blob/c1f7fd7220a25ed0c1e10aa8306fcd7267a26b3d/couch/datadog_checks/couch/couch.py#L314-L328

The algorithm is based on the both data retrieved from `/_all_dbs` and `/_membership` api endpoints and if the data returned vary a little bit or inconsistent (stability using cluster and replication is sometimes hard) you won't get the same dbs each time.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
