### PR TITLE
Add wmi integration test and fix filter sampler

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -400,7 +400,7 @@ class WMISampler(object):
             while f:
                 prop, value = f.popitem()
 
-                if isinstance(value, tuple):
+                if isinstance(value, (tuple, list)) and len(value) == 2:
                     oper = value[0]
                     value = value[1]
                 elif isinstance(value, string_types) and '%' in value:

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -146,14 +146,15 @@ class WMISampler(object):
 
         self._runSampleEvent = Event()
         self._sampleCompleteEvent = Event()
+        self._sampler_thread = None
 
     def start(self):
         """
         Start internal thread for sampling
         """
-        thread = Thread(target=self._query_sample_loop, name=self.class_name)
-        thread.daemon = True  # Python 2 does not support daemon as Thread constructor parameter
-        thread.start()
+        self._sampler_thread = Thread(target=self._query_sample_loop, name=self.class_name)
+        self._sampler_thread.daemon = True  # Python 2 does not support daemon as Thread constructor parameter
+        self._sampler_thread.start()
 
     def stop(self):
         """
@@ -261,7 +262,9 @@ class WMISampler(object):
         """
         self._sampling = True
         self._runSampleEvent.set()
-        self._sampleCompleteEvent.wait()
+        while not self._sampleCompleteEvent.wait(timeout=float(self._timeout_duration)):
+            if not self._sampler_thread.is_alive():
+                raise Exception("The sampler thread terminated unexpectedly")
         self._sampleCompleteEvent.clear()
         self._sampling = False
 

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -403,7 +403,7 @@ class WMISampler(object):
             while f:
                 prop, value = f.popitem()
 
-                if isinstance(value, (tuple, list)) and len(value) == 2:
+                if isinstance(value, (tuple, list)) and len(value) == 2 and isinstance(value[0], string_types):
                     oper = value[0]
                     value = value[1]
                 elif isinstance(value, string_types) and '%' in value:

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -400,7 +400,7 @@ class WMISampler(object):
             while f:
                 prop, value = f.popitem()
 
-                if isinstance(value, (tuple, list)):
+                if isinstance(value, tuple):
                     oper = value[0]
                     value = value[1]
                 elif isinstance(value, string_types) and '%' in value:
@@ -408,7 +408,7 @@ class WMISampler(object):
                 else:
                     oper = '='
 
-                if isinstance(value, (tuple, list)):
+                if isinstance(value, list):
                     if not len(value):
                         continue
 
@@ -466,11 +466,15 @@ class WMISampler(object):
 
         Returns: List of WMI objects or `TimeoutException`.
         """
-        formated_property_names = ",".join(self.property_names)
-        wql = "Select {property_names} from {class_name}{filters}".format(
-            property_names=formated_property_names, class_name=self.class_name, filters=self.formatted_filters
-        )
-        self.logger.debug(u"Querying WMI: %s", wql)
+        try:
+            formated_property_names = ",".join(self.property_names)
+            wql = "Select {property_names} from {class_name}{filters}".format(
+                property_names=formated_property_names, class_name=self.class_name, filters=self.formatted_filters
+            )
+            self.logger.debug(u"Querying WMI: %s", wql)
+        except Exception as e:
+            self.logger.error(e)
+            return []
 
         try:
             # From: https://msdn.microsoft.com/en-us/library/aa393866(v=vs.85).aspx

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -411,7 +411,7 @@ class WMISampler(object):
                 else:
                     oper = '='
 
-                if isinstance(value, list):
+                if isinstance(value, (tuple, list)):
                     if not len(value):
                         continue
 
@@ -476,7 +476,7 @@ class WMISampler(object):
             )
             self.logger.debug(u"Querying WMI: %s", wql)
         except Exception as e:
-            self.logger.error(e)
+            self.logger.error(str(e))
             return []
 
         try:

--- a/datadog_checks_base/tests/test_wmisampler.py
+++ b/datadog_checks_base/tests/test_wmisampler.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import collections
 
 import pytest
 from tests.utils import requires_windows
@@ -51,15 +52,17 @@ def test_format_filter_tuple():
 @requires_windows
 @pytest.mark.unit
 def test_format_filter_win32_log():
-    query = {
-        'TimeGenerated': ('>=', '202056101355.000000+'),
-        'Type': [('=', 'Warning')],
-        'SourceName': [('=', 'MSSQLSERVER')],
-    }
+    query = collections.OrderedDict(
+        {
+            'TimeGenerated': ('>=', '202056101355.000000+'),
+            'Type': [('=', 'Warning'), ('=', 'Error')],
+            'SourceName': [('=', 'MSSQLSERVER')],
+        }
+    )
 
     sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=[query])
     formatted_filters = sampler.formatted_filters
     assert (
         formatted_filters == " WHERE ( ( SourceName = 'MSSQLSERVER' ) "
-        "AND ( Type = 'Warning' ) AND TimeGenerated >= '202056101355.000000+' )"
+        "AND ( Type = 'Warning' OR Type = 'Error' ) AND TimeGenerated >= '202056101355.000000+' )"
     )

--- a/datadog_checks_base/tests/test_wmisampler.py
+++ b/datadog_checks_base/tests/test_wmisampler.py
@@ -53,11 +53,11 @@ def test_format_filter_tuple():
 @pytest.mark.unit
 def test_format_filter_win32_log():
     query = collections.OrderedDict(
-        {
-            'TimeGenerated': ('>=', '202056101355.000000+'),
-            'Type': [('=', 'Warning'), ('=', 'Error')],
-            'SourceName': [('=', 'MSSQLSERVER')],
-        }
+        (
+            ('TimeGenerated', ('>=', '202056101355.000000+')),
+            ('Type', [('=', 'Warning'), ('=', 'Error')]),
+            ('SourceName', [('=', 'MSSQLSERVER')]),
+        )
     )
 
     sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=[query])

--- a/datadog_checks_base/tests/test_wmisampler.py
+++ b/datadog_checks_base/tests/test_wmisampler.py
@@ -55,3 +55,21 @@ def test_format_filter_tuple():
     sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=filters)
     formatted_filters = sampler.formatted_filters
     assert formatted_filters == " WHERE ( a < '3' )"
+
+
+@requires_windows
+@pytest.mark.unit
+def test_format_filter_win32_log():
+    query = {
+        'TimeGenerated': ('>=', '202056101355.000000+'),
+        'User': ('=', 'frank'),
+        'Type': [('=', 'Warning')],
+        'SourceName': [('=', 'MSSQLSERVER')],
+    }
+
+    sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=[query])
+    formatted_filters = sampler.formatted_filters
+    assert (
+        formatted_filters == " WHERE ((SourceName = 'MSSQLSERVER' "
+        "AND (Type = 'Error' OR Type = 'Warning' AND TimeGenerated = '202056101355.000000+')"
+    )

--- a/datadog_checks_base/tests/test_wmisampler.py
+++ b/datadog_checks_base/tests/test_wmisampler.py
@@ -22,29 +22,11 @@ def test_format_filter_value():
 
 @requires_windows
 @pytest.mark.unit
-def test_format_filter_list():
-    filters = [{'a': ['>', 1, 'i_get_ignored']}]
-    sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=filters)
-    formatted_filters = sampler.formatted_filters
-    assert formatted_filters == " WHERE ( a > '1' )"
-
-
-@requires_windows
-@pytest.mark.unit
 def test_format_filter_like():
     filters = [{'a': '%foo'}]
     sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=filters)
     formatted_filters = sampler.formatted_filters
     assert formatted_filters == " WHERE ( a LIKE '%foo' )"
-
-
-@requires_windows
-@pytest.mark.unit
-def test_format_filter_list_expected():
-    filters = [{'a': ['<', 3]}]
-    sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=filters)
-    formatted_filters = sampler.formatted_filters
-    assert formatted_filters == " WHERE ( a < '3' )"
 
 
 @requires_windows
@@ -62,7 +44,6 @@ def test_format_filter_tuple():
 def test_format_filter_win32_log():
     query = {
         'TimeGenerated': ('>=', '202056101355.000000+'),
-        'User': ('=', 'frank'),
         'Type': [('=', 'Warning')],
         'SourceName': [('=', 'MSSQLSERVER')],
     }
@@ -70,6 +51,6 @@ def test_format_filter_win32_log():
     sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=[query])
     formatted_filters = sampler.formatted_filters
     assert (
-        formatted_filters == " WHERE ((SourceName = 'MSSQLSERVER' "
-        "AND (Type = 'Error' OR Type = 'Warning' AND TimeGenerated = '202056101355.000000+')"
+        formatted_filters == " WHERE ( ( SourceName = 'MSSQLSERVER' ) "
+        "AND ( Type = 'Warning' ) AND TimeGenerated >= '202056101355.000000+' )"
     )

--- a/datadog_checks_base/tests/test_wmisampler.py
+++ b/datadog_checks_base/tests/test_wmisampler.py
@@ -31,6 +31,15 @@ def test_format_filter_like():
 
 @requires_windows
 @pytest.mark.unit
+def test_format_filter_list_expected():
+    filters = [{'a': ['<', 3]}]
+    sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=filters)
+    formatted_filters = sampler.formatted_filters
+    assert formatted_filters == " WHERE ( a < '3' )"
+
+
+@requires_windows
+@pytest.mark.unit
 def test_format_filter_tuple():
     # needed for backwards compatibility and hardcoded filters
     filters = [{'a': ('<', 3)}]

--- a/win32_event_log/tests/test_win32_integration.py
+++ b/win32_event_log/tests/test_win32_integration.py
@@ -1,0 +1,13 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+import pytest
+
+from tests import common
+from tests.utils import requires_windows
+
+
+@pytest.mark.integration
+@requires_windows
+def test_basic_check(aggregator, check):
+    check.check(common.INSTANCE, rate=True)

--- a/win32_event_log/tests/test_win32_integration.py
+++ b/win32_event_log/tests/test_win32_integration.py
@@ -1,13 +1,18 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import platform
+
 import pytest
 
-from tests import common
-from tests.utils import requires_windows
+from datadog_checks.win32_event_log import Win32EventLogWMI
+
+from . import common
 
 
 @pytest.mark.integration
-@requires_windows
-def test_basic_check(aggregator, check):
-    check.check(common.INSTANCE, rate=True)
+@pytest.mark.skipif(platform.system() != 'Windows', reason="Test only valid on Windows")
+def test_basic_check(aggregator):
+    check = Win32EventLogWMI('win32_event_log', {}, {}, [common.INSTANCE])
+    check.check(common.INSTANCE)
+    check.check(common.INSTANCE)

--- a/wmi_check/tests/test_wmi_check.py
+++ b/wmi_check/tests/test_wmi_check.py
@@ -10,17 +10,6 @@ from . import common
 log = logging.getLogger(__file__)
 
 
-def test_basic_check(mock_proc_sampler, aggregator, check):
-    instance = copy.deepcopy(common.INSTANCE)
-    instance['tags'] = ["optional:tag1"]
-    check.check(instance)
-
-    for metric in common.INSTANCE_METRICS:
-        aggregator.assert_metric(metric, tags=['optional:tag1'], count=1)
-
-    aggregator.assert_all_metrics_covered()
-
-
 def test_tags(mock_proc_sampler, aggregator, check):
     instance = copy.deepcopy(common.INSTANCE)
     instance['tags'] = ["optional:tag1"]

--- a/wmi_check/tests/test_wmi_check.py
+++ b/wmi_check/tests/test_wmi_check.py
@@ -10,6 +10,17 @@ from . import common
 log = logging.getLogger(__file__)
 
 
+def test_basic_check(mock_proc_sampler, aggregator, check):
+    instance = copy.deepcopy(common.INSTANCE)
+    instance['tags'] = ["optional:tag1"]
+    check.check(instance)
+
+    for metric in common.INSTANCE_METRICS:
+        aggregator.assert_metric(metric, tags=['optional:tag1'], count=1)
+
+    aggregator.assert_all_metrics_covered()
+
+
 def test_tags(mock_proc_sampler, aggregator, check):
     instance = copy.deepcopy(common.INSTANCE)
     instance['tags'] = ["optional:tag1"]


### PR DESCRIPTION
The changes were introduced in https://github.com/DataDog/integrations-core/pull/5510
The tests were introduced in https://github.com/DataDog/integrations-core/pull/5859 

This caused `_query` method to throw an `index out of range` exception on `wmi_event_log` integration. When throwing the exception the sampler thread dies without signaling the parent that keeps waiting forever.

This branch addresses performs changes:

* Fixes compatibility with the win32 filters
* Adds specific test and removes wrong one
* Captures the exception so the thread does not get blocked in that case
* Adds an integration test to win32 that was hanging without the prior fixes