### PR TITLE
Add test checking selt.config.tags is not changed

### DIFF
--- a/postgres/tests/test_integration.py
+++ b/postgres/tests/test_integration.py
@@ -237,7 +237,7 @@ def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance)
 
     expected_tags = pg_instance['tags'] + ['server:{}'.format(HOST), 'port:{}'.format(PORT), 'db:datadog_test']
 
-    for i in range(3):
+    for _ in range(3):
         check.check(pg_instance)
         assert check.config.tags == expected_tags
 

--- a/postgres/tests/test_integration.py
+++ b/postgres/tests/test_integration.py
@@ -229,6 +229,19 @@ def test_query_timeout(aggregator, integration_check, pg_instance):
         cursor.execute("select pg_sleep(2000)")
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance):
+    pg_instance['tag_replication_role'] = True
+    check = integration_check(pg_instance)
+
+    expected_tags = pg_instance['tags'] + ['server:{}'.format(HOST), 'port:{}'.format(PORT), 'db:datadog_test']
+
+    for i in range(3):
+        check.check(pg_instance)
+        assert check.config.tags == expected_tags
+
+
 def assert_state_clean(check):
     assert check.metrics_cache.instance_metrics is None
     assert check.metrics_cache.bgw_metrics is None


### PR DESCRIPTION
### What does this PR do?

Add test to check that `config.tags` is not changing between checks.

### Motivation

There was previously a memory leak with `self.config.tags` when using the config `tag_replication_role`:

https://github.com/DataDog/integrations-core/blob/08e74f1004586b9eaec8983c250eeaa65845c99c/postgres/datadog_checks/postgres/postgres.py#L710

at each check run, a new tag was appended to `self.config.tags`.

It has been fixed by https://github.com/DataDog/integrations-core/pull/6500 

This PR adds a test for it to prevent future regression.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Bug introduced in https://github.com/DataDog/integrations-core/pull/4831

The issue was present since postgres v3.3.0 (agent v7.16.0) and will be fixed in next release (probably postgres v5.0.0 and agent v7.21.0) 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
