### PR TITLE
Override CaseInsensitiveDict `copy()` function

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -49,6 +49,9 @@ class CaseInsensitiveDict(dict):
         return super(CaseInsensitiveDict, self).get(key.lower())
 
     def copy(self):
+        """
+        Explicit copy to ensure keys are consistent
+        """
         copied = CaseInsensitiveDict()
         for key, value in self.items():
             copied[key] = value

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -49,7 +49,10 @@ class CaseInsensitiveDict(dict):
         return super(CaseInsensitiveDict, self).get(key.lower())
 
     def copy(self):
-        return CaseInsensitiveDict(self)
+        copied = CaseInsensitiveDict()
+        for key, value in self.items():
+            copied[key] = value
+        return copied
 
 
 class ProviderArchitectureMeta(type):

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -52,10 +52,7 @@ class CaseInsensitiveDict(dict):
         """
         Explicit copy to ensure we return an instance of `CaseInsensitiveDict`
         """
-        copied = CaseInsensitiveDict()
-        for key, value in self.items():
-            copied[key] = value
-        return copied
+        return CaseInsensitiveDict(self)
 
 
 class ProviderArchitectureMeta(type):

--- a/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/wmi/sampler.py
@@ -48,6 +48,9 @@ class CaseInsensitiveDict(dict):
     def get(self, key):
         return super(CaseInsensitiveDict, self).get(key.lower())
 
+    def copy(self):
+        return CaseInsensitiveDict(self)
+
 
 class ProviderArchitectureMeta(type):
     """

--- a/datadog_checks_base/tests/test_wmisampler.py
+++ b/datadog_checks_base/tests/test_wmisampler.py
@@ -97,4 +97,4 @@ def test_caseinsensitivedict():
     key2 = "DATA"
     value2 = "Dog"
     test_copy[key2] = value2
-    assert CaseInsensitiveDict({key2.lower: value2}) == test_copy
+    assert CaseInsensitiveDict({key2.lower(): value2}) == test_copy

--- a/datadog_checks_base/tests/test_wmisampler.py
+++ b/datadog_checks_base/tests/test_wmisampler.py
@@ -12,6 +12,13 @@ except ImportError:
     pass
 
 
+try:
+    from datadog_checks.base.checks.win.wmi.sampler import CaseInsensitiveDict
+except ImportError:
+    pass
+
+
+
 @requires_windows
 @pytest.mark.unit
 def test_format_filter_value():
@@ -66,3 +73,29 @@ def test_format_filter_win32_log():
         formatted_filters == " WHERE ( ( SourceName = 'MSSQLSERVER' ) "
         "AND ( Type = 'Warning' OR Type = 'Error' ) AND TimeGenerated >= '202056101355.000000+' )"
     )
+
+@requires_windows
+@pytest.mark.unit
+def test_caseinsensitivedict():
+    test_dict = CaseInsensitiveDict({})
+    key1 = "CAPS_KEY"
+    value1 = "CAPS_VALUE"
+    test_dict[key1] = value1
+
+    # Assert key is lowercase in CaseInsensitiveDict
+    assert CaseInsensitiveDict({key1.lower(): value1}) == test_dict
+
+    # Values do not change
+    assert test_dict.get(key1) == value1
+    assert test_dict.get(key1.lower()) == value1
+
+    # Copy dict
+    test_copy = test_dict.copy()
+    assert isinstance(test_copy, CaseInsensitiveDict)
+
+    # Add data to copied dict
+    key2 = "DATA"
+    value2 = "Dog"
+    test_copy[key2] = value2
+    assert CaseInsensitiveDict({key2.lower: value2}) == test_copy
+

--- a/datadog_checks_base/tests/test_wmisampler.py
+++ b/datadog_checks_base/tests/test_wmisampler.py
@@ -18,7 +18,6 @@ except ImportError:
     pass
 
 
-
 @requires_windows
 @pytest.mark.unit
 def test_format_filter_value():
@@ -74,6 +73,7 @@ def test_format_filter_win32_log():
         "AND ( Type = 'Warning' OR Type = 'Error' ) AND TimeGenerated >= '202056101355.000000+' )"
     )
 
+
 @requires_windows
 @pytest.mark.unit
 def test_caseinsensitivedict():
@@ -98,4 +98,3 @@ def test_caseinsensitivedict():
     value2 = "Dog"
     test_copy[key2] = value2
     assert CaseInsensitiveDict({key2.lower: value2}) == test_copy
-

--- a/datadog_checks_base/tests/test_wmisampler.py
+++ b/datadog_checks_base/tests/test_wmisampler.py
@@ -97,4 +97,9 @@ def test_caseinsensitivedict():
     key2 = "DATA"
     value2 = "Dog"
     test_copy[key2] = value2
-    assert CaseInsensitiveDict({key2.lower(): value2}) == test_copy
+    assert CaseInsensitiveDict({key1.lower(): value1, key2.lower(): value2}) == test_copy
+
+    assert test_copy.get(key1) == value1
+    assert test_copy.get(key1.lower()) == value1
+    assert test_copy.get(key2) == value2
+    assert test_copy.get(key2.lower()) == value2

--- a/win32_event_log/tests/legacy/common.py
+++ b/win32_event_log/tests/legacy/common.py
@@ -14,7 +14,7 @@ INSTANCE = {
 
 TEST_EVENT = {
     'EventCode': 1000.0,
-    'EventIdentifier': 10.42,
+    'EventIdentifier': 10.0,
     'EventType': 20,
     'InsertionStrings': '[insertionstring]',
     'Logfile': 'Application',

--- a/win32_event_log/tests/legacy/common.py
+++ b/win32_event_log/tests/legacy/common.py
@@ -2,6 +2,9 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+
+from datadog_checks.base.checks.win.wmi.sampler import CaseInsensitiveDict
+
 INSTANCE = {
     'host': ".",
     'tags': ["mytag1", "mytag2"],
@@ -12,15 +15,17 @@ INSTANCE = {
 }
 
 
-TEST_EVENT = {
-    'EventCode': 1000.0,
-    'EventIdentifier': 10.0,
-    'EventType': 20,
-    'InsertionStrings': '[insertionstring]',
-    'Logfile': 'Application',
-    'Message': 'SomeMessage',
-    'SourceName': 'MSQLSERVER',
-    'TimeGenerated': '21001224113047.000000-480',
-    'User': 'FooUser',
-    'Type': 'Error',
-}
+TEST_EVENT = CaseInsensitiveDict(
+    {
+        'eventcode': 1000.0,
+        'eventidentifier': 10.0,
+        'eventtype': 20,
+        'insertionstrings': '[insertionstring]',
+        'logfile': 'Application',
+        'message': 'SomeMessage',
+        'sourcename': 'MSQLSERVER',
+        'timegenerated': '21001224113047.000000-480',
+        'user': 'FooUser',
+        'type': 'Error',
+    }
+)

--- a/win32_event_log/tests/legacy/common.py
+++ b/win32_event_log/tests/legacy/common.py
@@ -10,3 +10,17 @@ INSTANCE = {
     'type': ["Error", "Warning"],
     'source_name': ["MSSQLSERVER"],
 }
+
+
+TEST_EVENT = {
+    'EventCode': 1000.0,
+    'EventIdentifier': 10.42,
+    'EventType': 20,
+    'InsertionStrings': '[insertionstring]',
+    'Logfile': 'Application',
+    'Message': 'SomeMessage',
+    'SourceName': 'MSQLSERVER',
+    'TimeGenerated': '21001224113047.000000-480',
+    'User': 'FooUser',
+    'Type': 'Error',
+}

--- a/win32_event_log/tests/legacy/test_check.py
+++ b/win32_event_log/tests/legacy/test_check.py
@@ -7,7 +7,7 @@ import pytest
 from mock import patch
 
 from datadog_checks.base import ConfigurationError
-from datadog_checks.base.win.wmi.sampler import CaseInsensitiveDict
+from datadog_checks.base.checks.win.wmi.sampler import CaseInsensitiveDict
 from datadog_checks.win32_event_log import Win32EventLogCheck
 from datadog_checks.win32_event_log.legacy.win32_event_log import LogEvent
 

--- a/win32_event_log/tests/legacy/test_check.py
+++ b/win32_event_log/tests/legacy/test_check.py
@@ -28,19 +28,7 @@ class FakeWmiSampler:
             yield wmi_object
 
     def sample(self):
-        self._wmi_objects = [
-            {
-                'EventCode': 1000.0,
-                'EventIdentifier': 10.0,
-                'EventType': 20,
-                'InsertionStrings': '[insertionstring]',
-                'Logfile': 'Application',
-                'Message': 'SomeMessage',
-                'SourceName': 'MSQLSERVER',
-                'TimeGenerated': '21001224113047.000000-480',
-                'User': 'FooUser',
-                'Type': 'Error',
-            }
+        self._wmi_objects = [TEST_EVENT
         ]
 
     def reset(self):

--- a/win32_event_log/tests/legacy/test_check.py
+++ b/win32_event_log/tests/legacy/test_check.py
@@ -88,19 +88,6 @@ def test_check(mock_from_time, mock_to_time, check, mock_get_wmi_sampler, aggreg
     )
 
 
-def test_log_event():
-    TEST_EVENT['EventIdentifier'] = 12.2345
-    ev = CaseInsensitiveDict(TEST_EVENT)
-
-    log_event = LogEvent(ev, None, None, [], None, None, None, None)
-
-    # Ensure that LogEvent.event is still a CaseInsensitiveDict
-    assert isinstance(log_event.event, CaseInsensitiveDict)
-
-    # Ensure event is normalized
-    assert isinstance(log_event.event['EventIdentifier'], int)
-
-
 def test_check_with_event_format(mock_from_time, mock_to_time, check, mock_get_wmi_sampler, aggregator):
     instance = {
         'host': ".",
@@ -149,6 +136,20 @@ Type: Error
         alert_type='error',
         source_type_name='event viewer',
     )
+
+
+def test_log_event():
+    test_ev = TEST_EVENT.copy()
+    test_ev['EventIdentifier'] = 12.2345
+    ev = CaseInsensitiveDict(test_ev)
+
+    log_event = LogEvent(ev, None, None, [], None, None, None, None)
+
+    # Ensure that LogEvent.event is still a CaseInsensitiveDict
+    assert isinstance(log_event.event, CaseInsensitiveDict)
+
+    # Ensure event is normalized
+    assert isinstance(log_event.event['EventIdentifier'], int)
 
 
 def test_no_filters(check):

--- a/win32_event_log/tests/legacy/test_check.py
+++ b/win32_event_log/tests/legacy/test_check.py
@@ -7,9 +7,11 @@ import pytest
 from mock import patch
 
 from datadog_checks.base import ConfigurationError
+from datadog_checks.base.win.wmi.sampler import CaseInsensitiveDict
 from datadog_checks.win32_event_log import Win32EventLogCheck
+from datadog_checks.win32_event_log.legacy.win32_event_log import LogEvent
 
-from .common import INSTANCE
+from .common import INSTANCE, TEST_EVENT
 
 log = logging.getLogger(__file__)
 
@@ -99,6 +101,19 @@ def test_check(mock_from_time, mock_to_time, check, mock_get_wmi_sampler, aggreg
     )
 
 
+def test_log_event():
+    TEST_EVENT['EventIdentifier'] = 12.2345
+    ev = CaseInsensitiveDict(TEST_EVENT)
+
+    log_event = LogEvent(ev, None, None, [], None, None, None, None)
+
+    # Ensure that LogEvent.event is still a CaseInsensitiveDict
+    assert isinstance(log_event.event, CaseInsensitiveDict)
+
+    # Ensure event is normalized
+    assert isinstance(log_event.event['EventIdentifier'], int)
+
+
 def test_check_with_event_format(mock_from_time, mock_to_time, check, mock_get_wmi_sampler, aggregator):
     instance = {
         'host': ".",
@@ -120,7 +135,6 @@ def test_check_with_event_format(mock_from_time, mock_to_time, check, mock_get_w
             'Type',
         ],
     }
-
     check.check(instance)
     check.check(instance)
     message = """%%%

--- a/win32_event_log/tests/legacy/test_check.py
+++ b/win32_event_log/tests/legacy/test_check.py
@@ -28,8 +28,7 @@ class FakeWmiSampler:
             yield wmi_object
 
     def sample(self):
-        self._wmi_objects = [TEST_EVENT
-        ]
+        self._wmi_objects = [TEST_EVENT]
 
     def reset(self):
         self._wmi_objects = []

--- a/win32_event_log/tests/legacy/test_check.py
+++ b/win32_event_log/tests/legacy/test_check.py
@@ -122,6 +122,7 @@ def test_check_with_event_format(mock_from_time, mock_to_time, check, mock_get_w
             'Type',
         ],
     }
+
     check.check(instance)
     check.check(instance)
     message = """%%%


### PR DESCRIPTION
[`ev.copy()`](https://github.com/DataDog/integrations-core/commit/cc324e83c2fedad3267f70ced9f09ef935ce51cf#diff-a18bcd3c932b0065b2de91257049764bR182) was returning a `dict()` instead of `CaseInsensitiveDict()`. This PR overrides the CaseInsensitiveDict `copy()` to return `CaseInsensitiveDict` copy of dictionary.

During QA, we were running into a `KeyError` at LogEvent class

![image (1)](https://user-images.githubusercontent.com/15065007/82695455-22d6f780-9c33-11ea-87fc-0bacc26222ca.png)


## Motivation

Bug introduced here: https://github.com/DataDog/integrations-core/commit/cc324e83c2fedad3267f70ced9f09ef935ce51cf#diff-a18bcd3c932b0065b2de91257049764bR182