### PR TITLE
Update metrics and use config spec

### DIFF
--- a/solr/assets/configuration/spec.yaml
+++ b/solr/assets/configuration/spec.yaml
@@ -1,0 +1,15 @@
+name: Solr
+files:
+- name: solr.yaml
+  options:
+  - template: init_config
+    options:
+    - template: init_config/jmx
+  - template: instances
+    options:
+    - template: instances/jmx
+      overrides:
+        host.description: Solr JMX host to connect to.
+        port.value.example: 9999
+        port.description: Solr JMX port to connect to.
+        name.value.example: solr_instance

--- a/solr/datadog_checks/solr/data/conf.yaml.example
+++ b/solr/datadog_checks/solr/data/conf.yaml.example
@@ -1,305 +1,163 @@
+## All options defined here are available to all instances.
+#
+init_config:
+
+    ## @param is_jmx - boolean - required
+    ## Whether or not this file is a configuration for a JMX integration.
+    #
+    is_jmx: true
+
+    ## @param collect_default_metrics - boolean - required
+    ## Whether or not the check should collect all default metrics.
+    #
+    collect_default_metrics: true
+
+    ## @param service_check_prefix - string - optional
+    ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.
+    ## If not set, the default service check used is the integration name.
+    #
+    # service_check_prefix: <SERVICE_CHECK_PREFIX>
+
+    ## @param conf - list of mappings - optional
+    ## The list of metrics to be collected by the integration
+    ## Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it
+    ## The default metrics to be collected are kept in metrics.yaml, but you can still
+    ## add your own metrics here.
+    #
+    # conf:
+    #   - include:
+    #       bean: <BEAN_NAME>
+    #       attribute:
+    #         MyAttribute:
+    #           alias: my.metric.name
+    #           metric_type: gauge
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Additionally, this sets the default `service` for every log source.
+    #
+    # service: <SERVICE>
+
+## Every instance is scheduled independent of the others.
+#
 instances:
 
     ## @param host - string - required
-    ## Solr host to connect to.
+    ## Solr JMX host to connect to.
     #
-  - host: localhost
+  - host: <HOST>
 
     ## @param port - integer - required
-    ## Solr port to connect to.
+    ## Solr JMX port to connect to.
     #
     port: 9999
 
     ## @param user - string - optional
-    ## Username from the credentials needed to connect to the host.
+    ## User to use when connecting to JMX.
     #
-    # user: <USERNAME>
+    # user: <USER>
 
     ## @param password - string - optional
-    ## Password from the credentials needed to connect to the host.
+    ## Password to use when connecting to JMX.
     #
     # password: <PASSWORD>
 
     ## @param process_name_regex - string - optional
-    ## Instead of specifying a host, and port. The agent can connect using the attach api.
-    ## This requires the JDK to be installed and the path to `tools.jar` to be set below in `tools_jar_path` parameter.
+    ## Instead of using a host and port, the Agent can connect using the attach API.
+    ## This requires the JDK to be installed and the path to tools.jar to be set below.
+    ## Note: It needs to be set when process_name_regex parameter is set
+    ## e.g. .*process_name.*
     #
-    # process_name_regex: .*process_name.*
+    # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## Needs to be set when process_name_regex parameter is set.
+    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
     #
-    # tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
+    # tools_jar_path: <TOOLS_JAR_PATH>
 
-    ## @param name - string - optional
-    ## Set your instance name.
+    ## @param name - string - optional - default: solr_instance
+    ## Set the instance name to be used as the `instance` tag.
     #
-    #  name: solr_instance
+    # name: solr_instance
 
     ## @param java_bin_path - string - optional
-    ## java_bin_path should be set if the agent cannot find your java executable
+    ## `java_bin_path` should be set if the Agent cannot find your java executable.
     #
-    # java_bin_path: <JAVA_PATH>
+    # java_bin_path: <JAVA_BIN_PATH>
 
     ## @param java_options - string - optional
-    ## List of Java JVM options.
+    ## A list of Java JVM options, for example: "-Xmx200m -Xms50m".
     #
-    # java_options: "-Xmx200m -Xms50m"
+    # java_options: <JAVA_OPTIONS>
 
     ## @param trust_store_path - string - optional
-    ## trust_store_path should be set if "com.sun.management.jmxremote.ssl" is
-    ## set to true on the target JVM.
-    ## It's the path to your trusted store
+    ## The path to your trusted store.
+    ## `trust_store_path` should be set if SSL is enabled.
     #
-    # trust_store_path: <TRUSTSTORE.JKS_PATH>
+    # trust_store_path: <TRUST_STORE_PATH>
 
     ## @param trust_store_password - string - optional
-    ## `trust_store_password` should be set if "com.sun.management.jmxremote.ssl" is
-    ## set to true on the target JVM. It's the password for your TrustStore.jks file.
+    ## The password for your TrustStore.jks file.
+    ## `trust_store_password` should be set if SSL is enabled.
     #
-    # trust_store_password: <PASSWORD>
+    # trust_store_password: <TRUST_STORE_PASSWORD>
 
     ## @param key_store_path - string - optional
-    ## key_store_path should be set if "com.sun.management.jmxremote.ssl.need.client.auth"
-    ## is set to true on the target JVM.
-    ## It's the path to your key store.
+    ## The path to your key store.
+    ## `key_store_path` should be set if client authentication is enabled on the target JVM.
     #
-    # key_store_path: <KEYSTORE.JKS_PATH>
+    # key_store_path: <KEY_STORE_PATH>
 
     ## @param key_store_password - string - optional
-    ## key_store_password should be set if "com.sun.management.jmxremote.ssl.need.client.auth"
-    ## is set to true on the target JVM.
-    ## It's the password for your KeyStore.jks file.
+    ## The password to your key store.
+    ## `key_store_password` should be set if client authentication is enabled on the target JVM.
     #
-    # key_store_password: <PASSWORD>
+    # key_store_password: <KEY_STORE_PASSWORD>
 
-    ## @param rmi_registry_ssl - boolean - optional
-    ## Whether or not the agent should connect to the rmi registry using ssl.
-    ## should be set to true if "com.sun.management.jmxremote.registry.ssl" is set to true on the target JVM.
+    ## @param rmi_registry_ssl - boolean - optional - default: false
+    ## Whether or not the Agent should connect to the RMI registry using SSL.
     #
     # rmi_registry_ssl: false
 
-    ## @param tags - list of key:value element - optional
-    ## List of tags to attach to every metric, event and service check emitted by this integration.
+    ## @param rmi_connection_timeout - number - optional - default: 30
+    ## The connection timeout, in seconds, when connecting to a remote JVM.
+    #
+    # rmi_connection_timeout: 30
+
+    ## @param rmi_client_timeout - number - optional - default: 30
+    ## The timeout to consider a remote connection, already successfully established, as lost.
+    ## If a connected remote JVM does not reply after `rmi_client_timeout` seconds jmxfetch
+    ## will give up on that connection and retry.
+    #
+    # rmi_client_timeout: 30
+
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
     ##
-    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
     #
     # tags:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
 
-init_config:
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Overrides any `service` defined in the `init_config` section.
+    #
+    # service: <SERVICE>
 
-  ## @param is_jmx - boolean - required
-  ## Whether or not this file is a configuration for a JMX integration
-  #
-  is_jmx: true
+    ## @param min_collection_interval - number - optional - default: 15
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    # min_collection_interval: 15
 
-  ## @param collect_default_metrics - boolean - required
-  ## Whether or not the check should collect all default metrics for this integration.
-  #
-  collect_default_metrics: true
-
-  ## @param conf - list of objects - required
-  ## List of metrics to be collected by the integration
-  ## Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it
-  ## Agent 5: Customize all your metrics below
-  ## Agent 6: The default metrics to be collected are kept in metrics.yaml, but you can still add your own metrics here
-  #
-  conf:
-    ## Solr 7 MBeans
-  - include:
-      category: SEARCHER
-      name:
-        - numDocs
-      scope:
-        - searcher
-      attribute:
-        Value:
-          alias: solr.searcher.numdocs
-          metric_type: gauge
-
-  - include:
-      category: SEARCHER
-      name: maxDoc
-      scope:
-        - searcher
-      attribute:
-        Value:
-          alias: solr.searcher.maxdocs
-          metric_type: gauge
-
-  - include:
-      category: SEARCHER
-      name: warmupTime
-      scope:
-        - searcher
-      attribute:
-        Value:
-          alias: solr.searcher.warmup
-          metric_type: gauge
-
-  - include:
-      category: CACHE
-      name: documentCache
-      scope:
-        - searcher
-      attribute:
-        cumulative_lookups:
-          alias: solr.document_cache.lookups
-          metric_type: counter
-        cumulative_hits:
-          alias: solr.document_cache.hits
-          metric_type: counter
-        cumulative_inserts:
-          alias: solr.document_cache.inserts
-          metric_type: counter
-        cumulative_evictions:
-          alias: solr.document_cache.evictions
-          metric_type: counter
-
-  - include:
-      category: CACHE
-      name: queryResultCache
-      scope:
-        - searcher
-      attribute:
-        cumulative_lookups:
-          alias: solr.query_result_cache.lookups
-          metric_type: counter
-        cumulative_hits:
-          alias: solr.query_result_cache.hits
-          metric_type: counter
-        cumulative_inserts:
-          alias: solr.query_result_cache.inserts
-          metric_type: counter
-        cumulative_evictions:
-          alias: solr.query_result_cache.evictions
-          metric_type: counter
-
-  - include:
-      category: CACHE
-      name: filterCache
-      scope:
-        - searcher
-      attribute:
-        cumulative_lookups:
-          alias: solr.filter_cache.lookups
-          metric_type: counter
-        cumulative_hits:
-          alias: solr.filter_cache.hits
-          metric_type: counter
-        cumulative_inserts:
-          alias: solr.filter_cache.inserts
-          metric_type: counter
-        cumulative_evictions:
-          alias: solr.filter_cache.evictions
-          metric_type: counter
-
-  - include:
-      category: QUERY
-      name: requests
-      attribute:
-        Count:
-          alias: solr.search_handler.requests
-          metric_type: counter
-
-  - include:
-      category: QUERY
-      name: timeouts
-      attribute:
-        Count:
-          alias: solr.search_handler.timeouts
-          metric_type: counter
-
-  - include:
-      category: QUERY
-      name: errors
-      attribute:
-        Count:
-          alias: solr.search_handler.errors
-          metric_type: counter
-
-  - include:
-      category: QUERY
-      name: totalTime
-      attribute:
-        Count:
-          alias: solr.search_handler.time
-          metric_type: counter
-
-  - include:
-      category: QUERY
-      name: requestTimes
-      attribute:
-        avgRequestsPerSecond:
-          alias: solr.search_handler.avg_requests_per_sec
-          metric_type: gauge
-        avgTimePerRequest:
-          alias: solr.search_handler.avg_time_per_req
-          metric_type: gauge
-
-    ## Solr version < 7 MBeans
-  - include:
-      type: searcher
-      attribute:
-        maxDoc:
-          alias: solr.searcher.maxdoc
-          metric_type: gauge
-        numDocs:
-          alias: solr.searcher.numdocs
-          metric_type: gauge
-        warmupTime:
-          alias: solr.searcher.warmup
-          metric_type: gauge
-  - include:
-      id: org.apache.solr.search.FastLRUCache
-      attribute:
-        cumulative_lookups:
-          alias: solr.cache.lookups
-          metric_type: counter
-        cumulative_hits:
-          alias: solr.cache.hits
-          metric_type: counter
-        cumulative_inserts:
-          alias: solr.cache.inserts
-          metric_type: counter
-        cumulative_evictions:
-          alias: solr.cache.evictions
-          metric_type: counter
-  - include:
-      id: org.apache.solr.search.LRUCache
-      attribute:
-        cumulative_lookups:
-          alias: solr.cache.lookups
-          metric_type: counter
-        cumulative_hits:
-          alias: solr.cache.hits
-          metric_type: counter
-        cumulative_inserts:
-          alias: solr.cache.inserts
-          metric_type: counter
-        cumulative_evictions:
-          alias: solr.cache.evictions
-          metric_type: counter
-  - include:
-      id: org.apache.solr.handler.component.SearchHandler
-      attribute:
-        errors:
-          alias: solr.search_handler.errors
-          metric_type: counter
-        requests:
-          alias: solr.search_handler.requests
-          metric_type: counter
-        timeouts:
-          alias: solr.search_handler.timeouts
-          metric_type: counter
-        totalTime:
-          alias: solr.search_handler.time
-          metric_type: counter
-        avgTimePerRequest:
-          alias: solr.search_handler.avg_time_per_req
-          metric_type: gauge
-        avgRequestsPerSecond:
-          alias: solr.search_handler.avg_requests_per_sec
-          metric_type: gauge
+    ## @param empty_default_hostname - boolean - optional - default: false
+    ## This forces the check to send metrics with no hostname.
+    ##
+    ## This is useful for cluster-level checks.
+    #
+    # empty_default_hostname: false

--- a/solr/datadog_checks/solr/data/metrics.yaml
+++ b/solr/datadog_checks/solr/data/metrics.yaml
@@ -126,11 +126,29 @@ jmx_metrics:
       category: QUERY
       name: requestTimes
       attribute:
-        avgRequestsPerSecond:
+        MeanRate:
           alias: solr.search_handler.avg_requests_per_sec
           metric_type: gauge
-        avgTimePerRequest:
-          alias: solr.search_handler.avg_time_per_req
+        50thPercentile:
+          alias: solr.search_handler.request_times.50percentile
+          metric_type: gauge
+        75thPercentile:
+          alias: solr.search_handler.request_times.75percentile
+          metric_type: gauge
+        95thPercentile:
+          alias: solr.search_handler.request_times.95percentile
+          metric_type: gauge
+        98thPercentile:
+          alias: solr.search_handler.request_times.98percentile
+          metric_type: gauge
+        99thPercentile:
+          alias: solr.search_handler.request_times.99percentile
+          metric_type: gauge
+        999thPercentile:
+          alias: solr.search_handler.request_times.999percentile
+          metric_type: gauge
+        OneMinuteRate:
+          alias: solr.search_handler.request_times.one_minute_rate
           metric_type: gauge
 
 

--- a/solr/datadog_checks/solr/data/metrics.yaml
+++ b/solr/datadog_checks/solr/data/metrics.yaml
@@ -126,8 +126,11 @@ jmx_metrics:
       category: QUERY
       name: requestTimes
       attribute:
+        Mean:
+          alias: solr.search_handler.request_times.mean
+          metric_type: gauge
         MeanRate:
-          alias: solr.search_handler.avg_requests_per_sec
+          alias: solr.search_handler.request_times.mean_rate
           metric_type: gauge
         50thPercentile:
           alias: solr.search_handler.request_times.50percentile

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -10,7 +10,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "solr.",
-  "metric_to_check": "solr.cache.hits",
+  "metric_to_check": "solr.searcher.numdocs",
   "name": "solr",
   "process_signatures": [
     "solr start"

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -26,6 +26,9 @@
   "type": "check",
   "integration_id": "solr",
   "assets": {
+    "configuration": {
+      "spec": "assets/configuration/spec.yaml"
+    },
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json"

--- a/solr/metadata.csv
+++ b/solr/metadata.csv
@@ -21,6 +21,6 @@ solr.search_handler.errors,gauge,10,error,second,Number of errors per second enc
 solr.search_handler.requests,gauge,10,request,second,Number of requests per second processed by the handler.,0,solr,search requests
 solr.search_handler.time,gauge,10,,,The sum of all request processing times (in milliseconds) per second.,0,solr,search time
 solr.search_handler.timeouts,gauge,10,timeout,second,Number of responses per second received with partial results.,-1,solr,search timeouts
-solr.searcher.maxdoc,gauge,10,document,,One greater than the largest possible document number.,0,solr,max doc id
+solr.searcher.maxdocs,gauge,10,document,,One greater than the largest possible document number.,0,solr,max doc id
 solr.searcher.numdocs,gauge,10,document,,The total number of indexed documents.,0,solr,num docs
 solr.searcher.warmup,gauge,10,millisecond,,The time spent warming up.,-1,solr,warmup time

--- a/solr/metadata.csv
+++ b/solr/metadata.csv
@@ -21,6 +21,7 @@ solr.search_handler.errors,gauge,10,error,second,Number of errors per second enc
 solr.search_handler.requests,gauge,10,request,second,Number of requests per second processed by the handler.,0,solr,search requests
 solr.search_handler.time,gauge,10,,,The sum of all request processing times (in milliseconds) per second.,0,solr,search time
 solr.search_handler.timeouts,gauge,10,timeout,second,Number of responses per second received with partial results.,-1,solr,search timeouts
+solr.searcher.maxdoc,gauge,10,document,,One greater than the largest possible document number (Solr version <= 6).,0,solr,max doc id solr6
 solr.searcher.maxdocs,gauge,10,document,,One greater than the largest possible document number.,0,solr,max doc id
 solr.searcher.numdocs,gauge,10,document,,The total number of indexed documents.,0,solr,num docs
 solr.searcher.warmup,gauge,10,millisecond,,The time spent warming up.,-1,solr,warmup time

--- a/solr/metadata.csv
+++ b/solr/metadata.csv
@@ -15,7 +15,14 @@ solr.query_result_cache.evictions,gauge,10,eviction,second,The total number of c
 solr.query_result_cache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,query result cache hits
 solr.query_result_cache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,query result cache sets
 solr.query_result_cache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,query result cache gets
-solr.search_handler.avg_requests_per_sec,gauge,10,request,second,The average number of requests per second.,1,solr,search reqs per sec
+solr.search_handler.request_times.50percentile,gauge,10,request,second,Request processing time in milliseconds (50percentile).,-1,solr,search reqs proces time 50p
+solr.search_handler.request_times.75percentile,gauge,10,request,second,Request processing time in milliseconds (75percentile).,-1,solr,search reqs proces time 75p
+solr.search_handler.request_times.95percentile,gauge,10,request,second,Request processing time in milliseconds (95percentile).,-1,solr,search reqs proces time 95p
+solr.search_handler.request_times.98percentile,gauge,10,request,second,Request processing time in milliseconds (98percentile).,-1,solr,search reqs proces time 98p
+solr.search_handler.request_times.99percentile,gauge,10,request,second,Request processing time in milliseconds (99percentile).,-1,solr,search reqs proces time 99p
+solr.search_handler.request_times.999percentile,gauge,10,request,second,Request processing time in milliseconds (999percentile).,-1,solr,search reqs proces time 999p
+solr.search_handler.request_times.one_minute_rate,gauge,10,request,second,Requests per second received over the past minutes.,-1,solr,search reqs proces time
+solr.search_handler.avg_requests_per_sec,gauge,10,request,second,Average number of requests received per second since the Solr core was first created.,1,solr,search reqs per sec
 solr.search_handler.avg_time_per_req,gauge,10,millisecond,request,The average time per request.,-1,solr,search time per req
 solr.search_handler.errors,gauge,10,error,second,Number of errors per second encountered by the handler.,-1,solr,search errors
 solr.search_handler.requests,gauge,10,request,second,Number of requests per second processed by the handler.,0,solr,search requests

--- a/solr/metadata.csv
+++ b/solr/metadata.csv
@@ -22,6 +22,8 @@ solr.search_handler.request_times.98percentile,gauge,10,request,second,Request p
 solr.search_handler.request_times.99percentile,gauge,10,request,second,Request processing time in milliseconds (99percentile).,-1,solr,search reqs proces time 99p
 solr.search_handler.request_times.999percentile,gauge,10,request,second,Request processing time in milliseconds (999percentile).,-1,solr,search reqs proces time 999p
 solr.search_handler.request_times.one_minute_rate,gauge,10,request,second,Requests per second received over the past minutes.,1,solr,search reqs proces time
+solr.search_handler.request_times.mean_rate,gauge,10,request,second,Average number of requests received per second since the Solr core was first created.,1,solr,search reqs mean rate
+solr.search_handler.request_times.mean,gauge,10,millisecond,request,The average time per request.,-1,solr,search time mean
 solr.search_handler.avg_requests_per_sec,gauge,10,request,second,Average number of requests received per second since the Solr core was first created.,1,solr,search reqs per sec
 solr.search_handler.avg_time_per_req,gauge,10,millisecond,request,The average time per request.,-1,solr,search time per req
 solr.search_handler.errors,gauge,10,error,second,Number of errors per second encountered by the handler.,-1,solr,search errors

--- a/solr/metadata.csv
+++ b/solr/metadata.csv
@@ -21,7 +21,7 @@ solr.search_handler.request_times.95percentile,gauge,10,request,second,Request p
 solr.search_handler.request_times.98percentile,gauge,10,request,second,Request processing time in milliseconds (98percentile).,-1,solr,search reqs proces time 98p
 solr.search_handler.request_times.99percentile,gauge,10,request,second,Request processing time in milliseconds (99percentile).,-1,solr,search reqs proces time 99p
 solr.search_handler.request_times.999percentile,gauge,10,request,second,Request processing time in milliseconds (999percentile).,-1,solr,search reqs proces time 999p
-solr.search_handler.request_times.one_minute_rate,gauge,10,request,second,Requests per second received over the past minutes.,-1,solr,search reqs proces time
+solr.search_handler.request_times.one_minute_rate,gauge,10,request,second,Requests per second received over the past minutes.,1,solr,search reqs proces time
 solr.search_handler.avg_requests_per_sec,gauge,10,request,second,Average number of requests received per second since the Solr core was first created.,1,solr,search reqs per sec
 solr.search_handler.avg_time_per_req,gauge,10,millisecond,request,The average time per request.,-1,solr,search time per req
 solr.search_handler.errors,gauge,10,error,second,Number of errors per second encountered by the handler.,-1,solr,search errors
@@ -29,6 +29,6 @@ solr.search_handler.requests,gauge,10,request,second,Number of requests per seco
 solr.search_handler.time,gauge,10,,,The sum of all request processing times (in milliseconds) per second.,0,solr,search time
 solr.search_handler.timeouts,gauge,10,timeout,second,Number of responses per second received with partial results.,-1,solr,search timeouts
 solr.searcher.maxdoc,gauge,10,document,,One greater than the largest possible document number (Solr version <= 6).,0,solr,max doc id solr6
-solr.searcher.maxdocs,gauge,10,document,,One greater than the largest possible document number.,0,solr,max doc id
+solr.searcher.maxdocs,gauge,10,document,,One greater than the largest possible document number (Solr version >= 7).,0,solr,max doc id
 solr.searcher.numdocs,gauge,10,document,,The total number of indexed documents.,0,solr,num docs
 solr.searcher.warmup,gauge,10,millisecond,,The time spent warming up.,-1,solr,warmup time

--- a/solr/tests/common.py
+++ b/solr/tests/common.py
@@ -47,6 +47,7 @@ SOLR_COMMON_METRICS = [
     "solr.search_handler.timeouts",
     "solr.searcher.numdocs",
     "solr.searcher.warmup",
+    "solr.search_handler.avg_requests_per_sec",
 ]
 
 SOLR_7_PLUS_METRICS = [
@@ -62,6 +63,13 @@ SOLR_7_PLUS_METRICS = [
     "solr.query_result_cache.hits",
     "solr.query_result_cache.inserts",
     "solr.query_result_cache.lookups",
+    "solr.search_handler.request_times.50percentile",
+    "solr.search_handler.request_times.75percentile",
+    "solr.search_handler.request_times.95percentile",
+    "solr.search_handler.request_times.98percentile",
+    "solr.search_handler.request_times.99percentile",
+    "solr.search_handler.request_times.999percentile",
+    "solr.search_handler.request_times.one_minute_rate",
     "solr.searcher.maxdocs",
 ]
 
@@ -70,7 +78,6 @@ SOLR_6_METRICS = [
     "solr.cache.hits",
     "solr.cache.inserts",
     "solr.cache.lookups",
-    "solr.search_handler.avg_requests_per_sec",
     "solr.search_handler.avg_time_per_req",
     "solr.searcher.maxdoc",
 ]

--- a/solr/tests/common.py
+++ b/solr/tests/common.py
@@ -3,8 +3,9 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import os
 
-from datadog_checks.dev import get_docker_hostname
 from packaging import version
+
+from datadog_checks.dev import get_docker_hostname
 
 HOST = get_docker_hostname()
 SOLR_VERSION_RAW = os.environ['SOLR_VERSION']

--- a/solr/tests/common.py
+++ b/solr/tests/common.py
@@ -1,0 +1,39 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+
+JVM_METRICS = [
+    "jvm.thread_count",
+    "jvm.gc.cms.count",
+    "jvm.gc.parnew.time",
+    "jvm.buffer_pool.mapped.count",
+    "jvm.buffer_pool.mapped.capacity",
+    "jvm.buffer_pool.mapped.used",
+    "jvm.gc.cms.count",
+    "jvm.gc.parnew.time",
+    "jvm.gc.survivor_size",
+    "jvm.gc.old_gen_size",
+    "jvm.buffer_pool.direct.count",
+    "jvm.buffer_pool.direct.capacity",
+    "jvm.buffer_pool.direct.used",
+    "jvm.os.open_file_descriptors",
+    "jvm.cpu_load.system",
+    "jvm.cpu_load.process",
+    "jvm.loaded_classes",
+    "jvm.gc.eden_size",
+    "jvm.heap_memory_init",
+    "jvm.heap_memory_committed",
+    "jvm.heap_memory_max",
+    "jvm.heap_memory",
+    "jvm.non_heap_memory_init",
+    "jvm.non_heap_memory_committed",
+    "jvm.non_heap_memory_max",
+    "jvm.non_heap_memory",
+]
+
+SOLR_METRICS = [
+    "solr.searcher.maxdocs",
+    "solr.searcher.numdocs",
+    "solr.searcher.warmup",
+]

--- a/solr/tests/common.py
+++ b/solr/tests/common.py
@@ -47,7 +47,7 @@ SOLR_COMMON_METRICS = [
     "solr.search_handler.timeouts",
     "solr.searcher.numdocs",
     "solr.searcher.warmup",
-    "solr.search_handler.avg_requests_per_sec",
+
 ]
 
 SOLR_7_PLUS_METRICS = [
@@ -69,6 +69,8 @@ SOLR_7_PLUS_METRICS = [
     "solr.search_handler.request_times.98percentile",
     "solr.search_handler.request_times.99percentile",
     "solr.search_handler.request_times.999percentile",
+    "solr.search_handler.request_times.mean",
+    "solr.search_handler.request_times.mean_rate",
     "solr.search_handler.request_times.one_minute_rate",
     "solr.searcher.maxdocs",
 ]
@@ -79,6 +81,7 @@ SOLR_6_METRICS = [
     "solr.cache.inserts",
     "solr.cache.lookups",
     "solr.search_handler.avg_time_per_req",
+    "solr.search_handler.avg_requests_per_sec",
     "solr.searcher.maxdoc",
 ]
 

--- a/solr/tests/common.py
+++ b/solr/tests/common.py
@@ -1,7 +1,9 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+from datadog_checks.dev import get_docker_hostname
 
+HOST = get_docker_hostname()
 
 JVM_METRICS = [
     "jvm.thread_count",
@@ -33,6 +35,22 @@ JVM_METRICS = [
 ]
 
 SOLR_METRICS = [
+    "solr.document_cache.evictions",
+    "solr.document_cache.hits",
+    "solr.document_cache.inserts",
+    "solr.document_cache.lookups",
+    "solr.filter_cache.evictions",
+    "solr.filter_cache.hits",
+    "solr.filter_cache.inserts",
+    "solr.filter_cache.lookups",
+    "solr.query_result_cache.evictions",
+    "solr.query_result_cache.hits",
+    "solr.query_result_cache.inserts",
+    "solr.query_result_cache.lookups",
+    "solr.search_handler.errors",
+    "solr.search_handler.requests",
+    "solr.search_handler.time",
+    "solr.search_handler.timeouts",
     "solr.searcher.maxdocs",
     "solr.searcher.numdocs",
     "solr.searcher.warmup",

--- a/solr/tests/common.py
+++ b/solr/tests/common.py
@@ -47,7 +47,6 @@ SOLR_COMMON_METRICS = [
     "solr.search_handler.timeouts",
     "solr.searcher.numdocs",
     "solr.searcher.warmup",
-
 ]
 
 SOLR_7_PLUS_METRICS = [

--- a/solr/tests/common.py
+++ b/solr/tests/common.py
@@ -1,9 +1,14 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import os
+
 from datadog_checks.dev import get_docker_hostname
+from packaging import version
 
 HOST = get_docker_hostname()
+SOLR_VERSION_RAW = os.environ['SOLR_VERSION']
+SOLR_VERSION = version.parse(SOLR_VERSION_RAW)
 
 JVM_METRICS = [
     "jvm.thread_count",
@@ -34,7 +39,16 @@ JVM_METRICS = [
     "jvm.non_heap_memory",
 ]
 
-SOLR_METRICS = [
+SOLR_COMMON_METRICS = [
+    "solr.search_handler.errors",
+    "solr.search_handler.requests",
+    "solr.search_handler.time",
+    "solr.search_handler.timeouts",
+    "solr.searcher.numdocs",
+    "solr.searcher.warmup",
+]
+
+SOLR_7_PLUS_METRICS = [
     "solr.document_cache.evictions",
     "solr.document_cache.hits",
     "solr.document_cache.inserts",
@@ -47,11 +61,23 @@ SOLR_METRICS = [
     "solr.query_result_cache.hits",
     "solr.query_result_cache.inserts",
     "solr.query_result_cache.lookups",
-    "solr.search_handler.errors",
-    "solr.search_handler.requests",
-    "solr.search_handler.time",
-    "solr.search_handler.timeouts",
     "solr.searcher.maxdocs",
-    "solr.searcher.numdocs",
-    "solr.searcher.warmup",
 ]
+
+SOLR_6_METRICS = [
+    "solr.cache.evictions",
+    "solr.cache.hits",
+    "solr.cache.inserts",
+    "solr.cache.lookups",
+    "solr.search_handler.avg_requests_per_sec",
+    "solr.search_handler.avg_time_per_req",
+    "solr.searcher.maxdoc",
+]
+
+
+if SOLR_VERSION.major == 6:
+    SOLR_METRICS = SOLR_COMMON_METRICS + SOLR_6_METRICS
+elif SOLR_VERSION.major >= 7:
+    SOLR_METRICS = SOLR_COMMON_METRICS + SOLR_7_PLUS_METRICS
+else:
+    SOLR_METRICS = []

--- a/solr/tests/common.py
+++ b/solr/tests/common.py
@@ -91,4 +91,4 @@ if SOLR_VERSION.major == 6:
 elif SOLR_VERSION.major >= 7:
     SOLR_METRICS = SOLR_COMMON_METRICS + SOLR_7_PLUS_METRICS
 else:
-    SOLR_METRICS = []
+    raise Exception('Version not supported: {}'.format(SOLR_VERSION))

--- a/solr/tests/conftest.py
+++ b/solr/tests/conftest.py
@@ -8,11 +8,13 @@ import pytest
 
 from datadog_checks.dev import docker_run, get_here
 from datadog_checks.dev.utils import load_jmx_config
+from .common import HOST
 
 
 @pytest.fixture(scope="session")
 def dd_environment():
     with docker_run(os.path.join(get_here(), 'docker', 'docker-compose.yml')):
         instance = load_jmx_config()
+        instance['instances'][0]['host'] = HOST
         instance['instances'][0]['port'] = 18983
         yield instance, {'use_jmx': True}

--- a/solr/tests/conftest.py
+++ b/solr/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 
 from datadog_checks.dev import docker_run, get_here
 from datadog_checks.dev.utils import load_jmx_config
+
 from .common import HOST
 
 

--- a/solr/tests/docker/docker-compose.yml
+++ b/solr/tests/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   solr:
-    image: solr:7.7.2
+    image: solr:${SOLR_VERSION}
     ports:
      - 8983:8983
      - 18983:18983
@@ -11,5 +11,6 @@ services:
     environment:
       ENABLE_REMOTE_JMX_OPTS: "true"
       RMI_PORT: 18983
+      # `java.rmi.server.hostname=localhost` is needed to local connect to JMX endpoint
       SOLR_OPTS: >-
         -Djava.rmi.server.hostname=localhost

--- a/solr/tests/docker/docker-compose.yml
+++ b/solr/tests/docker/docker-compose.yml
@@ -9,4 +9,7 @@ services:
       - solr-precreate
       - gettingstarted
     environment:
-     - ENABLE_REMOTE_JMX_OPTS=true
+      ENABLE_REMOTE_JMX_OPTS: "true"
+      RMI_PORT: 18983
+      SOLR_OPTS: >-
+        -Djava.rmi.server.hostname=localhost

--- a/solr/tests/docker/docker-compose.yml
+++ b/solr/tests/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   solr:
-    image: solr
+    image: solr:7.7.2
     ports:
      - 8983:8983
      - 18983:18983

--- a/solr/tests/test_check.py
+++ b/solr/tests/test_check.py
@@ -13,10 +13,12 @@ from .common import JVM_METRICS, SOLR_METRICS
 @pytest.mark.e2e
 def test_e2e(dd_agent_check):
     instance = {}
-    aggregator = dd_agent_check(instance)  # type: AggregatorStub
+    aggregator = dd_agent_check(instance, rate=True)  # type: AggregatorStub
 
     for metric in SOLR_METRICS + JVM_METRICS:
         aggregator.assert_metric(metric)
 
     aggregator.assert_all_metrics_covered()
+
+    # TODO: At the moment, JMX reported metrics are NOT in-app metrics, hence we can't assert the type yet.
     aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_metric_type=False, exclude=JVM_METRICS)

--- a/solr/tests/test_check.py
+++ b/solr/tests/test_check.py
@@ -19,4 +19,4 @@ def test_e2e(dd_agent_check):
         aggregator.assert_metric(metric)
 
     aggregator.assert_all_metrics_covered()
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=JVM_METRICS)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_metric_type=False, exclude=JVM_METRICS)

--- a/solr/tests/test_check.py
+++ b/solr/tests/test_check.py
@@ -4,41 +4,49 @@
 
 import pytest
 
+from datadog_checks.base.stubs.aggregator import AggregatorStub
+from datadog_checks.dev.utils import get_metadata_metrics
+
+JVM_METRICS = [
+    "jvm.thread_count",
+    "jvm.gc.cms.count",
+    "jvm.gc.parnew.time",
+    "jvm.buffer_pool.mapped.count",
+    "jvm.buffer_pool.mapped.capacity",
+    "jvm.buffer_pool.mapped.used",
+    "jvm.gc.cms.count",
+    "jvm.gc.parnew.time",
+    "jvm.gc.survivor_size",
+    "jvm.gc.old_gen_size",
+    "jvm.buffer_pool.direct.count",
+    "jvm.buffer_pool.direct.capacity",
+    "jvm.buffer_pool.direct.used",
+    "jvm.os.open_file_descriptors",
+    "jvm.cpu_load.system",
+    "jvm.cpu_load.process",
+    "jvm.loaded_classes",
+    "jvm.gc.eden_size",
+    "jvm.heap_memory_init",
+    "jvm.heap_memory_committed",
+    "jvm.heap_memory_max",
+    "jvm.heap_memory",
+    "jvm.non_heap_memory_init",
+    "jvm.non_heap_memory_committed",
+    "jvm.non_heap_memory_max",
+    "jvm.non_heap_memory",
+]
 
 @pytest.mark.e2e
 def test_e2e(dd_agent_check):
     instance = {}
-    aggregator = dd_agent_check(instance)
+    aggregator = dd_agent_check(instance)  # type: AggregatorStub
     metrics = [
         "solr.searcher.maxdocs",
         "solr.searcher.numdocs",
         "solr.searcher.warmup",
-        "jvm.thread_count",
-        "jvm.gc.cms.count",
-        "jvm.gc.parnew.time",
-        "jvm.buffer_pool.mapped.count",
-        "jvm.buffer_pool.mapped.capacity",
-        "jvm.buffer_pool.mapped.used",
-        "jvm.gc.cms.count",
-        "jvm.gc.parnew.time",
-        "jvm.gc.survivor_size",
-        "jvm.gc.old_gen_size",
-        "jvm.buffer_pool.direct.count",
-        "jvm.buffer_pool.direct.capacity",
-        "jvm.buffer_pool.direct.used",
-        "jvm.os.open_file_descriptors",
-        "jvm.cpu_load.system",
-        "jvm.cpu_load.process",
-        "jvm.loaded_classes",
-        "jvm.gc.eden_size",
-        "jvm.heap_memory_init",
-        "jvm.heap_memory_committed",
-        "jvm.heap_memory_max",
-        "jvm.heap_memory",
-        "jvm.non_heap_memory_init",
-        "jvm.non_heap_memory_committed",
-        "jvm.non_heap_memory_max",
-        "jvm.non_heap_memory",
     ]
-    for metric in metrics:
+    for metric in metrics + JVM_METRICS:
         aggregator.assert_metric(metric)
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=JVM_METRICS)

--- a/solr/tests/test_check.py
+++ b/solr/tests/test_check.py
@@ -7,45 +7,15 @@ import pytest
 from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.dev.utils import get_metadata_metrics
 
-JVM_METRICS = [
-    "jvm.thread_count",
-    "jvm.gc.cms.count",
-    "jvm.gc.parnew.time",
-    "jvm.buffer_pool.mapped.count",
-    "jvm.buffer_pool.mapped.capacity",
-    "jvm.buffer_pool.mapped.used",
-    "jvm.gc.cms.count",
-    "jvm.gc.parnew.time",
-    "jvm.gc.survivor_size",
-    "jvm.gc.old_gen_size",
-    "jvm.buffer_pool.direct.count",
-    "jvm.buffer_pool.direct.capacity",
-    "jvm.buffer_pool.direct.used",
-    "jvm.os.open_file_descriptors",
-    "jvm.cpu_load.system",
-    "jvm.cpu_load.process",
-    "jvm.loaded_classes",
-    "jvm.gc.eden_size",
-    "jvm.heap_memory_init",
-    "jvm.heap_memory_committed",
-    "jvm.heap_memory_max",
-    "jvm.heap_memory",
-    "jvm.non_heap_memory_init",
-    "jvm.non_heap_memory_committed",
-    "jvm.non_heap_memory_max",
-    "jvm.non_heap_memory",
-]
+from .common import JVM_METRICS, SOLR_METRICS
+
 
 @pytest.mark.e2e
 def test_e2e(dd_agent_check):
     instance = {}
     aggregator = dd_agent_check(instance)  # type: AggregatorStub
-    metrics = [
-        "solr.searcher.maxdocs",
-        "solr.searcher.numdocs",
-        "solr.searcher.warmup",
-    ]
-    for metric in metrics + JVM_METRICS:
+
+    for metric in SOLR_METRICS + JVM_METRICS:
         aggregator.assert_metric(metric)
 
     aggregator.assert_all_metrics_covered()

--- a/solr/tox.ini
+++ b/solr/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py38-{6.6, 7.7, 8.5}
+    py38-{6.6,7.7,8.5}
 
 [testenv]
 description =

--- a/solr/tox.ini
+++ b/solr/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py38-{7.7, 8.5}
+    py38-{6.6, 7.7, 8.5}
 
 [testenv]
 description =
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 setenv =
+    6.6: SOLR_VERSION=6.6.6
     7.7: SOLR_VERSION=7.7.2
     8.5: SOLR_VERSION=8.5.0
 commands =

--- a/solr/tox.ini
+++ b/solr/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py38
+    py38-{7.7, 8.5}
 
 [testenv]
 description =
@@ -17,5 +17,8 @@ deps =
 passenv =
     DOCKER*
     COMPOSE*
+setenv =
+    7.7: SOLR_VERSION=7.7.2
+    8.5: SOLR_VERSION=8.5.0
 commands =
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- `avgRequestsPerSecond` and `avgTimePerRequest` does not exist for Solr version >= 7, hence replaced with similar metrics.
- Use condfig spec
- Update metrics to check to use on available for all Solr versions

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
