### PR TITLE
Add vendor tag for all profiles

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/_base_cisco.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_base_cisco.yaml
@@ -6,6 +6,9 @@ extends:
   - _generic-router-tcp.yaml
   - _generic-router-udp.yaml
 
+tags: 
+  "vendor:cisco"
+
 metrics:
   - MIB: CISCO-ENTITY-FRU-CONTROL-MIB
     table:

--- a/snmp/datadog_checks/snmp/data/profiles/arista.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/arista.yaml
@@ -5,6 +5,9 @@ extends:
 
 sysobjectid: 1.3.6.1.4.1.30065.*
 
+tags:
+  "vendor:arista"
+
 metrics:
   ### Sensor
 

--- a/snmp/datadog_checks/snmp/data/profiles/aruba.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/aruba.yaml
@@ -4,6 +4,9 @@ extends:
 
 sysobjectid: 1.3.6.1.4.1.14823.*
 
+tags:
+  "vendor:aruba"
+
 metrics:
   ### Sensor
 

--- a/snmp/datadog_checks/snmp/data/profiles/checkpoint-firewall.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/checkpoint-firewall.yaml
@@ -4,6 +4,9 @@ extends:
 
 sysobjectid: 1.3.6.1.4.1.2620.1.*
 
+tags:
+  "vendor:checkpoint"
+
 metrics:
     # CPU
   - MIB: CHECKPOINT-MIB

--- a/snmp/datadog_checks/snmp/data/profiles/dell-poweredge.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/dell-poweredge.yaml
@@ -10,6 +10,9 @@ extends:
 
 sysobjectid: 1.3.6.1.4.1.674.10892.1.*
 
+tags:
+  "vendor:dell"
+
 metrics:
   - MIB: MIB-Dell-10892
     table:

--- a/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
@@ -6,6 +6,9 @@ extends:
 
 sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*
 
+tags:
+  "vendor:f5"
+
 metrics:
   # Memory stats
   - MIB: F5-BIGIP-SYSTEM-MIB

--- a/snmp/datadog_checks/snmp/data/profiles/hp-ilo4.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/hp-ilo4.yaml
@@ -8,6 +8,9 @@ extends:
 
 sysobjectid: 1.3.6.1.4.1.232.9.4.10
 
+tags:
+  "vendor:hp"
+
 metrics:
   # iLO controller metrics.
 

--- a/snmp/datadog_checks/snmp/data/profiles/hpe-proliant.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/hpe-proliant.yaml
@@ -4,6 +4,9 @@ extends:
 
 sysobjectid: 1.3.6.1.4.1.232.*
 
+tags:
+  "vendor:hp"
+
 metrics:
   - MIB: CPQSTDEQ-MIB
     table:

--- a/snmp/datadog_checks/snmp/data/profiles/idrac.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/idrac.yaml
@@ -5,6 +5,9 @@ extends:
 
 sysobjectid: 1.3.6.1.4.1.674.10892.*
 
+tags:
+  "vendor:dell"
+
 metrics:
   - MIB: IDRAC-MIB-SMIv2
     table:

--- a/snmp/datadog_checks/snmp/data/profiles/meraki-cloud-controller.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/meraki-cloud-controller.yaml
@@ -4,6 +4,9 @@
 
 sysobjectid: 1.3.6.1.4.1.29671.*
 
+tags:
+  "vendor:cisco_meraki"
+
 metrics:
   - MIB: MERAKI-CLOUD-CONTROLLER-MIB
     table:

--- a/snmp/datadog_checks/snmp/data/profiles/palo-alto.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/palo-alto.yaml
@@ -10,6 +10,10 @@ extends:
 
 sysobjectid: 1.3.6.1.4.1.25461.*
 
+tags:
+  "vendor:palo_alto"
+
+
 metrics:
   #
   # Session Utilization Metrics
@@ -63,4 +67,3 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.25461.2.1.2.5.1.3
       name: panGPGWUtilizationActiveTunnels
-


### PR DESCRIPTION
### What does this PR do?
Adds a tag with the name of the vendor of the device to each metric. A vendor tag allows customers to be able to see all of their Cisco metrics, or all of the Dell metrics. 

### Motivation
Wayfair wants to be able to group their devices by vendor, and filter metrics by vendor. 

### Additional Notes
This works especially well when a customer wants to do something like show me all of the metrics for all of my cisco devices, and then show me all of the metrics for all my cisco routers or cisco switches. We intend to add another device type tag that will help lots of customers build dashboards and get value OOTB from all of our profiles.  

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
