### PR TITLE
Gracefully skip quantile-less summary metrics

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -804,7 +804,19 @@ class OpenMetricsScraperMixin(object):
                     hostname=custom_hostname,
                 )
             else:
-                sample[self.SAMPLE_LABELS]["quantile"] = str(float(sample[self.SAMPLE_LABELS]["quantile"]))
+                try:
+                    quantile = sample[self.SAMPLE_LABELS]["quantile"]
+                except KeyError:
+                    # In the Prometheus spec the 'quantile' label is optional, but it's not clear yet
+                    # what we should do in this case. Let's skip for now and submit the rest of metrics.
+                    message = (
+                        '"quantile" label not present in metric %r.'
+                        'Quantile-less summary metrics are not currently supported. Skipping...'
+                    )
+                    self.log.warning(message, metric_name)
+                    continue
+
+                sample[self.SAMPLE_LABELS]["quantile"] = str(float(quantile))
                 tags = self._metric_tags(metric_name, val, sample, scraper_config, hostname=custom_hostname)
                 self.gauge(
                     "{}.{}.quantile".format(scraper_config['namespace'], metric_name),

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -807,13 +807,13 @@ class OpenMetricsScraperMixin(object):
                 try:
                     quantile = sample[self.SAMPLE_LABELS]["quantile"]
                 except KeyError:
-                    # In the Prometheus spec the 'quantile' label is optional, but it's not clear yet
+                    # TODO: In the Prometheus spec the 'quantile' label is optional, but it's not clear yet
                     # what we should do in this case. Let's skip for now and submit the rest of metrics.
                     message = (
-                        '"quantile" label not present in metric %r.'
+                        '"quantile" label not present in metric %r. '
                         'Quantile-less summary metrics are not currently supported. Skipping...'
                     )
-                    self.log.warning(message, metric_name)
+                    self.log.debug(message, metric_name)
                     continue
 
                 sample[self.SAMPLE_LABELS]["quantile"] = str(float(quantile))

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -498,6 +498,7 @@ def test_submit_summary(
     _sum.add_sample("my_summary", {"quantile": "0.5"}, 24547.0)
     _sum.add_sample("my_summary", {"quantile": "0.9"}, 25763.0)
     _sum.add_sample("my_summary", {"quantile": "0.99"}, 25763.0)
+    _sum.add_sample("my_summary", {}, 25764.0)  # Quantile-less not supported yet and should be skipped.
     check = mocked_prometheus_check
     check.submit_openmetric('custom.summary', _sum, mocked_prometheus_scraper_config)
 
@@ -507,6 +508,7 @@ def test_submit_summary(
     aggregator.assert_metric('prometheus.custom.summary.quantile', 24547.0, tags=['quantile:0.5'], count=1)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.9'], count=1)
     aggregator.assert_metric('prometheus.custom.summary.quantile', 25763.0, tags=['quantile:0.99'], count=1)
+    aggregator.assert_metric('prometheus.custom.summary.quantile', 25764.0, tags=[], count=0)
 
     # If `send_monotonic_with_gauge` is true, assert a monotonic_count with suffixed `.total` is submitted
     if count_monotonic_gauge:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Handle summary metrics that don't have a  `quantile` by skipping them to prevent crashing.

### Motivation
<!-- What inspired you to submit this pull request? -->
In a customer's setup, a system is submitting summary metrics without a quantile, eg:

```console
# HELP resilience4j_circuitbreaker_calls Total number of successful calls
# TYPE resilience4j_circuitbreaker_calls summary
resilience4j_circuitbreaker_calls_count{kind="ignored",name="mood",} 0.0
resilience4j_circuitbreaker_calls_sum{kind="ignored",name="mood",} 0.0
resilience4j_circuitbreaker_calls_count{kind="failed",name="mood",} 0.0
resilience4j_circuitbreaker_calls_sum{kind="failed",name="mood",} 0.0
# vvv
resilience4j_circuitbreaker_calls{kind="not_permitted",name="sapi",} 0.0
resilience4j_circuitbreaker_calls{kind="not_permitted",name="mood",} 0.0
# ^^^
```

Currently this makes the check crash with a `KeyError`, meaning that the rest of metrics is not submitted which is a major pain point.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
We can look at how what to do with quantile-less metrics later.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
