### PR TITLE
Make max file count configurable in the directory check

### DIFF
--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -55,7 +55,7 @@ class DirectoryCheck(AgentCheck):
         ignore_missing = is_affirmative(instance.get('ignore_missing', False))
         follow_symlinks = is_affirmative(instance.get('follow_symlinks', True))
         custom_tags = instance.get('tags', [])
-        max_filegauge_count = instance.get('max_filegauge_count', MAX_FILEGAUGE_COUNT)
+        max_filegauge_count = instance.get('max_filegauge_count', self.MAX_FILEGAUGE_COUNT)
         
         if not exists(abs_directory):
             msg = (

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -42,6 +42,7 @@ class DirectoryCheck(AgentCheck):
 
         abs_directory = abspath(directory)
         name = instance.get('name', directory)
+        
         pattern = instance.get('pattern')
         exclude_dirs = instance.get('exclude_dirs', [])
         exclude_dirs_pattern = re_compile('|'.join(exclude_dirs)) if exclude_dirs else None
@@ -54,7 +55,8 @@ class DirectoryCheck(AgentCheck):
         ignore_missing = is_affirmative(instance.get('ignore_missing', False))
         follow_symlinks = is_affirmative(instance.get('follow_symlinks', True))
         custom_tags = instance.get('tags', [])
-
+        max_filegauge_count = instance.get('max_filegauge_count', MAX_FILEGAUGE_COUNT)
+        
         if not exists(abs_directory):
             msg = (
                 "Either directory '{}' doesn't exist or the Agent doesn't "
@@ -79,6 +81,7 @@ class DirectoryCheck(AgentCheck):
             follow_symlinks,
             countonly,
             custom_tags,
+            max_filegauge_count,
         )
 
     def _get_stats(
@@ -95,12 +98,13 @@ class DirectoryCheck(AgentCheck):
         follow_symlinks,
         countonly,
         tags,
+        max_filegauge_count,
     ):
         dirtags = ['{}:{}'.format(dirtagname, name)]
         dirtags.extend(tags)
         directory_bytes = 0
         directory_files = 0
-        max_filegauge_balance = self.MAX_FILEGAUGE_COUNT
+        max_filegauge_balance = max_filegauge_count
 
         # If we do not want to recursively search sub-directories only get the root.
         walker = walk(directory, follow_symlinks) if recursive else (next(walk(directory, follow_symlinks)),)

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -42,7 +42,6 @@ class DirectoryCheck(AgentCheck):
 
         abs_directory = abspath(directory)
         name = instance.get('name', directory)
-        
         pattern = instance.get('pattern')
         exclude_dirs = instance.get('exclude_dirs', [])
         exclude_dirs_pattern = re_compile('|'.join(exclude_dirs)) if exclude_dirs else None
@@ -56,7 +55,7 @@ class DirectoryCheck(AgentCheck):
         follow_symlinks = is_affirmative(instance.get('follow_symlinks', True))
         custom_tags = instance.get('tags', [])
         max_filegauge_count = instance.get('max_filegauge_count', self.MAX_FILEGAUGE_COUNT)
-        
+
         if not exists(abs_directory):
             msg = (
                 "Either directory '{}' doesn't exist or the Agent doesn't "


### PR DESCRIPTION

### What does this PR do?
makes max_filegauge_count an undocumented configurable setting

### Motivation
I wanted to monitor more than 20 files and expected this setting to be configureable like in our [rabbitmq check](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py#L183-L187) and the [jmx fetch based integrations](https://github.com/DataDog/jmxfetch/blob/master/src/main/java/org/datadog/jmxfetch/Instance.java#L64)


### Additional Notes
I'm not sure if any unit tests or things also need to be updated, just let me know if so.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
