### PR TITLE
Update default config for E2E Agent builds

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/config.py
@@ -42,6 +42,8 @@ DEFAULT_CONFIG = {
     },
     'agents': {
         'master': {'docker': 'datadog/agent-dev:master', 'local': 'latest'},
+        '7': {'docker': 'datadog/agent:7', 'local': '7'},
+        '6': {'docker': 'datadog/agent:6', 'local': '6'},
     },
     'orgs': {
         'default': {
@@ -98,7 +100,7 @@ def update_config():
     config = copy_default_config()
     config.update(load_config())
 
-    # Support legacy config where agent5 and agent6 were strings
+    # Support legacy config where agent6 was a string
     if isinstance(config.get('agent6'), str):
         config['agent6'] = {'docker': config['agent6'], 'local': 'latest'}
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/config.py
@@ -99,10 +99,8 @@ def update_config():
     config.update(load_config())
 
     # Support legacy config where agent5 and agent6 were strings
-    if isinstance(config['agent6'], str):
+    if isinstance(config.get('agent6'), str):
         config['agent6'] = {'docker': config['agent6'], 'local': 'latest'}
-    if isinstance(config['agent5'], str):
-        config['agent5'] = {'docker': config['agent5'], 'local': 'latest'}
 
     save_config(config)
     return config

--- a/datadog_checks_dev/datadog_checks/dev/tooling/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/config.py
@@ -41,8 +41,7 @@ DEFAULT_CONFIG = {
         'agent': os.path.join('~', 'dd', 'datadog-agent'),
     },
     'agents': {
-        '6': {'docker': 'datadog/agent-dev:master', 'local': 'latest'},
-        '5': {'docker': 'datadog/dev-dd-agent:master', 'local': 'latest'},
+        'master': {'docker': 'datadog/agent-dev:master', 'local': 'latest'},
     },
     'orgs': {
         'default': {


### PR DESCRIPTION
Reflect doc site configuration setting for agent and removes legacy agent 5 config.

Also supports adding new default agent settings for A6 and A7 official images.

https://datadoghq.dev/integrations-core/ddev/configuration/#agent

**TESTING**:
Delete `[agents.<version>]` entries in `config.toml` by running
```
ddev config show
```

Then run
```
ddev config update
```

to see the following added:
```

[agents.master]
docker = "datadog/agent-dev:master"
local = "latest"

[agents.7]
docker = "datadog/agent:7"
local = "7"

[agents.6]
docker = "datadog/agent:6"
local = "6"
```
