### PR TITLE
[WIP] Make startup commands less flaky

### DIFF
--- a/oracle/tests/scripts/install_instant_client.sh
+++ b/oracle/tests/scripts/install_instant_client.sh
@@ -8,7 +8,7 @@ INSTANT_CLIENT_URL="https://ddintegrations.blob.core.windows.net/oracle/instantc
 mkdir /opt/oracle
 
 # Retry:
-# - Retry `apt-get`: we might not be able to fetch deps from debian
+# - Retry `apt-get`: we might be flaky when fetching packages
 # - Retry curl: donwload might fail due to:
 #   curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110
 for i in 2 4 8 16 32; do

--- a/oracle/tests/scripts/install_instant_client.sh
+++ b/oracle/tests/scripts/install_instant_client.sh
@@ -9,7 +9,7 @@ mkdir /opt/oracle
 
 # Retry:
 # - Retry `apt-get`: we might not be able to fetch deps from debian
-# - Retry of curl donwload needed due to:
+# - Retry curl: donwload might fail due to:
 #   curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110
 for i in 2 4 8 16 32; do
   apt-get update
@@ -18,4 +18,5 @@ for i in 2 4 8 16 32; do
   sleep $i
 done
 
+# Unzip will fail if the oracle client download failed
 unzip /opt/oracle/instantclient.zip -d /opt/oracle

--- a/oracle/tests/scripts/install_instant_client.sh
+++ b/oracle/tests/scripts/install_instant_client.sh
@@ -1,14 +1,19 @@
 # This script makes the necessary setup to be able to compile pymqi on the agent machine
 
+set -x  # Show executed commands
+set -e  # Stop on first failure
+
 INSTANT_CLIENT_URL="https://ddintegrations.blob.core.windows.net/oracle/instantclient-basiclite-linux.x64-19.3.0.0.0dbru.zip"
 
 mkdir /opt/oracle
-apt-get update
-apt-get install unzip
 
-# Retry necessary due to flaky download that might trigger:
-# curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110
+# Retry:
+# - Retry `apt-get`: we might not be able to fetch deps from debian
+# - Retry of curl donwload needed due to:
+#   curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110
 for i in 2 4 8 16 32; do
+  apt-get update
+  apt-get install -y unzip
   curl -o /opt/oracle/instantclient.zip $INSTANT_CLIENT_URL && break
   sleep $i
 done


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Make startup commands less flaky

### Motivation
<!-- What inspired you to submit this pull request? -->

```
Err:1 http://deb.debian.org/debian bullseye/main amd64 unzip amd64 6.0-25
  Cannot initiate the connection to deb.debian.org:80 (2a04:4e42:d::645). - connect (101: Network is unreachable) Could not connect to deb.debian.org:80 (151.101.54.133), connection timed out
E: Failed to fetch http://deb.debian.org/debian/pool/main/u/unzip/unzip_6.0-25_amd64.deb  Cannot initiate the connection to deb.debian.org:80 (2a04:4e42:d::645). - connect (101: Network is unreachable) Could not connect to deb.debian.org:80 (151.101.54.133), connection timed out
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  4 35.0M    4 1743k    0     0  1609k      0  0:00:22  0:00:01  0:00:21 1608k
 68 35.0M   68 24.0M    0     0  11.4M      0  0:00:03  0:00:02  0:00:01 11.3M
100 35.0M  100 35.0M    0     0  14.4M      0  0:00:02  0:00:02 --:--:-- 14.4M
/tmp/install_instant_client.sh: line 16: unzip: command not found

```
https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=15258&view=logs&jobId=c3a06451-088b-587c-b2b9-012b146267bb&j=c3a06451-088b-587c-b2b9-012b146267bb&t=e44c90e6-e662-54c2-0387-1cf630531015

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
