### PR TITLE
Move event to non legacy folder

### DIFF
--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -12,7 +12,7 @@ from pyVmomi import vim, vmodl
 from datadog_checks.base.log import CheckLoggingAdapter
 from datadog_checks.vsphere.config import VSphereConfig
 from datadog_checks.vsphere.constants import ALL_RESOURCES, MAX_QUERY_METRICS_OPTION, UNLIMITED_HIST_METRICS_PER_QUERY
-from datadog_checks.vsphere.legacy.event import ALLOWED_EVENTS
+from datadog_checks.vsphere.event import ALLOWED_EVENTS
 from datadog_checks.vsphere.types import InfrastructureData
 
 CallableT = TypeVar('CallableT', bound=Callable)

--- a/vsphere/datadog_checks/vsphere/constants.py
+++ b/vsphere/datadog_checks/vsphere/constants.py
@@ -3,6 +3,8 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from pyVmomi import vim
 
+SOURCE_TYPE = 'vsphere'
+
 ALLOWED_FILTER_TYPES = ['whitelist', 'blacklist']
 ALLOWED_FILTER_PROPERTIES = ['name', 'inventory_path', 'tag']
 EXTRA_FILTER_PROPERTIES_FOR_VMS = ['hostname', 'guest_hostname']

--- a/vsphere/datadog_checks/vsphere/event.py
+++ b/vsphere/datadog_checks/vsphere/event.py
@@ -11,7 +11,7 @@ from pyVmomi import vim
 
 from datadog_checks.base import ensure_unicode
 
-from .common import SOURCE_TYPE
+from .constants import SOURCE_TYPE
 
 EXCLUDE_FILTERS = {
     'AlarmStatusChangedEvent': [r'Gray to Green', r'Green to Gray'],

--- a/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
+++ b/vsphere/datadog_checks/vsphere/legacy/vsphere_legacy.py
@@ -25,10 +25,10 @@ from datadog_checks.base.checks.libs.vmware.all_metrics import ALL_METRICS
 from datadog_checks.base.checks.libs.vmware.basic_metrics import BASIC_METRICS
 from datadog_checks.base.config import is_affirmative
 
+from ..event import VSphereEvent
 from .cache_config import CacheConfig
 from .common import REALTIME_RESOURCES, SOURCE_TYPE
 from .errors import BadConfigError, ConnectionError
-from .event import VSphereEvent
 from .metadata_cache import MetadataCache, MetadataNotFoundError
 from .mor_cache import MorCache, MorNotFoundError
 from .objects_queue import ObjectsQueue

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -26,7 +26,7 @@ from datadog_checks.vsphere.constants import (
     REALTIME_METRICS_INTERVAL_ID,
     REALTIME_RESOURCES,
 )
-from datadog_checks.vsphere.legacy.event import VSphereEvent
+from datadog_checks.vsphere.event import VSphereEvent
 from datadog_checks.vsphere.metrics import ALLOWED_METRICS_FOR_MOR, PERCENT_METRICS
 from datadog_checks.vsphere.resource_filters import TagFilter
 from datadog_checks.vsphere.types import (

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -8,7 +8,7 @@ import pytest
 from pyVmomi import vim
 
 from datadog_checks.vsphere import VSphereCheck
-from datadog_checks.vsphere.legacy.event import ALLOWED_EVENTS
+from datadog_checks.vsphere.event import ALLOWED_EVENTS
 
 from .legacy.utils import mock_alarm_event
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Move event to non legacy folder.

`event.py` is still used by new implementation.

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/pull/6659/files#r430287309
