### PR TITLE
Submit `can_connect` service check on each check run

### DIFF
--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -39,7 +39,6 @@ class ClickhouseCheck(AgentCheck):
 
         # We'll connect on the first check run
         self._client = None
-        self.check_initializations.append(self.create_connection)
 
         self._query_manager = QueryManager(
             self,
@@ -58,6 +57,7 @@ class ClickhouseCheck(AgentCheck):
         self.check_initializations.append(self._query_manager.compile_queries)
 
     def check(self, _):
+        self.connect()
         self._query_manager.execute()
         self.collect_version()
 
@@ -76,7 +76,12 @@ class ClickhouseCheck(AgentCheck):
         if not self._server:
             raise ConfigurationError('the `server` setting is required')
 
-    def create_connection(self):
+    def connect(self):
+        if self._client is not None:
+            # Already connected.
+            self.service_check(self.SERVICE_CHECK_CONNECT, self.OK, tags=self._tags)
+            return
+
         try:
             client = clickhouse_driver.Client(
                 host=self._server,

--- a/clickhouse/tests/test_clickhouse.py
+++ b/clickhouse/tests/test_clickhouse.py
@@ -28,6 +28,19 @@ def test_check(aggregator, instance):
     aggregator.assert_metric(
         'clickhouse.dictionary.item.current', tags=[server_tag, port_tag, 'db:default', 'foo:bar', 'dictionary:test']
     )
+    aggregator.assert_service_check("clickhouse.can_connect", count=1)
+
+
+def test_can_connect(aggregator, instance):
+    """
+    Regression test: a copy of the `can_connect` service check must be submitted for each check run.
+    (It used to be submitted only once on check init, which led to customer seeing "no data" in the UI.)
+    """
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    num_runs = 3
+    for _ in range(num_runs):
+        check.run()
+    aggregator.assert_service_check("clickhouse.can_connect", count=num_runs)
 
 
 def test_custom_queries(aggregator, instance):

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -17,10 +17,9 @@ pytestmark = pytest.mark.unit
 def test_config(instance):
     check = ClickhouseCheck('clickhouse', {}, [instance])
     check.check_id = 'test-clickhouse'
-    check.check = lambda _: None
 
     with mock.patch('clickhouse_driver.Client') as m:
-        check.run()
+        check.connect()
         m.assert_called_once_with(
             host=instance['server'],
             port=instance['port'],


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Tweak ClickHouse connect code so that it submits the `can_connect` service check on each check run.

### Motivation
<!-- What inspired you to submit this pull request? -->
Currently the check sends a single copy of the service check, i.e. on check init.

A customer is having issues with this because it means the service check shows "no data" after a while and it cannot be used for status check monitors.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
The "connect only once" logic is kept because ideally we should hold the connection as long as possible, and only reconnect on errors. This "reconnect on error" logic is still TODO later.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
