### PR TITLE
Throw error if two profiles have the same sysObjectID

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -105,10 +105,10 @@ class SnmpCheck(AgentCheck):
         for name, profile in self.profiles.items():
             sys_object_oid = profile['definition'].get('sysobjectid')
             if sys_object_oid is not None:
-                profile_matches = [prof_name for oid, prof_name in profiles_by_oid.items() if oid == sys_object_oid]
-                for profile_name in profile_matches:
+                profile_match = profiles_by_oid.get(sys_object_oid)
+                if profile_match:
                     raise ConfigurationError(
-                        "Profile {} has the same sysObjectID ({}) as {}".format(name, sys_object_oid, profile_name)
+                        "Profile {} has the same sysObjectID ({}) as {}".format(name, sys_object_oid, profile_match)
                     )
                 else:
                     profiles_by_oid[sys_object_oid] = name

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -101,11 +101,17 @@ class SnmpCheck(AgentCheck):
         """
         Get the mapping from sysObjectID to profile.
         """
-        profiles_by_oid = {}
+        profiles_by_oid = {}  # type: Dict[str, str]
         for name, profile in self.profiles.items():
             sys_object_oid = profile['definition'].get('sysobjectid')
             if sys_object_oid is not None:
-                profiles_by_oid[sys_object_oid] = name
+                profile_matches = [prof_name for oid, prof_name in profiles_by_oid.items() if oid == sys_object_oid]
+                for profile_name in profile_matches:
+                    raise ConfigurationError(
+                        "Profile {} has the same sysObjectID ({}) as {}".format(name, sys_object_oid, profile_name)
+                    )
+                else:
+                    profiles_by_oid[sys_object_oid] = name
         return profiles_by_oid
 
     def _build_config(self, instance):

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+import copy
 import os
 import time
 from concurrent import futures
@@ -192,6 +193,22 @@ def test_profile_error():
         init_config = {'profiles': {'profile1': {'definition_file': profile_file}}}
         with pytest.raises(ConfigurationError):
             SnmpCheck('snmp', init_config, [instance])
+
+
+def test_duplicate_sysobjectid_error():
+    profile1 = {'sysobjectid': '1.3.6.1.4.1.30932.*'}
+    profile2 = copy.copy(profile1)
+
+    instance = common.generate_instance_config([])
+    init_config = {'profiles': {'profile1': {'definition': profile1}, 'profile2': {'definition': profile2}}}
+
+    with pytest.raises(ConfigurationError) as e:
+        SnmpCheck('snmp', init_config, [instance])
+    assert "has the same sysObjectID" in str(e.value)
+
+    # no errors are raised
+    init_config['profiles']['profile2']['definition']['sysobjectid'] = '1.3.6.2.4.1.30932.*'
+    SnmpCheck('snmp', init_config, [instance])
 
 
 def test_no_address():


### PR DESCRIPTION
### What does this PR do?
Two profiles should not have the same sysObjectID

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
