### PR TITLE
added test for persistent volume without a storage class + fix

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -861,9 +861,12 @@ class KubernetesState(OpenMetricsBaseCheck):
         object_counter = Counter()
 
         for sample in metric.samples:
-            tags = [
-                self._label_to_tag(l, sample[self.SAMPLE_LABELS], scraper_config) for l in config['allowed_labels']
-            ] + scraper_config['custom_tags']
+            tags = []
+            for l in config['allowed_labels']:
+                tag = self._label_to_tag(l, sample[self.SAMPLE_LABELS], scraper_config)
+                if tag is not None:
+                    tags.append(tag)
+            tags += scraper_config['custom_tags']
             object_counter[tuple(sorted(tags))] += sample[self.SAMPLE_VALUE]
 
         for tags, count in iteritems(object_counter):

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -864,8 +864,9 @@ class KubernetesState(OpenMetricsBaseCheck):
             tags = []
             for l in config['allowed_labels']:
                 tag = self._label_to_tag(l, sample[self.SAMPLE_LABELS], scraper_config)
-                if tag is not None:
-                    tags.append(tag)
+                if tag is None:
+                    tag = self._format_tag(l, "unknown", scraper_config)
+                tags.append(tag)
             tags += scraper_config['custom_tags']
             object_counter[tuple(sorted(tags))] += sample[self.SAMPLE_VALUE]
 

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -286,10 +286,16 @@ kube_persistentvolume_status_phase{persistentvolume="local-pv-15d0a3a3",phase="B
 kube_persistentvolume_status_phase{persistentvolume="local-pv-15d0a3a3",phase="Failed"} 0
 kube_persistentvolume_status_phase{persistentvolume="local-pv-15d0a3a3",phase="Pending"} 0
 kube_persistentvolume_status_phase{persistentvolume="local-pv-15d0a3a3",phase="Released"} 0
+kube_persistentvolume_status_phase{persistentvolume="local-pv-16d0a3a3",phase="Available"} 0
+kube_persistentvolume_status_phase{persistentvolume="local-pv-16d0a3a3",phase="Bound"} 1
+kube_persistentvolume_status_phase{persistentvolume="local-pv-16d0a3a3",phase="Failed"} 0
+kube_persistentvolume_status_phase{persistentvolume="local-pv-16d0a3a3",phase="Pending"} 0
+kube_persistentvolume_status_phase{persistentvolume="local-pv-16d0a3a3",phase="Released"} 0
 # HELP kube_persistentvolume_info Information about persistentvolume.
 # TYPE kube_persistentvolume_info gauge
 kube_persistentvolume_info{persistentvolume="local-pv-103fef5d",storageclass="local-data"} 1
 kube_persistentvolume_info{persistentvolume="local-pv-15d0a3a3",storageclass="local-data"} 1
+kube_persistentvolume_info{persistentvolume="local-pv-16d0a3a3",storageclass=""} 1
 # HELP kube_persistentvolumeclaim_info Information about persistent volume claim.
 # TYPE kube_persistentvolumeclaim_info gauge
 kube_persistentvolumeclaim_info{namespace="default",persistentvolumeclaim="task-pv-claim",storageclass="manual"} 1

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -337,6 +337,12 @@ def test_update_kube_state_metrics(aggregator, instance, check):
         tags=['storageclass:local-data', 'phase:bound', 'optional:tag1'],
         value=2,
     )
+    # No storage class
+    aggregator.assert_metric(
+        NAMESPACE + '.persistentvolumes.by_phase',
+        tags=['phase:bound', 'optional:tag1'],
+        value=1,
+    )
     aggregator.assert_metric(
         NAMESPACE + '.persistentvolumes.by_phase',
         tags=['storageclass:local-data', 'phase:failed', 'optional:tag1'],
@@ -782,9 +788,9 @@ def test_telemetry(aggregator, instance):
 
     for _ in range(2):
         check.check(instance)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=90948.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=914.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1288.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=91486.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=926.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1300.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.blacklist.count', tags=['optional:tag1'], value=24.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=374.0)
     aggregator.assert_metric(

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -340,7 +340,7 @@ def test_update_kube_state_metrics(aggregator, instance, check):
     # No storage class
     aggregator.assert_metric(
         NAMESPACE + '.persistentvolumes.by_phase',
-        tags=['phase:bound', 'optional:tag1'],
+        tags=['storageclass:unknown', 'phase:bound', 'optional:tag1'],
         value=1,
     )
     aggregator.assert_metric(


### PR DESCRIPTION
### What does this PR do?
Fix an issue when the storage class of a persistent volume is empty.
Adds a test for this use case.

### Motivation
Customer reported this issue because some of their persistent volumes did not have a storage class.
This can happen if persistent volumes are restored.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
