### PR TITLE
pass the password to be used for pkey decryption

### DIFF
--- a/ssh_check/assets/configuration/spec.yaml
+++ b/ssh_check/assets/configuration/spec.yaml
@@ -24,7 +24,10 @@ files:
               type: string
 
           - name: password
-            description: Password to use for the SSH connection.
+            description: |
+              Password to use for the SSH connection.
+              If an encrypted SSH private key is specified in `private_key_file`, 
+                the given password will be used to decrypt the key.
             value:
               type: string
 
@@ -41,7 +44,10 @@ files:
               type: boolean
 
           - name: private_key_file
-            description: File path to a SSH private key.
+            description: |
+              File path to a SSH private key.
+              If the SSH private key is encrypted, `password` will be used to decrypt the key.
+              See: http://docs.paramiko.org/en/stable/api/keys.html#paramiko.pkey.PKey.from_private_key_file
             value:
               type: string
 

--- a/ssh_check/datadog_checks/ssh_check/data/conf.yaml.example
+++ b/ssh_check/datadog_checks/ssh_check/data/conf.yaml.example
@@ -25,6 +25,8 @@ instances:
 
     ## @param password - string - optional
     ## Password to use for the SSH connection.
+    ## If an encrypted SSH private key is specified in `private_key_file`, 
+    ##   the given password will be used to decrypt the key.
     #
     # password: <PASSWORD>
 
@@ -40,6 +42,8 @@ instances:
 
     ## @param private_key_file - string - optional
     ## File path to a SSH private key.
+    ## If the SSH private key is encrypted, `password` will be used to decrypt the key.
+    ## See: http://docs.paramiko.org/en/stable/api/keys.html#paramiko.pkey.PKey.from_private_key_file
     #
     # private_key_file: <PRIVATE_KEY_FILE>
 

--- a/ssh_check/datadog_checks/ssh_check/ssh_check.py
+++ b/ssh_check/datadog_checks/ssh_check/ssh_check.py
@@ -45,9 +45,9 @@ class CheckSSH(AgentCheck):
         if self.private_key_file is not None:
             try:
                 if self.private_key_type == 'ecdsa':
-                    private_key = paramiko.ECDSAKey.from_private_key_file(self.private_key_file)
+                    private_key = paramiko.ECDSAKey.from_private_key_file(self.private_key_file, password=self.password)
                 else:
-                    private_key = paramiko.RSAKey.from_private_key_file(self.private_key_file)
+                    private_key = paramiko.RSAKey.from_private_key_file(self.private_key_file, password=self.password)
             except IOError:
                 self.warning("Unable to find private key file: %s", self.private_key_file)
             except paramiko.ssh_exception.PasswordRequiredException:


### PR DESCRIPTION
###What does this PR do?
If `private_key_file` exists, `password` is used for decryption instead of plain username/password auth


### Motivation
AI-909

### Additional Notes
- I used the existing `password` parameter since it will not be used in plain authentication if a `private_key_file` was set; it will instead be used for decrypting the private key file. If this is not fine, we could possibly add `private_key_file_password` 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
