### PR TITLE
Ensure bytes for ssl connection

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/connection.py
+++ b/ibm_mq/datadog_checks/ibm_mq/connection.py
@@ -51,10 +51,10 @@ def get_ssl_connection(config):
     Get the connection with SSL
     """
     cd = _get_channel_definition(config)
-    cd.SSLCipherSpec = config.ssl_cipher_spec
+    cd.SSLCipherSpec = pymqi.ensure_bytes(config.ssl_cipher_spec)
 
     sco = pymqi.SCO()
-    sco.KeyRepository = config.ssl_key_repository_location
+    sco.KeyRepository = pymqi.ensure_bytes(config.ssl_key_repository_location)
 
     queue_manager = pymqi.QueueManager(None)
     queue_manager.connect_with_options(config.queue_manager_name, cd, sco)

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -172,3 +172,22 @@ def test_channel_queue_config_error(instance_config):
         IBMMQConfig(instance_config)
 
     assert 'channel, queue_manager are required configurations' in str(excinfo.value)
+
+
+def test_ssl_connection(instance):
+    # TODO: We should test SSL in e2e
+    instance['ssl_auth'] = 'yes'
+    instance['ssl_cipher_spec'] = 'TLS_RSA_WITH_AES_256_CBC_SHA256'
+    instance['ssl_key_repository_location'] = '/dummy'
+
+    check = IbmMqCheck('ibm_mq', {}, [instance])
+
+    check.check(instance)
+
+    assert len(check.warnings) == 1
+    warning = check.warnings[0]
+
+    # Check that we are not getting a unicode/bytes type error but a MQRC_KEY_REPOSITORY_ERROR (dummy location)
+    assert 'bytes' not in warning
+    assert 'unicode' not in warning
+    assert 'MQRC_KEY_REPOSITORY_ERROR' in warning

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -174,8 +174,12 @@ def test_channel_queue_config_error(instance_config):
     assert 'channel, queue_manager are required configurations' in str(excinfo.value)
 
 
-def test_ssl_connection(instance):
-    # TODO: We should test SSL in e2e
+def test_ssl_connection_creation(instance):
+    """
+    Test that we are not getting unicode/bytes type error.
+
+    TODO: We should test SSL in e2e
+    """
     instance['ssl_auth'] = 'yes'
     instance['ssl_cipher_spec'] = 'TLS_RSA_WITH_AES_256_CBC_SHA256'
     instance['ssl_key_repository_location'] = '/dummy'


### PR DESCRIPTION
### What does this PR do?

Ensure bytes for ssl connection

### Motivation

The integration is broken for Python 3 when TLS is used:

> 2020-06-19 09:17:13 UTC | CORE | WARN | (pkg/collector/python/datadog_agent.go:119 in LogMessage) | ibm_mq:9d243cc47a1f6817 | (ibm_mq.py:44) | cannot connect to queue manager: Python 3 style string (unicode) found but not allowed here: `TLS_RSA_WITH_AES_256_CBC_SHA256`. Convert to bytes.

### Additional Notes

This is a quick fix with simple unit test. I plan to add a e2e test for ssl, but will take more time.

