### PR TITLE
Simplify labels exclusion and add docs

### DIFF
--- a/istio/README.md
+++ b/istio/README.md
@@ -50,6 +50,8 @@ Add one of the configuration blocks below to your `istio.d/conf.yaml` file to st
 
 Each of the endpoints is optional, but at least one must be configured. See the [Istio documentation][5] to learn more about the Prometheus adapter.
 
+Note: Following Prometheus labels are excluded: `connectionID`, `destination_service`, `source_workload`
+
 ##### Disable sidecar injection
 
 If you are installing the [Datadog Agent in a container][10], Datadog recommends that you first disable Istio's sidecar injection.

--- a/istio/README.md
+++ b/istio/README.md
@@ -50,7 +50,7 @@ Add one of the configuration blocks below to your `istio.d/conf.yaml` file to st
 
 Each of the endpoints is optional, but at least one must be configured. See the [Istio documentation][5] to learn more about the Prometheus adapter.
 
-Note: Following Prometheus labels are excluded: `connectionID`, `destination_service`, `source_workload`
+Note: `connectionID` Prometheus label is excluded.
 
 ##### Disable sidecar injection
 

--- a/istio/datadog_checks/istio/istio.py
+++ b/istio/datadog_checks/istio/istio.py
@@ -22,11 +22,7 @@ class Istio(OpenMetricsBaseCheck):
         metrics = instance.get('metrics', []) + [ISTIOD_METRICS]
 
         # Include default and user configured labels
-        exclude_labels = instance.get('exclude_labels', [])
-        exclude_labels.extend(BLACKLIST_LABELS)
-
-        # Support additional configured metric mappings
-        metrics = instance.get('metrics', []) + [ISTIOD_METRICS]
+        exclude_labels = instance.get('exclude_labels', []) + BLACKLIST_LABELS
 
         instance.update(
             {

--- a/istio/datadog_checks/istio/legacy_1_4.py
+++ b/istio/datadog_checks/istio/legacy_1_4.py
@@ -93,8 +93,7 @@ class LegacyIstioCheck_1_4(OpenMetricsBaseCheck):
         """
         result = []
         for instance in instances:
-            exclude_labels = instance.get('exclude_labels', [])
-            exclude_labels.extend(BLACKLIST_LABELS)
+            exclude_labels = instance.get('exclude_labels', []) + BLACKLIST_LABELS
             instance.update({'exclude_labels': exclude_labels})
 
             if 'istio_mesh_endpoint' in instance:


### PR DESCRIPTION
Minor changes for https://github.com/DataDog/integrations-core/pull/6375

- Remove not necessary `extend`. We are currently extending `instance["exclude_labels"]` then replacing it, which feel unusual.
- Remove duplicate code for line `metrics = instance.get('metrics', []) + [ISTIOD_METRICS]`
- Add docs
