### PR TITLE
Add FiraCode font

### DIFF
--- a/docs/developer/assets/css/custom.css
+++ b/docs/developer/assets/css/custom.css
@@ -95,4 +95,11 @@ div.doc-contents:not(.first) {
   100% {
     background-position: 6rem 0; } }
 
+
+/* Fira code */
+code { font-family: 'Fira Code', monospace; }
+
+@supports (font-variation-settings: normal) {
+  code { font-family: 'Fira Code VF', monospace; }
+}
 /* END TODO */

--- a/docs/developer/assets/css/custom.css
+++ b/docs/developer/assets/css/custom.css
@@ -19,6 +19,13 @@ div.doc-contents:not(.first) {
   padding: 0.5em 1em;
 }
 
+/* Fira code */
+code { font-family: 'Fira Code', monospace; }
+
+@supports (font-variation-settings: normal) {
+  code { font-family: 'Fira Code VF', monospace; }
+}
+
 /* https://facelessuser.github.io/pymdown-extensions/extensions/progressbar/ */
 
 /* TODO: replace all this when there is an updated example https://github.com/facelessuser/pymdown-extensions/issues/912 */
@@ -95,11 +102,4 @@ div.doc-contents:not(.first) {
   100% {
     background-position: 6rem 0; } }
 
-
-/* Fira code */
-code { font-family: 'Fira Code', monospace; }
-
-@supports (font-variation-settings: normal) {
-  code { font-family: 'Fira Code VF', monospace; }
-}
 /* END TODO */

--- a/docs/developer/assets/css/custom.css
+++ b/docs/developer/assets/css/custom.css
@@ -19,7 +19,7 @@ div.doc-contents:not(.first) {
   padding: 0.5em 1em;
 }
 
-/* Fira code */
+/* FiraCode https://github.com/tonsky/FiraCode */
 code { font-family: 'Fira Code', monospace; }
 
 @supports (font-variation-settings: normal) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,5 +161,6 @@ extra:
       link: https://www.instagram.com/datadoghq
 extra_css:
   - assets/css/custom.css
+  - https://cdn.jsdelivr.net/gh/tonsky/FiraCode@4/distr/fira_code.css
 extra_javascript:
   - assets/js/custom.js


### PR DESCRIPTION
### What does this PR do?
Adds [FiraCode](https://github.com/tonsky/FiraCode) font to code blocks in docs site.

### Motivation
Makes symbols in code blocks more readable

### Additional Notes
**Example**

before:
<img width="506" alt="Screen Shot 2020-05-26 at 10 52 01 AM" src="https://user-images.githubusercontent.com/33498636/82919731-69369a00-9f44-11ea-8f3b-6776a02d0ffd.png">

after:
<img width="485" alt="Screen Shot 2020-05-26 at 10 53 59 AM" src="https://user-images.githubusercontent.com/33498636/82919736-6c318a80-9f44-11ea-88c5-53b94914acfe.png">

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
