### PR TITLE
Add option to open DogStatsD port on agent

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -47,7 +47,7 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
 )
 @click.option('--org-name', '-o', help='The org to use for data submission.')
 @click.option('--profile-memory', '-pm', is_flag=True, help='Whether to collect metrics about memory usage')
-@click.option('--dogstatsd', '-d', is_flag=True, help='Enable dogstatsd port on agent')
+@click.option('--dogstatsd', is_flag=True, help='Enable dogstatsd port on agent')
 @click.pass_context
 def start(ctx, check, env, agent, python, dev, base, env_vars, org_name, profile_memory, dogstatsd):
     """Start an environment."""

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/agent.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/agent.py
@@ -23,6 +23,8 @@ FAKE_API_KEY = 'a' * 32
 
 MANIFEST_VERSION_PATTERN = r'agent (\d)'
 
+DEFAULT_DOGSTATSD_PORT = 8125
+
 
 def get_rate_flag(agent_version):
     if agent_version >= 6:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -9,6 +9,7 @@ from ...utils import find_free_port, get_ip, path_join
 from ..constants import REQUIREMENTS_IN, get_root
 from .agent import (
     DEFAULT_AGENT_VERSION,
+    DEFAULT_DOGSTATSD_PORT,
     DEFAULT_PYTHON_VERSION,
     FAKE_API_KEY,
     MANIFEST_VERSION_PATTERN,
@@ -38,6 +39,7 @@ class DockerInterface(object):
         log_url=None,
         python_version=DEFAULT_PYTHON_VERSION,
         default_agent=False,
+        dogstatsd=False,
     ):
         self.check = check
         self.env = env
@@ -50,6 +52,7 @@ class DockerInterface(object):
         self.dd_url = dd_url
         self.log_url = log_url
         self.python_version = python_version or DEFAULT_PYTHON_VERSION
+        self.dogstatsd = dogstatsd
 
         self._agent_version = self.metadata.get('agent_version')
         self.container_name = f'dd_{self.check}_{self.env}'
@@ -254,6 +257,9 @@ class DockerInterface(object):
         # Any environment variables passed to the start command
         for key, value in sorted(env_vars.items()):
             command.extend(['-e', f'{key}={value}'])
+
+        if self.dogstatsd:
+            command.extend(['-p', f'{DEFAULT_DOGSTATSD_PORT}:{DEFAULT_DOGSTATSD_PORT}/udp'])
 
         if 'proxy' in self.metadata:
             if 'http' in self.metadata['proxy']:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -43,6 +43,7 @@ class LocalAgentInterface(object):
         log_url=None,
         python_version=DEFAULT_PYTHON_VERSION,
         default_agent=False,
+        dogstatsd=False,
     ):
         self.check = check
         self.env = env
@@ -56,6 +57,7 @@ class LocalAgentInterface(object):
         self.dd_url = dd_url
         self.log_url = log_url
         self.python_version = python_version or DEFAULT_PYTHON_VERSION
+        self.dogstatsd = dogstatsd
 
         self._agent_version = self.metadata.get('agent_version')
         self.config_dir = locate_config_dir(check, env)


### PR DESCRIPTION
### What does this PR do?
When trying to test a DogStatsD configuration, the Agent container needs a port mapped along with some environment variables set.

While the envvars can be easily done via `-e` options to `ddev env start`, the port mapping isn't so easy, hence this PR.
