### PR TITLE
Collect port and host from same source in _generate_instance_key

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -134,7 +134,7 @@ class Redis(AgentCheck):
         if 'unix_socket_path' in instance:
             return instance.get('unix_socket_path'), instance.get('db')
         else:
-            return instance.get('host'), self.instance.get('port'), instance.get('db')
+            return instance.get('host'), instance.get('port'), instance.get('db')
 
     def _get_conn(self, instance=None):
         if instance is None:


### PR DESCRIPTION
### What does this PR do?

- QA for #6424 https://github.com/DataDog/integrations-core/pull/6424/files#diff-007657375bf223afe6f7c10e926f892bR135
- Collects the host and port values from the same source instance
- This method cannot be refactored to use self.instance because of it is called in `_get_conn`, which is called with a new instance here: https://github.com/DataDog/integrations-core/blob/master/redisdb/datadog_checks/redisdb/redisdb.py#L321

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
