### PR TITLE
Update scraper config with instance

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -59,7 +59,6 @@ class OpenMetricsScraperMixin(object):
         if instance is None:
             instance = {}
 
-        # Create an empty configuration
         # Supports new configuration options
         config = copy.deepcopy(instance)
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
+import copy
 from fnmatch import translate
 from math import isinf, isnan
 from os.path import isfile
@@ -59,7 +60,8 @@ class OpenMetricsScraperMixin(object):
             instance = {}
 
         # Create an empty configuration
-        config = {}
+        # Supports new configuration options
+        config = copy.deepcopy(instance)
 
         # Set the endpoint
         endpoint = instance.get('prometheus_url')

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -125,6 +125,16 @@ def mock_get():
         yield text_data
 
 
+def test_config_instance(mocked_prometheus_check):
+    """Ensure scraper config persists instance options"""
+    check = mocked_prometheus_check
+    instance = copy.deepcopy(PROMETHEUS_CHECK_INSTANCE)
+    instance['new_option'] = 'test123'
+
+    config = check.create_scraper_configuration(instance)
+    config['new_option'] = 'test123'
+
+
 def test_process(text_data, mocked_prometheus_check, mocked_prometheus_scraper_config, ref_gauge):
     check = mocked_prometheus_check
     check.poll = mock.MagicMock(return_value=MockResponse(text_data, text_content_type))


### PR DESCRIPTION
### What does this PR do?
Openmetrics was creating a new empty `scraper_config` with every instance. New/standardized HTTP wrapper options were not being persisted.

### Motivation
Resolves https://github.com/DataDog/integrations-core/issues/6538

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
