### PR TITLE
Include Node system stats

### DIFF
--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -15,6 +15,7 @@ from .metrics import (
     CLUSTER_PENDING_TASKS,
     health_stats_for_version,
     index_stats_for_version,
+    node_system_stats_for_version,
     pshard_stats_for_version,
     stats_for_version,
 )
@@ -62,6 +63,9 @@ class ESCheck(AgentCheck):
 
         health_url, stats_url, pshard_stats_url, pending_tasks_url = self._get_urls(version, config.cluster_stats)
         stats_metrics = stats_for_version(version)
+        if config.cluster_stats:
+            # Include Node System metrics
+            stats_metrics.update(node_system_stats_for_version(version))
         pshard_stats_metrics = pshard_stats_for_version(version)
 
         # Load stats data.

--- a/elastic/datadog_checks/elastic/metrics.py
+++ b/elastic/datadog_checks/elastic/metrics.py
@@ -469,6 +469,28 @@ CLUSTER_PENDING_TASKS = {
     'elasticsearch.pending_tasks_time_in_queue': ('gauge', 'pending_tasks_time_in_queue'),
 }
 
+NODE_SYSTEM_METRICS = {
+    'system.mem.free': ('gauge', 'os.mem.free_in_bytes'),
+    'system.mem.usable': ('gauge', 'os.mem.free_in_bytes'),
+    'system.mem.used': ('gauge', 'os.mem.used_in_bytes'),
+    'system.swap.free': ('gauge', 'os.swap.free_in_bytes'),
+    'system.swap.used': ('gauge', 'os.swap.used_in_bytes'),
+    'system.net.bytes_rcvd': ('gauge', 'transport.rx_size_in_bytes'),
+    'system.net.bytes_sent': ('gauge', 'transport.tx_size_in_bytes'),
+}
+
+NODE_SYSTEM_METRICS_POST_1 = {
+    'system.mem.total': ('gauge', 'os.mem.total_in_bytes'),
+    'system.swap.total': ('gauge', 'os.swap.total_in_bytes'),
+}
+
+NODE_SYSTEM_METRICS_POST_5 = {
+    'system.cpu.idle': ('gauge', 'os.cpu.percent', lambda v: (100 - v)),
+    'system.load.1': ('gauge', 'os.cpu.load_average.1m'),
+    'system.load.5': ('gauge', 'os.cpu.load_average.5m'),
+    'system.load.15': ('gauge', 'os.cpu.load_average.15m'),
+}
+
 
 def stats_for_version(version):
     """
@@ -571,3 +593,17 @@ def index_stats_for_version(version):
         index_stats.update(INDEX_STATS_METRICS)
 
     return index_stats
+
+
+def node_system_stats_for_version(version):
+    """
+    Get the proper set of os metrics for the specified ES version
+    """
+    node_system_stats = dict(NODE_SYSTEM_METRICS)
+
+    if version >= [1, 0, 0]:
+        node_system_stats.update(NODE_SYSTEM_METRICS_POST_1)
+    if version >= [5, 0, 0]:
+        node_system_stats.update(NODE_SYSTEM_METRICS_POST_5)
+
+    return node_system_stats

--- a/elastic/tests/test_metrics.py
+++ b/elastic/tests/test_metrics.py
@@ -3,7 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
-from datadog_checks.elastic.metrics import health_stats_for_version, pshard_stats_for_version, stats_for_version
+from datadog_checks.elastic.metrics import (
+    health_stats_for_version,
+    node_system_stats_for_version,
+    pshard_stats_for_version,
+    stats_for_version,
+)
 
 
 @pytest.mark.unit
@@ -165,3 +170,54 @@ def test_health_stats_for_version():
     # v6.3.0
     metrics = health_stats_for_version([6, 3, 0])
     assert len(metrics) == 9
+
+
+@pytest.mark.unit
+def test_node_system_stats_for_version():
+    # v0.90
+    metrics = node_system_stats_for_version([0, 90, 0])
+    assert len(metrics) == 7
+
+    # v0.90.5
+    metrics = node_system_stats_for_version([0, 90, 5])
+    assert len(metrics) == 7
+
+    # v0.90.10
+    metrics = node_system_stats_for_version([0, 90, 10])
+    assert len(metrics) == 7
+
+    # v1
+    metrics = node_system_stats_for_version([1, 0, 0])
+    assert len(metrics) == 9
+
+    # v1.3.0
+    metrics = node_system_stats_for_version([1, 3, 0])
+    assert len(metrics) == 9
+
+    # v1.4.0
+    metrics = node_system_stats_for_version([1, 4, 0])
+    assert len(metrics) == 9
+
+    # v1.5.0
+    metrics = node_system_stats_for_version([1, 5, 0])
+    assert len(metrics) == 9
+
+    # v1.6.0
+    metrics = node_system_stats_for_version([1, 6, 0])
+    assert len(metrics) == 9
+
+    # v2
+    metrics = node_system_stats_for_version([2, 0, 0])
+    assert len(metrics) == 9
+
+    # v2.1.0
+    metrics = node_system_stats_for_version([2, 1, 0])
+    assert len(metrics) == 9
+
+    # v5
+    metrics = node_system_stats_for_version([5, 0, 0])
+    assert len(metrics) == 13
+
+    # v6.3.0
+    metrics = node_system_stats_for_version([6, 3, 0])
+    assert len(metrics) == 13


### PR DESCRIPTION
### What does this PR do?
Include node system stats if external/cluster_stats is enabled

### Motivation
- 2118-elasticsearch-fr-to-include-os-nodestats
- 1748-obtain-os-metrics-when-querying-nodes-stats

### Additional Notes
- There are still some system metrics in our default dashboard "Elasticsearch - Metrics" that are not accounted for.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
