### PR TITLE
Fix the coredns metric type metadata

### DIFF
--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -1,10 +1,10 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-coredns.response_code_count,gauge,,,,number of responses per zone and rcode,1,coredns,response code
-coredns.proxy_request_count,gauge,,request,,query count per upstream.,1,coredns,proxy request count
-coredns.cache_hits_count,gauge,,hit,,Counter of cache hits by cache type,1,coredns,cache hit
-coredns.cache_misses_count,gauge,,miss,,Counter of cache misses.,1,coredns,cache miss
-coredns.request_count,gauge,,request,,total query count.,1,coredns,request count
-coredns.request_type_count,gauge,,,,counter of queries per zone and type,1,coredns,request type
+coredns.response_code_count,count,,,,number of responses per zone and rcode,1,coredns,response code
+coredns.proxy_request_count,count,,request,,query count per upstream.,1,coredns,proxy request count
+coredns.cache_hits_count,count,,hit,,Counter of cache hits by cache type,1,coredns,cache hit
+coredns.cache_misses_count,count,,miss,,Counter of cache misses.,1,coredns,cache miss
+coredns.request_count,count,,request,,total query count.,1,coredns,request count
+coredns.request_type_count,count,,,,counter of queries per zone and type,1,coredns,request type
 coredns.request_duration.seconds.sum,gauge,,second,,duration to process each query,-1,coredns,proxy request duration
 coredns.request_duration.seconds.count,count,,second,,duration to process each query,-1,coredns,request duration
 coredns.proxy_request_duration.seconds.sum,gauge,,second,,duration per upstream interaction,-1,coredns,proxy request duration
@@ -20,7 +20,7 @@ coredns.request_size.bytes.sum,gauge,,byte,,size of the request in bytes,0,cored
 coredns.request_size.bytes.count,count,,byte,,size of the request in bytes,0,coredns,request size
 coredns.response_size.bytes.sum,gauge,,byte,,size of the request in bytes,0,coredns,response size
 coredns.response_size.bytes.count,count,,byte,,size of the request in bytes,0,coredns,response size
-coredns.cache_size.count,count,,entry,,,1,coredns,cache size
+coredns.cache_size.count,gauge,,entry,,,1,coredns,cache size
 coredns.panic_count.count,count,,entry,,,1,coredns,total number of panics
 coredns.go.gc_duration_seconds.count,gauge,,second,,Count of the GC invocation durations.,0,coredns,
 coredns.go.gc_duration_seconds.sum,gauge,,second,,Sum of the GC invocation durations.,0,coredns,


### PR DESCRIPTION
The metric types for the following are emitted as counter metrics but their metadata metric type is gauge.
The following metrics are submitted as monotonic_count by the check. This PR updates the metadata type to reflect the correct type.
```
# TYPE coredns_cache_hits_total counter
# TYPE coredns_cache_size gauge
# TYPE coredns_cache_misses_total counter
# TYPE coredns_dns_request_count_total counter
# TYPE coredns_dns_request_type_count_total counter
# TYPE coredns_dns_response_rcode_count_total counter
# TYPE coredns_proxy_request_count_total counter

```