### PR TITLE
Add send_monotonic_with_gauge config option and refactor test

### DIFF
--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -390,14 +390,14 @@ def test_submit_counter(aggregator, mocked_prometheus_check, mocked_prometheus_s
 
 
 @pytest.mark.parametrize(
-    ('config, count_metric_monotonic, sum_metric_monotonic'),
+    'config, count_metric_monotonic, sum_metric_monotonic',
     (
         ({}, False, False),
         ({'send_distribution_counts_as_monotonic': True}, True, False),
         ({'send_distribution_sums_as_monotonic': True}, False, True),
         ({'send_distribution_counts_as_monotonic': True, 'send_distribution_sums_as_monotonic': True}, True, True),
     ),
-    ids=('default', 'count only as monotonic_count', 'sum only as monotonic_count', 'count and sum as monotonic_count'),
+    ids=('default', 'count as monotonic_count', 'sum as monotonic_count', 'count and sum as monotonic_count'),
 )
 def test_submit_summary(
     aggregator,
@@ -415,6 +415,8 @@ def test_submit_summary(
     if sum_metric_monotonic:
         sum_type = aggregator.MONOTONIC_COUNT
 
+    mocked_prometheus_scraper_config.update(config)
+
     _sum = SummaryMetricFamily('my_summary', 'Random summary')
     _sum.add_metric([], 5.0, 120512.0)
     _sum.add_sample("my_summary", {"quantile": "0.5"}, 24547.0)
@@ -431,7 +433,7 @@ def test_submit_summary(
 
 
 @pytest.mark.parametrize(
-    ('config, count_metric_monotonic, sum_metric_monotonic'),
+    'config, count_metric_monotonic, sum_metric_monotonic',
     (
         ({}, False, False),
         ({'send_distribution_counts_as_monotonic': True}, True, False),

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -98,6 +98,14 @@
   value:
     example: true
     type: boolean
+- name: send_monotonic_with_gauge
+  description: |
+    Set send_monotonic_with_gauge to true to send counters as both monotonic counters and gauges.
+    This option only works when `send_monotonic_counter` is False.
+  hidden: true
+  value:
+    example: false
+    type: boolean
 - name: send_distribution_counts_as_monotonic
   description: |
     Set send_distribution_counts_as_monotonic to true to send histograms & summary


### PR DESCRIPTION
The `send_monotonic_with_gauge` config option submits a monotonic_count along with the gauge for  Prometheus `counter` metrics and histogram/summary metrics (that should be a counter). The monotonic_count metric is differentiated from the gauge metric with an appended `.total`.

This option is hidden by default as it only really applies for legacy behavior.

This PR also refactors tests to de-duplicate code/assertions and use `pytest.parametrize` for testing the various submission type flags that affect histogram/summary count and sum metrics and counter metrics.