### PR TITLE
Support more tag formats when generating changelogs

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -15,7 +15,7 @@ from ...git import get_commits_since
 from ...github import from_contributor, get_changelog_types, get_pr, parse_pr_numbers
 from ...release import get_release_tag_string
 from ...utils import complete_testable_checks, get_valid_checks, get_version_string
-from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, validate_check_arg
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, validate_check_arg, echo_success
 
 ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, author_url, from_contributor')
 
@@ -65,6 +65,7 @@ def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_
 
     user_config = ctx.obj
     entries = defaultdict(list)
+    generated_changelogs = 0
     for pr_num in pr_numbers:
         try:
             payload = get_pr(pr_num, user_config)
@@ -85,6 +86,8 @@ def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_
                 # No changelog entry for this PR
                 echo_info(f'Skipping PR #{pr_num} from changelog due to label')
             continue
+
+        generated_changelogs += 1
 
         author = payload.get('user', {}).get('login')
         author_url = payload.get('user', {}).get('html_url')
@@ -138,3 +141,4 @@ def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_
     else:
         # overwrite the old changelog
         write_file(changelog_path, changelog_buffer.getvalue())
+        echo_success(f"Successfully generated {generated_changelogs} change{'s' if generated_changelogs > 1 else ''}")

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -15,7 +15,7 @@ from ...git import get_commits_since
 from ...github import from_contributor, get_changelog_types, get_pr, parse_pr_numbers
 from ...release import get_release_tag_string
 from ...utils import complete_testable_checks, get_valid_checks, get_version_string
-from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, validate_check_arg, echo_success
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, validate_check_arg
 
 ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, author_url, from_contributor')
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
@@ -12,15 +12,17 @@ from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_su
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Show all the pending PRs for a given check.')
 @click.argument('check', autocompletion=complete_valid_checks, callback=validate_check_arg)
+@click.option('--tag-pattern', default=None)
+@click.option('--tag-prefix', default=None)
 @click.option('--dry-run', '-n', is_flag=True)
 @click.pass_context
-def changes(ctx, check, dry_run):
+def changes(ctx, check, tag_pattern, tag_prefix, dry_run):
     """Show all the pending PRs for a given check."""
     if not dry_run and check and check not in get_valid_checks():
         abort(f'Check `{check}` is not an Agent-based Integration')
 
     # get the name of the current release tag
-    cur_version = get_version_string(check)
+    cur_version = get_version_string(check, pattern=tag_pattern, tag_prefix=tag_prefix)
     target_tag = get_release_tag_string(check, cur_version)
 
     # get the diff from HEAD

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -148,8 +148,10 @@ def get_latest_tag(pattern=None, tag_prefix='v'):
     Filters on pattern first, otherwise based off all tags
     Removes prefixed `v` if applicable
     """
+    if not pattern:
+        pattern = rf'^({tag_prefix})?\d+\.\d+\.\d+.*'
     all_tags = sorted(
-        (parse_version_info(t.replace(tag_prefix, '', 1)), t) for t in git_tag_list(rf'^({tag_prefix})?\d+\.\d+\.\d+$')
+        (parse_version_info(t.replace(tag_prefix, '', 1)), t) for t in git_tag_list(pattern)
     )
     # reverse so we have descendant order
     return list(reversed(all_tags))[0][1]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -150,9 +150,7 @@ def get_latest_tag(pattern=None, tag_prefix='v'):
     """
     if not pattern:
         pattern = rf'^({tag_prefix})?\d+\.\d+\.\d+.*'
-    all_tags = sorted(
-        (parse_version_info(t.replace(tag_prefix, '', 1)), t) for t in git_tag_list(pattern)
-    )
+    all_tags = sorted((parse_version_info(t.replace(tag_prefix, '', 1)), t) for t in git_tag_list(pattern))
     # reverse so we have descendant order
     return list(reversed(all_tags))[0][1]
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -273,7 +273,7 @@ def read_version_file(check_name):
     return read_file(get_version_file(check_name))
 
 
-def get_version_string(check_name, tag_prefix='v'):
+def get_version_string(check_name, tag_prefix='v', pattern=None):
     """
     Get the version string for the given check.
     """
@@ -284,7 +284,7 @@ def get_version_string(check_name, tag_prefix='v'):
         if version:
             return version.group(1)
     else:
-        return get_latest_tag(tag_prefix=tag_prefix)
+        return get_latest_tag(pattern=pattern, tag_prefix=tag_prefix)
 
 
 def load_manifest(check_name):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the ddev cli git utilities to support more tag formats when looking for changes between tags and generating changelogs.

Also adds a success message at the end of the changelog generation, to confirm things worked as expected. 

### Motivation
<!-- What inspired you to submit this pull request? -->
There are projects that have tag prefixes or beta versions that don't currently play nicely with the existing regex. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
