### PR TITLE
Collect version metadata

### DIFF
--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -9,7 +9,6 @@ init_config:
     - ci_docker_machines_provider_machine_states
     - ci_runner_builds
     - ci_runner_errors
-    - ci_runner_version_info
     - ci_ssh_docker_machines_provider_machine_creation_duration_seconds
     - ci_ssh_docker_machines_provider_machine_states
     - gitlab_runner_autoscaling_machine_creation_duration_seconds

--- a/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
@@ -84,6 +84,8 @@ class GitlabRunnerCheck(OpenMetricsBaseCheck):
                 # Defaults that were set when gitlab_runner was based on PrometheusCheck
                 'send_monotonic_counter': instance.get('send_monotonic_counter', False),
                 'health_service_check': instance.get('health_service_check', False),
+                'metadata_metric_name': 'ci_runner_version_info',
+                'metadata_label_map': {'version': 'version'},
             }
         )
 
@@ -141,3 +143,9 @@ class GitlabRunnerCheck(OpenMetricsBaseCheck):
         else:
             self.service_check(self.MASTER_SERVICE_CHECK_NAME, OpenMetricsBaseCheck.OK, tags=service_check_tags)
         self.log.debug("gitlab check succeeded")
+
+    def transform_metadata(self, metric, scraper_config):
+        # override the method in the base class to continue to send version metric
+        super(GitlabRunnerCheck, self).transform_metadata(metric, scraper_config)
+
+        self.submit_openmetric('ci_runner_version_info', metric, scraper_config)

--- a/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py
@@ -72,6 +72,11 @@ class GitlabRunnerCheck(OpenMetricsBaseCheck):
         if allowed_metrics is None:
             raise CheckException("At least one metric must be whitelisted in `allowed_metrics`.")
 
+        # Users may want to only report the version
+        # OpenMetricsCheck doesn't allow the metadata_metric_name to be one of the metrics
+        if 'ci_runner_version_info' in allowed_metrics:
+            allowed_metrics.remove('ci_runner_version_info')
+
         gitlab_runner_instance = deepcopy(instance)
 
         # gitlab_runner uses 'prometheus_endpoint' and not 'prometheus_url', so we have to rename the key

--- a/gitlab_runner/tests/common.py
+++ b/gitlab_runner/tests/common.py
@@ -29,6 +29,7 @@ CUSTOM_TAGS = ['optional:tag1']
 # be available yet, hence we validate a stable subset
 ALLOWED_METRICS = [
     'ci_runner_errors',
+    'ci_runner_version_info',
     'process_max_fds',
     'process_open_fds',
     'process_resident_memory_bytes',

--- a/gitlab_runner/tests/common.py
+++ b/gitlab_runner/tests/common.py
@@ -20,6 +20,8 @@ GITLAB_RUNNER_URL = "http://{}:{}/metrics".format(HOST, GITLAB_LOCAL_RUNNER_PORT
 
 GITLAB_RUNNER_TAGS = ['gitlab_host:{}'.format(HOST), 'gitlab_port:{}'.format(GITLAB_LOCAL_MASTER_PORT)]
 
+GITLAB_RUNNER_VERSION = os.environ['GITLAB_RUNNER_VERSION']
+
 CUSTOM_TAGS = ['optional:tag1']
 
 # Note that this is a subset of the ones defined in GitlabCheck
@@ -27,7 +29,6 @@ CUSTOM_TAGS = ['optional:tag1']
 # be available yet, hence we validate a stable subset
 ALLOWED_METRICS = [
     'ci_runner_errors',
-    'ci_runner_version_info',
     'process_max_fds',
     'process_open_fds',
     'process_resident_memory_bytes',

--- a/gitlab_runner/tests/compose/docker-compose.yml
+++ b/gitlab_runner/tests/compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   gitlab_runner:
-    image: gitlab/gitlab-runner:v10.8.0
+    image: gitlab/gitlab-runner:v${GITLAB_RUNNER_VERSION}
     depends_on:
       - gitlab
     volumes:

--- a/gitlab_runner/tox.ini
+++ b/gitlab_runner/tox.ini
@@ -23,3 +23,5 @@ deps =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
+setenv =
+    GITLAB_RUNNER_VERSION=10.8.0


### PR DESCRIPTION
### What does this PR do?
Collect version metadata for `gitlab_runner`

### Motivation

### Additional Notes
The metric `ci_runner_version_info` must be removed from the metric list.
It will be sent by `transform_metadata`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
