### PR TITLE
[DOCS-326] Split reference and how-to doc

### DIFF
--- a/docs/dev/check_references.md
+++ b/docs/dev/check_references.md
@@ -1,0 +1,135 @@
+---
+title: Integration assets reference
+kind: documentation
+---
+
+## Configuration file
+
+When preparing a new integration, you must include an example configuration that contains the necessary options and reasonable defaults. The example configuration file, which in this case is located at `awesome/datadog_checks/awesome/data/conf.yaml.example`, has two top-level elements: `init_config` and `instances`. The configuration under `init_config` is applied to the integration globally, and is used in every instantiation of the integration, whereas anything within `instances` is specific to a given instantiation.
+
+Configuration blocks in either section take the following form:
+
+```yaml
+## @<COMMAND> [- <ARGS>]
+## <DESCRIPTION LINE 1>
+## <DESCRIPTION LINE 2>
+#
+<KEY>: <VALUE>
+```
+
+Configuration blocks follow a few guidelines:
+
+- Description must not be empty
+- Placeholders should always follow this format: `<THIS_IS_A_PLACEHOLDER>`, as per the documentation [contributing guidelines][9]:
+- All required parameters are **not** commented by default.
+- All optional parameters are commented by default.
+- If a placeholder has a default value for an integration (like the status endpoint of an integration), it can be used instead of a generic placeholder.
+
+### @param specification
+
+Practically speaking, the only command is `@param`, which is used to describe configuration blocks—primarily for documentation purposes. `@param` is implemented using one of the following forms:
+
+```text
+@param <name> - <type> - required
+@param <name> - <type> - optional
+@param <name> - <type> - optional - default: <defval>
+```
+
+Arguments:
+
+- `name`: the name of the parameter, e.g. `search_string` (mandatory).
+- `type`: the data type for the parameter value (mandatory). Possible values:
+  - _boolean_
+  - _string_
+  - _integer_
+  - _double_
+  - _float_
+  - _dictionary_
+  - _list\*_
+  - _object_
+- `defval`: default value for the parameter; can be empty (optional).
+
+`list` and `object` variables span over multiple lines and have special rules.
+
+- In a `list`, individual elements are not documented with the `@param` specification
+- In an `object` you can choose to either document elements individually with the `@param` specification or to have a common top-level description following the specification of the object itself.
+
+### Optional parameters
+
+An optional parameter must be commented by default. Before every line the parameter spans on, add `#` (note the space) with the same indentation as the `@param` specification.
+
+### Block comments
+
+You can add a block comment anywhere in the configuration file with the following rules:
+
+- Comments start with `##` (note the space)
+- Comments should be indented like any variable (the hyphen doesn't count)
+
+For more information about YAML syntax, see [Wikipedia][17]. Feel free to play around with the [Online YAML Parser][18], too!
+
+## Manifest file
+
+Every integration contains a `manifest.json` file that describes operating parameters, positioning within the greater Datadog integration eco-system, and other such items.
+
+The complete list of mandatory and optional attributes for the `manifest.json` file:
+
+| Attribute                   | Type            | Mandatory/Optional | Description                                                                                                                                                                                                              |
+| --------------------------- | --------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `integration_id`            | String          | Mandatory          | The unique identifying name of this integration. Usually kebab case of the Display Name                                                                                                                                  |
+| `categories`                | Array of String | Mandatory          | Integration categories used on the [public documentation integrations page][10].                                                                                                                                         |
+| `creates_events`            | Boolean         | Mandatory          | If the integration should be able to create events. If this is set to `false`, attempting to create an event from the integration results in an error.                                                                   |
+| `display_name`              | String          | Mandatory          | Title displayed on the corresponding integration tile in the Datadog application and on the [public documentation integrations page][10]                                                                                 |
+| `guid`                      | String          | Mandatory          | Unique ID for the integration. [Generate a UUID][11]                                                                                                                                                                     |
+| `is_public`                 | Boolean         | Mandatory          | If set to `false` the integration `README.md` content is not indexed by bots in the Datadog public documentation.                                                                                                        |
+| `maintainer`                | String          | Mandatory          | Email of the owner of the integration.                                                                                                                                                                                   |
+| `manifest_version`          | String          | Mandatory          | Version of the current manifest.                                                                                                                                                                                         |
+| `name`                      | String          | Mandatory          | Unique name for the integration. Use the folder name for this parameter.                                                                                                                                                 |
+| `public_title`              | String          | Mandatory          | Title of the integration displayed on the documentation. Should follow the following format: `Datadog-<INTEGRATION_NAME> integration`.                                                                                   |
+| `short_description`         | String          | Mandatory          | This text appears at the top of the integration tile as well as the integration's rollover text on the integrations page. Maximum 80 characters.                                                                         |
+| `support`                   | String          | Mandatory          | Owner of the integration.                                                                                                                                                                                                |
+| `supported_os`              | Array of String | Mandatory          | List of supported OSs. Choose among `linux`,`mac_os`, and `windows`.                                                                                                                                                     |
+| `type`                      | String          | Mandatory          | Type of the integration, should be set to `check`.                                                                                                                                                                       |
+| `aliases`                   | Array of String | Optional           | A list of URL aliases for the Datadog documentation.                                                                                                                                                                     |
+| `description`               | String          | Optional           | This text appears when sharing an integration documentation link.                                                                                                                                                        |
+| `is_beta`                   | Boolean         | Optional           | Default `false`. If set to `true` the integration `README.md` content is not displayed in the Datadog public documentation.                                                                                              |
+| `metric_to_check`           | String          | Optional           | The presence of this metric determines if this integration is working properly. If this metric is not being reported when this integration is installed, the integration is marked as broken in the Datadog application. |
+| `metric_prefix`             | String          | Optional           | The namespace for this integration's metrics. Every metric reported by this integration will be prepended with this value.                                                                                               |
+| `process_signatures`        | Array of String | Optional           | A list of signatures that matches the command line of this integration.                                                                                                                                                  |
+| `assets`                    | Dictionary      | Mandatory          | Relative location of where certain asset files live and their respective names.                                                                                                                                          |
+| `assets`-> `dashboards`     | Dictionary      | Mandatory          | Dictionary where the key is the name of the dashboard (must be globally unique across integrations) and the value is the relative file path where the dashboard definition lives.                                        |
+| `assets`-> `monitors`       | Dictionary      | Mandatory          | Dictionary where the key is the name of the monitor (must be globally unique across integrations) and the value is the relative file path where the dashboard definition lives.                                          |
+| `assets`-> `service_checks` | String          | Mandatory          | Relative location of where the `service_checks.json` file lives.                                                                                                                                                         |
+
+## Metrics metadata file
+
+The `metadata.csv` file describes all of the metrics that can be collected by the integration.
+
+Descriptions of each column of the `metadata.csv` file:
+
+| Column name     | Mandatory/Optional | Description                                                                                                                                                                                                                                                                                                                             |
+| --------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `metric_name`   | Mandatory          | Name of the metric.                                                                                                                                                                                                                                                                                                                     |
+| `metric_type`   | Mandatory          | [Type of the metric][12].                                                                                                                                                                                                                                                                                                               |
+| `interval`      | Optional           | Collection interval of the metric in second.                                                                                                                                                                                                                                                                                            |
+| `unit_name`     | Optional           | Unit of the metric. [Complete list of supported units][13].                                                                                                                                                                                                                                                                             |
+| `per_unit_name` | Optional           | If there is a unit sub-division, i.e `request per second`                                                                                                                                                                                                                                                                               |
+| `description`   | Optional           | Description of the metric.                                                                                                                                                                                                                                                                                                              |
+| `orientation`   | Mandatory          | Set to `1` if the metric should go up, i.e `myapp.turnover`. Set to `0` if the metric variations are irrelevant. Set to `-1` if the metric should go down, i.e `myapp.latency`.                                                                                                                                                         |
+| `integration`   | Mandatory          | Name of the integration that emits the metric. Must be the normalized version of the `display_name` from the `manifest.json` file. Any character besides letters, underscores, dashes and numbers are converted to underscores. E.g. `Openstack Controller` -> `openstack_controller`and `ASP.NET` -> `asp_net` and `CRI-o` -> `cri-o`. |
+| `short_name`    | Mandatory          | Explicit Unique ID for the metric.                                                                                                                                                                                                                                                                                                      |
+
+## Service check file
+
+The `service_check.json` file describes the service checks made by the integration.
+
+The `service_checks.json` file contains the following mandatory attributes:
+
+| Attribute       | Description                                                                                                                |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `agent_version` | Minimum Agent version supported.                                                                                           |
+| `integration`   | The name of the integration that emits this service check. Must be the non-normalized `display_name` from `manifest.json`. |
+| `check`         | Name of the Service Check. It must be unique.                                                                              |
+| `statuses`      | List of different status of the check, to choose among `ok`, `warning`, and `critical`. `unknown` is also a possibility.   |
+| `groups`        | [Tags][14] sent with the Service Check.                                                                                    |
+| `name`          | Displayed name of the Service Check. The displayed name must be self-explanatory and unique across all integrations.       |
+| `description`   | Description of the Service Check                                                                                           |

--- a/docs/dev/check_references.md
+++ b/docs/dev/check_references.md
@@ -5,7 +5,7 @@ kind: documentation
 
 ## Configuration file
 
-When preparing a new integration, you must include an example configuration that contains the necessary options and reasonable defaults. The example configuration file, which in this case is located at `awesome/datadog_checks/awesome/data/conf.yaml.example`, has two top-level elements: `init_config` and `instances`. The configuration under `init_config` is applied to the integration globally, and is used in every instantiation of the integration, whereas anything within `instances` is specific to a given instantiation.
+When preparing a new integration, you must include an example configuration that contains the necessary options and reasonable defaults. The example configuration file, which in this case is located at `<CHECK_NAME>/datadog_checks/<CHECK_NAME>/data/conf.yaml.example`, has two top-level elements: `init_config` and `instances`. The configuration under `init_config` is applied to the integration globally, and is used in every instantiation of the integration, whereas anything within `instances` is specific to a given instantiation.
 
 Configuration blocks in either section take the following form:
 

--- a/docs/dev/check_references.md
+++ b/docs/dev/check_references.md
@@ -20,7 +20,7 @@ Configuration blocks in either section take the following form:
 Configuration blocks follow a few guidelines:
 
 - Description must not be empty
-- Placeholders should always follow this format: `<THIS_IS_A_PLACEHOLDER>`, as per the documentation [contributing guidelines][9]:
+- Placeholders should always follow this format: `<THIS_IS_A_PLACEHOLDER>`, as per the documentation [contributing guidelines][1]:
 - All required parameters are **not** commented by default.
 - All optional parameters are commented by default.
 - If a placeholder has a default value for an integration (like the status endpoint of an integration), it can be used instead of a generic placeholder.
@@ -65,7 +65,7 @@ You can add a block comment anywhere in the configuration file with the followin
 - Comments start with `##` (note the space)
 - Comments should be indented like any variable (the hyphen doesn't count)
 
-For more information about YAML syntax, see [Wikipedia][17]. Feel free to play around with the [Online YAML Parser][18], too!
+For more information about YAML syntax, see [Wikipedia][2]. Feel free to play around with the [Online YAML Parser][3], too!
 
 ## Manifest file
 
@@ -76,10 +76,10 @@ The complete list of mandatory and optional attributes for the `manifest.json` f
 | Attribute                   | Type            | Mandatory/Optional | Description                                                                                                                                                                                                              |
 | --------------------------- | --------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `integration_id`            | String          | Mandatory          | The unique identifying name of this integration. Usually kebab case of the Display Name                                                                                                                                  |
-| `categories`                | Array of String | Mandatory          | Integration categories used on the [public documentation integrations page][10].                                                                                                                                         |
+| `categories`                | Array of String | Mandatory          | Integration categories used on the [public documentation integrations page][4].                                                                                                                                          |
 | `creates_events`            | Boolean         | Mandatory          | If the integration should be able to create events. If this is set to `false`, attempting to create an event from the integration results in an error.                                                                   |
-| `display_name`              | String          | Mandatory          | Title displayed on the corresponding integration tile in the Datadog application and on the [public documentation integrations page][10]                                                                                 |
-| `guid`                      | String          | Mandatory          | Unique ID for the integration. [Generate a UUID][11]                                                                                                                                                                     |
+| `display_name`              | String          | Mandatory          | Title displayed on the corresponding integration tile in the Datadog application and on the [public documentation integrations page][4]                                                                                  |
+| `guid`                      | String          | Mandatory          | Unique ID for the integration. [Generate a UUID][5]                                                                                                                                                                      |
 | `is_public`                 | Boolean         | Mandatory          | If set to `false` the integration `README.md` content is not indexed by bots in the Datadog public documentation.                                                                                                        |
 | `maintainer`                | String          | Mandatory          | Email of the owner of the integration.                                                                                                                                                                                   |
 | `manifest_version`          | String          | Mandatory          | Version of the current manifest.                                                                                                                                                                                         |
@@ -109,9 +109,9 @@ Descriptions of each column of the `metadata.csv` file:
 | Column name     | Mandatory/Optional | Description                                                                                                                                                                                                                                                                                                                             |
 | --------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `metric_name`   | Mandatory          | Name of the metric.                                                                                                                                                                                                                                                                                                                     |
-| `metric_type`   | Mandatory          | [Type of the metric][12].                                                                                                                                                                                                                                                                                                               |
+| `metric_type`   | Mandatory          | [Type of the metric][6].                                                                                                                                                                                                                                                                                                                |
 | `interval`      | Optional           | Collection interval of the metric in second.                                                                                                                                                                                                                                                                                            |
-| `unit_name`     | Optional           | Unit of the metric. [Complete list of supported units][13].                                                                                                                                                                                                                                                                             |
+| `unit_name`     | Optional           | Unit of the metric. [Complete list of supported units][7].                                                                                                                                                                                                                                                                              |
 | `per_unit_name` | Optional           | If there is a unit sub-division, i.e `request per second`                                                                                                                                                                                                                                                                               |
 | `description`   | Optional           | Description of the metric.                                                                                                                                                                                                                                                                                                              |
 | `orientation`   | Mandatory          | Set to `1` if the metric should go up, i.e `myapp.turnover`. Set to `0` if the metric variations are irrelevant. Set to `-1` if the metric should go down, i.e `myapp.latency`.                                                                                                                                                         |
@@ -130,6 +130,15 @@ The `service_checks.json` file contains the following mandatory attributes:
 | `integration`   | The name of the integration that emits this service check. Must be the non-normalized `display_name` from `manifest.json`. |
 | `check`         | Name of the Service Check. It must be unique.                                                                              |
 | `statuses`      | List of different status of the check, to choose among `ok`, `warning`, and `critical`. `unknown` is also a possibility.   |
-| `groups`        | [Tags][14] sent with the Service Check.                                                                                    |
+| `groups`        | [Tags][8] sent with the Service Check.                                                                                     |
 | `name`          | Displayed name of the Service Check. The displayed name must be self-explanatory and unique across all integrations.       |
 | `description`   | Description of the Service Check                                                                                           |
+
+[1]: https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md
+[2]: https://en.wikipedia.org/wiki/YAML
+[3]: http://yaml-online-parser.appspot.com/
+[4]: https://docs.datadoghq.com/integrations
+[5]: https://www.uuidgenerator.net
+[6]: https://docs.datadoghq.com/developers/metrics/metrics_type/
+[7]: https://docs.datadoghq.com/developers/metrics/metrics_units/
+[8]: https://docs.datadoghq.com/getting_started/tagging

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -98,7 +98,7 @@ Checks are organized in regular Python packages under the `datadog_checks` names
 
 ### Implement check logic
 
-Let's say you want to create an Agent Check composed only of a Service Check named `awesome.search` that searches for a string on a web page. It will result in `OK` if the string is present, `WARNING` if the page is accessible but the string was not found, and `CRITICAL` if the page is inaccessible. See the [Metric Submission: Custom Agent Check](https://docs.datadoghq.com/developers/metrics/agent_metrics_submission/) if you want to learn how to submit metrics with your Agent Check.
+Let's say you want to create an Agent Check composed only of a Service Check named `awesome.search` that searches for a string on a web page. It will result in `OK` if the string is present, `WARNING` if the page is accessible but the string was not found, and `CRITICAL` if the page is inaccessible. See the [Metric Submission: Custom Agent Check][5] if you want to learn how to submit metrics with your Agent Check.
 
 The code contained within `awesome/datadog_checks/awesome/awesome.py` would look something like this:
 
@@ -137,7 +137,7 @@ class AwesomeCheck(AgentCheck):
                 self.service_check('awesome.search', self.WARNING)
 ```
 
-To learn more about the base Python class, see the [Python API documentation][5].
+To learn more about the base Python class, see the [Python API documentation][6].
 
 ### Writing tests
 
@@ -146,9 +146,9 @@ There are two basic types of tests:
 - Unit tests for specific functionality.
 - Integration tests that execute the `check` method and verify proper metrics collection.
 
-Tests are _required_ if you want your integration to be included in `integrations-extras`. Note that [pytest][6] and [tox][7] are used to run the tests.
+Tests are _required_ if you want your integration to be included in `integrations-extras`. Note that [pytest][7] and [tox][8] are used to run the tests.
 
-For more information, see the [Datadog Checks Dev documentation][8].
+For more information, see the [Datadog Checks Dev documentation][9].
 
 #### Unit test
 
@@ -183,7 +183,7 @@ def test_config():
     c.check({'url': 'http://foobar', 'search_string': 'foo'})
 ```
 
-`pytest` has the concept of _markers_ that can be used to group tests into categories. Notice that  `test_config` is marked as a `unit` test.
+`pytest` has the concept of _markers_ that can be used to group tests into categories. Notice that `test_config` is marked as a `unit` test.
 
 The scaffolding has already been set up to run all tests located in `awesome/tests`. Run the tests:
 
@@ -270,10 +270,10 @@ The check is almost done. Let's add the final touches by adding the integration 
 In order for your check to be complete you need to populate a set of assets provided by the ddev scaffolding . They already have the correct format but you must fill out the documents with the relevant information:
 
 - **A `README.md` file**: This contains the documentation for your Check, how to set it up, which data it collects, etc..
-- **A `conf.yaml` file**: This contains all configuration options for your Agent check. [See the configuration file reference documentation to learn its logic.](https://github.com/DataDog/integrations-core/blob/master/docs/dev/check_references.md#configuration-file)
-- **A `manifest.json` file**: This contains the metadata for your Agent Check like its title, its categories... [See the manifest reference documentation to lean more.](https://github.com/DataDog/integrations-core/blob/master/docs/dev/check_references.md#manifest-file)
-- **A `metadata.csv` file**: This contains the list of all metrics collected by your Agent Check. [See the metrics metadata reference documentation to learn more.](https://github.com/DataDog/integrations-core/blob/master/docs/dev/check_references.md#metrics-metadata-file)
-- **A `service_check.json` file**: This contains the list of all Service Checks collected by your Agent check. [See the Service Check reference documentation to learn more.](https://github.com/DataDog/integrations-core/blob/master/docs/dev/check_references.md#service-check-file)
+- **A `conf.yaml` file**: This contains all configuration options for your Agent check. [See the configuration file reference documentation to learn its logic.][10]
+- **A `manifest.json` file**: This contains the metadata for your Agent Check like its title, its categories... [See the manifest reference documentation to lean more.][11]
+- **A `metadata.csv` file**: This contains the list of all metrics collected by your Agent Check. [See the metrics metadata reference documentation to learn more.][12]
+- **A `service_check.json` file**: This contains the list of all Service Checks collected by your Agent check. [See the Service Check reference documentation to learn more.][13]
 
 For this example, those files would have the following shape:
 
@@ -291,11 +291,10 @@ init_config:
 ## of the init_config part.
 
 instances:
-
-    ## @param url - string - required
-    ## The URL you want to check
-    ## (Note the indentation with the hyphen)
-    #
+  ## @param url - string - required
+  ## The URL you want to check
+  ## (Note the indentation with the hyphen)
+  #
   - url: http://example.org
 
     ## @param search_string - string - required
@@ -318,18 +317,16 @@ instances:
     ## Optional flags you can set
     #
     options:
-
       ## @param follow_redirects - boolean - optional - default: false
       ## Set to true to follow 301 Redirect
       #
       # follow_redirects: false
-
 ```
 
 {{% /tab %}}
 {{% tab "Manifest" %}}
 
-The `awesome/manifest.json` for the Awesome service check. Note that the `guid` must be unique (and valid), so do *not* use the one from this example—the tooling will generate one for you in any case:
+The `awesome/manifest.json` for the Awesome service check. Note that the `guid` must be unique (and valid), so do _not_ use the one from this example—the tooling will generate one for you in any case:
 
 ```json
 {
@@ -343,15 +340,9 @@ The `awesome/manifest.json` for the Awesome service check. Note that the `guid` 
   "short_description": "",
   "guid": "x16b8750-df1e-46c0-839a-2056461b604x",
   "support": "contrib",
-  "supported_os": [
-    "linux",
-    "mac_os",
-    "windows"
-  ],
+  "supported_os": ["linux", "mac_os", "windows"],
   "public_title": "Datadog-awesome Integration",
-  "categories": [
-    "web"
-  ],
+  "categories": ["web"],
   "type": "check",
   "is_public": false,
   "integration_id": "awesome",
@@ -378,15 +369,15 @@ The example integration contains a service check, so you need to add it to the `
 
 ```json
 [
-    {
-        "agent_version": "6.0.0",
-        "integration": "awesome",
-        "check": "awesome.search",
-        "statuses": ["ok", "warning", "critical"],
-        "groups": [],
-        "name": "Awesome search!",
-        "description": "Returns `CRITICAL` if the check can't access the page, `WARNING` if the search string was not found, or `OK` otherwise."
-    }
+  {
+    "agent_version": "6.0.0",
+    "integration": "awesome",
+    "check": "awesome.search",
+    "statuses": ["ok", "warning", "critical"],
+    "groups": [],
+    "name": "Awesome search!",
+    "description": "Returns `CRITICAL` if the check can't access the page, `WARNING` if the search string was not found, or `OK` otherwise."
+  }
 ]
 ```
 
@@ -395,7 +386,7 @@ The example integration contains a service check, so you need to add it to the `
 
 ## Building
 
-`setup.py` provides the setuptools setup script that helps us package and build the wheel. To learn more about Python packaging, take a look at [the official Python documentation][15].
+`setup.py` provides the setuptools setup script that helps us package and build the wheel. To learn more about Python packaging, take a look at [the official Python documentation][14].
 
 Once your `setup.py` is ready, create a wheel:
 
@@ -408,7 +399,7 @@ The wheel contains only the files necessary for the functioning of the integrati
 
 ## Installing
 
-The wheel is installed via the Agent `integration` command, available in [Agent v6.10.0 and up][16]. Depending on your environment, you may need to execute this command as a specific user or with particular privileges:
+The wheel is installed via the Agent `integration` command, available in [Agent v6.10.0 and up][15]. Depending on your environment, you may need to execute this command as a specific user or with particular privileges:
 
 **Linux** (as `dd-agent`):
 
@@ -440,17 +431,14 @@ For Agent versions >= 6.12:
 [2]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/python.md
 [3]: https://github.com/DataDog/integrations-extras
 [4]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_dev
-[5]: https://github.com/DataDog/datadog-agent/blob/6.2.x/docs/dev/checks/python/check_api.md
-[6]: https://docs.pytest.org/en/latest
-[7]: https://tox.readthedocs.io/en/latest
-[8]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_dev#development
-[9]: https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md
-[10]: https://docs.datadoghq.com/integrations
-[11]: https://www.uuidgenerator.net
-[12]: https://docs.datadoghq.com/developers/metrics/metrics_type/
-[13]: https://docs.datadoghq.com/developers/metrics/metrics_units/
-[14]: https://docs.datadoghq.com/getting_started/tagging
-[15]: https://packaging.python.org/tutorials/distributing-packages
-[16]: https://docs.datadoghq.com/agent/
-[17]: https://en.wikipedia.org/wiki/YAML
-[18]: http://yaml-online-parser.appspot.com/
+[5]: https://docs.datadoghq.com/developers/metrics/agent_metrics_submission/
+[6]: https://github.com/DataDog/datadog-agent/blob/6.2.x/docs/dev/checks/python/check_api.md
+[7]: https://docs.pytest.org/en/latest
+[8]: https://tox.readthedocs.io/en/latest
+[9]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_dev#development
+[10]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/check_references.md#configuration-file
+[11]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/check_references.md#manifest-file
+[12]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/check_references.md#metrics-metadata-file
+[13]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/check_references.md#service-check-file
+[14]: https://packaging.python.org/tutorials/distributing-packages
+[15]: https://docs.datadoghq.com/agent/

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -267,13 +267,13 @@ The check is almost done. Let's add the final touches by adding the integration 
 
 ### Create the check assets
 
-In order for your check to be complete you need to populate a set of assets provided by the ddev scaffolding . They already have the correct format but you must fill out the documents with the relevant information:
+In order for your check to be complete you need to populate a set of assets provided by the ddev scaffolding . They already have the correct format but you must fill out the documents with the relevant information from the file:
 
-- **A `README.md` file**: This contains the documentation for your Check, how to set it up, which data it collects, etc..
-- **A `conf.yaml` file**: This contains all configuration options for your Agent check. [See the configuration file reference documentation to learn its logic.][10]
-- **A `manifest.json` file**: This contains the metadata for your Agent Check like its title, its categories... [See the manifest reference documentation to lean more.][11]
-- **A `metadata.csv` file**: This contains the list of all metrics collected by your Agent Check. [See the metrics metadata reference documentation to learn more.][12]
-- **A `service_check.json` file**: This contains the list of all Service Checks collected by your Agent check. [See the Service Check reference documentation to learn more.][13]
+- **`README.md`**: This contains the documentation for your Check, how to set it up, which data it collects, etc..
+- **`conf.yaml`**: This contains all configuration options for your Agent check. [See the configuration file reference documentation to learn its logic.][10]
+- **`manifest.json`**: This contains the metadata for your Agent Check like its title, its categories... [See the manifest reference documentation to lean more.][11]
+- **`metadata.csv`**: This contains the list of all metrics collected by your Agent Check. [See the metrics metadata reference documentation to learn more.][12]
+- **`service_check.json`**: This contains the list of all Service Checks collected by your Agent check. [See the Service Check reference documentation to learn more.][13]
 
 For this example, those files would have the following shape:
 

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -10,7 +10,7 @@ aliases:
 
 To consider an Agent-based integration complete, and thus ready to be included in the core repository and bundled with the Agent package, a number of prerequisites must be met:
 
-- A `README.md` file with the right format
+- A `README.md` file with the correct format and contents
 - A battery of tests verifying metrics collection
 - A `metadata.csv` file listing all of the collected metrics
 - A complete `manifest.json` file
@@ -90,7 +90,7 @@ After answering the questions, the output matches that of the dry-run above, exc
 
 A Check is a Python class with the following requirements:
 
-- If running with Agent v7+ it should be Python 3 compatible, Python 2 otherwise for Agent v5 and v6.
+- Integrations run via Agent v7+ must be Python 3 compatible; however, Agents v5 and v6 still use Python 2.7.
 - It must derive from `AgentCheck`
 - It must provide a method with this signature: `check(self, instance)`
 
@@ -152,7 +152,7 @@ For more information, see the [Datadog Checks Dev documentation][9].
 
 #### Unit test
 
-The first part of the `check` method retrieves and verifies two pieces of information needed from the configuration file. This is a good candidate for a unit test. Open the file at `awesome/tests/test_awesome.py` and replace the contents with something like this:
+The first part of the `check` method retrieves and verifies two elements from the configuration file. This is a good candidate for a unit test. Open the file at `awesome/tests/test_awesome.py` and replace the contents with something like this:
 
 ```python
 import pytest
@@ -265,9 +265,9 @@ ddev test -m integration awesome
 
 The check is almost done. Let's add the final touches by adding the integration configurations.
 
-### Create the check assets
+### Create the Check assets
 
-In order for your check to be complete you need to populate a set of assets provided by the ddev scaffolding . They already have the correct format but you must fill out the documents with the relevant information from the file:
+The set of assets created by the ddev scaffolding must be populated in order for a check to be considered for inclusion:
 
 - **`README.md`**: This contains the documentation for your Check, how to set it up, which data it collects, etc..
 - **`conf.yaml`**: This contains all configuration options for your Agent check. [See the configuration file reference documentation to learn its logic.][10]
@@ -275,7 +275,7 @@ In order for your check to be complete you need to populate a set of assets prov
 - **`metadata.csv`**: This contains the list of all metrics collected by your Agent Check. [See the metrics metadata reference documentation to learn more.][12]
 - **`service_check.json`**: This contains the list of all Service Checks collected by your Agent check. [See the Service Check reference documentation to learn more.][13]
 
-For this example, those files would have the following shape:
+For this example, those files would have the following form:
 
 {{< tabs >}}
 {{% tab "Configuration file" %}}
@@ -326,7 +326,7 @@ instances:
 {{% /tab %}}
 {{% tab "Manifest" %}}
 
-The `awesome/manifest.json` for the Awesome service check. Note that the `guid` must be unique (and valid), so do _not_ use the one from this example—the tooling will generate one for you in any case:
+The `awesome/manifest.json` for the Awesome Service Check. Note that the `guid` must be unique (and valid), so do _not_ use the one from this example (the tooling will generate one for you in any case):
 
 ```json
 {

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -2,26 +2,26 @@
 title: Create a new integration
 kind: documentation
 aliases:
-    - /developers/integrations/integration_sdk/
-    - /developers/integrations/testing/
-    - /integrations/datadog_checks_dev/
-    - /guides/new_integration/
+  - /developers/integrations/integration_sdk/
+  - /developers/integrations/testing/
+  - /integrations/datadog_checks_dev/
+  - /guides/new_integration/
 ---
 
 To consider an Agent-based integration complete, and thus ready to be included in the core repository and bundled with the Agent package, a number of prerequisites must be met:
 
-* A `README.md` file with the right format
-* A battery of tests verifying metrics collection
-* A `metadata.csv` file listing all of the collected metrics
-* A complete `manifest.json` file
-* If the integration collects Service Checks, the `service_checks.json` must be complete as well
+- A `README.md` file with the right format
+- A battery of tests verifying metrics collection
+- A `metadata.csv` file listing all of the collected metrics
+- A complete `manifest.json` file
+- If the integration collects Service Checks, the `service_checks.json` must be complete as well
 
 These requirements are used during the code review process as a checklist. This documentation covers the requirements and implementation details for a brand new integration.
 
 ## Prerequisites
 
-* Python 3.8+ needs to be available on your system; Python 2.7 is optional but recommended.
-* Docker to run the full test suite.
+- Python 3.8+ needs to be available on your system; Python 2.7 is optional but recommended.
+- Docker to run the full test suite.
 
 In general, creating and activating [Python virtual environments][1] to isolate the development environment is good practice; however, it is not mandatory. For more information, see the [Python Environment documentation][2].
 
@@ -38,25 +38,25 @@ git clone https://github.com/DataDog/integrations-extras.git
 
 The [Developer Toolkit][4] is comprehensive and includes a lot of functionality. Here's what you need to get started:
 
-```
+```bash
 pip install "datadog-checks-dev[cli]"
 ```
 
 If you chose to clone this repository to somewhere other than `$HOME/dd/`, you'll need to adjust the configuration file:
 
-```
+```bash
 ddev config set extras "/path/to/integrations-extras"
 ```
 
 If you intend to work primarily on `integrations-extras`, set it as the default working repository:
 
-```
+```bash
 ddev config set repo extras
 ```
 
 **Note**: If you do not do this step, you'll need to use `-e` for every invocation to ensure the context is `integrations-extras`:
 
-```
+```bash
 ddev -e COMMAND [OPTIONS]
 ```
 
@@ -68,21 +68,21 @@ One of the developer toolkit features is the `create` command, which creates the
 
 Let's try a dry-run using the `-n/--dry-run` flag, which won't write anything to disk.
 
-```
+```bash
 ddev create -n awesome
 ```
 
-This will display the path where the files would have been written, as well as the structure itself. For now, just make sure that the path in the *first line* of output matches your Extras repository.
+This displays the path where the files would have been written, as well as the structure itself. For now, just make sure that the path in the _first line_ of output matches your Extras repository.
 
 ### Interactive mode
 
 The interactive mode is a wizard for creating new integrations. By answering a handful of questions, the scaffolding will be set up and lightly pre-configured for you.
 
-```
+```bash
 ddev create awesome
 ```
 
-After answering the questions, the output will match that of the dry-run above, except in this case the scaffolding for your new integration will actually exist!
+After answering the questions, the output matches that of the dry-run above, except in this case the scaffolding for your new integration actually exists!
 
 ## Write the check
 
@@ -90,15 +90,15 @@ After answering the questions, the output will match that of the dry-run above, 
 
 A Check is a Python class with the following requirements:
 
-* If running with Agent v7+ it should be Python 3 compatible, Python 2 otherwise.
-* It must derive from `AgentCheck`
-* It must provide a method with this signature: `check(self, instance)`
+- If running with Agent v7+ it should be Python 3 compatible, Python 2 otherwise for Agent v5 and v6.
+- It must derive from `AgentCheck`
+- It must provide a method with this signature: `check(self, instance)`
 
 Checks are organized in regular Python packages under the `datadog_checks` namespace, so your code should live under `awesome/datadog_checks/awesome`. The only requirement is that the name of the package has to be the same as the check name. There are no particular restrictions on the name of the Python modules within that package, nor on the name of the class implementing the check.
 
 ### Implement check logic
 
-Let's say we want to create a Service Check named `awesome.search` that searches for a string on a web page. It will result in `OK` if the string is present, `WARNING` if the page is accessible but the string was not found, and `CRITICAL` if the page is inaccessible.
+Let's say you want to create an Agent Check composed only of a Service Check named `awesome.search` that searches for a string on a web page. It will result in `OK` if the string is present, `WARNING` if the page is accessible but the string was not found, and `CRITICAL` if the page is inaccessible. See the [Metric Submission: Custom Agent Check](https://docs.datadoghq.com/developers/metrics/agent_metrics_submission/) if you want to learn how to submit metrics with your Agent Check.
 
 The code contained within `awesome/datadog_checks/awesome/awesome.py` would look something like this:
 
@@ -141,13 +141,18 @@ To learn more about the base Python class, see the [Python API documentation][5]
 
 ### Writing tests
 
-There are two basic types of tests: unit tests for specific functionality, and integration tests that execute the `check` method and verify proper metrics collection. Tests are _required_ if you want your integration to be included in `integrations-extras`. Note that [pytest][6] and [tox][7] are used to run the tests.
+There are two basic types of tests:
+
+- Unit tests for specific functionality.
+- Integration tests that execute the `check` method and verify proper metrics collection.
+
+Tests are _required_ if you want your integration to be included in `integrations-extras`. Note that [pytest][6] and [tox][7] are used to run the tests.
 
 For more information, see the [Datadog Checks Dev documentation][8].
 
 #### Unit test
 
-The first part of the `check` method retrieves and verifies two pieces of information we need from the configuration file. This is a good candidate for a unit test. Open the file at `awesome/tests/test_awesome.py` and replace the contents with something like this:
+The first part of the `check` method retrieves and verifies two pieces of information needed from the configuration file. This is a good candidate for a unit test. Open the file at `awesome/tests/test_awesome.py` and replace the contents with something like this:
 
 ```python
 import pytest
@@ -178,20 +183,20 @@ def test_config():
     c.check({'url': 'http://foobar', 'search_string': 'foo'})
 ```
 
-`pytest` has the concept of _markers_ that can be used to group tests into categories. Notice we've marked `test_config` as a `unit` test.
+`pytest` has the concept of _markers_ that can be used to group tests into categories. Notice that  `test_config` is marked as a `unit` test.
 
 The scaffolding has already been set up to run all tests located in `awesome/tests`. Run the tests:
 
-```
+```bash
 ddev test awesome
 ```
 
 #### Building an integration test
 
-This test doesn't check our collection _logic_ though, so let's add an integration test. We use `docker` to spin up an Nginx container and let the check retrieve the welcome page. Create a compose file at `awesome/tests/docker-compose.yml` with the following contents:
+This test doesn't check the collection _logic_ though, so let's add an integration test. `docker` is used to spin up an Nginx container and let the check retrieve the welcome page. Create a compose file at `awesome/tests/docker-compose.yml` with the following contents:
 
 ```yaml
-version: '3'
+version: "3"
 
 services:
   nginx:
@@ -234,7 +239,7 @@ def instance():
 
 #### Integration test
 
-Finally, add an integration test to our `awesome/tests/test_awesome.py` file:
+Finally, add an integration test to the `awesome/tests/test_awesome.py` file:
 
 ```python
 @pytest.mark.integration
@@ -254,82 +259,26 @@ def test_service_check(aggregator, instance):
 
 Run only integration tests for faster development using the `-m/--marker` option:
 
-```
+```bash
 ddev test -m integration awesome
 ```
 
 The check is almost done. Let's add the final touches by adding the integration configurations.
 
-## Configuration
+### Create the check assets
 
-### Populate the README
+In order for your check to be complete you need to populate a set of assets provided by the ddev scaffolding . They already have the correct format but you must fill out the documents with the relevant information:
 
-The `awesome/README.md` file provided by our scaffolding already has the correct format. You must fill out the document with the relevant information.
+- **A `README.md` file**: This contains the documentation for your Check, how to set it up, which data it collects, etc..
+- **A `conf.yaml` file**: This contains all configuration options for your Agent check. [See the configuration file reference documentation to learn its logic.](https://github.com/DataDog/integrations-core/blob/master/docs/dev/check_references.md#configuration-file)
+- **A `manifest.json` file**: This contains the metadata for your Agent Check like its title, its categories... [See the manifest reference documentation to lean more.](https://github.com/DataDog/integrations-core/blob/master/docs/dev/check_references.md#manifest-file)
+- **A `metadata.csv` file**: This contains the list of all metrics collected by your Agent Check. [See the metrics metadata reference documentation to learn more.](https://github.com/DataDog/integrations-core/blob/master/docs/dev/check_references.md#metrics-metadata-file)
+- **A `service_check.json` file**: This contains the list of all Service Checks collected by your Agent check. [See the Service Check reference documentation to learn more.](https://github.com/DataDog/integrations-core/blob/master/docs/dev/check_references.md#service-check-file)
 
-### Configuration file
+For this example, those files would have the following shape:
 
-When preparing a new integration, you must include an example configuration that contains the necessary options and reasonable defaults. The example configuration file, which in this case is located at `awesome/datadog_checks/awesome/data/conf.yaml.example`, has two top-level elements: `init_config` and `instances`. The configuration under `init_config` is applied to the integration globally, and is used in every instantiation of the integration, whereas anything within `instances` is specific to a given instantiation.
-
-Configuration blocks in either section take the following form:
-
-```yaml
-## @<COMMAND> [- <ARGS>]
-## <DESCRIPTION LINE 1>
-## <DESCRIPTION LINE 2>
-#
-<KEY>: <VALUE>
-```
-
-Configuration blocks follow a few guidelines:
-
-* Description must not be empty
-* Placeholders should always follow this format: `<THIS_IS_A_PLACEHOLDER>`, as per the documentation [contributing guidelines][9]:
-* All required parameters are **not** commented by default.
-* All optional parameters are commented by default.
-* If a placeholder has a default value for an integration (like the status endpoint of an integration), it can be used instead of a generic placeholder.
-
-#### @param specification
-
-Practically speaking, the only command is `@param`, which is used to describe configuration blocks—primarily for documentation purposes. `@param` is implemented using one of the following forms:
-
-```
-@param <name> - <type> - required
-@param <name> - <type> - optional
-@param <name> - <type> - optional - default: <defval>
-```
-
-Arguments:
-
-* `name`: the name of the parameter, e.g. `search_string` (mandatory).
-* `type`: the data type for the parameter value (mandatory). Possible values:
-  * *boolean*
-  * *string*
-  * *integer*
-  * *double*
-  * *float*
-  * *dictionary*
-  * *list&#42;*
-  * *object*
-* `defval`: default value for the parameter; can be empty (optional).
-
-`list` and `object` variables span over multiple lines and have special rules.
-
-* In a `list`, individual elements are not documented with the `@param` specification
-* In an `object` you can choose to either document elements individually with the `@param` specification or to have a common top-level description following the specification of the object itself.
-
-#### Optional parameters
-
-An optional parameter must be commented by default. Before every line the parameter spans on, add `# ` (note the space) with the same indentation as the `@param` specification.
-
-#### Block comments
-
-You can add a block comment anywhere in the configuration file with the following rules:
-
-* Comments start with `## ` (note the space)
-* Comments should be indented like any variable (the hyphen doesn't count)
-
-
-#### Example configuration
+{{< tabs >}}
+{{% tab "Configuration file" %}}
 
 The `awesome/datadog_checks/awesome/data/conf.yaml.example` for the Awesome service check:
 
@@ -377,44 +326,10 @@ instances:
 
 ```
 
-For more information about YAML syntax, see [Wikipedia][17]. Feel free to play around with the [Online YAML Parser][18], too!
+{{% /tab %}}
+{{% tab "Manifest" %}}
 
-### Manifest file
-
-Every integration contains a `manifest.json` file that describes operating parameters, positioning within the greater Datadog integration eco-system, and other such items.
-
-The complete list of mandatory and optional attributes for the `manifest.json` file:
-
-| Attribute                   | Type            | Mandatory/Optional | Description                                                                                                                                                                                                              |
-| --------------------        | --------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `integration_id`            | String          | Mandatory          | The unique identifying name of this integration. Usually kebab case of the Display Name                                                                                                                                  |
-| `categories`                | Array of String | Mandatory          | Integration categories used on the [public documentation integrations page][10].                                                                                                                                         |
-| `creates_events`            | Boolean         | Mandatory          | If the integration should be able to create events. If this is set to `false`, attempting to create an event from the integration results in an error.                                                                   |
-| `display_name`              | String          | Mandatory          | Title displayed on the corresponding integration tile in the Datadog application and on the [public documentation integrations page][10]                                                                                 |
-| `guid`                      | String          | Mandatory          | Unique ID for the integration. [Generate a UUID][11]                                                                                                                                                                     |
-| `is_public`                 | Boolean         | Mandatory          | If set to `false` the integration `README.md` content is not indexed by bots in the Datadog public documentation.                                                                                                        |
-| `maintainer`                | String          | Mandatory          | Email of the owner of the integration.                                                                                                                                                                                   |
-| `manifest_version`          | String          | Mandatory          | Version of the current manifest.                                                                                                                                                                                         |
-| `name`                      | String          | Mandatory          | Unique name for the integration. Use the folder name for this parameter.                                                                                                                                                 |
-| `public_title`              | String          | Mandatory          | Title of the integration displayed on the documentation. Should follow the following format: `Datadog-<INTEGRATION_NAME> integration`.                                                                                   |
-| `short_description`         | String          | Mandatory          | This text appears at the top of the integration tile as well as the integration's rollover text on the integrations page. Maximum 80 characters.                                                                         |
-| `support`                   | String          | Mandatory          | Owner of the integration.                                                                                                                                                                                                |
-| `supported_os`              | Array of String | Mandatory          | List of supported OSs. Choose among `linux`,`mac_os`, and `windows`.                                                                                                                                                     |
-| `type`                      | String          | Mandatory          | Type of the integration, should be set to `check`.                                                                                                                                                                       |
-| `aliases`                   | Array of String | Optional           | A list of URL aliases for the Datadog documentation.                                                                                                                                                                     |
-| `description`               | String          | Optional           | This text appears when sharing an integration documentation link.                                                                                                                                                        |
-| `is_beta`                   | Boolean         | Optional           | Default `false`. If set to `true` the integration `README.md` content is not displayed in the Datadog public documentation.                                                                                              |
-| `metric_to_check`           | String          | Optional           | The presence of this metric determines if this integration is working properly. If this metric is not being reported when this integration is installed, the integration is marked as broken in the Datadog application. |
-| `metric_prefix`             | String          | Optional           | The namespace for this integration's metrics. Every metric reported by this integration will be prepended with this value.                                                                                               |
-| `process_signatures`        | Array of String | Optional           | A list of signatures that matches the command line of this integration.                                                                                                                                                  |
-| `assets`                    | Dictionary      | Mandatory          | Relative location of where certain asset files live and their respective names.                                                                                                                                          |
-| `assets`-> `dashboards`     | Dictionary      | Mandatory          | Dictionary where the key is the name of the dashboard (must be globally unique across integrations) and the value is the relative file path where the dashboard definition lives.                                        |
-| `assets`-> `monitors`       | Dictionary      | Mandatory          | Dictionary where the key is the name of the monitor (must be globally unique across integrations) and the value is the relative file path where the dashboard definition lives.                                          |
-| `assets`-> `service_checks` | String          | Mandatory          | Relative location of where the `service_checks.json` file lives.                                                                                                                                                         |
-
-##### Example manifest config
-
-Our example integration has a very simple `awesome/manifest.json`, the bulk of which is generated by the tooling. Note that the `guid` must be unique (and valid), so do *not* use the one from this example—the tooling will generate one for you in any case.
+The `awesome/manifest.json` for the Awesome service check. Note that the `guid` must be unique (and valid), so do *not* use the one from this example—the tooling will generate one for you in any case:
 
 ```json
 {
@@ -451,47 +366,15 @@ Our example integration has a very simple `awesome/manifest.json`, the bulk of w
 }
 ```
 
-#### Metrics metadata file
+{{% /tab %}}
+{{% tab "Metadata" %}}
 
-The `metadata.csv` file describes all of the metrics that can be collected by the integration.
+The example integration doesn't send any metrics, so in this case the generated `awesome/metadata.csv` contains only the row containing CSV column names.
 
-Descriptions of each column of the `metadata.csv` file:
+{{% /tab %}}
+{{% tab "Service Check" %}}
 
-| Column name     | Mandatory/Optional | Description                                                                                                                                                                     |
-| ---             | ----               | ----                                                                                                                                                                            |
-| `metric_name`   | Mandatory          | Name of the metric.                                                                                                                                                             |
-| `metric_type`   | Mandatory          | [Type of the metric][12].                                                                                                                                                       |
-| `interval`      | Optional           | Collection interval of the metric in second.                                                                                                                                    |
-| `unit_name`     | Optional           | Unit of the metric. [Complete list of supported units][13].                                                                                                                     |
-| `per_unit_name` | Optional           | If there is a unit sub-division, i.e `request per second`                                                                                                                       |
-| `description`   | Optional           | Description of the metric.                                                                                                                                                      |
-| `orientation`   | Mandatory          | Set to `1` if the metric should go up, i.e `myapp.turnover`. Set to `0` if the metric variations are irrelevant. Set to `-1` if the metric should go down, i.e `myapp.latency`. |
-| `integration`   | Mandatory          | Name of the integration that emits the metric. Must be the normalized version of the `display_name` from the `manifest.json` file. Any character besides letters, underscores, dashes and numbers are converted to underscores. E.g. `Openstack Controller` -> `openstack_controller`and `ASP.NET` -> `asp_net` and `CRI-o` -> `cri-o`.                                                                                                                                |
-| `short_name`    | Mandatory          | Explicit Unique ID for the metric.                                                                                                                                              |
-
-##### Example metadata config
-
-Our example integration doesn't send any metrics, so in this case the generated `awesome/metadata.csv` contains only the row containing CSV column names.
-
-#### Service check file
-
-The `service_check.json` file describes the service checks made by the integration.
-
-The `service_checks.json` file contains the following mandatory attributes:
-
-| Attribute       | Description                                                                                                              |
-| ----            | ----                                                                                                                     |
-| `agent_version` | Minimum Agent version supported.                                                                                         |
-| `integration`   | The name of the integration that emits this service check. Must be the non-normalized `display_name` from `manifest.json`.                                                                                                      |
-| `check`         | Name of the Service Check. It must be unique.                                                                            |
-| `statuses`      | List of different status of the check, to choose among `ok`, `warning`, and `critical`. `unknown` is also a possibility. |
-| `groups`        | [Tags][14] sent with the Service Check.                                                                                  |
-| `name`          | Displayed name of the Service Check. The displayed name must be self-explanatory and unique across all integrations.                             |
-| `description`   | Description of the Service Check                                                                                         |
-
-##### Example service check config
-
-Our example integration contains a service check, so we need to add it to the `awesome/assets/service_checks.json` file:
+The example integration contains a service check, so you need to add it to the `awesome/assets/service_checks.json` file:
 
 ```json
 [
@@ -507,7 +390,10 @@ Our example integration contains a service check, so we need to add it to the `a
 ]
 ```
 
-### Building
+{{% /tab %}}
+{{< /tabs >}}
+
+## Building
 
 `setup.py` provides the setuptools setup script that helps us package and build the wheel. To learn more about Python packaging, take a look at [the official Python documentation][15].
 
@@ -516,36 +402,39 @@ Once your `setup.py` is ready, create a wheel:
 - With the `ddev` tooling (recommended): `ddev release build <INTEGRATION_NAME>`
 - Without the `ddev` tooling: `cd <INTEGRATION_DIR> && python setup.py bdist_wheel`
 
-#### What's in the wheel?
+### What's in the wheel?
 
-The wheel contains only the files necessary for the functioning of the integration itself. This includes the Check itself, the configuration example file, and some artifacts generated during the build of the wheel. All of the other elements, including the metadata files are *not* meant to be contained within the wheel. These latter elements are used elsewhere by the greater Datadog platform and eco-system.
+The wheel contains only the files necessary for the functioning of the integration itself. This includes the Check itself, the configuration example file, and some artifacts generated during the build of the wheel. All of the other elements, including the metadata files are _not_ meant to be contained within the wheel. These latter elements are used elsewhere by the greater Datadog platform and eco-system.
 
-### Installing
+## Installing
 
 The wheel is installed via the Agent `integration` command, available in [Agent v6.10.0 and up][16]. Depending on your environment, you may need to execute this command as a specific user or with particular privileges:
 
 **Linux** (as `dd-agent`):
-```
+
+```bash
 sudo -u dd-agent datadog-agent integration install -w /path/to/wheel.whl
 ```
 
 **OSX** (as admin):
-```
+
+```bash
 sudo datadog-agent integration install -w /path/to/wheel.whl
 ```
 
 **Windows** (Ensure that your shell session has _administrator_ privileges):
 
 For Agent versions <= 6.11:
-```
+
+```ps
 "C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" integration install -w /path/to/wheel.whl
 ```
 
 For Agent versions >= 6.12:
-```
+
+```ps
 "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" integration install -w /path/to/wheel.whl
 ```
-
 
 [1]: https://virtualenv.pypa.io/en/stable
 [2]: https://github.com/DataDog/integrations-core/blob/master/docs/dev/python.md

--- a/docs/dev/python.md
+++ b/docs/dev/python.md
@@ -7,7 +7,7 @@ This document covers how to setup a Python environment to work on Agent-based In
 
 ## Python 2 or Python 3?
 
-Integrations run either within the Agent's embedded Python environment or within the testing environment. The current version of the embedded environment is recorded in the [Omnibus code][1]. The Agent and testing environments are Python 2, but an eventual upgrade to Python 3 is inevitable, thus new Integrations must be compatible with both versions.
+Integrations run either within the Agent's embedded Python environment or within the testing environment. The current version of the embedded environment is recorded in the [Omnibus code][1]. The Agent and testing environments are Python 2 for Agent v6, and Python 3 for Agent v7. Make sure your Integrations are compatible with both versions.
 
 ## Install Python
 

--- a/docs/dev/python.md
+++ b/docs/dev/python.md
@@ -15,22 +15,22 @@ Many operating systems come with Python pre-installed. If your system Python is 
 
 ### macOS
 
-Any recent version of macOS comes with Python pre-installed, however, it may be older than the version used in the Agent, and might also lack required tools and dependencies. You must install a fresh, dedicated Python interpreter that you can manage *without* the App Store.
+Any recent version of macOS comes with Python pre-installed, however, it may be older than the version used in the Agent, and might also lack required tools and dependencies. You must install a fresh, dedicated Python interpreter that you can manage _without_ the App Store.
 
 Some options include:
 
-* [Homebrew][2]: Follow the "[Doing it Right][3]" instructions.
-* [Miniconda][4]: Follow the "[Conda installation][5]" instructions.
+- [Homebrew][2]: Follow the "[Doing it Right][3]" instructions.
+- [Miniconda][4]: Follow the "[Conda installation][5]" instructions.
 
-It is recommended to install an [environment manager][6] in order to preserve a clean system Python.
+It is recommended to install an [environment manager](#virtual-environment-manager) in order to preserve a clean system Python.
 
 ### Linux
 
-All mainstream distributions of Linux come with Python pre-installed — likely one of an acceptable version level. It is recommended to install an [environment manager][6] in order to preserve a clean system Python. Refer to your distribution's package management documentation for more information.
+All mainstream distributions of Linux come with Python pre-installed — likely one of an acceptable version level. It is recommended to install an [environment manager](#virtual-environment-manager) in order to preserve a clean system Python. Refer to your distribution's package management documentation for more information.
 
 ### Windows
 
-Windows does not normally have a Python environment present. The [official Python documentation][7] contains detailed installation instructions and links to further documentation and tooling.
+Windows does not normally have a Python environment present. The [official Python documentation][6] contains detailed installation instructions and links to further documentation and tooling.
 
 ## Virtual environment manager
 
@@ -38,20 +38,19 @@ Each integration has its own set of dependencies that must be added to Python in
 
 ### Virtualenv and Virtualenvwrapper
 
-Datadog recommends using [Virtualenv][8] to manage Python virtual environments, and [virtualenvwrapper][9] to make the process smoother. There's a [comprehensive guide][10] in the Hitchhiker's Guide to Python describing how to set up these two tools.
+Datadog recommends using [Virtualenv][7] to manage Python virtual environments, and [virtualenvwrapper][8] to make the process smoother. There's a [comprehensive guide][9] in the Hitchhiker's Guide to Python describing how to set up these two tools.
 
 ### Miniconda
 
-If you're using Miniconda, a tool to manage virtual environments is included. Refer to the [official guide][11] for more information.
+If you're using Miniconda, a tool to manage virtual environments is included. Refer to the [official guide][10] for more information.
 
 [1]: https://github.com/DataDog/omnibus-software/blob/master/config/software/python.rb#L21
 [2]: https://brew.sh/#install
 [3]: https://docs.python-guide.org/en/latest/starting/install/osx/#doing-it-right
 [4]: https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh
 [5]: https://conda.io/docs/user-guide/install/macos.html
-[6]: #virtual-environment-manager
-[7]: https://docs.python.org/2.7/using/windows.html
-[8]: https://pypi.python.org/pypi/virtualenv
-[9]: https://virtualenvwrapper.readthedocs.io/en/latest/index.html
-[10]: https://docs.python-guide.org/en/latest/dev/virtualenvs/#lower-level-virtualenv
-[11]: https://conda.io/docs/user-guide/tasks/manage-environments.html
+[6]: https://docs.python.org/2.7/using/windows.html
+[7]: https://pypi.python.org/pypi/virtualenv
+[8]: https://virtualenvwrapper.readthedocs.io/en/latest/index.html
+[9]: https://docs.python-guide.org/en/latest/dev/virtualenvs/#lower-level-virtualenv
+[10]: https://conda.io/docs/user-guide/tasks/manage-environments.html


### PR DESCRIPTION
### What does this PR do?

Refactors a bit the integrations how to documentation in order to focus the how to on how to build an integration, and move to a dedicated page all reference materials for the check assets (manifest, conf, service_check.json etc etc)

### Motivation
Make the how to guide more streamlined and allow an easy linking to assets references.

### Additional Notes

Find the preview of those two new page here: https://github.com/DataDog/documentation/pull/7264

* [New how to page](https://docs-staging.datadoghq.com/gus/new-integration-how-to/developers/integrations/new_check_howto/?tab=configurationfile)
* [New reference page](https://docs-staging.datadoghq.com/gus/new-integration-how-to/developers/integrations/check_references/) 

