### PR TITLE
Remove `calculate_text_stack_trace` setting from Clickhouse Integration

### DIFF
--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -89,8 +89,7 @@ class ClickhouseCheck(AgentCheck):
                 sync_request_timeout=self._connect_timeout,
                 compression=self._compression,
                 secure=self._tls_verify,
-                # Don't pollute the Agent logs
-                settings={'calculate_text_stack_trace': False},
+                settings={},
                 # Make every client unique for server logs
                 client_name='datadog-{}'.format(self.check_id),
             )

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -32,7 +32,7 @@ def test_config(instance):
             sync_request_timeout=10,
             compression=False,
             secure=False,
-            settings={'calculate_text_stack_trace': False},
+            settings={},
             client_name='datadog-test-clickhouse',
         )
 


### PR DESCRIPTION
Clickhouse integration - in the connection to database, passes a setting that according to CH docs is only needed if a huge amount of incorrect syntax queries are passed.  The queries that this integration sends are all valid syntax.  With this setting being passed, the user account on the CH side must have permissions to modify its own settings, and therefore cannot just be a read-only account.

### What does this PR do?
Removes the clickhouse_driver setting `calculate_text_stack_trace` to False.

### Motivation
<!-- What inspired you to submit this pull request? -->
With Clickhouse, if you pass any settings as part of the connection, the user account you're connecting with must not be read-only (as modifying a setting is a "write").
The only setting that is being passed is `calculate_text_stack_trace`.  According to [Clickhouse Docs this setting](https://github.com/ClickHouse/ClickHouse/blob/33d491edf324da5a3121a4500b07185711a1af04/src/Core/Settings.h#L376) is useful only when "huge amount of wrong queries are executed. In normal cases you should not disable this option."

Based on the queries managed in this integration, this setting seems unnecessary.


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
