### PR TITLE
Use tenacity instead of retrying library

### DIFF
--- a/.azure-pipelines/scripts/sqlserver/windows/40_install_sqlserver.py
+++ b/.azure-pipelines/scripts/sqlserver/windows/40_install_sqlserver.py
@@ -1,13 +1,14 @@
 import subprocess
 
-from retrying import retry
+from tenacity import wait_exponential, retry, stop_after_attempt
 
 
-@retry(stop_max_attempt_number=5, wait_exponential_multiplier=1000)
+@retry(wait=wait_exponential(min=2, max=60), stop=stop_after_attempt(5))
 def install_sqlserver():
     """
     Install with TCP/IP enabled, see: https://chocolatey.org/packages/sql-server-2017
     """
+    print("Install sql-server-2017 ...")
     subprocess.run(["choco", "install", "sql-server-2017", "--no-progress", "--params", "'/TCPENABLED:1'"], check=True)
 
 

--- a/.azure-pipelines/scripts/sqlserver/windows/40_install_sqlserver.py
+++ b/.azure-pipelines/scripts/sqlserver/windows/40_install_sqlserver.py
@@ -9,7 +9,7 @@ def install_sqlserver():
     Install with TCP/IP enabled, see: https://chocolatey.org/packages/sql-server-2017
     """
     print("Install sql-server-2017 ...")
-    subprocess.run(["choco", "install", "xxsql-server-2017", "--no-progress", "--params", "'/TCPENABLED:1'"], check=True)
+    subprocess.run(["choco", "install", "sql-server-2017", "--no-progress", "--params", "'/TCPENABLED:1'"], check=True)
 
 
 install_sqlserver()

--- a/.azure-pipelines/scripts/sqlserver/windows/40_install_sqlserver.py
+++ b/.azure-pipelines/scripts/sqlserver/windows/40_install_sqlserver.py
@@ -9,7 +9,7 @@ def install_sqlserver():
     Install with TCP/IP enabled, see: https://chocolatey.org/packages/sql-server-2017
     """
     print("Install sql-server-2017 ...")
-    subprocess.run(["choco", "install", "sql-server-2017", "--no-progress", "--params", "'/TCPENABLED:1'"], check=True)
+    subprocess.run(["choco", "install", "xxsql-server-2017", "--no-progress", "--params", "'/TCPENABLED:1'"], check=True)
 
 
 install_sqlserver()

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -35,6 +35,7 @@ REQUIRES = [
     'six',
     "shutilwhich==1.1.0; python_version < '3.0'",
     "subprocess32==3.5.4; python_version < '3.0'",
+    'tenacity',
 ]
 
 
@@ -78,7 +79,6 @@ setup(
             'pylint',
             'Pillow',
             'pyperclip>=1.7.0',
-            'retrying',
             'semver',
             'setuptools>=38.6.0',
             'toml>=0.9.4, <1.0.0',

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2018-present
+# (C) Datadog, Inc. 2018-presentx
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 '''

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2018-presentx
+# (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 '''


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use better maintained `tenacity` instead of `retrying`.

Adding `tenacity` to `install_requires` instead of `extras_require` since it will also be used in tests. Example: https://github.com/DataDog/integrations-core/pull/6437

### Motivation
<!-- What inspired you to submit this pull request? -->

Tenacity is more active/maintained library:
- https://github.com/jd/tenacity/graphs/contributors
- https://github.com/rholder/retrying/graphs/contributors

### Additional Notes
<!-- Anything else we should know when reviewing? -->

See retry at work here: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=14061&view=logs&j=9720347a-34cb-5824-38aa-606c39f81a9d&t=52e13ecb-251f-50b6-62d7-aff675c67a91

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
