### PR TITLE
Assert metrics using metadata

### DIFF
--- a/activemq_xml/metadata.csv
+++ b/activemq_xml/metadata.csv
@@ -12,6 +12,6 @@ activemq.topic.size,gauge,10,,,The size of a topic.,0,activemq_xml,topic size
 activemq.subscriber.count,gauge,,,,The number of subscribers.,0,activemq_xml,sub count
 activemq.subscriber.dequeue_counter,gauge,,message,,The number of messages sent to and acknowledged by the client.,0,activemq_xml,sub deq cntr
 activemq.subscriber.dispatched_counter,gauge,,message,,The number of messages sent to the client.,0,activemq_xml,sub disptchd cntr
-activemq.subscriber.dipatched_queue_size,gauge,,message,,The number of messages dispatched that are awaiting acknowledgement.,0,activemq_xml,sub disptchd que size
+activemq.subscriber.dispatched_queue_size,gauge,,message,,The number of messages dispatched that are awaiting acknowledgement.,0,activemq_xml,sub disptchd que size
 activemq.subscriber.enqueue_counter,gauge,,message,,The number of messages that matched the subscription.,0,activemq_xml,sub enq cntr
 activemq.subscriber.pending_queue_size,gauge,,message,,The number of messages pending delivery.,0,activemq_xml,sub pend que size

--- a/activemq_xml/tests/test_activemq_xml.py
+++ b/activemq_xml/tests/test_activemq_xml.py
@@ -7,6 +7,7 @@ import pytest
 
 from datadog_checks.activemq_xml import ActiveMQXML
 
+from datadog_checks.dev.utils import get_metadata_metrics
 from .common import CHECK_NAME, CONFIG, GENERAL_METRICS, QUEUE_METRICS, SUBSCRIBER_METRICS, TOPIC_METRICS, URL
 
 
@@ -25,6 +26,8 @@ def test_integration(aggregator):
 def test_e2e(dd_agent_check):
     aggregator = dd_agent_check(CONFIG)
     _test_check(aggregator)
+
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 def _test_check(aggregator):

--- a/activemq_xml/tests/test_activemq_xml.py
+++ b/activemq_xml/tests/test_activemq_xml.py
@@ -19,12 +19,14 @@ def test_integration(aggregator):
     """
     check = ActiveMQXML(CHECK_NAME, {}, [CONFIG])
     check.check(CONFIG)
+
     _test_check(aggregator)
 
 
 @pytest.mark.e2e
 def test_e2e(dd_agent_check):
     aggregator = dd_agent_check(CONFIG)
+
     _test_check(aggregator)
 
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())

--- a/activemq_xml/tests/test_activemq_xml.py
+++ b/activemq_xml/tests/test_activemq_xml.py
@@ -6,8 +6,8 @@ from itertools import product
 import pytest
 
 from datadog_checks.activemq_xml import ActiveMQXML
-
 from datadog_checks.dev.utils import get_metadata_metrics
+
 from .common import CHECK_NAME, CONFIG, GENERAL_METRICS, QUEUE_METRICS, SUBSCRIBER_METRICS, TOPIC_METRICS, URL
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Assert metrics using metadata

### Motivation
<!-- What inspired you to submit this pull request? -->

```
tests/test_activemq_xml.py:32: in test_e2e
    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:341: in assert_metrics_using_metadata
    assert not errors, "Metadata assertion errors using metadata.csv:\n" + "\n\t- ".join(sorted(errors))
E   AssertionError: Metadata assertion errors using metadata.csv:
E     Expect `activemq.subscriber.dispatched_queue_size` to be in metadata.csv.
E   assert not set(['Expect `activemq.subscriber.dispatched_queue_size` to be in metadata.csv.'])
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
