### PR TITLE
Avoid logging warnings if AutoFS is enabled

### DIFF
--- a/nfsstat/assets/configuration/spec.yaml
+++ b/nfsstat/assets/configuration/spec.yaml
@@ -15,7 +15,7 @@ files:
         default: null
     - name: autofs_enabled
       description: |
-        If your environment uses AutoFS, enable this option to continue collecting metrics with no mount points.
+        If your environment uses AutoFS, enable this option to only log DEBUG-level messages when there are no mounts.
         See more information on AutoFS here: https://help.ubuntu.com/community/Autofs
       value:
         type: boolean

--- a/nfsstat/assets/configuration/spec.yaml
+++ b/nfsstat/assets/configuration/spec.yaml
@@ -13,6 +13,13 @@ files:
         type: string
         example: /usr/local/sbin/nfsiostat
         default: null
+    - name: autofs_enabled
+      description: |
+        If your environment uses AutoFS, enable this option to continue collecting metrics with no mount points.
+        See more information on AutoFS here: https://help.ubuntu.com/community/Autofs
+      value:
+        type: boolean
+        example: false
     - template: init_config/default
   - template: instances
     options:

--- a/nfsstat/datadog_checks/nfsstat/data/conf.yaml.example
+++ b/nfsstat/datadog_checks/nfsstat/data/conf.yaml.example
@@ -10,7 +10,7 @@ init_config:
     # nfsiostat_path: /usr/local/sbin/nfsiostat
 
     ## @param autofs_enabled - boolean - optional - default: false
-    ## If your environment uses AutoFS, enable this option to only log debug messages when there are no mounts.
+    ## If your environment uses AutoFS, enable this option to only log DEBUG-level messages when there are no mounts.
     ## See more information on AutoFS here: https://help.ubuntu.com/community/Autofs
     #
     # autofs_enabled: false

--- a/nfsstat/datadog_checks/nfsstat/data/conf.yaml.example
+++ b/nfsstat/datadog_checks/nfsstat/data/conf.yaml.example
@@ -10,7 +10,7 @@ init_config:
     # nfsiostat_path: /usr/local/sbin/nfsiostat
 
     ## @param autofs_enabled - boolean - optional - default: false
-    ## If your environment uses AutoFS, enable this option to continue collecting metrics with no mount points.
+    ## If your environment uses AutoFS, enable this option to only log debug messages when there are no mounts.
     ## See more information on AutoFS here: https://help.ubuntu.com/community/Autofs
     #
     # autofs_enabled: false

--- a/nfsstat/datadog_checks/nfsstat/data/conf.yaml.example
+++ b/nfsstat/datadog_checks/nfsstat/data/conf.yaml.example
@@ -9,6 +9,12 @@ init_config:
     #
     # nfsiostat_path: /usr/local/sbin/nfsiostat
 
+    ## @param autofs_enabled - boolean - optional - default: false
+    ## If your environment uses AutoFS, enable this option to continue collecting metrics with no mount points.
+    ## See more information on AutoFS here: https://help.ubuntu.com/community/Autofs
+    #
+    # autofs_enabled: false
+
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
     ##

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -42,9 +42,9 @@ class NfsStatCheck(AgentCheck):
         if 'No NFS mount point' in stats[0]:
             if not self.autofs_enabled:
                 self.warning("No NFS mount points were found.")
-                return
             else:
-                self.log.debug("AutoFS enabled.")
+                self.log.debug("AutoFS enabled: no mount points currently.")
+            return
 
         for l in stats:
             if not l:

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import os
 
-from datadog_checks.base import AgentCheck, ensure_unicode
+from datadog_checks.base import AgentCheck, ensure_unicode, is_affirmative
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'nfsstat'
@@ -30,6 +30,7 @@ class NfsStatCheck(AgentCheck):
                     'nfsstat check requires nfsiostat be installed, please install it '
                     '(through nfs-utils) or set the path to the installed version'
                 )
+        self.autofs_enabled = is_affirmative(init_config.get('autofs_enabled', False))
 
     def check(self, instance):
         stat_out, err, _ = get_subprocess_output(self.nfs_cmd, self.log)
@@ -39,8 +40,11 @@ class NfsStatCheck(AgentCheck):
         stats = stat_out.splitlines()
 
         if 'No NFS mount point' in stats[0]:
-            self.warning("No NFS mount points were found")
-            return
+            if not self.autofs_enabled:
+                self.warning("No NFS mount points were found.")
+                return
+            else:
+                self.log.debug("AutoFS enabled.")
 
         for l in stats:
             if not l:

--- a/nfsstat/tests/test_nfsstat.py
+++ b/nfsstat/tests/test_nfsstat.py
@@ -63,8 +63,7 @@ class TestNfsstat:
 
         assert aggregator.metrics_asserted_pct == 100.0
 
-    def test_autofs_enabled(self, aggregator, caplog):
-        caplog.set_level(logging.DEBUG)
+    def test_autofs_enabled(self, aggregator):
         instance = self.INSTANCES['main']
         init_config = deepcopy(self.INIT_CONFIG)
         init_config['autofs_enabled'] = True
@@ -76,9 +75,4 @@ class TestNfsstat:
             return_value=('No NFS mount points were found', '', 0),
         ):
             c.check(instance)
-            assert 'AutoFS enabled.' in caplog.text
-
-        for metric in METRICS:
-            aggregator.assert_metric(metric)
-
-        assert aggregator.metrics_asserted_pct == 100.0
+        c.log.debug.assert_called_once_with("AutoFS enabled: no mount points currently.")


### PR DESCRIPTION
### What does this PR do?
For environments that use autoFS, the log warning when no mount points are found is noisy.

This PR allows users to enable a flag and sends a debug-level message for nfsstat check runs in environments with automounting configured.

AutoFS unmounts old mounts: https://docs.oracle.com/cd/E26502_01/html/E29006/fsmount-5.html#fsoverview-26

### Motivation
Resolves https://github.com/DataDog/integrations-core/issues/6743
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
