### PR TITLE
[WIP] Fix collect_events

### DIFF
--- a/.stubs/pyVmomi/vim/event.pyi
+++ b/.stubs/pyVmomi/vim/event.pyi
@@ -3,10 +3,11 @@ from typing import List
 
 class Event:
     createdTime: datetime
+    key: int
 
 class EventFilterSpec:
     class ByTime:
-        def __init__(self, beginTime: datetime): ...
+        def [__init__(self, beginTime: datetime): ...
     time: EventFilterSpec.ByTime
 
 class EventManager:

--- a/.stubs/pyVmomi/vim/event.pyi
+++ b/.stubs/pyVmomi/vim/event.pyi
@@ -7,7 +7,7 @@ class Event:
 
 class EventFilterSpec:
     class ByTime:
-        def [__init__(self, beginTime: datetime): ...
+        def __init__(self, beginTime: datetime): ...
     time: EventFilterSpec.ByTime
 
 class EventManager:

--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -260,12 +260,6 @@ class VSphereAPI(object):
         return event_manager.QueryEvents(query_filter)
 
     @smart_retry
-    def get_latest_event_timestamp(self):
-        # type: () -> dt.datetime
-        event_manager = self._conn.content.eventManager
-        return event_manager.latestEvent.createdTime
-
-    @smart_retry
     def get_max_query_metrics(self):
         # type: () -> float
         vcenter_settings = self._conn.content.setting.QueryOptions(MAX_QUERY_METRICS_OPTION)

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -499,7 +499,11 @@ class VSphereCheck(AgentCheck):
             event_config = {'collect_vcenter_alarms': True}
             for event in new_events:
                 if event.key in self.latest_processed_events:
-                    self.log.debug("Skip already processed event (key=%s).", event.key)
+                    self.log.debug(
+                        "Skip already processed event (current event key: %s, latest processed events: %s).",
+                        event.key,
+                        self.latest_processed_events,
+                    )
                     continue
                 self.log.debug("Process event (key=%s)", event.key)
                 latest_processed_events.append(event.key)

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -76,7 +76,7 @@ class VSphereCheck(AgentCheck):
         self.config = VSphereConfig(instance, self.log)
 
         self.latest_event_query_time = dt.datetime.utcnow()
-        self.latest_processed_events = []
+        self.latest_processed_events = []  # type: List[int]
         self.infrastructure_cache = InfrastructureCache(interval_sec=self.config.refresh_infrastructure_cache_interval)
         self.metrics_metadata_cache = MetricsMetadataCache(
             interval_sec=self.config.refresh_metrics_metadata_cache_interval

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -75,7 +75,8 @@ class VSphereCheck(AgentCheck):
         instance = cast(InstanceConfig, self.instance)
         self.config = VSphereConfig(instance, self.log)
 
-        self.latest_event_query = dt.datetime.now()
+        self.latest_event_query_time = dt.datetime.utcnow()
+        self.latest_event_key = None
         self.infrastructure_cache = InfrastructureCache(interval_sec=self.config.refresh_infrastructure_cache_interval)
         self.metrics_metadata_cache = MetricsMetadataCache(
             interval_sec=self.config.refresh_metrics_metadata_cache_interval
@@ -485,7 +486,7 @@ class VSphereCheck(AgentCheck):
         latest_event = None
         try:
             t0 = Timer()
-            new_events = self.api.get_new_events(start_time=self.latest_event_query)
+            new_events = self.api.get_new_events(start_time=self.latest_event_query_time)
             self.gauge(
                 'datadog.vsphere.collect_events.time',
                 t0.total(),
@@ -496,6 +497,9 @@ class VSphereCheck(AgentCheck):
             self.log.debug("Got %s new events from the vCenter event manager", len(new_events))
             event_config = {'collect_vcenter_alarms': True}
             for event in new_events:
+                if event.key == self.latest_event_key:
+                    self.log.debug("Skip already processed event (key=%s).", event.key)
+                    continue
                 self.log.debug("Process event (key=%s)", event.key)
                 normalized_event = VSphereEvent(event, event_config, self.config.base_tags)
                 # Can return None if the event if filtered out
@@ -510,7 +514,8 @@ class VSphereCheck(AgentCheck):
             self.log.warning("Unable to fetch Events %s", e)
 
         if latest_event is not None:
-            self.latest_event_query = latest_event.createdTime + dt.timedelta(seconds=1)
+            self.latest_event_query_time = latest_event.createdTime
+            self.latest_event_key = latest_event.key
 
     def check(self, _):
         # type: (Any) -> None

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -75,7 +75,7 @@ class VSphereCheck(AgentCheck):
         instance = cast(InstanceConfig, self.instance)
         self.config = VSphereConfig(instance, self.log)
 
-        self.latest_event_query = dt.datetime.now()
+        self.latest_event_query = dt.datetime.utcnow()
         self.infrastructure_cache = InfrastructureCache(interval_sec=self.config.refresh_infrastructure_cache_interval)
         self.metrics_metadata_cache = MetricsMetadataCache(
             interval_sec=self.config.refresh_metrics_metadata_cache_interval
@@ -482,6 +482,7 @@ class VSphereCheck(AgentCheck):
     def collect_events(self):
         # type: () -> None
         self.log.debug("Starting events collection.")
+        new_event_query_time = dt.datetime.utcnow()
         try:
             t0 = Timer()
             new_events = self.api.get_new_events(start_time=self.latest_event_query)
@@ -505,7 +506,7 @@ class VSphereCheck(AgentCheck):
             # Ignore them for next pass
             self.log.warning("Unable to fetch Events %s", e)
 
-        self.latest_event_query = self.api.get_latest_event_timestamp() + dt.timedelta(seconds=1)
+        self.latest_event_query = new_event_query_time
 
     def check(self, _):
         # type: (Any) -> None

--- a/vsphere/tests/common.py
+++ b/vsphere/tests/common.py
@@ -4,3 +4,19 @@
 import os
 
 HERE = os.path.abspath(os.path.dirname(__file__))
+
+LAB_USERNAME = os.environ.get('TEST_VSPHERE_USER')
+LAB_PASSWORD = os.environ.get('TEST_VSPHERE_PASS')
+
+LAB_INSTANCE = {
+    'host': 'aws.vcenter.localdomain',
+    'username': LAB_USERNAME,
+    'password': LAB_PASSWORD,
+    'collection_level': 4,
+    'collection_type': 'both',
+    'use_legacy_check_version': False,
+    'collect_metric_instance_values': True,
+    'ssl_verify': False,
+    'collect_tags': True,
+    'collect_events': True,
+}

--- a/vsphere/tests/conftest.py
+++ b/vsphere/tests/conftest.py
@@ -5,7 +5,9 @@ import os
 
 import pytest
 from mock import MagicMock, Mock, patch
-from tests.mocked_api import MockedAPI, mock_http_rest_api
+
+from .common import LAB_INSTANCE
+from .mocked_api import MockedAPI, mock_http_rest_api
 
 try:
     from contextlib import ExitStack
@@ -13,17 +15,9 @@ except ImportError:
     from contextlib2 import ExitStack
 
 
-@pytest.fixture()
-def realtime_instance():
-    return {
-        'collection_level': 4,
-        'empty_default_hostname': True,
-        'use_legacy_check_version': False,
-        'host': os.environ.get('VSPHERE_URL', 'FAKE'),
-        'username': os.environ.get('VSPHERE_USERNAME', 'FAKE'),
-        'password': os.environ.get('VSPHERE_PASSWORD', 'FAKE'),
-        'ssl_verify': False,
-    }
+@pytest.fixture(scope='session')
+def dd_environment():
+    yield LAB_INSTANCE
 
 
 @pytest.fixture()

--- a/vsphere/tests/conftest.py
+++ b/vsphere/tests/conftest.py
@@ -21,6 +21,19 @@ def dd_environment():
 
 
 @pytest.fixture()
+def realtime_instance():
+    return {
+        'collection_level': 4,
+        'empty_default_hostname': True,
+        'use_legacy_check_version': False,
+        'host': os.environ.get('VSPHERE_URL', 'FAKE'),
+        'username': os.environ.get('VSPHERE_USERNAME', 'FAKE'),
+        'password': os.environ.get('VSPHERE_PASSWORD', 'FAKE'),
+        'ssl_verify': False,
+    }
+
+
+@pytest.fixture()
 def historical_instance():
     return {
         'collection_level': 1,

--- a/vsphere/tests/legacy/utils.py
+++ b/vsphere/tests/legacy/utils.py
@@ -142,3 +142,24 @@ def get_mocked_server():
     server_mock = MagicMock()
     server_mock.configure_mock(**{'RetrieveContent.return_value': content_mock, 'content': content_mock})
     return server_mock
+
+
+def mock_alarm_event(from_status='green', to_status='red', message='Some error', key=0):
+    now = datetime.utcnow()
+    vm = MockedMOR(spec='VirtualMachine')
+    dc = MockedMOR(spec="Datacenter")
+    dc_arg = vim.event.DatacenterEventArgument(datacenter=dc, name='dc1')
+    alarm = MockedMOR(spec="Alarm")
+    alarm_arg = vim.event.AlarmEventArgument(alarm=alarm, name='alarm1')
+    entity = vim.event.ManagedEntityEventArgument(entity=vm, name='vm1')
+    event = vim.event.AlarmStatusChangedEvent(
+        entity=entity,
+        fullFormattedMessage=message,
+        createdTime=now,
+        to=to_status,
+        datacenter=dc_arg,
+        alarm=alarm_arg,
+        key=key,
+    )
+    setattr(event, 'from', from_status)  # noqa: B009
+    return event

--- a/vsphere/tests/mocked_api.py
+++ b/vsphere/tests/mocked_api.py
@@ -28,6 +28,7 @@ class MockedAPI(object):
         self.config = config
         self.infrastructure_data = {}
         self.metrics_data = []
+        self.mock_events = []
 
     def check_health(self):
         return True
@@ -107,6 +108,9 @@ class MockedAPI(object):
 
     def get_latest_event_timestamp(self):
         return datetime.now()
+
+    def get_new_events(self, start_time):
+        return self.mock_events
 
 
 class MockResponse(Response):

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -32,6 +32,7 @@ def test_realtime_metrics(aggregator, dd_run_check, realtime_instance):
                 metric['name'], metric.get('value'), hostname=metric.get('hostname'), tags=metric.get('tags')
             )
 
+    aggregator.assert_metric('datadog.vsphere.collect_events.time')
     aggregator.assert_all_metrics_covered()
 
 

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -1,0 +1,40 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+import pytest
+
+from datadog_checks.vsphere import VSphereCheck
+
+from .legacy.utils import mock_alarm_event
+
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
+def test_events_time(aggregator, dd_run_check, realtime_instance, datadog_agent):
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
+    check.initiate_api_connection()
+
+    event1 = mock_alarm_event(from_status='green', key=10)
+    event2 = mock_alarm_event(from_status='yellow', key=20)
+    event3 = mock_alarm_event(from_status='red', key=30)
+
+    check.check(None)
+    assert len(aggregator.events) == 0
+    assert check.latest_processed_events == []
+
+    check.api.mock_events = [event1]
+    check.check(None)
+    aggregator.assert_event("vCenter monitor status changed on this alarm, it was green and it's now red.", count=1)
+    assert len(aggregator.events) == 1
+    assert check.latest_processed_events == [10]
+
+    aggregator.reset()
+
+    check.api.mock_events = [event1, event2, event3]
+    check.check(None)
+    for status, count in [('yellow', 1), ('red', 1), ('green', 0)]:
+        aggregator.assert_event(
+            "vCenter monitor status changed on this alarm, it was {} and it's now red.".format(status), count=count
+        )
+    assert len(aggregator.events) == 2
+    assert check.latest_processed_events == [20, 30]

--- a/vsphere/tests/test_lab.py
+++ b/vsphere/tests/test_lab.py
@@ -8,7 +8,7 @@ import pytest
 from datadog_checks.base import is_affirmative
 from datadog_checks.vsphere import VSphereCheck
 
-from .common import HERE
+from .common import HERE, LAB_INSTANCE
 
 
 def test_lab(aggregator):
@@ -30,23 +30,9 @@ def test_lab(aggregator):
             "Skipped! Set TEST_VSPHERE_RUN_LAB to run this test. "
             "TEST_VSPHERE_USER and TEST_VSPHERE_PASS must also be set."
         )
-    username = os.environ['TEST_VSPHERE_USER']
-    password = os.environ['TEST_VSPHERE_PASS']
-    instance = {
-        'host': 'aws.vcenter.localdomain',
-        'username': username,
-        'password': password,
-        'collection_level': 4,
-        'collection_type': 'both',
-        'use_legacy_check_version': False,
-        'collect_metric_instance_values': True,
-        'ssl_verify': False,
-        'collect_tags': True,
-        'collect_events': True,
-    }
-    check = VSphereCheck('vsphere', {}, [instance])
+    check = VSphereCheck('vsphere', {}, [LAB_INSTANCE])
     check.initiate_api_connection()
-    check.check(instance)
+    check.check(LAB_INSTANCE)
 
     # Basic assert
     aggregator.assert_metric('vsphere.cpu.coreUtilization.avg')

--- a/vsphere/tests/test_lab.py
+++ b/vsphere/tests/test_lab.py
@@ -42,6 +42,7 @@ def test_lab(aggregator):
         'collect_metric_instance_values': True,
         'ssl_verify': False,
         'collect_tags': True,
+        'collect_events': True,
     }
     check = VSphereCheck('vsphere', {}, [instance])
     check.initiate_api_connection()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Avoid calling `get_latest_event_timestamp` to track last event time.

Todo:

- [ ] Reproduce issue on vSphere 6.7. The issue. likely happen for a specific type of event.

### Motivation
<!-- What inspired you to submit this pull request? -->

Call to `event_manager.latestEvent.createdTime` might raise parse error for some events:

```
Traceback (most recent call last):
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\datadog_checks\\base\\checks\\base.py\", line 713, in run
    self.check(instance)
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\datadog_checks\\vsphere\\vsphere.py\", line 513, in check
    self.collect_events()
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\datadog_checks\\vsphere\\vsphere.py\", line 456, in collect_events
    self.latest_event_query = self.api.get_latest_event_timestamp() + timedelta(seconds=1)
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\datadog_checks\\vsphere\\api.py\", line 47, in wrapper
    return f(api_instance, *args, **kwargs)
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\datadog_checks\\vsphere\\api.py\", line 196, in get_latest_event_timestamp
    return event_manager.latestEvent.createdTime
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\pyVmomi\\VmomiSupport.py\", line 574, in __call__
    return self.f(*args, **kwargs)
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\pyVmomi\\VmomiSupport.py\", line 394, in _InvokeAccessor
    return self._stub.InvokeAccessor(self, info)
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\pyVmomi\\StubAdapterAccessorImpl.py\", line 41, in InvokeAccessor
    result = self._pc.RetrievePropertiesEx(specSet=[filterSpec],
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\pyVmomi\\VmomiSupport.py\", line 580, in <lambda>
    self.f(*(self.args + (obj,) + args), **kwargs)
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\pyVmomi\\VmomiSupport.py\", line 386, in _InvokeMethod
    return self._stub.InvokeMethod(self, info, args)
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\pyVmomi\\SoapAdapter.py\", line 1357, in InvokeMethod
    raise exc
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\pyVmomi\\SoapAdapter.py\", line 1347, in InvokeMethod
    obj = deserializer.Deserialize(fd, info.result)
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\pyVmomi\\SoapAdapter.py\", line 833, in Deserialize
    ParseData(self.parser, response)
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\pyVmomi\\SoapAdapter.py\", line 513, in ParseData
    reraise(ParserError, pe, tb)
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\six.py\", line 692, in reraise
    raise value.with_traceback(tb)
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\pyVmomi\\SoapAdapter.py\", line 502, in ParseData
    parser.ParseFile(data)
  File \"c:\\a\\27\\s\\modules\\pyexpat.c\", line 461, in EndElement
  File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\pyVmomi\\SoapAdapter.py\", line 732, in EndElementHandler
    raise TypeError(data)\npyVmomi.SoapAdapter.ParserError: 'xml document: <http.client.HTTPResponse object at 0x000000000D2E6B80> parse error at: line:7, col:924'\n"}]
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
