### PR TITLE
[WIP] Pin `setuptools_scm` to 3.5.0

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -69,7 +69,7 @@ selectors34==1.2.0; sys_platform == 'win32' and python_version < '3.4'
 semver==2.9.0
 serpent==1.27; sys_platform == 'win32'
 service_identity[idna]==18.1.0
-setuptools_scm==3.5.0
+setuptools-scm==3.5.0
 simplejson==3.6.5
 six==1.14.0
 supervisor==4.1.0

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -69,6 +69,7 @@ selectors34==1.2.0; sys_platform == 'win32' and python_version < '3.4'
 semver==2.9.0
 serpent==1.27; sys_platform == 'win32'
 service_identity[idna]==18.1.0
+setuptools_scm==3.5.0
 simplejson==3.6.5
 six==1.14.0
 supervisor==4.1.0

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -19,7 +19,7 @@ requests-kerberos==0.12.0
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1
 # `setuptools_scm` 4.0 breaks on Windows + 2.7: https://github.com/pypa/setuptools_scm/issues/442
-setuptools_scm==3.5.0
+setuptools-scm==3.5.0
 simplejson==3.6.5
 six==1.14.0
 typing==3.7.4.1; python_version < '3.0'

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -18,6 +18,8 @@ requests==2.22.0
 requests-kerberos==0.12.0
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1
+# `setuptools_scm` 4.0 breaks on Windows + 2.7: https://github.com/pypa/setuptools_scm/issues/442
+setuptools_scm==3.5.0
 simplejson==3.6.5
 six==1.14.0
 typing==3.7.4.1; python_version < '3.0'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Pin `setuptools_scm` to 3.5.0
### Motivation
<!-- What inspired you to submit this pull request? -->

 `setuptools_scm` 4.0 breaks on Windows + 2.7:

https://github.com/pypa/setuptools_scm/issues/442

`setuptools_scm` is a dep from `ddtrace`:
https://github.com/DataDog/dd-trace-py/blob/master/setup.py#L149

Failing build: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=16424&view=logs&j=2c9050e0-5be6-5014-27c6-a7b39b941d76&t=b67d05b8-4057-5a69-16ef-b4379dc0abda&l=76


```
Collecting ddtrace==0.32.2
  Downloading ddtrace-0.32.2.tar.gz (549 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: 'D:\a\1\s\datadog_checks_base\.tox\py27\Scripts\python.exe' 'D:\a\1\s\datadog_checks_base\.tox\py27\lib\site-packages\pip' install --ignore-installed --no-user --prefix 'c:\users\vssadm~1\appdata\local\temp\pip-build-env-l8dpvs\normal' --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- setuptools_scm
       cwd: None
  Complete output (35 lines):
  DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
  Collecting setuptools_scm
    Downloading setuptools_scm-4.0.0.tar.gz (46 kB)
    Installing build dependencies: started
    Installing build dependencies: finished with status 'done'
    Getting requirements to build wheel: started
    Getting requirements to build wheel: finished with status 'error'
    ERROR: Command errored out with exit status 1:
     command: 'D:\a\1\s\datadog_checks_base\.tox\py27\Scripts\python.exe' 'D:\a\1\s\datadog_checks_base\.tox\py27\lib\site-packages\pip\_vendor\pep517\_in_process.py' get_requires_for_build_wheel 'c:\users\vssadm~1\appdata\local\temp\tmpetxrzo'
         cwd: c:\users\vssadm~1\appdata\local\temp\pip-install-glx3ob\setuptools-scm
    Complete output (22 lines):
    c:\users\vssadm~1\appdata\local\temp\pip-install-glx3ob\setuptools-scm\src
    <pkg_resources.WorkingSet object at 0x000000000412E948>
    Traceback (most recent call last):
      File "D:\a\1\s\datadog_checks_base\.tox\py27\lib\site-packages\pip\_vendor\pep517\_in_process.py", line 280, in <module>
        main()
      File "D:\a\1\s\datadog_checks_base\.tox\py27\lib\site-packages\pip\_vendor\pep517\_in_process.py", line 263, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "D:\a\1\s\datadog_checks_base\.tox\py27\lib\site-packages\pip\_vendor\pep517\_in_process.py", line 114, in get_requires_for_build_wheel
        return hook(config_settings)
      File "c:\users\vssadm~1\appdata\local\temp\pip-build-env-yfuvkw\overlay\Lib\site-packages\setuptools\build_meta.py", line 146, in get_requires_for_build_wheel
        return self._get_build_requires(config_settings, requirements=['wheel'])
      File "c:\users\vssadm~1\appdata\local\temp\pip-build-env-yfuvkw\overlay\Lib\site-packages\setuptools\build_meta.py", line 127, in _get_build_requires
        self.run_setup()
      File "c:\users\vssadm~1\appdata\local\temp\pip-build-env-yfuvkw\overlay\Lib\site-packages\setuptools\build_meta.py", line 142, in run_setup
        exec(compile(code, __file__, 'exec'), locals())
      File "setup.py", line 53, in <module>
        setuptools.setup(**scm_config())
      File "setup.py", line 31, in scm_config
        from setuptools_scm.git import parse as parse_git
      File "c:\users\vssadm~1\appdata\local\temp\pip-install-glx3ob\setuptools-scm\src\setuptools_scm\git.py", line 9, in <module>
        from os.path import samefile
    ImportError: cannot import name samefile
    ----------------------------------------
  ERROR: Command errored out with exit status 1: 'D:\a\1\s\datadog_checks_base\.tox\py27\Scripts\python.exe' 'D:\a\1\s\datadog_checks_base\.tox\py27\lib\site-packages\pip\_vendor\pep517\_in_process.py' get_requires_for_build_wheel 'c:\users\vssadm~1\appdata\local\temp\tmpetxrzo' Check the logs for full command output.
  
```


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
