### PR TITLE
Fix thread leak in wmi checks

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py
@@ -274,7 +274,7 @@ class WinWMICheck(AgentCheck):
 
         If no matching WMISampler is running yet, start one and cache it.
         """
-        if not self._wmi_sampler:
+        if self._wmi_sampler is None:
             property_list = list(properties) + [tag_by] if tag_by else list(properties)
             self._wmi_sampler = WMISampler(self.log, wmi_class, property_list, **kwargs)
             self._wmi_sampler.start()

--- a/datadog_checks_base/tests/test_wmicheck.py
+++ b/datadog_checks_base/tests/test_wmicheck.py
@@ -15,5 +15,6 @@ except ImportError:
 @pytest.mark.unit
 def test_get_running_sampler_does_not_leak():
     check = WinWMICheck('wmi_base_check', {}, [{}])
-    sampler = check.get_running_wmi_sampler(properties=[], filters=[])
-    assert check.get_running_wmi_sampler(properties=[], filters=[]) is sampler
+    with check.get_running_wmi_sampler(properties=[], filters=[]) as sampler:
+        assert sampler is not None
+        assert check.get_running_wmi_sampler(properties=[], filters=[]) is sampler

--- a/datadog_checks_base/tests/test_wmicheck.py
+++ b/datadog_checks_base/tests/test_wmicheck.py
@@ -1,0 +1,19 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+from tests.utils import requires_windows
+
+try:
+    from datadog_checks.base.checks.win.wmi import WinWMICheck
+except ImportError:
+    pass
+
+
+@requires_windows
+@pytest.mark.unit
+def test_get_running_sampler_does_not_leak():
+    check = WinWMICheck('wmi_base_check', {}, [{}])
+    sampler = check.get_running_wmi_sampler(properties=[], filters=[])
+    assert check.get_running_wmi_sampler(properties=[], filters=[]) is sampler


### PR DESCRIPTION
Fixes bug introduced in https://github.com/DataDog/integrations-core/pull/6329/files#diff-18a6bd2d960250c9f7f5d53bb88bdc37R277
The issue happens due to WMISampler class having its own `__len__` implementation