### PR TITLE
Fix debug log line for job metrics

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -550,8 +550,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         if ts.isdigit():
             return int(ts)
         else:
-            msg = 'Cannot extract ts from job name {}'
-            self.log.debug(msg, name)
+            self.log.debug("Cannot extract ts from job name %s", name)
             return None
 
     # Labels attached: namespace, pod


### PR DESCRIPTION
### What does this PR do?
Fix an issue where job metrics are missing when the agent uses `DEBUG` level logging

### Motivation
Parsing the `job` label for job metrics when the agent is set to `DEBUG` logging results in the following type error:

```
2020-05-20 19:09:44 UTC | CORE | WARN | (pkg/collector/python/datadog_agent.go:118 in LogMessage) | kubernetes_state:5594cf03e448ecbf | (mixins.py:638) | Error handling metric: kube_job_status_failed - error: not all arguments converted during string formatting
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
