### PR TITLE
Collect version metadata

### DIFF
--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -5,6 +5,7 @@ import re
 from collections import defaultdict
 
 import requests
+from six.moves.urllib.parse import urljoin
 
 from datadog_checks.base import AgentCheck
 
@@ -51,6 +52,8 @@ class Envoy(AgentCheck):
 
         if self.caching_metrics is None:
             self.caching_metrics = instance.get('cache_metrics', True)
+
+        self._collect_metadata(stats_url)
 
         try:
             response = self.http.get(stats_url)
@@ -138,3 +141,34 @@ class Envoy(AgentCheck):
             return not blacklisted
         else:
             return True
+
+    @AgentCheck.metadata_entrypoint
+    def _collect_metadata(self, stats_url):
+        # From http://domain/thing/stats to http://domain/thing/server_info
+        server_info_url = urljoin(stats_url, 'server_info')
+
+        try:
+            response = self.http.get(server_info_url)
+            # {
+            #   "version": "222aaacccfff888/1.14.1/Clean/RELEASE/BoringSSL",
+            #   "state": "LIVE",
+            #   ...
+            # }
+            raw_version = response.json()["version"].split('/')[1]
+        except requests.exceptions.Timeout:
+            msg = 'Envoy endpoint `{}` timed out after {} seconds'.format(
+                server_info_url, timeout=self.http.options['timeout']
+            )
+            self.log.info(msg)
+            return
+        except (requests.exceptions.RequestException, requests.exceptions.ConnectionError):
+            msg = 'Error accessing Envoy endpoint `{}`'.format(server_info_url)
+            self.log.info(msg)
+            return
+
+        if response.status_code != 200:
+            msg = 'Envoy endpoint `{}` responded with HTTP status code {}'.format(server_info_url, response.status_code)
+            self.log.info(msg)
+            return
+
+        self.set_metadata('version', raw_version)

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -149,6 +149,12 @@ class Envoy(AgentCheck):
 
         try:
             response = self.http.get(server_info_url)
+            if response.status_code != 200:
+                msg = 'Envoy endpoint `{}` responded with HTTP status code {}'.format(
+                    server_info_url, response.status_code
+                )
+                self.log.info(msg)
+                return
             # {
             #   "version": "222aaacccfff888/1.14.1/Clean/RELEASE/BoringSSL",
             #   "state": "LIVE",
@@ -156,18 +162,11 @@ class Envoy(AgentCheck):
             # }
             raw_version = response.json()["version"].split('/')[1]
         except requests.exceptions.Timeout:
-            msg = 'Envoy endpoint `{}` timed out after {} seconds'.format(
-                server_info_url, timeout=self.http.options['timeout']
-            )
+            msg = 'Envoy endpoint `{}` timed out after {} seconds'.format(server_info_url, self.http.options['timeout'])
             self.log.info(msg)
             return
         except (requests.exceptions.RequestException, requests.exceptions.ConnectionError):
             msg = 'Error accessing Envoy endpoint `{}`'.format(server_info_url)
-            self.log.info(msg)
-            return
-
-        if response.status_code != 200:
-            msg = 'Envoy endpoint `{}` responded with HTTP status code {}'.format(server_info_url, response.status_code)
             self.log.info(msg)
             return
 

--- a/envoy/tests/common.py
+++ b/envoy/tests/common.py
@@ -23,12 +23,21 @@ INSTANCES = {
         'metric_blacklist': [r'envoy\.cluster\.out\.'],
     },
 }
+SERVER_INFO = {
+    "version": "222aaacccfff888/1.14.1/Clean/RELEASE/BoringSSL",
+    "state": "LIVE",
+}
+ENVOY_VERSION = os.getenv('ENVOY_VERSION')
 
 
 class MockResponse:
     def __init__(self, content, status_code):
         self.content = content
         self.status_code = status_code
+
+    def json(self):
+        # Metadata
+        return SERVER_INFO
 
 
 @lru_cache(maxsize=None)

--- a/envoy/tests/docker/default/docker-compose.yaml
+++ b/envoy/tests/docker/default/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   front-envoy:
-    image: envoyproxy/envoy:${ENVOY_VERSION}
+    image: envoyproxy/envoy:v${ENVOY_VERSION}
     command: ["/usr/local/bin/envoy", "-c", "/etc/front-envoy.yaml", "--service-cluster", "front-proxy"]
     volumes:
       - ./front-envoy.yaml:/etc/front-envoy.yaml

--- a/envoy/tox.ini
+++ b/envoy/tox.ini
@@ -20,7 +20,7 @@ passenv =
     COMPOSE*
 setenv =
     FLAVOR=default
-    ENVOY_VERSION=v1.14.1
+    ENVOY_VERSION=1.14.1
 commands =
     pip install -r requirements.in
     pytest -v {posargs} --benchmark-skip


### PR DESCRIPTION
### What does this PR do?
Retrieve envoy version and set the associated metadata.

### Motivation

### Additional Notes
The version is available at `http://domain/thing/server_info`, so it uses the `stats_url` attribute in the config file `http://domain/thing/stats` and transforms it. So there is no additional attribute in the configuration file, but it does not cover some edge cases.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
