### PR TITLE
Fix `add_missing_keys` not saving keys to host keys file

### DIFF
--- a/ssh_check/tests/common.py
+++ b/ssh_check/tests/common.py
@@ -18,27 +18,15 @@ INSTANCES = {
         'username': 'level1',
         'password': 'level1',
         'sftp_check': False,
-        'private_key_file': '',
-        'add_missing_keys': True,
         'tags': ['optional:tag1'],
     },
-    'bad_auth': {
-        'host': 'localhost',
-        'port': 22,
-        'username': 'test',
-        'password': 'yodawg',
-        'sftp_check': False,
-        'private_key_file': '',
-        'add_missing_keys': True,
-    },
+    'bad_auth': {'host': 'localhost', 'port': 22, 'username': 'test', 'password': 'yodawg', 'sftp_check': False},
     'bad_hostname': {
         'host': 'wronghost',
         'port': 22,
         'username': 'datadog01',
         'password': 'abcd',
         'sftp_check': False,
-        'private_key_file': '',
-        'add_missing_keys': True,
     },
 }
 
@@ -49,6 +37,8 @@ INSTANCE_INTEGRATION = {
     "username": "root",
     "add_missing_keys": True,
 }
+
+INTEGRATION_ADDED_KEY_HOST = "[127.0.0.1]:8022"
 
 
 def wait_for_threads():

--- a/ssh_check/tests/test_ssh.py
+++ b/ssh_check/tests/test_ssh.py
@@ -4,9 +4,8 @@
 import threading
 from collections import namedtuple
 
-import pytest
 import mock
-from mock import MagicMock
+import pytest
 
 from datadog_checks.ssh_check import CheckSSH
 
@@ -115,8 +114,8 @@ def test_add_missing_keys(tmp_path):
     ],
 )
 def test_collect_metadata(version, metadata, datadog_agent):
-    client = MagicMock()
-    client.get_transport = MagicMock(return_value=namedtuple('Transport', ['remote_version'])(version))
+    client = mock.MagicMock()
+    client.get_transport = mock.MagicMock(return_value=namedtuple('Transport', ['remote_version'])(version))
 
     ssh = CheckSSH('ssh_check', {}, {}, list(common.INSTANCES.values()))
     ssh.check_id = 'test:123'
@@ -125,8 +124,8 @@ def test_collect_metadata(version, metadata, datadog_agent):
 
 
 def test_collect_bad_metadata(datadog_agent):
-    client = MagicMock()
-    client.get_transport = MagicMock(return_value=namedtuple('Transport', ['remote_version'])('Cannot parse this'))
+    client = mock.MagicMock()
+    client.get_transport = mock.MagicMock(return_value=namedtuple('Transport', ['remote_version'])('Cannot parse this'))
 
     ssh = CheckSSH('ssh_check', {}, {}, list(common.INSTANCES.values()))
     ssh.check_id = 'test:123'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix `add_missing_keys` option: despite the docs saying so, the keys were not actually written back to the host keys file.

A bunch of tests were misconfigured and started failing due to this feature now working as expected, so there are a few changes to tests as well. Wondering if this breakage could also happen among customers, but this is a legit fix…

### Motivation
<!-- What inspired you to submit this pull request? -->
Customer was trying to setup SFTP monitoring but the check kept complaining about `known_hosts` not complaining the destination host despite `add_missing_keys` being enabled.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Possible follow-up action items, noticed while navigating through the code:

- Use Agent 6+ signature & refactor tests to use a single instance at a time
- Add more unit tests for config options.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
