### PR TITLE
Add response duration metric to nginx ingress controller check

### DIFF
--- a/nginx_ingress_controller/CHANGELOG.md
+++ b/nginx_ingress_controller/CHANGELOG.md
@@ -1,9 +1,5 @@
 # CHANGELOG - nginx-ingress-controller
 
-## 1.4.0 / 2020-06-05
-
-* [Added] Add response duration metric for default metric collection. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
-
 ## 1.3.0 / 2020-05-17
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).

--- a/nginx_ingress_controller/CHANGELOG.md
+++ b/nginx_ingress_controller/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - nginx-ingress-controller
 
+## 1.4.0 / 2020-06-05
+
+* [Added] Add response duration metric for default metric collection. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
+
 ## 1.3.0 / 2020-05-17
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
@@ -19,4 +23,3 @@
 ## 1.1.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3546](https://github.com/DataDog/integrations-core/pull/3546).
-

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/__about__.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.3.0'
+__version__ = '1.4.0'

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/__about__.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.4.0'
+__version__ = '1.3.0'

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -19,3 +19,9 @@ instances:
     ## Overrides the default timeout value in second
     #
     # prometheus_timeout: 10
+
+    ## @param send_histograms_buckets - boolean - optional - default: true
+    ## Histogram buckets can be noisy and generate many tags.
+    ## Set send_histograms_buckets to true to pull them.
+    #
+    # send_histograms_buckets: true

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
@@ -35,6 +35,7 @@ class NginxIngressControllerCheck(OpenMetricsBaseCheck):
                         # controller metrics
                         {'nginx_ingress_controller_success': 'controller.reload.success'},
                         {'nginx_ingress_controller_ingress_upstream_latency_seconds': 'controller.upstream.latency'},
+                        {'nginx_ingress_controller_response_duration_seconds': 'controller.response.duration'},
                         {'nginx_ingress_controller_requests': 'controller.requests'},
                         {'process_cpu_seconds_total': 'controller.cpu.time'},
                         {'process_resident_memory_bytes': 'controller.mem.resident'},

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
@@ -41,6 +41,7 @@ class NginxIngressControllerCheck(OpenMetricsBaseCheck):
                         {'process_resident_memory_bytes': 'controller.mem.resident'},
                         {'process_virtual_memory_bytes': 'controller.mem.virtual'},
                     ],
+                    'send_histograms_buckets': True,
                 }
             },
             default_namespace="nginx_ingress",

--- a/nginx_ingress_controller/metadata.csv
+++ b/nginx_ingress_controller/metadata.csv
@@ -13,7 +13,7 @@ nginx_ingress.controller.upstream.latency.count,gauge,,,,Count of upstream servi
 nginx_ingress.controller.upstream.latency.sum,gauge,,second,,Sum of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency sum
 nginx_ingress.controller.upstream.latency.quantile,gauge,,second,,Quantiles of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency quant
 nginx_ingress.controller.response.duration.count,gauge,,,,Count of response duration per Ingress,0,nginx-ingress-controller,response duration count
-nginx_ingress.controller.response.duration.sum,gauge,,second,,Sum of upstream response per Ingress,0,nginx-ingress-controller,response duration sum
+nginx_ingress.controller.response.duration.sum,gauge,,second,,Sum of response duration per Ingress,0,nginx-ingress-controller,response duration sum
 nginx_ingress.controller.requests,count,,request,,The total number of client requests,0,nginx-ingress-controller,nb reqs
 nginx_ingress.controller.cpu.time,count,,second,,Cpu usage in seconds,0,nginx-ingress-controller,cpu
 nginx_ingress.controller.mem.resident,gauge,,byte,,Resident memory size in bytes,0,nginx-ingress-controller,mem rss

--- a/nginx_ingress_controller/metadata.csv
+++ b/nginx_ingress_controller/metadata.csv
@@ -12,6 +12,8 @@ nginx_ingress.controller.reload.success,count,,,,Cumulative number of Ingress co
 nginx_ingress.controller.upstream.latency.count,gauge,,,,Count of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency count
 nginx_ingress.controller.upstream.latency.sum,gauge,,second,,Sum of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency sum
 nginx_ingress.controller.upstream.latency.quantile,gauge,,second,,Quantiles of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency quant
+nginx_ingress.controller.response.duration.count,gauge,,,,Count of response duration per Ingress,0,nginx-ingress-controller,response duration count
+nginx_ingress.controller.response.duration.sum,gauge,,second,,Sum of upstream response per Ingress,0,nginx-ingress-controller,response duration sum
 nginx_ingress.controller.requests,count,,request,,The total number of client requests,0,nginx-ingress-controller,nb reqs
 nginx_ingress.controller.cpu.time,count,,second,,Cpu usage in seconds,0,nginx-ingress-controller,cpu
 nginx_ingress.controller.mem.resident,gauge,,byte,,Resident memory size in bytes,0,nginx-ingress-controller,mem rss

--- a/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
+++ b/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
@@ -51,6 +51,8 @@ def test_nginx_ingress_controller(aggregator, mock_data):
     aggregator.assert_metric(NAMESPACE + '.controller.upstream.latency.count')
     aggregator.assert_metric(NAMESPACE + '.controller.upstream.latency.sum')
     aggregator.assert_metric(NAMESPACE + '.controller.upstream.latency.quantile')
+    aggregator.assert_metric(NAMESPACE + '.controller.response.duration.count')
+    aggregator.assert_metric(NAMESPACE + '.controller.response.duration.sum')
     aggregator.assert_metric(NAMESPACE + '.controller.requests')
     aggregator.assert_metric(NAMESPACE + '.controller.cpu.time')
     aggregator.assert_metric(NAMESPACE + '.controller.mem.resident')


### PR DESCRIPTION
### What does this PR do?

Nginx Ingress Controller has a [response duration metric](https://github.com/kubernetes/ingress-nginx/blob/master/internal/ingress/metric/collectors/socket.go#L136) that is useful to calculate quantiles such as p50, p90, p95, p99 on latency for a response served by a microservice behind the ingress controller. The existing default metric of latency measures the time to connect to the ingress resource and not the time it takes for that response to be served. The response duration is the more useful metric compared to the latency metric.

### Motivation
Ability to answer questions around "what’s the p50, p90, p99 latency for service behind an Nginx ingress controller?"

### Additional Notes
The distribution of this metric with p50, p90, p95, p99 quantiles will be useful, by itself the metric can be used for the average duration (sum/count), which by itself isn't very useful. 

This entire PR is based on the difference between `latency` and `duration`, with duration being the key metric of interest. Duration is how long it takes to serve the response.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
