### PR TITLE
Fix test for version 6.0

### DIFF
--- a/redisdb/tests/test_auth.py
+++ b/redisdb/tests/test_auth.py
@@ -46,4 +46,5 @@ def test_redis_auth_wrong_pass(redis_auth):
         redis.check(instance)
         assert 0, "Check should raise an exception"
     except Exception as e:
-        assert "invalid password" in str(e).lower()
+        msg = str(e).lower()
+        assert ("invalid password" in msg) or ("wrongpass" in msg)

--- a/redisdb/tox.ini
+++ b/redisdb/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{3.2,4.0,latest}
+    py{27,38}-{3.2,4.0,5.0,6.0,latest}
 
 [testenv]
 description =
@@ -22,4 +22,6 @@ commands =
 setenv =
     3.2: REDIS_VERSION=3.2
     4.0: REDIS_VERSION=4.0
+    5.0: REDIS_VERSION=5.0
+    6.0: REDIS_VERSION=6.0
     latest: REDIS_VERSION=latest

--- a/redisdb/tox.ini
+++ b/redisdb/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{3.2,4.0,5.0,6.0,latest}
+    py{27,38}-{3.2,4.0,6.0,latest}
 
 [testenv]
 description =
@@ -22,6 +22,5 @@ commands =
 setenv =
     3.2: REDIS_VERSION=3.2
     4.0: REDIS_VERSION=4.0
-    5.0: REDIS_VERSION=5.0
     6.0: REDIS_VERSION=6.0
     latest: REDIS_VERSION=latest


### PR DESCRIPTION
## Description

Fix test for version 6.0. The invalid password error message has changed.

## Motivation

```
During handling of the above exception, another exception occurred:
tests/test_auth.py:49: in test_redis_auth_wrong_pass
    assert "invalid password" in str(e).lower()
E   AssertionError: assert 'invalid password' in 'wrongpass invalid username-password pair'
E    +  where 'wrongpass invalid username-password pair' = <built-in method lower of str object at 0x7fb61884d810>()
E    +    where <built-in method lower of str object at 0x7fb61884d810> = 'WRONGPASS invalid username-password pair'.lower
E    +      where 'WRONGPASS invalid username-password pair' = str(ResponseError('WRONGPASS invalid username-password pair'))

```

https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=15050&view=logs&jobId=28d964ed-ced8-53cb-c786-cadbc5b4e9d8&j=28d964ed-ced8-53cb-c786-cadbc5b4e9d8&t=7dc8caee-95fa-519d-d7e9-36857a8301f5
