### PR TITLE
Updated the agent file naming convention

### DIFF
--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -82,7 +82,7 @@ For instance, to see the latest event logged in the `Security` LogFile, use:
 Get-WmiObject -Class Win32_NTLogEvent -Filter "LogFile='Security'" | select -First 1
 ```
 
-The values listed in the output of the command can be set in `win32_event_log.yaml` to capture the same kind of events.
+The values listed in the output of the command can be set in `win32_event_log.d/conf.yaml` to capture the same kind of events.
 
 <div class="alert alert-info">
 The information given by the  <code> Get-EventLog</code> PowerShell command or the Windows Event ViewerGUI may slightly differ from <code>Get-WmiObject</code>.<br>
@@ -98,7 +98,7 @@ Double-check your filters' values with <code>Get-WmiObject</code> if the integra
       - source_name: Any available source name
       - user: Any valid user name
 
-    For each filter, add an instance in the configuration file at `conf.d/win32_event_log.yaml`.
+    For each filter, add an instance in the configuration file at `win32_event_log.d/conf.yaml`.
 
     Some example filters:
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This page was using the old naming convention: 
conf.d/<INTEGRATION>.yml: Old file naming convention
conf.d/<INTEGRATION>.d/*.yml: New file naming convention  
Updated it to use the new one 

### Motivation
<!-- What inspired you to submit this pull request? -->
This is super confusing for our clients who think they need both files

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
