### PR TITLE
Fix name KeyError

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -380,7 +380,7 @@ class SnmpCheck(AgentCheck):
             self.warning(error)
         except Exception as e:
             if not error:
-                error = 'Failed to collect metrics for {} - {}'.format(instance['name'], e)
+                error = 'Failed to collect metrics for {} - {}'.format(instance.get('name', 'unknown'), e)
             self.warning(error)
         finally:
             # Report service checks

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -68,7 +68,6 @@ class SnmpCheck(AgentCheck):
         self.profiles = self._load_profiles()
         self.profiles_by_oid = self._get_profiles_mapping()
 
-        self.instance['name'] = self._get_instance_name(self.instance)
         self._config = self._build_config(self.instance)
 
     def _load_profiles(self):
@@ -380,7 +379,7 @@ class SnmpCheck(AgentCheck):
             self.warning(error)
         except Exception as e:
             if not error:
-                error = 'Failed to collect metrics for {} - {}'.format(instance.get('name', 'unknown'), e)
+                error = 'Failed to collect metrics for {} - {}'.format(self._get_instance_name(instance), e)
             self.warning(error)
         finally:
             # Report service checks


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix name KeyError.

Currently `instance['name']`might be missing and we also needs to recompute the name when new instances are created from autodiscovery. Hence, it's more appropriate to get the name dynamically using `_get_instance_name`.

### Motivation
<!-- What inspired you to submit this pull request? -->

```
2020-06-01 16:14:44 UTC | CORE | ERROR | (pkg/collector/python/datadog_agent.go:112 in LogMessage) | - | (_base.py:330) | exception calling callback for <Future at 0x7fa7ed79b9a0 state=finished raised KeyError>
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/snmp/snmp.py", line 374, in _check_with_config
    results, error = self.fetch_results(config, config.all_oids, config.next_oids, config.bulk_oids)
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/snmp/snmp.py", line 187, in fetch_results
    self.log.debug('Raw results: %s', OIDPrinter(results, with_values=False))
  File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 1785, in debug
    self.log(DEBUG, msg, *args, **kwargs)
  File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 1829, in log
    self.logger.log(level, msg, *args, **kwargs)
  File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 1500, in log
    self._log(level, msg, args, **kwargs)
  File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 1577, in _log
    self.handle(record)
  File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 1587, in handle
    self.callHandlers(record)
  File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 1649, in callHandlers
    hdlr.handle(record)
  File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 950, in handle
    self.emit(record)
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/log.py", line 89, in emit
    datadog_agent.log(message, record.levelno)
ValueError: embedded null character
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python3.8/concurrent/futures/_base.py", line 328, in _invoke_callbacks
    callback(self)
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/snmp/snmp.py", line 347, in _check_config_done
    if future.result():
  File "/opt/datadog-agent/embedded/lib/python3.8/concurrent/futures/_base.py", line 432, in result
    return self.__get_result()
  File "/opt/datadog-agent/embedded/lib/python3.8/concurrent/futures/_base.py", line 388, in __get_result
    raise self._exception
  File "/opt/datadog-agent/embedded/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/snmp/snmp.py", line 383, in _check_with_config
    error = 'Failed to collect metrics for {} - {}'.format(instance['name'], e)
KeyError: 'name'
```