### PR TITLE
Fix logs documentation

### DIFF
--- a/airflow/manifest.json
+++ b/airflow/manifest.json
@@ -16,7 +16,8 @@
   ],
   "public_title": "Datadog-Airflow Integration",
   "categories": [
-    "processing"
+    "processing",
+    "log collection"
   ],
   "type": "check",
   "is_public": true,

--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -14,9 +14,52 @@ The ClickHouse check is included in the [Datadog Agent][3] package. No additiona
 
 ### Configuration
 
+#### Host
 1. To start collecting your ClickHouse performance data, edit the `clickhouse.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample clickhouse.d/conf.yaml][4] for all available configuration options.
 
 2. [Restart the Agent][5].
+
+##### Log Collection
+
+1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
+
+   ```yaml
+   logs_enabled: true
+   ```
+
+2. Add the log files you are interested in to your `clickhouse.d/conf.yaml` file to start collecting your ClickHouse logs:
+
+   ```yaml
+     logs:
+       - type: file
+         path: /var/log/clickhouse-server/clickhouse-server.log
+         source: clickhouse
+         service: "<SERVICE_NAME>"
+   ```
+
+    Change the `path` and `service` parameter values and configure them for your environment. See the [sample clickhouse.d/conf.yaml][4] for all available configuration options.
+
+3. [Restart the Agent][6].
+
+#### Containerized
+
+For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.
+
+#### Metric Collection
+
+| Parameter            | Value                                                      |
+|----------------------|------------------------------------------------------------|
+| `<INTEGRATION_NAME>` | `clickhouse`                                                   |
+| `<INIT_CONFIG>`      | blank or `{}`                                              |
+| `<INSTANCE_CONFIG>`  | `{"server": "%%host%%", "port": "%%port%%", "username": "<USER>", "password": "<PASSWORD>"}`       |
+
+##### Log collection
+
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes log collection documentation][9].
+
+| Parameter      | Value                                     |
+|----------------|-------------------------------------------|
+| `<LOG_CONFIG>` | `{"source": "clickhouse", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
 

--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -15,6 +15,9 @@ The ClickHouse check is included in the [Datadog Agent][3] package. No additiona
 ### Configuration
 
 #### Host
+
+#### Metric Collection
+
 1. To start collecting your ClickHouse performance data, edit the `clickhouse.d/conf.yaml` file in the `conf.d/` folder at the root of your Agent's configuration directory. See the [sample clickhouse.d/conf.yaml][4] for all available configuration options.
 
 2. [Restart the Agent][5].

--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -95,3 +95,4 @@ Need help? Contact [Datadog support][8].
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [7]: https://github.com/DataDog/integrations-core/blob/master/clickhouse/metadata.csv
 [8]: https://docs.datadoghq.com/help/
+[9]: https://docs.datadoghq.com/agent/kubernetes/log/

--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -42,7 +42,7 @@ The ClickHouse check is included in the [Datadog Agent][3] package. No additiona
 
     Change the `path` and `service` parameter values and configure them for your environment. See the [sample clickhouse.d/conf.yaml][4] for all available configuration options.
 
-3. [Restart the Agent][6].
+3. [Restart the Agent][5].
 
 #### Containerized
 

--- a/confluent_platform/manifest.json
+++ b/confluent_platform/manifest.json
@@ -18,7 +18,8 @@
   "categories": [
     "processing",
     "messaging",
-    "autodiscovery"
+    "autodiscovery",
+    "log collection"
   ],
   "type": "check",
   "is_public": true,

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -14,15 +14,11 @@ The CoreDNS check is included in the [Datadog Agent][1] package, so you don't ne
 
 ### Configuration
 
-#### Host
-
-Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
-
-Edit the `coredns.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2], to point to your server and port and set the masters to monitor. See the [sample coredns.d/conf.yaml][3] for all available configuration options.
-
 #### Containerized
 
 For containerized environments, see the [Autodiscovery Integration Templates][7] for guidance on applying the parameters below.
+
+#### Metric Collection
 
 | Parameter            | Value                                                                            |
 | -------------------- | -------------------------------------------------------------------------------- |
@@ -34,6 +30,14 @@ For containerized environments, see the [Autodiscovery Integration Templates][7]
 
 - The `dns-pod` tag keeps track of the target DNS pod IP. The other tags are related to the dd-agent that is polling the information using the service discovery.
 - The service discovery annotations need to be done on the pod. In case of a deployment, add the annotations to the metadata of the template's specifications. Do not add it at the outer specification level.
+
+##### Log collection
+
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes log collection documentation][9].
+
+| Parameter      | Value                                     |
+|----------------|-------------------------------------------|
+| `<LOG_CONFIG>` | `{"source": "coredns", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
 

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -33,7 +33,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][7]
 
 ##### Log collection
 
-Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes log collection documentation][9].
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes log collection documentation][8].
 
 | Parameter      | Value                                     |
 |----------------|-------------------------------------------|
@@ -75,3 +75,4 @@ for more details about how to test and develop Agent based integrations.
 [5]: https://github.com/DataDog/integrations-core/blob/master/coredns/metadata.csv
 [6]: http://docs.datadoghq.com/help
 [7]: https://docs.datadoghq.com/agent/kubernetes/integrations/
+[8]: https://docs.datadoghq.com/agent/kubernetes/log/

--- a/coredns/manifest.json
+++ b/coredns/manifest.json
@@ -15,7 +15,8 @@
   "categories": [
     "containers",
     "network",
-    "autodiscovery"
+    "autodiscovery",
+    "log collection"
   ],
   "type": "check",
   "aliases": [],

--- a/couchbase/README.md
+++ b/couchbase/README.md
@@ -42,30 +42,6 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 2. [Restart the Agent][5].
 
-#### Log collection
-
-_Available for Agent versions >6.0_
-
-1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
-
-   ```yaml
-   logs_enabled: true
-   ```
-
-2. Add this configuration block to your `couchbase.d/conf.yaml` file to start collecting your Apache Logs:
-
-   ```yaml
-   logs:
-     - type: file
-       path: /opt/couchbase/var/lib/couchbase/logs/*.log
-       source: couchbase
-       service: <SERVICE>
-   ```
-
-    Change the `path` and `service` parameter values and configure them for your environment. See the [sample couchbase.d/conf.yaml][4] for all available configuration options.
-
-3. [Restart the Agent][5].
-
 #### Containerized
 
 For containerized environments, see the [Autodiscovery Integration Templates][6] for guidance on applying the parameters below.
@@ -77,16 +53,6 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 | `<INTEGRATION_NAME>` | `couchbase`                          |
 | `<INIT_CONFIG>`      | blank or `{}`                        |
 | `<INSTANCE_CONFIG>`  | `{"server": "http://%%host%%:8091"}` |
-
-##### Log collection
-
-_Available for Agent versions >6.0_
-
-Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes log collection documentation][7].
-
-| Parameter      | Value                                                  |
-| -------------- | ------------------------------------------------------ |
-| `<LOG_CONFIG>` | `{"source": "couchbase", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
 

--- a/couchbase/manifest.json
+++ b/couchbase/manifest.json
@@ -1,7 +1,6 @@
 {
   "categories": [
     "data store",
-    "log collection",
     "autodiscovery"
   ],
   "creates_events": false,

--- a/druid/manifest.json
+++ b/druid/manifest.json
@@ -17,7 +17,8 @@
   "public_title": "Datadog-Druid Integration",
   "categories": [
     "processing",
-    "data store"
+    "data store",
+    "log collection"
   ],
   "type": "check",
   "is_public": true,

--- a/flink/manifest.json
+++ b/flink/manifest.json
@@ -18,7 +18,8 @@
   "categories": [
     "processing",
     "data streams",
-    "dataflow"
+    "dataflow",
+    "log collection"
   ],
   "type": "check",
   "is_public": true,

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -153,16 +153,6 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 | `<INIT_CONFIG>`      | blank or `{}`                                                     |
 | `<INSTANCE_CONFIG>`  | `{"monitor_agent_url": "http://%%host%%:24220/api/plugins.json"}` |
 
-##### Log collection
-
-_Available for Agent versions >6.0_
-
-Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes log collection documentation][18].
-
-| Parameter      | Value                                                |
-| -------------- | ---------------------------------------------------- |
-| `<LOG_CONFIG>` | `{"source": "fluentd", "service": "<SERVICE_NAME>"}` |
-
 ### Validation
 
 [Run the Agent's status subcommand][14] and look for `fluentd` under the Checks section.

--- a/go-metro/manifest.json
+++ b/go-metro/manifest.json
@@ -1,7 +1,6 @@
 {
   "categories": [
-    "languages",
-    "log collection"
+    "languages"
   ],
   "creates_events": false,
   "display_name": "Go-Metro",

--- a/go_expvar/manifest.json
+++ b/go_expvar/manifest.json
@@ -4,7 +4,6 @@
   ],
   "categories": [
     "languages",
-    "log collection",
     "autodiscovery"
   ],
   "creates_events": false,

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -79,7 +79,7 @@ By default Haproxy sends logs over UDP to port 514. The Agent can listen for the
    logs:
      - type: udp
        port: 514
-       service: haproxy
+       service: <SERVICE_NAME>
        source: haproxy
    ```
 

--- a/istio/README.md
+++ b/istio/README.md
@@ -79,22 +79,12 @@ Istio contains two types of logs. Envoy access logs that are collected with the 
 
 _Available for Agent versions >6.0_
 
-1. Collecting logs is disabled by default in the Datadog Agent. Enable it in your [daemonset configuration][4]:
+See the [Autodiscovery Integration Templates][1] for guidance on applying the parameters below.
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes log collection documentation][16].
 
-   ```yaml
-       (...)
-       env:
-         # (...)
-         - name: DD_LOGS_ENABLED
-             value: "true"
-         - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-             value: "true"
-     # (...)
-   ```
-
-2. Make sure that the Docker socket is mounted to the Datadog Agent as done in [this manifest][5] or mount the `/var/log/pods` directory if you are not using docker.
-
-3. [Restart the Agent][13].
+| Parameter      | Value                                                |
+| -------------- | ---------------------------------------------------- |
+| `<LOG_CONFIG>` | `{"source": "istio", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
 
@@ -150,3 +140,4 @@ Additional helpful documentation, links, and articles:
 [13]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [14]: https://www.datadoghq.com/blog/istio-metrics/
 [15]: https://docs.datadoghq.com/agent/guide/integration-management/#install
+[16]: https://docs.datadoghq.com/agent/kubernetes/log/

--- a/kube_scheduler/README.md
+++ b/kube_scheduler/README.md
@@ -13,6 +13,8 @@ No additional installation is needed on your server.
 
 ### Configuration
 
+See the [Autodiscovery Integration Templates][9] for guidance on applying the parameters below.
+
 #### Metric collection
 
 1. Edit the `kube_scheduler.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your kube_scheduler performance data. See the [sample kube_scheduler.d/conf.yaml][2] for all available configuration options.
@@ -21,24 +23,11 @@ No additional installation is needed on your server.
 
 #### Log collection
 
-_Available for Agent versions >6.0_
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes log collection documentation][10].
 
-1. Collecting logs is disabled by default in the Datadog Agent. Enable it in your [daemonset configuration][4]:
-
-   ```yaml
-     # (...)
-     env:
-       # (...)
-       - name: DD_LOGS_ENABLED
-           value: "true"
-       - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
-           value: "true"
-     # (...)
-   ```
-
-2. Make sure that the Docker socket is mounted to the Datadog Agent as done in [this manifest][5].
-
-3. [Restart the Agent][3].
+| Parameter      | Value                                     |
+|----------------|-------------------------------------------|
+| `<LOG_CONFIG>` | `{"source": "kube_scheduler", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
 
@@ -71,3 +60,5 @@ Need help? Contact [Datadog support][8].
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [7]: https://github.com/DataDog/integrations-core/blob/master/kube_scheduler/metadata.csv
 [8]: https://docs.datadoghq.com/help/
+[9]: https://docs.datadoghq.com/agent/kubernetes/integrations/
+[10]: https://docs.datadoghq.com/agent/kubernetes/log/

--- a/mapr/README.md
+++ b/mapr/README.md
@@ -65,7 +65,7 @@ Then update the `/opt/mapr/fluentd/fluentd-<VERSION>/etc/fluentd/fluentd.conf` w
     @type datadog
     @id dd_agent
     include_tag_key true
-    dd_source mapr
+    dd_source mapr  # Sets "source: mapr" on every log to allow automatic parsing on Datadog.
     dd_tags "<KEY>:<VALUE>"
     service <YOUR_SERVICE_NAME>
     api_key <YOUR_API_KEY>

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -5,8 +5,7 @@
   "categories": [
     "configuration & deployment",
     "containers",
-    "orchestration",
-    "log collection"
+    "orchestration"
   ],
   "creates_events": false,
   "display_name": "Mesos Master",

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -5,7 +5,8 @@
   "categories": [
     "configuration & deployment",
     "containers",
-    "orchestration"
+    "orchestration",
+    "log collection"
   ],
   "creates_events": false,
   "display_name": "Mesos Master",

--- a/nginx_ingress_controller/README.md
+++ b/nginx_ingress_controller/README.md
@@ -58,7 +58,7 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 | Parameter      | Value                                                              |
 | -------------- | ------------------------------------------------------------------ |
-| `<LOG_CONFIG>` | `[{"service": "controller", "source":"nginx-ingress-controller"}]` |
+| `<LOG_CONFIG>` | `[{"service": "controller", "source": "nginx-ingress-controller"}]` |
 
 ### Validation
 

--- a/vault/manifest.json
+++ b/vault/manifest.json
@@ -2,6 +2,7 @@
   "categories": [
     "security",
     "configuration & deployment",
+    "log collection",
     "autodiscovery"
   ],
   "creates_events": true,

--- a/zk/README.md
+++ b/zk/README.md
@@ -96,7 +96,7 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 | Parameter      | Value                                           |
 | -------------- | ----------------------------------------------- |
-| `<LOG_CONFIG>` | `{"source": "zk", "service": "<SERVICE_NAME>"}` |
+| `<LOG_CONFIG>` | `{"source": "zookeeper", "service": "<SERVICE_NAME>"}` |
 
 ### Validation
 


### PR DESCRIPTION
Some integration were incorrectly documented as "collecting logs". Some others were not documenting log collection correctly.

This PR fixes a few of those mistakes