### PR TITLE
Fix time utilities

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/time.py
+++ b/datadog_checks_base/datadog_checks/base/utils/time.py
@@ -33,6 +33,8 @@ def get_timestamp(dt=None):
         # - Alpine
         return epoch_offset()
 
+    # TODO: when we drop support for Python 2 switch to:
+    # normalize_datetime(dt).timestamp()
     return (normalize_datetime(dt) - EPOCH).total_seconds()
 
 

--- a/datadog_checks_base/datadog_checks/base/utils/time.py
+++ b/datadog_checks_base/datadog_checks/base/utils/time.py
@@ -17,10 +17,11 @@ def get_timestamp(dt=None):
     If `dt` is not specified or `None`, the current time in UTC is assumed.
     """
     if dt is None:
+        # The precision is different between Python 2 and 3
         return epoch_offset()
 
     # TODO: when we drop support for Python 2 switch to:
-    # normalize_datetime(dt).timestamp()
+    # return normalize_datetime(dt).timestamp()
     return (normalize_datetime(dt) - EPOCH).total_seconds()
 
 

--- a/datadog_checks_base/datadog_checks/base/utils/time.py
+++ b/datadog_checks_base/datadog_checks/base/utils/time.py
@@ -6,61 +6,41 @@ from __future__ import absolute_import
 from datetime import datetime
 from time import time as epoch_offset
 
-import pytz
-from six import PY2
+from dateutil.tz import UTC
 
-UTC = pytz.utc
-EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+EPOCH = datetime.fromtimestamp(0, UTC)
 
 
-if PY2:
-
-    def get_timestamp(dt=None):
-        """
-        Returns the number of seconds since the Unix epoch.
-        If `dt` is not specified or `None`, the current time in UTC is assumed.
-        """
-        if dt is None:
-            return epoch_offset()
-
-        return (dt - EPOCH).total_seconds()
-
-
-else:
-
-    def get_timestamp(dt=None):
-        """
-        Returns the number of seconds since the Unix epoch.
-        If `dt` is not specified or `None`, the current time in UTC is assumed.
-        """
-        if dt is None:
-            # NOTE: Although the epoch is platform dependent, it appears to be the same
-            # for all platforms we've tested, therefore we use `time.time` for speed.
-            #
-            # Here is the test:
-            #
-            #     $ python -c "import time;print(tuple(time.gmtime(0)[:9]))"
-            #     (1970, 1, 1, 0, 0, 0, 3, 1, 0)
-            #
-            # If you can reproduce, add to the following list of tested platforms:
-            #
-            # - Windows
-            # - macOS
-            # - Ubuntu
-            # - Alpine
-            return epoch_offset()
-
-        return normalize_datetime(dt).timestamp()
-
-
-def get_aware_datetime(dt=None, tz=UTC):
+def get_timestamp(dt=None):
     """
-    Returns an aware datetime object. If `dt` is not specified or `None`, the current time in UTC is assumed.
+    Returns the number of seconds since the Unix epoch.
+    If `dt` is not specified or `None`, the current time in UTC is assumed.
     """
     if dt is None:
-        return datetime.now(tz)
-    else:
-        return normalize_datetime(dt)
+        # NOTE: Although the epoch is platform dependent, it appears to be the same
+        # for all platforms we've tested, therefore we use `time.time` for speed.
+        #
+        # Here is the test:
+        #
+        #     $ python -c "import time;print(tuple(time.gmtime(0)[:9]))"
+        #     (1970, 1, 1, 0, 0, 0, 3, 1, 0)
+        #
+        # If you can reproduce, add to the following list of tested platforms:
+        #
+        # - Windows
+        # - macOS
+        # - Ubuntu
+        # - Alpine
+        return epoch_offset()
+
+    return (normalize_datetime(dt) - EPOCH).total_seconds()
+
+
+def get_current_datetime(tz=UTC):
+    """
+    Returns an aware datetime object representing the current time. If `tz` is not specified, UTC is assumed.
+    """
+    return datetime.now(tz)
 
 
 def normalize_datetime(dt, default_tz=UTC):
@@ -71,3 +51,6 @@ def normalize_datetime(dt, default_tz=UTC):
         dt = dt.replace(tzinfo=default_tz)
 
     return dt
+
+
+__all__ = ['EPOCH', 'UTC', 'get_current_datetime', 'get_timestamp', 'normalize_datetime']

--- a/datadog_checks_base/datadog_checks/base/utils/time.py
+++ b/datadog_checks_base/datadog_checks/base/utils/time.py
@@ -17,20 +17,6 @@ def get_timestamp(dt=None):
     If `dt` is not specified or `None`, the current time in UTC is assumed.
     """
     if dt is None:
-        # NOTE: Although the epoch is platform dependent, it appears to be the same
-        # for all platforms we've tested, therefore we use `time.time` for speed.
-        #
-        # Here is the test:
-        #
-        #     $ python -c "import time;print(tuple(time.gmtime(0)[:9]))"
-        #     (1970, 1, 1, 0, 0, 0, 3, 1, 0)
-        #
-        # If you can reproduce, add to the following list of tested platforms:
-        #
-        # - Windows
-        # - macOS
-        # - Ubuntu
-        # - Alpine
         return epoch_offset()
 
     # TODO: when we drop support for Python 2 switch to:

--- a/datadog_checks_base/datadog_checks/base/utils/time.py
+++ b/datadog_checks_base/datadog_checks/base/utils/time.py
@@ -21,8 +21,8 @@ def get_timestamp(dt=None):
         return epoch_offset()
 
     # TODO: when we drop support for Python 2 switch to:
-    # return normalize_datetime(dt).timestamp()
-    return (normalize_datetime(dt) - EPOCH).total_seconds()
+    # return ensure_aware_datetime(dt).timestamp()
+    return (ensure_aware_datetime(dt) - EPOCH).total_seconds()
 
 
 def get_current_datetime(tz=UTC):
@@ -32,7 +32,7 @@ def get_current_datetime(tz=UTC):
     return datetime.now(tz)
 
 
-def normalize_datetime(dt, default_tz=UTC):
+def ensure_aware_datetime(dt, default_tz=UTC):
     """
     Ensures that the returned datetime object is not naive.
     """
@@ -42,4 +42,4 @@ def normalize_datetime(dt, default_tz=UTC):
     return dt
 
 
-__all__ = ['EPOCH', 'UTC', 'get_current_datetime', 'get_timestamp', 'normalize_datetime']
+__all__ = ['EPOCH', 'UTC', 'ensure_aware_datetime', 'get_current_datetime', 'get_timestamp']

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -10,6 +10,7 @@ orjson==2.6.1; python_version > '3.0'
 prometheus-client==0.7.1
 protobuf==3.7.0
 pysocks==1.7.0
+python-dateutil==2.8.0
 pytz==2019.3
 pywin32==227; sys_platform == 'win32'
 pyyaml==5.3.1

--- a/datadog_checks_base/tests/test_time.py
+++ b/datadog_checks_base/tests/test_time.py
@@ -56,8 +56,3 @@ class TestConstants:
         from datetime import timezone
 
         assert EPOCH == datetime(1970, 1, 1, tzinfo=timezone.utc)
-
-    def test_utc(self):
-        from datetime import timezone
-
-        assert UTC.utcoffset(None) == timezone.utc.utcoffset(None)

--- a/datadog_checks_base/tests/test_time.py
+++ b/datadog_checks_base/tests/test_time.py
@@ -1,0 +1,60 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datetime import datetime
+
+import pytest
+from dateutil import tz
+from six import PY2
+
+from datadog_checks.base.utils.time import EPOCH, UTC, get_current_datetime, get_timestamp, normalize_datetime
+
+pytestmark = pytest.mark.time
+
+
+def test_timestamp_type():
+    assert isinstance(get_timestamp(), float)
+
+
+class TestNormalization:
+    def test_replace(self):
+        now = datetime.now()
+        assert now.tzinfo is None
+
+        assert normalize_datetime(now).tzinfo is UTC
+
+    def test_utc(self):
+        nyc = tz.gettz('America/New_York')
+        now = datetime.now(nyc)
+
+        assert normalize_datetime(now).tzinfo is nyc
+
+
+class TestCurrentDatetime:
+    def test_default_utc(self):
+        dt = get_current_datetime()
+        now = datetime.now(UTC)
+
+        assert now.tzinfo is UTC
+        assert get_timestamp(now) - get_timestamp(dt) < 0.01
+
+    def test_tz(self):
+        nyc = tz.gettz('America/New_York')
+        dt = get_current_datetime(nyc)
+        now = datetime.now(nyc)
+
+        assert now.tzinfo is nyc
+        assert get_timestamp(now) - get_timestamp(dt) < 0.01
+
+
+@pytest.mark.skipif(PY2, reason='Using Python 3 features')
+class TestConstants:
+    def test_epoch(self):
+        from datetime import timezone
+
+        assert EPOCH == datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+    def test_utc(self):
+        from datetime import timezone
+
+        assert UTC.utcoffset(None) == timezone.utc.utcoffset(None)

--- a/datadog_checks_base/tests/test_time.py
+++ b/datadog_checks_base/tests/test_time.py
@@ -27,7 +27,10 @@ class TestNormalization:
         nyc = tz.gettz('America/New_York')
         now = datetime.now(nyc)
 
-        assert normalize_datetime(now).tzinfo is nyc
+        normalized = normalize_datetime(now)
+
+        assert normalized is now
+        assert normalized.tzinfo is nyc
 
 
 class TestCurrentDatetime:


### PR DESCRIPTION
### What does this PR do?

1. Fixes delta computation error https://github.com/DataDog/integrations-core/pull/6663#discussion_r426651814
2. Simplified `get_aware_datetime` to `get_current_datetime`
3. Removed use of `pytz` as per https://discuss.python.org/t/get-local-time-zone/4169/7
4. Added full test coverage

### Notes

- We already ship `python-dateutil` https://github.com/DataDog/integrations-core/blob/7.19.x/datadog_checks_base/datadog_checks/base/data/agent_requirements.in#L54
- I didn't do https://github.com/DataDog/integrations-core/pull/6663#discussion_r426667812 as I'm not sure that's worth it to us, lmk what we think
- `pytz` is only used in one other spot https://github.com/DataDog/integrations-core/pull/5524/files should we remove that now too or after the release?

### Additional Notes

@pganssle Anything look amiss to you in general? https://github.com/DataDog/integrations-core/blob/ofek/time/datadog_checks_base/datadog_checks/base/utils/time.py