### PR TITLE
Move SNMP ddev commands to a sub-package

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/__init__.py
@@ -1,0 +1,18 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import click
+
+from ...console import CONTEXT_SETTINGS
+from .translate_profile import translate_profile
+
+ALL_COMMANDS = [translate_profile]
+
+
+@click.group(context_settings=CONTEXT_SETTINGS, short_help='SNMP utilities')
+def snmp():
+    pass
+
+
+for command in ALL_COMMANDS:
+    snmp.add_command(command)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
@@ -6,12 +6,7 @@ import os
 import click
 import yaml
 
-from ..console import CONTEXT_SETTINGS
-
-
-@click.group(context_settings=CONTEXT_SETTINGS, short_help='SNMP utilities')
-def snmp():
-    pass
+from ...console import CONTEXT_SETTINGS
 
 
 def fetch_mib(mib):
@@ -32,7 +27,7 @@ def fetch_mib(mib):
     mibCompiler.compile(mib)
 
 
-@snmp.command(context_settings=CONTEXT_SETTINGS, short_help='Translate MIB name to OIDs in SNMP profiles')
+@click.command(context_settings=CONTEXT_SETTINGS, short_help='Translate MIB name to OIDs in SNMP profiles')
 @click.argument('profile_path')
 @click.pass_context
 def translate_profile(ctx, profile_path):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Convert `meta/snmp.py` into `meta/snmp/...`, following the same pattern as for other groups.

### Motivation
<!-- What inspired you to submit this pull request? -->
Standardization, and required cleanup step if we wanted to add more `ddev meta snmp ...` commands.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
