### PR TITLE
Avoid calling get_latest_event_timestamp

### DIFF
--- a/.stubs/pyVmomi/vim/event.pyi
+++ b/.stubs/pyVmomi/vim/event.pyi
@@ -4,6 +4,8 @@ from typing import List, Type
 
 class Event:
     createdTime: datetime
+    key: int
+    fullFormattedMessage: str
 
 class EventFilterSpec:
     class ByTime:

--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -262,12 +262,6 @@ class VSphereAPI(object):
         return event_manager.QueryEvents(query_filter)
 
     @smart_retry
-    def get_latest_event_timestamp(self):
-        # type: () -> dt.datetime
-        event_manager = self._conn.content.eventManager
-        return event_manager.latestEvent.createdTime
-
-    @smart_retry
     def get_max_query_metrics(self):
         # type: () -> float
         vcenter_settings = self._conn.content.setting.QueryOptions(MAX_QUERY_METRICS_OPTION)

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -499,14 +499,14 @@ class VSphereCheck(AgentCheck):
             event_config = {'collect_vcenter_alarms': True}
             for event in new_events:
                 self.log.debug(
-                    "Processing event number:%s, type:%s: msg:%s", event.key, type(event), event.fullFormattedMessage
+                    "Processing event with id:%s, type:%s: msg:%s", event.key, type(event), event.fullFormattedMessage
                 )
                 normalized_event = VSphereEvent(event, event_config, self.config.base_tags)
                 # Can return None if the event if filtered out
                 event_payload = normalized_event.get_datadog_payload()
                 if event_payload is not None:
                     self.log.debug(
-                        "Submit event number:%s, type:%s: msg:%s", event.key, type(event), event.fullFormattedMessage
+                        "Submit event with id:%s, type:%s: msg:%s", event.key, type(event), event.fullFormattedMessage
                     )
                     self.event(event_payload)
                 if latest_event_time is None or event.createdTime > latest_event_time:

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -513,7 +513,7 @@ class VSphereCheck(AgentCheck):
         except Exception as e:
             # Don't get stuck on a failure to fetch an event
             # Ignore them for next pass
-            self.log.warning("Unable to fetch Events %s", str(e))
+            self.log.warning("Unable to fetch Events %s", e)
 
         if latest_event_time is not None:
             self.latest_event_query = latest_event_time + dt.timedelta(seconds=1)

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -14,6 +14,7 @@ from six import iteritems
 
 from datadog_checks.base import AgentCheck, is_affirmative, to_string
 from datadog_checks.base.checks.libs.timer import Timer
+from datadog_checks.base.utils.time import get_current_datetime
 from datadog_checks.vsphere.api import APIConnectionError, VSphereAPI
 from datadog_checks.vsphere.api_rest import VSphereRestAPI
 from datadog_checks.vsphere.cache import InfrastructureCache, MetricsMetadataCache
@@ -75,7 +76,7 @@ class VSphereCheck(AgentCheck):
         instance = cast(InstanceConfig, self.instance)
         self.config = VSphereConfig(instance, self.log)
 
-        self.latest_event_query = dt.datetime.utcnow()
+        self.latest_event_query = get_current_datetime()
         self.infrastructure_cache = InfrastructureCache(interval_sec=self.config.refresh_infrastructure_cache_interval)
         self.metrics_metadata_cache = MetricsMetadataCache(
             interval_sec=self.config.refresh_metrics_metadata_cache_interval
@@ -483,7 +484,7 @@ class VSphereCheck(AgentCheck):
         # type: () -> None
         self.log.debug("Starting events collection (query start time: %s).", self.latest_event_query)
         latest_event_time = None
-        collect_start_time = dt.datetime.utcnow()
+        collect_start_time = get_current_datetime()
         try:
             t0 = Timer()
             new_events = self.api.get_new_events(start_time=self.latest_event_query)

--- a/vsphere/tests/mocked_api.py
+++ b/vsphere/tests/mocked_api.py
@@ -4,7 +4,6 @@
 import json
 import os
 import re
-from datetime import datetime
 
 from mock import MagicMock
 from pyVmomi import vim
@@ -105,9 +104,6 @@ class MockedAPI(object):
 
     def get_max_query_metrics(self):
         return 256
-
-    def get_latest_event_timestamp(self):
-        return datetime.now()
 
     def get_new_events(self, start_time):
         return self.mock_events

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -2,9 +2,15 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+import datetime as dt
+
+import pytest
 from pyVmomi import vim
 
+from datadog_checks.vsphere import VSphereCheck
 from datadog_checks.vsphere.legacy.event import ALLOWED_EVENTS
+
+from .legacy.utils import mock_alarm_event
 
 
 def test_allowed_event_list():
@@ -20,3 +26,41 @@ def test_allowed_event_list():
         vim.event.VmSuspendedEvent,
     ]
     assert sorted(str(e) for e in expected_events) == sorted(str(e) for e in ALLOWED_EVENTS)
+
+
+@pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
+def test_events_collection(aggregator, realtime_instance):
+    check = VSphereCheck('vsphere', {}, [realtime_instance])
+    check.initiate_api_connection()
+    time_initial = check.latest_event_query
+
+    time1 = dt.datetime.now()
+    time2 = time1 + dt.timedelta(seconds=3)
+    time3 = time1 + dt.timedelta(seconds=5)
+    event1 = mock_alarm_event(from_status='green', key=10, created_time=time1)
+    event2 = mock_alarm_event(from_status='yellow', key=20, created_time=time3)
+    event3 = mock_alarm_event(from_status='red', key=30, created_time=time2)
+
+    # No events
+    check.check(None)
+    assert len(aggregator.events) == 0
+    assert check.latest_event_query > time_initial  # check time not changed if there is no event
+
+    # 1 events
+    aggregator.reset()
+    check.api.mock_events = [event1]
+    check.check(None)
+    aggregator.assert_event("vCenter monitor status changed on this alarm, it was green and it's now red.", count=1)
+    assert len(aggregator.events) == 1
+    assert check.latest_event_query == time1 + dt.timedelta(seconds=1)
+
+    # 3 events
+    aggregator.reset()
+    check.api.mock_events = [event2, event3, event3]
+    check.check(None)
+    for status, count in [('yellow', 1), ('red', 2)]:
+        aggregator.assert_event(
+            "vCenter monitor status changed on this alarm, it was {} and it's now red.".format(status), count=count
+        )
+    assert len(aggregator.events) == 3
+    assert check.latest_event_query == time3 + dt.timedelta(seconds=1)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Avoid calling get_latest_event_timestamp

### Motivation
<!-- What inspired you to submit this pull request? -->

Call to get_latest_event_timestamp might fail due to parsing issue. Details:
- https://github.com/vmware/pyvmomi/issues/872
- https://github.com/vmware/pyvmomi/issues/190

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
