### PR TITLE
Reduce log level of version collection warnings to DEBUG

### DIFF
--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -120,13 +120,13 @@ class Fluentd(AgentCheck):
         try:
             out, _, _ = get_subprocess_output(version_command, self.log, raise_on_empty_output=False)
         except OSError as exc:
-            self.log.warning("Error collecting fluentd version: %s", exc)
+            self.log.debug("Error collecting fluentd version: %s", exc)
             return None
 
         match = re.match(self.VERSION_PATTERN, out)
 
         if match is None:
-            self.log.warning("fluentd version not found in stdout: `%s`", out)
+            self.log.debug("fluentd version not found in stdout: `%s`", out)
             return None
 
         return match.group('version')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Reduce log level of version collection failures from WARN to DEBUG.

### Motivation
<!-- What inspired you to submit this pull request? -->
Customers that run Fluentd < 1.8 (before https://github.com/fluent/fluentd/pull/2706 was released and https://github.com/DataDog/integrations-core/pull/6062 can work) may see `WARN` logs such as the one below if the `fluentd` program is not available locally, which is noisy and unnecessary:

```console
WARN | (fluentd.py:117) | fluentd version not found in stdout: ``
```

Users can set `enable_metadata_collection: false` in `datadog.yaml` but this is not well documented nor intuitive, hence this quality of life improvement.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
