### PR TITLE
Condense output of Trello release status command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/status.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/status.py
@@ -28,7 +28,7 @@ def status(ctx: click.Context, as_json: bool, clipboard: bool) -> None:
 
     counts = trello.count_by_columns()
 
-    row_format = '{:30} | {:<15} | {:<15} | {:<15} | {:<15} | {}'
+    row_format = '{:15} | {:<8} | {:<8} | {:<8} | {:<8} | {}'
     headers = ('Total', 'In Progress', 'Issues Found', 'Awaiting Build', 'Done')
 
     if as_json:
@@ -38,7 +38,8 @@ def status(ctx: click.Context, as_json: bool, clipboard: bool) -> None:
     totals = dict(zip(headers, [0] * len(headers)))
 
     output = []
-    output.append(row_format.format('Team', *headers))
+    output.append(row_format.format('', '', 'In', 'Issues', 'Awaiting', ''))
+    output.append(row_format.format('Team', 'Total', 'Progress', 'Found', 'Build', 'Done'))
     output.append(row_format.format('--', *['--' for _ in headers]))
 
     for team, data in counts.items():


### PR DESCRIPTION
### What does this PR do?
Make the output of `ddev release trello status` more condensed to easily fit in a slack channel.

Example:
```
❯ ddev release trello status

Trello Status Report:

                |          | In       | Issues   | Awaiting |
Team            | Total    | Progress | Found    | Build    | Done
--              | --       | --       | --       | --       | --
Containers      | 55       | 4        | 0        | 0        | 50
Container App   | 4        | 1        | 0        | 0        | 3
Core            | 28       | 4        | 0        | 1        | 23
Integrations    | 182      | 2        | 0        | 1        | 178
Logs            | 0        | 0        | 0        | 0        | 0
Platform        | 58       | 8        | 0        | 0        | 50
Networks        | 27       | 4        | 1        | 0        | 22
Processes       | 9        | 1        | 0        | 0        | 8
Trace           | 7        | 2        | 0        | 0        | 5
--              | --       | --       | --       | --       | --
TOTALS          | 370      | 26       | 1        | 2        | 339
```
