### PR TITLE
Safer metadata error handling

### DIFF
--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -161,12 +161,12 @@ class Envoy(AgentCheck):
             # }
             raw_version = response.json()["version"].split('/')[1]
         except requests.exceptions.Timeout:
-            msg = 'Envoy endpoint `{}` timed out after {} seconds'.format(server_info_url, self.http.options['timeout'])
-            self.log.info(msg)
+            self.log.warning(
+                'Envoy endpoint `%s` timed out after %s seconds', server_info_url, self.http.options['timeout']
+            )
             return
-        except (requests.exceptions.RequestException, requests.exceptions.ConnectionError):
-            msg = 'Error accessing Envoy endpoint `{}`'.format(server_info_url)
-            self.log.info(msg)
+        except Exception as e:
+            self.log.warning('Error collecting Envoy version with url=`%s`. Error: %s', server_info_url, str(e))
             return
 
         self.set_metadata('version', raw_version)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Safer metadata error handling

### Motivation
<!-- What inspired you to submit this pull request? -->

1. Collection might fail the check if the version payload data is invalid. e.g. missing `version` in data or index error at `split('/')[1]`.

2. Warning seems more appropriate since we don't expect failure.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
