### PR TITLE
Support more recent version in metadata

### DIFF
--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -169,8 +169,6 @@ class PgBouncer(AgentCheck):
             pgbouncer_version = self.get_version()
             if pgbouncer_version:
                 self.set_metadata('version', pgbouncer_version)
-            else:
-                self.log.debug("Couldn't detect version")
 
     def get_version(self):
         db = self._get_connection()
@@ -184,3 +182,4 @@ class PgBouncer(AgentCheck):
             res = re.findall(regex, data)
             if res:
                 return res[0]
+            self.log.debug("Couldn't detect version from %s", data)

--- a/pgbouncer/tests/common.py
+++ b/pgbouncer/tests/common.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2010-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import os
+
 from datadog_checks.base.utils.common import get_docker_hostname
 
 HOST = get_docker_hostname()
@@ -12,3 +14,7 @@ DB = 'datadog_test'
 DEFAULT_INSTANCE = {'host': HOST, 'port': PORT, 'username': USER, 'password': PASS, 'tags': ['optional:tag1']}
 
 INSTANCE_URL = {'database_url': 'postgresql://datadog:datadog@localhost:16432/datadog_test', 'tags': ['optional:tag1']}
+
+
+def get_version_from_env():
+    return os.environ.get('PGBOUNCER_VERSION').replace('_', '.').split('.')

--- a/pgbouncer/tests/common.py
+++ b/pgbouncer/tests/common.py
@@ -3,6 +3,8 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import os
 
+from packaging import version
+
 from datadog_checks.base.utils.common import get_docker_hostname
 
 HOST = get_docker_hostname()
@@ -17,4 +19,4 @@ INSTANCE_URL = {'database_url': 'postgresql://datadog:datadog@localhost:16432/da
 
 
 def get_version_from_env():
-    return os.environ.get('PGBOUNCER_VERSION').replace('_', '.').split('.')
+    return version.parse(os.environ.get('PGBOUNCER_VERSION'))

--- a/pgbouncer/tests/compose/docker-compose-old.yml
+++ b/pgbouncer/tests/compose/docker-compose-old.yml
@@ -11,7 +11,7 @@ services:
       - "5432:5432"
 
   pgbouncer:
-    image: "datadog/docker-library:pgbouncer_${PGBOUNCER_VERSION}"
+    image: "datadog/docker-library:${PGBOUNCER_IMAGE_TAG}"
     environment:
       PG_ENV_POSTGRESQL_USER: postgres
       PG_ENV_POSTGRESQL_PASS: datadog

--- a/pgbouncer/tests/compose/docker-compose-old.yml
+++ b/pgbouncer/tests/compose/docker-compose-old.yml
@@ -11,13 +11,13 @@ services:
       - "5432:5432"
 
   pgbouncer:
-    image: "pgbouncer/pgbouncer:${PGBOUNCER_VERSION}"
+    image: "datadog/docker-library:pgbouncer_${PGBOUNCER_VERSION}"
     environment:
-      DATABASES_USER: postgres
-      DATABASES_PASSWORD: datadog
-      DATABASES_HOST: postgres
-      DATABASES_PORT: 5432
-      PGBOUNCER_LISTEN_PORT: 6432
+      PG_ENV_POSTGRESQL_USER: postgres
+      PG_ENV_POSTGRESQL_PASS: datadog
+      PG_PORT_5432_TCP_ADDR: postgres
+      PG_PORT_5432_TCP_PORT: 5432
+      PG_ENV_POSTGRESQL_ADMIN_USERS: postgres
     ports:
       - "6432:6432"
     depends_on:

--- a/pgbouncer/tests/compose/docker-compose.yml
+++ b/pgbouncer/tests/compose/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "5432:5432"
 
   pgbouncer:
-    image: "pgbouncer/pgbouncer:${PGBOUNCER_VERSION}"
+    image: "pgbouncer/pgbouncer:${PGBOUNCER_IMAGE_TAG}"
     environment:
       DATABASES_USER: postgres
       DATABASES_PASSWORD: datadog

--- a/pgbouncer/tests/conftest.py
+++ b/pgbouncer/tests/conftest.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 
 import psycopg2
 import pytest
+from packaging import version
 
 from datadog_checks.dev import WaitFor, docker_run
 
@@ -30,8 +31,8 @@ def dd_environment():
     Start postgres and install pgbouncer. If there's any problem executing docker-compose, let the exception bubble up.
     """
     compose_file = 'docker-compose.yml'
-    version = common.get_version_from_env()
-    if int(version[1]) < 10:
+    env_version = common.get_version_from_env()
+    if env_version < version.parse('1.10'):
         compose_file = 'docker-compose-old.yml'
 
     with docker_run(

--- a/pgbouncer/tests/conftest.py
+++ b/pgbouncer/tests/conftest.py
@@ -27,12 +27,15 @@ def container_up(service_name, port):
 @pytest.fixture(scope="session")
 def dd_environment():
     """
-    Start postgres and install pgbouncer. If there's any problem executing
-    docker-compose, let the exception bubble up.
+    Start postgres and install pgbouncer. If there's any problem executing docker-compose, let the exception bubble up.
     """
+    compose_file = 'docker-compose.yml'
+    version = common.get_version_from_env()
+    if int(version[1]) < 10:
+        compose_file = 'docker-compose-old.yml'
 
     with docker_run(
-        compose_file=os.path.join(HERE, 'compose', 'docker-compose.yml'),
+        compose_file=os.path.join(HERE, 'compose', compose_file),
         env_vars={'TEST_RESOURCES_PATH': os.path.join(HERE, 'resources')},
         conditions=[
             WaitFor(container_up, args=("Postgres", 5432)),

--- a/pgbouncer/tox.ini
+++ b/pgbouncer/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{1.7,1.8}
+    py{27,38}-{1.7,1.8,1.12}
 
 [testenv]
 dd_check_style = true
@@ -22,3 +22,4 @@ commands =
 setenv =
     1.7: PGBOUNCER_VERSION=1_7
     1.8: PGBOUNCER_VERSION=1_8
+    1.12: PGBOUNCER_VERSION=1.12.0

--- a/pgbouncer/tox.ini
+++ b/pgbouncer/tox.ini
@@ -20,6 +20,9 @@ commands =
     pip install -r requirements.in
     pytest -v {posargs}
 setenv =
-    1.7: PGBOUNCER_VERSION=1_7
-    1.8: PGBOUNCER_VERSION=1_8
+    1.7: PGBOUNCER_IMAGE_TAG=pgbouncer_1_7
+    1.7: PGBOUNCER_VERSION=1.7.2
+    1.8: PGBOUNCER_IMAGE_TAG=pgbouncer_1_8
+    1.8: PGBOUNCER_VERSION=1.8.1
+    1.12: PGBOUNCER_IMAGE_TAG=1.12.0
     1.12: PGBOUNCER_VERSION=1.12.0


### PR DESCRIPTION
Since 1.12, show version doesn't use notices anymore but regular rows.
The regular expression also didn't support versions > 1.9.
This also logs at debug when it fails, instead of a warning.