### PR TITLE
Fix missing `time.clock` attribute in Python 3.8

### DIFF
--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -27,7 +27,7 @@ jobs:
 - template: './templates/test-single-windows.yml'
   parameters:
     job_name: Changed
-    check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dotnetclr exchange_server iis pdh_check sqlserver win32_event_log windows_service wmi_check'
+    check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dns_check dotnetclr exchange_server iis pdh_check sqlserver win32_event_log windows_service wmi_check'
     display: Windows
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'

--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -104,6 +104,9 @@ jobs:
     - checkName: dns_check
       displayName: DNS
       os: linux
+    - checkName: dns_check
+      displayName: DNS
+      os: windows
     - checkName: dotnetclr
       displayName: .NET CLR
       os: windows

--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -102,10 +102,10 @@ jobs:
       displayName: Disk (Windows)
       os: windows
     - checkName: dns_check
-      displayName: DNS
+      displayName: DNS (Linux)
       os: linux
     - checkName: dns_check
-      displayName: DNS
+      displayName: DNS (Windows)
       os: windows
     - checkName: dotnetclr
       displayName: .NET CLR

--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -4,12 +4,21 @@
 
 from __future__ import unicode_literals
 
+import sys
 import time
 
 import dns.resolver
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.platform import Platform
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    # use higher precision clock available in Python3
+    time_func = time.perf_counter
+else:
+    time_func = time.time
 
 # These imports are necessary because otherwise dynamic type
 # resolution will fail on windows without it.
@@ -21,9 +30,8 @@ if Platform.is_win32():
     # for tiny time deltas, time.time on Windows reports the same value
     # of the clock more than once, causing the computation of response_time
     # to be often 0; let's use time.clock that is more precise.
-    time_func = time.clock
-else:
-    time_func = time.time
+    if not PY3:
+        time_func = time.clock
 
 
 class BadConfException(Exception):


### PR DESCRIPTION
### What does this PR do?
`time.clock` has been removed from Python 3.8, so this check fails with an `AttributeError` on Windows.

While we are updating, might as well update the base check to use `perf_counter` which is the recommended version for measuring short durations.

This also adds the check to be run under Windows to catch issues like this in the future.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
