### PR TITLE
Use higher precision clock measurements for Python 3

### DIFF
--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -27,7 +27,7 @@ jobs:
 - template: './templates/test-single-windows.yml'
   parameters:
     job_name: Changed
-    check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dns_check dotnetclr exchange_server iis pdh_check sqlserver win32_event_log windows_service wmi_check'
+    check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dns_check dotnetclr exchange_server iis pdh_check sqlserver tcp_check win32_event_log windows_service wmi_check'
     display: Windows
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'

--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -381,8 +381,11 @@ jobs:
       displayName: System Swap
       os: linux
     - checkName: tcp_check
-      displayName: TCP
+      displayName: TCP (Linux)
       os: linux
+    - checkName: tcp_check
+      displayName: TCP (Windows)
+      os: windows
     - checkName: teamcity
       displayName: TeamCity
       os: linux

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -5,7 +5,21 @@ import socket
 import time
 from contextlib import closing
 
+from six import PY3
+
 from datadog_checks.base import AgentCheck, ConfigurationError
+from datadog_checks.base.utils.platform import Platform
+
+if PY3:
+    # use higher precision clock available in Python3
+    time_func = time.perf_counter
+elif Platform.is_win32():
+    # for tiny time deltas, time.time on Windows reports the same value
+    # of the clock more than once, causing the computation of response_time
+    # to be often 0; let's use time.clock that is more precise.
+    time_func = time.clock
+else:
+    time_func = time.time
 
 
 class TCPCheck(AgentCheck):
@@ -67,13 +81,13 @@ class TCPCheck(AgentCheck):
     def connect(self):
         with closing(socket.socket(self.socket_type)) as sock:
             sock.settimeout(self.timeout)
-            start = time.time()
+            start = time_func()
             sock.connect((self.addr, self.port))
-            response_time = time.time() - start
+            response_time = time_func() - start
             return response_time
 
     def check(self, instance):
-        start = time.time()  # Avoid initialisation warning
+        start = time_func()  # Avoid initialisation warning
         self.log.debug("Connecting to %s %d", self.addr, self.port)
         try:
             response_time = self.connect()
@@ -84,7 +98,7 @@ class TCPCheck(AgentCheck):
                     'network.tcp.response_time', response_time, tags=self.tags,
                 )
         except Exception as e:
-            length = int((time.time() - start) * 1000)
+            length = int((time_func() - start) * 1000)
             if isinstance(e, socket.error) and "timed out" in str(e):
                 # The connection timed out because it took more time than the system tcp stack allows
                 self.log.warning(

--- a/tcp_check/tests/test_integration.py
+++ b/tcp_check/tests/test_integration.py
@@ -8,7 +8,7 @@ from . import common
 pytestmark = pytest.mark.integration
 
 
-@pytest.mark.usefixture("dd_environment")
+@pytest.mark.usefixtures("dd_environment")
 def test_check(aggregator, check, instance):
     check.check(instance)
     common._test_check(aggregator)


### PR DESCRIPTION
### What does this PR do?

Use the higher precision clock available in Python 3, `time.perf_counter`.  This pattern has been previously adopted as part of #6478 and #6682. 

Additionally, test this check under Windows CI as well.
