### PR TITLE
Sync JMX template example config

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
@@ -12,6 +12,26 @@ init_config:
     #
     collect_default_metrics: true
 
+    ## @param service_check_prefix - string - optional
+    ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.
+    ## If not set, the default service check used is the integration name.
+    #
+    # service_check_prefix: <SERVICE_CHECK_PREFIX>
+
+    ## @param conf - list of mappings - optional
+    ## The list of metrics to be collected by the integration
+    ## Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it
+    ## The default metrics to be collected are kept in metrics.yaml, but you can still
+    ## add your own metrics here.
+    #
+    # conf:
+    #   - include:
+    #       bean: <BEAN_NAME>
+    #       attribute:
+    #         MyAttribute:
+    #           alias: my.metric.name
+    #           metric_type: gauge
+
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
     ##
@@ -23,7 +43,96 @@ init_config:
 #
 instances:
 
-  -
+    ## @param host - string - required
+    ## JMX hostname to connect to.
+    #
+  - host: <HOST>
+
+    ## @param port - integer - required
+    ## JMX port to connect to.
+    #
+    port: <PORT>
+
+    ## @param user - string - optional
+    ## User to use when connecting to JMX.
+    #
+    # user: <USER>
+
+    ## @param password - string - optional
+    ## Password to use when connecting to JMX.
+    #
+    # password: <PASSWORD>
+
+    ## @param process_name_regex - string - optional
+    ## Instead of using a host and port, the Agent can connect using the attach API.
+    ## This requires the JDK to be installed and the path to tools.jar to be set below.
+    ## Note: It needs to be set when process_name_regex parameter is set
+    ## e.g. .*process_name.*
+    #
+    # process_name_regex: <PROCESS_NAME_REGEX>
+
+    ## @param tools_jar_path - string - optional
+    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
+    #
+    # tools_jar_path: <TOOLS_JAR_PATH>
+
+    ## @param name - string - optional
+    ## Set the instance name to be used as the `instance` tag.
+    #
+    # name: <NAME>
+
+    ## @param java_bin_path - string - optional
+    ## `java_bin_path` should be set if the Agent cannot find your java executable.
+    #
+    # java_bin_path: <JAVA_BIN_PATH>
+
+    ## @param java_options - string - optional
+    ## A list of Java JVM options, for example: "-Xmx200m -Xms50m".
+    #
+    # java_options: <JAVA_OPTIONS>
+
+    ## @param trust_store_path - string - optional
+    ## The path to your trusted store.
+    ## `trust_store_path` should be set if SSL is enabled.
+    #
+    # trust_store_path: <TRUST_STORE_PATH>
+
+    ## @param trust_store_password - string - optional
+    ## The password for your TrustStore.jks file.
+    ## `trust_store_password` should be set if SSL is enabled.
+    #
+    # trust_store_password: <TRUST_STORE_PASSWORD>
+
+    ## @param key_store_path - string - optional
+    ## The path to your key store.
+    ## `key_store_path` should be set if client authentication is enabled on the target JVM.
+    #
+    # key_store_path: <KEY_STORE_PATH>
+
+    ## @param key_store_password - string - optional
+    ## The password to your key store.
+    ## `key_store_password` should be set if client authentication is enabled on the target JVM.
+    #
+    # key_store_password: <KEY_STORE_PASSWORD>
+
+    ## @param rmi_registry_ssl - boolean - optional - default: false
+    ## Whether or not the Agent should connect to the RMI registry using SSL.
+    #
+    # rmi_registry_ssl: false
+
+    ## @param rmi_connection_timeout - number - optional - default: 30
+    ## The connection timeout, in seconds, when connecting to a remote JVM.
+    #
+    # rmi_connection_timeout: 30
+
+    ## @param rmi_client_timeout - number - optional - default: 30
+    ## The timeout to consider a remote connection, already successfully established, as lost.
+    ## If a connected remote JVM does not reply after `rmi_client_timeout` seconds jmxfetch
+    ## will give up on that connection and retry.
+    #
+    # rmi_client_timeout: 30
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Sync the `conf.yaml.example` file in the JMX integration template,.

### Motivation
<!-- What inspired you to submit this pull request? -->
Cleanup for https://github.com/DataDog/integrations-core/pull/6611

The PR updated the config spec but now when a new JMX integration is generated, eg `ddev create -t jmx foo`, then `ddev validate config` fails:

```console
$ ddev validate config
Validating default configuration files...
foo:
    File `conf.yaml.example` needs to be synced

Files with errors: 1
Files valid: 196
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Diff obtained by running `ddev validate config --sync` on a throwaway JMX integration.

Discovered as part of QAing #6611

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
