### PR TITLE
[PROD] change hdd read req to vda read req in default dashboard

### DIFF
--- a/openstack/assets/dashboards/openstack-controller.json
+++ b/openstack/assets/dashboards/openstack-controller.json
@@ -550,7 +550,7 @@
             "tile_def": {
                 "requests": [
                     {
-                        "q": "avg:openstack.nova.server.hdd_read_req{$project} by {host}",
+                        "q": "avg:openstack.nova.server.vda_read_req{$project} by {host}",
                         "style": {
                             "palette": "dog_classic",
                             "type": "solid",


### PR DESCRIPTION
### What does this PR do?
Overlooked a metric name when initially building the OpenStack controller dashboard. openstack.nova.server.hdd_read_req should be openstack.nova.server.vda_read_req. 

See screenshot below for proof that this is the correct metric name. 


![https://a.cl.ly/jkulX0pD](screenshot)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
