### PR TITLE
Support multiple properties in tag_by

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
@@ -195,7 +195,8 @@ class WinWMICheck(AgentCheck):
                 else:
                     continue
                 # Tag with `tag_by` parameter
-                for t in [t.strip() for t in tag_by.split(',')]:
+                for t in tag_by.split(','):
+                    t = t.strip()
                     if wmi_property == t:
                         tag_value = str(wmi_value).lower()
                         if tag_queries and tag_value.find("#") > 0:

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
@@ -205,7 +205,7 @@ class WinWMICheck(AgentCheck):
                         continue
 
                 # No metric extraction on 'Name' and properties in tag_by
-                if wmi_property == 'name' or wmi_property.lower() in tag_by.lower():
+                if wmi_property == 'name' or normalized_wmi_property in tag_by.lower():
                     continue
 
                 try:

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
@@ -182,14 +182,17 @@ class WinWMICheck(AgentCheck):
             for wmi_property, wmi_value in iteritems(wmi_obj):
                 # skips any property not in arguments since SWbemServices.ExecQuery will return key prop properties
                 # https://msdn.microsoft.com/en-us/library/aa393866(v=vs.85).aspx
-                found = False
+
+                # skip wmi_property "foo,bar"; there will be a separate wmi_property for each "foo" and "bar"
+                if ',' in wmi_property:
+                    continue
+
+                normalized_wmi_property = wmi_property.lower()
                 for s in wmi_sampler.property_names:
-                    if wmi_property.lower() in s.lower():
+                    if normalized_wmi_property in s.lower():
                         # wmi_property: "foo" should be found in property_names ["foo,bar", "name"]
-                        found = True
-                        continue
-                if not found or ',' in wmi_property:
-                    # skip wmi_property "foo,bar"; there will be a separate wmi_property for each "foo" and "bar"
+                        break
+                else:
                     continue
                 # Tag with `tag_by` parameter
                 for t in [t.strip() for t in tag_by.split(',')]:

--- a/wmi_check/assets/configuration/spec.yaml
+++ b/wmi_check/assets/configuration/spec.yaml
@@ -99,9 +99,11 @@ files:
       description: |
         The `tag_by` parameter lets you tag each metric with a property from the WMI class you're using.
         This is only useful when you will have multiple values for your WMI query.
+        Comma-separated list of property names
       value:
         type: string
-        example: Name
+        default: null
+        example: Name,Label
     - name: tag_queries
       description: |
         The `tag_queries`  parameter lets you specify a list of queries, to tag metrics with a target class property.

--- a/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
+++ b/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
@@ -88,8 +88,9 @@ instances:
     ## @param tag_by - string - optional - default: Name
     ## The `tag_by` parameter lets you tag each metric with a property from the WMI class you're using.
     ## This is only useful when you will have multiple values for your WMI query.
+    ## Comma-separated list of property names
     #
-    # tag_by: Name
+    # tag_by: "Name,Label"
 
     ## @param tag_queries - list of lists - optional
     ## The `tag_queries`  parameter lets you specify a list of queries, to tag metrics with a target class property.

--- a/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
+++ b/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
@@ -85,12 +85,12 @@ instances:
     #
     # provider: 64
 
-    ## @param tag_by - string - optional - default: Name
+    ## @param tag_by - string - optional
     ## The `tag_by` parameter lets you tag each metric with a property from the WMI class you're using.
     ## This is only useful when you will have multiple values for your WMI query.
     ## Comma-separated list of property names
     #
-    # tag_by: "Name,Label"
+    # tag_by: Name,Label
 
     ## @param tag_queries - list of lists - optional
     ## The `tag_queries`  parameter lets you specify a list of queries, to tag metrics with a target class property.


### PR DESCRIPTION
### What does this PR do?
Allow for multiple comma-separated properties in `tag_by`

### Motivation
- https://trello.com/c/0SpTMh4a/2277-wmi-allow-multiple-tagby-properties-to-be-specified

### Additional Notes
- It works as it is and there might be a better way. I just can't fully grasp the WMI check; also why there's no test

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
