### PR TITLE
Add post-release patch docs

### DIFF
--- a/docs/developer/ddev/configuration.md
+++ b/docs/developer/ddev/configuration.md
@@ -89,7 +89,7 @@ If not:
 
 ## Trello
 
-To participate as an [Agent release manager](../process/agent-release.md), you need to set `trello.key`/`trello.token` in your config file.
+To participate as an [Agent release manager](../process/agent-release/agent-release.md), you need to set `trello.key`/`trello.token` in your config file.
 
 Run `ddev config show` to see if your Trello key and token is set.
 
@@ -104,6 +104,6 @@ If not:
 
 ### Card Assignment
 
-To automatically assign [QA cards](../process/agent-release.md#create-items), add a `trello_users_$team` table, with keys being
+To automatically assign [QA cards](../process/agent-release/agent-release.md#create-items), add a `trello_users_$team` table, with keys being
 GitHub usernames and values being their corresponding Trello IDs (not names). You can find current team member
 information in [this document](https://github.com/DataDog/devops/wiki/GitHub-usernames-and-Trello-IDs).

--- a/docs/developer/process/agent-release/agent-release.md
+++ b/docs/developer/process/agent-release/agent-release.md
@@ -15,9 +15,9 @@ ships a snapshot of [integrations-core][].
 
 Ensure that you have configured the following:
 
-- [GitHub](../ddev/configuration.md#github) credentials
-- [Trello](../ddev/configuration.md#trello) credentials
-- [Trello team mappings](../ddev/configuration.md#card-assignment)
+- [GitHub](../../ddev/configuration.md#github) credentials
+- [Trello](../../ddev/configuration.md#trello) credentials
+- [Trello team mappings](../../ddev/configuration.md#card-assignment)
 
 ## Freeze
 
@@ -26,11 +26,11 @@ all integrations with pending changes then branch off.
 
 ### Release
 
-1. Make a pull request to release [any new integrations](integration-release.md#new-integrations), then merge it and pull `master`
-1. Make a pull request to release [all changed integrations](integration-release.md#bulk-releases), then merge it and pull `master`
+1. Make a pull request to release [any new integrations](../integration-release.md#new-integrations), then merge it and pull `master`
+1. Make a pull request to release [all changed integrations](../integration-release.md#bulk-releases), then merge it and pull `master`
 
 !!! important
-    [Update PyPI](integration-release.md#pypi) if you released `datadog_checks_base` or `datadog_checks_dev`.
+    [Update PyPI](../integration-release.md#pypi) if you released `datadog_checks_base` or `datadog_checks_dev`.
 
 
 ### Branch
@@ -54,7 +54,7 @@ We test all changes to integrations that were introduced since the last release.
 ### Create items
 
 Create an item for every change in [our board](https://trello.com/b/ICjijxr4/agent-release-sprint) using
-the Trello subcommand called [testable](../ddev/cli.md#testable).
+the Trello subcommand called [testable](../../ddev/cli.md#testable).
 
 For example:
 
@@ -66,7 +66,7 @@ would select all commits that were merged between the Git references.
 
 The command will display each change and prompt you to assign a team or skip. Purely documentation changes are automatically skipped.
 
-Cards are automatically assigned if `$trello_users_$team` table is [configured](../ddev/configuration.md#card-assignment).
+Cards are automatically assigned if `$trello_users_$team` table is [configured](../../ddev/configuration.md#card-assignment).
 
 ### Release candidates
 
@@ -75,7 +75,7 @@ The main Agent release manager will increment and build a new `rc` every day a b
 Before each build is triggered:
 
 1. Merge any fixes that have been approved, then pull `master`
-1. Release [all changed integrations](integration-release.md#bulk-releases) with the exception of `datadog_checks_dev`
+1. Release [all changed integrations](../integration-release.md#bulk-releases) with the exception of `datadog_checks_dev`
 
 For each fix merged, you must cherry-pick to the [branch](#branch):
 
@@ -89,7 +89,7 @@ After all fixes have been cherry-picked:
 
 ### Communication
 
-The Agent Release Manager will post a [daily status](../ddev/cli.md#status) for the entire release cycle.
+The Agent Release Manager will post a [daily status](../../ddev/cli.md#status) for the entire release cycle.
 
 ```
 #agent-integrations status:
@@ -109,23 +109,3 @@ Each release candidate is deployed in a staging environment. We observe the `WAR
 
 After QA week ends the code freeze is lifted, even if there are items yet to be tested. The release manager will continue
 the same process outlined above.
-
-## Finalize
-
-On the day of the final stable release, [tag](#tag) the [branch](#branch) with `<MAJOR>.<MINOR>.0`.
-
-After the main Agent release manager confirms successful deployment to a few targets, create a branch based on `master` and run:
-
-```
-ddev agent changelog
-ddev agent integrations
-```
-
-See more options for [`ddev agent changelog`](../ddev/cli.md#changelog) and [`ddev agent integrations`](../ddev/cli.md#integrations).
-
-Run the following commands to update the contents: 
-
-1. `ddev agent changelog -w -f` to update the existing [`AGENT_CHANGELOG`][agent-changelog] file
-2. `ddev agent integrations -w -f` to update the existing [`AGENT_INTEGRATIONS`][agent-integrations] file. 
-
-Create a pull request and wait for approval before merging.

--- a/docs/developer/process/agent-release/post-release.md
+++ b/docs/developer/process/agent-release/post-release.md
@@ -33,6 +33,7 @@ Releases after the final Agent release should be reserved for critical issues on
 
 However, it's possible that from the time [code freeze ended](agent-release.md#release-week) and a bugfix is needed,
 the integration has other non-critical commits or was released.
+
 The next section will describe the process for preparing the patch release candidates.
 
 ### Multiple check releases between bugfix release

--- a/docs/developer/process/agent-release/post-release.md
+++ b/docs/developer/process/agent-release/post-release.md
@@ -58,3 +58,6 @@ Follow the following steps to add patch release:
 
 4. [Tag](agent-release.md#tag) the branch with the new bumped version `<MAJOR>.<MINOR>.<PATCH>-rc.1`.
 
+5. When the patch release is ready, follow the same steps to [finalize the release](post-release.md#finalize).
+Also manually update the changelog of the integrations that were released on the release branch, see [example](https://github.com/DataDog/integrations-core/pull/6617).
+

--- a/docs/developer/process/agent-release/post-release.md
+++ b/docs/developer/process/agent-release/post-release.md
@@ -32,11 +32,29 @@ Create a pull request and wait for approval before merging.
 Releases after the final Agent release should be reserved for critical issues only. Cherry-picking commits and releases for
  the patch release is mostly similar to the process for [preparing release candidates](agent-release.md#release-candidates).
 
-However, it's possible that from the time [code freeze ended](agent-release.md#release-week),
+However, it's possible that from the time [code freeze ended](agent-release.md#release-week) and a bugfix is needed,
 the integration has other non-critical commits or was released.
 The next section will describe the process for preparing the patch release candidates.
 
 ### Multiple check releases between bugfix release
 
+Given the effort of QA-ing the Agent release, any new changes should be _carefully_ selected and included for the patch.
 
+Follow the following steps to add patch release:
+
+1. Cherry-pick the bugfix commit to the [release branch](agent-release.md#branch).
+2. Release the integration on the release branch.
+    - Make a pull request with [integration release](../integration-release.md#new-integrations), then merge it to the release branch.
+
+    !!! important
+        Remember to trigger the release pipeline and build the wheel. You can do so by [tagging the release](../../ddev/cli.md#tag):
+
+            `ddev release tag <INTEGRATION>`
+
+        Note: only release PRs merged to master automatically build a wheel.
+
+
+3. Then pull the latest release branch so your branch has both the bugfix commit and release commit.
+
+4. [Tag](agent-release.md#tag) the branch with the new bumped version `<MAJOR>.<MINOR>.<PATCH>-rc.1`.
 

--- a/docs/developer/process/agent-release/post-release.md
+++ b/docs/developer/process/agent-release/post-release.md
@@ -1,0 +1,42 @@
+# Post release
+
+-----
+
+## Finalize
+
+On the day of the final stable release, [tag](#tag) the [branch](#branch) with `<MAJOR>.<MINOR>.0`.
+
+After the main Agent release manager confirms successful deployment to a few targets, create a branch based on `master` and run:
+
+```
+ddev agent changelog
+ddev agent integrations
+```
+
+See more options for [`ddev agent changelog`](../../ddev/cli.md#changelog) and [`ddev agent integrations`](../../ddev/cli.md#integrations).
+
+Run the following commands to update the contents:
+
+1. `ddev agent changelog -w -f` to update the existing [`AGENT_CHANGELOG`][agent-changelog] file
+2. `ddev agent integrations -w -f` to update the existing [`AGENT_INTEGRATIONS`][agent-integrations] file.
+
+Create a pull request and wait for approval before merging.
+
+
+## Patches
+
+!!! important
+    Only critical fixes are included in patches. See definition for
+    [critical fixes](https://github.com/DataDog/datadog-floss-guidance/blob/master/docs/severity.md#critical).
+
+Releases after the final Agent release should be reserved for critical issues only. Cherry-picking commits and releases for
+ the patch release is mostly similar to the process for [preparing release candidates](agent-release.md#release-candidates).
+
+However, it's possible that from the time [code freeze ended](agent-release.md#release-week),
+the integration has other non-critical commits or was released.
+The next section will describe the process for preparing the patch release candidates.
+
+### Multiple check releases between bugfix release
+
+
+

--- a/docs/developer/process/agent-release/post-release.md
+++ b/docs/developer/process/agent-release/post-release.md
@@ -22,7 +22,6 @@ Run the following commands to update the contents:
 
 Create a pull request and wait for approval before merging.
 
-
 ## Patches
 
 !!! important
@@ -60,4 +59,3 @@ Follow the following steps to add patch release:
 
 5. When the patch release is ready, follow the same steps to [finalize the release](post-release.md#finalize).
 Also manually update the changelog of the integrations that were released on the release branch, see [example](https://github.com/DataDog/integrations-core/pull/6617).
-

--- a/docs/developer/process/agent-release/post-release.md
+++ b/docs/developer/process/agent-release/post-release.md
@@ -4,7 +4,7 @@
 
 ## Finalize
 
-On the day of the final stable release, [tag](#tag) the [branch](#branch) with `<MAJOR>.<MINOR>.0`.
+On the day of the final stable release, [tag](agent-release.md#tag) the [branch](agent-release.md#branch) with `<MAJOR>.<MINOR>.0`.
 
 After the main Agent release manager confirms successful deployment to a few targets, create a branch based on `master` and run:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,7 +72,9 @@ nav:
     - vSphere: architecture/vsphere.md
   - Process:
     - Integration release: process/integration-release.md
-    - Agent release: process/agent-release.md
+    - Agent release:
+      - process/agent-release/agent-release.md
+      - process/agent-release/post-release.md
   - FAQ:
     - FAQ: faq/faq.md
     - Acknowledgements: faq/acknowledgements.md
@@ -161,6 +163,7 @@ extra:
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/datadoghq
     - icon: fontawesome/brands/instagram
+      link: https://www.instagram.com/datadoghq
       link: https://www.instagram.com/datadoghq
 extra_css:
   - assets/css/custom.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,7 +164,6 @@ extra:
       link: https://twitter.com/datadoghq
     - icon: fontawesome/brands/instagram
       link: https://www.instagram.com/datadoghq
-      link: https://www.instagram.com/datadoghq
 extra_css:
   - assets/css/custom.css
   - https://cdn.jsdelivr.net/gh/tonsky/FiraCode@4/distr/fira_code.css


### PR DESCRIPTION
### What does this PR do?

Refactor the agent release docs.

Document process for creating patch RCs when time has elapsed between release and bugfix.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
