### PR TITLE
Assert metrics using metadata and add missing metrics

### DIFF
--- a/aerospike/metadata.csv
+++ b/aerospike/metadata.csv
@@ -578,6 +578,14 @@ aerospike.namespace.xdr_from_proxy_delete_timeout,gauge,,transaction,,Number of 
 aerospike.namespace.xdr_from_proxy_write_error,gauge,,transaction,,Number of errors for XDR write transactions proxied from another node.,0,aerospike,
 aerospike.namespace.xdr_from_proxy_write_success,gauge,,transaction,,Number of successful XDR write transactions proxied from another node.,0,aerospike,
 aerospike.namespace.xdr_from_proxy_write_timeout,gauge,,transaction,,Number of timeouts for XDR write transactions proxied from another node.,0,aerospike,
+aerospike.namespace.latency.read_ops_sec,gauge,,transaction,,Read operations per sec.,-1,aerospike,read ops sec
+aerospike.namespace.latency.read_over_1ms,gauge,,transaction,,Read latency over 1ms.,-1,aerospike,read latency 1ms
+aerospike.namespace.latency.read_over_64ms,gauge,,transaction,,Read latency over 4ms.,-1,aerospike,read latency 4ms
+aerospike.namespace.latency.read_over_8ms,gauge,,transaction,,Read latency over 8ms.,-1,aerospike,read latency 8ms
+aerospike.namespace.latency.write_ops_sec,gauge,,transaction,,Write operations per sec.,-1,aerospike,write ops sec
+aerospike.namespace.latency.write_over_1ms,gauge,,transaction,,Write latency over 1ms.,-1,aerospike,write latency 1ms
+aerospike.namespace.latency.write_over_64ms,gauge,,transaction,,Write latency over 4ms.,-1,aerospike,write latency 4ms
+aerospike.namespace.latency.write_over_8ms,gauge,,transaction,,Write latency over 8ms.,-1,aerospike,write latency 8ms
 aerospike.set.tombstones,gauge,,,,Total number of tombstones (master and all replicas) in this set on this node.,0,aerospike,
 aerospike.set.truncate_lut,gauge,,,,The "most covering" truncate_lut for this set.,0,aerospike,
 aerospike.batch_index_delay,gauge,,,,Number of times a batch index response buffer has been delayed (WOULDBLOCK on the send).,0,aerospike,

--- a/aerospike/tests/test_aerospike.py
+++ b/aerospike/tests/test_aerospike.py
@@ -7,6 +7,7 @@ import mock
 import pytest
 
 from datadog_checks.aerospike import AerospikeCheck
+from datadog_checks.dev.utils import get_metadata_metrics
 
 from .common import LAZY_METRICS, NAMESPACE_METRICS, SET_METRICS, STATS_METRICS
 
@@ -52,6 +53,8 @@ def test_e2e(dd_agent_check, instance):
     aggregator = dd_agent_check(instance)
 
     _test_check(aggregator)
+
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 def _test_check(aggregator):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Assert metrics using metadata
### Motivation
<!-- What inspired you to submit this pull request? -->

```
tests/test_aerospike.py:57: in test_e2e
    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:341: in assert_metrics_using_metadata
    assert not errors, "Metadata assertion errors using metadata.csv:\n" + "\n\t- ".join(sorted(errors))
E   AssertionError: Metadata assertion errors using metadata.csv:
E     Expect `aerospike.namespace.latency.read_ops_sec` to be in metadata.csv.
E     	- Expect `aerospike.namespace.latency.read_over_1ms` to be in metadata.csv.
E     	- Expect `aerospike.namespace.latency.read_over_64ms` to be in metadata.csv.
E     	- Expect `aerospike.namespace.latency.read_over_8ms` to be in metadata.csv.
E     	- Expect `aerospike.namespace.latency.write_ops_sec` to be in metadata.csv.
E     	- Expect `aerospike.namespace.latency.write_over_1ms` to be in metadata.csv.
E     	- Expect `aerospike.namespace.latency.write_over_64ms` to be in metadata.csv.
E     	- Expect `aerospike.namespace.latency.write_over_8ms` to be in metadata.csv.
E   assert not set(['Expect `aerospike.namespace.latency.read_ops_sec` to be in metadata.csv.', 'Expect `aerospike.namespace.latency....e_ops_sec` to be in metadata.csv.', 'Expect `aerospike.namespace.latency.write_over_1ms` to be in metadata.csv.', ...])

```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
