### PR TITLE
Fix encoding and parsing issues when processing connection configuration

### DIFF
--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -33,11 +33,11 @@ def build_url(scheme, host, path='/', username=None, password=None, query_params
     else:
         netloc = host
 
-    params = ""
+    path_params = ""
     query = urlencode(query_params or {})
     fragment = ""
 
-    return urlunparse([scheme, netloc, path, params, query, fragment])
+    return urlunparse([scheme, netloc, path, path_params, query, fragment])
 
 
 class MongoDb(AgentCheck):

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -10,12 +10,13 @@ from distutils.version import LooseVersion
 
 import pymongo
 from six import PY3, iteritems, itervalues
-from six.moves.urllib.parse import unquote_plus, urlsplit, urlunparse, urlencode, quote_plus
+from six.moves.urllib.parse import unquote_plus, urlsplit
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.utils.common import round_value
 
 from . import metrics
+from .utils import build_url
 
 if PY3:
     long = int
@@ -23,21 +24,6 @@ if PY3:
 DEFAULT_TIMEOUT = 30
 ALLOWED_CUSTOM_METRICS_TYPES = ['gauge', 'rate', 'count', 'monotonic_count']
 ALLOWED_CUSTOM_QUERIES_COMMANDS = ['aggregate', 'count', 'find']
-
-
-def build_url(scheme, host, path='/', username=None, password=None, query_params=None):
-    # type: (str, str, str, str, str, dict) -> str
-    """Build an URL from individual parts. Makes sure that parts are properly URL-encoded."""
-    if username and password:
-        netloc = '{}:{}@{}'.format(quote_plus(username), quote_plus(password), host)
-    else:
-        netloc = host
-
-    path_params = ""
-    query = urlencode(query_params or {})
-    fragment = ""
-
-    return urlunparse([scheme, netloc, path, path_params, query, fragment])
 
 
 class MongoDb(AgentCheck):

--- a/mongo/datadog_checks/mongo/utils.py
+++ b/mongo/datadog_checks/mongo/utils.py
@@ -1,0 +1,19 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from six.moves.urllib.parse import urlunparse, urlencode, quote_plus
+
+
+def build_url(scheme, host, path='/', username=None, password=None, query_params=None):
+    # type: (str, str, str, str, str, dict) -> str
+    """Build an URL from individual parts. Make sure that parts are properly URL-encoded."""
+    if username and password:
+        netloc = '{}:{}@{}'.format(quote_plus(username), quote_plus(password), host)
+    else:
+        netloc = host
+
+    path_params = ""
+    query = urlencode(query_params or {})
+    fragment = ""
+
+    return urlunparse([scheme, netloc, path, path_params, query, fragment])

--- a/mongo/datadog_checks/mongo/utils.py
+++ b/mongo/datadog_checks/mongo/utils.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from six.moves.urllib.parse import urlunparse, urlencode, quote_plus
+from six.moves.urllib.parse import quote_plus, urlencode, urlunparse
 
 
 def build_url(scheme, host, path='/', username=None, password=None, query_params=None):

--- a/mongo/tests/common.py
+++ b/mongo/tests/common.py
@@ -26,6 +26,14 @@ INSTANCE_AUTHDB = {
     'password': 'testPass',
     'options': {'authSource': 'authDB'},
 }
+INSTANCE_AUTHDB_ALT = {
+    # Include special cases, e.g. default port and special characters
+    'hosts': [HOST],
+    'database': 'test',
+    'username': 'special test user',
+    'password': 's3\\kr@t',
+    'options': {'authSource': 'authDB'},
+}
 INSTANCE_AUTHDB_LEGACY_CONFIG = {
     'server': 'mongodb://testUser:testPass@{}:{}/test?authSource=authDB'.format(HOST, PORT1)
 }

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -156,5 +156,6 @@ class InitializeDB(LazyFunction):
 
         auth_db = cli['authDB']
         auth_db.command("createUser", 'testUser', pwd='testPass', roles=[{'role': 'read', 'db': 'test'}])
+        auth_db.command("createUser", 'special test user', pwd='s3\\kr@t', roles=[{'role': 'read', 'db': 'test'}])
 
         db.command("createUser", 'testUser2', pwd='testPass2', roles=[{'role': 'read', 'db': 'test'}])

--- a/mongo/tests/test_mongo.py
+++ b/mongo/tests/test_mongo.py
@@ -50,6 +50,7 @@ pytestmark = pytest.mark.usefixtures('dd_environment')
     'instance_authdb',
     [
         pytest.param(common.INSTANCE_AUTHDB, id='standard'),
+        pytest.param(common.INSTANCE_AUTHDB_ALT, id='standard-alternative'),
         pytest.param(common.INSTANCE_AUTHDB_LEGACY_CONFIG, id='legacy'),
     ],
 )

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -152,19 +152,19 @@ def test_parse_server_config(check):
     """
     instance = {
         'hosts': ['localhost', 'localhost:27018'],
-        'username': 'john\\doe',  # Backslash
-        'password': 'p@ss word',  # Special character and space
+        'username': 'john doe',  # Space
+        'password': 'p@ss\\word',  # Special characters
         'database': 'test',
         'options': {'replicaSet': 'bar!baz'},  # Special character
     }
     check = check(instance)
-    assert check.server == 'mongodb://john%5Cdoe:p%40ss+word@localhost:27017,localhost:27018/test?replicaSet=bar%21baz'
-    assert check.username == 'john\\doe'
-    assert check.password == 'p@ss word'
+    assert check.server == 'mongodb://john+doe:p%40ss%5Cword@localhost:27017,localhost:27018/test?replicaSet=bar%21baz'
+    assert check.username == 'john doe'
+    assert check.password == 'p@ss\\word'
     assert check.db_name == 'test'
     assert check.nodelist == [('localhost', 27017), ('localhost', 27018)]
     assert check.clean_server_name == (
-        'mongodb://john\\doe:*****@localhost:27017,localhost:27018/test?replicaSet=bar!baz'
+        'mongodb://john doe:*****@localhost:27017,localhost:27018/test?replicaSet=bar!baz'
     )
     assert check.auth_source is None
 

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -153,14 +153,14 @@ def test_parse_server_config(check):
     instance = {
         'hosts': ['localhost', 'localhost:27018'],
         'username': 'john\\doe',  # Backslash
-        'password': 'pass word',  # Space
+        'password': 'p@ss word',  # Special character and space
         'database': 'test',
         'options': {'replicaSet': 'bar!baz'},  # Special character
     }
     check = check(instance)
-    assert check.server == 'mongodb://john%5Cdoe:pass+word@localhost:27017,localhost:27018/test?replicaSet=bar%21baz'
+    assert check.server == 'mongodb://john%5Cdoe:p%40ss+word@localhost:27017,localhost:27018/test?replicaSet=bar%21baz'
     assert check.username == 'john\\doe'
-    assert check.password == 'pass word'
+    assert check.password == 'p@ss word'
     assert check.db_name == 'test'
     assert check.nodelist == [('localhost', 27017), ('localhost', 27018)]
     assert check.clean_server_name == (

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -145,6 +145,30 @@ def test_server_uri_sanitization(check, instance):
         assert expected_clean_name == clean_name
 
 
+def test_parse_server_config(check):
+    """
+    Connection parameters are properly parsed, sanitized and stored from instance configuration,
+    and special characters are dealt with.
+    """
+    instance = {
+        'hosts': ['localhost', 'localhost:27018'],
+        'username': 'john\\doe',  # Backslash
+        'password': 'pass word',  # Space
+        'database': 'test',
+        'options': {'replicaSet': 'bar!baz'},  # Special character
+    }
+    check = check(instance)
+    assert check.server == 'mongodb://john%5Cdoe:pass+word@localhost:27017,localhost:27018/test?replicaSet=bar%21baz'
+    assert check.username == 'john\\doe'
+    assert check.password == 'pass word'
+    assert check.db_name == 'test'
+    assert check.nodelist == [('localhost', 27017), ('localhost', 27018)]
+    assert check.clean_server_name == (
+        'mongodb://john\\doe:*****@localhost:27017,localhost:27018/test?replicaSet=bar!baz'
+    )
+    assert check.auth_source is None
+
+
 def test_legacy_config_deprecation(check):
     check = check(common.INSTANCE_BASIC_LEGACY_CONFIG)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix potential URL encoding issues introduced by #6574 by:

- Making sure all parts of the URL are properly URL-encoded.
- Matching the behavior of the current `server` option by passing the built connection string through our existing `parse_uri` function, making sure that it is a valid MongoDB URI and any existing sanitization is applied too (eg for the username).

### Motivation
<!-- What inspired you to submit this pull request? -->
#6574 introduced a new connection configuration interface by taking parameters from the `instance`. The approach was to build the connection string from those, which is legit, but the URL was built manually which introduced a whole set of possible bugs due to [URL formatting and encoding being hard](https://sethmlarson.dev/blog/2020-04-10/why-urls-are-hard-path-params-urlparse).

For example, using a password with an `@` in it (like mentioned in [this SO question](https://stackoverflow.com/questions/7486623/mongodb-password-with-in-it)) would break things because `@` needs to be URL-encoded to `%40` . This also applies to other parts of the URL, e.g. username, database name and options.

Besides, the resulting connection string was not validated against pymongo's `uri_parser`, which means that we wouldn't get the same validation behavior than with the now legacy approach.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
