### PR TITLE
Remove unused `os_host` parameter from example configuration

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/data/conf.yaml.example
+++ b/openstack_controller/datadog_checks/openstack_controller/data/conf.yaml.example
@@ -1,12 +1,5 @@
 init_config:
 
-    ## @param os_host - string - optional
-    ## The hostname of this machine registered with Nova.
-    ## Defaults to the Hostname detected by the Agent -
-    ## https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/
-    #
-    # os_host: <HOSTNAME>
-
     ## @param proxy - object - optional
     ## Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
     ## to specify hosts that must bypass proxies.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove `os_host` from `conf.yaml.example` for `openstack_controller` integration.

### Motivation
<!-- What inspired you to submit this pull request? -->
This is probably an oversight from copying the example config from the legacy `openstack` integration.

`os_host` is used by the legacy `openstack` integration (for OpenStack < 12) to filter hypervisors and resources for the host the Agent is running on.

The `openstack_controller` integration (for OpenStack 13+) was redesigned to collect metrics from all servers, hypervisors and networks — it runs on a single Agent. Quoting the README:

```markdown
### Configuration

The OpenStack Controller integration is designed to collect information from all compute nodes and the servers running it. The integration should be run from a single Agent to monitor your OpenStack environment, and can be deployed on your controller node or an adjacent server that has access to the Keystone and Nova endpoints.
```

This means the logic based on `os_host` doesn't make sense anymore, and `os_host` is not used.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This was discovered while investigating a customer issue.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
