### PR TITLE
Add missing metric to metadata and assert metrics

### DIFF
--- a/ibm_mq/metadata.csv
+++ b/ibm_mq/metadata.csv
@@ -64,3 +64,4 @@ ibm_mq.queue_manager.dist_lists,gauge,,resource,,This indicates whether distribu
 ibm_mq.queue_manager.max_msg_list,gauge,,byte,,the length of the longest message the queue manager can handle,0,ibm_mq,max message length
 ibm_mq.queue.max_channels,gauge,,connection,,the max number of channels that can be connected,0,ibm_mq,max channels
 ibm_mq.queue.oldest_message_age,gauge,,second,,the age of the oldest message on the queue in seconds,0,ibm_mq,oldest message
+ibm_mq.queue.uncommitted_msgs,gauge,,message,,the number of uncommitted messages on the queue.,0,ibm_mq,uncommitted msgs

--- a/ibm_mq/tests/test_ibm_mq_e2e.py
+++ b/ibm_mq/tests/test_ibm_mq_e2e.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+from datadog_checks.dev.utils import get_metadata_metrics
 from .common import assert_all_metrics
 
 
@@ -12,3 +13,4 @@ def test_e2e_check_all(dd_agent_check, instance_collect_all):
     aggregator = dd_agent_check(instance_collect_all, rate=True)
 
     assert_all_metrics(aggregator)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())

--- a/ibm_mq/tests/test_ibm_mq_e2e.py
+++ b/ibm_mq/tests/test_ibm_mq_e2e.py
@@ -5,6 +5,7 @@
 import pytest
 
 from datadog_checks.dev.utils import get_metadata_metrics
+
 from .common import assert_all_metrics
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add missing metric to metadata and assert metrics

### Motivation
<!-- What inspired you to submit this pull request? -->

Found using `assert_metrics_using_metadata`:
```
tests/test_ibm_mq_e2e.py:16: in test_e2e_check_all
    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:341: in assert_metrics_using_metadata
    assert not errors, "Metadata assertion errors using metadata.csv:\n" + "\n\t- ".join(sorted(errors))
E   AssertionError: Metadata assertion errors using metadata.csv:
E     Expect `ibm_mq.queue.uncommitted_msgs` to be in metadata.csv.
E   assert not {'Expect `ibm_mq.queue.uncommitted_msgs` to be in metadata.csv.'}
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
