### PR TITLE
Remove use of `label_to_match` to prevent deprecation warnings

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
@@ -29,7 +29,7 @@ instances:
     #
     # label_joins:
     #  kube_deployment_labels:
-    #    label_to_match: deployment
+    #    labels_to_match: deployment
     #    labels_to_get:
     #      - label_addonmanager_kubernetes_io_mode
 

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -328,14 +328,8 @@ class KubernetesState(OpenMetricsBaseCheck):
                     'kube_verticalpodautoscaler_labels',
                 ],
                 'label_joins': {
-                    'kube_pod_info': {
-                        'labels_to_match': ['pod', 'namespace'],
-                        'labels_to_get': ['node'],
-                    },
-                    'kube_pod_status_phase': {
-                        'labels_to_match': ['pod', 'namespace'],
-                        'labels_to_get': ['phase'],
-                    },
+                    'kube_pod_info': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node'],},
+                    'kube_pod_status_phase': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['phase'],},
                     'kube_persistentvolume_info': {
                         'labels_to_match': ['persistentvolume'],  # Persistent Volumes are not namespaced
                         'labels_to_get': ['storageclass'],

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -328,14 +328,20 @@ class KubernetesState(OpenMetricsBaseCheck):
                     'kube_verticalpodautoscaler_labels',
                 ],
                 'label_joins': {
-                    'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node']},
-                    'kube_pod_status_phase': {'label_to_match': 'pod', 'labels_to_get': ['phase']},
+                    'kube_pod_info': {
+                        'labels_to_match': ['pod', 'namespace'],
+                        'labels_to_get': ['node'],
+                    },
+                    'kube_pod_status_phase': {
+                        'labels_to_match': ['pod', 'namespace'],
+                        'labels_to_get': ['phase'],
+                    },
                     'kube_persistentvolume_info': {
-                        'label_to_match': 'persistentvolume',
+                        'labels_to_match': ['persistentvolume'], # Persistent Volumes are not namespaced
                         'labels_to_get': ['storageclass'],
                     },
                     'kube_persistentvolumeclaim_info': {
-                        'label_to_match': 'persistentvolumeclaim',
+                        'labels_to_match': ['persistentvolumeclaim', 'namespace'],
                         'labels_to_get': ['storageclass'],
                     },
                 },

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -328,8 +328,8 @@ class KubernetesState(OpenMetricsBaseCheck):
                     'kube_verticalpodautoscaler_labels',
                 ],
                 'label_joins': {
-                    'kube_pod_info': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node'],},
-                    'kube_pod_status_phase': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['phase'],},
+                    'kube_pod_info': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node'], },
+                    'kube_pod_status_phase': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['phase'], },
                     'kube_persistentvolume_info': {
                         'labels_to_match': ['persistentvolume'],  # Persistent Volumes are not namespaced
                         'labels_to_get': ['storageclass'],

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -328,8 +328,8 @@ class KubernetesState(OpenMetricsBaseCheck):
                     'kube_verticalpodautoscaler_labels',
                 ],
                 'label_joins': {
-                    'kube_pod_info': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node'], },
-                    'kube_pod_status_phase': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['phase'], },
+                    'kube_pod_info': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node']},
+                    'kube_pod_status_phase': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['phase']},
                     'kube_persistentvolume_info': {
                         'labels_to_match': ['persistentvolume'],  # Persistent Volumes are not namespaced
                         'labels_to_get': ['storageclass'],

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -337,7 +337,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                         'labels_to_get': ['phase'],
                     },
                     'kube_persistentvolume_info': {
-                        'labels_to_match': ['persistentvolume'], # Persistent Volumes are not namespaced
+                        'labels_to_match': ['persistentvolume'],  # Persistent Volumes are not namespaced
                         'labels_to_get': ['storageclass'],
                     },
                     'kube_persistentvolumeclaim_info': {


### PR DESCRIPTION
### What does this PR do?

Openmetrics mixin logs a deprecation warning on use of `label_to_match` at check init time:
`label_to_match` is being deprecated, please use `labels_to_match`

This prevents this warning and ensures namespaced resources are joined to with namespace.

### Motivation
Warning free user experience out of the box.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
