### PR TITLE
Add flag to enable CLIENT command metrics

### DIFF
--- a/redisdb/datadog_checks/redisdb/data/conf.yaml.example
+++ b/redisdb/datadog_checks/redisdb/data/conf.yaml.example
@@ -36,11 +36,11 @@ instances:
     #
     # password: <PASSWORD>
 
-    ## @param collect_client_connection - boolean - optional
-    ## Enable to collect the `redis.net.connections` metric.
+    ## @param enable_client_command - boolean - optional
+    ## Enable to collect metrics using the `CLIENT` command
     ## This requires the Redis CLIENT command to be available on your servers.
     #
-    # collect_client_connection: false
+    # enable_client_command: false
 
     ## @param socket_timeout - integer - optional - default: 5
     ## Custom timeout for the check request.

--- a/redisdb/datadog_checks/redisdb/data/conf.yaml.example
+++ b/redisdb/datadog_checks/redisdb/data/conf.yaml.example
@@ -36,11 +36,11 @@ instances:
     #
     # password: <PASSWORD>
 
-    ## @param enable_client_command - boolean - optional
+    ## @param collect_client_metrics - boolean - optional
     ## Enable to collect metrics using the `CLIENT` command
     ## This requires the Redis CLIENT command to be available on your servers.
     #
-    # enable_client_command: false
+    # collect_client_metrics: false
 
     ## @param socket_timeout - integer - optional - default: 5
     ## Custom timeout for the check request.

--- a/redisdb/datadog_checks/redisdb/data/conf.yaml.example
+++ b/redisdb/datadog_checks/redisdb/data/conf.yaml.example
@@ -36,6 +36,12 @@ instances:
     #
     # password: <PASSWORD>
 
+    ## @param collect_client_connection - boolean - optional
+    ## Enable to collect the `redis.net.connections` metric.
+    ## This requires the Redis CLIENT command to be available on your servers.
+    #
+    # collect_client_connection: false
+
     ## @param socket_timeout - integer - optional - default: 5
     ## Custom timeout for the check request.
     #

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -109,7 +109,7 @@ class Redis(AgentCheck):
         self.last_timestamp_seen = 0
         custom_tags = self.instance.get('tags', [])
         self.tags = self._get_tags(custom_tags)
-        self.collect_client_connection = is_affirmative(self.instance.get('collect_client_connection', False))
+        self.enable_client_command = is_affirmative(self.instance.get('enable_client_command', False))
         if ("host" not in self.instance or "port" not in self.instance) and "unix_socket_path" not in self.instance:
             raise ConfigurationError("You must specify a host/port couple or a unix_socket_path")
 
@@ -250,7 +250,7 @@ class Redis(AgentCheck):
             if metric_name is not None:
                 self.gauge(metric_name, value, tags=tags)
 
-        if self.collect_client_connection:
+        if self.enable_client_command:
             # Save client connections statistics
             clients = conn.client_list()
             clients_by_name = Counter(client["name"] or DEFAULT_CLIENT_NAME for client in clients)

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -109,7 +109,7 @@ class Redis(AgentCheck):
         self.last_timestamp_seen = 0
         custom_tags = self.instance.get('tags', [])
         self.tags = self._get_tags(custom_tags)
-        self.enable_client_command = is_affirmative(self.instance.get('enable_client_command', False))
+        self.collect_client_metrics = is_affirmative(self.instance.get('collect_client_metrics', False))
         if ("host" not in self.instance or "port" not in self.instance) and "unix_socket_path" not in self.instance:
             raise ConfigurationError("You must specify a host/port couple or a unix_socket_path")
 
@@ -250,7 +250,7 @@ class Redis(AgentCheck):
             if metric_name is not None:
                 self.gauge(metric_name, value, tags=tags)
 
-        if self.enable_client_command:
+        if self.collect_client_metrics:
             # Save client connections statistics
             clients = conn.client_list()
             clients_by_name = Counter(client["name"] or DEFAULT_CLIENT_NAME for client in clients)

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -109,6 +109,7 @@ class Redis(AgentCheck):
         self.last_timestamp_seen = 0
         custom_tags = self.instance.get('tags', [])
         self.tags = self._get_tags(custom_tags)
+        self.collect_client_connection = is_affirmative(self.instance.get('collect_client_connection', False))
         if ("host" not in self.instance or "port" not in self.instance) and "unix_socket_path" not in self.instance:
             raise ConfigurationError("You must specify a host/port couple or a unix_socket_path")
 
@@ -249,11 +250,12 @@ class Redis(AgentCheck):
             if metric_name is not None:
                 self.gauge(metric_name, value, tags=tags)
 
-        # Save client connections statistics
-        clients = conn.client_list()
-        clients_by_name = Counter(client["name"] or DEFAULT_CLIENT_NAME for client in clients)
-        for name, count in clients_by_name.items():
-            self.gauge("redis.net.connections", count, tags=tags + ['source:' + name])
+        if self.collect_client_connection:
+            # Save client connections statistics
+            clients = conn.client_list()
+            clients_by_name = Counter(client["name"] or DEFAULT_CLIENT_NAME for client in clients)
+            for name, count in clients_by_name.items():
+                self.gauge("redis.net.connections", count, tags=tags + ['source:' + name])
 
         # Save the number of commands.
         self.rate('redis.net.commands', info['total_commands_processed'], tags=tags)

--- a/redisdb/tests/conftest.py
+++ b/redisdb/tests/conftest.py
@@ -84,7 +84,7 @@ def redis_instance():
         'password': PASSWORD,
         'keys': ['test_*'],
         'tags': ["foo:bar"],
-        'collect_client_connections': True,
+        'enable_client_command': True,
     }
 
 

--- a/redisdb/tests/conftest.py
+++ b/redisdb/tests/conftest.py
@@ -78,7 +78,14 @@ def dd_environment(master_instance):
 
 @pytest.fixture
 def redis_instance():
-    return {'host': HOST, 'port': PORT, 'password': PASSWORD, 'keys': ['test_*'], 'tags': ["foo:bar"], 'collect_client_connection': True}
+    return {
+        'host': HOST,
+        'port': PORT,
+        'password': PASSWORD,
+        'keys': ['test_*'],
+        'tags': ["foo:bar"],
+        'collect_client_connections': True,
+    }
 
 
 @pytest.fixture

--- a/redisdb/tests/conftest.py
+++ b/redisdb/tests/conftest.py
@@ -78,7 +78,7 @@ def dd_environment(master_instance):
 
 @pytest.fixture
 def redis_instance():
-    return {'host': HOST, 'port': PORT, 'password': PASSWORD, 'keys': ['test_*'], 'tags': ["foo:bar"]}
+    return {'host': HOST, 'port': PORT, 'password': PASSWORD, 'keys': ['test_*'], 'tags': ["foo:bar"], 'collect_client_connection': True}
 
 
 @pytest.fixture

--- a/redisdb/tests/conftest.py
+++ b/redisdb/tests/conftest.py
@@ -84,7 +84,7 @@ def redis_instance():
         'password': PASSWORD,
         'keys': ['test_*'],
         'tags': ["foo:bar"],
-        'enable_client_command': True,
+        'collect_client_metrics': True,
     }
 
 
@@ -95,7 +95,7 @@ def replica_instance():
 
 @pytest.fixture(scope='session')
 def master_instance():
-    return {'host': HOST, 'port': MASTER_PORT, 'keys': ['test_*'], 'enable_client_command': True}
+    return {'host': HOST, 'port': MASTER_PORT, 'keys': ['test_*'], 'collect_client_metrics': True}
 
 
 @pytest.fixture

--- a/redisdb/tests/conftest.py
+++ b/redisdb/tests/conftest.py
@@ -95,7 +95,7 @@ def replica_instance():
 
 @pytest.fixture(scope='session')
 def master_instance():
-    return {'host': HOST, 'port': MASTER_PORT, 'keys': ['test_*']}
+    return {'host': HOST, 'port': MASTER_PORT, 'keys': ['test_*'], 'enable_client_command': True}
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?
This PR puts the features from https://github.com/DataDog/integrations-core/pull/6495 behind a flag `collect_client_metrics`


### Motivation
Some servers block the `CLIENT` command due to security reasons:
https://redis.io/topics/security
https://cloud.google.com/memorystore/docs/redis/product-constraints#blocked_redis_commands

Resolves https://github.com/DataDog/integrations-core/issues/6875
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
