### PR TITLE
Allow to verify that no special hostname was submitted with a metric

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -223,7 +223,7 @@ class AggregatorStub(object):
             if expected_tags and expected_tags != sorted(metric.tags):
                 continue
 
-            if hostname and hostname != metric.hostname:
+            if hostname is not None and hostname != metric.hostname:
                 continue
 
             if metric_type is not None and metric_type != metric.type:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update `assert_metric()` so that it's possible to do `assert_metric(..., hostname='')` to verify that no special `hostname` was submitted.

### Motivation
<!-- What inspired you to submit this pull request? -->
Currently passing `hostname=''` does nothing in `assert_metric()`. This is because `if hostname` evaluates to `False` in that case, so `hostname` and `metric.hostname` are not compared.

Note: this is already supported by `assert_service_check()`, so this PR gets `assert_metric()` in line with it.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
**Use case**

The `openstack_controller` integration passes `hostname=''` to `assert_metric()` in several tests to verify that no special `hostname` is sent with the metric.

It's important to verify this because a `hostname` _could_ be sent by the integration in some other cases.

Currently those assertions on `hostname` are not enforced, although they're correct (which is why this PR passes the OpenStack Controller test suite).

Example assertions:

https://github.com/DataDog/integrations-core/blob/8d17d4c009c9008db67d1f070a74d620620b3673/openstack_controller/tests/test_openstack.py#L196-L201

https://github.com/DataDog/integrations-core/blob/8d17d4c009c9008db67d1f070a74d620620b3673/openstack_controller/tests/test_metrics.py#L250-L255

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
