### PR TITLE
Fix disk check spec file

### DIFF
--- a/disk/assets/configuration/spec.yaml
+++ b/disk/assets/configuration/spec.yaml
@@ -1,6 +1,7 @@
 name: Disk
 files:
   - name: disk.yaml
+    example_name: conf.yaml.default
     options:
       - template: init_config
       - template: instances


### PR DESCRIPTION
A more formal fix to #6880, this adds the proper file name to the spec so that it will pass validation and future syncs.