### PR TITLE
Improving SNMP Profiles for PA, F5, Cisco, Infoblox devices

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/_base.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_base.yaml
@@ -1,5 +1,4 @@
 # Base profile that should only contain any items we want to provide for all profiles.
-
 metric_tags:
   - MIB: SNMPv2-MIB
     symbol: sysName

--- a/snmp/datadog_checks/snmp/data/profiles/_base_cisco.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_base_cisco.yaml
@@ -22,6 +22,11 @@ metrics:
     metric_tags:
       - index: 1
         tag: fru
+      - tag: entPhysicalDescr
+        OID: 1.3.6.1.2.1.47.1.1.1.1.2
+        column: entPhysicalDescr
+        table: entPhysicalTable
+        MIB: ENTITY-MIB
   - MIB: CISCO-PROCESS-MIB
     table:
       OID: 1.3.6.1.4.1.9.9.109.1.1.1

--- a/snmp/datadog_checks/snmp/data/profiles/_generic-host-resources.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-host-resources.yaml
@@ -20,25 +20,45 @@ metrics:
   # Storage Devices
   #
   - MIB: HOST-RESOURCES-MIB
-    table: hrStorageTable
+    table:
+      OID: 1.3.6.1.2.1.25.2.3
+      name: hrStorageTable
     symbols:
-      - hrStorageAllocationUnits
-      - hrStorageSize
-      - hrStorageUsed
-      - hrStorageAllocationFailures
+      - OID: 1.3.6.1.2.1.25.2.3.1.4
+        name: hrStorageAllocationUnits
+      - OID: 1.3.6.1.2.1.25.2.3.1.5
+        name: hrStorageSize
+      - OID: 1.3.6.1.2.1.25.2.3.1.6
+        name: hrStorageUsed
+      - OID: 1.3.6.1.2.1.25.2.3.1.7
+        name: hrStorageAllocationFailures
     metric_tags:
-      - tag: storagedesc
-        column: hrStorageDescr
-      - tag: storagetype
-        column: hrStorageType
+    - column:
+        OID: 1.3.6.1.2.1.25.2.3.1.3
+        name: hrStorageDescr
+        table: hrStorageTable
+      tag: hrStorageDescr
+    - column:
+        OID: 1.3.6.1.2.1.25.2.3.1.2
+        name: hrStorageType
+        table: hrStorageTable
+      tag: hrStorageType
 
   #
   # Processor Load
   #
   - MIB: HOST-RESOURCES-MIB
-    table: hrProcessorTable
+    table:
+      OID: 1.3.6.1.2.1.25.3.3
+      name: hrProcessorTable
     symbols:
-      - hrProcessorLoad
+      - OID: 1.3.6.1.2.1.25.3.3.1.2
+        name: hrProcessorLoad
     metric_tags:
       - tag: processorid
         column: hrProcessorFrwID
+      - column:
+          OID: 1.3.6.1.2.1.25.3.2.1.3
+          name: hrDeviceDescr
+          table: hrDeviceTable
+        tag: hrDevice

--- a/snmp/datadog_checks/snmp/data/profiles/_generic-router-if-32bit.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-router-if-32bit.yaml
@@ -1,0 +1,38 @@
+# Generic network interfaces metrics for routers that respond to 32 bit metric
+
+#TCP stats
+extends:
+  - _generic-router-if.yaml
+
+metrics:
+- MIB: IF-MIB
+  table:
+    OID: 1.3.6.1.2.1.2.2
+    name: ifTable
+  forced_type: monotonic_count
+  symbols:
+  - OID: 1.3.6.1.2.1.2.2.1.16
+    name: ifOutOctets
+  - OID: 1.3.6.1.2.1.2.2.1.10
+    name: ifInOctets
+  metric_tags:
+  - column:
+      OID: 1.3.6.1.2.1.31.1.1.1.1
+      name: ifName
+      table: ifXTable
+    tag: interface
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.2
+      name: ifDescr
+      table: ifTable
+    tag: ifDescr
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.6
+      name: ifPhysAddress
+      table: ifTable
+    tag: ifPhysAddress
+  - column:
+      OID: 1.3.6.1.2.1.31.1.1.1.18
+      name: ifAlias
+      table: ifXTable
+    tag: ifAlias

--- a/snmp/datadog_checks/snmp/data/profiles/_generic-router-if.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-router-if.yaml
@@ -1,5 +1,6 @@
 # Generic network interfaces metrics for routers.
-#
+
+#TCP stats
 metrics:
 - MIB: IF-MIB
   table:
@@ -21,6 +22,22 @@ metrics:
       name: ifName
       table: ifXTable
     tag: interface
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.2
+      name: ifDescr
+      table: ifTable
+    tag: ifDescr
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.6
+      name: ifPhysAddress
+      table: ifTable
+    tag: ifPhysAddress
+  - column:
+      OID: 1.3.6.1.2.1.31.1.1.1.18
+      name: ifAlias
+      table: ifXTable
+    tag: ifAlias
+
 - MIB: IF-MIB
   table:
     OID: 1.3.6.1.2.1.2.2
@@ -38,6 +55,22 @@ metrics:
       name: ifName
       table: ifXTable
     tag: interface
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.2
+      name: ifDescr
+      table: ifTable
+    tag: ifDescr
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.6
+      name: ifPhysAddress
+      table: ifTable
+    tag: ifPhysAddress
+  - column:
+      OID: 1.3.6.1.2.1.31.1.1.1.18
+      name: ifAlias
+      table: ifXTable
+    tag: ifAlias
+
 - MIB: IF-MIB
   table:
     OID: 1.3.6.1.2.1.31.1.1
@@ -60,7 +93,24 @@ metrics:
   - column:
       OID: 1.3.6.1.2.1.31.1.1.1.1
       name: ifName
+      table: ifXTable
     tag: interface
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.2
+      name: ifDescr
+      table: ifTable
+    tag: ifDescr
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.6
+      name: ifPhysAddress
+      table: ifTable
+    tag: ifPhysAddress
+  - column:
+      OID: 1.3.6.1.2.1.31.1.1.1.18
+      name: ifAlias
+      table: ifXTable
+    tag: ifAlias
+
 - MIB: IF-MIB
   table:
     OID: 1.3.6.1.2.1.31.1.1
@@ -75,7 +125,24 @@ metrics:
   - column:
       OID: 1.3.6.1.2.1.31.1.1.1.1
       name: ifName
+      table: ifXTable
     tag: interface
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.2
+      name: ifDescr
+      table: ifTable
+    tag: ifDescr
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.6
+      name: ifPhysAddress
+      table: ifTable
+    tag: ifPhysAddress
+  - column:
+      OID: 1.3.6.1.2.1.31.1.1.1.18
+      name: ifAlias
+      table: ifXTable
+    tag: ifAlias
+
 - MIB: IF-MIB
   table:
     OID: 1.3.6.1.2.1.31.1.1
@@ -87,4 +154,20 @@ metrics:
   - column:
       OID: 1.3.6.1.2.1.31.1.1.1.1
       name: ifName
+      table: ifXTable
     tag: interface
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.2
+      name: ifDescr
+      table: ifTable
+    tag: ifDescr
+  - column:
+      OID: 1.3.6.1.2.1.2.2.1.6
+      name: ifPhysAddress
+      table: ifTable
+    tag: ifPhysAddress
+  - column:
+      OID: 1.3.6.1.2.1.31.1.1.1.18
+      name: ifAlias
+      table: ifXTable
+    tag: ifAlias

--- a/snmp/datadog_checks/snmp/data/profiles/_generic-sensor-stats.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-sensor-stats.yaml
@@ -1,0 +1,22 @@
+metrics:
+    #Temperature & Fan Stats
+  - MIB: ENTITY-SENSOR-MIB
+    table:
+      OID: 1.3.6.1.2.1.99.1.1
+      name: entPhySensorTable
+    symbols:
+      - OID: 1.3.6.1.2.1.99.1.1.1.4
+        name: entPhySensorValue
+      - OID: 1.3.6.1.2.1.99.1.1.1.5
+        name: entPhySensorOperStatus
+    metric_tags:
+      - tag: entPhySensorUnitsDisplay
+        OID: 1.3.6.1.2.1.99.1.1.1.6
+        column: entPhySensorUnitsDisplay
+        table: entPhySensorTable
+        MIB: ENTITY-SENSOR-MIB
+      - tag: entPhysicalDescr
+        OID: 1.3.6.1.2.1.47.1.1.1.1.2
+        column: entPhysicalDescr
+        table: entPhysicalTable
+        MIB: ENTITY-MIB

--- a/snmp/datadog_checks/snmp/data/profiles/cisco-3850.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/cisco-3850.yaml
@@ -20,6 +20,17 @@ metrics:
         tag: sensor_type
       - index: 1
         tag: sensor_id
+      - tag: entPhySensorUnitsDisplay
+        OID: 1.3.6.1.2.1.99.1.1.1.6
+        column: entPhySensorUnitsDisplay
+        table: entPhySensorTable
+        MIB: ENTITY-SENSOR-MIB
+      - tag: entPhysicalDescr
+        OID: 1.3.6.1.2.1.47.1.1.1.1.2
+        column: entPhysicalDescr
+        table: entPhysicalTable
+        MIB: ENTITY-MIB
+
   - MIB: CISCO-IF-EXTENSION-MIB
     table:
       OID: 1.3.6.1.4.1.9.9.276.1.1.1

--- a/snmp/datadog_checks/snmp/data/profiles/cisco-asa-5525.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/cisco-asa-5525.yaml
@@ -70,3 +70,85 @@ metrics:
         tag: sensor_type
       - index: 1
         tag: sensor_id
+
+    # SVC Sessions
+  - MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.9.9.392.1.3.35
+      name: crasSVCNumSessions
+
+    # ASA VPN Tunnel stats
+  - MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+    table:
+      OID: 1.3.6.1.4.1.9.9.171.1.2.3
+      name: cikeTunnelTable
+    symbols:
+      - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.16
+        name: cikeTunActiveTime
+      - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.19
+        name: cikeTunInOctets
+      - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.27
+        name: cikeTunOutOctets
+    metric_tags:
+      - tag: vpn_tunnel_hexip
+        OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.8
+        column: cikeTunRemoteAddr
+        table: cikeTunnelTable
+        MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+      - tag: vpn_tunnel_ip
+        OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.7
+        column: cikeTunRemoteValue
+        table: cikeTunnelTable
+        MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+
+  - MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+    table:
+      OID: 1.3.6.1.4.1.9.9.171.1.3.2
+      name: cipSecTunnelTable
+    symbols:
+      - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.2
+        name: cipSecTunIkeTunnelIndex
+      - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.3
+        name: cipSecTunIkeTunnelAlive
+      - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.26
+        name: cipSecTunInOctets
+      - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.39
+        name: cipSecTunOutOctets
+    metric_tags:
+      - tag: vpn_tunnel_hexip
+        OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.5
+        column: cipSecTunRemoteAddr
+        table: cipSecTunnelTable
+        MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+
+  # Cluster status
+  - MIB: CISCO-FIREWALL-MIB
+    table:
+      OID: 1.3.6.1.4.1.9.9.147.1.2.1.1
+      name: cfwHardwareStatusTable
+    symbol:
+      OID: 1.3.6.1.4.1.9.9.147.1.2.1.1.1.3
+      name: cfwHardwareStatusValue
+    metric_tags:
+      - tag: cfwHardwareInformation
+        OID: 1.3.6.1.4.1.9.9.147.1.2.1.1.1.2
+        column: cfwHardwareInformation
+        table: cfwHardwareStatusTable
+        MIB: CISCO-FIREWALL-MIB
+
+  # Connection stats
+  - MIB: CISCO-FIREWALL-MIB
+    table:
+      OID: 1.3.6.1.4.1.9.9.147.1.2.2.2
+      name: cfwConnectionStatTable
+    symbols:
+      - OID: 1.3.6.1.4.1.9.9.147.1.2.2.2.1.5
+        name: cfwConnectionStatValue
+      - OID: 1.3.6.1.4.1.9.9.147.1.2.2.2.1.4
+        name: cfwConnectionStatCount
+    metric_tags:
+      - tag: cfwConnectionStatDescription
+        OID: 1.3.6.1.4.1.9.9.147.1.2.2.2.1.3
+        column: cfwConnectionStatDescription
+        table: cfwConnectionStatTable
+        MIB: CISCO-FIREWALL-MIB

--- a/snmp/datadog_checks/snmp/data/profiles/cisco-nexus.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/cisco-nexus.yaml
@@ -14,9 +14,20 @@ metrics:
       - OID: 1.3.6.1.4.1.9.9.91.1.1.1.1.4
         name: entSensorValue
     metric_tags:
+      - index: 1
+        tag: sensor_id
       - column:
           OID: 1.3.6.1.4.1.9.9.91.1.1.1.1.1
           name: entSensorType
         tag: sensor_type
-      - index: 1
-        tag: sensor_id
+      - tag: entPhysicalDescr
+        OID: 1.3.6.1.2.1.47.1.1.1.1.2
+        column: entPhysicalDescr
+        table: entPhysicalTable
+        MIB: ENTITY-MIB
+
+  # Supervisor Memory utilisation
+  - MIB: CISCO-SYSTEM-EXT-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.9.9.305.1.1.2
+      name: cseSysMemoryUtilization

--- a/snmp/datadog_checks/snmp/data/profiles/data-domain.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/data-domain.yaml
@@ -1,0 +1,167 @@
+# Default profile for Dell EMC Data Domain device
+
+extends:
+  - _generic_router_if.yaml
+
+sysobjectid: 1.3.6.1.4.1.19746.*
+
+metrics:
+    # Filesystem stats
+  - MIB: DATA-DOMAIN-MIB
+    table:
+      OID: 1.3.6.1.4.1.19746.1.3.2.1
+      name: fileSystemSpaceTable
+    symbols:
+      - OID: 1.3.6.1.4.1.19746.1.3.2.1.1.7
+        name: fileSystemPercentUsed
+      - OID: 1.3.6.1.4.1.19746.1.3.2.1.1.1
+        name: fileSystemResourceIndex
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.3.2.1.1.3
+          name: fileSystemResourceName
+          table: fileSystemSpaceTable
+        tag: fileSystemResourceName
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.3.2.1.1.4
+          name: fileSystemSpaceSize
+          table: fileSystemSpaceTable
+        tag: fileSystemSpaceSize
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.3.2.1.1.5
+          name: fileSystemSpaceUsed
+          table: fileSystemSpaceTable
+        tag: fileSystemSpaceUsed
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.3.2.1.1.6
+          name: fileSystemSpaceAvail
+          table: fileSystemSpaceTable
+        tag: fileSystemSpaceAvail
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.3.2.1.1.9
+          name: fileSystemResourceTier
+          table: fileSystemSpaceTable
+        tag: fileSystemResourceTier
+
+  # Fan stats
+  # fanStatus: notfound(0), ok(1), fail(2)
+  # fanLevel: unknown(0), low(1), medium(2), high(3)
+  - MIB: DATA-DOMAIN-MIB
+    table:
+      OID: 1.3.6.1.4.1.19746.1.1.3.1.1
+      name: fanPropertiesTable
+    symbols:
+      - OID: 1.3.6.1.4.1.19746.1.1.3.1.1.1.5
+        name: fanLevel
+      - OID: 1.3.6.1.4.1.19746.1.1.3.1.1.1.6
+        name: fanStatus
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.1.3.1.1.1.4
+          name: fanDescription
+          table: fanPropertiesTable
+        tag: fanDescription
+
+    # Power module stats
+    # powerModuleStatus: absent(0), ok(1), failed(2), faulty(3), acnone(4), unknown(99)
+  - MIB: DATA-DOMAIN-MIB
+    table:
+      OID: 1.3.6.1.4.1.19746.1.1.1.1.1
+      name: powerModuleTable
+    symbols:
+      - OID: 1.3.6.1.4.1.19746.1.1.1.1.1.1.4
+        name: powerModuleStatus
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.1.1.1.1.1.3
+          name: powerModuleDescription
+          table: powerModuleTable
+        tag: powerModuleDescription
+
+    # Temperature sensor stats
+    # tempSensorStatus: failed(0), ok(1), notfound(2), overheatWarning(3), overheatCritical(4)
+  - MIB: DATA-DOMAIN-MIB
+    table:
+      OID: 1.3.6.1.4.1.19746.1.1.2.1.1
+      name: temperatureSensorTable
+    symbols:
+      - OID: 1.3.6.1.4.1.19746.1.1.2.1.1.1.5
+        name: tempSensorCurrentValue
+      - OID: 1.3.6.1.4.1.19746.1.1.2.1.1.1.6
+        name: tempSensorStatus
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.1.2.1.1.1.4
+          name: tempSensorDescription
+          table: temperatureSensorTable
+        tag: tempSensorDescription
+
+    # Disk stats
+    # diskPerfState: ok(1), unknown(2), absent(3), failed(4), spare(5), available(6)
+  - MIB: DATA-DOMAIN-MIB
+    table:
+      OID: 1.3.6.1.4.1.19746.1.6.2.1
+      name: diskPerformanceTable
+    symbols:
+      - OID: 1.3.6.1.4.1.19746.1.6.2.1.1.6
+        name: diskBusy
+      - OID: 1.3.6.1.4.1.19746.1.6.2.1.1.7
+        name: diskPerfState
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.6.1.1.1.4
+          name: diskModel
+          table: diskPropertiesTable
+        tag: diskModel
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.6.1.1.1.5
+          name: diskFirmwareVersion
+          table: diskPropertiesTable
+        tag: diskFirmwareVersion
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.6.1.1.1.6
+          name: diskSerialNumber
+          table: diskPropertiesTable
+        tag: diskSerialNumber
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.6.1.1.1.7
+          name: diskCapacity
+          table: diskPropertiesTable
+        tag: diskCapacity
+
+    # Battery stats
+    # nvramBatteryStatus: ok(0), disabled(1), discharged(2), softdisabled(3)
+  - MIB: DATA-DOMAIN-MIB
+    table:
+      OID: 1.3.6.1.4.1.19746.1.2.3.1
+      name: nvramBatteryTable
+    symbols:
+      - OID: 1.3.6.1.4.1.19746.1.2.3.1.1.3
+        name: nvramBatteryStatus
+      - OID: 1.3.6.1.4.1.19746.1.2.3.1.1.4
+        name: nvramBatteryCharge
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.2.3.1.1.1
+          name: nvramBatteriesIndex
+          table: nvramBatteryTable
+        tag: nvramBatteryCardIndex
+      - column:
+          OID: 1.3.6.1.4.1.19746.1.2.3.1.1.2
+          name: nvramBatteryIndex
+          table: nvramBatteryTable
+        tag: nvramBatteryIndex
+
+  - MIB: HOST-RESOURCES-MIB
+    table:
+      OID: 1.3.6.1.2.1.25.3.3
+      name: hrProcessorTable
+    symbols:
+      - OID: 1.3.6.1.2.1.25.3.3.1.2
+        name: hrProcessorLoad
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.2.1.25.3.2.1.3
+          name: hrDeviceDescr
+          table: hrDeviceTable
+        tag: hrDevice

--- a/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
@@ -492,3 +492,39 @@ metrics:
         column:
           OID: 1.3.6.1.4.1.3375.2.2.5.4.3.1.28
           name: ltmPoolMemberStatNodeName
+
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.3
+      name: memTotalSwap
+
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.4
+      name: memAvailSwap
+
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.5
+      name: memTotalReal
+
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.6
+      name: memAvailReal
+
+  - MIB: UCD-SNMP-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.2021.4.11
+      name: memTotalFree
+
+    # Connection stats
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.8
+      name: sysStatClientCurConns
+
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.9.2
+      name: sysClientsslStatCurConns

--- a/snmp/datadog_checks/snmp/data/profiles/f5-guest.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5-guest.yaml
@@ -1,0 +1,21 @@
+# Generic Profile for f5 Guest devices
+extends:
+  - _base.yaml
+  - _generic-router-if.yaml
+  - _generic-host-resources.yaml
+  - _generic-sensor-stats.yaml
+  - f5-host.yaml
+
+sysobjectid: 1.3.6.1.4.1.3375.2.1.13.*
+
+metrics:
+  # Sync status of the cluster
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.3375.2.1.14.1.1 
+      name: sysCmSyncStatusId 
+    metric_tags:
+      - MIB: F5-BIGIP-SYSTEM-MIB
+        column:
+          OID: 1.3.6.1.4.1.3375.2.1.14.1.2
+          name: sysCmSyncStatusStatus

--- a/snmp/datadog_checks/snmp/data/profiles/f5-host.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5-host.yaml
@@ -1,0 +1,20 @@
+# Generic Profile for f5 Host
+extends:
+  - _base.yaml
+  - _generic-router-if.yaml
+  - _generic-host-resources.yaml
+  - _generic-sensor-stats.yaml
+  - f5-big-ip.yaml
+
+sysobjectid: 1.3.6.1.4.1.3375.2.1.*
+
+metrics:
+  # Sync status of the cluster
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    symbol:
+      OID: 1.3.6.1.4.1.3375.2.1.14.3.1
+      name: sysCmFailoverStatusId
+    metric_tags:
+      - tag: sysCmFailoverStatusStatus
+        column: sysCmFailoverStatusStatus
+        OID: 1.3.6.1.4.1.3375.2.1.14.3.2

--- a/snmp/datadog_checks/snmp/data/profiles/f5.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5.yaml
@@ -1,0 +1,77 @@
+# Generic Profile for F5 devices, Host and Guest F5 does not Hardware stats
+extends:
+  - _base.yaml
+  - _generic-router-if.yaml
+  - _generic-host-resources.yaml
+  - f5-guest.yaml
+
+sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*
+
+metrics:
+    # Device Hardware stats
+
+    # Fan stats
+    # sysChassisFanStatus: bad(0), good(1), notpresent(2)
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    table:
+      OID: 1.3.6.1.4.1.3375.2.1.3.2.1.2
+      name: sysChassisFanTable
+    symbols:
+      - OID: 1.3.6.1.4.1.3375.2.1.3.2.1.2.1.3
+        name: sysChassisFanSpeed
+      - OID: 1.3.6.1.4.1.3375.2.1.3.2.1.2.1.2
+        name: sysChassisFanStatus
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.3375.2.1.3.2.1.2.1.1
+          name: sysChassisFanIndex
+          table: sysChassisFanTable
+        tag: sysChassisFanIndex
+
+    # Chassis Temperature stats
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    table:
+      OID: 1.3.6.1.4.1.3375.2.1.3.2.3.2
+      name: sysChassisTempTable
+    symbols:
+      - OID: 1.3.6.1.4.1.3375.2.1.3.2.3.2.1.2
+        name: sysChassisTempTemperature
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.3375.2.1.3.2.3.2.1.1
+          name: sysChassisTempIndex
+          table: sysChassisTempTemperature
+        tag: sysChassisTempIndex
+
+    # CPU Sensor stats
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    table:
+      OID: 1.3.6.1.4.1.3375.2.1.3.6.2
+      name: sysCpuSensorTable
+    symbols:
+      - OID: 1.3.6.1.4.1.3375.2.1.3.6.2.1.2
+        name: sysCpuSensorTemperature
+      - OID: 1.3.6.1.4.1.3375.2.1.3.6.2.1.3
+        name: sysCpuSensorFanSpeed
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.3375.2.1.3.6.2.1.4
+          name: sysCpuSensorName
+          table: sysCpuSensorTable
+        tag: sysCpuSensorName
+
+    # Chassus PSU Stats
+    # sysChassisPowerSupplyStatus: bad(0), good(1), notpresent(2)
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    table:
+      OID: 1.3.6.1.4.1.3375.2.1.3.2.2.2
+      name: sysChassisPowerSupplyTable
+    symbols:
+      - OID: 1.3.6.1.4.1.3375.2.1.3.2.2.2.1.2
+        name: sysChassisPowerSupplyStatus
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.3375.2.1.3.2.2.2.1.1
+          name: sysChassisPowerSupplyIndex
+          table: sysChassisPowerSupplyTable
+        tag: sysChassisPowerSupplyIndex

--- a/snmp/datadog_checks/snmp/data/profiles/hitachi.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/hitachi.yaml
@@ -1,0 +1,59 @@
+# Profile for Hitachi devices
+
+sysobjectid: 1.3.6.1.4.1.116.*
+
+metrics:
+  - MIB: HDS9900MIB
+    table:
+      OID: 1.3.6.1.4.1.116.5.11.4.1.1.6
+      name: raidExMibDKCHWTable
+    symbols:
+      - OID: 1.3.6.1.4.1.116.5.11.4.1.1.6.1.2
+        name: Hitachi DKC Processor
+      - OID: 1.3.6.1.4.1.116.5.11.4.1.1.6.1.3
+        name: Hitachi DKC Internal Bus
+      - OID: 1.3.6.1.4.1.116.5.11.4.1.1.6.1.4
+        name: Hitachi DKC Cache
+      - OID: 1.3.6.1.4.1.116.5.11.4.1.1.6.1.5
+        name: Hitachi DKC Shared Memory
+      - OID: 1.3.6.1.4.1.116.5.11.4.1.1.6.1.6
+        name: Hitachi DKC Power Supply
+      - OID: 1.3.6.1.4.1.116.5.11.4.1.1.6.1.7
+        name: Hitachi DKC Battery
+      - OID: 1.3.6.1.4.1.116.5.11.4.1.1.6.1.8
+        name: Hitachi DKC Fan
+      - OID: 1.3.6.1.4.1.116.5.11.4.1.1.6.1.9
+        name: Hitachi DKC Environment
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.116.5.11.4.1.1.6.1.1
+          name: dkcRaidListIndexSerialNumber
+          table: raidExMibDKCHWTable
+        tag: DKC serial number
+
+  - MIB: HDS9900MIB
+    table:
+      OID: 1.3.6.1.4.1.116.5.11.4.1.1.7
+      name: raidExMibDKUHWTable
+    symbols:
+      - OID: 1.3.6.1.4.1.116.5.11.4.1.1.7.1.2
+        name: Hitachi DKU Power Supply
+      - OID: 1.3.6.1.4.1.116.5.11.4.1.1.7.1.3
+        name: Hitachi DKU Fan
+      - OID: 1.3.6.1.4.1.116.5.11.4.1.1.7.1.4
+        name: Hitachi DKU Environment
+      - OID: 1.3.6.1.4.1.116.5.11.4.1.1.7.1.5
+        name: Hitachi DKU Drive
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.116.5.11.4.1.1.7.1.1
+          name: dkuRaidListIndexSerialNumber
+          table: raidExMibDKUHWTable
+        tag: DKU serial number
+
+# The status of each component is a single digit which shows the following:
+# 1: Normal.
+# 2: Acute failure detected.
+# 3: Serious failure detected.
+# 4: Moderate failure detected.
+# 5: Service failure detected.

--- a/snmp/datadog_checks/snmp/data/profiles/infoblox.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/infoblox.yaml
@@ -1,0 +1,5 @@
+# Generic Profile for Infoblox devices
+extends:
+  - _base.yaml
+  - _generic-router-if.yaml
+  - _generic-host-resources.yaml

--- a/snmp/datadog_checks/snmp/data/profiles/palo-alto.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/palo-alto.yaml
@@ -8,6 +8,7 @@ extends:
   - _generic-router-if.yaml
   - _generic-host-resources.yaml
   - _generic-router-ospf.yaml
+  - _generic-sensor-stats.yaml
 
 sysobjectid: 1.3.6.1.4.1.25461.*
 
@@ -94,5 +95,5 @@ metrics:
         column:
           OID: 1.3.6.1.2.1.47.1.1.1.1.2
           name: entPhysicalDescr
-        table: entPhysicalTable
+          table: entPhysicalTable
         tag: ent_descr


### PR DESCRIPTION
### What does this PR do?

- Adds cluster status, Hardware & Connection stats for generic F5 profile.
- ASA Connection tunnel, SVC sessions and cluster status stats.
- Supervisor memory stats for Cisco Nexus devices
- Improves overall tagging of Interface and hardware stats with descriptive names instead of IDs.

### Motivation
Default profiles were missing some important OIDs.

### Additional Notes
Proper tagging with descriptive names will help customer identify the issues quickly.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
