### PR TITLE
Updated ssh_check readme to change integration name to ssh_check

### DIFF
--- a/ssh_check/README.md
+++ b/ssh_check/README.md
@@ -40,7 +40,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][8]
 
 | Parameter            | Value                                                        |
 | -------------------- | ------------------------------------------------------------ |
-| `<INTEGRATION_NAME>` | `ssh`                                                        |
+| `<INTEGRATION_NAME>` | `ssh_check`                                                  |
 | `<INIT_CONFIG>`      | blank or `{}`                                                |
 | `<INSTANCE_CONFIG>`  | `{"host": "%%host%%", "port":"22", "username":"<USERNAME>"}` |
 


### PR DESCRIPTION
### What does this PR do?
Fixes the documentation to direct users to the correct integration name: `ssh_check`

### Motivation
<!-- What inspired you to submit this pull request? -->
Save users time by providing the correct integration name.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
