### PR TITLE
Fixed infinite stream of Vault leader detection events

### DIFF
--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -185,6 +185,8 @@ class Vault(OpenMetricsBaseCheck):
                     }
                 )
             )
+            # Update _previous_leader for the next run
+            self._previous_leader = current_leader
 
     def check_health_v1(self, submission_queue, dynamic_tags):
         url = self._api_url + '/sys/health'


### PR DESCRIPTION
### What does this PR do?

Fix Vault leader detection. 

### Motivation

When the Vault leader changes, Datadog agent sends an infinite stream of "leader change" events. This is because the script does not keep update `self._previous_leader` upon change of the leader.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
