### PR TITLE
Change events order

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -160,8 +160,8 @@ class WMISampler(object):
         Dispose of the internal thread
         """
         self._stopping = True
-        self._runSampleEvent.set()
         self._sampleCompleteEvent.wait()
+        self._runSampleEvent.set()
 
     def __enter__(self):
         self.start()


### PR DESCRIPTION
h1. Background
There's a been a few reports in which client on agent 6.18/7.18 aren't able to collect events. The problem with these seems that the check runs but no event is being collected. Some of these cases the client were able to work around by downgrading back to >7.17/6.17

In that version this change was introduced: https://github.com/DataDog/integrations-core/pull/5659

h1. Possible fix
I reversed the order of the last two lines in `stop`. Cause otherwise `_query_sample` can potentially reach `self._sampleCompleteEvent.set()` before `stop` has called `wait`