### PR TITLE
Remove custom tag from default dashboard

### DIFF
--- a/istio/assets/dashboards/istio_1_5_overview
+++ b/istio/assets/dashboards/istio_1_5_overview
@@ -60,7 +60,7 @@
             "tile_def": {
                 "requests": [
                     {
-                        "q": "top(avg:istio.mesh.request.count{cluster-name:istio-annotated-workaround} by {host}, 10, 'mean', 'desc')",
+                        "q": "top(avg:istio.mesh.request.count{*} by {host}, 10, 'mean', 'desc')",
                         "style": {
                             "palette": "dog_classic",
                             "type": "solid",


### PR DESCRIPTION
### What does this PR do?
A tag was left behind in the default dashboard. One of the graphs won't populate correctly.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
