### PR TITLE
WIP: Rebrand twistlock metrics

### DIFF
--- a/twistlock/README.md
+++ b/twistlock/README.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-[Twistlock][1] is a security scanner. It scans containers, hosts, and packages to find vulnerabilities and compliance issues.
+[Prisma Cloud Compute Edition][1] is a security scanner. It scans containers, hosts, and packages to find vulnerabilities and compliance issues.
 
 ## Setup
 
 ### Installation
 
-The Twistlock check is included in the [Datadog Agent][3] package, so you do not need to install anything else on your server.
+The Prisma Cloud Compute Edition check is included in the [Datadog Agent][3] package, so you do not need to install anything else on your server.
 
 ### Configuration
 
@@ -127,17 +127,17 @@ See [metadata.csv][9] for a list of metrics provided by this check.
 
 ### Events
 
-Twistlock sends an event when a new CVE is found.
+Prisma Cloud Compute Edition sends an event when a new CVE is found.
 
 ### Service Checks
 
-Twistlock sends service checks when a scan fails.
+Prisma Cloud Compute Edition sends service checks when a scan fails.
 
 ## Troubleshooting
 
 Need help? Contact [Datadog support][10].
 
-[1]: https://www.twistlock.com
+[1]: https://www.paloaltonetworks.com/prisma/cloud
 [2]: https://docs.datadoghq.com/agent/kubernetes/integrations/
 [3]: https://github.com/DataDog/integrations-core/blob/master/twistlock/datadog_checks/twistlock/data/conf.yaml.example
 [4]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent

--- a/twistlock/assets/configuration/spec.yaml
+++ b/twistlock/assets/configuration/spec.yaml
@@ -20,5 +20,12 @@ files:
         See https://cdn.twistlock.com/docs/api/twistlock_api.html
       value:
         type: string
+    - name: use_prisma_prefix
+      description: Wether to use `prisma` or  the legacy `twistlock` prefix for metrics
+      required: true
+      value:
+        type: boolean
+        example: true
+        default: false
     - template: instances/http
     - template: instances/default

--- a/twistlock/datadog_checks/twistlock/__init__.py
+++ b/twistlock/datadog_checks/twistlock/__init__.py
@@ -2,6 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .__about__ import __version__
-from .twistlock import TwistlockCheck
+from .twistlock import PrismaCloudCheck
 
-__all__ = ['__version__', 'TwistlockCheck']
+__all__ = ['__version__', 'PrismaCloudCheck']

--- a/twistlock/datadog_checks/twistlock/data/conf.yaml.example
+++ b/twistlock/datadog_checks/twistlock/data/conf.yaml.example
@@ -56,6 +56,11 @@ instances:
     #
     # project: <PROJECT>
 
+    ## @param use_prisma_prefix - boolean - required
+    ## Wether to use `prisma` or  the legacy `twistlock` prefix for metrics
+    #
+    use_prisma_prefix: true
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/twistlock/datadog_checks/twistlock/twistlock.py
+++ b/twistlock/datadog_checks/twistlock/twistlock.py
@@ -32,14 +32,15 @@ SEVERITY_TAGS = {
 }
 
 
-class TwistlockCheck(AgentCheck):
+class PrismaCloudCheck(AgentCheck):
     NAMESPACE = 'twistlock'
 
     HTTP_CONFIG_REMAPPER = {'ssl_verify': {'name': 'tls_verify'}}
 
     def __init__(self, name, init_config, instances):
-        super(TwistlockCheck, self).__init__(name, init_config, instances)
-
+        super(PrismaCloudCheck, self).__init__(name, init_config, instances)
+        if self.instance.get('use_prisma_prefix', False):
+            self.NAMESPACE = 'prisma'
         self.last_run = datetime.utcnow()
 
         self.config = None

--- a/twistlock/manifest.json
+++ b/twistlock/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog Prisma Cloud Compute Edition Integration",
+  "public_title": "Datadog-Prisma Cloud Compute Edition Integration",
   "categories": [
     "security",
     "log collection",

--- a/twistlock/manifest.json
+++ b/twistlock/manifest.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "Prisma Cloud Compute Edition",
+  "display_name": "Twistlock",
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "name": "twistlock",

--- a/twistlock/manifest.json
+++ b/twistlock/manifest.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "Twistlock",
+  "display_name": "Prisma Cloud Compute Edition",
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "name": "twistlock",
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Twistlock Integration",
+  "public_title": "Datadog Prisma Cloud Compute Edition Integration",
   "categories": [
     "security",
     "log collection",

--- a/twistlock/metadata.csv
+++ b/twistlock/metadata.csv
@@ -13,3 +13,17 @@ twistlock.hosts.cve.details,gauge,,occurrence,,the details of a CVE on a host,-1
 twistlock.hosts.cve.count,gauge,,occurrence,,the number of CVEs a host has,-1,twistlock,cve_count
 twistlock.hosts.compliance.count,gauge,,occurrence,,the number of compliance violations a host has,-1,twistlock,compliance_count
 twistlock.containers.compliance.count,gauge,,occurrence,,the number of compliance violations a container has,-1,twistlock,compliance_count
+prisma.registry.cve.details,gauge,,occurrence,,the details of a CVE on an image in a registry,-1,twistlock,cve_details
+prisma.registry.cve.count,gauge,,occurrence,,the number of CVEs an image has,-1,twistlock,cve_count
+prisma.registry.compliance.count,gauge,,occurrence,,the number of compliance violations an image has,-1,twistlock,compliance_count
+prisma.registry.size,gauge,,byte,,the size of an image in a registry,0,twistlock,size
+prisma.registry.layer_count,gauge,,occurrence,,the count of layers in an image in a registry,0,twistlock,layer_count
+prisma.images.cve.details,gauge,,occurrence,,the details of a CVE on an image,-1,twistlock,cve_details
+prisma.images.cve.count,gauge,,occurrence,,the number of CVEs an image has,-1,twistlock,cve_count
+prisma.images.compliance.count,gauge,,occurrence,,the number of compliance violations an image has,-1,twistlock,compliance_count
+prisma.images.size,gauge,,byte,,the size of a local image,0,twistlock,size
+prisma.images.layer_count,gauge,,occurrence,,the count of layers in a local image,0,twistlock,layer_count
+prisma.hosts.cve.details,gauge,,occurrence,,the details of a CVE on a host,-1,twistlock,cve_details
+prisma.hosts.cve.count,gauge,,occurrence,,the number of CVEs a host has,-1,twistlock,cve_count
+prisma.hosts.compliance.count,gauge,,occurrence,,the number of compliance violations a host has,-1,twistlock,compliance_count
+prisma.containers.compliance.count,gauge,,occurrence,,the number of compliance violations a container has,-1,twistlock,compliance_count


### PR DESCRIPTION
Depends on:
* https://github.com/DataDog/integrations-core/pull/6793
* https://github.com/DataDog/integrations-core/pull/6795

And still pending discussion on wether `prisma` or  `prisma_cloud`