### PR TITLE
Add constant for jmx default metrics

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/jmx.py
+++ b/datadog_checks_dev/datadog_checks/dev/jmx.py
@@ -1,0 +1,30 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+JVM_E2E_METRICS = [
+    'jvm.buffer_pool.direct.capacity',
+    'jvm.buffer_pool.direct.count',
+    'jvm.buffer_pool.direct.used',
+    'jvm.buffer_pool.mapped.capacity',
+    'jvm.buffer_pool.mapped.count',
+    'jvm.buffer_pool.mapped.used',
+    'jvm.cpu_load.process',
+    'jvm.cpu_load.system',
+    'jvm.gc.cms.count',
+    'jvm.gc.eden_size',
+    'jvm.gc.old_gen_size',
+    'jvm.gc.parnew.time',
+    'jvm.gc.survivor_size',
+    'jvm.heap_memory',
+    'jvm.heap_memory_committed',
+    'jvm.heap_memory_init',
+    'jvm.heap_memory_max',
+    'jvm.loaded_classes',
+    'jvm.non_heap_memory',
+    'jvm.non_heap_memory_committed',
+    'jvm.non_heap_memory_init',
+    'jvm.non_heap_memory_max',
+    'jvm.os.open_file_descriptors',
+    'jvm.thread_count',
+]


### PR DESCRIPTION
cc @ofek 
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add contant for jmx default metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->

jmx default metrics are useful for testing jmx integrations. Example: https://github.com/DataDog/integrations-core/pull/6486

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
