### PR TITLE
Fix local test setup

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -44,7 +44,7 @@ pyhdb==0.3.4
 pymongo==3.8.0
 pymqi==1.10.1; sys_platform != 'win32' and sys_platform != 'darwin'
 pymysql==0.9.3
-pyodbc==4.0.26; sys_platform != 'darwin'
+pyodbc==4.0.26
 pyro4==4.73; sys_platform == 'win32'
 pysmi==0.3.4
 pysnmp==4.4.9

--- a/sqlserver/requirements.in
+++ b/sqlserver/requirements.in
@@ -1,5 +1,5 @@
 adodbapi==2.6.0.7; sys_platform == 'win32'
-pyodbc==4.0.26; sys_platform != 'darwin'
+pyodbc==4.0.26
 pyro4==4.73; sys_platform == 'win32'
 pywin32==227; sys_platform == 'win32'
 selectors34==1.2.0; sys_platform == 'win32' and python_version < '3.4'

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -36,11 +36,14 @@ EXPECTED_METRICS = [m[0] for m in SQLServer.METRICS] + CUSTOM_METRICS
 INSTANCE_DOCKER = {
     'host': '{},1433'.format(HOST),
     'connector': 'odbc',
-    'driver': 'FreeTDS',
+    'driver': get_local_driver(),
     'username': 'sa',
     'password': 'Password123',
     'tags': ['optional:tag1'],
 }
+
+INSTANCE_E2E = INSTANCE_DOCKER.copy()
+INSTANCE_E2E['driver'] = 'FreeTDS'
 
 INSTANCE_SQL2017 = {
     'host': LOCAL_SERVER,
@@ -88,7 +91,7 @@ INIT_CONFIG_OBJECT_NAME = {
     ]
 }
 
-FULL_CONFIG = {"init_config": INIT_CONFIG, "instances": [INSTANCE_DOCKER]}
+FULL_E2E_CONFIG = {"init_config": INIT_CONFIG, "instances": [INSTANCE_E2E]}
 
 E2E_METADATA = {
     'start_commands': ['apt-get update', 'apt-get install -y tdsodbc unixodbc-dev'],

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -5,7 +5,6 @@
 import os
 
 from datadog_checks.dev import get_docker_hostname, get_here
-from datadog_checks.dev._env import e2e_testing
 from datadog_checks.dev.utils import ON_MACOS, ON_WINDOWS
 from datadog_checks.sqlserver import SQLServer
 

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -37,7 +37,7 @@ EXPECTED_METRICS = [m[0] for m in SQLServer.METRICS] + CUSTOM_METRICS
 INSTANCE_DOCKER = {
     'host': '{},1433'.format(HOST),
     'connector': 'odbc',
-    'driver': 'FreeTDS' if e2e_testing() else get_local_driver(),
+    'driver': 'FreeTDS',
     'username': 'sa',
     'password': 'Password123',
     'tags': ['optional:tag1'],

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -12,11 +12,12 @@ from datadog_checks.dev import WaitFor, docker_run
 from .common import (
     DOCKER_SERVER,
     E2E_METADATA,
-    FULL_CONFIG,
+    FULL_E2E_CONFIG,
     HERE,
     INIT_CONFIG,
     INIT_CONFIG_OBJECT_NAME,
     INSTANCE_DOCKER,
+    INSTANCE_E2E,
     INSTANCE_SQL2017,
     get_local_driver,
 )
@@ -47,6 +48,11 @@ def instance_docker():
     return deepcopy(INSTANCE_DOCKER)
 
 
+@pytest.fixture
+def instance_e2e():
+    return deepcopy(INSTANCE_E2E)
+
+
 @pytest.fixture(scope='session')
 def dd_environment():
     if pyodbc is None:
@@ -60,4 +66,4 @@ def dd_environment():
         compose_file=os.path.join(HERE, 'compose', 'docker-compose.yaml'),
         conditions=[WaitFor(sqlserver, wait=3, attempts=10)],
     ):
-        yield FULL_CONFIG, E2E_METADATA
+        yield FULL_E2E_CONFIG, E2E_METADATA

--- a/sqlserver/tests/test_sqlserver.py
+++ b/sqlserver/tests/test_sqlserver.py
@@ -142,8 +142,8 @@ def test_check_adoprovider(aggregator, init_config, instance_sql2017, adoprovide
 
 
 @pytest.mark.e2e
-def test_check_docker_e2e(dd_agent_check, init_config, instance_docker):
-    aggregator = dd_agent_check({'init_config': init_config, 'instances': [instance_docker]}, rate=True)
+def test_check_docker_e2e(dd_agent_check, init_config, instance_e2e):
+    aggregator = dd_agent_check({'init_config': init_config, 'instances': [instance_e2e]}, rate=True)
 
     aggregator.assert_metric_has_tag('sqlserver.db.commit_table_entries', 'db:master')
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

`get_local_driver` is used here
https://github.com/DataDog/integrations-core/blob/1bf1bcf5f4af4a54f16bf45ad76d55c4f364ce05/sqlserver/tests/conftest.py#L56

but shouldn't be needed for `INSTANCE_DOCKER`.

### Motivation
<!-- What inspired you to submit this pull request? -->

On MacOS

```
ddev env start sqlserver py38
ddev env check sqlserver py38
```

Leads to

```
      datadog_checks.sqlserver.sqlserver.SQLConnectionError: Unable to connect to SQL Server for instance localhost,1433 - master: Error('01000', "[01000] [unixODBC][Driver Manager]Can't open lib '/usr/local/lib/libtdsodbc.so' : file not found (0) (SQLDriverConnect)")
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
