### PR TITLE
Move `mock_alarm_event`

### DIFF
--- a/vsphere/tests/legacy/utils.py
+++ b/vsphere/tests/legacy/utils.py
@@ -142,3 +142,25 @@ def get_mocked_server():
     server_mock = MagicMock()
     server_mock.configure_mock(**{'RetrieveContent.return_value': content_mock, 'content': content_mock})
     return server_mock
+
+
+def mock_alarm_event(from_status='green', to_status='red', message='Some error', key=0, created_time=None):
+    if created_time is None:
+        created_time = datetime.utcnow()
+    vm = MockedMOR(spec='VirtualMachine')
+    dc = MockedMOR(spec="Datacenter")
+    dc_arg = vim.event.DatacenterEventArgument(datacenter=dc, name='dc1')
+    alarm = MockedMOR(spec="Alarm")
+    alarm_arg = vim.event.AlarmEventArgument(alarm=alarm, name='alarm1')
+    entity = vim.event.ManagedEntityEventArgument(entity=vm, name='vm1')
+    event = vim.event.AlarmStatusChangedEvent(
+        entity=entity,
+        fullFormattedMessage=message,
+        createdTime=created_time,
+        to=to_status,
+        datacenter=dc_arg,
+        alarm=alarm_arg,
+        key=key,
+    )
+    setattr(event, 'from', from_status)  # noqa: B009
+    return event

--- a/vsphere/tests/mocked_api.py
+++ b/vsphere/tests/mocked_api.py
@@ -28,6 +28,7 @@ class MockedAPI(object):
         self.config = config
         self.infrastructure_data = {}
         self.metrics_data = []
+        self.mock_events = []
 
     def check_health(self):
         return True
@@ -107,6 +108,9 @@ class MockedAPI(object):
 
     def get_latest_event_timestamp(self):
         return datetime.now()
+
+    def get_new_events(self, start_time):
+        return self.mock_events
 
 
 class MockResponse(Response):

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -32,6 +32,7 @@ def test_realtime_metrics(aggregator, dd_run_check, realtime_instance):
                 metric['name'], metric.get('value'), hostname=metric.get('hostname'), tags=metric.get('tags')
             )
 
+    aggregator.assert_metric('datadog.vsphere.collect_events.time', metric_type=aggregator.GAUGE, count=1)
     aggregator.assert_all_metrics_covered()
 
 


### PR DESCRIPTION
Move `mock_alarm_event` also needed for other tests (other PRs using it come later).