### PR TITLE
Add domain environment Agent setup instruction

### DIFF
--- a/active_directory/README.md
+++ b/active_directory/README.md
@@ -1,4 +1,4 @@
-# active_directory Integration
+# Active Directory Integration
 
 ## Overview
 
@@ -9,6 +9,8 @@ Get metrics and logs from Microsoft Active Directory to visualize and monitor it
 ### Installation
 
 The Agent's Active Directory check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your servers.
+
+If installing the Datadog Agent on a domain environment, see [the installation requirements for the Agent][9]
 
 ### Configuration
 
@@ -75,3 +77,4 @@ Need help? Contact [Datadog support][8].
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [7]: https://github.com/DataDog/integrations-core/blob/master/active_directory/metadata.csv
 [8]: https://docs.datadoghq.com/help/
+[9]: https://docs.datadoghq.com/agent/faq/windows-agent-ddagent-user/#installation-in-a-domain-environment


### PR DESCRIPTION
Installing the Datadog Agent in a windows domain environment requires passing a `DDAGENT_USER` and `DDAGENT_PASSWORD` in order to properly install. Otherwise the default installation step will rollback and throw an error.

This PR updates the README to include a link to the docs page.