### PR TITLE
Add disk timeout configuration option

### DIFF
--- a/disk/assets/configuration/spec.yaml
+++ b/disk/assets/configuration/spec.yaml
@@ -159,3 +159,9 @@ files:
             value:
               example: 0
               type: number
+          - name: timeout
+            description: Timeout of the disk query in seconds
+            value:
+              example: 5
+              default: 5
+              type: integer

--- a/disk/datadog_checks/disk/data/conf.yaml.example
+++ b/disk/datadog_checks/disk/data/conf.yaml.example
@@ -142,3 +142,8 @@ instances:
     ## Exclude devices with a total disk size less than a minimum value (in MiB)
     #
     # min_disk_size: 0
+
+    ## @param timeout - integer - optional - default: 5
+    ## Timeout of the disk query in seconds
+    #
+    # timeout: 5

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -235,9 +235,14 @@ class Disk(AgentCheck):
         metrics = {}
         # we need to timeout this, too.
         try:
-            inodes = timeout(5)(os.statvfs)(mountpoint)
+            inodes = timeout(self._timeout)(os.statvfs)(mountpoint)
         except TimeoutException:
-            self.log.warning(u'Timeout while retrieving the disk usage of `%s` mountpoint. Skipping...', mountpoint)
+            self.log.warning(
+                u'Timeout after %d seconds while retrieving the disk usage of `%s` mountpoint. '
+                u'You might want to change the timeout length in the settings.',
+                self._timeout,
+                mountpoint,
+            )
             return metrics
         except Exception as e:
             self.log.warning('Unable to get disk metrics for %s: %s', mountpoint, e)

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -78,7 +78,6 @@ class Disk(AgentCheck):
 
             # Get disk metrics here to be able to exclude on total usage
             try:
-                self.log.debug("Check %s", part.mountpoint)
                 disk_usage = timeout(self._timeout)(psutil.disk_usage)(part.mountpoint)
             except TimeoutException:
                 self.log.warning(

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -78,6 +78,7 @@ class Disk(AgentCheck):
 
             # Get disk metrics here to be able to exclude on total usage
             try:
+                self.log.debug("Check %s", part.mountpoint)
                 disk_usage = timeout(self._timeout)(psutil.disk_usage)(part.mountpoint)
             except TimeoutException:
                 self.log.warning(

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -30,6 +30,7 @@ def test_default_options():
     assert check._device_tag_re == []
     assert check._service_check_rw is False
     assert check._min_disk_size == 0
+    assert check._timeout == 5
 
 
 def test_bad_config():

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -9,10 +9,11 @@ import pytest
 from six import iteritems
 
 from datadog_checks.base.utils.platform import Platform
+from datadog_checks.base.utils.timeout import TimeoutException
 from datadog_checks.disk import Disk
 
 from .common import DEFAULT_DEVICE_BASE_NAME, DEFAULT_DEVICE_NAME, DEFAULT_FILE_SYSTEM, DEFAULT_MOUNT_POINT
-from .mocks import MockDiskMetrics, mock_blkid_output
+from .mocks import MockDiskMetrics, MockPart, mock_blkid_output
 
 
 def test_default_options():
@@ -212,3 +213,61 @@ def test_blkid_cache_file_contains_no_labels(
     c.check(instance_blkid_cache_file_no_label)
     for metric in chain(gauge_metrics, rate_metrics):
         aggregator.assert_metric(metric, tags=['device:/dev/sda1', 'device_name:sda1'])
+
+
+@pytest.mark.usefixtures('psutil_mocks')
+def test_timeout_config(aggregator, gauge_metrics, rate_metrics):
+    """Test timeout configuration value is used on every timeout on the check."""
+
+    # Arbitrary value
+    TIMEOUT_VALUE = 42
+    instance = {'timeout': TIMEOUT_VALUE}
+    c = Disk('disk', {}, [instance])
+
+    # Mock timeout version
+    def no_timeout(fun):
+        return lambda *args: fun(args)
+
+    with mock.patch('psutil.disk_partitions', return_value=[MockPart()]), mock.patch(
+        'datadog_checks.disk.disk.timeout', return_value=no_timeout
+    ) as mock_timeout:
+        c.check(instance)
+
+    mock_timeout.assert_called_with(TIMEOUT_VALUE)
+
+
+@pytest.mark.usefixtures('psutil_mocks')
+def test_timeout_warning(aggregator, gauge_metrics, rate_metrics):
+    """Test a warning is raised when there is a Timeout exception."""
+
+    # Raise exception for "/faulty" mountpoint
+    def faulty_timeout(fun):
+        def f(mountpoint):
+            if mountpoint == "/faulty":
+                raise TimeoutException
+            else:
+                return fun(mountpoint)
+
+        return f
+
+    c = Disk('disk', {}, [{}])
+    c.log = mock.MagicMock()
+    m = MockDiskMetrics()
+    m.total = 0
+
+    with mock.patch('psutil.disk_partitions', return_value=[MockPart(), MockPart(mountpoint="/faulty")]), mock.patch(
+        'psutil.disk_usage', return_value=m, __name__='disk_usage'
+    ), mock.patch('datadog_checks.disk.disk.timeout', return_value=faulty_timeout):
+        c.check({})
+
+    # Check that the warning is called once for the faulty disk
+    c.log.warning.assert_called_once()
+
+    for name in gauge_metrics:
+        aggregator.assert_metric(name, count=0)
+
+    for name in rate_metrics:
+        aggregator.assert_metric_has_tag(name, 'device:{}'.format(DEFAULT_DEVICE_NAME))
+        aggregator.assert_metric_has_tag(name, 'device_name:{}'.format(DEFAULT_DEVICE_BASE_NAME))
+
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Add disk timeout configuration option to allow users to customize it for slow disks.
- Rewrite warning to hint at the new configuration option

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
