### PR TITLE
Bump the dot version of haproxy for our test env

### DIFF
--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -23,7 +23,7 @@ setenv =
   17: HAPROXY_VERSION=1.7.10
   18: HAPROXY_VERSION=1.8.5
   20: HAPROXY_VERSION=2.0.12
-  21: HAPROXY_VERSION=2.1.2
+  21: HAPROXY_VERSION=2.1.4
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?
Bumps our version for e2e testing from `2.1.2` to `2.1.4` to match the latest dot release currently available.

### Motivation
While this is a minor version update, we received a bug report (https://github.com/DataDog/integrations-core/issues/6568) for something observed in `2.1.4` which hadn't been seen in our test environment.  