### PR TITLE
Refactor commonly used metrics in tests

### DIFF
--- a/snmp/tests/metrics.py
+++ b/snmp/tests/metrics.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+# Generic TCP metrics for routers
+# _generic-router-tcp.yaml
 TCP_COUNTS = [
     'tcpActiveOpens',
     'tcpPassiveOpens',
@@ -14,7 +16,13 @@ TCP_COUNTS = [
     'tcpOutRsts',
 ]
 TCP_GAUGES = ['tcpCurrEstab']
+
+# Generic UDP metrics for routers
+# _generic-router-udp.yaml
 UDP_COUNTS = ['udpHCInDatagrams', 'udpNoPorts', 'udpInErrors', 'udpHCOutDatagrams']
+
+# Generic network interfaces metrics for routers.
+# _generic-router-if.yaml
 IF_COUNTS = ['ifInErrors', 'ifInDiscards', 'ifOutErrors', 'ifOutDiscards']
 IFX_COUNTS = [
     'ifHCInOctets',
@@ -32,6 +40,8 @@ IF_RATES = [
 ]
 IF_GAUGES = ['ifAdminStatus', 'ifOperStatus']
 
+# Generic IP metrics for routers
+# _generic-router-ip.yaml
 IP_COUNTS = [
     'ipSystemStatsHCInReceives',
     'ipSystemStatsInHdrErrors',
@@ -95,7 +105,8 @@ IP_IF_COUNTS = [
     'ipIfStatsHCOutBcastPkts',
 ]
 
-
+# IDRAC profile metrics
+# idrac.yaml
 ADAPTER_IF_COUNTS = [
     'adapterRxPackets',
     'adapterTxPackets',
@@ -108,7 +119,6 @@ ADAPTER_IF_COUNTS = [
     'adapterRxMulticast',
     'adapterCollisions',
 ]
-
 SYSTEM_STATUS_GAUGES = [
     'systemStateChassisStatus',
     'systemStatePowerUnitStatusRedundancy',
@@ -124,8 +134,6 @@ SYSTEM_STATUS_GAUGES = [
     'systemStateProcessorDeviceStatusCombined',
     'systemStateTemperatureStatisticsStatusCombined',
 ]
-
-
 DISK_GAUGES = [
     'physicalDiskState',
     'physicalDiskCapacityInMB',
@@ -133,18 +141,18 @@ DISK_GAUGES = [
     'physicalDiskFreeSpaceInMB',
 ]
 
+# Base profile metrics for Cisco devices
+# _base_cisco.yaml
 FRU_METRICS = [
     "cefcFRUPowerAdminStatus",
     "cefcFRUPowerOperStatus",
     "cefcFRUCurrent",
 ]
-
 CPU_METRICS = [
     "cpmCPUTotalMonIntervalValue",
     "cpmCPUMemoryUsed",
     "cpmCPUMemoryFree",
 ]
-
 CIE_METRICS = [
     "cieIfLastInTime",
     "cieIfLastOutTime",

--- a/snmp/tests/metrics.py
+++ b/snmp/tests/metrics.py
@@ -1,0 +1,130 @@
+TCP_COUNTS = [
+    'tcpActiveOpens',
+    'tcpPassiveOpens',
+    'tcpAttemptFails',
+    'tcpEstabResets',
+    'tcpHCInSegs',
+    'tcpHCOutSegs',
+    'tcpRetransSegs',
+    'tcpInErrs',
+    'tcpOutRsts',
+]
+TCP_GAUGES = ['tcpCurrEstab']
+UDP_COUNTS = ['udpHCInDatagrams', 'udpNoPorts', 'udpInErrors', 'udpHCOutDatagrams']
+IF_COUNTS = ['ifInErrors', 'ifInDiscards', 'ifOutErrors', 'ifOutDiscards']
+IFX_COUNTS = [
+    'ifHCInOctets',
+    'ifHCInUcastPkts',
+    'ifHCInMulticastPkts',
+    'ifHCInBroadcastPkts',
+    'ifHCOutOctets',
+    'ifHCOutUcastPkts',
+    'ifHCOutMulticastPkts',
+    'ifHCOutBroadcastPkts',
+]
+IF_RATES = [
+    'ifHCInOctets.rate',
+    'ifHCOutOctets.rate',
+]
+IF_GAUGES = ['ifAdminStatus', 'ifOperStatus']
+
+IP_COUNTS = [
+    'ipSystemStatsHCInReceives',
+    'ipSystemStatsInHdrErrors',
+    'ipSystemStatsOutFragReqds',
+    'ipSystemStatsOutFragFails',
+    'ipSystemStatsHCOutTransmits',
+    'ipSystemStatsReasmReqds',
+    'ipSystemStatsHCInMcastPkts',
+    'ipSystemStatsReasmFails',
+    'ipSystemStatsHCOutMcastPkts',
+]
+IPX_COUNTS = [
+    'ipSystemStatsHCInOctets',
+    'ipSystemStatsInNoRoutes',
+    'ipSystemStatsInAddrErrors',
+    'ipSystemStatsInUnknownProtos',
+    'ipSystemStatsInTruncatedPkts',
+    'ipSystemStatsHCInForwDatagrams',
+    'ipSystemStatsReasmOKs',
+    'ipSystemStatsInDiscards',
+    'ipSystemStatsHCInDelivers',
+    'ipSystemStatsHCOutRequests',
+    'ipSystemStatsOutNoRoutes',
+    'ipSystemStatsHCOutForwDatagrams',
+    'ipSystemStatsOutDiscards',
+    'ipSystemStatsOutFragOKs',
+    'ipSystemStatsOutFragCreates',
+    'ipSystemStatsHCOutOctets',
+    'ipSystemStatsHCInMcastOctets',
+    'ipSystemStatsHCOutMcastOctets',
+    'ipSystemStatsHCInBcastPkts',
+    'ipSystemStatsHCOutBcastPkts',
+]
+IP_IF_COUNTS = [
+    'ipIfStatsHCInOctets',
+    'ipIfStatsInHdrErrors',
+    'ipIfStatsInNoRoutes',
+    'ipIfStatsInAddrErrors',
+    'ipIfStatsInUnknownProtos',
+    'ipIfStatsInTruncatedPkts',
+    'ipIfStatsHCInForwDatagrams',
+    'ipIfStatsReasmReqds',
+    'ipIfStatsReasmOKs',
+    'ipIfStatsReasmFails',
+    'ipIfStatsInDiscards',
+    'ipIfStatsHCInDelivers',
+    'ipIfStatsHCOutRequests',
+    'ipIfStatsHCOutForwDatagrams',
+    'ipIfStatsOutDiscards',
+    'ipIfStatsOutFragReqds',
+    'ipIfStatsOutFragOKs',
+    'ipIfStatsOutFragFails',
+    'ipIfStatsOutFragCreates',
+    'ipIfStatsHCOutTransmits',
+    'ipIfStatsHCOutOctets',
+    'ipIfStatsHCInMcastPkts',
+    'ipIfStatsHCInMcastOctets',
+    'ipIfStatsHCOutMcastPkts',
+    'ipIfStatsHCOutMcastOctets',
+    'ipIfStatsHCInBcastPkts',
+    'ipIfStatsHCOutBcastPkts',
+]
+
+
+ADAPTER_IF_COUNTS = [
+    'adapterRxPackets',
+    'adapterTxPackets',
+    'adapterRxBytes',
+    'adapterTxBytes',
+    'adapterRxErrors',
+    'adapterTxErrors',
+    'adapterRxDropped',
+    'adapterTxDropped',
+    'adapterRxMulticast',
+    'adapterCollisions',
+]
+
+SYSTEM_STATUS_GAUGES = [
+    'systemStateChassisStatus',
+    'systemStatePowerUnitStatusRedundancy',
+    'systemStatePowerSupplyStatusCombined',
+    'systemStateAmperageStatusCombined',
+    'systemStateCoolingUnitStatusRedundancy',
+    'systemStateCoolingDeviceStatusCombined',
+    'systemStateTemperatureStatusCombined',
+    'systemStateMemoryDeviceStatusCombined',
+    'systemStateChassisIntrusionStatusCombined',
+    'systemStatePowerUnitStatusCombined',
+    'systemStateCoolingUnitStatusCombined',
+    'systemStateProcessorDeviceStatusCombined',
+    'systemStateTemperatureStatisticsStatusCombined',
+]
+
+
+DISK_GAUGES = [
+    'physicalDiskState',
+    'physicalDiskCapacityInMB',
+    'physicalDiskUsedSpaceInMB',
+    'physicalDiskFreeSpaceInMB',
+]

--- a/snmp/tests/metrics.py
+++ b/snmp/tests/metrics.py
@@ -128,3 +128,22 @@ DISK_GAUGES = [
     'physicalDiskUsedSpaceInMB',
     'physicalDiskFreeSpaceInMB',
 ]
+
+FRU_METRICS = [
+    "cefcFRUPowerAdminStatus",
+    "cefcFRUPowerOperStatus",
+    "cefcFRUCurrent",
+]
+
+CPU_METRICS = [
+    "cpmCPUTotalMonIntervalValue",
+    "cpmCPUMemoryUsed",
+    "cpmCPUMemoryFree",
+]
+
+CIE_METRICS = [
+    "cieIfLastInTime",
+    "cieIfLastOutTime",
+    "cieIfInputQueueDrops",
+    "cieIfOutputQueueDrops",
+]

--- a/snmp/tests/metrics.py
+++ b/snmp/tests/metrics.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
 TCP_COUNTS = [
     'tcpActiveOpens',
     'tcpPassiveOpens',

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -18,8 +18,8 @@ from .metrics import (
     IF_RATES,
     IFX_COUNTS,
     IP_COUNTS,
-    IPX_COUNTS,
     IP_IF_COUNTS,
+    IPX_COUNTS,
     SYSTEM_STATUS_GAUGES,
     TCP_COUNTS,
     TCP_GAUGES,
@@ -431,54 +431,19 @@ def test_dell_poweredge(aggregator):
         aggregator.assert_metric('snmp.networkDeviceStatus', metric_type=aggregator.GAUGE, tags=tags, at_least=1)
 
     # Intel Adapter
-    if_counts = [
-        'adapterRxPackets',
-        'adapterTxPackets',
-        'adapterRxBytes',
-        'adapterTxBytes',
-        'adapterRxErrors',
-        'adapterTxErrors',
-        'adapterRxDropped',
-        'adapterTxDropped',
-        'adapterRxMulticast',
-        'adapterCollisions',
-    ]
-
     interfaces = ['eth0', 'en1']
     for interface in interfaces:
         tags = ['adapter:{}'.format(interface)] + common_tags
-        for count in if_counts:
+        for count in ADAPTER_IF_COUNTS:
             aggregator.assert_metric(
                 'snmp.{}'.format(count), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
 
     # IDRAC
-    status_gauges = [
-        'systemStateChassisStatus',
-        'systemStatePowerUnitStatusRedundancy',
-        'systemStatePowerSupplyStatusCombined',
-        'systemStateAmperageStatusCombined',
-        'systemStateCoolingUnitStatusRedundancy',
-        'systemStateCoolingDeviceStatusCombined',
-        'systemStateTemperatureStatusCombined',
-        'systemStateMemoryDeviceStatusCombined',
-        'systemStateChassisIntrusionStatusCombined',
-        'systemStatePowerUnitStatusCombined',
-        'systemStateCoolingUnitStatusCombined',
-        'systemStateProcessorDeviceStatusCombined',
-        'systemStateTemperatureStatisticsStatusCombined',
-    ]
-    disk_gauges = [
-        'physicalDiskState',
-        'physicalDiskCapacityInMB',
-        'physicalDiskUsedSpaceInMB',
-        'physicalDiskFreeSpaceInMB',
-    ]
-
     indexes = ['26', '29']
     for index in indexes:
         tags = ['chassis_index:{}'.format(index)] + common_tags
-        for gauge in status_gauges:
+        for gauge in SYSTEM_STATUS_GAUGES:
             aggregator.assert_metric('snmp.{}'.format(gauge), metric_type=aggregator.GAUGE, tags=tags, count=1)
     powers = ['supply1', 'supply2']
     for power in powers:
@@ -487,7 +452,7 @@ def test_dell_poweredge(aggregator):
     disks = ['disk1', 'disk2']
     for disk in disks:
         tags = ['disk_name:{}'.format(disk)] + common_tags
-        for gauge in disk_gauges:
+        for gauge in DISK_GAUGES:
             aggregator.assert_metric('snmp.{}'.format(gauge), metric_type=aggregator.GAUGE, tags=tags, count=1)
 
     aggregator.assert_all_metrics_covered()

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -649,38 +649,21 @@ def test_proliant(aggregator):
         for metric in drive_gauges:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
 
-    if_counts = ['ifInErrors', 'ifInDiscards', 'ifOutErrors', 'ifOutDiscards']
-    if_gauges = ['ifAdminStatus', 'ifOperStatus']
-    ifx_counts = [
-        'ifHCInOctets',
-        'ifHCInUcastPkts',
-        'ifHCInMulticastPkts',
-        'ifHCInBroadcastPkts',
-        'ifHCOutOctets',
-        'ifHCOutUcastPkts',
-        'ifHCOutMulticastPkts',
-        'ifHCOutBroadcastPkts',
-    ]
-    if_rates = [
-        'ifHCInOctets.rate',
-        'ifHCOutOctets.rate',
-    ]
-
     for interface in ['eth0', 'eth1']:
         if_tags = ['interface:{}'.format(interface)] + common_tags
-        for metric in if_counts:
+        for metric in IF_COUNTS:
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=if_tags, count=1
             )
 
-        for metric in if_gauges:
+        for metric in IF_GAUGES:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=if_tags, count=1)
 
-        for metric in ifx_counts:
+        for metric in IFX_COUNTS:
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=if_tags, count=1
             )
-        for metric in if_rates:
+        for metric in IF_RATES:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=if_tags, count=1)
 
     aggregator.assert_all_metrics_covered()
@@ -753,79 +736,48 @@ def test_cisco_asa_5525(aggregator):
 
     common_tags = common.CHECK_TAGS + ['snmp_profile:cisco-asa-5525', 'snmp_host:kept']
 
-    tcp_counts = [
-        'tcpActiveOpens',
-        'tcpPassiveOpens',
-        'tcpAttemptFails',
-        'tcpEstabResets',
-        'tcpHCInSegs',
-        'tcpHCOutSegs',
-        'tcpRetransSegs',
-        'tcpInErrs',
-        'tcpOutRsts',
-    ]
-    tcp_gauges = ['tcpCurrEstab']
-    udp_counts = ['udpHCInDatagrams', 'udpNoPorts', 'udpInErrors', 'udpHCOutDatagrams']
-    if_counts = ['ifInErrors', 'ifInDiscards', 'ifOutErrors', 'ifOutDiscards']
-    if_gauges = ['ifAdminStatus', 'ifOperStatus']
-    ifx_counts = [
-        'ifHCInOctets',
-        'ifHCInUcastPkts',
-        'ifHCInMulticastPkts',
-        'ifHCInBroadcastPkts',
-        'ifHCOutOctets',
-        'ifHCOutUcastPkts',
-        'ifHCOutMulticastPkts',
-        'ifHCOutBroadcastPkts',
-    ]
-    if_rates = [
-        'ifHCInOctets.rate',
-        'ifHCOutOctets.rate',
-    ]
-    for metric in tcp_counts:
+    for metric in TCP_COUNTS:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=common_tags, count=1
         )
 
-    for metric in tcp_gauges:
+    for metric in TCP_GAUGES:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=common_tags, count=1)
 
-    for metric in udp_counts:
+    for metric in UDP_COUNTS:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=common_tags, count=1
         )
 
     if_tags = ['interface:0x42010aa40033'] + common_tags
-    for metric in if_counts:
+    for metric in IF_COUNTS:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=if_tags, count=1
         )
 
-    for metric in if_gauges:
+    for metric in IF_GAUGES:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=if_tags, count=1)
 
     hc_tags = ['interface:Jaded oxen acted acted'] + common_tags
-    for metric in ifx_counts:
+    for metric in IFX_COUNTS:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=hc_tags, count=1
         )
-    for metric in if_rates:
+    for metric in IF_RATES:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=hc_tags, count=1)
 
     aggregator.assert_metric('snmp.cieIfResetCount', metric_type=aggregator.MONOTONIC_COUNT, tags=common_tags, count=1)
 
-    fru_metrics = ["cefcFRUPowerAdminStatus", "cefcFRUPowerOperStatus", "cefcFRUCurrent"]
     frus = [3, 4, 5, 7, 16, 17, 24, 25]
     for fru in frus:
         tags = ['fru:{}'.format(fru)] + common_tags
-        for metric in fru_metrics:
+        for metric in FRU_METRICS:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
 
     cpus = [7746]
-    cpu_metrics = ["cpmCPUTotalMonIntervalValue", "cpmCPUMemoryUsed", "cpmCPUMemoryFree"]
     for cpu in cpus:
         tags = ['cpu:{}'.format(cpu)] + common_tags
-        for metric in cpu_metrics:
+        for metric in CPU_METRICS:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
     sensor_tags = ['sensor_id:31', 'sensor_type:9'] + common_tags
     aggregator.assert_metric('snmp.entPhySensorValue', metric_type=aggregator.GAUGE, tags=sensor_tags, count=1)

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -9,7 +9,10 @@ from datadog_checks.snmp import SnmpCheck
 from . import common
 from .metrics import (
     ADAPTER_IF_COUNTS,
+    CIE_METRICS,
+    CPU_METRICS,
     DISK_GAUGES,
+    FRU_METRICS,
     IF_COUNTS,
     IF_GAUGES,
     IF_RATES,
@@ -217,7 +220,7 @@ def test_3850(aggregator):
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=common_tags, count=1
         )
-    for metric in TCP_COUNTS:
+    for metric in TCP_GAUGES:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=common_tags, count=1)
     for metric in UDP_COUNTS:
         aggregator.assert_metric(
@@ -227,23 +230,20 @@ def test_3850(aggregator):
     for sensor in sensors:
         tags = ['sensor_id:{}'.format(sensor), 'sensor_type:8'] + common_tags
         aggregator.assert_metric('snmp.entSensorValue', metric_type=aggregator.GAUGE, tags=tags, count=1)
-    fru_metrics = ["cefcFRUPowerAdminStatus", "cefcFRUPowerOperStatus", "cefcFRUCurrent"]
     frus = [1001, 1010, 2001, 2010]
     for fru in frus:
         tags = ['fru:{}'.format(fru)] + common_tags
-        for metric in fru_metrics:
+        for metric in FRU_METRICS:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
 
     cpus = [1000, 2000]
-    cpu_metrics = ["cpmCPUTotalMonIntervalValue", "cpmCPUMemoryUsed", "cpmCPUMemoryFree"]
     for cpu in cpus:
         tags = ['cpu:{}'.format(cpu)] + common_tags
-        for metric in cpu_metrics:
+        for metric in CPU_METRICS:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
-    cie_metrics = ["cieIfLastInTime", "cieIfLastOutTime", "cieIfInputQueueDrops", "cieIfOutputQueueDrops"]
     for interface in interfaces:
         tags = ['interface:{}'.format(interface)] + common_tags
-        for metric in cie_metrics:
+        for metric in CIE_METRICS:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
         aggregator.assert_metric('snmp.cieIfResetCount', metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1)
 
@@ -301,36 +301,6 @@ def test_idrac(aggregator):
 def test_cisco_nexus(aggregator):
     run_profile_check('cisco_nexus')
 
-    tcp_counts = [
-        'tcpActiveOpens',
-        'tcpPassiveOpens',
-        'tcpAttemptFails',
-        'tcpEstabResets',
-        'tcpHCInSegs',
-        'tcpHCOutSegs',
-        'tcpRetransSegs',
-        'tcpInErrs',
-        'tcpOutRsts',
-    ]
-    tcp_gauges = ['tcpCurrEstab']
-    udp_counts = ['udpHCInDatagrams', 'udpNoPorts', 'udpInErrors', 'udpHCOutDatagrams']
-    if_counts = ['ifInErrors', 'ifInDiscards', 'ifOutErrors', 'ifOutDiscards']
-    ifx_counts = [
-        'ifHCInOctets',
-        'ifHCInUcastPkts',
-        'ifHCInMulticastPkts',
-        'ifHCInBroadcastPkts',
-        'ifHCOutOctets',
-        'ifHCOutUcastPkts',
-        'ifHCOutMulticastPkts',
-        'ifHCOutBroadcastPkts',
-    ]
-    if_rates = [
-        'ifHCInOctets.rate',
-        'ifHCOutOctets.rate',
-    ]
-    if_gauges = ['ifAdminStatus', 'ifOperStatus']
-
     interfaces = ["GigabitEthernet1/0/{}".format(i) for i in range(1, 9)]
 
     common_tags = common.CHECK_TAGS + ['snmp_host:Nexus-eu1.companyname.managed', 'snmp_profile:cisco-nexus']
@@ -341,31 +311,31 @@ def test_cisco_nexus(aggregator):
 
     for interface in interfaces:
         tags = ['interface:{}'.format(interface)] + common_tags
-        for metric in if_counts:
+        for metric in IF_COUNTS:
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
-        for metric in if_rates:
+        for metric in IF_RATES:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=tags, count=1)
-        for metric in if_gauges:
+        for metric in IF_GAUGES:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
 
     for interface in interfaces:
         tags = ['interface:{}'.format(interface)] + common_tags
-        for metric in ifx_counts:
+        for metric in IFX_COUNTS:
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
 
-    for metric in tcp_counts:
+    for metric in TCP_COUNTS:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=common_tags, count=1
         )
 
-    for metric in tcp_gauges:
+    for metric in TCP_GAUGES:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=common_tags, count=1)
 
-    for metric in udp_counts:
+    for metric in UDP_COUNTS:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=common_tags, count=1
         )
@@ -375,18 +345,16 @@ def test_cisco_nexus(aggregator):
         tags = ['sensor_id:{}'.format(sensor), 'sensor_type:8'] + common_tags
         aggregator.assert_metric('snmp.entSensorValue', metric_type=aggregator.GAUGE, tags=tags, count=1)
 
-    fru_metrics = ["cefcFRUPowerAdminStatus", "cefcFRUPowerOperStatus", "cefcFRUCurrent"]
     frus = [6, 7, 15, 16, 19, 27, 30, 31]
     for fru in frus:
         tags = ['fru:{}'.format(fru)] + common_tags
-        for metric in fru_metrics:
+        for metric in FRU_METRICS:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
 
     cpus = [3173, 6692, 11571, 19529, 30674, 38253, 52063, 54474, 55946, 63960]
-    cpu_metrics = ["cpmCPUTotalMonIntervalValue", "cpmCPUMemoryUsed", "cpmCPUMemoryFree"]
     for cpu in cpus:
         tags = ['cpu:{}'.format(cpu)] + common_tags
-        for metric in cpu_metrics:
+        for metric in CPU_METRICS:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
 
     aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -7,6 +7,21 @@ import pytest
 from datadog_checks.snmp import SnmpCheck
 
 from . import common
+from .metrics import (
+    ADAPTER_IF_COUNTS,
+    DISK_GAUGES,
+    IF_COUNTS,
+    IF_GAUGES,
+    IF_RATES,
+    IFX_COUNTS,
+    IP_COUNTS,
+    IPX_COUNTS,
+    IP_IF_COUNTS,
+    SYSTEM_STATUS_GAUGES,
+    TCP_COUNTS,
+    TCP_GAUGES,
+    UDP_COUNTS,
+)
 
 pytestmark = pytest.mark.usefixtures("dd_environment")
 
@@ -67,25 +82,7 @@ def test_f5(aggregator):
         'sysMultiHostCpuSoftirq',
         'sysMultiHostCpuIowait',
     ]
-    if_gauges = ['ifAdminStatus', 'ifOperStatus']
-    if_counts = [
-        'ifHCInOctets',
-        'ifInErrors',
-        'ifHCOutOctets',
-        'ifOutErrors',
-        'ifHCInBroadcastPkts',
-        'ifHCOutUcastPkts',
-        'ifHCOutMulticastPkts',
-        'ifOutDiscards',
-        'ifHCInUcastPkts',
-        'ifHCInMulticastPkts',
-        'ifHCOutBroadcastPkts',
-        'ifInDiscards',
-    ]
-    if_rates = [
-        'ifHCInOctets.rate',
-        'ifHCOutOctets.rate',
-    ]
+    if_counts = IF_COUNTS + IFX_COUNTS
     interfaces = ['1.0', 'mgmt', '/Common/internal', '/Common/http-tunnel', '/Common/socks-tunnel']
     tags = ['snmp_profile:f5-big-ip', 'snmp_host:f5-big-ip-adc-good-byol-1-vm.c.datadog-integrations-lab.internal']
     tags += common.CHECK_TAGS
@@ -103,11 +100,11 @@ def test_f5(aggregator):
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=interface_tags, count=1,
             )
-        for metric in if_rates:
+        for metric in IF_RATES:
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=interface_tags, count=1
             )
-    for metric in if_gauges:
+    for metric in IF_GAUGES:
         for interface in interfaces:
             aggregator.assert_metric(
                 'snmp.{}'.format(metric),
@@ -121,127 +118,34 @@ def test_f5(aggregator):
 
 def test_router(aggregator):
     run_profile_check('network')
-
-    tcp_counts = [
-        'tcpActiveOpens',
-        'tcpPassiveOpens',
-        'tcpAttemptFails',
-        'tcpEstabResets',
-        'tcpHCInSegs',
-        'tcpHCOutSegs',
-        'tcpRetransSegs',
-        'tcpInErrs',
-        'tcpOutRsts',
-    ]
-    tcp_gauges = ['tcpCurrEstab']
-    udp_counts = ['udpHCInDatagrams', 'udpNoPorts', 'udpInErrors', 'udpHCOutDatagrams']
-    if_counts = [
-        'ifInErrors',
-        'ifInDiscards',
-        'ifOutErrors',
-        'ifOutDiscards',
-        'ifHCInOctets',
-        'ifHCInUcastPkts',
-        'ifHCInMulticastPkts',
-        'ifHCInBroadcastPkts',
-        'ifHCOutOctets',
-        'ifHCOutUcastPkts',
-        'ifHCOutMulticastPkts',
-        'ifHCOutBroadcastPkts',
-    ]
-    if_rates = [
-        'ifHCInOctets.rate',
-        'ifHCOutOctets.rate',
-    ]
-    if_gauges = ['ifAdminStatus', 'ifOperStatus']
-    ip_counts = [
-        'ipSystemStatsHCInReceives',
-        'ipSystemStatsHCInOctets',
-        'ipSystemStatsInHdrErrors',
-        'ipSystemStatsInNoRoutes',
-        'ipSystemStatsInAddrErrors',
-        'ipSystemStatsInUnknownProtos',
-        'ipSystemStatsInTruncatedPkts',
-        'ipSystemStatsHCInForwDatagrams',
-        'ipSystemStatsReasmReqds',
-        'ipSystemStatsReasmOKs',
-        'ipSystemStatsReasmFails',
-        'ipSystemStatsInDiscards',
-        'ipSystemStatsHCInDelivers',
-        'ipSystemStatsHCOutRequests',
-        'ipSystemStatsOutNoRoutes',
-        'ipSystemStatsHCOutForwDatagrams',
-        'ipSystemStatsOutDiscards',
-        'ipSystemStatsOutFragReqds',
-        'ipSystemStatsOutFragOKs',
-        'ipSystemStatsOutFragFails',
-        'ipSystemStatsOutFragCreates',
-        'ipSystemStatsHCOutTransmits',
-        'ipSystemStatsHCOutOctets',
-        'ipSystemStatsHCInMcastPkts',
-        'ipSystemStatsHCInMcastOctets',
-        'ipSystemStatsHCOutMcastPkts',
-        'ipSystemStatsHCOutMcastOctets',
-        'ipSystemStatsHCInBcastPkts',
-        'ipSystemStatsHCOutBcastPkts',
-    ]
-    ip_if_counts = [
-        'ipIfStatsHCInOctets',
-        'ipIfStatsInHdrErrors',
-        'ipIfStatsInNoRoutes',
-        'ipIfStatsInAddrErrors',
-        'ipIfStatsInUnknownProtos',
-        'ipIfStatsInTruncatedPkts',
-        'ipIfStatsHCInForwDatagrams',
-        'ipIfStatsReasmReqds',
-        'ipIfStatsReasmOKs',
-        'ipIfStatsReasmFails',
-        'ipIfStatsInDiscards',
-        'ipIfStatsHCInDelivers',
-        'ipIfStatsHCOutRequests',
-        'ipIfStatsHCOutForwDatagrams',
-        'ipIfStatsOutDiscards',
-        'ipIfStatsOutFragReqds',
-        'ipIfStatsOutFragOKs',
-        'ipIfStatsOutFragFails',
-        'ipIfStatsOutFragCreates',
-        'ipIfStatsHCOutTransmits',
-        'ipIfStatsHCOutOctets',
-        'ipIfStatsHCInMcastPkts',
-        'ipIfStatsHCInMcastOctets',
-        'ipIfStatsHCOutMcastPkts',
-        'ipIfStatsHCOutMcastOctets',
-        'ipIfStatsHCInBcastPkts',
-        'ipIfStatsHCOutBcastPkts',
-    ]
     common_tags = common.CHECK_TAGS + ['snmp_profile:generic-router']
     for interface in ['eth0', 'eth1']:
         tags = ['interface:{}'.format(interface)] + common_tags
-        for metric in if_counts:
+        for metric in IF_COUNTS + IFX_COUNTS:
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
-        for metric in if_rates:
+        for metric in IF_RATES:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=tags, count=1)
-        for metric in if_gauges:
+        for metric in IF_GAUGES:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
-    for metric in tcp_counts:
+    for metric in TCP_COUNTS:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=common_tags, count=1
         )
-    for metric in tcp_gauges:
+    for metric in TCP_GAUGES:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=common_tags, count=1)
-    for metric in udp_counts:
+    for metric in UDP_COUNTS:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=common_tags, count=1
         )
     for version in ['ipv4', 'ipv6']:
         tags = ['ipversion:{}'.format(version)] + common_tags
-        for metric in ip_counts:
+        for metric in IP_COUNTS + IPX_COUNTS:
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
-        for metric in ip_if_counts:
+        for metric in IP_IF_COUNTS:
             for interface in ['17', '21']:
                 tags = ['ipversion:{}'.format(version), 'interface:{}'.format(interface)] + common_tags
                 aggregator.assert_metric(
@@ -262,37 +166,7 @@ def test_f5_router(aggregator):
     check = SnmpCheck('snmp', init_config, [instance])
     check.check(instance)
 
-    if_counts = [
-        'ifInErrors',
-        'ifInDiscards',
-        'ifOutErrors',
-        'ifOutDiscards',
-        'ifHCInOctets',
-        'ifHCInUcastPkts',
-        'ifHCInMulticastPkts',
-        'ifHCInBroadcastPkts',
-        'ifHCOutOctets',
-        'ifHCOutUcastPkts',
-        'ifHCOutMulticastPkts',
-        'ifHCOutBroadcastPkts',
-    ]
-    if_rates = [
-        'ifHCInOctets.rate',
-        'ifHCOutOctets.rate',
-    ]
-    if_gauges = ['ifAdminStatus', 'ifOperStatus']
-    # We only get a subset of metrics
-    ip_counts = [
-        'ipSystemStatsHCInReceives',
-        'ipSystemStatsInHdrErrors',
-        'ipSystemStatsOutFragReqds',
-        'ipSystemStatsOutFragFails',
-        'ipSystemStatsHCOutTransmits',
-        'ipSystemStatsReasmReqds',
-        'ipSystemStatsHCInMcastPkts',
-        'ipSystemStatsReasmFails',
-        'ipSystemStatsHCOutMcastPkts',
-    ]
+    if_counts = IF_COUNTS + IFX_COUNTS
     interfaces = ['1.0', 'mgmt', '/Common/internal', '/Common/http-tunnel', '/Common/socks-tunnel']
     common_tags = ['snmp_profile:router', 'snmp_host:f5-big-ip-adc-good-byol-1-vm.c.datadog-integrations-lab.internal']
     common_tags.extend(common.CHECK_TAGS)
@@ -302,13 +176,13 @@ def test_f5_router(aggregator):
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
-        for metric in if_rates:
+        for metric in IF_RATES:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=tags, count=1)
-        for metric in if_gauges:
+        for metric in IF_GAUGES:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
     for version in ['ipv4', 'ipv6']:
         tags = ['ipversion:{}'.format(version)] + common_tags
-        for metric in ip_counts:
+        for metric in IP_COUNTS:
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
@@ -319,63 +193,33 @@ def test_f5_router(aggregator):
 
 def test_3850(aggregator):
     run_profile_check('3850')
-
-    tcp_counts = [
-        'tcpActiveOpens',
-        'tcpPassiveOpens',
-        'tcpAttemptFails',
-        'tcpEstabResets',
-        'tcpHCInSegs',
-        'tcpHCOutSegs',
-        'tcpRetransSegs',
-        'tcpInErrs',
-        'tcpOutRsts',
-    ]
-    tcp_gauges = ['tcpCurrEstab']
-    udp_counts = ['udpHCInDatagrams', 'udpNoPorts', 'udpInErrors', 'udpHCOutDatagrams']
-    if_counts = ['ifInErrors', 'ifInDiscards', 'ifOutErrors', 'ifOutDiscards']
-    ifx_counts = [
-        'ifHCInOctets',
-        'ifHCInUcastPkts',
-        'ifHCInMulticastPkts',
-        'ifHCInBroadcastPkts',
-        'ifHCOutOctets',
-        'ifHCOutUcastPkts',
-        'ifHCOutMulticastPkts',
-        'ifHCOutBroadcastPkts',
-    ]
-    if_rates = [
-        'ifHCInOctets.rate',
-        'ifHCOutOctets.rate',
-    ]
-    if_gauges = ['ifAdminStatus', 'ifOperStatus']
     # We're not covering all interfaces
     interfaces = ["GigabitEthernet1/0/{}".format(i) for i in range(1, 48)]
     common_tags = common.CHECK_TAGS + ['snmp_host:Cat-3850-4th-Floor.companyname.local', 'snmp_profile:cisco-3850']
     for interface in interfaces:
         tags = ['interface:{}'.format(interface)] + common_tags
-        for metric in if_counts:
+        for metric in IF_COUNTS:
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
-        for metric in if_gauges:
+        for metric in IF_GAUGES:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
     interfaces = ["Gi1/0/{}".format(i) for i in range(1, 48)]
     for interface in interfaces:
         tags = ['interface:{}'.format(interface)] + common_tags
-        for metric in ifx_counts:
+        for metric in IFX_COUNTS:
             aggregator.assert_metric(
                 'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
-        for metric in if_rates:
+        for metric in IF_RATES:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=tags, count=1)
-    for metric in tcp_counts:
+    for metric in TCP_COUNTS:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=common_tags, count=1
         )
-    for metric in tcp_gauges:
+    for metric in TCP_COUNTS:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=common_tags, count=1)
-    for metric in udp_counts:
+    for metric in UDP_COUNTS:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=common_tags, count=1
         )
@@ -428,51 +272,18 @@ def test_meraki_cloud_controller(aggregator):
 def test_idrac(aggregator):
     run_profile_check('idrac')
 
-    if_counts = [
-        'adapterRxPackets',
-        'adapterTxPackets',
-        'adapterRxBytes',
-        'adapterTxBytes',
-        'adapterRxErrors',
-        'adapterTxErrors',
-        'adapterRxDropped',
-        'adapterTxDropped',
-        'adapterRxMulticast',
-        'adapterCollisions',
-    ]
-    status_gauges = [
-        'systemStateChassisStatus',
-        'systemStatePowerUnitStatusRedundancy',
-        'systemStatePowerSupplyStatusCombined',
-        'systemStateAmperageStatusCombined',
-        'systemStateCoolingUnitStatusRedundancy',
-        'systemStateCoolingDeviceStatusCombined',
-        'systemStateTemperatureStatusCombined',
-        'systemStateMemoryDeviceStatusCombined',
-        'systemStateChassisIntrusionStatusCombined',
-        'systemStatePowerUnitStatusCombined',
-        'systemStateCoolingUnitStatusCombined',
-        'systemStateProcessorDeviceStatusCombined',
-        'systemStateTemperatureStatisticsStatusCombined',
-    ]
-    disk_gauges = [
-        'physicalDiskState',
-        'physicalDiskCapacityInMB',
-        'physicalDiskUsedSpaceInMB',
-        'physicalDiskFreeSpaceInMB',
-    ]
     interfaces = ['eth0', 'en1']
     common_tags = common.CHECK_TAGS + ['snmp_profile:idrac']
     for interface in interfaces:
         tags = ['adapter:{}'.format(interface)] + common_tags
-        for count in if_counts:
+        for count in ADAPTER_IF_COUNTS:
             aggregator.assert_metric(
                 'snmp.{}'.format(count), metric_type=aggregator.MONOTONIC_COUNT, tags=tags, count=1
             )
     indexes = ['26', '29']
     for index in indexes:
         tags = ['chassis_index:{}'.format(index)] + common_tags
-        for gauge in status_gauges:
+        for gauge in SYSTEM_STATUS_GAUGES:
             aggregator.assert_metric('snmp.{}'.format(gauge), metric_type=aggregator.GAUGE, tags=tags, count=1)
     powers = ['supply1', 'supply2']
     for power in powers:
@@ -481,7 +292,7 @@ def test_idrac(aggregator):
     disks = ['disk1', 'disk2']
     for disk in disks:
         tags = ['disk_name:{}'.format(disk)] + common_tags
-        for gauge in disk_gauges:
+        for gauge in DISK_GAUGES:
             aggregator.assert_metric('snmp.{}'.format(gauge), metric_type=aggregator.GAUGE, tags=tags, count=1)
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
SNMP profile tests have a lot of duplicated metrics lists. This PR moves those commonly used metrics to `tests/metrics.py` and refactors the tests.