### PR TITLE
Allow ddev release command to work for different organizations

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -25,12 +25,13 @@ ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, autho
 @click.argument('version')
 @click.argument('old_version', required=False)
 @click.option('--initial', is_flag=True)
+@click.option('--organization', '-r', default=None)
 @click.option('--quiet', '-q', is_flag=True)
 @click.option('--dry-run', '-n', is_flag=True)
 @click.option('--output-file', '-o', default='CHANGELOG.md', show_default=True)
 @click.option('--tag-prefix', '-tp', default='v', show_default=True)
 @click.pass_context
-def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_file, tag_prefix):
+def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_file, tag_prefix, organization):
     """Perform the operations needed to update the changelog.
 
     This method is supposed to be used by other tasks and not directly.
@@ -68,7 +69,7 @@ def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_
     generated_changelogs = 0
     for pr_num in pr_numbers:
         try:
-            payload = get_pr(pr_num, user_config)
+            payload = get_pr(pr_num, user_config, organization)
         except Exception as e:
             echo_failure(f'Unable to fetch info for PR #{pr_num}: {e}')
             continue

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
@@ -12,11 +12,12 @@ from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_su
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Show all the pending PRs for a given check.')
 @click.argument('check', autocompletion=complete_valid_checks, callback=validate_check_arg)
+@click.option('--organization', '-r', default=None)
 @click.option('--tag-pattern', default=None)
 @click.option('--tag-prefix', default=None)
 @click.option('--dry-run', '-n', is_flag=True)
 @click.pass_context
-def changes(ctx, check, tag_pattern, tag_prefix, dry_run):
+def changes(ctx, check, tag_pattern, tag_prefix, dry_run, organization):
     """Show all the pending PRs for a given check."""
     if not dry_run and check and check not in get_valid_checks():
         abort(f'Check `{check}` is not an Agent-based Integration')
@@ -39,7 +40,7 @@ def changes(ctx, check, tag_pattern, tag_prefix, dry_run):
 
         for pr_num in pr_numbers:
             try:
-                payload = get_pr(pr_num, user_config)
+                payload = get_pr(pr_num, user_config, organization)
             except Exception as e:
                 echo_failure(f'Unable to fetch info for PR #{pr_num}: {e}')
                 continue
@@ -58,7 +59,7 @@ def changes(ctx, check, tag_pattern, tag_prefix, dry_run):
     else:
         for pr_num in pr_numbers:
             try:
-                payload = get_pr(pr_num, user_config)
+                payload = get_pr(pr_num, user_config, organization)
             except Exception as e:
                 echo_failure(f'Unable to fetch info for PR #{pr_num}: {e}')
                 continue

--- a/datadog_checks_dev/datadog_checks/dev/tooling/github.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/github.py
@@ -53,12 +53,16 @@ def get_changelog_types(pr_payload):
     return changelog_labels
 
 
-def get_pr(pr_num, config=None, raw=False):
+def get_pr(pr_num, config=None, raw=False, org=None):
     """
     Get the payload for the given PR number. Let exceptions bubble up.
     """
+    pull = PR_ENDPOINT.format(repo, pr_num)
+    if org:
+        pull = API_URL + f'/repos/{org}/{repo}/pulls/{pr_num}'
+
     repo = basepath(get_root())
-    response = requests.get(PR_ENDPOINT.format(repo, pr_num), auth=get_auth_info(config))
+    response = requests.get(pull, auth=get_auth_info(config))
 
     if raw:
         return response


### PR DESCRIPTION
### What does this PR do?
- add option for github organization to ddev release commands 
### Motivation
- We want to use it for https://github.com/jenkinsci/datadog-plugin
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
