### PR TITLE
Raise an error if only one of `username` or `password` is set

### DIFF
--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -107,11 +107,21 @@ class MongoDb(AgentCheck):
             hosts = self.instance.get('hosts', [])
             if not hosts:
                 raise ConfigurationError('No `hosts` specified')
+
+            username = self.instance.get('username')
+            password = self.instance.get('password')
+
+            if username and not password:
+                raise ConfigurationError('`password` must be set when a `username` is specified')
+
+            if password and not username:
+                raise ConfigurationError('`username` must be set when a `password` is specified')
+
             self.server = self._build_connection_string(
                 hosts,
                 scheme=self.instance.get('connection_scheme', 'mongodb'),
-                username=self.instance.get('username'),
-                password=self.instance.get('password'),
+                username=username,
+                password=password,
                 database=self.instance.get('database'),
                 options=self.instance.get('options'),
             )

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -15,31 +15,31 @@ from . import common
 
 
 @pytest.fixture(scope='session')
-def dd_environment(instance):
+def dd_environment():
     compose_file = os.path.join(common.HERE, 'compose', 'docker-compose.yml')
 
     with docker_run(
         compose_file, conditions=[WaitFor(setup_sharding, args=(compose_file,), attempts=5, wait=5), InitializeDB()]
     ):
-        yield instance
+        yield common.INSTANCE_BASIC
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def instance():
     return copy.deepcopy(common.INSTANCE_BASIC)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def instance_user():
     return copy.deepcopy(common.INSTANCE_USER)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def instance_authdb():
     return copy.deepcopy(common.INSTANCE_AUTHDB)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def instance_custom_queries():
     instance = copy.deepcopy(common.INSTANCE_USER)
     instance['custom_queries'] = [
@@ -82,7 +82,7 @@ def instance_custom_queries():
     return instance
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def instance_1valid_and_1invalid_custom_queries():
     instance = copy.deepcopy(common.INSTANCE_USER)
     instance['custom_queries'] = [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Raise a `ConfigurationError` if the user forgot to set `username` or `password` while the other item is set.

### Motivation
<!-- What inspired you to submit this pull request? -->
Small UX improvement for #6574

Prompted by https://github.com/DataDog/integrations-core/pull/6686#discussion_r427266274

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Connection configuration is a new feature introduced for 7.20, but this won't cause issues per se. Not absolute on whether we should merge this for 7.20.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
