### PR TITLE
Exit discovery thread when check is gc-ed

### DIFF
--- a/snmp/datadog_checks/snmp/discovery.py
+++ b/snmp/datadog_checks/snmp/discovery.py
@@ -5,16 +5,20 @@
 import copy
 import json
 import time
-from typing import Any
+import weakref
+from typing import TYPE_CHECKING
 
 from datadog_checks.base import ConfigurationError
 
 from .compat import write_persistent_cache
 from .config import InstanceConfig
 
+if TYPE_CHECKING:
+    from .snmp import SnmpCheck
+
 
 def discover_instances(config, interval, check_ref):
-    # type: (InstanceConfig, float, Any) -> None
+    # type: (InstanceConfig, float, weakref.ref[SnmpCheck]) -> None
     """Function looping over a subnet to discover devices, meant to run in a thread.
 
     This is extracted from the check class to not keep a strong reference to

--- a/snmp/datadog_checks/snmp/discovery.py
+++ b/snmp/datadog_checks/snmp/discovery.py
@@ -1,0 +1,70 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+import copy
+import json
+import time
+from typing import Any
+
+from datadog_checks.base import ConfigurationError
+
+from .compat import write_persistent_cache
+from .config import InstanceConfig
+
+
+def discover_instances(config, interval, check_ref):
+    # type: (InstanceConfig, float, Any) -> None
+    """Function looping over a subnet to discover devices, meant to run in a thread.
+
+    This is extracted from the check class to not keep a strong reference to
+    the check instance. This way if the agent unschedules the check and deletes
+    the reference to the instance, the check is garbage collected properly and
+    that function can stop.
+    """
+
+    while True:
+        start_time = time.time()
+        for host in config.network_hosts():
+            check = check_ref()
+            if check is None or not check._running:
+                return
+            instance = copy.deepcopy(config.instance)
+            instance.pop('network_address')
+            instance['ip_address'] = host
+
+            host_config = check._build_config(instance)
+
+            try:
+                sys_object_oid = check.fetch_sysobject_oid(host_config)
+            except Exception as e:
+                check.log.debug("Error scanning host %s: %s", host, e)
+                del check
+                continue
+
+            try:
+                profile = check._profile_for_sysobject_oid(sys_object_oid)
+            except ConfigurationError:
+                if not (host_config.all_oids or host_config.bulk_oids):
+                    check.log.warning("Host %s didn't match a profile for sysObjectID %s", host, sys_object_oid)
+                    del check
+                    continue
+            else:
+                host_config.refresh_with_profile(check.profiles[profile])
+                host_config.add_profile_tag(profile)
+
+            config.discovered_instances[host] = host_config
+
+            write_persistent_cache(check.check_id, json.dumps(list(config.discovered_instances)))
+            del check
+
+        check = check_ref()
+        if check is None:
+            return
+        # Write again at the end of the loop, in case some host have been removed since last
+        write_persistent_cache(check.check_id, json.dumps(list(config.discovered_instances)))
+        del check
+
+        time_elapsed = time.time() - start_time
+        if interval - time_elapsed > 0:
+            time.sleep(interval - time_elapsed)

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -679,7 +679,7 @@ def test_discovery(aggregator):
             aggregator.reset()
     finally:
         check._running = False
-        del check
+        del check  # This is what the Agent would do when unscheduling the check.
 
     for metric in common.SUPPORTED_METRIC_TYPES:
         metric_name = "snmp." + metric['name']

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -679,7 +679,7 @@ def test_discovery(aggregator):
             aggregator.reset()
     finally:
         check._running = False
-        check._thread.join()
+        del check
 
     for metric in common.SUPPORTED_METRIC_TYPES:
         metric_name = "snmp." + metric['name']

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -17,9 +17,9 @@ from datadog_checks.base import ConfigurationError
 from datadog_checks.dev import temp_dir
 from datadog_checks.snmp import SnmpCheck
 from datadog_checks.snmp.config import InstanceConfig
+from datadog_checks.snmp.discovery import discover_instances
 from datadog_checks.snmp.parsing import ParsedSymbolMetric, ParsedTableMetric
 from datadog_checks.snmp.resolver import OIDTrie
-from datadog_checks.snmp.snmp import discover_instances
 from datadog_checks.snmp.utils import _load_default_profiles, oid_pattern_specificity, recursively_expand_base_profiles
 
 from . import common
@@ -315,7 +315,7 @@ def test_cache_corrupted(write_mock, read_mock):
 
 
 @mock.patch("datadog_checks.snmp.snmp.read_persistent_cache")
-@mock.patch("datadog_checks.snmp.snmp.write_persistent_cache")
+@mock.patch("datadog_checks.snmp.discovery.write_persistent_cache")
 def test_cache_building(write_mock, read_mock):
     instance = common.generate_instance_config(common.SUPPORTED_METRIC_TYPES)
     instance['timeout'] = 1

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -5,6 +5,7 @@
 import copy
 import os
 import time
+import weakref
 from concurrent import futures
 from typing import Any, List
 
@@ -18,6 +19,7 @@ from datadog_checks.snmp import SnmpCheck
 from datadog_checks.snmp.config import InstanceConfig
 from datadog_checks.snmp.parsing import ParsedSymbolMetric, ParsedTableMetric
 from datadog_checks.snmp.resolver import OIDTrie
+from datadog_checks.snmp.snmp import discover_instances
 from datadog_checks.snmp.utils import _load_default_profiles, oid_pattern_specificity, recursively_expand_base_profiles
 
 from . import common
@@ -291,7 +293,7 @@ def test_cache_discovered_host(read_mock):
 
     read_mock.return_value = '["192.168.0.1"]'
     check = SnmpCheck('snmp', {}, [instance])
-    check.discover_instances = lambda: None
+    check._thread_factory = lambda **kwargs: mock.Mock()
     check.check(instance)
 
     assert '192.168.0.1' in check._config.discovered_instances
@@ -305,7 +307,7 @@ def test_cache_corrupted(write_mock, read_mock):
     instance['network_address'] = '192.168.0.0/24'
     read_mock.return_value = '["192.168.0."]'
     check = SnmpCheck('snmp', {}, [instance])
-    check.discover_instances = lambda: None
+    check._thread_factory = lambda **kwargs: mock.Mock()
     check.check(instance)
 
     assert not check._config.discovered_instances
@@ -459,7 +461,7 @@ def test_discovery_tags():
 
     check.fetch_sysobject_oid = mock_fetch
 
-    check.discover_instances(interval=0)
+    discover_instances(check._config, 0, weakref.ref(check))
 
     config = check._config.discovered_instances['192.168.0.2']
     assert set(config.tags) == {'snmp_device:192.168.0.2', 'test:check', 'snmp_profile:generic-router'}


### PR DESCRIPTION
To have the AgentCheck be collected properly, we can't have a thread
running referencing it directly. This extract the method and keep a
weakref to the check.

Note: this requires an agent change to fix finalize call.