### PR TITLE
Allow optional dependency installation for all checks

### DIFF
--- a/active_directory/setup.py
+++ b/active_directory/setup.py
@@ -19,9 +19,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -55,6 +58,7 @@ setup(
     packages=['datadog_checks.active_directory'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/activemq/setup.py
+++ b/activemq/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -52,6 +55,7 @@ setup(
     packages=['datadog_checks.activemq'],
     # Run-time dependencies
     install_requires=['datadog_checks_base'],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/activemq_xml/setup.py
+++ b/activemq_xml/setup.py
@@ -20,8 +20,12 @@ with open(path.join(HERE, "datadog_checks", "activemq_xml", "__about__.py")) as 
     exec(f.read(), ABOUT)
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -55,6 +59,7 @@ setup(
     packages=['datadog_checks.activemq_xml'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/aerospike/setup.py
+++ b/aerospike/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.aerospike'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/airflow/setup.py
+++ b/airflow/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.airflow'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/amazon_msk/setup.py
+++ b/amazon_msk/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.amazon_msk'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/ambari/setup.py
+++ b/ambari/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=7.0.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.ambari'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/apache/setup.py
+++ b/apache/setup.py
@@ -17,12 +17,6 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
-        return f.readlines()
-
-
 def read(*parts):
     with open(path.join(HERE, *parts), 'r') as fp:
         return fp.read()
@@ -32,6 +26,15 @@ def read(*parts):
 ABOUT = {}
 with open(path.join(HERE, "datadog_checks", "apache", "__about__.py")) as f:
     exec(f.read(), ABOUT)
+
+
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
 
 
 CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
@@ -64,6 +67,7 @@ setup(
     packages=['datadog_checks.apache'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/aspdotnet/setup.py
+++ b/aspdotnet/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.aspdotnet'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/btrfs/setup.py
+++ b/btrfs/setup.py
@@ -17,8 +17,12 @@ with open(path.join(HERE, "datadog_checks", "btrfs", "__about__.py")) as f:
     exec(f.read(), ABOUT)
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -52,6 +56,7 @@ setup(
     packages=['datadog_checks.btrfs'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/cacti/setup.py
+++ b/cacti/setup.py
@@ -19,9 +19,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -55,6 +58,7 @@ setup(
     packages=['datadog_checks.cacti'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/cassandra/setup.py
+++ b/cassandra/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -52,6 +55,7 @@ setup(
     packages=['datadog_checks.cassandra'],
     # Run-time dependencies
     install_requires=['datadog_checks_base'],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/cassandra_nodetool/setup.py
+++ b/cassandra_nodetool/setup.py
@@ -19,8 +19,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -55,6 +59,7 @@ setup(
     packages=['datadog_checks.cassandra_nodetool'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/ceph/setup.py
+++ b/ceph/setup.py
@@ -17,9 +17,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -53,6 +56,7 @@ setup(
     packages=['datadog_checks.ceph'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/cilium/setup.py
+++ b/cilium/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.cilium'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/cisco_aci/setup.py
+++ b/cisco_aci/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog_checks_base'
 
 setup(
@@ -44,6 +53,7 @@ setup(
     packages=['datadog_checks.cisco_aci'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/clickhouse/setup.py
+++ b/clickhouse/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.clickhouse'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/cockroachdb/setup.py
+++ b/cockroachdb/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.cockroachdb'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/confluent_platform/setup.py
+++ b/confluent_platform/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.confluent_platform'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/consul/setup.py
+++ b/consul/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -53,6 +56,7 @@ setup(
     packages=['datadog_checks.consul'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/coredns/setup.py
+++ b/coredns/setup.py
@@ -8,6 +8,15 @@ from os import path
 from setuptools import setup
 
 HERE = path.abspath(path.dirname(__file__))
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.1.0'
 
 # Get version info
@@ -42,6 +51,7 @@ setup(
     ],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # The package we're going to ship
     packages=['datadog_checks.coredns'],
     include_package_data=True,

--- a/coredns/setup.py
+++ b/coredns/setup.py
@@ -8,6 +8,17 @@ from os import path
 from setuptools import setup
 
 HERE = path.abspath(path.dirname(__file__))
+
+# Get version info
+ABOUT = {}
+with open(path.join(HERE, "datadog_checks", "coredns", "__about__.py")) as f:
+    exec(f.read(), ABOUT)
+
+# Get the long description from the README file
+with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+
 def get_dependencies():
     dep_file = path.join(HERE, 'requirements.in')
     if not path.isfile(dep_file):
@@ -19,14 +30,6 @@ def get_dependencies():
 
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.1.0'
 
-# Get version info
-ABOUT = {}
-with open(path.join(HERE, "datadog_checks", "coredns", "__about__.py")) as f:
-    exec(f.read(), ABOUT)
-
-# Get the long description from the README file
-with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
 
 setup(
     name='datadog-coredns',

--- a/couch/setup.py
+++ b/couch/setup.py
@@ -21,8 +21,12 @@ with open(path.join(HERE, "datadog_checks", "couch", "__about__.py")) as f:
     exec(f.read(), ABOUT)
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -56,6 +60,7 @@ setup(
     packages=['datadog_checks.couch'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/couchbase/setup.py
+++ b/couchbase/setup.py
@@ -21,8 +21,12 @@ with open(path.join(HERE, "datadog_checks", "couchbase", "__about__.py")) as f:
     exec(f.read(), ABOUT)
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -56,6 +60,7 @@ setup(
     packages=['datadog_checks.couchbase'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/crio/setup.py
+++ b/crio/setup.py
@@ -15,6 +15,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base'
 
 
@@ -46,6 +55,7 @@ setup(
     packages=['datadog_checks.crio'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
+# Licensed under a 3-clause BSOD style license (see LICENSE)
 __version__ = "11.6.0"

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/setup.py
@@ -15,6 +15,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 
@@ -46,6 +55,7 @@ setup(
     packages=['datadog_checks.{check_name}'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/setup.py
@@ -55,7 +55,7 @@ setup(
     packages=['datadog_checks.{check_name}'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
-    extras_require={'deps': get_dependencies()},
+    extras_require={{'deps': get_dependencies()}},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/setup.py
@@ -61,7 +61,7 @@ setup(
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
-    extras_require={'deps': get_dependencies()},
+    extras_require={{'deps': get_dependencies()}},
 
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/setup.py
@@ -15,6 +15,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base'
 
 
@@ -52,6 +61,7 @@ setup(
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
 
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/setup.py
@@ -15,6 +15,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 
@@ -46,6 +55,7 @@ setup(
     packages=['datadog_checks.{check_name}'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/setup.py
@@ -55,7 +55,7 @@ setup(
     packages=['datadog_checks.{check_name}'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
-    extras_require={'deps': get_dependencies()},
+    extras_require={{'deps': get_dependencies()}},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/datadog_checks_downloader/setup.py
+++ b/datadog_checks_downloader/setup.py
@@ -18,8 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     LONG_DESC = f.read()
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 

--- a/directory/setup.py
+++ b/directory/setup.py
@@ -21,9 +21,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -57,6 +60,7 @@ setup(
     packages=['datadog_checks.directory'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/disk/setup.py
+++ b/disk/setup.py
@@ -19,9 +19,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -55,6 +58,7 @@ setup(
     packages=['datadog_checks.disk'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/dns_check/setup.py
+++ b/dns_check/setup.py
@@ -19,8 +19,12 @@ with open(path.join(HERE, "datadog_checks", "dns_check", "__about__.py")) as f:
     exec(f.read(), ABOUT)
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +58,7 @@ setup(
     packages=['datadog_checks.dns_check'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/dotnetclr/setup.py
+++ b/dotnetclr/setup.py
@@ -16,6 +16,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog_checks_base>=11.4.0'
 
 setup(
@@ -46,6 +55,7 @@ setup(
     packages=['datadog_checks.dotnetclr'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/druid/setup.py
+++ b/druid/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.druid'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/ecs_fargate/setup.py
+++ b/ecs_fargate/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.ecs_fargate'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/eks_fargate/setup.py
+++ b/eks_fargate/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.eks_fargate'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/elastic/setup.py
+++ b/elastic/setup.py
@@ -14,16 +14,19 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
-        return f.readlines()
-
-
 # Get version info
 ABOUT = {}
 with open(path.join(HERE, "datadog_checks", "elastic", "__about__.py")) as f:
     exec(f.read(), ABOUT)
+
+
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
 
 
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
@@ -56,6 +59,7 @@ setup(
     packages=['datadog_checks.elastic'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/envoy/setup.py
+++ b/envoy/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.envoy'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/etcd/setup.py
+++ b/etcd/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.etcd'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/exchange_server/setup.py
+++ b/exchange_server/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.exchange_server'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/external_dns/setup.py
+++ b/external_dns/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.external_dns'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/flink/setup.py
+++ b/flink/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.flink'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/fluentd/setup.py
+++ b/fluentd/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.fluentd'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/gearmand/setup.py
+++ b/gearmand/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.gearmand'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/gitlab/setup.py
+++ b/gitlab/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.gitlab'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/gitlab_runner/setup.py
+++ b/gitlab_runner/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.gitlab_runner'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/go-metro/setup.py
+++ b/go-metro/setup.py
@@ -17,9 +17,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -57,6 +60,7 @@ setup(
 
     # Run-time dependencies
     install_requires=['datadog_checks_base'],
+    extras_require={'deps': get_dependencies()},
 
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/go_expvar/setup.py
+++ b/go_expvar/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.go_expvar'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/gunicorn/setup.py
+++ b/gunicorn/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.gunicorn'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/haproxy/setup.py
+++ b/haproxy/setup.py
@@ -16,6 +16,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
 
 setup(
@@ -46,6 +55,7 @@ setup(
     packages=['datadog_checks.haproxy'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/harbor/setup.py
+++ b/harbor/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=10.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.harbor'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/hazelcast/setup.py
+++ b/hazelcast/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.hazelcast'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/hdfs_datanode/setup.py
+++ b/hdfs_datanode/setup.py
@@ -21,8 +21,12 @@ with open(path.join(HERE, "datadog_checks", "hdfs_datanode", "__about__.py")) as
     exec(f.read(), ABOUT)
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -56,6 +60,7 @@ setup(
     packages=['datadog_checks.hdfs_datanode'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/hdfs_namenode/setup.py
+++ b/hdfs_namenode/setup.py
@@ -21,8 +21,12 @@ with open(path.join(HERE, "datadog_checks", "hdfs_namenode", "__about__.py")) as
     exec(f.read(), ABOUT)
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -56,6 +60,7 @@ setup(
     packages=['datadog_checks.hdfs_namenode'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/hive/setup.py
+++ b/hive/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.hive'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/http_check/setup.py
+++ b/http_check/setup.py
@@ -21,8 +21,12 @@ with open(path.join(HERE, "datadog_checks", "http_check", "__about__.py")) as f:
     exec(f.read(), ABOUT)
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -56,6 +60,7 @@ setup(
     packages=['datadog_checks.http_check'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/hyperv/setup.py
+++ b/hyperv/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.hyperv'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/ibm_db2/setup.py
+++ b/ibm_db2/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=6.0.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.ibm_db2'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/ibm_mq/setup.py
+++ b/ibm_mq/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.ibm_mq'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/ibm_was/setup.py
+++ b/ibm_was/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=7.0.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.ibm_was'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/ignite/setup.py
+++ b/ignite/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.ignite'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/iis/setup.py
+++ b/iis/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.iis'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/istio/setup.py
+++ b/istio/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.istio'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/jboss_wildfly/setup.py
+++ b/jboss_wildfly/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.jboss_wildfly'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/kafka/setup.py
+++ b/kafka/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -52,6 +55,7 @@ setup(
     packages=['datadog_checks.kafka'],
     # Run-time dependencies
     install_requires=['datadog_checks_base'],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/kafka_consumer/setup.py
+++ b/kafka_consumer/setup.py
@@ -19,9 +19,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -51,6 +54,7 @@ setup(
     packages=['datadog_checks.kafka_consumer'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/kong/setup.py
+++ b/kong/setup.py
@@ -19,9 +19,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -55,6 +58,7 @@ setup(
     packages=['datadog_checks.kong'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/kube_apiserver_metrics/setup.py
+++ b/kube_apiserver_metrics/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.kube_apiserver_metrics'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/kube_controller_manager/setup.py
+++ b/kube_controller_manager/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.kube_controller_manager'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/kube_dns/setup.py
+++ b/kube_dns/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.kube_dns'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/kube_metrics_server/setup.py
+++ b/kube_metrics_server/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.kube_metrics_server'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/kube_proxy/setup.py
+++ b/kube_proxy/setup.py
@@ -19,6 +19,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog_checks_base'
 
 setup(
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.kube_proxy'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/kube_scheduler/setup.py
+++ b/kube_scheduler/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.kube_scheduler'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/kubelet/setup.py
+++ b/kubelet/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.kubelet'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/kubernetes/setup.py
+++ b/kubernetes/setup.py
@@ -17,9 +17,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -59,6 +62,7 @@ setup(
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
 
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/kubernetes_state/setup.py
+++ b/kubernetes_state/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.kubernetes_state'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/kyototycoon/setup.py
+++ b/kyototycoon/setup.py
@@ -21,9 +21,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -57,6 +60,7 @@ setup(
     packages=['datadog_checks.kyototycoon'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/lighttpd/setup.py
+++ b/lighttpd/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -50,6 +53,7 @@ setup(
     packages=['datadog_checks.lighttpd'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/linkerd/setup.py
+++ b/linkerd/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog_checks_base'
 
 setup(
@@ -48,6 +57,7 @@ setup(
     packages=['datadog_checks.linkerd'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/linux_proc_extras/setup.py
+++ b/linux_proc_extras/setup.py
@@ -19,9 +19,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -55,6 +58,7 @@ setup(
     packages=['datadog_checks.linux_proc_extras'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/mapr/setup.py
+++ b/mapr/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.mapr'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/mapreduce/setup.py
+++ b/mapreduce/setup.py
@@ -21,8 +21,12 @@ with open(path.join(HERE, "datadog_checks", "mapreduce", "__about__.py")) as f:
     exec(f.read(), ABOUT)
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -56,6 +60,7 @@ setup(
     packages=['datadog_checks.mapreduce'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/marathon/setup.py
+++ b/marathon/setup.py
@@ -16,9 +16,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -50,6 +53,7 @@ setup(
     ],
     packages=['datadog_checks.marathon'],
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/mcache/setup.py
+++ b/mcache/setup.py
@@ -19,9 +19,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -51,6 +54,7 @@ setup(
     packages=['datadog_checks.mcache'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/mesos_master/setup.py
+++ b/mesos_master/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.mesos_master'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/mesos_slave/setup.py
+++ b/mesos_slave/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.mesos_slave'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/mongo/setup.py
+++ b/mongo/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.mongo'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.mysql'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/nagios/setup.py
+++ b/nagios/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.nagios'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/network/setup.py
+++ b/network/setup.py
@@ -17,8 +17,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -52,6 +56,7 @@ setup(
     packages=['datadog_checks.network'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/nfsstat/setup.py
+++ b/nfsstat/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.nfsstat'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/nginx/setup.py
+++ b/nginx/setup.py
@@ -18,10 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
 
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -55,6 +57,7 @@ setup(
     packages=['datadog_checks.nginx'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/nginx_ingress_controller/setup.py
+++ b/nginx_ingress_controller/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.nginx_ingress_controller'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/openldap/setup.py
+++ b/openldap/setup.py
@@ -19,9 +19,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -51,6 +54,7 @@ setup(
     packages=['datadog_checks.openldap'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     package_data={'datadog_checks.openldap': ['conf.yaml.example']},
     include_package_data=True,

--- a/openmetrics/setup.py
+++ b/openmetrics/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -55,6 +58,7 @@ setup(
     packages=['datadog_checks.openmetrics'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/openstack/setup.py
+++ b/openstack/setup.py
@@ -21,8 +21,12 @@ with open(path.join(HERE, "datadog_checks", "openstack", "__about__.py")) as f:
     exec(f.read(), ABOUT)
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -56,6 +60,7 @@ setup(
     packages=['datadog_checks.openstack'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/openstack_controller/setup.py
+++ b/openstack_controller/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.openstack_controller'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/oracle/setup.py
+++ b/oracle/setup.py
@@ -21,8 +21,12 @@ with open(path.join(HERE, "datadog_checks", "oracle", "__about__.py")) as f:
     exec(f.read(), ABOUT)
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -56,6 +60,7 @@ setup(
     packages=['datadog_checks.oracle'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/pdh_check/setup.py
+++ b/pdh_check/setup.py
@@ -20,9 +20,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -56,6 +59,7 @@ setup(
     packages=['datadog_checks.pdh_check'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/pgbouncer/setup.py
+++ b/pgbouncer/setup.py
@@ -16,9 +16,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -47,6 +50,7 @@ setup(
     ],
     packages=['datadog_checks.pgbouncer'],
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/php_fpm/setup.py
+++ b/php_fpm/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.php_fpm'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/postfix/setup.py
+++ b/postfix/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.postfix'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/postgres/setup.py
+++ b/postgres/setup.py
@@ -19,9 +19,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -51,6 +54,7 @@ setup(
     packages=['datadog_checks.postgres'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/powerdns_recursor/setup.py
+++ b/powerdns_recursor/setup.py
@@ -13,16 +13,19 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
-        return f.readlines()
-
-
 # Get version info
 ABOUT = {}
 with open(path.join(HERE, "datadog_checks", "powerdns_recursor", "__about__.py")) as f:
     exec(f.read(), ABOUT)
+
+
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
 
 
 CHECKS_BASE_REQ = 'datadog_checks_base'
@@ -55,6 +58,7 @@ setup(
     packages=['datadog_checks.powerdns_recursor'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/presto/setup.py
+++ b/presto/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base'
 
 
@@ -55,6 +64,7 @@ setup(
 
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
 
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/process/setup.py
+++ b/process/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.process'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/prometheus/setup.py
+++ b/prometheus/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog_checks_base'
 
 setup(
@@ -48,6 +57,7 @@ setup(
     packages=['datadog_checks.prometheus'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/proxysql/setup.py
+++ b/proxysql/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = ['datadog-checks-base>=11.3.1']  # Needs fix integrations-core/#6146 for the QueryManager
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.proxysql'],
     # Run-time dependencies
     install_requires=CHECKS_BASE_REQ,
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/rabbitmq/setup.py
+++ b/rabbitmq/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.rabbitmq'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/redisdb/setup.py
+++ b/redisdb/setup.py
@@ -19,9 +19,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -51,6 +54,7 @@ setup(
     packages=['datadog_checks.redisdb'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/rethinkdb/setup.py
+++ b/rethinkdb/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.rethinkdb'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/riak/setup.py
+++ b/riak/setup.py
@@ -19,9 +19,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -55,6 +58,7 @@ setup(
     packages=['datadog_checks.riak'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/riakcs/setup.py
+++ b/riakcs/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.riakcs'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/sap_hana/setup.py
+++ b/sap_hana/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.sap_hana'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/scylla/setup.py
+++ b/scylla/setup.py
@@ -23,6 +23,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -54,6 +63,7 @@ setup(
     packages=['datadog_checks.scylla'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/sidekiq/setup.py
+++ b/sidekiq/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.sidekiq'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/snmp/setup.py
+++ b/snmp/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.snmp'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/solr/setup.py
+++ b/solr/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -52,6 +55,7 @@ setup(
     packages=['datadog_checks.solr'],
     # Run-time dependencies
     install_requires=['datadog_checks_base'],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/spark/setup.py
+++ b/spark/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.spark'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/sqlserver/setup.py
+++ b/sqlserver/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.sqlserver'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/squid/setup.py
+++ b/squid/setup.py
@@ -13,16 +13,19 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
-        return f.readlines()
-
-
 # Get version info
 ABOUT = {}
 with open(path.join(HERE, "datadog_checks", "squid", "__about__.py")) as f:
     exec(f.read(), ABOUT)
+
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
 
 CHECKS_BASE_REQ = 'datadog_checks_base'
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.squid'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/squid/setup.py
+++ b/squid/setup.py
@@ -18,6 +18,7 @@ ABOUT = {}
 with open(path.join(HERE, "datadog_checks", "squid", "__about__.py")) as f:
     exec(f.read(), ABOUT)
 
+
 def get_dependencies():
     dep_file = path.join(HERE, 'requirements.in')
     if not path.isfile(dep_file):

--- a/ssh_check/setup.py
+++ b/ssh_check/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.ssh_check'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/statsd/setup.py
+++ b/statsd/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.statsd'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/supervisord/setup.py
+++ b/supervisord/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.supervisord'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/system_core/setup.py
+++ b/system_core/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.system_core'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/system_swap/setup.py
+++ b/system_swap/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.system_swap'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/tcp_check/setup.py
+++ b/tcp_check/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.tcp_check'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/teamcity/setup.py
+++ b/teamcity/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -50,6 +53,7 @@ setup(
     packages=['datadog_checks.teamcity'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/tenable/setup.py
+++ b/tenable/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.tenable'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/tls/setup.py
+++ b/tls/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=6.6.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.tls'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/tokumx/setup.py
+++ b/tokumx/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.tokumx'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/tomcat/setup.py
+++ b/tomcat/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -52,6 +55,7 @@ setup(
     packages=['datadog_checks.tomcat'],
     # Run-time dependencies
     install_requires=['datadog_checks_base'],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/twemproxy/setup.py
+++ b/twemproxy/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.twemproxy'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/twistlock/setup.py
+++ b/twistlock/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=11.3.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.twistlock'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/varnish/setup.py
+++ b/varnish/setup.py
@@ -20,6 +20,7 @@ ABOUT = {}
 with open(path.join(HERE, "datadog_checks", "varnish", "__about__.py")) as f:
     exec(f.read(), ABOUT)
 
+
 def get_dependencies():
     dep_file = path.join(HERE, 'requirements.in')
     if not path.isfile(dep_file):

--- a/varnish/setup.py
+++ b/varnish/setup.py
@@ -16,14 +16,18 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
-        return f.readlines()
-
-
 ABOUT = {}
 with open(path.join(HERE, "datadog_checks", "varnish", "__about__.py")) as f:
     exec(f.read(), ABOUT)
+
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
 
 CHECKS_BASE_REQ = 'datadog_checks_base'
 
@@ -55,6 +59,7 @@ setup(
     packages=['datadog_checks.varnish'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/vault/setup.py
+++ b/vault/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.vault'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/vertica/setup.py
+++ b/vertica/setup.py
@@ -18,6 +18,15 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
 CHECKS_BASE_REQ = 'datadog-checks-base>=8.2.0'
 
 
@@ -49,6 +58,7 @@ setup(
     packages=['datadog_checks.vertica'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/vsphere/setup.py
+++ b/vsphere/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -50,6 +53,7 @@ setup(
     packages=['datadog_checks.vsphere'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/win32_event_log/setup.py
+++ b/win32_event_log/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.win32_event_log'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/windows_service/setup.py
+++ b/windows_service/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.windows_service'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/wmi_check/setup.py
+++ b/wmi_check/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.wmi_check'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/yarn/setup.py
+++ b/yarn/setup.py
@@ -21,8 +21,12 @@ with open(path.join(HERE, "datadog_checks", "yarn", "__about__.py")) as f:
     exec(f.read(), ABOUT)
 
 
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -56,6 +60,7 @@ setup(
     packages=['datadog_checks.yarn'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/zk/setup.py
+++ b/zk/setup.py
@@ -18,9 +18,12 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-# Parse requirements
-def get_requirements(fpath):
-    with open(path.join(HERE, fpath), encoding='utf-8') as f:
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
         return f.readlines()
 
 
@@ -54,6 +57,7 @@ setup(
     packages=['datadog_checks.zk'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )


### PR DESCRIPTION
### Motivation

Ease management of community integrations

### Additional Notes

I intentionally included the templates for new Logs & JMX integrations so if Python parts are added no one will have to touch `setup.py`