### PR TITLE
Clarify postgres conf docs

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -63,8 +63,9 @@ files:
         example: "false"
     - name: query_timeout
       description: |
-        Abort any statement that takes more than the specified number of milliseconds, starting from the time the command
-        arrives at the server from the client. A value of zero (the default) turns this off.
+        Adds a statement_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STATEMENT-TIMEOUT
+        to all metric collection queries. Aborts any statement that takes more than the specified number of milliseconds,
+        starting from the time the command arrives at the server from the client. A value of zero turns this off.
         Cancelled queries won't log any metrics
       value:
         type: integer
@@ -118,7 +119,7 @@ files:
         type: boolean
         example: false
     - name: collect_count_metrics
-      description: Collect count metrics.
+      description: Collect count of user tables up to max_relations size from pg_stat_user_tables
       value:
         type: boolean
         example: true

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -56,7 +56,7 @@ files:
 
         For a detailed description of how these options work see https://www.postgresql.org/docs/current/libpq-ssl.html
 
-        Note: `true` is an alias for `require`, and `false` is an alias for `disable`
+        Note: `true` is an alias for `require`, and `false` is an alias for `disable`.
       value:
         type: string
         default: false
@@ -66,7 +66,7 @@ files:
         Adds a statement_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STATEMENT-TIMEOUT
         to all metric collection queries. Aborts any statement that takes more than the specified number of milliseconds,
         starting from the time the command arrives at the server from the client. A value of zero turns this off.
-        Cancelled queries won't log any metrics
+        Cancelled queries won't log any metrics.
       value:
         type: integer
         example: 1000
@@ -77,7 +77,7 @@ files:
         If enabled, `dbname` should be specified to collect database-specific relations metrics.
         You can either specify a single relation by its exact name in 'relation_name' or use a regex to track metrics
         from all matching relations (useful in cases where relation names are dynamically generated, e.g. TimescaleDB).
-        Each relation generates many metrics (10 + 10 per index)
+        Each relation generates many metrics (10 + 10 per index).
         By default all schemas are included. To track relations from specific schemas only,
         you can specify the `schemas` attribute and provide a list of schemas to use for filtering.
 
@@ -108,18 +108,18 @@ files:
                - <SCHEMA_NAME1>
           - relation_regex: <TABLE_PATTERN>
     - name: max_relations
-      description: Determines the maximum number of relations to fetch
+      description: Determines the maximum number of relations to fetch.
       value:
         type: integer
         example: 300
     - name: collect_function_metrics
       description: |
-        If set to true, collects metrics regarding PL/pgSQL functions from pg_stat_user_functions
+        If set to true, collects metrics regarding PL/pgSQL functions from pg_stat_user_functions.
       value:
         type: boolean
         example: false
     - name: collect_count_metrics
-      description: Collect count of user tables up to max_relations size from pg_stat_user_tables
+      description: Collect count of user tables up to max_relations size from pg_stat_user_tables.
       value:
         type: boolean
         example: true
@@ -146,7 +146,7 @@ files:
         type: boolean
         example: false
     - name: table_count_limit
-      description: The maximum number of tables to collect metrics from
+      description: The maximum number of tables to collect metrics from.
       value:
         type: integer
         default: 200

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -58,7 +58,7 @@ instances:
     ##
     ## For a detailed description of how these options work see https://www.postgresql.org/docs/current/libpq-ssl.html
     ##
-    ## Note: `true` is an alias for `require`, and `false` is an alias for `disable`
+    ## Note: `true` is an alias for `require`, and `false` is an alias for `disable`.
     #
     # ssl: 'false'
 
@@ -66,7 +66,7 @@ instances:
     ## Adds a statement_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STATEMENT-TIMEOUT
     ## to all metric collection queries. Aborts any statement that takes more than the specified number of milliseconds,
     ## starting from the time the command arrives at the server from the client. A value of zero turns this off.
-    ## Cancelled queries won't log any metrics
+    ## Cancelled queries won't log any metrics.
     #
     # query_timeout: 1000
 
@@ -75,7 +75,7 @@ instances:
     ## If enabled, `dbname` should be specified to collect database-specific relations metrics.
     ## You can either specify a single relation by its exact name in 'relation_name' or use a regex to track metrics
     ## from all matching relations (useful in cases where relation names are dynamically generated, e.g. TimescaleDB).
-    ## Each relation generates many metrics (10 + 10 per index)
+    ## Each relation generates many metrics (10 + 10 per index).
     ## By default all schemas are included. To track relations from specific schemas only,
     ## you can specify the `schemas` attribute and provide a list of schemas to use for filtering.
     ##
@@ -92,17 +92,17 @@ instances:
     #   - relation_regex: <TABLE_PATTERN>
 
     ## @param max_relations - integer - optional - default: 300
-    ## Determines the maximum number of relations to fetch
+    ## Determines the maximum number of relations to fetch.
     #
     # max_relations: 300
 
     ## @param collect_function_metrics - boolean - optional - default: false
-    ## If set to true, collects metrics regarding PL/pgSQL functions from pg_stat_user_functions
+    ## If set to true, collects metrics regarding PL/pgSQL functions from pg_stat_user_functions.
     #
     # collect_function_metrics: false
 
     ## @param collect_count_metrics - boolean - optional - default: true
-    ## Collect count of user tables up to max_relations size from pg_stat_user_tables
+    ## Collect count of user tables up to max_relations size from pg_stat_user_tables.
     #
     # collect_count_metrics: true
 
@@ -128,7 +128,7 @@ instances:
     # tag_replication_role: false
 
     ## @param table_count_limit - integer - optional - default: 200
-    ## The maximum number of tables to collect metrics from
+    ## The maximum number of tables to collect metrics from.
     #
     # table_count_limit: 200
 

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -63,8 +63,9 @@ instances:
     # ssl: 'false'
 
     ## @param query_timeout - integer - optional
-    ## Abort any statement that takes more than the specified number of milliseconds, starting from the time the command
-    ## arrives at the server from the client. A value of zero (the default) turns this off.
+    ## Adds a statement_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STATEMENT-TIMEOUT
+    ## to all metric collection queries. Aborts any statement that takes more than the specified number of milliseconds,
+    ## starting from the time the command arrives at the server from the client. A value of zero turns this off.
     ## Cancelled queries won't log any metrics
     #
     # query_timeout: 1000
@@ -101,7 +102,7 @@ instances:
     # collect_function_metrics: false
 
     ## @param collect_count_metrics - boolean - optional - default: true
-    ## Collect count metrics.
+    ## Collect count of user tables up to max_relations size from pg_stat_user_tables
     #
     # collect_count_metrics: true
 


### PR DESCRIPTION
### What does this PR do?
* Remove mention of default from query_timeout.  0 is postgres default, not the agents'.
* Clarify query_timeout is statement_timeout and add link the postgres docs
* Clarify collect_count_metrics


### Motivation
I couldn't understand some of the docs.

### Additional Notes

The count metric just gives tables counts and the doc didn't make that clear to me.
https://github.com/DataDog/integrations-core/blob/279322c2566208a3d6404e6075e95626f3c2b663/postgres/datadog_checks/postgres/util.py#L189-L205
 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
