### PR TITLE
Add flag to collect subset of histogram metrics

### DIFF
--- a/nginx_ingress_controller/assets/configuration/spec.yaml
+++ b/nginx_ingress_controller/assets/configuration/spec.yaml
@@ -9,8 +9,10 @@ files:
       options:
         - name: collect_nginx_histograms
           description: |
-            Enable to collect histogram metrics that are known to have high tag cardinality which can cause context explosion.
-            Recommended to use with distribution metrics, enable `send_distribution_buckets`.
+            Enable to collect histogram metrics that are known to have high tag cardinality.
+            Recommended to use with distribution metrics tag whitelist, please enable `send_distribution_buckets`.
+            For more information about distribution metrics and tags,
+            see https://docs.datadoghq.com/metrics/distributions/#customize-tagging.
           value:
             example: false
             type: boolean

--- a/nginx_ingress_controller/assets/configuration/spec.yaml
+++ b/nginx_ingress_controller/assets/configuration/spec.yaml
@@ -7,6 +7,13 @@ files:
         - template: init_config/openmetrics
     - template: instances
       options:
+        - name: collect_nginx_histograms
+          description: |
+            Enable to collect histogram metrics that are known to have high tag cardinality which can cause context explosion.
+            Recommended to use with distribution metrics, enable `send_distribution_buckets`.
+          value:
+            example: false
+            type: boolean
         - template: instances/openmetrics
           overrides:
             prometheus_url.value.example: http://localhost:10254/metrics

--- a/nginx_ingress_controller/assets/configuration/spec.yaml
+++ b/nginx_ingress_controller/assets/configuration/spec.yaml
@@ -19,3 +19,4 @@ files:
         - template: instances/openmetrics
           overrides:
             prometheus_url.value.example: http://localhost:10254/metrics
+            prometheus_url.display_priority: 1

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -47,7 +47,10 @@ instances:
 
   -
     ## @param collect_nginx_histograms - boolean - optional - default: false
-    ## Enable to collect histogram metrics that are known to have high tag cardinality that can cause context explosion.
+    ## Enable to collect histogram metrics that are known to have high tag cardinality.
+    ## Recommended to use with distribution metrics tag whitelist, please enable `send_distribution_buckets`.
+    ## For more information about distribution metrics and tags,
+    ## see https://docs.datadoghq.com/metrics/distributions/#customize-tagging.
     #
     # collect_nginx_histograms: false
 

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -45,10 +45,16 @@ init_config:
 #
 instances:
 
+  -
+    ## @param collect_nginx_histograms - boolean - optional - default: false
+    ## Enable to collect histogram metrics that are known to have high tag cardinality that can cause context explosion.
+    #
+    # collect_nginx_histograms: false
+
     ## @param prometheus_url - string - required
     ## The URL where your application metrics are exposed by Prometheus.
     #
-  - prometheus_url: http://localhost:10254/metrics
+    prometheus_url: http://localhost:10254/metrics
 
     ## @param prometheus_metrics_prefix - string - optional
     ## <PREFIX> for exposed Prometheus metrics.

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -45,7 +45,11 @@ init_config:
 #
 instances:
 
-  -
+    ## @param prometheus_url - string - required
+    ## The URL where your application metrics are exposed by Prometheus.
+    #
+  - prometheus_url: http://localhost:10254/metrics
+
     ## @param collect_nginx_histograms - boolean - optional - default: false
     ## Enable to collect histogram metrics that are known to have high tag cardinality.
     ## Recommended to use with distribution metrics tag whitelist, please enable `send_distribution_buckets`.
@@ -53,11 +57,6 @@ instances:
     ## see https://docs.datadoghq.com/metrics/distributions/#customize-tagging.
     #
     # collect_nginx_histograms: false
-
-    ## @param prometheus_url - string - required
-    ## The URL where your application metrics are exposed by Prometheus.
-    #
-    prometheus_url: http://localhost:10254/metrics
 
     ## @param prometheus_metrics_prefix - string - optional
     ## <PREFIX> for exposed Prometheus metrics.

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
@@ -43,7 +43,7 @@ class NginxIngressControllerCheck(OpenMetricsBaseCheck):
         # Allow for additional metric mappings
         metrics = instance.get('metrics', []) + DEFAULT_METRICS
 
-        if instance.get('collect_histograms'):
+        if instance.get('collect_nginx_histograms', False):
             metrics += HISTOGRAM_METRICS
 
         super(NginxIngressControllerCheck, self).__init__(

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
+from datadog_checks.base import is_affirmative
+
 
 DEFAULT_METRICS = [
     # nginx metrics
@@ -43,7 +45,7 @@ class NginxIngressControllerCheck(OpenMetricsBaseCheck):
         # Allow for additional metric mappings
         metrics = instance.get('metrics', []) + DEFAULT_METRICS
 
-        if instance.get('collect_nginx_histograms', False):
+        if is_affirmative(instance.get('collect_nginx_histograms', False)):
             metrics += HISTOGRAM_METRICS
 
         super(NginxIngressControllerCheck, self).__init__(

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
@@ -3,6 +3,32 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 
+DEFAULT_METRICS = [
+    # nginx metrics
+    {'nginx_ingress_controller_nginx_process_connections': 'nginx.connections.current'},
+    {'nginx_ingress_controller_nginx_process_connections_total': 'nginx.connections.total'},
+    {'nginx_ingress_controller_nginx_process_requests_total': 'nginx.requests.total'},
+    # nginx process metrics
+    {'nginx_ingress_controller_nginx_process_num_procs': 'nginx.process.count'},
+    {'nginx_ingress_controller_nginx_process_read_bytes_total': 'nginx.bytes.read'},
+    {'nginx_ingress_controller_nginx_process_write_bytes_total': 'nginx.bytes.write'},
+    {'nginx_ingress_controller_nginx_process_cpu_seconds_total': 'nginx.cpu.time'},
+    {'nginx_ingress_controller_nginx_process_resident_memory_bytes': 'nginx.mem.resident'},
+    {'nginx_ingress_controller_nginx_process_virtual_memory_bytes': 'nginx.mem.virtual'},
+    # controller metrics
+    {'nginx_ingress_controller_success': 'controller.reload.success'},
+    {'nginx_ingress_controller_ingress_upstream_latency_seconds': 'controller.upstream.latency'},
+    {'nginx_ingress_controller_requests': 'controller.requests'},
+    {'process_cpu_seconds_total': 'controller.cpu.time'},
+    {'process_resident_memory_bytes': 'controller.mem.resident'},
+    {'process_virtual_memory_bytes': 'controller.mem.virtual'},
+]
+
+HISTOGRAM_METRICS = [
+    {'nginx_ingress_controller_response_duration_seconds': 'controller.response.duration'},
+    {'nginx_ingress_controller_request_duration_seconds': 'controller.request.duration'},
+]
+
 
 class NginxIngressControllerCheck(OpenMetricsBaseCheck):
     """
@@ -12,6 +38,14 @@ class NginxIngressControllerCheck(OpenMetricsBaseCheck):
     DEFAULT_METRIC_LIMIT = 0
 
     def __init__(self, name, init_config, instances):
+        instance = instances[0]
+
+        # Allow for additional metric mappings
+        metrics = instance.get('metrics', []) + DEFAULT_METRICS
+
+        if instance.get('collect_histograms'):
+            metrics += HISTOGRAM_METRICS
+
         super(NginxIngressControllerCheck, self).__init__(
             name,
             init_config,
@@ -20,28 +54,7 @@ class NginxIngressControllerCheck(OpenMetricsBaseCheck):
                 "nginx_ingress": {
                     'prometheus_url': 'http://localhost:10254/metrics',
                     'namespace': 'nginx_ingress',
-                    'metrics': [
-                        # nginx metrics
-                        {'nginx_ingress_controller_nginx_process_connections': 'nginx.connections.current'},
-                        {'nginx_ingress_controller_nginx_process_connections_total': 'nginx.connections.total'},
-                        {'nginx_ingress_controller_nginx_process_requests_total': 'nginx.requests.total'},
-                        # nginx process metrics
-                        {'nginx_ingress_controller_nginx_process_num_procs': 'nginx.process.count'},
-                        {'nginx_ingress_controller_nginx_process_read_bytes_total': 'nginx.bytes.read'},
-                        {'nginx_ingress_controller_nginx_process_write_bytes_total': 'nginx.bytes.write'},
-                        {'nginx_ingress_controller_nginx_process_cpu_seconds_total': 'nginx.cpu.time'},
-                        {'nginx_ingress_controller_nginx_process_resident_memory_bytes': 'nginx.mem.resident'},
-                        {'nginx_ingress_controller_nginx_process_virtual_memory_bytes': 'nginx.mem.virtual'},
-                        # controller metrics
-                        {'nginx_ingress_controller_success': 'controller.reload.success'},
-                        {'nginx_ingress_controller_ingress_upstream_latency_seconds': 'controller.upstream.latency'},
-                        {'nginx_ingress_controller_response_duration_seconds': 'controller.response.duration'},
-                        {'nginx_ingress_controller_requests': 'controller.requests'},
-                        {'process_cpu_seconds_total': 'controller.cpu.time'},
-                        {'process_resident_memory_bytes': 'controller.mem.resident'},
-                        {'process_virtual_memory_bytes': 'controller.mem.virtual'},
-                    ],
-                    'send_histograms_buckets': True,
+                    'metrics': metrics,
                 }
             },
             default_namespace="nginx_ingress",

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
@@ -1,9 +1,8 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base import is_affirmative
-
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 
 DEFAULT_METRICS = [
     # nginx metrics

--- a/nginx_ingress_controller/metadata.csv
+++ b/nginx_ingress_controller/metadata.csv
@@ -12,9 +12,11 @@ nginx_ingress.controller.reload.success,count,,,,Cumulative number of Ingress co
 nginx_ingress.controller.upstream.latency.count,gauge,,,,Count of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency count
 nginx_ingress.controller.upstream.latency.sum,gauge,,second,,Sum of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency sum
 nginx_ingress.controller.upstream.latency.quantile,gauge,,second,,Quantiles of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency quant
-nginx_ingress.controller.response.duration.count,gauge,,,,Count of response duration per Ingress,0,nginx-ingress-controller,response duration count
+nginx_ingress.controller.response.duration.count,count,,,,Count of response duration per Ingress,0,nginx-ingress-controller,response duration count
 nginx_ingress.controller.response.duration.sum,gauge,,second,,Sum of response duration per Ingress,0,nginx-ingress-controller,response duration sum
 nginx_ingress.controller.requests,count,,request,,The total number of client requests,0,nginx-ingress-controller,nb reqs
 nginx_ingress.controller.cpu.time,count,,second,,Cpu usage in seconds,0,nginx-ingress-controller,cpu
 nginx_ingress.controller.mem.resident,gauge,,byte,,Resident memory size in bytes,0,nginx-ingress-controller,mem rss
 nginx_ingress.controller.mem.virtual,gauge,,byte,,Virtual memory size in bytes,0,nginx-ingress-controller,mem virt
+nginx_ingress.controller.request.duration.count,count,,,,The count of request processing time,0,nginx_ingress-controller,request duration count
+nginx_ingress.controller.request.duration.sum,gauge,,millisecond,,The sum of request processing time,0,nginx_ingress-controller,request duration sum

--- a/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
+++ b/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
@@ -10,7 +10,7 @@ from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.nginx_ingress_controller import NginxIngressControllerCheck
 
 INSTANCE = {'prometheus_url': 'http://localhost:10249/metrics'}
-INSTANCE_HISTO = {'prometheus_url': 'http://localhost:10249/metrics', 'collect_histograms': True}
+INSTANCE_HISTO = {'prometheus_url': 'http://localhost:10249/metrics', 'collect_nginx_histograms': True}
 
 CHECK_NAME = 'nginx_ingress_controller'
 NAMESPACE = 'nginx_ingress'

--- a/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
+++ b/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
@@ -6,9 +6,11 @@ import os
 import mock
 import pytest
 
+from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.nginx_ingress_controller import NginxIngressControllerCheck
 
-instance = {'prometheus_url': 'http://localhost:10249/metrics'}
+INSTANCE = {'prometheus_url': 'http://localhost:10249/metrics'}
+INSTANCE_HISTO = {'prometheus_url': 'http://localhost:10249/metrics', 'collect_histograms': True}
 
 CHECK_NAME = 'nginx_ingress_controller'
 NAMESPACE = 'nginx_ingress'
@@ -28,34 +30,64 @@ def mock_data():
         yield
 
 
+EXPECTED_METRICS = [
+    # nginx metrics
+    '.nginx.connections.current',
+    '.nginx.connections.total',
+    '.nginx.requests.total',
+    # nginx process metrics
+    '.nginx.bytes.read',
+    '.nginx.process.count',
+    '.nginx.bytes.write',
+    '.nginx.cpu.time',
+    '.nginx.mem.resident',
+    '.nginx.mem.virtual',
+    # controller metrics
+    '.controller.reload.success',
+    '.controller.upstream.latency.count',
+    '.controller.upstream.latency.sum',
+    '.controller.upstream.latency.quantile',
+    '.controller.requests',
+    '.controller.cpu.time',
+    '.controller.mem.resident',
+    '.controller.mem.virtual',
+]
+
+
 def test_nginx_ingress_controller(aggregator, mock_data):
     """
     Testing nginx ingress controller.
     """
 
-    c = NginxIngressControllerCheck(CHECK_NAME, {}, [instance])
-    c.check(instance)
-    # nginx metrics
-    aggregator.assert_metric(NAMESPACE + '.nginx.connections.current')
-    aggregator.assert_metric(NAMESPACE + '.nginx.connections.total')
-    aggregator.assert_metric(NAMESPACE + '.nginx.requests.total')
-    # nginx process metrics
-    aggregator.assert_metric(NAMESPACE + '.nginx.process.count')
-    aggregator.assert_metric(NAMESPACE + '.nginx.bytes.read')
-    aggregator.assert_metric(NAMESPACE + '.nginx.bytes.write')
-    aggregator.assert_metric(NAMESPACE + '.nginx.cpu.time')
-    aggregator.assert_metric(NAMESPACE + '.nginx.mem.resident')
-    aggregator.assert_metric(NAMESPACE + '.nginx.mem.virtual')
-    # controller metrics
-    aggregator.assert_metric(NAMESPACE + '.controller.reload.success')
-    aggregator.assert_metric(NAMESPACE + '.controller.upstream.latency.count')
-    aggregator.assert_metric(NAMESPACE + '.controller.upstream.latency.sum')
-    aggregator.assert_metric(NAMESPACE + '.controller.upstream.latency.quantile')
-    aggregator.assert_metric(NAMESPACE + '.controller.response.duration.count')
-    aggregator.assert_metric(NAMESPACE + '.controller.response.duration.sum')
-    aggregator.assert_metric(NAMESPACE + '.controller.requests')
-    aggregator.assert_metric(NAMESPACE + '.controller.cpu.time')
-    aggregator.assert_metric(NAMESPACE + '.controller.mem.resident')
-    aggregator.assert_metric(NAMESPACE + '.controller.mem.virtual')
+    c = NginxIngressControllerCheck(CHECK_NAME, {}, [INSTANCE])
+    c.check(INSTANCE)
+
+    for metric in EXPECTED_METRICS:
+        aggregator.assert_metric(NAMESPACE + metric)
+
+    # By default, the integration does not collect histogram metrics due to high label cardinality
+    aggregator.assert_metric(NAMESPACE + '.controller.response.duration.count', count=0)
+    aggregator.assert_metric(NAMESPACE + '.controller.response.duration.sum', count=0)
+    aggregator.assert_metric(NAMESPACE + '.controller.request.duration.count', count=0)
+    aggregator.assert_metric(NAMESPACE + '.controller.request.duration.sum', count=0)
 
     aggregator.assert_all_metrics_covered()
+
+
+def test_with_histograms(aggregator, mock_data):
+    """
+    Testing nginx ingress controller with `collect_histogram` enabled.
+    """
+    c = NginxIngressControllerCheck(CHECK_NAME, {}, [INSTANCE_HISTO])
+    c.check(INSTANCE_HISTO)
+
+    for metric in EXPECTED_METRICS:
+        aggregator.assert_metric(NAMESPACE + metric)
+
+    aggregator.assert_metric(NAMESPACE + '.controller.response.duration.count')
+    aggregator.assert_metric(NAMESPACE + '.controller.response.duration.sum')
+    aggregator.assert_metric(NAMESPACE + '.controller.request.duration.count')
+    aggregator.assert_metric(NAMESPACE + '.controller.request.duration.sum')
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_metric_type=False)


### PR DESCRIPTION
### What does this PR do?
Introduces a `collect_nginx_histograms` option to collect a subset of nginx ingress controller histogram metrics.

```
    {'nginx_ingress_controller_response_duration_seconds': 'controller.response.duration'},
    {'nginx_ingress_controller_request_duration_seconds': 'controller.request.duration'},
```

This flag allows these metrics to be collected when enabled. By default, this flag is disabled.

### Motivation
A subset of nginx_ingress_controller histogram metrics are known to have high cardinality due to `host` and `path` labels. This flag allows customers who want to monitor the histograms to collect them on an opt-in basis.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
