### PR TITLE
Postgres lock metrics are relation metrics

### DIFF
--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -57,7 +57,7 @@ instances:
     ## arrives at the server from the client. A value of zero (the default) turns this off.
     ## Cancelled queries won't log any metrics
     #
-    # timeout: 1000
+    # query_timeout: 1000
 
     ## @param tags - list of key:value elements - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -52,6 +52,13 @@ instances:
     #
     # ssl: false
 
+    ## @param timeout - int - optional
+    ## Abort any statement that takes more than the specified number of milliseconds, starting from the time the command
+    ## arrives at the server from the client. A value of zero (the default) turns this off.
+    ## Cancelled queries won't log any metrics
+    #
+    # timeout: 1000
+
     ## @param tags - list of key:value elements - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.
     ##

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -52,7 +52,7 @@ instances:
     #
     # ssl: false
 
-    ## @param timeout - integer - optional
+    ## @param query_timeout - integer - optional
     ## Abort any statement that takes more than the specified number of milliseconds, starting from the time the command
     ## arrives at the server from the client. A value of zero (the default) turns this off.
     ## Cancelled queries won't log any metrics

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -52,7 +52,7 @@ instances:
     #
     # ssl: false
 
-    ## @param timeout - int - optional
+    ## @param timeout - integer - optional
     ## Abort any statement that takes more than the specified number of milliseconds, starting from the time the command
     ## arrives at the server from the client. A value of zero (the default) turns this off.
     ## Cancelled queries won't log any metrics

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -527,7 +527,7 @@ class PostgreSql(AgentCheck):
                     database=dbname,
                     sslmode=ssl,
                     application_name="datadog-agent",
-                    options='-c statement_timeout=%s' % query_timeout if query_timeout else None
+                    options='-c statement_timeout=%s' % query_timeout if query_timeout else None,
                 )
             else:
                 self.db = psycopg2.connect(
@@ -537,7 +537,7 @@ class PostgreSql(AgentCheck):
                     database=dbname,
                     sslmode=ssl,
                     application_name="datadog-agent",
-                    options='-c statement_timeout=%s' % query_timeout if query_timeout else None
+                    options='-c statement_timeout=%s' % query_timeout if query_timeout else None,
                 )
 
     def _get_custom_queries(self, tags, custom_queries):

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -683,7 +683,7 @@ class PostgreSql(AgentCheck):
 
         user = self.instance.get('username', '')
         password = self.instance.get('password', '')
-        query_timeout = self.instance.get('timeout')
+        query_timeout = self.instance.get('query_timeout')
 
         table_count_limit = self.instance.get('table_count_limit', TABLE_COUNT_LIMIT)
         collect_function_metrics = is_affirmative(self.instance.get('collect_function_metrics', False))

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -458,7 +458,7 @@ class PostgreSql(AgentCheck):
         bgw_instance_metrics = self._get_bgw_metrics()
         archiver_instance_metrics = self._get_archiver_metrics()
 
-        metric_scope = [CONNECTION_METRICS, LOCK_METRICS]
+        metric_scope = [CONNECTION_METRICS]
 
         if collect_function_metrics:
             metric_scope.append(FUNCTION_METRICS)
@@ -468,7 +468,7 @@ class PostgreSql(AgentCheck):
         # Do we need relation-specific metrics?
         relations_config = {}
         if relations:
-            metric_scope += [REL_METRICS, IDX_METRICS, SIZE_METRICS, STATIO_METRICS]
+            metric_scope += [LOCK_METRICS, REL_METRICS, IDX_METRICS, SIZE_METRICS, STATIO_METRICS]
             relations_config = self._build_relations_config(relations)
 
         replication_metrics = self._get_replication_metrics()

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -516,7 +516,7 @@ class PostgreSql(AgentCheck):
                 # Use ident method
                 connection_string = "user=%s dbname=%s, application_name=%s" % (user, dbname, "datadog-agent")
                 if query_timeout:
-                    connection_string += "options='-c statement_timeout=%s'" % query_timeout
+                    connection_string += " options='-c statement_timeout=%s'" % query_timeout
                 self.db = psycopg2.connect(connection_string)
             elif port != '':
                 self.db = psycopg2.connect(

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -118,10 +118,11 @@ SELECT mode,
   JOIN pg_database pd ON (l.database = pd.oid)
   JOIN pg_class pc ON (l.relation = pc.oid)
   LEFT JOIN pg_namespace pn ON (pn.oid = pc.relnamespace)
- WHERE l.mode IS NOT NULL
+ WHERE {relations}
+   AND l.mode IS NOT NULL
    AND pc.relname NOT LIKE 'pg_%%'
  GROUP BY pd.datname, pc.relname, pn.nspname, locktype, mode""",
-    'relation': False,
+    'relation': True,
 }
 
 REL_METRICS = {

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2010-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import copy
 import os
 
 import psycopg2
@@ -13,6 +14,7 @@ from datadog_checks.postgres import PostgreSql
 from .common import DB_NAME, HOST, PASSWORD, PORT, USER
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+INSTANCE = {'host': HOST, 'port': PORT, 'username': USER, 'password': PASSWORD, 'dbname': DB_NAME, 'tags': ['foo:bar']}
 
 
 def connect_to_pg():
@@ -46,9 +48,9 @@ def integration_check():
 
 @pytest.fixture
 def pg_instance():
-    return {'host': HOST, 'port': PORT, 'username': USER, 'password': PASSWORD, 'dbname': DB_NAME, 'tags': ['foo:bar']}
+    return copy.deepcopy(INSTANCE)
 
 
 @pytest.fixture(scope='session')
 def e2e_instance():
-    return {'host': HOST, 'port': PORT, 'username': USER, 'password': PASSWORD, 'dbname': DB_NAME, 'tags': ['foo:bar']}
+    return copy.deepcopy(INSTANCE)

--- a/postgres/tests/test_integration.py
+++ b/postgres/tests/test_integration.py
@@ -11,7 +11,7 @@ from semver import VersionInfo
 from datadog_checks.postgres import PostgreSql
 from datadog_checks.postgres.util import PartialFormatter, fmt
 
-from .common import DB_NAME, HOST, PORT, POSTGRES_VERSION, check_bgw_metrics, check_common_metrics, USER, PASSWORD
+from .common import DB_NAME, HOST, PASSWORD, PORT, POSTGRES_VERSION, USER, check_bgw_metrics, check_common_metrics
 from .utils import requires_over_10
 
 CONNECTION_METRICS = ['postgresql.max_connections', 'postgresql.percent_usage_connections']

--- a/postgres/tests/test_integration.py
+++ b/postgres/tests/test_integration.py
@@ -11,7 +11,7 @@ from semver import VersionInfo
 from datadog_checks.postgres import PostgreSql
 from datadog_checks.postgres.util import PartialFormatter, fmt
 
-from .common import DB_NAME, HOST, PORT, POSTGRES_VERSION, check_bgw_metrics, check_common_metrics
+from .common import DB_NAME, HOST, PORT, POSTGRES_VERSION, check_bgw_metrics, check_common_metrics, USER, PASSWORD
 from .utils import requires_over_10
 
 CONNECTION_METRICS = ['postgresql.max_connections', 'postgresql.percent_usage_connections']
@@ -216,6 +216,16 @@ def test_state_clears_on_connection_error(integration_check, pg_instance):
         with pytest.raises(socket.error):
             check.check(pg_instance)
     assert_state_clean(check)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_query_timeout(aggregator, integration_check, pg_instance):
+    check = integration_check(pg_instance)
+    check._connect(HOST, PORT, USER, PASSWORD, DB_NAME, ssl='disable', query_timeout=1000)
+    cursor = check.db.cursor()
+    with pytest.raises(psycopg2.errors.QueryCanceled):
+        cursor.execute("select pg_sleep(2000)")
 
 
 def assert_state_clean(check):

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -1,7 +1,9 @@
 # (C) Datadog, Inc. 2010-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import psycopg2
 import pytest
+from .common import HOST, DB_NAME, PORT
 
 RELATION_METRICS = [
     'postgresql.seq_scans',
@@ -130,3 +132,27 @@ def test_index_metrics(aggregator, integration_check, pg_instance):
 
     for name in IDX_METRICS:
         aggregator.assert_metric(name, count=1, tags=expected_tags)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_locks_metrics(aggregator, integration_check, pg_instance):
+    pg_instance['relations'] = ['persons']
+    pg_instance['dbname'] = 'datadog_test'
+
+    check = integration_check(pg_instance)
+    with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres", password="datad0g") as conn:
+        with conn.cursor() as cur:
+            cur.execute('LOCK persons')
+            check.check(pg_instance)
+
+    expected_tags = pg_instance['tags'] + [
+        'server:{}'.format(HOST),
+        'port:{}'.format(PORT),
+        'db:datadog_test',
+        'lock_mode:AccessExclusiveLock',
+        'lock_type:relation',
+        'table:persons',
+        'schema:public',
+    ]
+    aggregator.assert_metric('postgresql.locks', count=1, tags=expected_tags)

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -139,7 +139,7 @@ def test_index_metrics(aggregator, integration_check, pg_instance):
 @pytest.mark.usefixtures('dd_environment')
 def test_locks_metrics(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = ['persons']
-    pg_instance['query_timeout'] = 1000  # One of the relation queries waits for the table to not be locked
+    pg_instance['timeout'] = 1000  # One of the relation queries waits for the table to not be locked
 
     check = integration_check(pg_instance)
     with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres", password="datad0g") as conn:

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -139,7 +139,7 @@ def test_index_metrics(aggregator, integration_check, pg_instance):
 @pytest.mark.usefixtures('dd_environment')
 def test_locks_metrics(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = ['persons']
-    pg_instance['timeout'] = 1000  # One of the relation queries waits for the table to not be locked
+    pg_instance['query_timeout'] = 1000  # One of the relation queries waits for the table to not be locked
 
     check = integration_check(pg_instance)
     with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres", password="datad0g") as conn:

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -3,7 +3,8 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import psycopg2
 import pytest
-from .common import HOST, DB_NAME, PORT
+
+from .common import DB_NAME, HOST, PORT
 
 RELATION_METRICS = [
     'postgresql.seq_scans',
@@ -138,7 +139,7 @@ def test_index_metrics(aggregator, integration_check, pg_instance):
 @pytest.mark.usefixtures('dd_environment')
 def test_locks_metrics(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = ['persons']
-    pg_instance['dbname'] = 'datadog_test'
+    pg_instance['query_timeout'] = 1000  # One of the relation queries waits for the table to not be locked
 
     check = integration_check(pg_instance)
     with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres", password="datad0g") as conn:
@@ -155,4 +156,5 @@ def test_locks_metrics(aggregator, integration_check, pg_instance):
         'table:persons',
         'schema:public',
     ]
+
     aggregator.assert_metric('postgresql.locks', count=1, tags=expected_tags)


### PR DESCRIPTION
### What does this PR do?
* Puts locks metrics under relations  (This is a breaking change)
* Adds a new query timeout config option (needed to be able to test the prior point)
* Adds tag deduplication (lock metrics were now getting duplicate tags)

### Motivation
Tag explosion as locks metrics are tagged by relation
