### PR TITLE
Document join_standard_tags setting in conf.example.yaml

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -55,3 +55,16 @@ instances:
     ## Metrics can be found under `kubernetes_state.telemetry`
     #
     # telemetry: false
+
+    ## @param join_standard_tags - boolean - optional - default: false
+    ## To enable joining standard tags from labels, you must set this parameter to true.
+    ## It will join standard tags found in these labels coming from info Kube State metrics (*_labels).
+    ##   tags.datadoghq.com/env     => env
+    ##   tags.datadoghq.com/service => service
+    ##   tags.datadoghq.com/version => version
+    ##
+    ## Resources enabled for join_standard_tags include:
+    ## Pod, Deployment, ReplicaSet, DaemonSet, StatefulSet, Job, CronJob
+    ##
+    #
+    # join_standard_tags: false


### PR DESCRIPTION
### What does this PR do?

Document `join_standard_tags` setting in `conf.example.yaml`.

### Motivation

Missing documentation.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
