### PR TITLE
Add parsing from `/stats/summary` for Windows

### DIFF
--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -30,12 +30,15 @@ def tags_for_pod(pod_id, cardinality):
     return tagger.tag('kubernetes_pod_uid://%s' % pod_id, cardinality) or []
 
 
-def tags_for_docker(cid, cardinality):
+def tags_for_docker(cid, cardinality, with_prefix=False):
     """
-    Queries the tagger for a given container id
+    Queries the tagger for a given container id.
+    If with_prefix=true, method won't add `container_id://` to `cid`
     :return: string array, empty if container not found
     """
-    return tagger.tag('container_id://%s' % cid, cardinality) or []
+    if not with_prefix:
+        cid = 'container_id://%s' % cid
+    return tagger.tag(cid, cardinality) or []
 
 
 def get_pod_by_uid(uid, podlist):

--- a/kubelet/datadog_checks/kubelet/summary.py
+++ b/kubelet/datadog_checks/kubelet/summary.py
@@ -1,0 +1,136 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from __future__ import division
+
+from datadog_checks.base.utils.tagging import tagger
+
+from .common import replace_container_rt_prefix, tags_for_docker, tags_for_pod
+
+
+class SummaryScraperMixin(object):
+    """
+    This class scrapes metrics from Kubelet "/stats/summary" endpoint
+    """
+
+    def process_stats_summary(self, pod_list_utils, stats, instance_tags, main_stats_source):
+        # Reports system container metrics (node-wide)
+        self._report_system_container_metrics(stats, instance_tags)
+        # Reports POD & Container metrics. If `main_stats_source` is set, retrieve everything it can
+        # Otherwise retrieves only what we cannot get elsewhere
+        self._report_metrics(pod_list_utils, stats, instance_tags, main_stats_source)
+
+    def _report_metrics(self, pod_list_utils, stats, instance_tags, main_stats_source):
+        for pod in stats.get('pods', []):
+            pod_namespace = pod.get('podRef', {}).get('namespace')
+            pod_name = pod.get('podRef', {}).get('name')
+            pod_uid = pod.get('podRef', {}).get('uid')
+
+            if pod_namespace is None or pod_name is None or pod_uid is None:
+                self.log.warning("Got incomplete results from '/stats/summary', missing data for POD: %s", pod)
+                continue
+
+            self._report_pod_stats(pod_namespace, pod_name, pod_uid, pod, instance_tags, main_stats_source)
+            self._report_container_stats(
+                pod_namespace, pod_name, pod.get('containers', []), pod_list_utils, instance_tags, main_stats_source
+            )
+
+    def _report_pod_stats(self, pod_namespace, pod_name, pod_uid, pod, instance_tags, main_stats_source):
+        pod_tags = tags_for_pod(pod_uid, tagger.ORCHESTRATOR)
+        if not pod_tags:
+            self.log.debug("Tags not found for pod: %s/%s - no metrics will be sent", pod_namespace, pod_name)
+            return
+        pod_tags += instance_tags
+
+        used_bytes = pod.get('ephemeral-storage', {}).get('usedBytes')
+        if used_bytes:
+            self.gauge(self.NAMESPACE + '.ephemeral_storage.usage', used_bytes, pod_tags)
+
+        # Metrics below should already be gathered by another mean (cadvisor endpoints)
+        if not main_stats_source:
+            return
+
+        rx_bytes = pod.get('network', {}).get('rxBytes')
+        if rx_bytes:
+            self.rate(self.NAMESPACE + '.network.rx_bytes', rx_bytes, pod_tags)
+        tx_bytes = pod.get('network', {}).get('txBytes')
+        if tx_bytes:
+            self.rate(self.NAMESPACE + '.network.tx_bytes', tx_bytes, pod_tags)
+
+    def _report_container_stats(
+        self, pod_namespace, pod_name, containers, pod_list_utils, instance_tags, main_stats_source
+    ):
+        # Metrics below should already be gathered by another mean (cadvisor endpoints)
+        if not main_stats_source:
+            return
+
+        for container in containers:
+            container_name = container.get('name')
+            if container_name is None:
+                self.log.warning(
+                    "Kubelet reported stats without container name for pod: %s/%s", pod_namespace, pod_name
+                )
+                continue
+
+            # No mistake, we need to give a tuple as parameter
+            container_id = pod_list_utils.get_cid_by_name_tuple((pod_namespace, pod_name, container_name))
+            if container_id is None:
+                self.log.debug(
+                    "Container id not found from /pods for container: %s/%s/%s - no metrics will be sent",
+                    pod_namespace,
+                    pod_name,
+                    container_name,
+                )
+                continue
+
+            # TODO: In `containers` we also have terminated init-containers, probably to be excluded?
+            if pod_list_utils.is_excluded(container_id):
+                continue
+
+            # Finally, we can get tags for this container
+            container_tags = tags_for_docker(replace_container_rt_prefix(container_id), tagger.HIGH, True)
+            if not container_tags:
+                self.log.debug(
+                    "Tags not found for container: %s/%s/%s:%s - no metrics will be sent",
+                    pod_namespace,
+                    pod_name,
+                    container_name,
+                    container_id,
+                )
+            container_tags += instance_tags
+
+            cpu_total = container.get('cpu', {}).get('usageCoreNanoSeconds')
+            if cpu_total:
+                self.rate(self.NAMESPACE + '.cpu.usage.total', cpu_total, container_tags)
+
+            working_set = container.get('memory', {}).get('workingSetBytes')
+            if working_set:
+                self.gauge(self.NAMESPACE + '.memory.working_set', working_set, container_tags)
+
+            # TODO: Review meaning of these metrics as capacity != available + used
+            # availableBytes = container.get('rootfs', {}).get('availableBytes')
+            capacity_bytes = container.get('rootfs', {}).get('capacityBytes')
+            used_bytes = container.get('rootfs', {}).get('usedBytes')
+
+            if used_bytes is not None:
+                self.gauge(self.NAMESPACE + '.filesystem.usage', used_bytes, container_tags)
+            if used_bytes is not None and capacity_bytes is not None:
+                self.gauge(self.NAMESPACE + '.filesystem.usage_pct', float(used_bytes) / capacity_bytes, container_tags)
+
+    def _report_system_container_metrics(self, stats, instance_tags):
+        sys_containers = stats.get('node', {}).get('systemContainers', [])
+        for ctr in sys_containers:
+            if ctr.get('name') == 'runtime':
+                mem_rss = ctr.get('memory', {}).get('rssBytes')
+                if mem_rss:
+                    self.gauge(self.NAMESPACE + '.runtime.memory.rss', mem_rss, instance_tags)
+                cpu_usage = ctr.get('cpu', {}).get('usageNanoCores')
+                if cpu_usage:
+                    self.gauge(self.NAMESPACE + '.runtime.cpu.usage', cpu_usage, instance_tags)
+            if ctr.get('name') == 'kubelet':
+                mem_rss = ctr.get('memory', {}).get('rssBytes')
+                if mem_rss:
+                    self.gauge(self.NAMESPACE + '.kubelet.memory.rss', mem_rss, instance_tags)
+                cpu_usage = ctr.get('cpu', {}).get('usageNanoCores')
+                if cpu_usage:
+                    self.gauge(self.NAMESPACE + '.kubelet.cpu.usage', cpu_usage, instance_tags)

--- a/kubelet/tests/fixtures/pods_windows.json
+++ b/kubelet/tests/fixtures/pods_windows.json
@@ -1,0 +1,767 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "metadata": {
+        "name": "windows-server-iis-6c68545d57-gwtn9",
+        "generateName": "windows-server-iis-6c68545d57-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/windows-server-iis-6c68545d57-gwtn9",
+        "uid": "4740a3ec-392f-435f-80a4-b407a37463db",
+        "resourceVersion": "221969",
+        "creationTimestamp": "2020-04-24T15:39:40Z",
+        "labels": {
+          "app": "windows-server-iis",
+          "pod-template-hash": "6c68545d57",
+          "tier": "backend",
+          "track": "stable"
+        },
+        "annotations": {
+          "kubernetes.io/config.seen": "2020-04-24T15:48:03.7734424Z",
+          "kubernetes.io/config.source": "api",
+          "kubernetes.io/psp": "eks.privileged",
+          "vpc.amazonaws.com/PrivateIPv4Address": "172.29.134.211/18"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "name": "windows-server-iis-6c68545d57",
+            "uid": "ba98f494-6862-46c9-ac67-fbb00a6b882a",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-424zl",
+            "secret": {
+              "secretName": "default-token-424zl",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "windows-server-iis",
+            "image": "mcr.microsoft.com/windows/servercore:1809",
+            "command": [
+              "powershell.exe",
+              "-command",
+              "Add-WindowsFeature Web-Server; Invoke-WebRequest -UseBasicParsing -Uri 'https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe' -OutFile 'C:\\ServiceMonitor.exe'; echo '<html><body><br/><br/><marquee><H1>Hello EKS!!!<H1><marquee></body><html>' > C:\\inetpub\\wwwroot\\default.html; C:\\ServiceMonitor.exe 'w3svc'; "
+            ],
+            "ports": [
+              {
+                "name": "http",
+                "containerPort": 80,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "vpc.amazonaws.com/PrivateIPv4Address": "1"
+              },
+              "requests": {
+                "vpc.amazonaws.com/PrivateIPv4Address": "1"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-424zl",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "nodeSelector": {
+          "beta.kubernetes.io/os": "windows"
+        },
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "ip-172-29-160-189.ec2.internal",
+        "securityContext": {},
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-04-24T15:48:03Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-04-24T15:49:04Z"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-04-24T15:49:04Z"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-04-24T15:48:03Z"
+          }
+        ],
+        "hostIP": "172.29.160.189",
+        "podIP": "172.29.134.211",
+        "startTime": "2020-04-24T15:48:03Z",
+        "containerStatuses": [
+          {
+            "name": "windows-server-iis",
+            "state": {
+              "running": {
+                "startedAt": "2020-04-24T15:49:02Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "mcr.microsoft.com/windows/servercore:1809",
+            "imageID": "docker-pullable://mcr.microsoft.com/windows/servercore@sha256:f4fb84430141b363d2c988ca90a03a958108d8a4d4bf74c1e4ca443b40ca5386",
+            "containerID": "docker://43dfa29d17d358cbdd0bfb290cf27ce82c4de0c88d22d7cac4b88c85de87efba"
+          }
+        ],
+        "qosClass": "BestEffort"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dd-datadog-lbvkl",
+        "generateName": "dd-datadog-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/dd-datadog-lbvkl",
+        "uid": "8ddf0e3f-ac6c-4d44-87d7-0bc41f6729ec",
+        "resourceVersion": "221968",
+        "creationTimestamp": "2020-04-24T15:47:53Z",
+        "labels": {
+          "app": "dd-datadog",
+          "controller-revision-hash": "5f99b4f849",
+          "pod-template-generation": "1"
+        },
+        "annotations": {
+          "checksum/autoconf-config": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+          "checksum/checksd-config": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+          "checksum/confd-config": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+          "kubernetes.io/config.seen": "2020-04-24T15:48:03.7734424Z",
+          "kubernetes.io/config.source": "api",
+          "kubernetes.io/psp": "eks.privileged",
+          "vpc.amazonaws.com/PrivateIPv4Address": "172.29.172.70/18"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "name": "dd-datadog",
+            "uid": "7572aac0-75ec-4aa2-8634-6637c0187ca8",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "config",
+            "emptyDir": {}
+          },
+          {
+            "name": "runtimesocket",
+            "hostPath": {
+              "path": "\\\\.\\pipe\\docker_engine",
+              "type": ""
+            }
+          },
+          {
+            "name": "pointerdir",
+            "hostPath": {
+              "path": "C:/var/log",
+              "type": ""
+            }
+          },
+          {
+            "name": "logpodpath",
+            "hostPath": {
+              "path": "C:/var/log/pods",
+              "type": ""
+            }
+          },
+          {
+            "name": "logdockercontainerpath",
+            "hostPath": {
+              "path": "C:/ProgramData/docker/containers",
+              "type": ""
+            }
+          },
+          {
+            "name": "dd-datadog-token-8lqzd",
+            "secret": {
+              "secretName": "dd-datadog-token-8lqzd",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "initContainers": [
+          {
+            "name": "init-volume",
+            "image": "datadog/agent:7.19.0-rc.7",
+            "command": [
+              "pwsh",
+              "-Command"
+            ],
+            "args": [
+              "Copy-Item -Recurse -Force C:/ProgramData/Datadog C:/Temp"
+            ],
+            "resources": {},
+            "volumeMounts": [
+              {
+                "name": "config",
+                "mountPath": "C:/Temp/Datadog"
+              },
+              {
+                "name": "dd-datadog-token-8lqzd",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          },
+          {
+            "name": "init-config",
+            "image": "datadog/agent:7.19.0-rc.7",
+            "command": [
+              "pwsh",
+              "-Command"
+            ],
+            "args": [
+              "Get-ChildItem 'entrypoint-ps1' | ForEach-Object { & $_.FullName if (-Not $?) { exit 1 } }"
+            ],
+            "env": [
+              {
+                "name": "DD_API_KEY",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "dd-datadog",
+                    "key": "api-key"
+                  }
+                }
+              },
+              {
+                "name": "DD_KUBERNETES_KUBELET_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.hostIP"
+                  }
+                }
+              },
+              {
+                "name": "KUBERNETES",
+                "value": "yes"
+              }
+            ],
+            "resources": {},
+            "volumeMounts": [
+              {
+                "name": "config",
+                "mountPath": "C:/ProgramData/Datadog"
+              },
+              {
+                "name": "runtimesocket",
+                "mountPath": "\\\\.\\pipe\\docker_engine"
+              },
+              {
+                "name": "dd-datadog-token-8lqzd",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "containers": [
+          {
+            "name": "agent",
+            "image": "datadog/agent:7.19.0-rc.7",
+            "command": [
+              "agent",
+              "start"
+            ],
+            "ports": [
+              {
+                "name": "dogstatsdport",
+                "containerPort": 8125,
+                "protocol": "UDP"
+              }
+            ],
+            "env": [
+              {
+                "name": "DD_API_KEY",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "dd-datadog",
+                    "key": "api-key"
+                  }
+                }
+              },
+              {
+                "name": "DD_KUBERNETES_KUBELET_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.hostIP"
+                  }
+                }
+              },
+              {
+                "name": "KUBERNETES",
+                "value": "yes"
+              },
+              {
+                "name": "DD_LOG_LEVEL",
+                "value": "INFO"
+              },
+              {
+                "name": "DD_DOGSTATSD_PORT",
+                "value": "8125"
+              },
+              {
+                "name": "DD_APM_ENABLED",
+                "value": "false"
+              },
+              {
+                "name": "DD_LOGS_ENABLED",
+                "value": "true"
+              },
+              {
+                "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
+                "value": "true"
+              },
+              {
+                "name": "DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE",
+                "value": "true"
+              },
+              {
+                "name": "DD_HEALTH_PORT",
+                "value": "5555"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "vpc.amazonaws.com/PrivateIPv4Address": "1"
+              },
+              "requests": {
+                "vpc.amazonaws.com/PrivateIPv4Address": "1"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "config",
+                "mountPath": "C:/ProgramData/Datadog"
+              },
+              {
+                "name": "runtimesocket",
+                "mountPath": "\\\\.\\pipe\\docker_engine"
+              },
+              {
+                "name": "pointerdir",
+                "mountPath": "C:/var/log"
+              },
+              {
+                "name": "logpodpath",
+                "readOnly": true,
+                "mountPath": "C:/var/log/pods"
+              },
+              {
+                "name": "logdockercontainerpath",
+                "readOnly": true,
+                "mountPath": "C:/ProgramData/docker/containers"
+              },
+              {
+                "name": "dd-datadog-token-8lqzd",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/health",
+                "port": 5555,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 15,
+              "timeoutSeconds": 5,
+              "periodSeconds": 15,
+              "successThreshold": 1,
+              "failureThreshold": 6
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          },
+          {
+            "name": "trace-agent",
+            "image": "datadog/agent:7.19.0-rc.7",
+            "command": [
+              "trace-agent",
+              "-foreground",
+              "-config=C:/ProgramData/Datadog/datadog.yaml"
+            ],
+            "ports": [
+              {
+                "name": "traceport",
+                "hostPort": 8126,
+                "containerPort": 8126,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "DD_API_KEY",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "dd-datadog",
+                    "key": "api-key"
+                  }
+                }
+              },
+              {
+                "name": "DD_KUBERNETES_KUBELET_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.hostIP"
+                  }
+                }
+              },
+              {
+                "name": "KUBERNETES",
+                "value": "yes"
+              },
+              {
+                "name": "DD_LOG_LEVEL",
+                "value": "INFO"
+              },
+              {
+                "name": "DD_APM_ENABLED",
+                "value": "true"
+              },
+              {
+                "name": "DD_APM_NON_LOCAL_TRAFFIC",
+                "value": "true"
+              },
+              {
+                "name": "DD_APM_RECEIVER_PORT",
+                "value": "8126"
+              }
+            ],
+            "resources": {},
+            "volumeMounts": [
+              {
+                "name": "config",
+                "mountPath": "C:/ProgramData/Datadog"
+              },
+              {
+                "name": "dd-datadog-token-8lqzd",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "livenessProbe": {
+              "tcpSocket": {
+                "port": 8126
+              },
+              "initialDelaySeconds": 15,
+              "timeoutSeconds": 5,
+              "periodSeconds": 15,
+              "successThreshold": 1,
+              "failureThreshold": 3
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          },
+          {
+            "name": "process-agent",
+            "image": "datadog/agent:7.19.0-rc.7",
+            "command": [
+              "process-agent",
+              "-foreground",
+              "-config=C:/ProgramData/Datadog/datadog.yaml"
+            ],
+            "env": [
+              {
+                "name": "DD_API_KEY",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "dd-datadog",
+                    "key": "api-key"
+                  }
+                }
+              },
+              {
+                "name": "DD_KUBERNETES_KUBELET_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.hostIP"
+                  }
+                }
+              },
+              {
+                "name": "KUBERNETES",
+                "value": "yes"
+              },
+              {
+                "name": "DD_LOG_LEVEL",
+                "value": "INFO"
+              }
+            ],
+            "resources": {},
+            "volumeMounts": [
+              {
+                "name": "config",
+                "mountPath": "C:/ProgramData/Datadog"
+              },
+              {
+                "name": "runtimesocket",
+                "mountPath": "\\\\.\\pipe\\docker_engine"
+              },
+              {
+                "name": "dd-datadog-token-8lqzd",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "nodeSelector": {
+          "kubernetes.io/os": "windows"
+        },
+        "serviceAccountName": "dd-datadog",
+        "serviceAccount": "dd-datadog",
+        "nodeName": "ip-172-29-160-189.ec2.internal",
+        "securityContext": {},
+        "affinity": {
+          "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+              "nodeSelectorTerms": [
+                {
+                  "matchFields": [
+                    {
+                      "key": "metadata.name",
+                      "operator": "In",
+                      "values": [
+                        "ip-172-29-160-189.ec2.internal"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/os",
+            "operator": "Equal",
+            "value": "windows",
+            "effect": "NoSchedule"
+          },
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute"
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute"
+          },
+          {
+            "key": "node.kubernetes.io/disk-pressure",
+            "operator": "Exists",
+            "effect": "NoSchedule"
+          },
+          {
+            "key": "node.kubernetes.io/memory-pressure",
+            "operator": "Exists",
+            "effect": "NoSchedule"
+          },
+          {
+            "key": "node.kubernetes.io/pid-pressure",
+            "operator": "Exists",
+            "effect": "NoSchedule"
+          },
+          {
+            "key": "node.kubernetes.io/unschedulable",
+            "operator": "Exists",
+            "effect": "NoSchedule"
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-04-24T15:53:36Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-04-24T15:53:44Z"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-04-24T15:53:44Z"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2020-04-24T15:48:03Z"
+          }
+        ],
+        "hostIP": "172.29.160.189",
+        "podIP": "172.29.172.70",
+        "startTime": "2020-04-24T15:48:03Z",
+        "initContainerStatuses": [
+          {
+            "name": "init-volume",
+            "state": {
+              "terminated": {
+                "exitCode": 0,
+                "reason": "Completed",
+                "startedAt": "2020-04-24T15:53:03Z",
+                "finishedAt": "2020-04-24T15:53:07Z",
+                "containerID": "docker://8b77800949d523c1faa135731ffb2f19eee4ee954c8d5eb0548562b82d5616a8"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "datadog/agent:7.19.0-rc.7",
+            "imageID": "docker-pullable://datadog/agent@sha256:61af60c157ad8a42b333a2be5efcd68c5c09de6fe4d0b27853d2e6636ec6cf2b",
+            "containerID": "docker://8b77800949d523c1faa135731ffb2f19eee4ee954c8d5eb0548562b82d5616a8"
+          },
+          {
+            "name": "init-config",
+            "state": {
+              "terminated": {
+                "exitCode": 0,
+                "reason": "Completed",
+                "startedAt": "2020-04-24T15:53:21Z",
+                "finishedAt": "2020-04-24T15:53:23Z",
+                "containerID": "docker://e81f832ebbb0c132ce51c2c6b199d47b7ae4df734fd31aee288d8447826824f2"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "datadog/agent:7.19.0-rc.7",
+            "imageID": "docker-pullable://datadog/agent@sha256:61af60c157ad8a42b333a2be5efcd68c5c09de6fe4d0b27853d2e6636ec6cf2b",
+            "containerID": "docker://e81f832ebbb0c132ce51c2c6b199d47b7ae4df734fd31aee288d8447826824f2"
+          }
+        ],
+        "containerStatuses": [
+          {
+            "name": "agent",
+            "state": {
+              "running": {
+                "startedAt": "2020-04-24T15:53:38Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "datadog/agent:7.19.0-rc.7",
+            "imageID": "docker-pullable://datadog/agent@sha256:61af60c157ad8a42b333a2be5efcd68c5c09de6fe4d0b27853d2e6636ec6cf2b",
+            "containerID": "docker://a26b9c2c92e4ab03f34b84d03d91bed92259c859576535a3167aa32d39206dc2"
+          },
+          {
+            "name": "process-agent",
+            "state": {
+              "running": {
+                "startedAt": "2020-04-24T15:53:41Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "datadog/agent:7.19.0-rc.7",
+            "imageID": "docker-pullable://datadog/agent@sha256:61af60c157ad8a42b333a2be5efcd68c5c09de6fe4d0b27853d2e6636ec6cf2b",
+            "containerID": "docker://98fb504eb0fab22ce9089d8b1cc172ccb2095ee11a00bacd244419b5c02ee635"
+          },
+          {
+            "name": "trace-agent",
+            "state": {
+              "running": {
+                "startedAt": "2020-04-24T15:53:39Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "datadog/agent:7.19.0-rc.7",
+            "imageID": "docker-pullable://datadog/agent@sha256:61af60c157ad8a42b333a2be5efcd68c5c09de6fe4d0b27853d2e6636ec6cf2b",
+            "containerID": "docker://d46a7d51f7b1e2a186a101ef3f0f4834423245b3299d9f4a4796a7c1efcc2ad4"
+          }
+        ],
+        "qosClass": "BestEffort"
+      }
+    }
+  ]
+}

--- a/kubelet/tests/fixtures/stats_summary_windows.json
+++ b/kubelet/tests/fixtures/stats_summary_windows.json
@@ -1,0 +1,411 @@
+{
+  "node": {
+   "nodeName": "ip-172-29-160-189.ec2.internal",
+   "systemContainers": [
+    {
+     "name": "pods",
+     "startTime": "2020-04-24T15:54:20Z",
+     "cpu": {
+      "time": "2020-04-24T15:54:20Z",
+      "usageNanoCores": 760136190,
+      "usageCoreNanoSeconds": 103250000000
+     },
+     "memory": {
+      "time": "2020-04-24T15:54:20Z",
+      "workingSetBytes": 401727488
+     },
+     "userDefinedMetrics": null
+    }
+   ],
+   "startTime": "2020-04-24T15:44:31Z",
+   "cpu": {
+    "time": "2020-04-24T15:54:11Z",
+    "usageNanoCores": 500000000,
+    "usageCoreNanoSeconds": 452800000000
+   },
+   "memory": {
+    "time": "2020-04-24T15:54:11Z",
+    "availableBytes": 15852421120,
+    "usageBytes": 2893811712,
+    "workingSetBytes": 924364800,
+    "rssBytes": 0,
+    "pageFaults": 0,
+    "majorPageFaults": 0
+   },
+   "network": {
+    "time": "2020-04-24T15:54:11Z",
+    "name": "",
+    "interfaces": [
+     {
+      "name": "6to4 Adapter",
+      "rxBytes": 0,
+      "rxErrors": 0,
+      "txBytes": 0,
+      "txErrors": 0
+     },
+     {
+      "name": "Hyper-V Virtual Ethernet Adapter _2",
+      "rxBytes": 1149346892,
+      "rxErrors": 0,
+      "txBytes": 4186701,
+      "txErrors": 0
+     },
+     {
+      "name": "Hyper-V Virtual Switch Extension Adapter _2",
+      "rxBytes": 0,
+      "rxErrors": 0,
+      "txBytes": 0,
+      "txErrors": 0
+     },
+     {
+      "name": "AWS PV Network Device",
+      "rxBytes": 0,
+      "rxErrors": 0,
+      "txBytes": 0,
+      "txErrors": 0
+     },
+     {
+      "name": "Hyper-V Virtual Switch Extension Adapter",
+      "rxBytes": 0,
+      "rxErrors": 0,
+      "txBytes": 0,
+      "txErrors": 0
+     },
+     {
+      "name": "Teredo Tunneling Pseudo-Interface",
+      "rxBytes": 0,
+      "rxErrors": 0,
+      "txBytes": 0,
+      "txErrors": 0
+     },
+     {
+      "name": "Amazon Elastic Network Adapter",
+      "rxBytes": 1150147728,
+      "rxErrors": 0,
+      "txBytes": 4278314,
+      "txErrors": 0
+     },
+     {
+      "name": "Microsoft IP-HTTPS Platform Interface",
+      "rxBytes": 0,
+      "rxErrors": 0,
+      "txBytes": 0,
+      "txErrors": 0
+     },
+     {
+      "name": "Hyper-V Virtual Ethernet Adapter",
+      "rxBytes": 0,
+      "rxErrors": 0,
+      "txBytes": 272,
+      "txErrors": 0
+     },
+     {
+      "name": "Microsoft Kernel Debug Network Adapter",
+      "rxBytes": 0,
+      "rxErrors": 0,
+      "txBytes": 0,
+      "txErrors": 0
+     }
+    ]
+   },
+   "fs": {
+    "time": "2020-04-24T15:54:11Z",
+    "availableBytes": 80788066304,
+    "capacityBytes": 107372081152,
+    "usedBytes": 26584014848
+   },
+   "runtime": {
+    "imageFs": {
+     "time": "2020-04-24T15:54:12Z",
+     "availableBytes": 80788066304,
+     "capacityBytes": 107372081152,
+     "usedBytes": 26584014848
+    }
+   }
+  },
+  "pods": [
+   {
+    "podRef": {
+     "name": "dd-datadog-lbvkl",
+     "namespace": "default",
+     "uid": "8ddf0e3f-ac6c-4d44-87d7-0bc41f6729ec"
+    },
+    "startTime": "2020-04-24T15:48:04Z",
+    "containers": [
+     {
+      "name": "process-agent",
+      "startTime": "2020-04-24T15:53:40Z",
+      "cpu": {
+       "time": "2020-04-24T15:54:14Z",
+       "usageCoreNanoSeconds": 9359375000
+      },
+      "memory": {
+       "time": "2020-04-24T15:54:14Z",
+       "workingSetBytes": 65474560
+      },
+      "rootfs": {
+       "time": "2020-04-24T15:54:14Z",
+       "availableBytes": 80754503680,
+       "capacityBytes": 107372081152,
+       "usedBytes": 0
+      },
+      "logs": {
+       "time": "2020-04-24T15:54:20Z",
+       "availableBytes": 80788066304,
+       "capacityBytes": 107372081152,
+       "usedBytes": 0,
+       "inodesUsed": 0
+      },
+      "userDefinedMetrics": null
+     },
+     {
+      "name": "trace-agent",
+      "startTime": "2020-04-24T15:53:38Z",
+      "cpu": {
+       "time": "2020-04-24T15:54:16Z",
+       "usageNanoCores": 343426740,
+       "usageCoreNanoSeconds": 9953125000
+      },
+      "memory": {
+       "time": "2020-04-24T15:54:16Z",
+       "workingSetBytes": 63348736
+      },
+      "rootfs": {
+       "time": "2020-04-24T15:54:16Z",
+       "availableBytes": 80754503680,
+       "capacityBytes": 107372081152,
+       "usedBytes": 0
+      },
+      "logs": {
+       "time": "2020-04-24T15:54:20Z",
+       "availableBytes": 80788066304,
+       "capacityBytes": 107372081152,
+       "usedBytes": 0,
+       "inodesUsed": 0
+      },
+      "userDefinedMetrics": null
+     },
+     {
+      "name": "agent",
+      "startTime": "2020-04-24T15:53:37Z",
+      "cpu": {
+       "time": "2020-04-24T15:54:18Z",
+       "usageNanoCores": 415804288,
+       "usageCoreNanoSeconds": 13796875000
+      },
+      "memory": {
+       "time": "2020-04-24T15:54:18Z",
+       "workingSetBytes": 136089600
+      },
+      "rootfs": {
+       "time": "2020-04-24T15:54:18Z",
+       "availableBytes": 80754503680,
+       "capacityBytes": 107372081152,
+       "usedBytes": 0
+      },
+      "logs": {
+       "time": "2020-04-24T15:54:20Z",
+       "availableBytes": 80788066304,
+       "capacityBytes": 107372081152,
+       "usedBytes": 0,
+       "inodesUsed": 0
+      },
+      "userDefinedMetrics": null
+     },
+     {
+      "name": "init-config",
+      "startTime": "2020-04-24T15:53:20Z",
+      "cpu": {
+       "time": "2020-04-24T15:54:18Z",
+       "usageNanoCores": 0,
+       "usageCoreNanoSeconds": 0
+      },
+      "memory": {
+       "time": "2020-04-24T15:54:18Z",
+       "workingSetBytes": 0
+      },
+      "rootfs": {
+       "time": "2020-04-24T15:54:18Z",
+       "availableBytes": 80754503680,
+       "capacityBytes": 107372081152,
+       "usedBytes": 0
+      },
+      "logs": {
+       "time": "2020-04-24T15:54:20Z",
+       "availableBytes": 80788066304,
+       "capacityBytes": 107372081152,
+       "usedBytes": 0,
+       "inodesUsed": 0
+      },
+      "userDefinedMetrics": null
+     },
+     {
+      "name": "init-volume",
+      "startTime": "2020-04-24T15:53:01Z",
+      "cpu": {
+       "time": "2020-04-24T15:54:18Z",
+       "usageNanoCores": 0,
+       "usageCoreNanoSeconds": 0
+      },
+      "memory": {
+       "time": "2020-04-24T15:54:18Z",
+       "workingSetBytes": 0
+      },
+      "rootfs": {
+       "time": "2020-04-24T15:54:18Z",
+       "availableBytes": 80754503680,
+       "capacityBytes": 107372081152,
+       "usedBytes": 0
+      },
+      "logs": {
+       "time": "2020-04-24T15:54:20Z",
+       "availableBytes": 80788066304,
+       "capacityBytes": 107372081152,
+       "usedBytes": 0,
+       "inodesUsed": 0
+      },
+      "userDefinedMetrics": null
+     }
+    ],
+    "cpu": {
+     "time": "2020-04-24T15:53:01Z",
+     "usageNanoCores": 759231028,
+     "usageCoreNanoSeconds": 33109375000
+    },
+    "memory": {
+     "time": "2020-04-24T15:54:18Z",
+     "availableBytes": 0,
+     "usageBytes": 0,
+     "workingSetBytes": 264912896,
+     "rssBytes": 0,
+     "pageFaults": 0,
+     "majorPageFaults": 0
+    },
+    "network": {
+     "time": "2020-04-24T15:54:20Z",
+     "name": "cid-41dfe66c6f1f5597dbdf6ab1029b4cf72baa10b530e85685adcd6105ad70d70a",
+     "rxBytes": 694636,
+     "txBytes": 163670,
+     "interfaces": [
+      {
+       "name": "cid-41dfe66c6f1f5597dbdf6ab1029b4cf72baa10b530e85685adcd6105ad70d70a",
+       "rxBytes": 694636,
+       "txBytes": 163670
+      }
+     ]
+    },
+    "volume": [
+     {
+      "time": "2020-04-24T15:53:27Z",
+      "availableBytes": 81055125504,
+      "capacityBytes": 107372081152,
+      "usedBytes": 919980,
+      "inodesFree": 0,
+      "inodes": 0,
+      "inodesUsed": 0,
+      "name": "config"
+     },
+     {
+      "time": "2020-04-24T15:48:50Z",
+      "availableBytes": 82672992256,
+      "capacityBytes": 107372081152,
+      "usedBytes": 5982,
+      "inodesFree": 0,
+      "inodes": 0,
+      "inodesUsed": 0,
+      "name": "dd-datadog-token-8lqzd"
+     }
+    ],
+    "ephemeral-storage": {
+     "time": "2020-04-24T15:54:20Z",
+     "availableBytes": 80788066304,
+     "capacityBytes": 107372081152,
+     "usedBytes": 919980,
+     "inodesUsed": 0
+    }
+   },
+   {
+    "podRef": {
+     "name": "windows-server-iis-6c68545d57-gwtn9",
+     "namespace": "default",
+     "uid": "4740a3ec-392f-435f-80a4-b407a37463db"
+    },
+    "startTime": "2020-04-24T15:48:04Z",
+    "containers": [
+     {
+      "name": "windows-server-iis",
+      "startTime": "2020-04-24T15:48:22Z",
+      "cpu": {
+       "time": "2020-04-24T15:54:20Z",
+       "usageNanoCores": 905162,
+       "usageCoreNanoSeconds": 70140625000
+      },
+      "memory": {
+       "time": "2020-04-24T15:54:20Z",
+       "workingSetBytes": 136814592
+      },
+      "rootfs": {
+       "time": "2020-04-24T15:54:20Z",
+       "availableBytes": 80754503680,
+       "capacityBytes": 107372081152,
+       "usedBytes": 0
+      },
+      "logs": {
+       "time": "2020-04-24T15:54:20Z",
+       "availableBytes": 80788066304,
+       "capacityBytes": 107372081152,
+       "usedBytes": 0,
+       "inodesUsed": 0
+      },
+      "userDefinedMetrics": null
+     }
+    ],
+    "cpu": {
+     "time": "2020-04-24T15:48:22Z",
+     "usageNanoCores": 905162,
+     "usageCoreNanoSeconds": 70140625000
+    },
+    "memory": {
+     "time": "2020-04-24T15:54:20Z",
+     "availableBytes": 0,
+     "usageBytes": 0,
+     "workingSetBytes": 136814592,
+     "rssBytes": 0,
+     "pageFaults": 0,
+     "majorPageFaults": 0
+    },
+    "network": {
+     "time": "2020-04-24T15:54:20Z",
+     "name": "cid-2c3029ae02af06f23ba7a07555a555808bcd17d193c892aa8300fc225eb229c3",
+     "rxBytes": 509185,
+     "txBytes": 258157,
+     "interfaces": [
+      {
+       "name": "cid-2c3029ae02af06f23ba7a07555a555808bcd17d193c892aa8300fc225eb229c3",
+       "rxBytes": 509185,
+       "txBytes": 258157
+      }
+     ]
+    },
+    "volume": [
+     {
+      "time": "2020-04-24T15:48:50Z",
+      "availableBytes": 82672992256,
+      "capacityBytes": 107372081152,
+      "usedBytes": 5970,
+      "inodesFree": 0,
+      "inodes": 0,
+      "inodesUsed": 0,
+      "name": "default-token-424zl"
+     }
+    ],
+    "ephemeral-storage": {
+     "time": "2020-04-24T15:54:20Z",
+     "availableBytes": 80788066304,
+     "capacityBytes": 107372081152,
+     "usedBytes": 0,
+     "inodesUsed": 0
+    }
+   }
+  ]
+ }

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -13,7 +13,7 @@ from six import iteritems
 from urllib3.exceptions import InsecureRequestWarning
 
 from datadog_checks.base.utils.date import UTC, parse_rfc3339
-from datadog_checks.kubelet import KubeletCheck, KubeletCredentials
+from datadog_checks.kubelet import KubeletCheck, KubeletCredentials, PodListUtils
 
 # Skip the whole tests module on Windows
 pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason='tests for linux only')
@@ -161,6 +161,32 @@ COMMON_TAGS = {
         'persistentvolumeclaim:www-web-2',
         'persistentvolumeclaim:www2-web-3',
         'pod_phase:running',
+    ],
+}
+
+WINDOWS_TAGS = {
+    'kubernetes_pod_uid://4740a3ec-392f-435f-80a4-b407a37463db': [
+        'kube_namespace:default',
+        'pod_name:windows-server-iis-6c68545d57-gwtn9',
+    ],
+    'container_id://43dfa29d17d358cbdd0bfb290cf27ce82c4de0c88d22d7cac4b88c85de87efba': [
+        'kube_namespace:default',
+        'pod_name:windows-server-iis-6c68545d57-gwtn9',
+        'kube_container_name:windows-server-iis',
+    ],
+    'kubernetes_pod_uid://8ddf0e3f-ac6c-4d44-87d7-0bc41f6729ec': [
+        'kube_namespace:default',
+        'pod_name:dd-datadog-lbvkl',
+    ],
+    'container_id://a26b9c2c92e4ab03f34b84d03d91bed92259c859576535a3167aa32d39206dc2': [
+        'kube_namespace:default',
+        'pod_name:dd-datadog-lbvkl',
+        'kube_container_name:agent',
+    ],
+    'container_id://98fb504eb0fab22ce9089d8b1cc172ccb2095ee11a00bacd244419b5c02ee635': [
+        'kube_namespace:default',
+        'pod_name:dd-datadog-lbvkl',
+        'kube_container_name:process-agent',
     ],
 }
 
@@ -876,20 +902,159 @@ def test_kubelet_stats_summary_not_available(monkeypatch, aggregator, tagger):
     check._retrieve_stats.assert_called_once()
 
 
-def test_system_container_metrics(monkeypatch, aggregator, tagger):
+def test_process_stats_summary_not_source_windows(monkeypatch, aggregator, tagger):
     check = KubeletCheck('kubelet', {}, [{}])
-    monkeypatch.setattr(
-        check, '_retrieve_stats', mock.Mock(return_value=json.loads(mock_from_file('stats_summary.json')))
+    pod_list_utils = PodListUtils(json.loads(mock_from_file('pods_windows.json')))
+    stats = json.loads(mock_from_file('stats_summary_windows.json'))
+
+    tagger.reset()
+    tagger.set_tags(WINDOWS_TAGS)
+
+    tags = ["instance:tag"]
+    check.process_stats_summary(pod_list_utils, stats, tags, False)
+
+    # As we did not activate `use_stats_summary_as_source`, we only have ephemeral storage metrics
+    # Kubelet stats not present as they are not returned on Windows
+    aggregator.assert_metric(
+        'kubernetes.ephemeral_storage.usage', 919980.0, tags + ['kube_namespace:default', 'pod_name:dd-datadog-lbvkl'],
     )
 
-    stats = check._retrieve_stats()
-    tags = ["instance:tag"]
-    check._report_system_container_metrics(stats, tags)
 
-    aggregator.assert_metric('kubernetes.kubelet.cpu.usage', 36755862.0, tags)
-    aggregator.assert_metric('kubernetes.runtime.cpu.usage', 19442853.0, tags)
-    aggregator.assert_metric('kubernetes.runtime.memory.rss', 101273600.0, tags)
-    aggregator.assert_metric('kubernetes.kubelet.memory.rss', 88477696.0, tags)
+def test_process_stats_summary_not_source_linux(monkeypatch, aggregator, tagger):
+    check = KubeletCheck('kubelet', {}, [{}])
+    pod_list_utils = PodListUtils(json.loads(mock_from_file('pods.json')))
+    stats = json.loads(mock_from_file('stats_summary.json'))
+
+    tagger.reset()
+    tagger.set_tags(COMMON_TAGS)
+
+    tags = ["instance:tag"]
+    check.process_stats_summary(pod_list_utils, stats, tags, False)
+
+    # As we did not activate `use_stats_summary_as_source`,
+    # we only have ephemeral storage metrics and kubelet stats
+    aggregator.assert_metric(
+        'kubernetes.ephemeral_storage.usage', 69406720.0, ['instance:tag', 'pod_name:dd-agent-ntepl']
+    )
+    aggregator.assert_metric(
+        'kubernetes.ephemeral_storage.usage', 49152.0, ['instance:tag', 'pod_name:demo-app-success-c485bc67b-klj45']
+    )
+    aggregator.assert_metric('kubernetes.runtime.cpu.usage', 19442853.0, ['instance:tag'])
+    aggregator.assert_metric('kubernetes.kubelet.cpu.usage', 36755862.0, ['instance:tag'])
+    aggregator.assert_metric('kubernetes.runtime.memory.rss', 101273600.0, ['instance:tag'])
+    aggregator.assert_metric('kubernetes.kubelet.memory.rss', 88477696.0, ['instance:tag'])
+
+
+def test_process_stats_summary_as_source(monkeypatch, aggregator, tagger):
+    check = KubeletCheck('kubelet', {}, [{}])
+    pod_list_utils = PodListUtils(json.loads(mock_from_file('pods_windows.json')))
+    stats = json.loads(mock_from_file('stats_summary_windows.json'))
+
+    tagger.reset()
+    tagger.set_tags(WINDOWS_TAGS)
+
+    tags = ["instance:tag"]
+    check.process_stats_summary(pod_list_utils, stats, tags, True)
+
+    aggregator.assert_metric(
+        'kubernetes.ephemeral_storage.usage', 919980.0, tags + ['kube_namespace:default', 'pod_name:dd-datadog-lbvkl'],
+    )
+    aggregator.assert_metric(
+        'kubernetes.network.tx_bytes', 163670.0, tags + ['kube_namespace:default', 'pod_name:dd-datadog-lbvkl'],
+    )
+    aggregator.assert_metric(
+        'kubernetes.network.rx_bytes', 694636.0, tags + ['kube_namespace:default', 'pod_name:dd-datadog-lbvkl'],
+    )
+    aggregator.assert_metric(
+        'kubernetes.network.tx_bytes',
+        258157.0,
+        tags + ['kube_namespace:default', 'pod_name:windows-server-iis-6c68545d57-gwtn9'],
+    )
+    aggregator.assert_metric(
+        'kubernetes.network.rx_bytes',
+        509185.0,
+        tags + ['kube_namespace:default', 'pod_name:windows-server-iis-6c68545d57-gwtn9'],
+    )
+    aggregator.assert_metric(
+        'kubernetes.cpu.usage.total',
+        13796875000.0,
+        tags + ['kube_container_name:agent', 'kube_namespace:default', 'pod_name:dd-datadog-lbvkl'],
+    )
+    aggregator.assert_metric(
+        'kubernetes.cpu.usage.total',
+        9359375000.0,
+        tags + ['kube_container_name:process-agent', 'kube_namespace:default', 'pod_name:dd-datadog-lbvkl'],
+    )
+    aggregator.assert_metric(
+        'kubernetes.cpu.usage.total',
+        70140625000.0,
+        tags
+        + [
+            'kube_container_name:windows-server-iis',
+            'kube_namespace:default',
+            'pod_name:windows-server-iis-6c68545d57-gwtn9',
+        ],
+    )
+    aggregator.assert_metric(
+        'kubernetes.memory.working_set',
+        136089600.0,
+        tags + ['kube_container_name:agent', 'kube_namespace:default', 'pod_name:dd-datadog-lbvkl'],
+    )
+    aggregator.assert_metric(
+        'kubernetes.memory.working_set',
+        65474560.0,
+        tags + ['kube_container_name:process-agent', 'kube_namespace:default', 'pod_name:dd-datadog-lbvkl'],
+    )
+    aggregator.assert_metric(
+        'kubernetes.memory.working_set',
+        136814592.0,
+        tags
+        + [
+            'kube_container_name:windows-server-iis',
+            'kube_namespace:default',
+            'pod_name:windows-server-iis-6c68545d57-gwtn9',
+        ],
+    )
+    aggregator.assert_metric(
+        'kubernetes.filesystem.usage',
+        0.0,
+        tags + ['kube_container_name:agent', 'kube_namespace:default', 'pod_name:dd-datadog-lbvkl'],
+    )
+    aggregator.assert_metric(
+        'kubernetes.filesystem.usage',
+        0.0,
+        tags + ['kube_container_name:process-agent', 'kube_namespace:default', 'pod_name:dd-datadog-lbvkl'],
+    )
+    aggregator.assert_metric(
+        'kubernetes.filesystem.usage',
+        0.0,
+        tags
+        + [
+            'kube_container_name:windows-server-iis',
+            'kube_namespace:default',
+            'pod_name:windows-server-iis-6c68545d57-gwtn9',
+        ],
+    )
+    aggregator.assert_metric(
+        'kubernetes.filesystem.usage_pct',
+        0.0,
+        tags + ['kube_container_name:agent', 'kube_namespace:default', 'pod_name:dd-datadog-lbvkl'],
+    )
+    aggregator.assert_metric(
+        'kubernetes.filesystem.usage_pct',
+        0.0,
+        tags + ['kube_container_name:process-agent', 'kube_namespace:default', 'pod_name:dd-datadog-lbvkl'],
+    )
+    aggregator.assert_metric(
+        'kubernetes.filesystem.usage_pct',
+        0.0,
+        tags
+        + [
+            'kube_container_name:windows-server-iis',
+            'kube_namespace:default',
+            'pod_name:windows-server-iis-6c68545d57-gwtn9',
+        ],
+    )
 
 
 def test_silent_tls_warning(monkeypatch, aggregator):


### PR DESCRIPTION
### What does this PR do?
The cAdvisor Prometheus endpoint does not return stats on Windows as cAdvisor is not supported on Windows. Only the `/stats/summary` endpoint is returning data through a different implementation in the Kubelet.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
