### PR TITLE
Provide a good default for `service` field of E2E logs config

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -79,6 +79,10 @@ def shared_logs(example_log_configs, mount_whitelist=None):
             example_log_config['path'] = agent_mount_path
             docker_volumes.append('{}:{}'.format(shared_log_file, agent_mount_path))
 
+            # If service is the default, use the source
+            if example_log_config.get('service', '<SERVICE>') == '<SERVICE>':
+                example_log_config['service'] = log_source
+
             # Make it available to reference for Docker volumes
             env_vars[log_name.upper()] = shared_log_file
 


### PR DESCRIPTION
### Motivation

Previous default was what the example configs use, `<SERVICE>`