### PR TITLE
Fix gitlab e2e metrics

### DIFF
--- a/gitlab/tests/common.py
+++ b/gitlab/tests/common.py
@@ -94,7 +94,7 @@ METRICS = [
 ]
 
 METRICS_TO_TEST = [
-    "unicorn.workers",
+    "puma.workers",
     "rack.http_requests_total",
     "ruby.process_start_time_seconds",
     "rack.http_request_duration_seconds.sum",


### PR DESCRIPTION
### What does this PR do?
- Updates flakey gitlab e2e test

### Motivation
- Gitlab now uses puma by default, so the latest image emits those metrics instead of` unicorn.*`
- https://about.gitlab.com/releases/2020/05/22/gitlab-13-0-released/#reduced-memory-consumption-of-gitlab-with-puma

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
