### PR TITLE
Update mkdocs-click dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     -e./datadog_checks_base[deps,http]
     -e./datadog_checks_dev[cli]
     ; for CLI auto-documentation of ddev
-    git+git://github.com/DataDog/mkdocs-click.git@1b950b870ce3777433a216e646b97161857acebd
+    mkdocs-click==0.1.*
 setenv =
     ; Use a set timestamp for reproducible builds.
     ; See https://reproducible-builds.org/specs/source-date-epoch/


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update docs dependency on `mkdocs-click` to use release from PyPI.

### Motivation
<!-- What inspired you to submit this pull request? -->
- https://github.com/DataDog/mkdocs-click/pull/3
- https://pypi.org/project/mkdocs-click/0.1.0/

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
