### PR TITLE
Fix flaky downloader test by adding retry

### DIFF
--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -12,6 +12,7 @@ import subprocess
 
 import requests
 import six
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 from datadog_checks.downloader.download import REPOSITORY_URL_PREFIX
 
@@ -49,6 +50,7 @@ def cleanup():
     delete_files(current_jsons)
 
 
+@retry(wait=wait_exponential(min=2, max=60), stop=stop_after_attempt(10))
 def download(package):
     # -v:     CRITICAL
     # -vv:    ERROR


### PR DESCRIPTION
Depend on: https://github.com/DataDog/integrations-core/pull/6472
Sandbox PR: https://github.com/DataDog/integrations-core/pull/6437

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->


180 successful builds:
![image](https://user-images.githubusercontent.com/49917914/80230063-aeb82c80-8651-11ea-81d6-c51a3aae828a.png)


### Motivation
<!-- What inspired you to submit this pull request? -->

```
    raise tuf.exceptions.NoWorkingMirrorError(file_mirror_errors)
tuf.exceptions.NoWorkingMirrorError: No working mirror was found:
  'dd-integrations-core-wheels-build-stable.datadoghq.com': HTTPError('403 Client Error: Forbidden for url: https://dd-integrations-core-wheels-build-stable.datadoghq.com/metadata.staged/1230.wheels-signer-t.json')

```
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=12320&view=logs&jobId=1e9c9f74-2d69-5fdc-e1d4-ad8b36d1f0fb&j=1e9c9f74-2d69-5fdc-e1d4-ad8b36d1f0fb&t=2a46c87d-55a3-5d2c-5347-60873770a3bd

```
  File "/home/vsts/work/1/s/datadog_checks_downloader/.tox/py38/lib/python3.8/site-packages/tuf/client/updater.py", line 1602, in _get_metadata_file
    raise tuf.exceptions.NoWorkingMirrorError(file_mirror_errors)
tuf.exceptions.NoWorkingMirrorError: No working mirror was found:
  'dd-integrations-core-wheels-build-stable.datadoghq.com': ReplayedMetadataError : Downloaded 'timestamp' is older (1999) than the version currently installed (2000).
```
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=13682&view=logs&j=1e9c9f74-2d69-5fdc-e1d4-ad8b36d1f0fb&t=7b16685f-adfa-55dc-4e24-e83d6ceca7ab&l=6559



### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
