### PR TITLE
Document `mc_cluster_states` configuration option

### DIFF
--- a/hazelcast/assets/configuration/spec.yaml
+++ b/hazelcast/assets/configuration/spec.yaml
@@ -21,7 +21,11 @@ files:
       value:
         type: object
         example:
-          <MC_CLUSTER_STATE>: <SERVICE_CHECK_STATUS>
+          Active: OK
+          No Migration: WARNING
+          Frozen: CRITICAL
+          Passive: CRITICAL
+          In Transition: WARNING
     - template: instances/jmx
       overrides:
         host.display_priority: 10

--- a/hazelcast/assets/configuration/spec.yaml
+++ b/hazelcast/assets/configuration/spec.yaml
@@ -15,6 +15,13 @@ files:
         to poll for the `hazelcast.mc_cluster_state` service check.
       value:
         type: string
+    - name: mc_cluster_states
+      description: |
+        Custom cluster state mapping used for configuring service check status.
+      value:
+        type: object
+        example:
+          <MC_CLUSTER_STATE>: <SERVICE_CHECK_STATUS>
     - template: instances/jmx
       overrides:
         host.display_priority: 10

--- a/hazelcast/assets/configuration/spec.yaml
+++ b/hazelcast/assets/configuration/spec.yaml
@@ -17,7 +17,7 @@ files:
         type: string
     - name: mc_cluster_states
       description: |
-        Custom cluster state mapping used for configuring service check status.
+        Override cluster state to `hazelcast.mc_cluster_state` service check status mapping.
       value:
         type: object
         example:

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -59,6 +59,12 @@ instances:
     #
     # mc_health_check_endpoint: <MC_HEALTH_CHECK_ENDPOINT>
 
+    ## @param mc_cluster_states - mapping - optional
+    ## Custom cluster state mapping used for configuring service check status.
+    #
+    # mc_cluster_states:
+    #   <MC_CLUSTER_STATE>: <SERVICE_CHECK_STATUS>
+
     ## @param user - string - optional
     ## User to use when connecting to JMX.
     #

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -60,7 +60,7 @@ instances:
     # mc_health_check_endpoint: <MC_HEALTH_CHECK_ENDPOINT>
 
     ## @param mc_cluster_states - mapping - optional
-    ## Custom cluster state mapping used for configuring service check status.
+    ## Override cluster state to `hazelcast.mc_cluster_state` service check status mapping.
     #
     # mc_cluster_states:
     #   <MC_CLUSTER_STATE>: <SERVICE_CHECK_STATUS>

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -63,7 +63,11 @@ instances:
     ## Override cluster state to `hazelcast.mc_cluster_state` service check status mapping.
     #
     # mc_cluster_states:
-    #   <MC_CLUSTER_STATE>: <SERVICE_CHECK_STATUS>
+    #   Active: OK
+    #   No Migration: WARNING
+    #   Frozen: CRITICAL
+    #   Passive: CRITICAL
+    #   In Transition: WARNING
 
     ## @param user - string - optional
     ## User to use when connecting to JMX.


### PR DESCRIPTION
Missing config option to override with custom cluster state to service check status mapping. 
https://github.com/DataDog/integrations-core/blob/865ad8da409bb91f286faec6c457f3051dc51004/hazelcast/datadog_checks/hazelcast/check.py#L21-L23