### PR TITLE
Skip matched_files loop if countonly is set

### DIFF
--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -129,12 +129,12 @@ class DirectoryCheck(AgentCheck):
 
             matched_files_length = get_length(matched_files)
             directory_files += matched_files_length
-
+            
+            # We're just looking to count the files.
+            if countonly:
+                continue
+            
             for file_entry in matched_files:
-                # We're just looking to count the files.
-                if countonly:
-                    continue
-
                 try:
                     file_stat = file_entry.stat()
 

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -129,11 +129,11 @@ class DirectoryCheck(AgentCheck):
 
             matched_files_length = get_length(matched_files)
             directory_files += matched_files_length
-            
+
             # We're just looking to count the files.
             if countonly:
                 continue
-            
+
             for file_entry in matched_files:
                 try:
                     file_stat = file_entry.stat()


### PR DESCRIPTION
### What does this PR do?
Tiny optimization.

### Motivation
We were looping and skipping all entries, we can directly not do the loop.
