### PR TITLE
Fix style to account for new flake8 rules

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,7 @@
 select = B,C,E,F,G,W,B001,B003,B006,B007,B301,B305,B306,B902
 # Ignore reasons:
 # - G200: logging exception is ok, we don't always want to log the stack trace too
-ignore = E203,E722,E741,F523,F541,W503,G200,
+ignore = E203,E722,E741,W503,G200,
 exclude = .eggs,.tox,build,compat.py,__init__.py,datadog_checks/dev/tooling/templates/*,datadog_checks/*/vendor/*
 max-line-length = 120
 enable-extensions=G

--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,7 @@
 select = B,C,E,F,G,W,B001,B003,B006,B007,B301,B305,B306,B902
 # Ignore reasons:
 # - G200: logging exception is ok, we don't always want to log the stack trace too
-ignore = E203,E722,E741,W503,G200,
+ignore = E203,E722,E741,W503,G200
 exclude = .eggs,.tox,build,compat.py,__init__.py,datadog_checks/dev/tooling/templates/*,datadog_checks/*/vendor/*
 max-line-length = 120
 enable-extensions=G

--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,7 @@
 select = B,C,E,F,G,W,B001,B003,B006,B007,B301,B305,B306,B902
 # Ignore reasons:
 # - G200: logging exception is ok, we don't always want to log the stack trace too
-ignore = E203,E722,W503,G200
+ignore = E203,E722,E741,F523,F541,W503,G200,
 exclude = .eggs,.tox,build,compat.py,__init__.py,datadog_checks/dev/tooling/templates/*,datadog_checks/*/vendor/*
 max-line-length = 120
 enable-extensions=G

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py
@@ -33,7 +33,7 @@ def setup(checks, changed):
         else:
             echo_info(f'Checks chosen: {", ".join(checks)}')
     else:
-        echo_info(f'Checks chosen: changed')
+        echo_info('Checks chosen: changed')
 
     check_envs = list(get_tox_envs(checks, every=True, sort=True, changed_only=changed))
     echo_info(f'Configuring these envs: {check_envs}')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -292,7 +292,7 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, org_name, profile
     if profile_memory and on_ci:
         environment.metadata['sampling_start_time'] = time.time()
 
-        echo_waiting('Updating metadata... '.format(env), nl=False)
+        echo_waiting('Updating metadata {}... '.format(env), nl=False)
         environment.write_config()
         echo_success('success!')
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -292,7 +292,7 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, org_name, profile
     if profile_memory and on_ci:
         environment.metadata['sampling_start_time'] = time.time()
 
-        echo_waiting('Updating metadata {}... '.format(env), nl=False)
+        echo_waiting('Updating metadata... ', nl=False)
         environment.write_config()
         echo_success('success!')
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_signature.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_signature.py
@@ -34,5 +34,5 @@ def legacy_signature(check):
         if check:
             echo_success(f"Check `{check}` uses the new agent signature.")
         else:
-            echo_success(f'All checks use the new agent signature.')
+            echo_success("All checks use the new agent signature.")
     return

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_signature.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_signature.py
@@ -34,5 +34,5 @@ def legacy_signature(check):
         if check:
             echo_success(f"Check `{check}` uses the new agent signature.")
         else:
-            echo_success("All checks use the new agent signature.")
+            echo_success('All checks use the new agent signature.')
     return

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dashboards.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dashboards.py
@@ -64,7 +64,7 @@ def dashboards():
                 failed_checks += 1
                 # Display detailed info if file is invalid
                 echo_info(f'{check_name}... ', nl=False)
-                echo_failure(f'{check_name} FAILED')
+                echo_failure(' FAILED')
                 for display_func, message in display_queue:
                     display_func(message)
             else:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dashboards.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dashboards.py
@@ -64,7 +64,7 @@ def dashboards():
                 failed_checks += 1
                 # Display detailed info if file is invalid
                 echo_info(f'{check_name}... ', nl=False)
-                echo_failure(' FAILED'.format(check_name))
+                echo_failure(f'{check_name} FAILED')
                 for display_func, message in display_queue:
                     display_func(message)
             else:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
@@ -229,7 +229,7 @@ def options_validator(options, loader, file_name, *sections):
         if not isinstance(description, str):
             loader.errors.append(
                 '{}, {}, {}{}: Attribute `description` must be a string'.format(
-                    loader.source, file_name, sections_display, option_name, description
+                    loader.source, file_name, sections_display, option_name
                 )
             )
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/template.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/template.py
@@ -115,7 +115,7 @@ class ConfigTemplates(object):
                 else:
                     raise ValueError(
                         'Template override has no named mapping `{}`'.format(
-                            '.'.join(override_keys) if override_keys else override, final_key
+                            '.'.join(override_keys) if override_keys else override
                         )
                     )
             else:

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -33,7 +33,6 @@ class Envoy(AgentCheck):
 
     def check(self, instance):
         custom_tags = instance.get('tags', [])
-        timeout = self.http.options['timeout']
 
         try:
             stats_url = instance['stats_url']
@@ -59,6 +58,7 @@ class Envoy(AgentCheck):
         try:
             response = self.http.get(stats_url)
         except requests.exceptions.Timeout:
+            timeout = self.http.options['timeout']
             msg = 'Envoy endpoint `{}` timed out after {} seconds'.format(stats_url, timeout)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, message=msg, tags=custom_tags)
             self.log.exception(msg)

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -33,6 +33,7 @@ class Envoy(AgentCheck):
 
     def check(self, instance):
         custom_tags = instance.get('tags', [])
+        timeout = self.http.options['timeout']
 
         try:
             stats_url = instance['stats_url']
@@ -58,9 +59,7 @@ class Envoy(AgentCheck):
         try:
             response = self.http.get(stats_url)
         except requests.exceptions.Timeout:
-            msg = 'Envoy endpoint `{}` timed out after {} seconds'.format(
-                stats_url, timeout=self.http.options['timeout']
-            )
+            msg = 'Envoy endpoint `{}` timed out after {} seconds'.format(stats_url, timeout)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, message=msg, tags=custom_tags)
             self.log.exception(msg)
             return


### PR DESCRIPTION
Fixes the following format errors:
```
F523 '...'.format(...) has unused arguments at position(s): 4
F541 f-string is missing placeholders
```

Adds the following to ignore:
```
E741 ambiguous variable name 'l'
```
https://www.flake8rules.com/rules/E741.html
