### PR TITLE
Add stream/zone_sync to Nginx plus api endpoint list

### DIFF
--- a/nginx/datadog_checks/nginx/data/conf.yaml.example
+++ b/nginx/datadog_checks/nginx/data/conf.yaml.example
@@ -69,7 +69,7 @@ instances:
     # use_plus_api: false
 
     ## @param plus_api_version - integer - optional - default: 2
-    ## Specify the version of the Plus API to use. The check supports versions 1, 2 & 3.
+    ## Specify the version of the Plus API to use. The check supports versions 1 & 2.
     #
     # plus_api_version: <PLUS_API_VERSION>
 
@@ -85,7 +85,7 @@ instances:
     ## Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
     ## to specify hosts that must bypass proxies.
     ##
-    ## The SOCKS protocol is also supported, for example:
+    ## The SOCKS protocol is also supported like so:
     ##
     ##   socks5://user:pass@host:port
     ##
@@ -135,7 +135,7 @@ instances:
     ##     |__ aws_host
     ##     |__ aws_service
     ##
-    ## The `aws` auth type relies on boto3 to automatically gather AWS credentials, for example: from `.aws/credentials`.
+    ## The `aws` auth type relies on boto3 to automatically gather AWS credentials (e.g. from `.aws/credentials`).
     ## Details: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials
     #
     # auth_type: basic
@@ -151,11 +151,11 @@ instances:
     # password: <PASSWORD>
 
     ## @param ntlm_domain - string - optional
-    ## If your services use NTLM authentication, specify
-    ## the domain used in the check. For NTLM Auth, append
+    ## If your services use NTLM authentication, you can specify
+    ## a domain that is used in the check. For NTLM Auth, append
     ## the username to domain, not as the `username` parameter.
     #
-    # ntlm_domain: <NTLM_DOMAIN>\<USERNAME>
+    # ntlm_domain: <NTLM_DOMAIN>/<USERNAME>
 
     ## @param kerberos_auth - string - optional - default: disabled
     ## If your services use Kerberos authentication, you can specify the Kerberos
@@ -176,7 +176,7 @@ instances:
     # kerberos_cache: <KERBEROS_CACHE>
 
     ## @param kerberos_delegate - boolean - optional - default: false
-    ## Set to `true` to enable Kerberos delegation of credentials to a server that requests delegation.
+    ## Set to `true` to enable kerberos delegation of credentials to a server that requests delegation.
     ##
     ## See https://github.com/requests/requests-kerberos#delegation
     #
@@ -192,7 +192,7 @@ instances:
 
     ## @param kerberos_hostname - string - optional
     ## Override the hostname used for the Kerberos GSS exchange if its DNS name doesn't
-    ## match its Kerberos hostname, for example: behind a content switch or load balancer.
+    ## match its kerberos hostname (e.g. behind a content switch or load balancer).
     ##
     ## See https://github.com/requests/requests-kerberos#hostname-override
     #
@@ -212,26 +212,26 @@ instances:
     # kerberos_keytab: <KEYTAB_FILE_PATH>
 
     ## @param aws_region - string - optional
-    ## If your services require AWS Signature Version 4 signing, set the region.
+    ## If your services require AWS Signature Version 4 Signing, set the region.
     ##
     ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
     #
     # aws_region: <AWS_REGION>
 
     ## @param aws_host - string - optional
-    ## If your services require AWS Signature Version 4 signing, set the host.
+    ## If your services require AWS Signature Version 4 Signing, set the host.
     ##
-    ## Note: This setting is not necessary for official integrations.
+    ## Note that this setting is not necessary for official integrations.
     ##
     ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
     #
     # aws_host: <AWS_HOST>
 
     ## @param aws_service - string - optional
-    ## If your services require AWS Signature Version 4 signing, set the service code. For a list
+    ## If your services require AWS Signature Version 4 Signing, set the service code. For a list
     ## of available service codes, see https://docs.aws.amazon.com/general/latest/gr/rande.html
     ##
-    ## Note: This setting is not necessary for official integrations.
+    ## Note that this setting is not necessary for official integrations.
     ##
     ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
     #
@@ -250,10 +250,6 @@ instances:
     ## @param tls_ignore_warning - boolean - optional - default: false
     ## If `tls_verify` is disabled, security warnings are logged by the check.
     ## Disable those by setting `tls_ignore_warning` to true.
-    ##
-    ## Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration.
-    ## If enabled for multiple instances, spurious warnings might still appear even if `tls_ignore_warning` is set
-    ## to true.
     #
     # tls_ignore_warning: false
 
@@ -358,10 +354,10 @@ instances:
 ## port / path / channel_path - required - Set port if type is tcp or udp.
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
-## source  - required - Attribute that defines which Integration sent the logs.
-## service - optional - The name of the service that generates the log.
+## source  - required - Attribute that defines which Integration sent the logs
+## service - required - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
-## tags - optional - Add tags to the collected logs.
+## tags - optional - Add tags to the collected logs
 ##
 ## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
 #

--- a/nginx/datadog_checks/nginx/data/conf.yaml.example
+++ b/nginx/datadog_checks/nginx/data/conf.yaml.example
@@ -69,7 +69,7 @@ instances:
     # use_plus_api: false
 
     ## @param plus_api_version - integer - optional - default: 2
-    ## Specify the version of the Plus API to use. The check supports versions 1 & 2.
+    ## Specify the version of the Plus API to use. The check supports versions 1, 2 & 3.
     #
     # plus_api_version: <PLUS_API_VERSION>
 

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -52,6 +52,7 @@ TAGGED_KEYS = {
     'upstreamZones': 'upstream',  # VTS
     'slabs': 'slab',
     'slots': 'slot',
+    'zones': 'zone',
 }
 
 

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -41,7 +41,7 @@ PLUS_API_ENDPOINTS = {
 PLUS_API_STREAM_ENDPOINTS = {
     "stream/server_zones": ["stream", "server_zones"],
     "stream/upstreams": ["stream", "upstreams"],
-    "stream/zone_sync": ["stream", "zone_sync"], # API v3 and above.
+    "stream/zone_sync": ["stream", "zone_sync"],  # API v3 and above.
 }
 
 TAGGED_KEYS = {

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -41,7 +41,7 @@ PLUS_API_ENDPOINTS = {
 PLUS_API_STREAM_ENDPOINTS = {
     "stream/server_zones": ["stream", "server_zones"],
     "stream/upstreams": ["stream", "upstreams"],
-    "stream/zone_sync": ["stream", "zone_sync"],
+    "stream/zone_sync": ["stream", "zone_sync"], # API v3 and above.
 }
 
 TAGGED_KEYS = {
@@ -100,6 +100,8 @@ class Nginx(AgentCheck):
             # These are all the endpoints we have to call to get the same data as we did with the old API
             # since we can't get everything in one place anymore.
             for endpoint, nest in chain(iteritems(PLUS_API_ENDPOINTS), iteritems(PLUS_API_STREAM_ENDPOINTS)):
+                if int(plus_api_version) < 3 and endpoint == "stream/zone_sync":
+                    continue
                 response = self._get_plus_api_data(url, plus_api_version, endpoint, nest)
                 self.log.debug("Nginx Plus API version %s `response`: %s", plus_api_version, response)
                 metrics.extend(self.parse_json(response, tags))

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -41,6 +41,7 @@ PLUS_API_ENDPOINTS = {
 PLUS_API_STREAM_ENDPOINTS = {
     "stream/server_zones": ["stream", "server_zones"],
     "stream/upstreams": ["stream", "upstreams"],
+    "stream/zone_sync": ["stream", "zone_sync"],
 }
 
 TAGGED_KEYS = {

--- a/nginx/metadata.csv
+++ b/nginx/metadata.csv
@@ -185,6 +185,6 @@ nginx.stream.zone_sync.status.msgs_in,gauge,,,,The number of messages received b
 nginx.stream.zone_sync.status.msgs_out,gauge,,,,The number of messages sent by this node.
 nginx.stream.zone_sync.status.bytes_in,gauge,,,,The number of bytes received by this node.
 nginx.stream.zone_sync.status.bytes_out,gauge,,,,The number of bytes sent by this node.
-nginx.stream.zone_sync.zones.$zone_name.records_total,gauge,,,,The total number of records stored in the shared memory zone.
-nginx.stream.zone_sync.zones.$zone_name.records_pending,gauge,,,,The number of records that need to be sent to the cluster.
+nginx.stream.zone_sync.zone.records_total,gauge,,,,The total number of records stored in the shared memory zone.
+nginx.stream.zone_sync.zone.records_pending,gauge,,,,The number of records that need to be sent to the cluster.
 nginx.version,gauge,,,,Version of nginx.,0,nginx,version

--- a/nginx/metadata.csv
+++ b/nginx/metadata.csv
@@ -179,12 +179,12 @@ nginx.upstream.peers.sent,gauge,,byte,,The total amount of data sent to this ser
 nginx.upstream.peers.sent_count,count,,byte,,The total amount of data sent to this server (shown as count).,0,nginx,upstr peers sent
 nginx.upstream.peers.unavail,gauge,,,,How many times the server became unavailable for client requests (state "unavail") due to the number of unsuccessful attempts reaching the max_fails threshold.,0,nginx,upstr peers unavail
 nginx.upstream.peers.unavail_count,count,,,,How many times the server became unavailable for client requests (state "unavail") due to the number of unsuccessful attempts reaching the max_fails threshold (shown as count).,0,nginx,upstr peers unavail
-nginx.stream.peers.weight,gauge,,,,Weight of the server.,0,nginx,upstr peers weight
-nginx.stream.zone_sync.status.nodes_online,gauge,,,nginx,The number of peers this node is connected to.
-nginx.stream.zone_sync.status.msgs_in,gauge,,,nginx,The number of messages received by this node.
-nginx.stream.zone_sync.status.msgs_out,gauge,,,nginx,The number of messages sent by this node.
-nginx.stream.zone_sync.status.bytes_in,gauge,,,nginx,The number of bytes received by this node.
-nginx.stream.zone_sync.status.bytes_out,gauge,,,nginx,The number of bytes sent by this node.
-nginx.stream.zone_sync.zones.$zone_name.records_total,gauge,,,nginx,The total number of records stored in the shared memory zone.
-nginx.stream.zone_sync.zones.$zone_name.records_pending,gauge,,,nginx,The number of records that need to be sent to the cluster.
+nginx.upstream.peers.weight,gauge,,,,Weight of the server.,0,nginx,upstr peers weight
+nginx.stream.zone_sync.status.nodes_online,gauge,,,,The number of peers this node is connected to.
+nginx.stream.zone_sync.status.msgs_in,gauge,,,,The number of messages received by this node.
+nginx.stream.zone_sync.status.msgs_out,gauge,,,,The number of messages sent by this node.
+nginx.stream.zone_sync.status.bytes_in,gauge,,,,The number of bytes received by this node.
+nginx.stream.zone_sync.status.bytes_out,gauge,,,,The number of bytes sent by this node.
+nginx.stream.zone_sync.zones.$zone_name.records_total,gauge,,,,The total number of records stored in the shared memory zone.
+nginx.stream.zone_sync.zones.$zone_name.records_pending,gauge,,,,The number of records that need to be sent to the cluster.
 nginx.version,gauge,,,,Version of nginx.,0,nginx,version

--- a/nginx/metadata.csv
+++ b/nginx/metadata.csv
@@ -179,5 +179,12 @@ nginx.upstream.peers.sent,gauge,,byte,,The total amount of data sent to this ser
 nginx.upstream.peers.sent_count,count,,byte,,The total amount of data sent to this server (shown as count).,0,nginx,upstr peers sent
 nginx.upstream.peers.unavail,gauge,,,,How many times the server became unavailable for client requests (state "unavail") due to the number of unsuccessful attempts reaching the max_fails threshold.,0,nginx,upstr peers unavail
 nginx.upstream.peers.unavail_count,count,,,,How many times the server became unavailable for client requests (state "unavail") due to the number of unsuccessful attempts reaching the max_fails threshold (shown as count).,0,nginx,upstr peers unavail
-nginx.upstream.peers.weight,gauge,,,,Weight of the server.,0,nginx,upstr peers weight
+nginx.stream.peers.weight,gauge,,,,Weight of the server.,0,nginx,upstr peers weight
+nginx.stream.zone_sync.status.nodes_online,gauge,,,,The number of peers this node is connected to.
+nginx.stream.zone_sync.status.msgs_in,gauge,,,,The number of messages received by this node.
+nginx.stream.zone_sync.status.msgs_out,gauge,,,,The number of messages sent by this node.
+nginx.stream.zone_sync.status.bytes_in,gauge,,,,The number of bytes received by this node.
+nginx.stream.zone_sync.status.bytes_out,gauge,,,,The number of bytes sent by this node.
+nginx.stream.zone_sync.zones.$zone_name.records_total,gauge,,,,The total number of records stored in the shared memory zone.
+nginx.stream.zone_sync.zones.$zone_name.records_pending,gauge,,,,The number of records that need to be sent to the cluster.
 nginx.version,gauge,,,,Version of nginx.,0,nginx,version

--- a/nginx/metadata.csv
+++ b/nginx/metadata.csv
@@ -180,11 +180,11 @@ nginx.upstream.peers.sent_count,count,,byte,,The total amount of data sent to th
 nginx.upstream.peers.unavail,gauge,,,,How many times the server became unavailable for client requests (state "unavail") due to the number of unsuccessful attempts reaching the max_fails threshold.,0,nginx,upstr peers unavail
 nginx.upstream.peers.unavail_count,count,,,,How many times the server became unavailable for client requests (state "unavail") due to the number of unsuccessful attempts reaching the max_fails threshold (shown as count).,0,nginx,upstr peers unavail
 nginx.stream.peers.weight,gauge,,,,Weight of the server.,0,nginx,upstr peers weight
-nginx.stream.zone_sync.status.nodes_online,gauge,,,,The number of peers this node is connected to.
-nginx.stream.zone_sync.status.msgs_in,gauge,,,,The number of messages received by this node.
-nginx.stream.zone_sync.status.msgs_out,gauge,,,,The number of messages sent by this node.
-nginx.stream.zone_sync.status.bytes_in,gauge,,,,The number of bytes received by this node.
-nginx.stream.zone_sync.status.bytes_out,gauge,,,,The number of bytes sent by this node.
-nginx.stream.zone_sync.zones.$zone_name.records_total,gauge,,,,The total number of records stored in the shared memory zone.
-nginx.stream.zone_sync.zones.$zone_name.records_pending,gauge,,,,The number of records that need to be sent to the cluster.
+nginx.stream.zone_sync.status.nodes_online,gauge,,,nginx,The number of peers this node is connected to.
+nginx.stream.zone_sync.status.msgs_in,gauge,,,nginx,The number of messages received by this node.
+nginx.stream.zone_sync.status.msgs_out,gauge,,,nginx,The number of messages sent by this node.
+nginx.stream.zone_sync.status.bytes_in,gauge,,,nginx,The number of bytes received by this node.
+nginx.stream.zone_sync.status.bytes_out,gauge,,,nginx,The number of bytes sent by this node.
+nginx.stream.zone_sync.zones.$zone_name.records_total,gauge,,,nginx,The total number of records stored in the shared memory zone.
+nginx.stream.zone_sync.zones.$zone_name.records_pending,gauge,,,nginx,The number of records that need to be sent to the cluster.
 nginx.version,gauge,,,,Version of nginx.,0,nginx,version

--- a/nginx/metadata.csv
+++ b/nginx/metadata.csv
@@ -180,11 +180,11 @@ nginx.upstream.peers.sent_count,count,,byte,,The total amount of data sent to th
 nginx.upstream.peers.unavail,gauge,,,,How many times the server became unavailable for client requests (state "unavail") due to the number of unsuccessful attempts reaching the max_fails threshold.,0,nginx,upstr peers unavail
 nginx.upstream.peers.unavail_count,count,,,,How many times the server became unavailable for client requests (state "unavail") due to the number of unsuccessful attempts reaching the max_fails threshold (shown as count).,0,nginx,upstr peers unavail
 nginx.upstream.peers.weight,gauge,,,,Weight of the server.,0,nginx,upstr peers weight
-nginx.stream.zone_sync.status.nodes_online,gauge,,,,The number of peers this node is connected to.
-nginx.stream.zone_sync.status.msgs_in,gauge,,,,The number of messages received by this node.
-nginx.stream.zone_sync.status.msgs_out,gauge,,,,The number of messages sent by this node.
-nginx.stream.zone_sync.status.bytes_in,gauge,,,,The number of bytes received by this node.
-nginx.stream.zone_sync.status.bytes_out,gauge,,,,The number of bytes sent by this node.
-nginx.stream.zone_sync.zone.records_total,gauge,,,,The total number of records stored in the shared memory zone.
-nginx.stream.zone_sync.zone.records_pending,gauge,,,,The number of records that need to be sent to the cluster.
+nginx.stream.zone_sync.status.nodes_online,gauge,,,,The number of peers this node is connected to.,0,nginx,Count of nodes online.
+nginx.stream.zone_sync.status.msgs_in,gauge,,,,The number of messages received by this node.,0,nginx,Total count of messages received. 
+nginx.stream.zone_sync.status.msgs_out,gauge,,,,The number of messages sent by this node.,0,nginx,Total count of messages sent.
+nginx.stream.zone_sync.status.bytes_in,gauge,,,,The number of bytes received by this node.,0,nginx,Total count of bytes received.
+nginx.stream.zone_sync.status.bytes_out,gauge,,,,The number of bytes sent by this node.,0,nginx,Total coun tof bytes sent. 
+nginx.stream.zone_sync.zone.records_total,count,,,,The total number of records stored in the shared memory zone.,0,nginx,Count of records in memory zone.
+nginx.stream.zone_sync.zone.records_pending,count,,,,The number of records that need to be sent to the cluster.,0,nginx, Count of records pending. 
 nginx.version,gauge,,,,Version of nginx.,0,nginx,version

--- a/nginx/metadata.csv
+++ b/nginx/metadata.csv
@@ -185,6 +185,6 @@ nginx.stream.zone_sync.status.msgs_in,gauge,,,,The number of messages received b
 nginx.stream.zone_sync.status.msgs_out,gauge,,,,The number of messages sent by this node.,0,nginx,Total count of messages sent.
 nginx.stream.zone_sync.status.bytes_in,gauge,,,,The number of bytes received by this node.,0,nginx,Total count of bytes received.
 nginx.stream.zone_sync.status.bytes_out,gauge,,,,The number of bytes sent by this node.,0,nginx,Total coun tof bytes sent. 
-nginx.stream.zone_sync.zone.records_total,count,,,,The total number of records stored in the shared memory zone.,0,nginx,Count of records in memory zone.
-nginx.stream.zone_sync.zone.records_pending,count,,,,The number of records that need to be sent to the cluster.,0,nginx, Count of records pending. 
+nginx.stream.zone_sync.zone.records_total,gauge,,,,The total number of records stored in the shared memory zone.,0,nginx,Count of records in memory zone.
+nginx.stream.zone_sync.zone.records_pending,gauge,,,,The number of records that need to be sent to the cluster.,0,nginx, Count of records pending. 
 nginx.version,gauge,,,,Version of nginx.,0,nginx,version

--- a/nginx/tests/fixtures/plus_api_stream_zone_sync.json
+++ b/nginx/tests/fixtures/plus_api_stream_zone_sync.json
@@ -1,0 +1,15 @@
+{
+  "status": {
+    "nodes_online": 2,
+    "msgs_in": 9809,
+    "msgs_out": 9478,
+    "bytes_in": 2038758,
+    "bytes_out": 1931412
+  },
+  "zones": {
+    "zone1": {
+      "records_total": 250,
+      "records_pending": 1
+    }
+  }
+}

--- a/nginx/tests/test_unit.py
+++ b/nginx/tests/test_unit.py
@@ -39,6 +39,7 @@ def test_flatten_json_timestamp(check):
 def test_plus_api(check, instance, aggregator):
     instance = deepcopy(instance)
     instance['use_plus_api'] = True
+    instance['plus_api_version'] = 3
     check = check(instance)
     check._perform_request = mock.MagicMock(side_effect=mocked_perform_request)
     check.check(instance)
@@ -46,7 +47,7 @@ def test_plus_api(check, instance, aggregator):
     total = 0
     for m in aggregator.metric_names:
         total += len(aggregator.metrics(m))
-    assert total == 1180
+    assert total == 1187
 
 
 def test_nest_payload(check):

--- a/nginx/tests/test_unit.py
+++ b/nginx/tests/test_unit.py
@@ -39,6 +39,20 @@ def test_flatten_json_timestamp(check):
 def test_plus_api(check, instance, aggregator):
     instance = deepcopy(instance)
     instance['use_plus_api'] = True
+    instance['plus_api_version'] = 2
+    check = check(instance)
+    check._perform_request = mock.MagicMock(side_effect=mocked_perform_request)
+    check.check(instance)
+
+    total = 0
+    for m in aggregator.metric_names:
+        total += len(aggregator.metrics(m))
+    assert total == 1180
+
+
+def test_plus_api_v3(check, instance, aggregator):
+    instance = deepcopy(instance)
+    instance['use_plus_api'] = True
     instance['plus_api_version'] = 3
     check = check(instance)
     check._perform_request = mock.MagicMock(side_effect=mocked_perform_request)

--- a/nginx/tests/utils.py
+++ b/nginx/tests/utils.py
@@ -18,38 +18,41 @@ def mocked_perform_request(*args, **kwargs):
     response = mock.MagicMock()
     url = args[0]
 
-    if '/2/nginx' in url:
+    if '/3/nginx' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_nginx.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/processes' in url:
+    elif '/3/processes' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_processes.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/connections' in url:
+    elif '/3/connections' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_connections.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/ssl' in url:
+    elif '/3/ssl' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_ssl.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/slabs' in url:
+    elif '/3/slabs' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_slabs.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/http/requests' in url:
+    elif '/3/http/requests' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_requests.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/http/server_zones' in url:
+    elif '/3/http/server_zones' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_server_zones.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/http/caches' in url:
+    elif '/3/http/caches' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_caches.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/http/upstreams' in url:
+    elif '/3/http/upstreams' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_upstreams.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/stream/upstreams' in url:
+    elif '/3/stream/upstreams' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_stream_upstreams.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/stream/server_zones' in url:
+    elif '/3/stream/server_zones' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_stream_server_zones.json'))
+        response.json.return_value = json.loads(file_contents)
+    elif '/3/stream/zone_sync' in url:
+        file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_stream_zone_sync.json'))
         response.json.return_value = json.loads(file_contents)
     else:
         response.json.return_value = ''

--- a/nginx/tests/utils.py
+++ b/nginx/tests/utils.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
 import os
+import re
 
 import mock
 
@@ -18,40 +19,40 @@ def mocked_perform_request(*args, **kwargs):
     response = mock.MagicMock()
     url = args[0]
 
-    if '/2/nginx' in url or '/3/nginx' in url:
+    if re.search('/[23]/nginx', url):
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_nginx.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/processes' in url or '/3/processes' in url:
+    elif re.search('/[23]/processes', url):
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_processes.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/connections' in url or '/3/connections' in url:
+    elif re.search('/[23]/connections', url):
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_connections.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/ssl' in url or '/3/ssl' in url:
+    elif re.search('/[23]/ssl', url):
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_ssl.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/slabs' in url or '/3/slabs' in url:
+    elif re.search('/[23]/slabs', url):
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_slabs.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/http/requests' in url or '/3/http/requests' in url:
+    elif re.search('/[23]/http/requests', url):
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_requests.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/http/server_zones' in url or '/3/http/server_zones' in url:
+    elif re.search('/[23]/http/server_zones', url):
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_server_zones.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/http/caches' in url or '/3/http/caches' in url:
+    elif re.search('/[23]/http/caches', url):
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_caches.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/http/upstreams' in url or '/3/http/upstreams' in url:
+    elif re.search('/[23]/http/upstreams', url):
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_upstreams.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/stream/upstreams' in url or '/3/stream/upstreams' in url:
+    elif re.search('/[23]/stream/upstreams', url):
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_stream_upstreams.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/stream/server_zones' in url or '/3/stream/server_zones' in url:
+    elif re.search('/[23]/stream/server_zones', url):
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_stream_server_zones.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/3/stream/zone_sync' in url:
+    elif re.search('/[3]/stream/zone_sync', url):
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_stream_zone_sync.json'))
         response.json.return_value = json.loads(file_contents)
     else:

--- a/nginx/tests/utils.py
+++ b/nginx/tests/utils.py
@@ -18,37 +18,37 @@ def mocked_perform_request(*args, **kwargs):
     response = mock.MagicMock()
     url = args[0]
 
-    if '/2/nginx' in url:
+    if '/2/nginx' in url or '/3/nginx' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_nginx.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/processes' in url:
+    elif '/2/processes' in url or '/3/processes' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_processes.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/connections' in url:
+    elif '/2/connections' in url or '/3/connections' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_connections.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/ssl' in url:
+    elif '/2/ssl' in url or '/3/ssl' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_ssl.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/slabs' in url:
+    elif '/2/slabs' in url or '/3/slabs' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_slabs.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/http/requests' in url:
+    elif '/2/http/requests' in url or '/3/http/requests' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_requests.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/http/server_zones' in url:
+    elif '/2/http/server_zones' in url or '/3/http/server_zones' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_server_zones.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/http/caches' in url:
+    elif '/2/http/caches' in url or '/3/http/caches' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_caches.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/http/upstreams' in url:
+    elif '/2/http/upstreams' in url or '/3/http/upstreams' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_upstreams.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/stream/upstreams' in url:
+    elif '/2/stream/upstreams' in url or '/3/stream/upstreams' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_stream_upstreams.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/2/stream/server_zones' in url:
+    elif '/2/stream/server_zones' in url or '/3/stream/server_zones' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_stream_server_zones.json'))
         response.json.return_value = json.loads(file_contents)
     elif '/3/stream/zone_sync' in url:

--- a/nginx/tests/utils.py
+++ b/nginx/tests/utils.py
@@ -18,37 +18,37 @@ def mocked_perform_request(*args, **kwargs):
     response = mock.MagicMock()
     url = args[0]
 
-    if '/3/nginx' in url:
+    if '/2/nginx' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_nginx.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/3/processes' in url:
+    elif '/2/processes' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_processes.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/3/connections' in url:
+    elif '/2/connections' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_connections.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/3/ssl' in url:
+    elif '/2/ssl' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_ssl.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/3/slabs' in url:
+    elif '/2/slabs' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_slabs.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/3/http/requests' in url:
+    elif '/2/http/requests' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_requests.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/3/http/server_zones' in url:
+    elif '/2/http/server_zones' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_server_zones.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/3/http/caches' in url:
+    elif '/2/http/caches' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_caches.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/3/http/upstreams' in url:
+    elif '/2/http/upstreams' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_http_upstreams.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/3/stream/upstreams' in url:
+    elif '/2/stream/upstreams' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_stream_upstreams.json'))
         response.json.return_value = json.loads(file_contents)
-    elif '/3/stream/server_zones' in url:
+    elif '/2/stream/server_zones' in url:
         file_contents = read_file(os.path.join(FIXTURES_PATH, 'plus_api_stream_server_zones.json'))
         response.json.return_value = json.loads(file_contents)
     elif '/3/stream/zone_sync' in url:


### PR DESCRIPTION
### What does this PR do?
Adds stream/zone_sync to the list of polled Nginx Plus API endpoints. 
*Note: zone_sync was added in API v3, as such the agent will throw off a warning if using the default api version (2). 

### Motivation
I need to have observability metrics on zone_sync. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
