### PR TITLE
Add test for tag resource filters

### DIFF
--- a/vsphere/tests/test_filters.py
+++ b/vsphere/tests/test_filters.py
@@ -8,6 +8,7 @@ import pytest
 from pyVmomi import vim
 from tests.mocked_api import MockedAPI
 
+from datadog_checks.base.errors import ConfigurationError
 from datadog_checks.vsphere import VSphereCheck
 from datadog_checks.vsphere.resource_filters import make_inventory_path
 from datadog_checks.vsphere.utils import (
@@ -99,3 +100,19 @@ def test_is_realtime_resource_collected_by_filters(realtime_instance):
             )
             == is_collected
         )
+
+
+def test_error_disabled_tags(realtime_instance):
+    realtime_instance['collect_tags'] = False
+    realtime_instance['resource_filters'] = [
+        {'resource': 'vm', 'property': 'name', 'patterns': [r'^\$VM5$', r'^VM4-2\d$']},
+        {'resource': 'vm', 'property': 'tag', 'patterns': [r'env:production']},
+    ]
+
+    # This config should not be possible
+    with pytest.raises(ConfigurationError):
+        VSphereCheck('vsphere', {}, [realtime_instance])
+
+    # collecting tags should not raise a configuration error
+    realtime_instance['collect_tags'] = True
+    VSphereCheck('vsphere', {}, [realtime_instance])


### PR DESCRIPTION
### What does this PR do?
- QA for https://github.com/DataDog/integrations-core/pull/6638
- Adds a test to ensure a configuration error is raised if `collect_tags` is disabled and there's a resource filter on a tag
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
