### PR TITLE
Push received metrics on partial failure

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -174,7 +174,7 @@ class SnmpCheck(AgentCheck):
                     self.ignore_nonincreasing_oid,
                 )
                 all_binds.extend(binds)
-            except PySnmpError as e:
+            except (PySnmpError, CheckException) as e:
                 message = 'Failed to collect some metrics: {}'.format(e)
                 if not error:
                     error = message
@@ -222,7 +222,7 @@ class SnmpCheck(AgentCheck):
                     # If we didn't catch the metric using snmpget, try snmpnext
                     next_oids.extend(missing_results)
 
-            except PySnmpError as e:
+            except (PySnmpError, CheckException) as e:
                 message = 'Failed to collect some metrics: {}'.format(e)
                 if not error:
                     error = message
@@ -248,7 +248,7 @@ class SnmpCheck(AgentCheck):
                 self.log.debug('Returned vars: %s', OIDPrinter(binds, with_values=True))
                 all_binds.extend(binds)
 
-            except PySnmpError as e:
+            except (PySnmpError, CheckException) as e:
                 message = 'Failed to collect some metrics: {}'.format(e)
                 if not error:
                     error = message

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -917,7 +917,13 @@ def test_timeout(aggregator, caplog):
     check = SnmpCheck('snmp', {}, [instance])
     check.check(instance)
 
-    aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.CRITICAL, at_least=1)
+    aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.WARNING, at_least=1)
+    # Some metrics still arrived
+    aggregator.assert_metric('snmp.ifInDiscards', count=4)
+    aggregator.assert_metric('snmp.ifInErrors', count=4)
+    aggregator.assert_metric('snmp.ifOutDiscards', count=4)
+    aggregator.assert_metric('snmp.ifOutErrors', count=4)
+    aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)
     aggregator.all_metrics_asserted()
 
     for record in caplog.records:

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -251,7 +251,7 @@ def test_removing_host():
     warnings = []
     check.warning = warnings.append
     check._config.discovered_instances['1.1.1.1'] = InstanceConfig(discovered_instance)
-    msg = 'No SNMP response received before timeout for instance 1.1.1.1'
+    msg = 'Failed to collect some metrics: No SNMP response received before timeout for instance 1.1.1.1'
 
     check._start_discovery = lambda: None
     check._executor = futures.ThreadPoolExecutor(max_workers=1)


### PR DESCRIPTION
During the refactoring of commands, the exception raised changed, and we
were not catching the proper exception at the lower level anymore to
continue retrieving metrics on errors. This fixes it, and updates the
fortunately present tests for this.