### PR TITLE
Isolate MIB builder caching trick

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import ipaddress
-import threading
 from collections import defaultdict
 from typing import Any, DefaultDict, Dict, Iterator, List, Optional, Set, Tuple
 
@@ -13,13 +12,7 @@ from .parsing import ParsedMetric, ParsedMetricTag, ParsedSymbolMetric, parse_me
 from .pysnmp_types import (
     CommunityData,
     ContextData,
-    DirMibSource,
-    MibBuilder,
-    MibInstrumController,
-    MibViewController,
-    MsgAndPduDispatcher,
     OctetString,
-    SnmpEngine,
     UdpTransportTarget,
     UsmUserData,
     hlapi,
@@ -27,6 +20,7 @@ from .pysnmp_types import (
     usmDESPrivProtocol,
     usmHMACMD5AuthProtocol,
 )
+from .mibs import MIBLoader
 from .resolver import OIDResolver
 from .types import OIDMatch
 
@@ -59,9 +53,6 @@ class InstanceConfig:
         'aes256c': 'usmAesCfb256Protocol',
     }
 
-    _mib_builders = {}  # type: Dict[Optional[str], Tuple[MibBuilder, MibInstrumController, MibViewController]]
-    _mib_lock = threading.Lock()
-
     def __init__(
         self,
         instance,  # type: dict
@@ -69,12 +60,13 @@ class InstanceConfig:
         mibs_path=None,  # type: str
         profiles=None,  # type: Dict[str, dict]
         profiles_by_oid=None,  # type: Dict[str, str]
-        shared_mib_builder=False,  # type: bool
+        loader=None,  # type: MIBLoader
     ):
         # type: (...) -> None
         global_metrics = [] if global_metrics is None else global_metrics
         profiles = {} if profiles is None else profiles
         profiles_by_oid = {} if profiles_by_oid is None else profiles_by_oid
+        loader = MIBLoader() if loader is None else loader
 
         # Clean empty or null values. This will help templating.
         for key, value in list(instance.items()):
@@ -92,7 +84,8 @@ class InstanceConfig:
             self.metrics.extend(global_metrics)
 
         self.enforce_constraints = is_affirmative(instance.get('enforce_mib_constraints', True))
-        self._snmp_engine, mib_view_controller = self.create_snmp_engine(mibs_path, shared_mib_builder)
+        self._snmp_engine = loader.create_snmp_engine(mibs_path)
+        mib_view_controller = loader.get_mib_view_controller(mibs_path)
         self._resolver = OIDResolver(mib_view_controller, self.enforce_constraints)
 
         self.ip_address = None
@@ -190,41 +183,6 @@ class InstanceConfig:
     def add_profile_tag(self, profile_name):
         # type: (str) -> None
         self.tags.append('snmp_profile:{}'.format(profile_name))
-
-    @staticmethod
-    def _create_mib_builder(mibs_path):
-        # type: (Optional[str]) -> Tuple[MibBuilder, MibInstrumController, MibViewController]
-        mib_builder = MibBuilder()
-        if mibs_path:
-            mib_builder.addMibSources(DirMibSource(mibs_path))
-        mib_instrum = MibInstrumController(mib_builder)
-        mib_view = MibViewController(mib_builder)
-        return mib_builder, mib_instrum, mib_view
-
-    @classmethod
-    def _get_mib_builder(cls, mibs_path, shared_mib_builder):
-        # type: (Optional[str], bool) -> Tuple[MibBuilder, MibInstrumController, MibViewController]
-        if not shared_mib_builder:
-            return cls._create_mib_builder(mibs_path)
-        # Use a lock to make sure we don't concurrently create the cached objects
-        with cls._mib_lock:
-            if cls._mib_builders.get(mibs_path) is None:
-                cls._mib_builders[mibs_path] = cls._create_mib_builder(mibs_path)
-            return cls._mib_builders[mibs_path]
-
-    @classmethod
-    def create_snmp_engine(cls, mibs_path, shared_mib_builder):
-        # type: (Optional[str], bool) -> Tuple[SnmpEngine, MibViewController]
-        """
-        Create a command generator to perform all the snmp query.
-        If mibs_path is not None, load the mibs present in the custom mibs
-        folder. (Need to be in pysnmp format)
-        """
-        _, instrum_controller, mib_view_controller = cls._get_mib_builder(mibs_path, shared_mib_builder)
-        message_dispatcher = MsgAndPduDispatcher(instrum_controller)
-        snmp_engine = SnmpEngine(msgAndPduDsp=message_dispatcher)
-
-        return snmp_engine, mib_view_controller
 
     @staticmethod
     def get_transport_target(instance, timeout, retries):

--- a/snmp/datadog_checks/snmp/mibs.py
+++ b/snmp/datadog_checks/snmp/mibs.py
@@ -72,7 +72,8 @@ class MIBLoader:
         """
         Create a command generator to perform SNMP queries.
 
-        If `mibs_path` is not None, load the mibs present in the custom MIBs folder. (MIBs must be in PySNMP format.)
+        `mibs_path` should point to a custom directory containing MIBs in the PySNMP format. If not given,
+        MIBs shipped with PySNMP are used.
         """
         _, instrum_controller, _ = self._get_or_create_builder_info(mibs_path)
         message_dispatcher = MsgAndPduDispatcher(instrum_controller)

--- a/snmp/datadog_checks/snmp/mibs.py
+++ b/snmp/datadog_checks/snmp/mibs.py
@@ -35,14 +35,22 @@ class MIBLoader:
     A helper for loading and caching MIB information using PySNMP.
 
     To save up memory, PySNMP MIB-related objects are cached by MIB path.
-
-    If this behavior is not desired, you should use separate loader instances.
     """
 
     def __init__(self):
         # type: () -> None
         self._builders = {}  # type: Dict[Optional[str], BuilderInfo]
         self._cache_lock = threading.Lock()
+
+    @classmethod
+    def shared_instance(cls):
+        # type: () -> MIBLoader
+        """
+        Return a globally shared loader instance. Can be used to save up memory across check instances.
+        """
+        if not hasattr(cls, "_instance"):
+            cls._instance = MIBLoader()  # type: ignore
+        return cls._instance  # type: ignore
 
     def _get_or_create_builder_info(self, mibs_path=None):
         # type: (str) -> BuilderInfo

--- a/snmp/datadog_checks/snmp/mibs.py
+++ b/snmp/datadog_checks/snmp/mibs.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2010-present
+# (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import threading

--- a/snmp/datadog_checks/snmp/mibs.py
+++ b/snmp/datadog_checks/snmp/mibs.py
@@ -1,0 +1,71 @@
+# (C) Datadog, Inc. 2010-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+import threading
+from typing import Dict, Tuple, Optional
+
+from .pysnmp_types import (
+    DirMibSource,
+    MibBuilder,
+    MibInstrumController,
+    MibViewController,
+    MsgAndPduDispatcher,
+    SnmpEngine,
+)
+
+
+BuilderInfo = Tuple[MibBuilder, MibInstrumController, MibViewController]
+
+
+def _create_mib_builder(mibs_path=None):
+    # type: (str) -> BuilderInfo
+    mib_builder = MibBuilder()
+
+    if mibs_path is not None:
+        mib_builder.addMibSources(DirMibSource(mibs_path))
+
+    mib_instrum = MibInstrumController(mib_builder)
+    mib_view = MibViewController(mib_builder)
+
+    return mib_builder, mib_instrum, mib_view
+
+
+class MIBLoader:
+    """
+    A helper for loading and caching MIB information using PySNMP.
+
+    To save up memory, PySNMP MIB-related objects are cached by MIB path.
+
+    If this behavior is not desired, you should use separate loader instances.
+    """
+
+    def __init__(self):
+        # type: () -> None
+        self._builders = {}  # type: Dict[Optional[str], BuilderInfo]
+        self._cache_lock = threading.Lock()
+
+    def _get_or_create_builder_info(self, mibs_path=None):
+        # type: (str) -> BuilderInfo
+        with self._cache_lock:  # Prevent concurrent builder cache access and updates.
+            if mibs_path not in self._builders:
+                self._builders[mibs_path] = _create_mib_builder(mibs_path)
+            return self._builders[mibs_path]
+
+    def get_mib_view_controller(self, mibs_path=None):
+        # type: (str) -> MibViewController
+        """
+        Create a PySNMP MibViewController instance, for use in MIB resolution.
+        """
+        _, _, mib_view_controller = self._get_or_create_builder_info(mibs_path)
+        return mib_view_controller
+
+    def create_snmp_engine(self, mibs_path=None):
+        # type: (str) -> SnmpEngine
+        """
+        Create a command generator to perform SNMP queries.
+
+        If `mibs_path` is not None, load the mibs present in the custom MIBs folder. (MIBs must be in PySNMP format.)
+        """
+        _, instrum_controller, _ = self._get_or_create_builder_info(mibs_path)
+        message_dispatcher = MsgAndPduDispatcher(instrum_controller)
+        return SnmpEngine(msgAndPduDsp=message_dispatcher)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -119,19 +119,9 @@ class SnmpCheck(AgentCheck):
                     profiles_by_oid[sys_object_oid] = name
         return profiles_by_oid
 
-    @property
-    def _mib_loader(self):
-        # type: () -> MIBLoader
-        """
-        A lazily-loaded shared MIB loader instance.
-        """
-        if not hasattr(self, "_mib_loader_instance"):
-            self._mib_loader_instance = MIBLoader()
-        return self._mib_loader_instance
-
     def _build_config(self, instance):
         # type: (dict) -> InstanceConfig
-        loader = self._mib_loader if self.shared_mib_builder else MIBLoader()
+        loader = MIBLoader.shared_instance() if self.shared_mib_builder else MIBLoader()
 
         return InstanceConfig(
             instance,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
PR over #6716 to isolate the MIB builder caching behavior into a separate `MIBLoader` component.

The `MIBLoader` _always_ caches MIB builder information. The switch between "cache" vs "don't cache" is managed in the `SnmpCheck._build_config()` method (by switching on the config flag).

The `.create_snmp_engine()` method was only used in the `InstanceConfig` constructor so it was moved to `MIBLoader` too (and split between a more legible `create_snmp_engine()` / `get_mib_view_controller()` duo).

### Motivation
<!-- What inspired you to submit this pull request? -->


### Additional Notes
<!-- Anything else we should know when reviewing? -->
IMO we should add unit tests for the caching behavior as a follow up (`MIBLoader` can be unit tested, as well as the switch-on-config-flag logic in `SnmpCheck._build_config()`).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
