### PR TITLE
Update sidekiq mappings to include new metrics 

### DIFF
--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -55,7 +55,8 @@ No additional installation is needed on your server.
      - name: sidekiq
        prefix: "sidekiq."
        mappings:
-         - match: "sidekiq.sidekiq.*"
+         - match: "sidekiq\.sidekiq\.(.*)"
+           match_type: "regex"
            name: "sidekiq.$1"
          - match: 'sidekiq\.jobs\.(.*)\.perform'
            name: "sidekiq.jobs.perform"

--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -57,24 +57,24 @@ No additional installation is needed on your server.
        mappings:
          - match: "sidekiq.sidekiq.*"
            name: "sidekiq.*"
-         - match: "sidekiq\.jobs\.(.*)\.perform"
+         - match: 'sidekiq\.jobs\.(.*)\.perform'
            name: "sidekiq.jobs.perform"
-           match_type: regex
+           match_type: "regex"
            tags:
              worker: "$1"
-         - match: "sidekiq\.jobs\.(.*)\.count"
+         - match: 'sidekiq\.jobs\.(.*)\.count'
            name: "sidekiq.jobs.count.total"
-           match_type: regex
+           match_type: "regex"
            tags:
              worker: "$1"
-         - match: "sidekiq\.jobs\.(.*)\.success"
+         - match: 'sidekiq\.jobs\.(.*)\.success'
            name: "sidekiq.jobs.success.total"
-           match_type: regex
+           match_type: "regex"
            tags:
              worker: "$1"
-        - match: "sidekiq\.jobs\.(.*)\.failure"
+        - match: 'sidekiq\.jobs\.(.*)\.failure'
            name: "sidekiq.jobs.failure.total"
-           match_type: regex
+           match_type: "regex"
            tags:
              worker: "$1"
     ```

--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -66,7 +66,7 @@ No additional installation is needed on your server.
            name: "sidekiq.jobs.worker.$2"
            match_type: "regex"
            tags:
-             worker: "$1
+             worker: "$1"
     ```
 
 4. [Restart the Agent][8].

--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -56,7 +56,7 @@ No additional installation is needed on your server.
        prefix: "sidekiq."
        mappings:
          - match: "sidekiq.sidekiq.*"
-           name: "sidekiq.*"
+           name: "sidekiq.$1"
          - match: 'sidekiq\.jobs\.(.*)\.perform'
            name: "sidekiq.jobs.perform"
            match_type: "regex"

--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -72,7 +72,7 @@ No additional installation is needed on your server.
            match_type: "regex"
            tags:
              worker: "$1"
-        - match: 'sidekiq\.jobs\.(.*)\.failure'
+         - match: 'sidekiq\.jobs\.(.*)\.failure'
            name: "sidekiq.jobs.failure.total"
            match_type: "regex"
            tags:

--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -62,21 +62,11 @@ No additional installation is needed on your server.
            match_type: "regex"
            tags:
              worker: "$1"
-         - match: 'sidekiq\.jobs\.(.*)\.count'
-           name: "sidekiq.jobs.count.total"
+        - match: 'sidekiq\.jobs\.(.*)\.(count|success|failure)'
+           name: "sidekiq.jobs.worker.$2"
            match_type: "regex"
            tags:
-             worker: "$1"
-         - match: 'sidekiq\.jobs\.(.*)\.success'
-           name: "sidekiq.jobs.success.total"
-           match_type: "regex"
-           tags:
-             worker: "$1"
-         - match: 'sidekiq\.jobs\.(.*)\.failure'
-           name: "sidekiq.jobs.failure.total"
-           match_type: "regex"
-           tags:
-             worker: "$1"
+             worker: "$1
     ```
 
 4. [Restart the Agent][8].

--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -57,8 +57,24 @@ No additional installation is needed on your server.
        mappings:
          - match: "sidekiq.sidekiq.*"
            name: "sidekiq.*"
-         - match: "sidekiq.jobs.*.perform"
+         - match: "sidekiq\.jobs\.(.*)\.perform"
            name: "sidekiq.jobs.perform"
+           match_type: regex
+           tags:
+             worker: "$1"
+         - match: "sidekiq\.jobs\.(.*)\.count"
+           name: "sidekiq.jobs.count.total"
+           match_type: regex
+           tags:
+             worker: "$1"
+         - match: "sidekiq\.jobs\.(.*)\.success"
+           name: "sidekiq.jobs.success.total"
+           match_type: regex
+           tags:
+             worker: "$1"
+        - match: "sidekiq\.jobs\.(.*)\.failure"
+           name: "sidekiq.jobs.failure.total"
+           match_type: regex
            tags:
              worker: "$1"
     ```

--- a/sidekiq/metadata.csv
+++ b/sidekiq/metadata.csv
@@ -11,7 +11,7 @@ sidekiq.jobs.worker.count,count,,job,,Count of Sidekiq jobs,0,sidekiq,jobs count
 sidekiq.jobs.worker.success,count,,job,,Count of successful Sidekiq jobs,0,sidekiq,jobs success
 sidekiq.jobs.worker.failure,count,,job,,Count of failed Sidekiq jobs,-1,sidekiq,jobs failure
 sidekiq.processed,count,,job,,Number of job executions completed (success or failure) (Enterprise only),0,sidekiq,job execution processed
-sidekiq.failures,count,,job,,Number of job executions which raised an error (Enterprise only),-1,sidekiq,jobs execution failures
+sidekiq.failed,count,,job,,Number of job executions which raised an error (Enterprise only),-1,sidekiq,jobs execution failures
 sidekiq.enqueued,count,,job,,Total size of all known queues (Enterprise only),0,sidekiq,jobs enqueued
 sidekiq.retries,count,,job,,Total retries size,0,sidekiq (Enterprise only),job retries
 sidekiq.dead,count,,job,,Total Dead Size (Enterprise only),0,sidekiq,jobs dead

--- a/sidekiq/metadata.csv
+++ b/sidekiq/metadata.csv
@@ -4,22 +4,22 @@ sidekiq.jobs.perform.avg,gauge,,,,Average amount of time spent in a worker,0,sid
 sidekiq.jobs.perform.max,gauge,,,,Max amount of time spent in a worker,0,sidekiq,jobs perform max
 sidekiq.jobs.perform.median,gauge,,,,Median amount of time spent in a worker,0,sidekiq,jobs perform median
 sidekiq.jobs.perform.95percentile,gauge,,,,95th percentile of amount of time spent in a worker,0,sidekiq,jobs perform perc
-sidekiq.jobs.count,count,,,,Total count of Sidekiq jobs,0,sidekiq,jobs count
-sidekiq.jobs.success,count,,,,Total count of successful Sidekiq jobs,0,sidekiq,jobs success
-sidekiq.jobs.failure,count,,,,Total count of failed Sidekiq jobs,-1,sidekiq,jobs failure
-sidekiq.jobs.worker.count,count,,,,Count of Sidekiq jobs,0,sidekiq,jobs count
-sidekiq.jobs.worker.success,count,,,,Count of successful Sidekiq jobs,0,sidekiq,jobs success
-sidekiq.jobs.worker.failure,count,,,,Count of failed Sidekiq jobs,-1,sidekiq,jobs failure
-sidekiq.processed,count,,,,Number of job executions completed (success or failure) (Enterprise only),0,sidekiq,job execution processed
-sidekiq.failures,count,,,,Number of job executions which raised an error (Enterprise only),-1,sidekiq,jobs execution failures
-sidekiq.enqueued,count,,,,Total size of all known queues (Enterprise only),0,sidekiq,jobs enqueued
-sidekiq.retries,count,,,,Total retries size,0,sidekiq (Enterprise only),job retries
-sidekiq.dead,count,,,,Total Dead Size (Enterprise only),0,sidekiq,jobs dead
-sidekiq.scheduled,count,,,,Total Scheduled Size (Enterprise only),0,sidekiq,jobs scheduled
-sidekiq.busy,count,,,,Total Busy Size (Enterprise only),0,sidekiq,jobs busy
-sidekiq.jobs.expired,count,,,,Count of when a job is expired,0,sidekiq,jobs expired
-sidekiq.jobs.recovered.push,count,,,,Count of when a job is recovered by reliable_push after network outage,0,sidekiq,jobs recovered push
-sidekiq.jobs.recovered.fetch,count,,,,Count of when a job is recovered by super_fetch after process crash,0,sidekiq,jobs recovered fetch
+sidekiq.jobs.count,count,,job,,Total count of Sidekiq jobs,0,sidekiq,jobs count
+sidekiq.jobs.success,count,,job,,Total count of successful Sidekiq jobs,0,sidekiq,jobs success
+sidekiq.jobs.failure,count,,job,,Total count of failed Sidekiq jobs,-1,sidekiq,jobs failure
+sidekiq.jobs.worker.count,count,,job,,Count of Sidekiq jobs,0,sidekiq,jobs count
+sidekiq.jobs.worker.success,count,,job,,Count of successful Sidekiq jobs,0,sidekiq,jobs success
+sidekiq.jobs.worker.failure,count,,job,,Count of failed Sidekiq jobs,-1,sidekiq,jobs failure
+sidekiq.processed,count,,job,,Number of job executions completed (success or failure) (Enterprise only),0,sidekiq,job execution processed
+sidekiq.failures,count,,job,,Number of job executions which raised an error (Enterprise only),-1,sidekiq,jobs execution failures
+sidekiq.enqueued,count,,job,,Total size of all known queues (Enterprise only),0,sidekiq,jobs enqueued
+sidekiq.retries,count,,job,,Total retries size,0,sidekiq (Enterprise only),job retries
+sidekiq.dead,count,,job,,Total Dead Size (Enterprise only),0,sidekiq,jobs dead
+sidekiq.scheduled,count,,job,,Total Scheduled Size (Enterprise only),0,sidekiq,jobs scheduled
+sidekiq.busy,count,,job,,Total Busy Size (Enterprise only),0,sidekiq,jobs busy
+sidekiq.jobs.expired,count,,job,,Count of when a job is expired,0,sidekiq,jobs expired
+sidekiq.jobs.recovered.push,count,,job,,Count of when a job is recovered by reliable_push after network outage,0,sidekiq,jobs recovered push
+sidekiq.jobs.recovered.fetch,count,,job,,Count of when a job is recovered by super_fetch after process crash,0,sidekiq,jobs recovered fetch
 sidekiq.batch.created,count,,,,Count of when a batch is created,0,sidekiq,batches created
 sidekiq.batch.complete,count,,,,Count of when a batch is completed,0,sidekiq,batches complete
 sidekiq.batch.success,count,,,,Count of when a batch is successful,0,sidekiq,batches successful

--- a/sidekiq/metadata.csv
+++ b/sidekiq/metadata.csv
@@ -7,13 +7,16 @@ sidekiq.jobs.perform.95percentile,gauge,,,,95th percentile of amount of time spe
 sidekiq.jobs.count,count,,,,Count of Sidekiq jobs,0,sidekiq,jobs count
 sidekiq.jobs.success,count,,,,Count of successful Sidekiq jobs,0,sidekiq,jobs success
 sidekiq.jobs.failure,count,,,,Count of failed Sidekiq jobs,-1,sidekiq,jobs failure
-sidekiq.processed,count,,,,Number of job executions completed (success or failure),0,sidekiq,job execution processed
-sidekiq.failures,count,,,,Number of job executions which raised an error,-1,sidekiq,jobs execution failures
-sidekiq.enqueued,count,,,,Total size of all known queues,0,sidekiq,jobs enqueued
-sidekiq.retries,count,,,,Total retries size,0,sidekiq,job retries
-sidekiq.dead,count,,,,Total Dead Size,0,sidekiq,jobs dead
-sidekiq.scheduled,count,,,,Total Scheduled Size,0,sidekiq,jobs scheduled
-sidekiq.busy,count,,,,Total Busy Size,0,sidekiq,jobs busy
+sidekiq.jobs.count.total,count,,,,Total count of Sidekiq jobs,0,sidekiq,jobs count
+sidekiq.jobs.success.total,count,,,,Total count of successful Sidekiq jobs,0,sidekiq,jobs success
+sidekiq.jobs.failure.total,count,,,,Total count of failed Sidekiq jobs,-1,sidekiq,jobs failure
+sidekiq.processed,count,,,,Number of job executions completed (success or failure) (Enterprise only),0,sidekiq,job execution processed
+sidekiq.failures,count,,,,Number of job executions which raised an error (Enterprise only),-1,sidekiq,jobs execution failures
+sidekiq.enqueued,count,,,,Total size of all known queues (Enterprise only),0,sidekiq,jobs enqueued
+sidekiq.retries,count,,,,Total retries size,0,sidekiq (Enterprise only),job retries
+sidekiq.dead,count,,,,Total Dead Size (Enterprise only),0,sidekiq,jobs dead
+sidekiq.scheduled,count,,,,Total Scheduled Size (Enterprise only),0,sidekiq,jobs scheduled
+sidekiq.busy,count,,,,Total Busy Size (Enterprise only),0,sidekiq,jobs busy
 sidekiq.jobs.expired,count,,,,Count of when a job is expired,0,sidekiq,jobs expired
 sidekiq.jobs.recovered.push,count,,,,Count of when a job is recovered by reliable_push after network outage,0,sidekiq,jobs recovered push
 sidekiq.jobs.recovered.fetch,count,,,,Count of when a job is recovered by super_fetch after process crash,0,sidekiq,jobs recovered fetch

--- a/sidekiq/metadata.csv
+++ b/sidekiq/metadata.csv
@@ -6,7 +6,7 @@ sidekiq.jobs.perform.median,gauge,,,,Median amount of time spent in a worker,0,s
 sidekiq.jobs.perform.95percentile,gauge,,,,95th percentile of amount of time spent in a worker,0,sidekiq,jobs perform perc
 sidekiq.jobs.count,count,,,,Total count of Sidekiq jobs,0,sidekiq,jobs count
 sidekiq.jobs.success,count,,,,Total count of successful Sidekiq jobs,0,sidekiq,jobs success
-sidekiq.jobs.failure,count,,,Total count of failed Sidekiq jobs,-1,sidekiq,jobs failure
+sidekiq.jobs.failure,count,,,,Total count of failed Sidekiq jobs,-1,sidekiq,jobs failure
 sidekiq.jobs.worker.count,count,,,,Count of Sidekiq jobs,0,sidekiq,jobs count
 sidekiq.jobs.worker.success,count,,,,Count of successful Sidekiq jobs,0,sidekiq,jobs success
 sidekiq.jobs.worker.failure,count,,,,Count of failed Sidekiq jobs,-1,sidekiq,jobs failure

--- a/sidekiq/metadata.csv
+++ b/sidekiq/metadata.csv
@@ -4,12 +4,12 @@ sidekiq.jobs.perform.avg,gauge,,,,Average amount of time spent in a worker,0,sid
 sidekiq.jobs.perform.max,gauge,,,,Max amount of time spent in a worker,0,sidekiq,jobs perform max
 sidekiq.jobs.perform.median,gauge,,,,Median amount of time spent in a worker,0,sidekiq,jobs perform median
 sidekiq.jobs.perform.95percentile,gauge,,,,95th percentile of amount of time spent in a worker,0,sidekiq,jobs perform perc
-sidekiq.jobs.count,count,,,,Count of Sidekiq jobs,0,sidekiq,jobs count
-sidekiq.jobs.success,count,,,,Count of successful Sidekiq jobs,0,sidekiq,jobs success
-sidekiq.jobs.failure,count,,,,Count of failed Sidekiq jobs,-1,sidekiq,jobs failure
-sidekiq.jobs.count.total,count,,,,Total count of Sidekiq jobs,0,sidekiq,jobs count
-sidekiq.jobs.success.total,count,,,,Total count of successful Sidekiq jobs,0,sidekiq,jobs success
-sidekiq.jobs.failure.total,count,,,,Total count of failed Sidekiq jobs,-1,sidekiq,jobs failure
+sidekiq.jobs.count,count,,,,Total count of Sidekiq jobs,0,sidekiq,jobs count
+sidekiq.jobs.success,count,,,,Total count of successful Sidekiq jobs,0,sidekiq,jobs success
+sidekiq.jobs.failure,count,,,Total count of failed Sidekiq jobs,-1,sidekiq,jobs failure
+sidekiq.jobs.worker.count,count,,,,Count of Sidekiq jobs,0,sidekiq,jobs count
+sidekiq.jobs.worker.success,count,,,,Count of successful Sidekiq jobs,0,sidekiq,jobs success
+sidekiq.jobs.worker.failure,count,,,,Count of failed Sidekiq jobs,-1,sidekiq,jobs failure
 sidekiq.processed,count,,,,Number of job executions completed (success or failure) (Enterprise only),0,sidekiq,job execution processed
 sidekiq.failures,count,,,,Number of job executions which raised an error (Enterprise only),-1,sidekiq,jobs execution failures
 sidekiq.enqueued,count,,,,Total size of all known queues (Enterprise only),0,sidekiq,jobs enqueued


### PR DESCRIPTION
### What does this PR do?
- updates sidekiq mappings to include mappings for job count, failure, and success: `sidekiq.jobs.<worker>.count -> sidekiq.jobs.count.total` 
- adds these metrics to the metadata.csv
- clarifies which metrics are enterprise-only
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
