### PR TITLE
Reuse MIB builder objects per SNMP engine

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -7,6 +7,7 @@ from typing import Any, DefaultDict, Dict, Iterator, List, Optional, Set, Tuple
 
 from datadog_checks.base import ConfigurationError, is_affirmative
 
+from .mibs import MIBLoader
 from .models import OID
 from .parsing import ParsedMetric, ParsedMetricTag, ParsedSymbolMetric, parse_metric_tags, parse_metrics
 from .pysnmp_types import (
@@ -20,7 +21,6 @@ from .pysnmp_types import (
     usmDESPrivProtocol,
     usmHMACMD5AuthProtocol,
 )
-from .mibs import MIBLoader
 from .resolver import OIDResolver
 from .types import OIDMatch
 

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import ipaddress
-import threading
 from collections import defaultdict
 from typing import Any, DefaultDict, Dict, Iterator, List, Optional, Set, Tuple
 
@@ -13,13 +12,7 @@ from .parsing import ParsedMetric, ParsedMetricTag, ParsedSymbolMetric, parse_me
 from .pysnmp_types import (
     CommunityData,
     ContextData,
-    DirMibSource,
-    MibBuilder,
-    MibInstrumController,
-    MibViewController,
-    MsgAndPduDispatcher,
     OctetString,
-    SnmpEngine,
     UdpTransportTarget,
     UsmUserData,
     hlapi,
@@ -27,6 +20,7 @@ from .pysnmp_types import (
     usmDESPrivProtocol,
     usmHMACMD5AuthProtocol,
 )
+from .mibs import MIBLoader
 from .resolver import OIDResolver
 from .types import OIDMatch
 
@@ -59,9 +53,6 @@ class InstanceConfig:
         'aes256c': 'usmAesCfb256Protocol',
     }
 
-    _mib_builders = {}  # type: Dict[Optional[str], Tuple[MibBuilder, MibInstrumController, MibViewController]]
-    _mib_lock = threading.Lock()
-
     def __init__(
         self,
         instance,  # type: dict
@@ -69,12 +60,13 @@ class InstanceConfig:
         mibs_path=None,  # type: str
         profiles=None,  # type: Dict[str, dict]
         profiles_by_oid=None,  # type: Dict[str, str]
-        shared_mib_builder=False,  # type: bool
+        loader=None,  # type: MIBLoader
     ):
         # type: (...) -> None
         global_metrics = [] if global_metrics is None else global_metrics
         profiles = {} if profiles is None else profiles
         profiles_by_oid = {} if profiles_by_oid is None else profiles_by_oid
+        loader = MIBLoader() if loader is None else loader
 
         # Clean empty or null values. This will help templating.
         for key, value in list(instance.items()):
@@ -92,7 +84,8 @@ class InstanceConfig:
             self.metrics.extend(global_metrics)
 
         self.enforce_constraints = is_affirmative(instance.get('enforce_mib_constraints', True))
-        self._snmp_engine, mib_view_controller = self.create_snmp_engine(mibs_path, shared_mib_builder)
+        self._snmp_engine = loader.create_snmp_engine(mibs_path)
+        mib_view_controller = loader.get_mib_view_controller(mibs_path)
         self._resolver = OIDResolver(mib_view_controller, self.enforce_constraints)
 
         self.ip_address = None
@@ -190,41 +183,6 @@ class InstanceConfig:
     def add_profile_tag(self, profile_name):
         # type: (str) -> None
         self.tags.append('snmp_profile:{}'.format(profile_name))
-
-    @staticmethod
-    def _create_mib_builder(mibs_path):
-        # type: (Optional[str]) -> Tuple[MibBuilder, MibInstrumController, MibViewController]
-        mib_builder = MibBuilder()
-        if mibs_path:
-            mib_builder.addMibSources(DirMibSource(mibs_path))
-        mib_instrum = MibInstrumController(mib_builder)
-        mib_view = MibViewController(mib_builder)
-        return mib_builder, mib_instrum, mib_view
-
-    @classmethod
-    def _get_mib_builder(cls, mibs_path, shared_mib_builder):
-        # type: (Optional[str], bool) -> Tuple[MibBuilder, MibInstrumController, MibViewController]
-        if not shared_mib_builder:
-            return cls._create_mib_builder(mibs_path)
-        # Use a lock to make sure we don't concurrently create the cached objects
-        with cls._mib_lock:
-            if cls._mib_builders.get(mibs_path) is None:
-                cls._mib_builders[mibs_path] = cls._create_mib_builder(mibs_path)
-            return cls._mib_builders[mibs_path]
-
-    @classmethod
-    def create_snmp_engine(cls, mibs_path, shared_mib_builder):
-        # type: (Optional[str], bool) -> Tuple[SnmpEngine, MibViewController]
-        """
-        Create a command generator to perform all the snmp query.
-        If mibs_path is not None, load the mibs present in the custom mibs
-        folder. (Need to be in pysnmp format)
-        """
-        _, instrum_controller, mib_view_controller = cls._get_mib_builder(mibs_path, shared_mib_builder)
-        message_dispatcher = MsgAndPduDispatcher(instrum_controller)
-        snmp_engine = SnmpEngine(msgAndPduDsp=message_dispatcher)
-
-        return snmp_engine, mib_view_controller
 
     @staticmethod
     def get_transport_target(instance, timeout, retries):

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -17,15 +17,15 @@ init_config:
   # ignore_nonincreasing_oid: false
 
   ## @param oid_batch_size - integer - optional - default: 10
-  ## Number of OIDs handled by each batch. Performance can be improved by increasing this number, though
-  ## it will also use more resources.
+  ## The number of OIDs handled by each batch. Increasing this number improves performance but
+  ## uses more resources.
   #
   # oid_batch_size: 10
 
   ## @param optimize_mib_memory_usage - boolean - optional - default: false
-  ## **Experimental** - Set this flag to true to attempt optimizing memory usage related to
-  ## MIB information. Under the hood this will share internal MIB data across instances.
-  ## Note that the absence of impact on MIB resolution of this strategy is not guaranteed yet.
+  ## **Experimental** - Setting this flag to true attempts to optimize memory usage related to
+  ## MIB information. This shares internal MIB data across instances.
+  ## Note: The absence of impact on MIB resolution for this strategy is not guaranteed yet.
   #
   # optimize_mib_memory_usage: false
 

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -18,7 +18,7 @@ init_config:
 
   ## @param oid_batch_size - integer - optional - default: 10
   ## Number of OIDs handled by each batch. Performance can be improved by increasing this number, though
-  ## it will also use more resource.
+  ## it will also use more resources.
   #
   # oid_batch_size: 10
 

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -23,7 +23,7 @@ init_config:
   # oid_batch_size: 10
 
   ## @param shared_mib_builder - boolean - optional - default: false
-  ## Set to true to share MIB builders between instance. It will reduce memory
+  ## Set to true to share MIB builders between instances. It will reduce memory
   ## usage, but doesn't work in some edge cases.
   #
   # shared_mib_builder: false

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -27,7 +27,7 @@ init_config:
   ## MIB information. Under the hood this will share internal MIB data across instances.
   ## Note that the absence of impact on MIB resolution of this strategy is not guaranteed yet.
   #
-  # shared_mib_builder: false
+  # optimize_mib_memory_usage: false
 
   ## @param global_metrics - list of elements - optional
   ## Specify global_metrics you want to monitor by using MIBS for Counter and Gauge.

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -22,9 +22,10 @@ init_config:
   #
   # oid_batch_size: 10
 
-  ## @param shared_mib_builder - boolean - optional - default: false
-  ## Set to true to share MIB builders between instances. It will reduce memory
-  ## usage, but doesn't work in some edge cases.
+  ## @param optimize_mib_memory_usage - boolean - optional - default: false
+  ## **Experimental** - Set this flag to true to attempt optimizing memory usage related to
+  ## MIB information. Under the hood this will share internal MIB data across instances.
+  ## Note that the absence of impact on MIB resolution of this strategy is not guaranteed yet.
   #
   # shared_mib_builder: false
 

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -16,6 +16,18 @@ init_config:
   #
   # ignore_nonincreasing_oid: false
 
+  ## @param oid_batch_size - integer - optional - default: 10
+  ## Number of OIDs handled by each batch. Performance can be improved by increasing this number, though
+  ## it will also use more resource.
+  #
+  # oid_batch_size: 10
+
+  ## @param shared_mib_builder - boolean - optional - default: false
+  ## Set to true to share MIB builders between instance. It will reduce memory
+  ## usage, but doesn't work in some edge cases.
+  #
+  # shared_mib_builder: false
+
   ## @param global_metrics - list of elements - optional
   ## Specify global_metrics you want to monitor by using MIBS for Counter and Gauge.
   ## global_metrics are applied to all instances where use_global_metrics is set to true at the instance level.

--- a/snmp/datadog_checks/snmp/mibs.py
+++ b/snmp/datadog_checks/snmp/mibs.py
@@ -33,7 +33,10 @@ class MIBLoader:
     """
     A helper for loading and caching MIB information using PySNMP.
 
-    To save up memory, PySNMP MIB-related objects are cached by MIB path.
+    To save up memory, PySNMP MIB-related objects are cached by MIB path. This
+    is not supported perfectly by pysnmp, as `MibBuilder` in particular is
+    globally modified by each SNMP clients, and it also fails to load
+    concurrently conflicting MIBs like RFC1213 and TCP.
     """
 
     def __init__(self):

--- a/snmp/datadog_checks/snmp/mibs.py
+++ b/snmp/datadog_checks/snmp/mibs.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import threading
-from typing import Dict, Tuple, Optional
+from typing import Dict, Optional, Tuple
 
 from .pysnmp_types import (
     DirMibSource,
@@ -12,7 +12,6 @@ from .pysnmp_types import (
     MsgAndPduDispatcher,
     SnmpEngine,
 )
-
 
 BuilderInfo = Tuple[MibBuilder, MibInstrumController, MibViewController]
 

--- a/snmp/datadog_checks/snmp/mibs.py
+++ b/snmp/datadog_checks/snmp/mibs.py
@@ -1,0 +1,80 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+import threading
+from typing import Dict, Tuple, Optional
+
+from .pysnmp_types import (
+    DirMibSource,
+    MibBuilder,
+    MibInstrumController,
+    MibViewController,
+    MsgAndPduDispatcher,
+    SnmpEngine,
+)
+
+
+BuilderInfo = Tuple[MibBuilder, MibInstrumController, MibViewController]
+
+
+def _create_mib_builder(mibs_path=None):
+    # type: (str) -> BuilderInfo
+    mib_builder = MibBuilder()
+
+    if mibs_path is not None:
+        mib_builder.addMibSources(DirMibSource(mibs_path))
+
+    mib_instrum = MibInstrumController(mib_builder)
+    mib_view = MibViewController(mib_builder)
+
+    return mib_builder, mib_instrum, mib_view
+
+
+class MIBLoader:
+    """
+    A helper for loading and caching MIB information using PySNMP.
+
+    To save up memory, PySNMP MIB-related objects are cached by MIB path.
+    """
+
+    def __init__(self):
+        # type: () -> None
+        self._builders = {}  # type: Dict[Optional[str], BuilderInfo]
+        self._cache_lock = threading.Lock()
+
+    @classmethod
+    def shared_instance(cls):
+        # type: () -> MIBLoader
+        """
+        Return a globally shared loader instance. Can be used to save up memory across check instances.
+        """
+        if not hasattr(cls, "_instance"):
+            cls._instance = MIBLoader()  # type: ignore
+        return cls._instance  # type: ignore
+
+    def _get_or_create_builder_info(self, mibs_path=None):
+        # type: (str) -> BuilderInfo
+        with self._cache_lock:  # Prevent concurrent builder cache access and updates.
+            if mibs_path not in self._builders:
+                self._builders[mibs_path] = _create_mib_builder(mibs_path)
+            return self._builders[mibs_path]
+
+    def get_mib_view_controller(self, mibs_path=None):
+        # type: (str) -> MibViewController
+        """
+        Create a PySNMP MibViewController instance, for use in MIB resolution.
+        """
+        _, _, mib_view_controller = self._get_or_create_builder_info(mibs_path)
+        return mib_view_controller
+
+    def create_snmp_engine(self, mibs_path=None):
+        # type: (str) -> SnmpEngine
+        """
+        Create a command generator to perform SNMP queries.
+
+        `mibs_path` should point to a custom directory containing MIBs in the PySNMP format. If not given,
+        MIBs shipped with PySNMP are used.
+        """
+        _, instrum_controller, _ = self._get_or_create_builder_info(mibs_path)
+        message_dispatcher = MsgAndPduDispatcher(instrum_controller)
+        return SnmpEngine(msgAndPduDsp=message_dispatcher)

--- a/snmp/datadog_checks/snmp/pysnmp_types.py
+++ b/snmp/datadog_checks/snmp/pysnmp_types.py
@@ -21,8 +21,10 @@ from pysnmp.hlapi import (
 from pysnmp.hlapi.asyncore.cmdgen import lcd
 from pysnmp.hlapi.transport import AbstractTransportTarget
 from pysnmp.proto.rfc1902 import ObjectName, Opaque
-from pysnmp.smi.builder import DirMibSource
+from pysnmp.proto.rfc3412 import MsgAndPduDispatcher
+from pysnmp.smi.builder import DirMibSource, MibBuilder
 from pysnmp.smi.exval import endOfMibView, noSuchInstance, noSuchObject
+from pysnmp.smi.instrum import MibInstrumController
 from pysnmp.smi.view import MibViewController
 
 __all__ = [
@@ -34,7 +36,10 @@ __all__ = [
     'endOfMibView',
     'hlapi',
     'lcd',
+    'MibBuilder',
+    'MibInstrumController',
     'MibViewController',
+    'MsgAndPduDispatcher',
     'noSuchInstance',
     'noSuchObject',
     'ObjectIdentity',

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -24,6 +24,7 @@ from .config import InstanceConfig
 from .discovery import discover_instances
 from .exceptions import PySnmpError
 from .metrics import as_metric_with_forced_type, as_metric_with_inferred_type
+from .mibs import MIBLoader
 from .models import OID
 from .parsing import ParsedMetric, ParsedMetricTag, ParsedTableMetric
 from .pysnmp_types import ObjectIdentity, ObjectType, noSuchInstance, noSuchObject
@@ -119,13 +120,15 @@ class SnmpCheck(AgentCheck):
 
     def _build_config(self, instance):
         # type: (dict) -> InstanceConfig
+        loader = MIBLoader.shared_instance() if self.shared_mib_builder else MIBLoader()
+
         return InstanceConfig(
             instance,
             global_metrics=self.init_config.get('global_metrics', []),
             mibs_path=self.mibs_path,
             profiles=self.profiles,
             profiles_by_oid=self.profiles_by_oid,
-            shared_mib_builder=self.shared_mib_builder,
+            loader=loader,
         )
 
     def _get_instance_name(self, instance):

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -63,6 +63,8 @@ class SnmpCheck(AgentCheck):
         # Load Custom MIB directory
         self.mibs_path = self.init_config.get('mibs_folder')
 
+        self.shared_mib_builder = is_affirmative(self.init_config.get('shared_mib_builder', False))
+
         self.ignore_nonincreasing_oid = is_affirmative(self.init_config.get('ignore_nonincreasing_oid', False))
 
         self.profiles = self._load_profiles()
@@ -123,6 +125,7 @@ class SnmpCheck(AgentCheck):
             mibs_path=self.mibs_path,
             profiles=self.profiles,
             profiles_by_oid=self.profiles_by_oid,
+            shared_mib_builder=self.shared_mib_builder,
         )
 
     def _get_instance_name(self, instance):

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -64,7 +64,7 @@ class SnmpCheck(AgentCheck):
         # Load Custom MIB directory
         self.mibs_path = self.init_config.get('mibs_folder')
 
-        self.shared_mib_builder = is_affirmative(self.init_config.get('shared_mib_builder', False))
+        self.optimize_mib_memory_usage = is_affirmative(self.init_config.get('optimize_mib_memory_usage', False))
 
         self.ignore_nonincreasing_oid = is_affirmative(self.init_config.get('ignore_nonincreasing_oid', False))
 
@@ -120,7 +120,7 @@ class SnmpCheck(AgentCheck):
 
     def _build_config(self, instance):
         # type: (dict) -> InstanceConfig
-        loader = MIBLoader.shared_instance() if self.shared_mib_builder else MIBLoader()
+        loader = MIBLoader.shared_instance() if self.optimize_mib_memory_usage else MIBLoader()
 
         return InstanceConfig(
             instance,

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -58,7 +58,7 @@ CAST_METRICS = [
     {'OID': "1.3.6.1.4.1.2021.10.1.6.1", 'name': "cpuload2"},  # Opaque
 ]
 
-CONSTRAINED_OID = [{"MIB": "RFC1213-MIB", "symbol": "tcpRtoAlgorithm"}]
+CONSTRAINED_OID = [{"MIB": "TCP-MIB", "symbol": "tcpRtoAlgorithm"}]
 
 DUMMY_MIB_OID = [
     ({"MIB": "DUMMY-MIB", "symbol": "scalar"}, AggregatorStub.GAUGE, 10),  # Integer


### PR DESCRIPTION
This allows re-using objects manipulating MIBs to reduce memory usage.
This is behind a flag for now, as there is at least one example of
breaking behavior when loading conflicting MIBs (like TCP and RFC1213).

I run a test with 40 devices and a small GCP instance using the agent autodiscovery:
rc6 takes about 230M of RSS
rc6 with patch takes 155M instead.
