### PR TITLE
Don't error when setting an invalid repo in config

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -92,7 +92,7 @@ def initialize_root(config, agent=False, core=False, extras=False, here=False):
 
     repo_choice = 'core' if core else 'extras' if extras else 'agent' if agent else config.get('repo', 'core')
     config['repo_choice'] = repo_choice
-    config['repo_name'] = REPO_CHOICES[repo_choice]
+    config['repo_name'] = REPO_CHOICES.get(repo_choice, repo_choice)
 
     message = None
     # TODO: remove this legacy fallback lookup in any future major version bump


### PR DESCRIPTION
### What does this PR do?
I accidentally set my repo as "integrations-core" and got this error whenever using ddev or trying to reset it:
```
 msg = initialize_root(config, agent, core, extras, here)
  File "/Users/sarah.witt/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/utils.py", line 95, in initialize_root
    config['repo_name'] = REPO_CHOICES[repo_choice]
KeyError: 'integrations-core'
```


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
Reproduce:
`ddev config set repo integrations-core`
`ddev config set repo core`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
