### PR TITLE
Document openmetrics interface and options

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/__init__.py
@@ -3,6 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
-from .base_check import OpenMetricsBaseCheck
+from .base_check import OpenMetricsBaseCheck, OpenMetricsScraperMixin
 
-__all__ = ['OpenMetricsBaseCheck']
+__all__ = ['OpenMetricsBaseCheck', 'OpenMetricsScraperMixin']

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/__init__.py
@@ -3,6 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
-from .base_check import OpenMetricsBaseCheck, OpenMetricsScraperMixin
+from .base_check import OpenMetricsBaseCheck
 
-__all__ = ['OpenMetricsBaseCheck', 'OpenMetricsScraperMixin']
+__all__ = ['OpenMetricsBaseCheck']

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -9,9 +9,9 @@ from .mixins import OpenMetricsScraperMixin
 class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
     """
     OpenMetricsBaseCheck is a class that helps instantiating PrometheusCheck only
-    with YAML configurations. As each check has it own states it maintains a map
+    with YAML configurations. As each check has its own states it maintains a map
     of all checks so that the one corresponding to the instance is executed.
-    Minimal example configuration::
+    Minimal example configuration:
 
         instances:
         - prometheus_url: http://example.com/endpoint
@@ -19,12 +19,6 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
             metrics:
             - bar
             - foo
-
-
-    Agent 5 signature:
-
-        OpenMetricsBaseCheck(name, init_config, agentConfig, instances=None, default_instances=None,
-                             default_namespace=None)
 
     Agent 6 signature:
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -8,7 +8,7 @@ from .mixins import OpenMetricsScraperMixin
 
 class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
     """
-    OpenMetricsBaseCheck is a class that helps instantiating PrometheusCheck only
+    OpenMetricsBaseCheck is a class that helps instantiating the PrometheusCheck only
     with YAML configurations. As each check has its own states it maintains a map
     of all checks so that the one corresponding to the instance is executed.
     Minimal example configuration:
@@ -85,6 +85,10 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         self.process(scraper_config)
 
     def get_scraper_config(self, instance):
+        """
+        Validates the instance configuration and creates a scraper configuration for a new instance.
+        If the endpoint already has a corresponding configuration, return the cached configuration.
+        """
         endpoint = instance.get('prometheus_url')
 
         if endpoint is None:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -35,8 +35,6 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
     OpenMetricsBaseCheck is a class that helps scrape endpoints that emit Prometheus metrics only
     with YAML configurations.
 
-    As each check has its own states it maintains a map
-    of all checks so that the one corresponding to the instance is executed.
     Minimal example configuration:
 
         instances:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -1,9 +1,33 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from six import PY2
 from ...errors import CheckException
 from .. import AgentCheck
 from .mixins import OpenMetricsScraperMixin
+
+
+STANDARD_FIELDS = [
+    'prometheus_url',
+    'namespace',
+    'metrics',
+    'prometheus_metrics_prefix',
+    'health_service_check',
+    'label_to_hostname',
+    'label_joins',
+    'labels_mapper',
+    'type_overrides',
+    'send_histograms_buckets',
+    'send_distribution_buckets',
+    'send_monotonic_counter',
+    'send_monotonic_with_gauge',
+    'send_distribution_counts_as_monotonic',
+    'send_distribution_sums_as_monotonic',
+    'exclude_labels',
+    'bearer_token_auth',
+    'bearer_token_path',
+    'ignore_metrics',
+]
 
 
 class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
@@ -123,3 +147,13 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         Used to filter metrics at the begining of the processing, by default no metric is filtered
         """
         return False
+
+
+# For documentation generation
+# TODO: use an enum and remove STANDARD_FIELDS when mkdocstrings supports it
+class StandardFields(object):
+    pass
+
+
+if not PY2:
+    StandardFields.__doc__ = '\n'.join('- `{}`'.format(field) for field in STANDARD_FIELDS)

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -9,7 +9,9 @@ from .mixins import OpenMetricsScraperMixin
 class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
     """
     OpenMetricsBaseCheck is a class that helps instantiating the PrometheusCheck only
-    with YAML configurations. As each check has its own states it maintains a map
+    with YAML configurations.
+
+    As each check has its own states it maintains a map
     of all checks so that the one corresponding to the instance is executed.
     Minimal example configuration:
 
@@ -37,6 +39,9 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
     }
 
     def __init__(self, *args, **kwargs):
+        """
+        The base class for any Prometheus-based integration.
+        """
         args = list(args)
         default_instances = kwargs.pop('default_instances', None) or {}
         default_namespace = kwargs.pop('default_namespace', None)

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -2,10 +2,10 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from six import PY2
+
 from ...errors import CheckException
 from .. import AgentCheck
 from .mixins import OpenMetricsScraperMixin
-
 
 STANDARD_FIELDS = [
     'prometheus_url',

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -32,7 +32,7 @@ STANDARD_FIELDS = [
 
 class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
     """
-    OpenMetricsBaseCheck is a class that helps instantiating the PrometheusCheck only
+    OpenMetricsBaseCheck is a class that helps scrape endpoints that emit Prometheus metrics only
     with YAML configurations.
 
     As each check has its own states it maintains a map

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -722,7 +722,7 @@ class OpenMetricsScraperMixin(object):
 
         Histograms generate a set of values instead of a unique metric.
         `send_histograms_buckets` is used to specify if you want to
-            send the buckets as tagged values when dealing with histograms.
+        send the buckets as tagged values when dealing with histograms.
 
         `custom_tags` is an array of `tag:value` that will be added to the
         metric when sending the gauge to Datadog.

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -476,7 +476,7 @@ class OpenMetricsScraperMixin(object):
 
     def process(self, scraper_config, metric_transformers=None):
         """
-        Polls the data from Prometheus and pushes them as gauges.
+        Polls the data from Prometheus and submits them as Datadog metrics.
         `endpoint` is the metrics endpoint to use to poll metrics from Prometheus
 
         Note that if the instance has a `tags` attribute, it will be pushed

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -381,9 +381,6 @@ class OpenMetricsScraperMixin(object):
         """
         Parse the MetricFamily from a valid `requests.Response` object to provide a MetricFamily object.
         The text format uses iter_lines() generator.
-
-        :param response: requests.Response
-        :return: core.Metric
         """
         if response.encoding is None:
             response.encoding = 'utf-8'
@@ -606,9 +603,9 @@ class OpenMetricsScraperMixin(object):
     def process_metric(self, metric, scraper_config, metric_transformers=None):
         """
         Handle a Prometheus metric according to the following flow:
-            - search `scraper_config['metrics_mapper']` for a prometheus.metric to datadog.metric mapping
-            - call check method with the same name as the metric
-            - log info if none of the above worked
+        - search `scraper_config['metrics_mapper']` for a prometheus.metric to datadog.metric mapping
+        - call check method with the same name as the metric
+        - log info if none of the above worked
 
         `metric_transformers` is a dict of `<metric name>:<function to run when the metric name is encountered>`
         """
@@ -667,16 +664,12 @@ class OpenMetricsScraperMixin(object):
 
     def poll(self, scraper_config, headers=None):
         """
-        Returns a valid requests.Response, otherwise raise requests.HTTPError if the status code of the
-        requests.Response isn't valid - see `response.raise_for_status()`
+        Returns a valid `requests.Response`, otherwise raise requests.HTTPError if the status code of the
+        response isn't valid - see `response.raise_for_status()`
 
-        The caller needs to close the requests.Response
+        The caller needs to close the requests.Response.
 
         Custom headers can be added to the default headers.
-
-        :param endpoint: string url endpoint
-        :param headers: extra headers
-        :return: requests.Response
         """
         endpoint = scraper_config.get('prometheus_url')
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -54,6 +54,14 @@ class OpenMetricsScraperMixin(object):
         super(OpenMetricsScraperMixin, self).__init__(*args, **kwargs)
 
     def create_scraper_configuration(self, instance=None):
+        """
+        Creates a scraper configuration.
+
+        If instance does not specify a value for a configuration option, the value will default to the `init_config`.
+        Otherwise, the `default_instance` value will be used.
+
+        A default mixin configuration will be returned if there is no instance.
+        """
 
         # We can choose to create a default mixin configuration for an empty instance
         if instance is None:
@@ -602,7 +610,7 @@ class OpenMetricsScraperMixin(object):
             - call check method with the same name as the metric
             - log info if none of the above worked
 
-        `metric_transformers` is a dict of <metric name>:<function to run when the metric name is encountered>
+        `metric_transformers` is a dict of `<metric name>:<function to run when the metric name is encountered>`
         """
         # If targeted metric, store labels
         self._store_labels(metric, scraper_config)

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -371,8 +371,9 @@ class OpenMetricsScraperMixin(object):
 
     def parse_metric_family(self, response, scraper_config):
         """
-        Parse the MetricFamily from a valid requests.Response object to provide a MetricFamily object (see [0])
+        Parse the MetricFamily from a valid `requests.Response` object to provide a MetricFamily object.
         The text format uses iter_lines() generator.
+
         :param response: requests.Response
         :return: core.Metric
         """
@@ -415,7 +416,7 @@ class OpenMetricsScraperMixin(object):
 
     def scrape_metrics(self, scraper_config):
         """
-        Poll the data from prometheus and return the metrics as a generator.
+        Poll the data from Prometheus and return the metrics as a generator.
         """
         response = self.poll(scraper_config)
         if scraper_config['telemetry']:
@@ -467,10 +468,10 @@ class OpenMetricsScraperMixin(object):
 
     def process(self, scraper_config, metric_transformers=None):
         """
-        Polls the data from prometheus and pushes them as gauges
+        Polls the data from Prometheus and pushes them as gauges.
         `endpoint` is the metrics endpoint to use to poll metrics from Prometheus
 
-        Note that if the instance has a 'tags' attribute, it will be pushed
+        Note that if the instance has a `tags` attribute, it will be pushed
         automatically as additional custom tags and added to the metrics
         """
         transformers = scraper_config['_default_metric_transformers'].copy()
@@ -596,10 +597,10 @@ class OpenMetricsScraperMixin(object):
 
     def process_metric(self, metric, scraper_config, metric_transformers=None):
         """
-        Handle a prometheus metric according to the following flow:
-            - search scraper_config['metrics_mapper'] for a prometheus.metric <--> datadog.metric mapping
+        Handle a Prometheus metric according to the following flow:
+            - search `scraper_config['metrics_mapper']` for a prometheus.metric to datadog.metric mapping
             - call check method with the same name as the metric
-            - log some info if none of the above worked
+            - log info if none of the above worked
 
         `metric_transformers` is a dict of <metric name>:<function to run when the metric name is encountered>
         """
@@ -658,12 +659,12 @@ class OpenMetricsScraperMixin(object):
 
     def poll(self, scraper_config, headers=None):
         """
-        Custom headers can be added to the default headers.
-
-        Returns a valid requests.Response, raise requests.HTTPError if the status code of the requests.Response
-        isn't valid - see response.raise_for_status()
+        Returns a valid requests.Response, otherwise raise requests.HTTPError if the status code of the
+        requests.Response isn't valid - see `response.raise_for_status()`
 
         The caller needs to close the requests.Response
+
+        Custom headers can be added to the default headers.
 
         :param endpoint: string url endpoint
         :param headers: extra headers
@@ -715,14 +716,14 @@ class OpenMetricsScraperMixin(object):
     def submit_openmetric(self, metric_name, metric, scraper_config, hostname=None):
         """
         For each sample in the metric, report it as a gauge with all labels as tags
-        except if a labels dict is passed, in which case keys are label names we'll extract
+        except if a labels `dict` is passed, in which case keys are label names we'll extract
         and corresponding values are tag names we'll use (eg: {'node': 'node'}).
 
         Histograms generate a set of values instead of a unique metric.
-        send_histograms_buckets is used to specify if yes or no you want to
+        `send_histograms_buckets` is used to specify if you want to
             send the buckets as tagged values when dealing with histograms.
 
-        `custom_tags` is an array of 'tag:value' that will be added to the
+        `custom_tags` is an array of `tag:value` that will be added to the
         metric when sending the gauge to Datadog.
         """
         if metric.type in ["gauge", "counter", "rate"]:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -329,7 +329,7 @@ class OpenMetricsScraperMixin(object):
 
     def get_http_handler(self, scraper_config):
         """
-        Get http handler for a specific scrapper config.
+        Get http handler for a specific scraper config.
         The http handler is cached using `prometheus_url` as key.
         """
         prometheus_url = scraper_config['prometheus_url']

--- a/docs/developer/.snippets/links.txt
+++ b/docs/developer/.snippets/links.txt
@@ -25,6 +25,7 @@
 [datadog-agent-logs]: https://docs.datadoghq.com/agent/logs/?tab=tailfiles
 [datadog-agent-status-page]: https://docs.datadoghq.com/agent/guide/agent-status-page/
 [datadog-checks-base]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_base
+[datadog-distribution-metrics]: https://docs.datadoghq.com/metrics/distributions/
 [datadog-checks-dev]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_dev
 [datadog-checks-dev-plugin-pytest]: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
 [datadog-checks-dev-plugin-tox]: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/plugin/tox.py

--- a/docs/developer/.snippets/links.txt
+++ b/docs/developer/.snippets/links.txt
@@ -18,7 +18,6 @@
 [config-spec-template-instances-http]: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
 [config-spec-template-init-config-openmetrics]: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/openmetrics.yaml
 [config-spec-template-instances-openmetrics]: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
-
 [config-spec-templates]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration
 [Datadog Agent]: https://docs.datadoghq.com/agent/
 [datadog-agent]: https://github.com/DataDog/datadog-agent

--- a/docs/developer/.snippets/links.txt
+++ b/docs/developer/.snippets/links.txt
@@ -16,6 +16,9 @@
 [config-spec-producer]: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/configuration/core.py
 [config-spec-template-init-config-http]: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/http.yaml
 [config-spec-template-instances-http]: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
+[config-spec-template-init-config-openmetrics]: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/openmetrics.yaml
+[config-spec-template-instances-openmetrics]: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+
 [config-spec-templates]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration
 [Datadog Agent]: https://docs.datadoghq.com/agent/
 [datadog-agent]: https://github.com/DataDog/datadog-agent

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -93,7 +93,7 @@ Summary metrics ending in:
 
 - `_sum` represent the total sum of all observed values. Generally [sums](https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations)
  are like counters but it's also possible for a negative observation which would not behave like a typical always increasing counter.
-- `_count` represent the count of events that have been observed.
+- `_count` represent the total number of events that have been observed.
 -  metrics with labels like `{quantile="<φ>"}` represent the streaming quantiles of observed events.
 
 Subtype|Config Option|Value|Datadog Metric Submitted

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -50,7 +50,7 @@ We currently support Prometheus `gauge`, `counter`, `histogram`, and `summary` m
 ### Gauge
 A gauge metric represents a single numerical value that can arbitrarily go up or down.
 
-Prometheus gauge metrics are submitted as Datadog gauge metrics
+Prometheus gauge metrics are submitted as Datadog gauge metrics.
 
 ### Counter
 

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -103,5 +103,3 @@ Subtype|Config Option|Value|Datadog Metric Submitted
 `_count`|`send_distribution_counts_as_monotonic`|`false` (default)|[`gauge`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L753-L763)
 &nbsp;|&nbsp;|`true`|`monotonic_count`
 `_quantile`|&nbsp;|&nbsp;|`gauge`
-=======
-### Summary

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -1,3 +1,20 @@
 # Prometheus
 
 -----
+[Prometheus](https://prometheus.io) is an open-source monitoring system for timeseries metric data. Many Datadog 
+integrations collect metrics based on Prometheus exported data sets.
+
+As of [Agent `6.5.0`](https://www.datadoghq.com/blog/monitor-prometheus-metrics/), Prometheus-based integrations use 
+the OpenMetric exposition format to monitor metrics.
+
+## Openmetrics Base Check
+### Interface
+All functionality is exposed by the `OpenMetricsBaseCheck` and `OpenMetricsScraperMixin` classes.
+
+::: datadog_checks.base.checks.openmetrics.OpenMetricsBaseCheck
+    rendering:
+      heading_level: 3
+
+### Options
+
+## Prometheus to Datadog metric types

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -15,7 +15,7 @@ All functionality is exposed by the `OpenMetricsBaseCheck` and `OpenMetricsScrap
     rendering:
       heading_level: 4
 
-::: datadog_checks.base.checks.openmetrics.OpenMetricsScraperMixin
+::: datadog_checks.base.checks.openmetrics.mixins.OpenMetricsScraperMixin
     rendering:
       heading_level: 4
     selection:
@@ -34,7 +34,7 @@ Some options can be set globally in `init_config` (with `instances` taking prece
 For complete documentation of every option, see the associated configuration templates for the
 [instances][config-spec-template-instances-openmetrics] and [init_config][config-spec-template-init-config-openmetrics] sections.
 
-Default options from the `HTTP` wrapper and `AgentCheck` are also supported.
+All [HTTP options](http.md#options) are also supported.
 
 
 ::: datadog_checks.base.checks.openmetrics.base_check.StandardFields
@@ -43,3 +43,14 @@ Default options from the `HTTP` wrapper and `AgentCheck` are also supported.
       show_root_toc_entry: false
 
 ## Prometheus to Datadog metric types
+
+The Openmetrics Base Check supports various configurations for submitting Prometheus metrics to Datadog.
+We currently support Prometheus `gauge`, `counter`, `histogram`, and `summary` metric types.
+
+### Gauge
+
+### Counter
+
+### Histogram
+
+### Summary

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -1,6 +1,7 @@
 # Prometheus
 
 -----
+
 [Prometheus](https://prometheus.io) is an open-source monitoring system for timeseries metric data. Many Datadog 
 integrations collect metrics based on Prometheus exported data sets.
 
@@ -8,12 +9,24 @@ As of [Agent `6.5.0`](https://www.datadoghq.com/blog/monitor-prometheus-metrics/
 the OpenMetric exposition format to monitor metrics.
 
 ## Openmetrics Base Check
+
 ### Interface
+
 All functionality is exposed by the `OpenMetricsBaseCheck` and `OpenMetricsScraperMixin` classes.
 
 ::: datadog_checks.base.checks.openmetrics.OpenMetricsBaseCheck
     rendering:
-      heading_level: 3
+      heading_level: 4
+
+::: datadog_checks.base.checks.openmetrics.OpenMetricsScraperMixin
+    rendering:
+      heading_level: 4
+        - parse_metric_family
+        - scrape_metrics
+        - process
+        - process_metric
+        - poll
+        - submit_openmetric
 
 ### Options
 

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -57,11 +57,49 @@ Prometheus gauge metrics are submitted as Datadog gauge metrics
 A [Prometheus counter](https://prometheus.io/docs/concepts/metric_types/#counter) is cumulative metric that represents 
 a single monotonically increasing counter whose value can only increase or be reset to zero on restart.
 
-Config Option|Value|Datadog metric submitted
+Config Option|Value|Datadog Metric Submitted
 -------------|-----|------------------------
 `send_monotonic_counter`|`true` (default)| [`monotonic_count`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L667-L668)
-`send_monotonic_counter`|`false`|[`gauge`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L671-L672)
+&nbsp;|`false`|[`gauge`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L671-L672)
 
 ### Histogram
 
+A [Prometheus histogram](https://prometheus.io/docs/concepts/metric_types/#histogram) samples observations and counts 
+them in configurable buckets along with a sum of all observed values.
+
+Histogram metrics ending in:
+
+- `_sum` represent the total sum of all observed values. Generally [sums](https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations)
+ are like counters but it's also possible for a negative observation which would not behave like a typical always increasing counter.
+- `_count` represent the count of events that have been observed.
+- `_bucket` represent the cumulative counters for the observation buckets. Note that buckets are only submitted if `send_histogram_buckets` is enabled.
+
+
+Subtype|Config Option|Value|Datadog Metric Submitted
+-------|-------------|-----|------------------------
+&nbsp;|`send_distribution_buckets`|`true`|The entire histogram can be submitted as a single [distribution metric][datadog-distribution-metrics]. If the option is enabled, none of the subtype metrics will be submitted.
+`_sum`|`send_distribution_sums_as_monotonic`|`false` (default)|[`gauge`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L826-L835)
+&nbsp;| &nbsp;|`true`|`monotonic_gauge`
+`_count`|`send_distribution_counts_as_monotonic`|`false` (default)|[`gauge`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L753-L763)
+&nbsp;|&nbsp;|`true`|`monotonic_count`
+`_bucket`|`non_cumulative_buckets`|`false` (default)|`gauge`
+&nbsp;|&nbsp;|`true`|`monotonic_count` under `.count` metric name if `send_distribution_counts_as_monotonic` is enabled. Otherwise, `gauge`.
+
+
 ### Summary
+Prometheus [summary metrics](https://prometheus.io/docs/concepts/metric_types/#summary) are similar to histograms but allow configurable quantiles.
+
+Summary metrics ending in:
+
+- `_sum` represent the total sum of all observed values. Generally [sums](https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations)
+ are like counters but it's also possible for a negative observation which would not behave like a typical always increasing counter.
+- `_count` represent the count of events that have been observed.
+-  metrics with labels like `{quantile="<φ>"}` represent the streaming quantiles of observed events.
+
+Subtype|Config Option|Value|Datadog Metric Submitted
+-------|-------------|-----|------------------------
+`_sum`|`send_distribution_sums_as_monotonic`|`false` (default)|[`gauge`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L826-L835)
+&nbsp;| &nbsp;|`true`|`monotonic_gauge`
+`_count`|`send_distribution_counts_as_monotonic`|`false` (default)|[`gauge`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L753-L763)
+&nbsp;|&nbsp;|`true`|`monotonic_count`
+`_quantile`|&nbsp;|&nbsp;|`gauge`

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -7,9 +7,7 @@ integrations collect metrics based on Prometheus exported data sets.
 
 Prometheus-based integrations use the OpenMetrics exposition format to collect metrics.
 
-## Openmetrics Base Check
-
-### Interface
+## Interface
 
 All functionality is exposed by the `OpenMetricsBaseCheck` and `OpenMetricsScraperMixin` classes.
 

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -21,13 +21,28 @@ All functionality is exposed by the `OpenMetricsBaseCheck` and `OpenMetricsScrap
 ::: datadog_checks.base.checks.openmetrics.OpenMetricsScraperMixin
     rendering:
       heading_level: 4
+    selection:
+      members:
         - parse_metric_family
         - scrape_metrics
         - process
-        - process_metric
         - poll
         - submit_openmetric
+        - process_metric
+        - create_scraper_configuration
 
 ### Options
+
+Some options can be set globally in `init_config` (with `instances` taking precedence).
+For complete documentation of every option, see the associated configuration templates for the
+[instances][config-spec-template-instances-openmetrics] and [init_config][config-spec-template-init-config-openmetrics] sections.
+
+Default options from the `HTTP` wrapper and `AgentCheck` are also supported.
+
+
+::: datadog_checks.base.checks.openmetrics.base_check.StandardFields
+    rendering:
+      show_root_heading: false
+      show_root_toc_entry: false
 
 ## Prometheus to Datadog metric types

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -71,7 +71,7 @@ Histogram metrics ending in:
 
 - `_sum` represent the total sum of all observed values. Generally [sums](https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations)
  are like counters but it's also possible for a negative observation which would not behave like a typical always increasing counter.
-- `_count` represent the count of events that have been observed.
+- `_count` represent the total number of events that have been observed.
 - `_bucket` represent the cumulative counters for the observation buckets. Note that buckets are only submitted if `send_histogram_buckets` is enabled.
 
 

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -5,8 +5,7 @@
 [Prometheus](https://prometheus.io) is an open-source monitoring system for timeseries metric data. Many Datadog 
 integrations collect metrics based on Prometheus exported data sets.
 
-As of [Agent `6.5.0`](https://www.datadoghq.com/blog/monitor-prometheus-metrics/), Prometheus-based integrations use 
-the OpenMetric exposition format to monitor metrics.
+Prometheus-based integrations use the OpenMetrics exposition format to collect metrics.
 
 ## Openmetrics Base Check
 

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -48,8 +48,19 @@ The Openmetrics Base Check supports various configurations for submitting Promet
 We currently support Prometheus `gauge`, `counter`, `histogram`, and `summary` metric types.
 
 ### Gauge
+A gauge metric represents a single numerical value that can arbitrarily go up or down.
+
+Prometheus gauge metrics are submitted as Datadog gauge metrics
 
 ### Counter
+
+A [Prometheus counter](https://prometheus.io/docs/concepts/metric_types/#counter) is cumulative metric that represents 
+a single monotonically increasing counter whose value can only increase or be reset to zero on restart.
+
+Config Option|Value|Datadog metric submitted
+-------------|-----|------------------------
+`send_monotonic_counter`|`true` (default)| [`monotonic_count`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L667-L668)
+`send_monotonic_counter`|`false`|[`gauge`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L671-L672)
 
 ### Histogram
 

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -28,7 +28,7 @@ All functionality is exposed by the `OpenMetricsBaseCheck` and `OpenMetricsScrap
         - process_metric
         - create_scraper_configuration
 
-### Options
+## Options
 
 Some options can be set globally in `init_config` (with `instances` taking precedence).
 For complete documentation of every option, see the associated configuration templates for the

--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -57,10 +57,10 @@ Prometheus gauge metrics are submitted as Datadog gauge metrics.
 A [Prometheus counter](https://prometheus.io/docs/concepts/metric_types/#counter) is cumulative metric that represents 
 a single monotonically increasing counter whose value can only increase or be reset to zero on restart.
 
-Config Option|Value|Datadog Metric Submitted
--------------|-----|------------------------
-`send_monotonic_counter`|`true` (default)| [`monotonic_count`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L667-L668)
-&nbsp;|`false`|[`gauge`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L671-L672)
+| Config Option | Value | Datadog Metric Submitted |
+| ------------- | ----- | ------------------------ |
+| `send_monotonic_counter` | `true` (default)| `monotonic_count` |
+| &nbsp; | `false` | `gauge` |
 
 ### Histogram
 
@@ -75,15 +75,15 @@ Histogram metrics ending in:
 - `_bucket` represent the cumulative counters for the observation buckets. Note that buckets are only submitted if `send_histogram_buckets` is enabled.
 
 
-Subtype|Config Option|Value|Datadog Metric Submitted
--------|-------------|-----|------------------------
-&nbsp;|`send_distribution_buckets`|`true`|The entire histogram can be submitted as a single [distribution metric][datadog-distribution-metrics]. If the option is enabled, none of the subtype metrics will be submitted.
-`_sum`|`send_distribution_sums_as_monotonic`|`false` (default)|[`gauge`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L826-L835)
-&nbsp;| &nbsp;|`true`|`monotonic_gauge`
-`_count`|`send_distribution_counts_as_monotonic`|`false` (default)|[`gauge`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L753-L763)
-&nbsp;|&nbsp;|`true`|`monotonic_count`
-`_bucket`|`non_cumulative_buckets`|`false` (default)|`gauge`
-&nbsp;|&nbsp;|`true`|`monotonic_count` under `.count` metric name if `send_distribution_counts_as_monotonic` is enabled. Otherwise, `gauge`.
+| Subtype | Config Option | Value | Datadog Metric Submitted |
+| ------- | ------------- | ----- | ------------------------ |
+| &nbsp; | `send_distribution_buckets` | `true` | The entire histogram can be submitted as a single [distribution metric][datadog-distribution-metrics]. If the option is enabled, none of the subtype metrics will be submitted.
+| `_sum` | `send_distribution_sums_as_monotonic` | `false` (default) | `gauge` |
+| &nbsp; | &nbsp; | `true` | `monotonic_gauge` |
+| `_count` | `send_distribution_counts_as_monotonic` | `false` (default) | `gauge` |
+| &nbsp; | &nbsp; | `true` | `monotonic_count` |
+| `_bucket` | `non_cumulative_buckets` | `false` (default) | `gauge` |
+| &nbsp; | &nbsp; | `true` | `monotonic_count` under `.count` metric name if `send_distribution_counts_as_monotonic` is enabled. Otherwise, `gauge`. |
 
 
 ### Summary
@@ -96,10 +96,10 @@ Summary metrics ending in:
 - `_count` represent the total number of events that have been observed.
 -  metrics with labels like `{quantile="<φ>"}` represent the streaming quantiles of observed events.
 
-Subtype|Config Option|Value|Datadog Metric Submitted
--------|-------------|-----|------------------------
-`_sum`|`send_distribution_sums_as_monotonic`|`false` (default)|[`gauge`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L826-L835)
-&nbsp;| &nbsp;|`true`|`monotonic_gauge`
-`_count`|`send_distribution_counts_as_monotonic`|`false` (default)|[`gauge`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L753-L763)
-&nbsp;|&nbsp;|`true`|`monotonic_count`
-`_quantile`|&nbsp;|&nbsp;|`gauge`
+| Subtype | Config Option | Value | Datadog Metric Submitted |
+| ------- | ------------- | ----- | ------------------------ |
+| `_sum` | `send_distribution_sums_as_monotonic` | `false` (default) |`gauge` |
+| &nbsp; | &nbsp; | `true` | `monotonic_gauge` |
+| `_count` | `send_distribution_counts_as_monotonic` | `false` (default) | `gauge` |
+| &nbsp; | &nbsp; | `true` | `monotonic_count` |
+| `_quantile` | &nbsp; | &nbsp; | `gauge` |


### PR DESCRIPTION
use mkdocs to render documentation for `openmetricsBaseClass` and scraper mixin.

https://datadoghq.dev/integrations-core/base/prometheus/

<img width="1079" alt="Screen Shot 2020-05-16 at 11 17 08 PM" src="https://user-images.githubusercontent.com/15065007/82134947-65c84380-97cb-11ea-9f18-8edb9853f0fa.png">
