### PR TITLE
Pin test image version

### DIFF
--- a/gitlab/tests/compose/docker-compose.yml
+++ b/gitlab/tests/compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   gitlab:
-    image: gitlab/gitlab-ce:12.10.6-ce.0
+    image: gitlab/gitlab-ce:${GITLAB_VERSION}
     volumes:
       - ./config/gitlab.rb:/etc/gitlab/gitlab.rb
     ports:

--- a/gitlab/tests/compose/docker-compose.yml
+++ b/gitlab/tests/compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   gitlab:
-    image: gitlab/gitlab-ce:latest
+    image: gitlab/gitlab-ce:12.10.6-ce.0
     volumes:
       - ./config/gitlab.rb:/etc/gitlab/gitlab.rb
     ports:

--- a/gitlab/tox.ini
+++ b/gitlab/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}
+    py{27,38}-{12}
     bench
 
 [testenv]
@@ -14,6 +14,8 @@ platform = linux|darwin|win32
 passenv =
     DOCKER*
     COMPOSE*
+setenv =
+    12: GITLAB_VERSION=12.10.6-ce.0
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt

--- a/gitlab/tox.ini
+++ b/gitlab/tox.ini
@@ -16,6 +16,7 @@ passenv =
     COMPOSE*
 setenv =
     12: GITLAB_VERSION=12.10.6-ce.0
+    bench: GITLAB_VERSION=12.10.6-ce.0
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt


### PR DESCRIPTION
### Motivation
<!-- What inspired you to submit this pull request? -->

Gitlab 13 breaks CI:

https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=16544&view=logs&jobId=e151b502-07f3-577a-ac2b-2e39b64667cd&j=e151b502-07f3-577a-ac2b-2e39b64667cd&t=cbcfeb30-3b2d-5df3-9246-46471dc3c130
