### PR TITLE
Fix hostname submission and tags for `openstack.nova.hypervisor.up` service check

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -255,6 +255,8 @@ class OpenStackControllerCheck(AgentCheck):
             'status:{}'.format(hyp['status']),
         ]
 
+        service_check_tags = tags + custom_tags
+
         # add hypervisor project names as tags
         project_names = hyp_project_names.get(hyp_hostname, set())
         for project_name in project_names:
@@ -263,16 +265,15 @@ class OpenStackControllerCheck(AgentCheck):
         host_tags = self._get_host_aggregate_tag(hyp_hostname, use_shortname=use_shortname)
         tags.extend(host_tags)
         tags.extend(custom_tags)
-        service_check_tags = list(custom_tags)
 
         hyp_state = hyp.get('state', None)
 
         if not hyp_state:
-            self.service_check(self.HYPERVISOR_SC, AgentCheck.UNKNOWN, hostname=hyp_hostname, tags=service_check_tags)
+            self.service_check(self.HYPERVISOR_SC, AgentCheck.UNKNOWN, tags=service_check_tags)
         elif hyp_state != self.HYPERVISOR_STATE_UP:
-            self.service_check(self.HYPERVISOR_SC, AgentCheck.CRITICAL, hostname=hyp_hostname, tags=service_check_tags)
+            self.service_check(self.HYPERVISOR_SC, AgentCheck.CRITICAL, tags=service_check_tags)
         else:
-            self.service_check(self.HYPERVISOR_SC, AgentCheck.OK, hostname=hyp_hostname, tags=service_check_tags)
+            self.service_check(self.HYPERVISOR_SC, AgentCheck.OK, tags=service_check_tags)
 
         if not collect_hypervisor_metrics:
             return

--- a/openstack_controller/tests/test_metrics.py
+++ b/openstack_controller/tests/test_metrics.py
@@ -194,6 +194,18 @@ def test_scenario(make_request, aggregator):
             return_value=auth_projects_response,
         ):
             check.check(common.MOCK_CONFIG['instances'][0])
+
+            # Service checks.
+
+            aggregator.assert_service_check(
+                'openstack.nova.hypervisor.up',
+                OpenStackControllerCheck.OK,
+                tags=['hypervisor:compute1.openstack.local', 'hypervisor_id:1', 'virt_type:QEMU', 'status:enabled'],
+                hostname='',
+            )
+
+            # Metrics.
+
             aggregator.assert_metric(
                 'openstack.nova.server.tx_errors',
                 value=0.0,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR:

- Updates `get_stats_for_single_hypervisor()` to:
    1. Not submit a custom `hostname` for the `hypervisor.up` service check.
    2. Submit hypervisor-related metadata as tags. (This is documented in `service_checks.json`, but previously only custom tags were submitted.)
- Adds a basic test for this service check - previously it was not tested at all.

### Motivation
<!-- What inspired you to submit this pull request? -->
This was revealed by a customer case, but there are several reasons why we the current behavior is wrong:

1. This information is already present as the `hypervisor` host - we don't currently submit it as a tag with the service check, but we should (it's an oversight).
1. Hypervisors are not _hosts_ themselves (at best the _server_ they run on can be considered a host - and we already correctly submit external host tags for those).
1. This is causing duplicate hosts to show up in the `Infrastructure List` for customers that have overridden the `hostname` in `datadog.yaml`. The scenario is as follows:
    1. Agent is running on a host that runs a hypervisor which will be discovered by this check.
    1. Hypervisor is named `hyper1`, and the user has defined `hostname: hyper1-abc` in their `datadog.yml`.
    1. Agent runs the check.
    1. Check submits `hostname:hyper1-abc` for metrics, as defined by `datadog.yml`.
    1. For hypervisor service checks, the check submits `hostname='hyper1'` when this host is processed, overriding the default `hyper1-abc` assigned by the Agent. (The `openstack_controller` monitors the entire OpenStack environment.)
    1. As a result, both `hyper1-abc` and `hyper1` show up in `Infrastructure List`, but the user expected `hyper1-abc` only (`hyper1` should not be there).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
