### PR TITLE
Document SCRAM authentication in example config

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -104,17 +104,17 @@ instances:
 
     ## @param sasl_mechanism - string - optional
     ## String picking sasl mechanism when security_protocol is SASL_PLAINTEXT or SASL_SSL.
-    ## Valid values are: PLAIN, GSSAPI, OAUTHBEARER.
+    ## Valid values are: PLAIN, GSSAPI, OAUTHBEARER, SCRAM-SHA-256, SCRAM-SHA-512.
     #
     # sasl_mechanism: PLAIN
 
     ## @param sasl_plain_username - string - optional
-    ## Username for sasl PLAIN authentication.
+    ## Username for sasl PLAIN or SCRAM authentication.
     #
     # sasl_plain_username: <USERNAME>
 
     ## @param sasl_plain_password - string - optional
-    ## Password for sasl PLAIN authentication.
+    ## Password for sasl PLAIN or SCRAM authentication.
     #
     # sasl_plain_password: <PASSWORD>
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update `conf.yaml.example` for `kafka_consumer` check to reflect support of SCRAM authentication.

### Motivation
<!-- What inspired you to submit this pull request? -->
Scrap support was added by upgrading to `kafka-python==2.0.0` via https://github.com/DataDog/integrations-core/pull/5696 (merged Feb 11, included in Agent 7.18.0), but the example config hasn't been updated yet.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Official `kafka-python` docs with mentions of SCRAM can be found here: https://kafka-python.readthedocs.io/en/stable/apidoc/BrokerConnection.html
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
