### PR TITLE
Add 'redis.net.connections' metric to count connections by client

### DIFF
--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -37,6 +37,7 @@ redis.mem.overhead,gauge,,byte,,Sum of all overheads allocated by Redis for mana
 redis.net.clients,gauge,,connection,,The number of connected clients (excluding slaves).,0,redis,clients
 redis.net.commands,gauge,,command,,The number of commands processed by the server.,0,redis,net commands
 redis.net.commands.instantaneous_ops_per_sec,gauge,,command,second,The number of commands processed by the server per second.,0,redis,net commands
+redis.net.connections,gauge,,connection,,The number of connections tagged by client name.,0,redis,connections
 redis.net.rejected,gauge,,connection,,The number of rejected connections.,-1,redis,net rejected
 redis.net.slaves,gauge,,connection,,The number of connected slaves.,0,redis,slaves
 redis.net.maxclients,gauge,,connection,,The maximum number of connected clients.,0,redis,maxclients

--- a/redisdb/tests/test_default.py
+++ b/redisdb/tests/test_default.py
@@ -81,10 +81,11 @@ def test_redis_default(aggregator, redis_auth, redis_instance):
     for name in aggregator.metric_names:
         if name in DB_TAGGED_METRICS:
             aggregator.assert_metric(name, tags=expected_db)
-        elif name != 'redis.key.length':
+        elif name not in ('redis.key.length', 'redis.net.connections'):
             aggregator.assert_metric(name, tags=expected)
 
     aggregator.assert_metric('redis.key.length', 3, count=1, tags=expected_db + ['key:test_list', 'key_type:list'])
+    aggregator.assert_metric('redis.net.connections', count=1, tags=expected + ['source:unknown'])
 
     aggregator.assert_metric('redis.net.maxclients')
 

--- a/redisdb/tests/test_e2e.py
+++ b/redisdb/tests/test_e2e.py
@@ -35,6 +35,7 @@ def assert_common_metrics(aggregator):
     aggregator.assert_metric('redis.stats.keyspace_misses', count=1, tags=tags)
     aggregator.assert_metric('redis.pubsub.channels', count=2, tags=tags)
     aggregator.assert_metric('redis.net.clients', count=2, tags=tags)
+    aggregator.assert_metric('redis.net.connections', count=2, tags=tags + ['source:unknown'])
     aggregator.assert_metric('redis.mem.used', count=2, tags=tags)
     aggregator.assert_metric('redis.mem.peak', count=2, tags=tags)
     aggregator.assert_metric('redis.stats.keyspace_hits', count=1, tags=tags)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds a new metric to the redisdb check counting the number of connection by client name

### Motivation
<!-- What inspired you to submit this pull request? -->

We have a internal check at datadog reporting this metric and we think it could be useful to a lot of people

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
