### PR TITLE
Remove metrics file from JMX template's config spec

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/assets/configuration/spec.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/assets/configuration/spec.yaml
@@ -20,17 +20,3 @@ files:
   - template: instances
     options:
     - template: instances/default
-- name: metrics.yaml
-  example_name: metrics.yaml
-  options:
-  - name: jmx_metrics
-    description: |
-      Default metrics collected by this check. You should not have to modify this.
-      See Cassandra's metrics.yaml as an example:
-      https://github.com/DataDog/integrations-core/blob/master/cassandra/datadog_checks/cassandra/data/metrics.yaml
-    value:
-      example: []
-      type: array
-      items:
-        type: object
-        properties: []

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/data/metrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/data/metrics.yaml
@@ -1,6 +1,2 @@
-## @param jmx_metrics - list of mappings - optional
-## Default metrics collected by this check. You should not have to modify this.
-## See Cassandra's metrics.yaml as an example:
-## https://github.com/DataDog/integrations-core/blob/master/cassandra/datadog_checks/cassandra/data/metrics.yaml
-#
-# jmx_metrics: []
+# Default metrics collected by this check. You should not have to modify this.
+jmx_metrics: []


### PR DESCRIPTION
### Motivation

We've been removing this from new checks because:

1. we often want custom formatting & comment structure
2. the jmxfetch config is not extremely well defined