### PR TITLE
Add methods for the persistent cache Agent interface

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -657,6 +657,18 @@ class AgentCheck(object):
 
         return entrypoint
 
+    def _persistent_cache_id(self, key):
+        # type: (str) -> str
+        return '{}_{}'.format(self.check_id, key)
+
+    def read_persistent_cache(self, key):
+        # type: (str) -> str
+        return datadog_agent.read_persistent_cache(self._persistent_cache_id(key))
+
+    def write_persistent_cache(self, key, value):
+        # type: (str, str) -> None
+        datadog_agent.write_persistent_cache(self._persistent_cache_id(key), value)
+
     def set_external_tags(self, external_tags):
         # type: (Sequence[ExternalTagType]) -> None
         # Example of external_tags format

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -15,6 +15,7 @@ class DatadogAgentStub(object):
 
     def __init__(self):
         self._metadata = {}
+        self._cache = {}
         self._config = self.get_default_config()
 
     def get_default_config(self):
@@ -22,6 +23,7 @@ class DatadogAgentStub(object):
 
     def reset(self):
         self._metadata.clear()
+        self._cache.clear()
         self._config = self.get_default_config()
 
     def assert_metadata(self, check_id, data):
@@ -55,6 +57,12 @@ class DatadogAgentStub(object):
 
     def tracemalloc_enabled(self, *args, **kwargs):
         return False
+
+    def write_persistent_cache(self, key, value):
+        self._cache[key] = value
+
+    def read_persistent_cache(self, key):
+        return self._cache.get(key, '')
 
 
 # Use the stub as a singleton

--- a/datadog_checks_base/tests/test_agent_check.py
+++ b/datadog_checks_base/tests/test_agent_check.py
@@ -44,6 +44,16 @@ def test_load_config():
     assert AgentCheck.load_config("raw_foo: bar") == {'raw_foo': 'bar'}
 
 
+def test_persistent_cache(datadog_agent):
+    check = AgentCheck()
+    check.check_id = 'test'
+
+    check.write_persistent_cache('foo', 'bar')
+
+    assert datadog_agent.read_persistent_cache('test_foo') == 'bar'
+    assert check.read_persistent_cache('foo') == 'bar'
+
+
 @pytest.mark.parametrize(
     'enable_metadata_collection, expected_is_metadata_collection_enabled',
     [(None, False), ('true', True), ('false', False)],


### PR DESCRIPTION
### Motivation

About to use it and realized the interface could be simplified since you'd want to utilize the unique check ID in all cases

https://github.com/DataDog/integrations-core/blob/bafe92ce829645b68b69c47f73c2189188d03a42/win32_event_log/datadog_checks/win32_event_log/check.py#L252-L263