### PR TITLE
Remvoe `destination_service` and `source_workload` from blacklist

### DIFF
--- a/istio/datadog_checks/istio/constants.py
+++ b/istio/datadog_checks/istio/constants.py
@@ -11,4 +11,4 @@ CITADEL_NAMESPACE = 'istio.citadel'
 ISTIOD_NAMESPACE = 'istio.istiod'
 
 # Known labels that cause context explosion
-BLACKLIST_LABELS = ["connectionID", "destination_service", "source_workload"]
+BLACKLIST_LABELS = ["connectionID"]


### PR DESCRIPTION
`destination_service` and `source_workload` are currently used in monitors, dashboards and screenboards for some orgs