### PR TITLE
Update metric_prefix

### DIFF
--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -10,7 +10,7 @@
   "is_public": true,
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
-  "metric_prefix": "kubernetes.",
+  "metric_prefix": "kubernetes",
   "metric_to_check": "kubernetes.cpu.usage.total",
   "name": "kubernetes",
   "public_title": "Datadog-Kubernetes Integration",


### PR DESCRIPTION
The OG prefix in dogweb was `kubernetes`.
The `kubernetes` integration tile supports metrics from kubernetes and kubernetes_state. The previous metric_prefix fails for the latter set of metrics