### PR TITLE
Add ability to generate docs site as a PDF

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/build.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/build.py
@@ -20,10 +20,9 @@ def build(verbose, pdf):
     command = ['tox', '-e', 'docs', '--', 'build', '--clean']
     insert_verbosity_flag(command, verbose)
 
-    if pdf:
-        os.environ["ENABLE_PDF_SITE_EXPORT"] = '1'
+    env_vars = {'ENABLE_PDF_SITE_EXPORT': '1' if pdf else '0'}
 
-    with chdir(get_root()):
+    with chdir(get_root(), env_vars=env_vars):
         process = subprocess.run(command)
 
     abort(code=process.returncode)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/build.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/build.py
@@ -1,10 +1,10 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
 import subprocess
 
 import click
-import os
 
 from .... import chdir
 from ...constants import get_root

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/build.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/build.py
@@ -4,6 +4,7 @@
 import subprocess
 
 import click
+import os
 
 from .... import chdir
 from ...constants import get_root
@@ -13,10 +14,14 @@ from .utils import insert_verbosity_flag
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Build documentation')
 @click.option('--verbose', '-v', count=True, help='Increase verbosity (can be used additively)')
-def build(verbose):
+@click.option('--pdf', is_flag=True, help='Also export the site as PDF')
+def build(verbose, pdf):
     """Build documentation."""
     command = ['tox', '-e', 'docs', '--', 'build', '--clean']
     insert_verbosity_flag(command, verbose)
+
+    if pdf:
+        os.environ["ENABLE_PDF_SITE_EXPORT"] = '1'
 
     with chdir(get_root()):
         process = subprocess.run(command)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/build.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/build.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import os
 import subprocess
 
 import click

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/serve.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/serve.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
 import subprocess
 import webbrowser
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/serve.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/serve.py
@@ -24,8 +24,7 @@ def serve(no_open, verbose, pdf):
     command = ['tox', '-e', 'docs', '--', 'serve', '--livereload', '--dev-addr', address]
     insert_verbosity_flag(command, verbose)
 
-    if pdf:
-        os.environ["ENABLE_PDF_SITE_EXPORT"] = '1'
+    env_vars = {'ENABLE_PDF_SITE_EXPORT': '1' if pdf else '0'}
 
     address = f'http://{address}'
     build_completion_indicator = f'Serving on {address}'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/serve.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/serve.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import os
 import subprocess
 import webbrowser
 
@@ -35,7 +34,7 @@ def serve(no_open, verbose, pdf):
     warning_prefixes = ('[W ', 'WARNING ')
     error_prefixes = ('[E ', 'ERROR ')
 
-    with chdir(get_root()):
+    with chdir(get_root(), env_vars=env_vars):
         with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as process:
 
             # To avoid blocking never use a pipe's file descriptor iterator. See https://bugs.python.org/issue3907

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/serve.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/serve.py
@@ -15,12 +15,16 @@ from .utils import insert_verbosity_flag
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Serve and view documentation in a web browser')
 @click.option('--no-open', '-n', is_flag=True, help='Do not open the documentation in a web browser')
 @click.option('--verbose', '-v', count=True, help='Increase verbosity (can be used additively)')
-def serve(no_open, verbose):
+@click.option('--pdf', is_flag=True, help='Also export the site as PDF')
+def serve(no_open, verbose, pdf):
     """Serve and view documentation in a web browser."""
     address = 'localhost:8000'
 
     command = ['tox', '-e', 'docs', '--', 'serve', '--livereload', '--dev-addr', address]
     insert_verbosity_flag(command, verbose)
+
+    if pdf:
+        os.environ["ENABLE_PDF_SITE_EXPORT"] = '1'
 
     address = f'http://{address}'
     build_completion_indicator = f'Serving on {address}'

--- a/docs/developer/.snippets/links.txt
+++ b/docs/developer/.snippets/links.txt
@@ -46,6 +46,7 @@
 [docs-extension-pymdown]: https://facelessuser.github.io/pymdown-extensions/
 [docs-plugin-auto-doc]: https://github.com/pawamoy/mkdocstrings
 [docs-plugin-minify]: https://github.com/byrnereese/mkdocs-minify-plugin
+[docs-plugin-pdf-export]: https://github.com/zhaoterryy/mkdocs-pdf-export-plugin
 [docs-plugin-revision-date]: https://github.com/timvink/mkdocs-git-revision-date-localized-plugin
 [docs-scripts]: https://github.com/DataDog/integrations-core/tree/master/docs/developer/.scripts
 [docs-snippets-abbreviations]: https://github.com/DataDog/integrations-core/blob/master/docs/developer/.snippets/abbrs.txt
@@ -109,3 +110,4 @@
 [terraform-templates-location]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_dev/datadog_checks/dev/tooling/templates/terraform
 [toml-github]: https://github.com/toml-lang/toml
 [tox-github]: https://github.com/tox-dev/tox
+[weasyprint-dependencies]: https://weasyprint.readthedocs.io/en/latest/install.html

--- a/docs/developer/meta/docs.md
+++ b/docs/developer/meta/docs.md
@@ -14,7 +14,7 @@ We use a select few [MkDocs plugins][mkdocs-plugins] to achieve the following:
 - minify HTML ([:octicons-octoface:][docs-plugin-minify])
 - display the date of the last Git modification of every page ([:octicons-octoface:][docs-plugin-revision-date])
 - automatically generate docs based on code and docstrings ([:octicons-octoface:][docs-plugin-auto-doc])
-- export the markdown pages as PDF ([:octicons-octoface:][docs-plugin-pdf-export])
+- export the site as a PDF ([:octicons-octoface:][docs-plugin-pdf-export])
 
 ## Extensions
 
@@ -71,7 +71,7 @@ ddev docs serve
 
 By default, live reloading is enabled so any modification will be reflected in near-real time.
 
-**Note:** In order to export the site as PDF, you can use the `--pdf` flag, but you will need some [external installations][weasyprint-dependencies].
+**Note:** In order to export the site as a PDF, you can use the `--pdf` flag, but you will need some [external dependencies][weasyprint-dependencies].
 
 ## Deploy
 

--- a/docs/developer/meta/docs.md
+++ b/docs/developer/meta/docs.md
@@ -14,6 +14,7 @@ We use a select few [MkDocs plugins][mkdocs-plugins] to achieve the following:
 - minify HTML ([:octicons-octoface:][docs-plugin-minify])
 - display the date of the last Git modification of every page ([:octicons-octoface:][docs-plugin-revision-date])
 - automatically generate docs based on code and docstrings ([:octicons-octoface:][docs-plugin-auto-doc])
+- export the markdown pages as PDF ([:octicons-octoface:][docs-plugin-pdf-export])
 
 ## Extensions
 
@@ -69,6 +70,8 @@ ddev docs serve
 ```
 
 By default, live reloading is enabled so any modification will be reflected in near-real time.
+
+**Note:** In order to export the site as PDF, you can use the `--pdf` flag, but you will need some [external installations][weasyprint-dependencies].
 
 ## Deploy
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,8 @@ plugins:
             show_if_no_docstring: yes
             show_root_heading: yes
             show_source: true
+  - pdf-export:
+    enabled_if_env: ENABLE_PDF_SITE_EXPORT
 
 markdown_extensions:
   # Built-in

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,7 @@ plugins:
             show_root_heading: yes
             show_source: true
   - pdf-export:
-    enabled_if_env: ENABLE_PDF_SITE_EXPORT
+      enabled_if_env: ENABLE_PDF_SITE_EXPORT
 
 markdown_extensions:
   # Built-in

--- a/tox.ini
+++ b/tox.ini
@@ -18,12 +18,15 @@ deps =
     mkdocs-minify-plugin>=0.3.0
     mkdocs-git-revision-date-localized-plugin>=0.5.2
     mkdocstrings>=0.11.0
+    mkdocs-pdf-export-plugin>=0.5.6
     ; Extensions
     pymdown-extensions>=7.1
     mkdocs-material-extensions>=1.0b2
     mkpatcher>=1.0.2
     ; Necessary for syntax highlighting in code blocks
     Pygments>=2.5.2
+    ; Necessary to generate PDF
+    WeasyPrint>=51
     ; for API auto-documentation
     -e./datadog_checks_base[deps,http]
     -e./datadog_checks_dev[cli]


### PR DESCRIPTION
### What does this PR do?
Add `--pdf` flag to build a PDF for each page.

### Motivation

### Additional Notes
Using https://github.com/zhaoterryy/mkdocs-pdf-export-plugin
It does not render correctly the `tabbed` element (like to dependencies in in `faq/acknowledgements` and print only one tab. Moreover the dependencies of `faq/acknowledgements` do not fit in a single page, so this page can't be rendered by this plugin.

The site can't be rendered as a unique PDF since the `acknowledgements` page can't be generated.

Don't forget the prerequisites to use it locally: https://weasyprint.readthedocs.io/en/latest/install.html

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
