### PR TITLE
Fix andrun typo

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -57,7 +57,7 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
             ' on any machine.\n'
             '2. Run `ddev release build {normalized_integration_name}` to build the package.\n'
             '3. [Download the Datadog Agent](https://app.datadoghq.com/account/settings#agent).\n'
-            '4. Upload the build artifact to any host with an Agent and'
+            '4. Upload the build artifact to any host with an Agent and '
             'run `datadog-agent integration install -w'
             ' path/to/{normalized_integration_name}/dist/<ARTIFACT_NAME>.whl`.'.format(
                 integration_name=integration_name, normalized_integration_name=normalized_integration_name

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -57,8 +57,8 @@ def construct_template_fields(integration_name, repo_choice, **kwargs):
             ' on any machine.\n'
             '2. Run `ddev release build {normalized_integration_name}` to build the package.\n'
             '3. [Download the Datadog Agent](https://app.datadoghq.com/account/settings#agent).\n'
-            '4. Upload the build artifact to any host with an Agent and '
-            'run `datadog-agent integration install -w'
+            '4. Upload the build artifact to any host with an Agent and'
+            ' run `datadog-agent integration install -w'
             ' path/to/{normalized_integration_name}/dist/<ARTIFACT_NAME>.whl`.'.format(
                 integration_name=integration_name, normalized_integration_name=normalized_integration_name
             )


### PR DESCRIPTION
I noticed a few contributor new integration PRs that had this `andrun` typo in the README. 

```
### Installation

To install the LB Connectivity Check check on your host:

1. Install the developer toolkit on any machine.
2. Run ddev release build lb_connectivity_check to build the package.
3. Download the Datadog Agent.
4. Upload the build artifact to any host with an Agent andrun datadog-agent integration install -w path/to/statuspage_componenets/dist/<ARTIFACT_NAME>.whl.
```