### PR TITLE
Validate log pipelines and send slack notification on failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ notify-slack-on-failure:
   only:
   - schedules
   variables:
-    MESSAGE: ":alert: Logs pipelines don't pass validation steps, please investigate $CI_PIPELINE_URL for errors."
+    MESSAGE: "Logs pipelines don't pass validation steps, please investigate $CI_PIPELINE_URL for errors."
   script:
     - postmessage agent-integrations "$MESSAGE" alert
   when: on_failure

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,8 @@
 variables:
   REMINDER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/integrations-core:reminder
   TAGGER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/integrations-core:tagger
+  VALIDATE_LOG_INTGS: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/integrations-core:validate_log_intgs
+  NOTIFIER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/slack-notifier:latest
   TAGGER_EMAIL: packages@datadoghq.com
   TAGGER_NAME: ci.integrations-core
 
@@ -14,10 +16,48 @@ variables:
 #     - ./.gitlab/reminder/release-reminder.sh 2>&1
 #   tags: [ "runner:main", "size:large" ]
 
+stages:
+  - build
+  - validate
+  - release
+  - notify
+
+
+validate-log-integrations:
+  stage: validate
+  image: $VALIDATE_LOG_INTGS
+  only:
+  - schedules
+  variables:
+    WEBUI_INTGS_FILE: web-ui/javascript/datadog/logs/lib/integrations/integrations.ts
+    LOGS_BACKEND_INTGS_ROOT: logs-backend/service/src/main/resources/integrations/
+    INTEGRATIONS_CORE_ROOT: .
+  script:
+    - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/Datadog/web-ui.git --depth 1
+    - ts-node /scripts/parse_ts.ts > logs_integrations.json
+    - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/Datadog/logs-backend.git --depth 1
+    - python3 /scripts/validate_log_intgs.py logs_integrations.json
+  tags: [ "runner:main", "size:large" ]
+
+notify-slack-on-failure:
+  stage: notify
+  image: $NOTIFIER_IMAGE
+  only:
+  - schedules
+  variables:
+    MESSAGE: ":alert: Logs pipelines don't pass validation steps, please investigate $CI_PIPELINE_URL for errors."
+  script:
+    - postmessage agent-integrations "$MESSAGE" alert
+  when: on_failure
+  tags: [ "runner:main", "size:large" ]
+
 release-auto:
+  stage: release
   image: $TAGGER_IMAGE
   only:
     - master
+  except:
+    - schedules
   script:
     - ddev --version
     - ddev config set core .
@@ -26,10 +66,13 @@ release-auto:
   tags: [ "runner:main", "size:large" ]
 
 release-manual:
+  stage: release
   image: $TAGGER_IMAGE
   only:
     # Integration release tags e.g. any_check-X.Y.Z-rc.N
     - /.*-\d+\.\d+\.\d+(-(rc|pre|alpha|beta)\.\d+)?$/
+  except:
+  - schedules
   script:
     # Get tagger info
     - tagger=$(git for-each-ref refs/tags/$CI_COMMIT_TAG  --format='%(taggername) %(taggeremail)')
@@ -45,6 +88,7 @@ release-manual:
   tags: [ "runner:main", "size:large" ]
 
 reminder-image-builder:
+  stage: build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:18.03.1
   only:
     changes:
@@ -59,6 +103,7 @@ reminder-image-builder:
   tags: [ "runner:docker", "size:large" ]
 
 tagger-image-builder:
+  stage: build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:18.03.1
   only:
     changes:
@@ -71,4 +116,19 @@ tagger-image-builder:
     - docker images $TAGGER_IMAGE
     - docker push $TAGGER_IMAGE
   except: [ tags, schedules ]
+  tags: [ "runner:docker", "size:large" ]
+
+validate-log-intgs-builder:
+  stage: build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:18.03.1
+  only:
+    changes:
+      - .gitlab/validate-logs-intgs/**
+    refs:
+      - schedules
+  script:
+    - cd .gitlab/validate-logs-intgs/
+    - docker build --tag $VALIDATE_LOG_INTGS .
+    - docker images $VALIDATE_LOG_INTGS
+    - docker push $VALIDATE_LOG_INTGS
   tags: [ "runner:docker", "size:large" ]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@ variables:
   NOTIFIER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/slack-notifier:latest
   TAGGER_EMAIL: packages@datadoghq.com
   TAGGER_NAME: ci.integrations-core
+  NOTIFICATIONS_SLACK_CHANNEL: agent-integrations
 
 # Uncomment when/if we modify script to use Jira
 #
@@ -36,19 +37,28 @@ validate-log-integrations:
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/Datadog/web-ui.git --depth 1
     - ts-node /scripts/parse_ts.ts > logs_integrations.json
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/Datadog/logs-backend.git --depth 1
-    - python3 /scripts/validate_log_intgs.py logs_integrations.json
+    - python3 /scripts/validate_log_intgs.py logs_integrations.json 2> errors.txt
+  artifacts:
+    paths:
+    - errors.txt
+    expire_in: 1 day
   tags: [ "runner:main", "size:large" ]
 
-notify-slack-on-failure:
+
+notify-slack:
   stage: notify
   image: $NOTIFIER_IMAGE
   only:
   - schedules
-  variables:
-    MESSAGE: "Logs pipelines don't pass validation steps, please investigate $CI_PIPELINE_URL for errors."
   script:
-    - postmessage agent-integrations "$MESSAGE" alert
-  when: on_failure
+    - |
+      if [[ -s ./errors.txt ]]; then
+          MESSAGE="Logs pipelines don't pass validation steps, please investigate $CI_PIPELINE_URL for errors.\n$(cat errors.txt)"
+          postmessage $NOTIFICATIONS_SLACK_CHANNEL $MESSAGE alert
+      else
+          MESSAGE="Logs pipelines passed validation steps, good job :+1:"
+          postmessage $NOTIFICATIONS_SLACK_CHANNEL $MESSAGE success
+      fi
   tags: [ "runner:main", "size:large" ]
 
 release-auto:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,7 @@ validate-log-integrations:
     paths:
     - errors.txt
     expire_in: 1 day
+    when: always
   tags: [ "runner:main", "size:large" ]
 
 
@@ -53,12 +54,14 @@ notify-slack:
   script:
     - |
       if [[ -s ./errors.txt ]]; then
-          MESSAGE="Logs pipelines don't pass validation steps, please investigate $CI_PIPELINE_URL for errors.\n$(cat errors.txt)"
-          postmessage $NOTIFICATIONS_SLACK_CHANNEL $MESSAGE alert
+          cat errors.txt
+          MESSAGE="Logs pipelines don't pass validation steps, please investigate $CI_JOB_URL for errors."
+          postmessage "$NOTIFICATIONS_SLACK_CHANNEL" "$MESSAGE" alert
       else
           MESSAGE="Logs pipelines passed validation steps, good job :+1:"
-          postmessage $NOTIFICATIONS_SLACK_CHANNEL $MESSAGE success
+          postmessage "$NOTIFICATIONS_SLACK_CHANNEL" "$MESSAGE" success
       fi
+  when: always
   tags: [ "runner:main", "size:large" ]
 
 release-auto:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,7 +135,7 @@ validate-log-intgs-builder:
     changes:
       - .gitlab/validate-logs-intgs/**
     refs:
-      - schedules
+      - master
   script:
     - cd .gitlab/validate-logs-intgs/
     - docker build --tag $VALIDATE_LOG_INTGS .

--- a/.gitlab/validate-logs-intgs/Dockerfile
+++ b/.gitlab/validate-logs-intgs/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:alpine
+RUN apk add git python3 --no-cache
+RUN pip3 install pyyaml
+RUN npm install -g ts-node
+RUN npm install typescript @typescript-eslint/parser @typescript-eslint/typescript-estree @types/node
+COPY parse_ts.ts /scripts/parse_ts.ts
+COPY validate_log_intgs.py /scripts/validate_log_intgs.py

--- a/.gitlab/validate-logs-intgs/parse_ts.ts
+++ b/.gitlab/validate-logs-intgs/parse_ts.ts
@@ -1,0 +1,23 @@
+import * as fs from 'fs';
+import * as ts from "typescript";
+import { parse, TSESTreeOptions } from "@typescript-eslint/typescript-estree";
+
+const source = fs.readFileSync(process.env.WEBUI_INTGS_FILE,'utf8');
+const options: TSESTreeOptions = {comment: false, jsx: false, range: true};
+const program = parse(source, options).body;
+
+// Remove everything from the program except variable declaration of type const where the variable is named LOG_INTEGRATIONS
+var filteredProgram = program.filter(x => x['type'] === 'VariableDeclaration' && x['kind'] === 'const' && x['declarations'][0]['id']['name'] == 'LOG_INTEGRATIONS');
+
+if(filteredProgram.length != 1) {
+    // raise exc
+}
+
+const logIntegrationVarLocation = filteredProgram[0]['range'];
+var logIntegrationDeclaration = source.slice(logIntegrationVarLocation[0], logIntegrationVarLocation[1]);
+
+logIntegrationDeclaration += "\nLOG_INTEGRATIONS;\n"
+
+const LOG_INTEGRATIONS = eval(ts.transpile(logIntegrationDeclaration))
+
+console.log(JSON.stringify(LOG_INTEGRATIONS));

--- a/.gitlab/validate-logs-intgs/validate_log_intgs.py
+++ b/.gitlab/validate-logs-intgs/validate_log_intgs.py
@@ -27,7 +27,7 @@ EXCEPTIONS = {
     'eks_fargate': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # Log collection but not from the agent
     'fluentd': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # Fluentd is about log collection but we don't collect fluentd logs
     'kubernetes': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # The agent collects logs from kubernetes environment but there is no pipeline per se
-    'win32_event_log': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # win32_event_log is about log collection but we don't collect fluentd logs
+    'win32_event_log': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # win32_event_log is about log collection but we don't collect win32_event_log logs
 
 }
 

--- a/.gitlab/validate-logs-intgs/validate_log_intgs.py
+++ b/.gitlab/validate-logs-intgs/validate_log_intgs.py
@@ -1,0 +1,197 @@
+"""Python script to parse the logs pipeline from the logs-backend repository.
+This script is expected to run from a CLI, do not import it."""
+import sys
+import json
+from typing import List, Optional, Set
+import re
+import yaml
+import os
+
+LOGS_BACKEND_INTGS_ROOT = os.path.abspath(os.environ['LOGS_BACKEND_INTGS_ROOT'])
+INTEGRATIONS_CORE = os.path.abspath(os.environ['INTEGRATIONS_CORE_ROOT'])
+
+ERR_UNEXPECTED_LOG_COLLECTION_CAT = "The check does not have a log pipeline but defines 'log collection' in its manifest file."
+ERR_UNEXPECTED_LOG_DOC = "The check does not have a log pipeline but defines a source in its README."
+ERR_MISSING_LOG_COLLECTION_CAT = "The check has a log pipeline called but does not define 'log collection' in its manifest file."
+ERR_MISSING_LOG_DOC = "The check has a log pipeline but does not document log collection in the README file."
+ERR_MULTIPLE_SOURCES = "The check has a log pipeline but documents multiple sources as part of its README file."
+ERR_NOT_DEFINED_WEB_UI = "The check has a log pipeline but does not have a corresponding entry defined in web-ui."
+
+EXCEPTIONS = {
+    'cilium': [
+        ERR_UNEXPECTED_LOG_COLLECTION_CAT,  # cilium does not need a pipeline to automatically parse the logs
+        ERR_UNEXPECTED_LOG_DOC  # The documentation says to use 'source: cilium'
+    ],
+    'mesos_master': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # We do support log collection for mesos environments
+    'amazon_eks': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # eks is just a tile
+    'eks_fargate': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # Log collection but not from the agent
+    'fluentd': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # Fluentd is about log collection but we don't collect fluentd logs
+    'kubernetes': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # The agent collects logs from kubernetes environment but there is no pipeline per se
+    'win32_event_log': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # win32_event_log is about log collection but we don't collect fluentd logs
+
+}
+
+
+class CheckDefinition(object):
+    """
+    Represents a single check/integration for the agent, with all the various identifiers
+    it may have.
+    """
+    def __init__(self, dir_name: str) -> None:
+        """
+        Creates the CheckDefinition instance by looking up all ids from the integration directory.
+        Note: Does not populate log_source_name and is_defined_in_web_ui as they can't be retrieved
+        from the integration folder.
+        :param dir_name: The integration directory in the integrations-core repository
+        """
+        self.dir_name = dir_name
+
+        with open(os.path.join(INTEGRATIONS_CORE, dir_name, "manifest.json"), 'r') as manifest:
+            content = json.load(manifest)
+            # name of the integration
+            self.name: str = content['name']
+            # id of the integration
+            self.integration_id: str = content['integration_id']
+            # boolean: whether or not the integration supports log collection
+            self.log_collection: bool = 'log collection' in content['categories']
+            # boolean: whether or not the integration has public facing docs
+            self.is_public: bool = content['is_public']
+
+        # The log source defined in the log pipeline for this integration. This is populated after parsing pipelines.
+        self.log_source_name: Optional[str] = None
+
+        # Whether or not this check has a log to metrics mapping defined in web-ui
+        self.is_defined_in_web_ui: bool = False
+
+        # All the log sources defined in the README (in theory only one or zero). Useful to alert if multiple sources
+        # are defined in the README or if documentation is missing.
+        self.source_names_readme: List[str] = self.get_log_sources_in_readme()
+
+    def get_log_sources_in_readme(self) -> List[str]:
+        """
+        Parses the README file to find `source: ID`. This log source is supposed to be the same as the one
+        defined in the logs pipeline.
+        :return: A list of all sources found in the README. Usually one or zero.
+        """
+        readme_file = os.path.join(INTEGRATIONS_CORE, self.dir_name, "README.md")
+        with open(readme_file, 'r') as f:
+            content = f.read()
+
+        code_sections: List[str] = re.findall(r'(```.*?```|`.*?`)', content, re.DOTALL)
+        sources = set(re.findall(r'(?:"source"|source): "?(\w+)"?', "\n".join(code_sections), re.MULTILINE))
+
+        return list(sources)
+
+    def is_self(self, other_check_name) -> bool:
+        candidates = [self.dir_name.lower(), self.name.lower(), self.integration_id.lower()]
+        for source in self.source_names_readme:
+            candidates.append(source.lower())
+        if other_check_name.lower() in candidates:
+            return True
+
+        return False
+
+    def validate(self) -> List[str]:
+        # TODO: Check json file from web-ui
+        if not self.is_public:
+            return []
+
+        errors = set()
+        if not self.log_source_name:
+            # This check doesn't appear to have a log pipeline.
+            if self.log_collection:
+                errors.add(ERR_UNEXPECTED_LOG_COLLECTION_CAT)
+            if self.source_names_readme:
+                errors.add(ERR_UNEXPECTED_LOG_DOC)
+        else:
+            # This check has a log pipeline, let's validate it.
+            if not self.log_collection:
+                errors.add(ERR_MISSING_LOG_COLLECTION_CAT)
+            if not self.source_names_readme:
+                errors.add(ERR_MISSING_LOG_DOC)
+            if len(self.source_names_readme) > 1:
+                errors.add(ERR_MULTIPLE_SOURCES)
+            if not self.is_defined_in_web_ui:
+                errors.add(ERR_NOT_DEFINED_WEB_UI)
+
+        # Filter out some expected edge cases:
+        for exp_err in EXCEPTIONS.get(self.name, []):
+            if exp_err in errors:
+                errors.remove(exp_err)
+        return list(errors)
+
+    def __repr__(self):
+        return "%s(%s)" % (self.__class__.__name__, ", ".join(f"{k}={v}" for k, v in self.__dict__.items()))
+
+
+def print_err(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def get_all_checks() -> List[CheckDefinition]:
+    check_dirs = [
+        d for d in os.listdir(INTEGRATIONS_CORE)
+        if not d.startswith('.')
+        and os.path.isfile(os.path.join(INTEGRATIONS_CORE, d, "manifest.json"))
+    ]
+    check_dirs.sort()
+
+    all_checks = []
+    for check_dir in check_dirs:
+        all_checks.append(CheckDefinition(check_dir))
+
+    return all_checks
+
+
+def get_all_log_pipelines_ids():
+    files = [os.path.join(LOGS_BACKEND_INTGS_ROOT, f) for f in os.listdir(LOGS_BACKEND_INTGS_ROOT)]
+    files = [f for f in files if os.path.isfile(f)]
+    files.sort()
+    for file in files:
+        with open(file, 'r') as f:
+            yield yaml.load(f, Loader=yaml.SafeLoader)['id']
+
+
+def get_log_to_metric_map(file_path):
+    with open(file_path) as f:
+        mapping = json.load(f)
+
+    return {x['logSourceName']: x['metricsPrefixes'] for x in mapping if 'logSourceName' in x}
+
+def get_check_for_pipeline(log_source_name, agt_intgs_checks):
+    for check in agt_intgs_checks:
+        if check.is_self(log_source_name):
+            return check
+    return None
+
+
+if len(sys.argv) != 2:
+    print_err("This script requires a single JSON file as an argument.")
+    sys.exit(1)
+
+logs_to_metrics_mapping = get_log_to_metric_map(sys.argv[1])
+
+all_checks = list(get_all_checks())
+for pipeline_id in get_all_log_pipelines_ids():
+    if check := get_check_for_pipeline(pipeline_id, all_checks):
+        check.log_source_name = pipeline_id
+        check.is_defined_in_web_ui = pipeline_id in logs_to_metrics_mapping
+
+
+validation_errors_per_check = {}
+for check in all_checks:
+    errors = check.validate()
+    if errors:
+        validation_errors_per_check[check.name] = errors
+
+if not validation_errors_per_check:
+    print("Success, no errors were found!")
+    sys.exit(0)
+
+print_err("Some errors were found while validating log pipelines:")
+# Filter to only agt integrations checks
+for check, errs in validation_errors_per_check.items():
+    for err in errs:
+        print_err(f"{check}: {err}")
+
+sys.exit(-1)

--- a/.gitlab/validate-logs-intgs/validate_log_intgs.py
+++ b/.gitlab/validate-logs-intgs/validate_log_intgs.py
@@ -188,10 +188,8 @@ if not validation_errors_per_check:
     print("Success, no errors were found!")
     sys.exit(0)
 
-print_err("Some errors were found while validating log pipelines:")
+print_err("Logs pipelines don't pass validation steps:")
 # Filter to only agt integrations checks
 for check, errs in validation_errors_per_check.items():
     for err in errs:
-        print_err(f"{check}: {err}")
-
-sys.exit(-1)
+        print_err(f"- {check}: {err}")


### PR DESCRIPTION
Add a new gitlab job that'll run on a schedule.
The job will make sure that:

Any integration that has a log pipeline also:
  - Sets "log collection" in the manifest
  - Documents "log collection" in the Readme with the correct source name
  - Has a log to metric mapping defined

Every integration that don't have a log pipeline:
  - Does not document log collection in any way

And will then send a slack notification.

Note: Because there is no simple "id" matching between an agent integrations and a log pipeline, the script generates a set of various identifiers for each integration based on various sources (the dir name, the integraiton_name, the integraiton_id ...) and checks if one of the log pipelines has a matching 'source'.