### PR TITLE
Break reference cycle with log formatter

### DIFF
--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -43,6 +43,9 @@ class CheckLoggingAdapter(logging.LoggerAdapter):
             # Default to `unknown` for checks that log during
             # `__init__` and therefore have no `check_id` yet
             self.extra['_check_id'] = self.check_id or 'unknown'
+            if self.check_id:
+                # Break the reference cycle, once we resolved check_id we don't need the check anymore
+                self.check = None
 
         kwargs.setdefault('extra', self.extra)
         return msg, kwargs


### PR DESCRIPTION
Once check_id is set, we don't need to keep the reference to check. It
could help garbage collect check instances.