### PR TITLE
Fix assert_metrics_using_metadata output

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -338,7 +338,7 @@ class AggregatorStub(object):
                             )
                         )
 
-        assert not errors, "Metadata assertion errors using metadata.csv:\n" + "\n\t- ".join(sorted(errors))
+        assert not errors, "Metadata assertion errors using metadata.csv:" + "\n\t- ".join([''] + sorted(errors))
 
     def assert_no_duplicate_all(self):
         """


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

Before:

```
E   AssertionError: Metadata assertion errors using metadata.csv:
E     Expect `network.http.can_connect` to be in metadata.csv.
E     	- Expect `network.http.cant_connect` to be in metadata.csv.
E     	- Expect `network.http.response_time` to be in metadata.csv.
E   assert not set(['Expect `network.http.can_connect` to be in metadata.csv.', 'Expect `network.http.cant_connect` to be in metadata.csv.', 'Expect `network.http.response_time` to be in metadata.csv.'])
```

After:

```
E   AssertionError: Metadata assertion errors using metadata.csv:
E     	- Expect `network.http.can_connect` to be in metadata.csv.
E     	- Expect `network.http.cant_connect` to be in metadata.csv.
E     	- Expect `network.http.response_time` to be in metadata.csv.
E   assert not set(['Expect `network.http.can_connect` to be in metadata.csv.', 'Expect `network.http.cant_connect` to be in metadata.csv.', 'Expect `network.http.response_time` to be in metadata.csv.'])
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
