### PR TITLE
Clarify that all WMI metrics are custom

### DIFF
--- a/wmi_check/README.md
+++ b/wmi_check/README.md
@@ -114,7 +114,7 @@ The setting `[IDProcess, Win32_Process, Handle, CommandLine]` tags each process 
 
 ### Metrics
 
-All metrics collected by the PHD check are forwarded to Datadog as [custom metrics][6], which may impact your [billing][7].
+All metrics collected by the WMI check are forwarded to Datadog as [custom metrics][6], which may impact your [billing][7].
 
 ### Events
 

--- a/wmi_check/README.md
+++ b/wmi_check/README.md
@@ -106,10 +106,6 @@ Each WMI query has 2 required options, `class` and `metrics` and six optional op
 
 The setting `[IDProcess, Win32_Process, Handle, CommandLine]` tags each process with its command line. Any instance number will be removed from tag_by values i.e. name:process#1 => name:process. NB: The agent must be running under an **Administrator** account for this to work as the `CommandLine` property is not accessible to non-admins.
 
-#### Metrics collection
-
-The WMI check can potentially emit [custom metrics][9], which may impact your [billing][10].
-
 ### Validation
 
 [Run the Agent's `status` subcommand][11] and look for `wmi_check` under the Checks section.
@@ -118,7 +114,7 @@ The WMI check can potentially emit [custom metrics][9], which may impact your [b
 
 ### Metrics
 
-See [metadata.csv][12] for a list of metrics provided by this integration.
+All metrics collected by the PHD check are forwarded to Datadog as [custom metrics][6], which may impact your [billing][7].
 
 ### Events
 

--- a/wmi_check/README.md
+++ b/wmi_check/README.md
@@ -114,7 +114,7 @@ The setting `[IDProcess, Win32_Process, Handle, CommandLine]` tags each process 
 
 ### Metrics
 
-All metrics collected by the WMI check are forwarded to Datadog as [custom metrics][6], which may impact your [billing][7].
+All metrics collected by the WMI check are forwarded to Datadog as [custom metrics][9], which may impact your [billing][10].
 
 ### Events
 


### PR DESCRIPTION
copied the more accurate wording from the PDH check: https://github.com/DataDog/integrations-core/edit/master/pdh_check/README.md

Making this change because of a note from sales team:

> Hi Team, Question from a  customer “https://docs.datadoghq.com/integrations/wmi_check/ It states that the WMI Checks “can potentially emit custom metrics, which may impact your billing.” Is there any way to elaborate on that or determine if its generating custom metrics?”

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
