### PR TITLE
Include uncommitted git files to files_changed

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -34,26 +34,29 @@ def get_current_branch():
         return run_command(command, capture='out').stdout.strip()
 
 
-def files_changed():
+def files_changed(include_uncommitted=True):
     """
     Return the list of file changed in the current branch compared to `master`
     """
     with chdir(get_root()):
         # Use `--name-status` to include moved files
         name_status_result = run_command('git diff --name-status master...', capture='out')
-        # Use `--name-only` to include uncommitted files
-        name_only_result = run_command('git diff --name-only master', capture='out')
 
     name_status_lines = name_status_result.stdout.splitlines()
-    name_only_lines = name_only_result.stdout.splitlines()
 
     changed_files = []
     for l in name_status_lines:
         files = l.split('\t')[1:]  # skip first element representing the type of change
         changed_files.extend(files)
 
-    changed_files = set(changed_files + name_only_lines)
-    return sorted([f for f in changed_files if f])
+    if include_uncommitted:
+        with chdir(get_root()):
+            # Use `--name-only` to include uncommitted files
+            name_only_result = run_command('git diff --name-only master', capture='out')
+        name_only_lines = name_only_result.stdout.splitlines()
+        changed_files.extend(name_only_lines)
+
+    return sorted([f for f in set(changed_files) if f])
 
 
 def get_commits_since(check_name, target_tag=None):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -39,13 +39,20 @@ def files_changed():
     Return the list of file changed in the current branch compared to `master`
     """
     with chdir(get_root()):
-        result = run_command('git diff --name-status master...', capture='out')
-    status_lines = result.stdout.splitlines()
+        # Use `--name-status` to include moved files
+        name_status_result = run_command('git diff --name-status master...', capture='out')
+        # Use `--name-only` to include uncommitted files
+        name_only_result = run_command('git diff --name-only master', capture='out')
+
+    name_status_lines = name_status_result.stdout.splitlines()
+    name_only_lines = name_only_result.stdout.splitlines()
 
     changed_files = []
-    for l in status_lines:
+    for l in name_status_lines:
         files = l.split('\t')[1:]  # skip first element representing the type of change
         changed_files.extend(files)
+
+    changed_files = set(changed_files + name_only_lines)
     return sorted([f for f in changed_files if f])
 
 

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -44,13 +44,52 @@ file2
             run.side_effect = [name_status_out, name_only_out]
             set_root('/foo/')
             retval = files_changed()
-            chdir.assert_called_once_with('/foo/')
+
+            chdir.assert_has_calls(
+                [
+                    # since chdir is a context manager, we need to also assert __enter__/__exit__
+                    mock.call('/foo/'),
+                    mock.call().__enter__(),
+                    mock.call().__exit__(None, None, None),
+                    mock.call('/foo/'),
+                    mock.call().__enter__(),
+                    mock.call().__exit__(None, None, None),
+                ]
+            )
             calls = [
                 mock.call('git diff --name-status master...', capture='out'),
                 mock.call('git diff --name-only master', capture='out'),
             ]
             run.assert_has_calls(calls, any_order=True)
             assert retval == ['bar', 'baz', 'file1', 'file2', 'foo', 'foo2', 'foo3']
+
+
+def test_files_changed_not_include_uncommitted():
+    with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
+        with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
+            name_status_out = mock.MagicMock()
+            name_status_out.stdout = '''
+M	foo
+R100	bar	baz
+R100	foo2	foo3
+            '''
+            run.side_effect = [name_status_out]
+            set_root('/foo/')
+            retval = files_changed(include_uncommitted=False)
+
+            chdir.assert_has_calls(
+                [
+                    # since chdir is a context manager, we need to also assert __enter__/__exit__
+                    mock.call('/foo/'),
+                    mock.call().__enter__(),
+                    mock.call().__exit__(None, None, None),
+                ]
+            )
+            calls = [
+                mock.call('git diff --name-status master...', capture='out'),
+            ]
+            run.assert_has_calls(calls, any_order=True)
+            assert retval == ['bar', 'baz', 'foo', 'foo2', 'foo3']
 
 
 def test_get_commits_since():

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -60,7 +60,7 @@ file2
                 mock.call('git diff --name-status master...', capture='out'),
                 mock.call('git diff --name-only master', capture='out'),
             ]
-            run.assert_has_calls(calls, any_order=True)
+            run.assert_has_calls(calls)
             assert retval == ['bar', 'baz', 'file1', 'file2', 'foo', 'foo2', 'foo3']
 
 
@@ -77,18 +77,8 @@ R100	foo2	foo3
             set_root('/foo/')
             retval = files_changed(include_uncommitted=False)
 
-            chdir.assert_has_calls(
-                [
-                    # since chdir is a context manager, we need to also assert __enter__/__exit__
-                    mock.call('/foo/'),
-                    mock.call().__enter__(),
-                    mock.call().__exit__(None, None, None),
-                ]
-            )
-            calls = [
-                mock.call('git diff --name-status master...', capture='out'),
-            ]
-            run.assert_has_calls(calls, any_order=True)
+            chdir.assert_called_once_with('/foo/')
+            run.assert_called_once_with('git diff --name-status master...', capture='out')
             assert retval == ['bar', 'baz', 'foo', 'foo2', 'foo3']
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Include uncommitted git files to files_changed

### Motivation
<!-- What inspired you to submit this pull request? -->

Currently, if some files are not committed they won't be included as `changed files` which is in someway unexpected.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
