### PR TITLE
Pin latest scylla release to 3.3.1

### DIFF
--- a/scylla/tox.ini
+++ b/scylla/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py{27,38}-{3.1,3.2,latest}
+    py{27,38}-{3.1,3.2,3.3}
 
 [testenv]
 dd_check_style = true
@@ -23,4 +23,4 @@ commands =
 setenv =
     3.1: SCYLLA_VERSION=3.1.2
     3.2: SCYLLA_VERSION=3.2.1
-    latest: SCYLLA_VERSION=latest
+    latest: SCYLLA_VERSION=3.3.1

--- a/scylla/tox.ini
+++ b/scylla/tox.ini
@@ -23,4 +23,4 @@ commands =
 setenv =
     3.1: SCYLLA_VERSION=3.1.2
     3.2: SCYLLA_VERSION=3.2.1
-    latest: SCYLLA_VERSION=3.3.1
+    3.3: SCYLLA_VERSION=3.3.1


### PR DESCRIPTION
### What does this PR do?
Scylla updated their docker image tag `latest` to a new `4.0` release, and now tests are failing.  Let's pin to the latest `3.3.x` release and add support for `4.0` at a later time.
