### PR TITLE
Add head_message_timestamp metric

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -50,6 +50,7 @@ QUEUE_ATTRIBUTES = [
     ('active_consumers', 'active_consumers', float),
     ('consumers', 'consumers', float),
     ('consumer_utilisation', 'consumer_utilisation', float),
+    ('head_message_timestamp', 'head_message_timestamp', int),
     ('memory', 'memory', float),
     ('messages', 'messages', float),
     ('messages_details/rate', 'messages.rate', float),

--- a/rabbitmq/metadata.csv
+++ b/rabbitmq/metadata.csv
@@ -29,6 +29,7 @@ rabbitmq.queue.active_consumers,gauge,,,,"Number of active consumers, consumers 
 rabbitmq.queue.bindings.count,gauge,,,,Number of bindings for a specific queue,0,rabbitmq,queue bind
 rabbitmq.queue.consumers,gauge,,,,Number of consumers,0,rabbitmq,cons
 rabbitmq.queue.consumer_utilisation,gauge,,fraction,,The ratio of time that a queue's consumers can take new messages,0,rabbitmq,cons util
+rabbitmq.queue.head_message_timestamp,gauge,,,,Timestamp of the head message of the queue,0,rabbitmq,head msg ts
 rabbitmq.queue.memory,gauge,,byte,,"Bytes of memory consumed by the Erlang process associated with the queue, including stack, heap and internal structures",0,rabbitmq,mem
 rabbitmq.queue.messages,gauge,,message,,Count of the total messages in the queue,0,rabbitmq,msgs
 rabbitmq.queue.messages.rate,gauge,,message,second,Count per second of the total messages in the queue,0,rabbitmq,msgs rate

--- a/rabbitmq/metadata.csv
+++ b/rabbitmq/metadata.csv
@@ -29,7 +29,7 @@ rabbitmq.queue.active_consumers,gauge,,,,"Number of active consumers, consumers 
 rabbitmq.queue.bindings.count,gauge,,,,Number of bindings for a specific queue,0,rabbitmq,queue bind
 rabbitmq.queue.consumers,gauge,,,,Number of consumers,0,rabbitmq,cons
 rabbitmq.queue.consumer_utilisation,gauge,,fraction,,The ratio of time that a queue's consumers can take new messages,0,rabbitmq,cons util
-rabbitmq.queue.head_message_timestamp,gauge,,,,Timestamp of the head message of the queue,0,rabbitmq,head msg ts
+rabbitmq.queue.head_message_timestamp,gauge,,millisecond,,Timestamp of the head message of the queue,0,rabbitmq,head msg ts
 rabbitmq.queue.memory,gauge,,byte,,"Bytes of memory consumed by the Erlang process associated with the queue, including stack, heap and internal structures",0,rabbitmq,mem
 rabbitmq.queue.messages,gauge,,message,,Count of the total messages in the queue,0,rabbitmq,msgs
 rabbitmq.queue.messages.rate,gauge,,message,second,Count per second of the total messages in the queue,0,rabbitmq,msgs rate

--- a/rabbitmq/tests/common.py
+++ b/rabbitmq/tests/common.py
@@ -9,6 +9,8 @@ from datadog_checks.base.utils.common import get_docker_hostname
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))
 
+RABBITMQ_VERSION = os.environ['RABBITMQ_VERSION']
+
 CHECK_NAME = 'rabbitmq'
 
 HOST = get_docker_hostname()

--- a/rabbitmq/tests/common.py
+++ b/rabbitmq/tests/common.py
@@ -4,12 +4,15 @@
 
 import os
 
+from packaging import version
+
 from datadog_checks.base.utils.common import get_docker_hostname
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))
 
-RABBITMQ_VERSION = os.environ['RABBITMQ_VERSION']
+RABBITMQ_VERSION_RAW = os.environ['RABBITMQ_VERSION']
+RABBITMQ_VERSION = version.parse(RABBITMQ_VERSION_RAW)
 
 CHECK_NAME = 'rabbitmq'
 

--- a/rabbitmq/tests/conftest.py
+++ b/rabbitmq/tests/conftest.py
@@ -110,6 +110,7 @@ def setup_more(rabbitmq_admin_script):
             'exchange={}'.format(name),
             'routing_key={}'.format(name),
             'payload="hello, world"',
+            'properties={"timestamp": 1500000}',
         ]
         subprocess.check_call(cmd)
 
@@ -122,6 +123,7 @@ def setup_more(rabbitmq_admin_script):
             'exchange={}'.format(name),
             'routing_key=bad_key',
             'payload="unroutable"',
+            'properties={"timestamp": 1500000}',
         ]
         subprocess.check_call(cmd)
 
@@ -151,6 +153,7 @@ def setup_more_with_vhosts(rabbitmq_admin_script):
                 'exchange=amq.default',
                 'routing_key={}'.format(name),
                 'payload="hello, world"',
+                'properties={"timestamp": 1500000}',
             ]
             subprocess.check_call(cmd)
 

--- a/rabbitmq/tests/metrics.py
+++ b/rabbitmq/tests/metrics.py
@@ -2,6 +2,10 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from packaging import version
+
+from .common import RABBITMQ_VERSION
+
 COMMON_METRICS = [
     'rabbitmq.node.fd_used',
     'rabbitmq.node.disk_free',
@@ -23,12 +27,15 @@ E_METRICS = [
 ]
 
 # Only present in 3.5
-E_METRICS_35 = [
-    'rabbitmq.exchange.messages.confirm.count',
-    'rabbitmq.exchange.messages.confirm.rate',
-    'rabbitmq.exchange.messages.return_unroutable.count',
-    'rabbitmq.exchange.messages.return_unroutable.rate',
-]
+if RABBITMQ_VERSION == version.parse('3.5'):
+    E_METRICS.extend(
+        [
+            'rabbitmq.exchange.messages.confirm.count',
+            'rabbitmq.exchange.messages.confirm.rate',
+            'rabbitmq.exchange.messages.return_unroutable.count',
+            'rabbitmq.exchange.messages.return_unroutable.rate',
+        ]
+    )
 
 Q_METRICS = [
     'rabbitmq.queue.consumers',
@@ -45,9 +52,8 @@ Q_METRICS = [
 ]
 
 # Present from 3.6
-Q_METRICS_36 = [
-    'rabbitmq.queue.head_message_timestamp',
-]
+if RABBITMQ_VERSION >= version.parse('3.6'):
+    Q_METRICS.extend(['rabbitmq.queue.head_message_timestamp'])
 
 OVERVIEW_METRICS_TOTALS = [
     'rabbitmq.overview.object_totals.connections',

--- a/rabbitmq/tests/metrics.py
+++ b/rabbitmq/tests/metrics.py
@@ -44,6 +44,11 @@ Q_METRICS = [
     'rabbitmq.queue.messages.publish.rate',
 ]
 
+# Present from 3.6
+Q_METRICS_36 = [
+    'rabbitmq.queue.head_message_timestamp',
+]
+
 OVERVIEW_METRICS_TOTALS = [
     'rabbitmq.overview.object_totals.connections',
     'rabbitmq.overview.object_totals.channels',

--- a/rabbitmq/tests/test_integration_e2e.py
+++ b/rabbitmq/tests/test_integration_e2e.py
@@ -48,15 +48,9 @@ def assert_metric_covered(aggregator):
     # Queue attributes, should be only one queue fetched
     for mname in metrics.Q_METRICS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test1', count=1)
-    if common.RABBITMQ_VERSION >= "3.6":
-        for mname in metrics.Q_METRICS_36:
-            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test1', count=1)
     # Exchange attributes, should be only one exchange fetched
     for mname in metrics.E_METRICS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test1', count=1)
-    if common.RABBITMQ_VERSION == "3.5":
-        for mname in metrics.E_METRICS_35:
-            aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test1', count=1)
     # Overview attributes
     for mname in metrics.OVERVIEW_METRICS_TOTALS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_cluster:rabbitmqtest', count=1)
@@ -93,22 +87,12 @@ def test_regex(aggregator, check):
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test1', count=1)
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test5', count=1)
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:tralala', count=0)
-    if common.RABBITMQ_VERSION == "3.5":
-        for mname in metrics.E_METRICS_35:
-            aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test1', count=1)
-            aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test5', count=1)
-            aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:tralala', count=0)
 
     # Queue attributes
     for mname in metrics.Q_METRICS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test1', count=3)
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test5', count=3)
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:tralala', count=0)
-    if common.RABBITMQ_VERSION >= "3.6":
-        for mname in metrics.Q_METRICS_36:
-            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test1', count=3)
-            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test5', count=3)
-            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:tralala', count=0)
 
     # Overview attributes
     for mname in metrics.OVERVIEW_METRICS_TOTALS:
@@ -142,16 +126,8 @@ def test_limit_vhosts(aggregator, check):
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test1', count=3)
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test5', count=3)
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:tralala', count=0)
-    if common.RABBITMQ_VERSION >= "3.6":
-        for mname in metrics.Q_METRICS_36:
-            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test1', count=3)
-            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test5', count=3)
-            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:tralala', count=0)
     for mname in metrics.E_METRICS:
         aggregator.assert_metric(mname, count=2)
-    if common.RABBITMQ_VERSION == "3.5":
-        for mname in metrics.E_METRICS_35:
-            aggregator.assert_metric(mname, count=2)
 
     # Overview attributes
     for mname in metrics.OVERVIEW_METRICS_TOTALS:
@@ -183,15 +159,9 @@ def test_family_tagging(aggregator, check):
     aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:myothervhost'], value=0, count=1)
     for mname in metrics.E_METRICS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange_family:test', count=2)
-    if common.RABBITMQ_VERSION == "3.5":
-        for mname in metrics.E_METRICS_35:
-            aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange_family:test', count=2)
 
     for mname in metrics.Q_METRICS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue_family:test', count=6)
-    if common.RABBITMQ_VERSION >= "3.6":
-        for mname in metrics.Q_METRICS_36:
-            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue_family:test', count=6)
     # Overview attributes
     for mname in metrics.OVERVIEW_METRICS_TOTALS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_cluster:rabbitmqtest', count=1)

--- a/rabbitmq/tests/test_integration_e2e.py
+++ b/rabbitmq/tests/test_integration_e2e.py
@@ -48,6 +48,9 @@ def assert_metric_covered(aggregator):
     # Queue attributes, should be only one queue fetched
     for mname in metrics.Q_METRICS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test1', count=1)
+    if common.RABBITMQ_VERSION >= "3.6":
+        for mname in metrics.Q_METRICS_36:
+            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test1', count=1)
     # Exchange attributes, should be only one exchange fetched
     for mname in metrics.E_METRICS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test1', count=1)
@@ -99,6 +102,11 @@ def test_regex(aggregator, check):
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test1', count=3)
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test5', count=3)
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:tralala', count=0)
+    if common.RABBITMQ_VERSION >= "3.6":
+        for mname in metrics.Q_METRICS_36:
+            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test1', count=3)
+            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test5', count=3)
+            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:tralala', count=0)
 
     # Overview attributes
     for mname in metrics.OVERVIEW_METRICS_TOTALS:
@@ -132,6 +140,11 @@ def test_limit_vhosts(aggregator, check):
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test1', count=3)
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test5', count=3)
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:tralala', count=0)
+    if common.RABBITMQ_VERSION >= "3.6":
+        for mname in metrics.Q_METRICS_36:
+            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test1', count=3)
+            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:test5', count=3)
+            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:tralala', count=0)
     for mname in metrics.E_METRICS:
         aggregator.assert_metric(mname, count=2)
     for mname in metrics.E_METRICS_35:
@@ -172,7 +185,9 @@ def test_family_tagging(aggregator, check):
 
     for mname in metrics.Q_METRICS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue_family:test', count=6)
-
+    if common.RABBITMQ_VERSION >= "3.6":
+        for mname in metrics.Q_METRICS_36:
+            aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue_family:test', count=6)
     # Overview attributes
     for mname in metrics.OVERVIEW_METRICS_TOTALS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_cluster:rabbitmqtest', count=1)

--- a/rabbitmq/tests/test_integration_e2e.py
+++ b/rabbitmq/tests/test_integration_e2e.py
@@ -54,8 +54,9 @@ def assert_metric_covered(aggregator):
     # Exchange attributes, should be only one exchange fetched
     for mname in metrics.E_METRICS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test1', count=1)
-    for mname in metrics.E_METRICS_35:
-        aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test1', at_least=0)
+    if common.RABBITMQ_VERSION == "3.5":
+        for mname in metrics.E_METRICS_35:
+            aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test1', count=1)
     # Overview attributes
     for mname in metrics.OVERVIEW_METRICS_TOTALS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_cluster:rabbitmqtest', count=1)
@@ -92,10 +93,11 @@ def test_regex(aggregator, check):
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test1', count=1)
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test5', count=1)
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:tralala', count=0)
-    for mname in metrics.E_METRICS_35:
-        aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test1', at_least=0)
-        aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test5', at_least=0)
-        aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:tralala', at_least=0)
+    if common.RABBITMQ_VERSION == "3.5":
+        for mname in metrics.E_METRICS_35:
+            aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test1', count=1)
+            aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:test5', count=1)
+            aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange:tralala', count=0)
 
     # Queue attributes
     for mname in metrics.Q_METRICS:
@@ -147,8 +149,9 @@ def test_limit_vhosts(aggregator, check):
             aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue:tralala', count=0)
     for mname in metrics.E_METRICS:
         aggregator.assert_metric(mname, count=2)
-    for mname in metrics.E_METRICS_35:
-        aggregator.assert_metric(mname, at_least=0)
+    if common.RABBITMQ_VERSION == "3.5":
+        for mname in metrics.E_METRICS_35:
+            aggregator.assert_metric(mname, count=2)
 
     # Overview attributes
     for mname in metrics.OVERVIEW_METRICS_TOTALS:
@@ -180,8 +183,9 @@ def test_family_tagging(aggregator, check):
     aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:myothervhost'], value=0, count=1)
     for mname in metrics.E_METRICS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange_family:test', count=2)
-    for mname in metrics.E_METRICS_35:
-        aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange_family:test', at_least=0)
+    if common.RABBITMQ_VERSION == "3.5":
+        for mname in metrics.E_METRICS_35:
+            aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange_family:test', count=2)
 
     for mname in metrics.Q_METRICS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue_family:test', count=6)

--- a/rabbitmq/tests/test_rabbitmq.py
+++ b/rabbitmq/tests/test_rabbitmq.py
@@ -1,17 +1,16 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import os
-
 import pytest
+
+from .common import RABBITMQ_VERSION
 
 
 @pytest.mark.usefixtures('dd_environment')
 def test_metadata(check, instance, datadog_agent):
     check.check_id = 'test:123'
 
-    version = os.environ['RABBITMQ_VERSION']
-    major, minor = version.split('.')
+    major, minor = RABBITMQ_VERSION.split('.')
 
     version_metadata = {'version.scheme': 'semver', 'version.major': major, 'version.minor': minor}
 

--- a/rabbitmq/tests/test_rabbitmq.py
+++ b/rabbitmq/tests/test_rabbitmq.py
@@ -3,14 +3,14 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
-from .common import RABBITMQ_VERSION
+from .common import RABBITMQ_VERSION_RAW
 
 
 @pytest.mark.usefixtures('dd_environment')
 def test_metadata(check, instance, datadog_agent):
     check.check_id = 'test:123'
 
-    major, minor = RABBITMQ_VERSION.split('.')
+    major, minor = RABBITMQ_VERSION_RAW.split('.')
 
     version_metadata = {'version.scheme': 'semver', 'version.major': major, 'version.minor': minor}
 


### PR DESCRIPTION
### What does this PR do?
Add `rabbitmq.queue.head_message_timestamp` available since v3.6 (https://github.com/rabbitmq/rabbitmq-server/pull/54)

### Motivation
Customer request

### Additional Notes
Since the timestamp unit can be chosen by the user, we can't be sure it in the metadata.
However it is often in ms (https://github.com/rabbitmq/rabbitmq-message-timestamp). 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
