### PR TITLE
Add status check for Harbor's read-only status

### DIFF
--- a/harbor/datadog_checks/harbor/api.py
+++ b/harbor/datadog_checks/harbor/api.py
@@ -61,6 +61,10 @@ class HarborAPI(object):
         self.harbor_version = [int(s) for s in version_str]
         self.with_chartrepo = systeminfo.get('with_chartmuseum', False)
 
+    def read_only_status(self):
+        systeminfo = self._make_get_request(SYSTEM_INFO_URL)
+        return systeminfo.get('read_only', None)
+
     def _make_paginated_get_request(self, url):
         http_params = {'page_size': 100}
         resp = self.http.get(self._resolve_url(url), params=http_params)

--- a/harbor/datadog_checks/harbor/harbor.py
+++ b/harbor/datadog_checks/harbor/harbor.py
@@ -97,6 +97,11 @@ class HarborCheck(AgentCheck):
         self.gauge('harbor.disk.free', disk_free, tags=base_tags)
         self.gauge('harbor.disk.total', disk_total, tags=base_tags)
 
+    def _submit_read_only_status(self, api, base_tags):
+        read_only_status = api.read_only_status()
+        if read_only_status is not None:
+            self.gauge('harbor.registry.read_only', int(read_only_status), tags=base_tags)
+
     def check(self, instance):
         harbor_url = instance["url"]
         tags = instance.get("tags", [])
@@ -106,6 +111,7 @@ class HarborCheck(AgentCheck):
             self._check_registries_health(api, tags)
             self._submit_project_metrics(api, tags)
             self._submit_disk_metrics(api, tags)
+            self._submit_read_only_status(api, tags)
         except Exception:
             self.log.exception("An error occured when collecting Harbor metrics")
             self.service_check(CAN_CONNECT, AgentCheck.CRITICAL)

--- a/harbor/metadata.csv
+++ b/harbor/metadata.csv
@@ -2,3 +2,4 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 harbor.projects.count,gauge,,,,The total number of projects.,0,harbor,nb projects
 harbor.disk.free,gauge,,byte,,The amount of storage space that is free.,0,harbor,disk free
 harbor.disk.total,gauge,,byte,,The total amount of storage space.,0,harbor,disk total
+harbor.registry.read_only,gauge,,,,The 'read_only' status of a registry.,0,harbor,registry read_only

--- a/harbor/tests/common.py
+++ b/harbor/tests/common.py
@@ -17,6 +17,7 @@ HARBOR_METRICS = [
     ('harbor.projects.count', False),
     ('harbor.disk.free', True),
     ('harbor.disk.total', True),
+    ('harbor.registry.read_only', False),
 ]
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -95,5 +96,7 @@ REGISTRIES_FIXTURE = [
 VOLUME_INFO_FIXTURE = {"storage": {"total": 1e6, "free": 5e5}}
 
 SYSTEM_INFO_FIXTURE = {"harbor_version": "v{}-25bb24ca".format(os.environ['HARBOR_VERSION'])}
+if HARBOR_VERSION >= VERSION_1_5:
+    SYSTEM_INFO_FIXTURE['read_only'] = False
 if HARBOR_VERSION >= VERSION_1_6:
     SYSTEM_INFO_FIXTURE['with_chartmuseum'] = True

--- a/harbor/tests/common.py
+++ b/harbor/tests/common.py
@@ -12,16 +12,18 @@ VERSION_1_8 = [1, 8, 0]
 
 HARBOR_COMPONENTS = ['chartmuseum', 'registry', 'redis', 'jobservice', 'registryctl', 'portal', 'core', 'database']
 
+HARBOR_VERSION = [int(i) for i in os.environ['HARBOR_VERSION'].split('.')]
+
 HARBOR_METRICS = [
     # Metric_name, requires admin privileges
     ('harbor.projects.count', False),
     ('harbor.disk.free', True),
     ('harbor.disk.total', True),
-    ('harbor.registry.read_only', False),
 ]
+if HARBOR_VERSION >= VERSION_1_5:
+    HARBOR_METRICS.append(('harbor.registry.read_only', False))
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-HARBOR_VERSION = [int(i) for i in os.environ['HARBOR_VERSION'].split('.')]
 URL = 'http://{}'.format(get_docker_hostname())
 INSTANCE = {'url': URL, 'username': 'NotAnAdmin', 'password': 'Str0ngPassw0rd'}
 ADMIN_INSTANCE = {'url': URL, 'username': 'admin', 'password': 'Harbor12345'}

--- a/harbor/tests/test_unit.py
+++ b/harbor/tests/test_unit.py
@@ -52,6 +52,16 @@ def test_submit_disk_metrics(aggregator, harbor_check, harbor_api):
     aggregator.assert_metric('harbor.disk.total', 1e6, tags=tags)
 
 
+@pytest.mark.usefixture("patch_requests")
+def test_submit_read_only_status(aggregator, harbor_check, harbor_api):
+    if harbor_api.harbor_version >= VERSION_1_5:
+        tags = ['tag1:val1', 'tag2']
+        harbor_check._submit_read_only_status(harbor_api, tags)
+        aggregator.assert_metric('harbor.registry.read_only', False, tags=tags)
+    else:
+        None
+
+
 def test_api__make_get_request(harbor_api):
     harbor_api.http = MagicMock()
     harbor_api.http.get = MagicMock(return_value=MockResponse({"json": True}, 200))

--- a/harbor/tests/test_unit.py
+++ b/harbor/tests/test_unit.py
@@ -7,7 +7,7 @@ from requests import HTTPError
 
 from datadog_checks.base import AgentCheck
 
-from .common import HARBOR_COMPONENTS, VERSION_1_5, VERSION_1_6, VERSION_1_8
+from .common import HARBOR_COMPONENTS, HARBOR_VERSION, VERSION_1_5, VERSION_1_6, VERSION_1_8
 from .conftest import MockResponse
 
 
@@ -53,13 +53,11 @@ def test_submit_disk_metrics(aggregator, harbor_check, harbor_api):
 
 
 @pytest.mark.usefixture("patch_requests")
+@pytest.mark.skipif(HARBOR_VERSION < VERSION_1_5, reason="The registry.read_only metric is submitted for Harbor 1.5+")
 def test_submit_read_only_status(aggregator, harbor_check, harbor_api):
-    if harbor_api.harbor_version >= VERSION_1_5:
-        tags = ['tag1:val1', 'tag2']
-        harbor_check._submit_read_only_status(harbor_api, tags)
-        aggregator.assert_metric('harbor.registry.read_only', False, tags=tags)
-    else:
-        None
+    tags = ['tag1:val1', 'tag2']
+    harbor_check._submit_read_only_status(harbor_api, tags)
+    aggregator.assert_metric('harbor.registry.read_only', False, tags=tags)
 
 
 def test_api__make_get_request(harbor_api):


### PR DESCRIPTION
### What does this PR do?
This adds a status check to monitor whether or not Harbor is in a system-wide read-only mode.

### Motivation
I added this check because we've had a few occurrences where Harbor has gone into a read-only mode and we haven't been able to figure out why. This is especially a problem if you're replicating to 1 or many instances, and replication stops because a registry has gone into read-only mode.

### Additional Notes
The Harbor API returns a boolean for the `read_only` status. I originally wanted to submit this data as a gauge (True = 1, False =0), however I wasn't able to get the tests to pass on Harbor version 1.4 (the read_only status isn't available in that version of Harbor).

Here are the reasons why I wanted to collect this as a gauge:
- Some folks may not care if their registry is in read-only mode, so it may not seem "critical" to them
- We have more flexibility from an alerting standpoint
- IMO, it's easier to see patterns / historical occurrences

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
