### PR TITLE
Add instructions about enabling Gitlab metrics

### DIFF
--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -24,16 +24,19 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `gitlab.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3], to point to the Gitlab's metrics [endpoint][13]. See the [sample gitlab.d/conf.yaml][4] for all available configuration options.
 
-    **Note**: The metrics in [metrics.py][11] are collected by default. The `allowed_metrics` configuration option in the `init_config` collects specific legacy metrics. Some metrics may not be collected depending on your Gitlab instance version and configuration. See [Gitlab's documentation][12] for further information about its metric collection.
+2. In the Gitlab settings page, ensure that the option `Enable Prometheus Metrics` is enabled. You will need to have administrator access. For more information on how to enable metric collection, see the [Gitlab documentation][12]
 
-2. Allow access to monitoring endpoints by updating your `/etc/gitlab/gitlab.rb` to include the following line:
+3. Allow access to monitoring endpoints by updating your `/etc/gitlab/gitlab.rb` to include the following line:
 
     ```
     gitlab_rails['monitoring_whitelist'] = ['127.0.0.0/8', '192.168.0.1']
     ```
-    **Note** Save and reconfigure Gitlab to see the changes.
+    **Note** Save and restart Gitlab to see the changes.
 
-2. [Restart the Agent][5]
+4. [Restart the Agent][5]
+
+**Note**: The metrics in [gitlab/metrics.py][11] are collected by default. The `allowed_metrics` configuration option in the `init_config` collects specific legacy metrics. Some metrics may not be collected depending on your Gitlab instance version and configuration. See [Gitlab's documentation][12] for further information about its metric collection.
+
 
 ##### Log collection
 

--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -24,7 +24,7 @@ Follow the instructions below to configure this check for an Agent running on a 
 
 1. Edit the `gitlab.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3], to point to the Gitlab's metrics [endpoint][13]. See the [sample gitlab.d/conf.yaml][4] for all available configuration options.
 
-2. In the Gitlab settings page, ensure that the option `Enable Prometheus Metrics` is enabled. You will need to have administrator access. For more information on how to enable metric collection, see the [Gitlab documentation][12]
+2. In the Gitlab settings page, ensure that the option `Enable Prometheus Metrics` is enabled. You will need to have administrator access. For more information on how to enable metric collection, see the [Gitlab documentation][12].
 
 3. Allow access to monitoring endpoints by updating your `/etc/gitlab/gitlab.rb` to include the following line:
 
@@ -33,7 +33,7 @@ Follow the instructions below to configure this check for an Agent running on a 
     ```
     **Note** Save and restart Gitlab to see the changes.
 
-4. [Restart the Agent][5]
+4. [Restart the Agent][5].
 
 **Note**: The metrics in [gitlab/metrics.py][11] are collected by default. The `allowed_metrics` configuration option in the `init_config` collects specific legacy metrics. Some metrics may not be collected depending on your Gitlab instance version and configuration. See [Gitlab's documentation][12] for further information about its metric collection.
 


### PR DESCRIPTION
### What does this PR do?
Adds a step that explicitly instructs users to enable prometheus metrics feature in their gitlab settings.

### Motivation
Make step more obvious.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
