### PR TITLE
[sandbox] Rename client

### DIFF
--- a/redisdb/tests/compose/1m-2s.compose
+++ b/redisdb/tests/compose/1m-2s.compose
@@ -7,7 +7,10 @@ services:
       - "6382:6382"
     networks:
       - network1
-    command: redis-server --port 6382
+    command: redis-server /etc/redis.conf --port 6382
+    volumes:
+      - ${REDIS_CONFIG}:/etc/redis.conf
+
 
   redis-slave:
     image: "redis:${REDIS_VERSION}"

--- a/redisdb/tests/config/redis.conf
+++ b/redisdb/tests/config/redis.conf
@@ -1,0 +1,1 @@
+rename-command CLIENT ABCD

--- a/redisdb/tests/conftest.py
+++ b/redisdb/tests/conftest.py
@@ -69,6 +69,7 @@ def dd_environment(master_instance):
     """
     with docker_run(
         os.path.join(HERE, 'compose', '1m-2s.compose'),
+        env_vars={'REDIS_CONFIG': os.path.join(HERE, 'config', 'redis.conf')},
         conditions=[
             CheckCluster({'port': MASTER_PORT, 'db': 14, 'host': HOST}, {'port': REPLICA_PORT, 'db': 14, 'host': HOST})
         ],


### PR DESCRIPTION
```
      Error: unknown command `CLIENT`, with args beginning with: `LIST`,
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 834, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/redisdb/redisdb.py", line 494, in check
          self._check_db()
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/redisdb/redisdb.py", line 253, in _check_db
          clients = conn.client_list()
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/redis/client.py", line 1194, in client_list
          return self.execute_command('CLIENT LIST')
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/redis/client.py", line 901, in execute_command
          return self.parse_response(conn, command_name, **options)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/redis/client.py", line 915, in parse_response
          response = connection.read_response()
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/redis/connection.py", line 747, in read_response
          raise response
      redis.exceptions.ResponseError: unknown command `CLIENT`, with args beginning with: `LIST`,

```