### PR TITLE
Fix nfsiostat command

### DIFF
--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -17,7 +17,7 @@ class NfsStatCheck(AgentCheck):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
         # if they set the path, use that
         if init_config.get('nfsiostat_path'):
-            self.nfs_cmd = [init_config.get('nfsiostat_path'), '1', '2']
+            self.nfs_cmd = init_config.get('nfsiostat_path').split() + ['1', '2']
         else:
             # if not, check if it's installed in the opt dir, if so use that
             if os.path.exists('/opt/datadog-agent/embedded/sbin/nfsiostat'):

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -17,7 +17,7 @@ class NfsStatCheck(AgentCheck):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
         # if they set the path, use that
         if init_config.get('nfsiostat_path'):
-            self.nfs_cmd = init_config.get('nfsiostat_path').split() + ['1', '2']
+            self.nfs_cmd = init_config['nfsiostat_path'].split() + ['1', '2']
         else:
             # if not, check if it's installed in the opt dir, if so use that
             if os.path.exists('/opt/datadog-agent/embedded/sbin/nfsiostat'):


### PR DESCRIPTION
### What does this PR do?
Fix the `nfsiostat` call command in case of a non-trivial path to the binary

### Motivation
We need the parameter `nfsiostat_path` to be `docker exec <ID> nfsiostat` for the e2e test

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
