### PR TITLE
Better error output when CheckCommandOutput fails

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/conditions.py
+++ b/datadog_checks_dev/datadog_checks/dev/conditions.py
@@ -132,7 +132,7 @@ class CheckCommandOutput(LazyFunction):
 
             time.sleep(self.wait)
         else:
-            patterns = '\t- '.join([''] + self.patterns)
+            patterns = '\t- '.join([''] + [str(p) for p in self.patterns])
             raise RetryError(
                 u'Command: {}\nTarget patterns:\n{}\nExit code: {}\nCaptured Output: {}'.format(self.command, patterns, exit_code, log_output)
             )

--- a/datadog_checks_dev/datadog_checks/dev/conditions.py
+++ b/datadog_checks_dev/datadog_checks/dev/conditions.py
@@ -132,7 +132,7 @@ class CheckCommandOutput(LazyFunction):
 
             time.sleep(self.wait)
         else:
-            patterns = '\t-'.join([''] + self.patterns)
+            patterns = '\t- '.join([''] + self.patterns)
             raise RetryError(
                 u'Command: {}\nTarget patterns:\n{}\nExit code: {}\nCaptured Output: {}'.format(self.command, patterns, exit_code, log_output)
             )

--- a/datadog_checks_dev/datadog_checks/dev/conditions.py
+++ b/datadog_checks_dev/datadog_checks/dev/conditions.py
@@ -132,8 +132,9 @@ class CheckCommandOutput(LazyFunction):
 
             time.sleep(self.wait)
         else:
+            patterns = '\t-'.join([''] + self.patterns)
             raise RetryError(
-                u'Command: {}\n' u'Exit code: {}\n' u'Captured Output: {}'.format(self.command, exit_code, log_output)
+                u'Command: {}\nTarget patterns:\n{}\nExit code: {}\nCaptured Output: {}'.format(self.command, patterns, exit_code, log_output)
             )
 
 

--- a/datadog_checks_dev/datadog_checks/dev/conditions.py
+++ b/datadog_checks_dev/datadog_checks/dev/conditions.py
@@ -134,7 +134,10 @@ class CheckCommandOutput(LazyFunction):
         else:
             patterns = '\t- '.join([''] + [str(p) for p in self.patterns])
             raise RetryError(
-                u'Command: {}\nTarget patterns:\n{}\nExit code: {}\nCaptured Output: {}'.format(self.command, patterns, exit_code, log_output)
+                u'Command: {}\nFailed to match `{}` of following patterns:\n{}\n'
+                u'Exit code: {}\nCaptured Output: {}'.format(
+                    self.command, self.matches, patterns, exit_code, log_output
+                )
             )
 
 


### PR DESCRIPTION
### Before

```
>           raise RetryError(
                u'Command: {}\n' u'Exit code: {}\n' u'Captured Output: {}'.format(self.command, exit_code, log_output)
            )
E           datadog_checks.dev.errors.RetryError: Command: ['docker-compose', '-f', '/Users/alexandre.yang/repos/alexyang/workspaces/integrations-core-ws/integrations-core/ceph/tests/compose/docker-compose.yaml', 'logs']
E           Exit code: 0
E           Captured Output: Attaching to dd-test-ceph
E           dd-test-ceph    | 2020-05-18 13:46:58  /entrypoint.sh: VERBOSE: activating bash debugging mode.
E           dd-test-ceph    | 2020-05-18 13:46:58  /entrypoint.sh: To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:
E           dd-test-ceph    | 2020-05-18 13:46:58  /entrypoint.sh: -e CEPH_ARGS='--debug-ms 1 --debug-osd 10'
```

### After
```
>           raise RetryError(
                u'Command: {}\nTarget patterns:\n{}\nExit code: {}\nCaptured Output: {}'.format(self.command, patterns, exit_code, log_output)
            )
E           datadog_checks.dev.errors.RetryError: Command: ['docker-compose', '-f', '/Users/alexandre.yang/repos/alexyang/workspaces/integrations-core-ws/integrations-core/ceph/tests/compose/docker-compose.yaml', 'logs']
E           Target patterns:
E           	- re.compile('Cluster is now healthy', re.MULTILINE)
E           Exit code: 0
E           Captured Output: Attaching to dd-test-ceph
E           dd-test-ceph    | 2020-05-18 14:03:36  /entrypoint.sh: VERBOSE: activating bash debugging mode.
E           dd-test-ceph    | 2020-05-18 14:03:36  /entrypoint.sh: To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:
E           dd-test-ceph    | 2020-05-18 14:03:36  /entrypoint.sh: -e CEPH_ARGS='--debug-ms 1 --debug-osd 10'
E           dd-test-ceph    | 2020-05-18 14:03:36  /entrypoint.sh: This container environement variables are: CEPH_DEMO_UID=demo
```