### PR TITLE
Check tag for table metric

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -3,7 +3,6 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import ipaddress
 from collections import defaultdict
-from logging import Logger, getLogger
 from typing import Any, DefaultDict, Dict, Iterator, List, Optional, Set, Tuple
 
 from datadog_checks.base import ConfigurationError, is_affirmative
@@ -61,7 +60,6 @@ class InstanceConfig:
         profiles=None,  # type: Dict[str, dict]
         profiles_by_oid=None,  # type: Dict[str, str]
         loader=None,  # type: MIBLoader
-        logger=None,  # type: Logger
     ):
         # type: (...) -> None
         global_metrics = [] if global_metrics is None else global_metrics
@@ -73,8 +71,6 @@ class InstanceConfig:
         for key, value in list(instance.items()):
             if value in (None, ""):
                 instance.pop(key)
-
-        self.logger = getLogger(__name__) if logger is None else logger
 
         self.instance = instance
         self.tags = instance.get('tags', [])
@@ -279,7 +275,7 @@ class InstanceConfig:
         """Parse configuration and returns data to be used for SNMP queries."""
         # Use bulk for SNMP version > 1 only.
         bulk_threshold = self.bulk_threshold if self._auth_data.mpModel else 0
-        result = parse_metrics(metrics, resolver=self._resolver, logger=self.logger, bulk_threshold=bulk_threshold)
+        result = parse_metrics(metrics, resolver=self._resolver, bulk_threshold=bulk_threshold)
         return result['oids'], result['next_oids'], result['bulk_oids'], result['parsed_metrics']
 
     def parse_metric_tags(self, metric_tags):

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -25,7 +25,7 @@ from .resolver import OIDResolver
 from .types import OIDMatch
 from .utils import register_device_target
 
-local_logger = getLogger(__name__)
+local_logger = weakref.ref(getLogger(__name__))  # type: weakref.ReferenceType[Logger]
 
 
 class InstanceConfig:
@@ -77,7 +77,7 @@ class InstanceConfig:
             if value in (None, ""):
                 instance.pop(key)
 
-        self.logger = local_logger if logger is None else weakref.ref(logger)
+        self.logger = local_logger if logger is None else weakref.ref(logger)  # type: weakref.ReferenceType[Logger]
 
         self.instance = instance
         self.tags = instance.get('tags', [])
@@ -282,7 +282,7 @@ class InstanceConfig:
         """Parse configuration and returns data to be used for SNMP queries."""
         # Use bulk for SNMP version > 1 only.
         bulk_threshold = self.bulk_threshold if self._auth_data.mpModel else 0
-        result = parse_metrics(metrics, resolver=self._resolver, logger=self.logger, bulk_threshold=bulk_threshold)
+        result = parse_metrics(metrics, resolver=self._resolver, logger=self.logger(), bulk_threshold=bulk_threshold)
         return result['oids'], result['next_oids'], result['bulk_oids'], result['parsed_metrics']
 
     def parse_metric_tags(self, metric_tags):

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -25,7 +25,7 @@ from .resolver import OIDResolver
 from .types import OIDMatch
 from .utils import register_device_target
 
-local_logger = weakref.ref(getLogger(__name__))  # type: weakref.ReferenceType[Logger]
+local_logger = getLogger(__name__)
 
 
 class InstanceConfig:
@@ -77,7 +77,7 @@ class InstanceConfig:
             if value in (None, ""):
                 instance.pop(key)
 
-        self.logger = local_logger if logger is None else weakref.ref(logger)  # type: weakref.ReferenceType[Logger]
+        self.logger = weakref.ref(local_logger) if logger is None else weakref.ref(logger)
 
         self.instance = instance
         self.tags = instance.get('tags', [])

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import ipaddress
 from collections import defaultdict
-from logging import getLogger
+from logging import Logger, getLogger
 from typing import Any, DefaultDict, Dict, Iterator, List, Optional, Set, Tuple
 
 from datadog_checks.base import ConfigurationError, is_affirmative
@@ -61,7 +61,7 @@ class InstanceConfig:
         profiles=None,  # type: Dict[str, dict]
         profiles_by_oid=None,  # type: Dict[str, str]
         loader=None,  # type: MIBLoader
-        logger=None,  # type: Any
+        logger=None,  # type: Logger
     ):
         # type: (...) -> None
         global_metrics = [] if global_metrics is None else global_metrics

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import ipaddress
 from collections import defaultdict
+from logging import Logger, getLogger
 from typing import Any, DefaultDict, Dict, Iterator, List, Optional, Set, Tuple
 
 from datadog_checks.base import ConfigurationError, is_affirmative
@@ -60,6 +61,7 @@ class InstanceConfig:
         profiles=None,  # type: Dict[str, dict]
         profiles_by_oid=None,  # type: Dict[str, str]
         loader=None,  # type: MIBLoader
+        logger=None,  # type: Logger
     ):
         # type: (...) -> None
         global_metrics = [] if global_metrics is None else global_metrics
@@ -71,6 +73,8 @@ class InstanceConfig:
         for key, value in list(instance.items()):
             if value in (None, ""):
                 instance.pop(key)
+
+        self.logger = getLogger(__name__) if logger is None else logger
 
         self.instance = instance
         self.tags = instance.get('tags', [])
@@ -275,7 +279,7 @@ class InstanceConfig:
         """Parse configuration and returns data to be used for SNMP queries."""
         # Use bulk for SNMP version > 1 only.
         bulk_threshold = self.bulk_threshold if self._auth_data.mpModel else 0
-        result = parse_metrics(metrics, resolver=self._resolver, bulk_threshold=bulk_threshold)
+        result = parse_metrics(metrics, resolver=self._resolver, logger=self.logger, bulk_threshold=bulk_threshold)
         return result['oids'], result['next_oids'], result['bulk_oids'], result['parsed_metrics']
 
     def parse_metric_tags(self, metric_tags):

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import ipaddress
+import weakref
 from collections import defaultdict
 from logging import Logger, getLogger
 from typing import Any, DefaultDict, Dict, Iterator, List, Optional, Set, Tuple
@@ -23,6 +24,8 @@ from .pysnmp_types import (
 from .resolver import OIDResolver
 from .types import OIDMatch
 from .utils import register_device_target
+
+local_logger = getLogger(__name__)
 
 
 class InstanceConfig:
@@ -74,7 +77,7 @@ class InstanceConfig:
             if value in (None, ""):
                 instance.pop(key)
 
-        self.logger = getLogger(__name__) if logger is None else logger
+        self.logger = local_logger if logger is None else weakref.ref(logger)
 
         self.instance = instance
         self.tags = instance.get('tags', [])

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import ipaddress
 from collections import defaultdict
-from logging import Logger, getLogger
+from logging import getLogger
 from typing import Any, DefaultDict, Dict, Iterator, List, Optional, Set, Tuple
 
 from datadog_checks.base import ConfigurationError, is_affirmative
@@ -61,7 +61,7 @@ class InstanceConfig:
         profiles=None,  # type: Dict[str, dict]
         profiles_by_oid=None,  # type: Dict[str, str]
         loader=None,  # type: MIBLoader
-        logger=None,  # type: Logger
+        logger=None,  # type: Any
     ):
         # type: (...) -> None
         global_metrics = [] if global_metrics is None else global_metrics

--- a/snmp/datadog_checks/snmp/discovery.py
+++ b/snmp/datadog_checks/snmp/discovery.py
@@ -55,6 +55,7 @@ def discover_instances(config, interval, check_ref):
 
             config.discovered_instances[host] = host_config
 
+            print(json.dumps(list(config.discovered_instances)))
             write_persistent_cache(check.check_id, json.dumps(list(config.discovered_instances)))
             del check
 
@@ -62,6 +63,7 @@ def discover_instances(config, interval, check_ref):
         if check is None:
             return
         # Write again at the end of the loop, in case some host have been removed since last
+        print(json.dumps(list(config.discovered_instances)))
         write_persistent_cache(check.check_id, json.dumps(list(config.discovered_instances)))
         del check
 

--- a/snmp/datadog_checks/snmp/discovery.py
+++ b/snmp/datadog_checks/snmp/discovery.py
@@ -55,7 +55,6 @@ def discover_instances(config, interval, check_ref):
 
             config.discovered_instances[host] = host_config
 
-            print(json.dumps(list(config.discovered_instances)))
             write_persistent_cache(check.check_id, json.dumps(list(config.discovered_instances)))
             del check
 
@@ -63,7 +62,6 @@ def discover_instances(config, interval, check_ref):
         if check is None:
             return
         # Write again at the end of the loop, in case some host have been removed since last
-        print(json.dumps(list(config.discovered_instances)))
         write_persistent_cache(check.check_id, json.dumps(list(config.discovered_instances)))
         del check
 

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -278,7 +278,10 @@ def _parse_table_metric(metric):
     else:
         logger = logging.getLogger('snmp')
         logger.warning(
-            "%s table has not metric_tags section. If the table has multiple rows, metrics may be missing.",
+            "%s table has not metric_tags section, all its metrics will use the same tags."
+            "If the table has multiple rows, only one row will be submitted."
+            "Please add at least one discriminating metric tag (such as a row index) "
+            "to ensure metrics of all rows are submitted.",
             str(metric['table']),
         )
 

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -142,6 +142,8 @@ def _parse_metric(metric):
         if 'symbols' not in metric:
             raise ConfigurationError('When specifying a table, you must specify a list of symbols')
         metric = cast(TableMetric, metric)
+        if not metric.get('metric_tags'):
+            raise ConfigurationError('When specifying a table, you must specify at least one additional tag')
         return _parse_table_metric(metric)
 
     raise ConfigurationError('When specifying a MIB, you must specify either a table or a symbol')

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -4,8 +4,8 @@
 """
 Helpers for parsing the `metrics` section of a config file.
 """
-# from logging import Logger
-from typing import Any, Dict, List, NamedTuple, Sequence, TypedDict, Union, cast
+from logging import Logger
+from typing import Dict, List, NamedTuple, Sequence, TypedDict, Union, cast
 
 from datadog_checks.base import ConfigurationError
 
@@ -32,7 +32,7 @@ ParseMetricsResult = TypedDict(
 
 
 def parse_metrics(metrics, resolver, logger, bulk_threshold=0):
-    # type: (List[Metric], OIDResolver, Any, int) -> ParseMetricsResult
+    # type: (List[Metric], OIDResolver, Logger, int) -> ParseMetricsResult
     """
     Parse the `metrics` section of a config file, and return OIDs to fetch and metrics to submit.
     """
@@ -90,7 +90,7 @@ MetricParseResult = NamedTuple(
 
 
 def _parse_metric(metric, logger):
-    # type: (Metric, Any) -> MetricParseResult
+    # type: (Metric, Logger) -> MetricParseResult
     """
     Parse a single metric in the `metrics` section of a config file.
 
@@ -240,7 +240,7 @@ def _parse_symbol(mib, symbol):
 
 
 def _parse_table_metric(metric, logger):
-    # type: (TableMetric, Any) -> MetricParseResult
+    # type: (TableMetric, Logger) -> MetricParseResult
     mib = metric['MIB']
 
     parsed_table = _parse_symbol(mib, metric['table'])

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -277,7 +277,7 @@ def _parse_table_metric(metric, logger):
                             index_mappings.append(IndexMapping(tag['column']['name'], index=index, mapping=mapping))
     elif logger:
         logger.warning(
-            "%s table doesn't have 'metric_tags' section, all its metrics will use the same tags."
+            "%s table doesn't have a 'metric_tags' section, all its metrics will use the same tags."
             "If the table has multiple rows, only one row will be submitted."
             "Please add at least one discriminating metric tag (such as a row index) "
             "to ensure metrics of all rows are submitted.",

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -4,8 +4,8 @@
 """
 Helpers for parsing the `metrics` section of a config file.
 """
-from logging import Logger
-from typing import Dict, List, NamedTuple, Sequence, TypedDict, Union, cast
+# from logging import Logger
+from typing import Any, Dict, List, NamedTuple, Sequence, TypedDict, Union, cast
 
 from datadog_checks.base import ConfigurationError
 
@@ -32,7 +32,7 @@ ParseMetricsResult = TypedDict(
 
 
 def parse_metrics(metrics, resolver, logger, bulk_threshold=0):
-    # type: (List[Metric], OIDResolver, Logger, int) -> ParseMetricsResult
+    # type: (List[Metric], OIDResolver, Any, int) -> ParseMetricsResult
     """
     Parse the `metrics` section of a config file, and return OIDs to fetch and metrics to submit.
     """
@@ -90,7 +90,7 @@ MetricParseResult = NamedTuple(
 
 
 def _parse_metric(metric, logger):
-    # type: (Metric, Logger) -> MetricParseResult
+    # type: (Metric, Any) -> MetricParseResult
     """
     Parse a single metric in the `metrics` section of a config file.
 
@@ -240,7 +240,7 @@ def _parse_symbol(mib, symbol):
 
 
 def _parse_table_metric(metric, logger):
-    # type: (TableMetric, Logger) -> MetricParseResult
+    # type: (TableMetric, Any) -> MetricParseResult
     mib = metric['MIB']
 
     parsed_table = _parse_symbol(mib, metric['table'])

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -255,7 +255,7 @@ def _parse_table_metric(metric):
     table_batches = {}  # type: TableBatches
 
     if metric.get('metric_tags'):
-        for metric_tag in metric.get('metric_tags'):
+        for metric_tag in metric['metric_tags']:
             parsed_table_metric_tag = _parse_table_metric_tag(mib, parsed_table, metric_tag)
 
             if isinstance(parsed_table_metric_tag, ParsedColumnMetricTag):
@@ -278,9 +278,8 @@ def _parse_table_metric(metric):
     else:
         logger = logging.getLogger('snmp')
         logger.warning(
-            "{} table has not metric_tags section. If the table has multiple rows, metrics will be missing.".format(
-                metric['table']
-            )
+            "%s table has not metric_tags section. If the table has multiple rows, metrics may be missing.",
+            str(metric['table']),
         )
 
     # Then process symbols in the table.

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -4,7 +4,7 @@
 """
 Helpers for parsing the `metrics` section of a config file.
 """
-from logging import Logger
+import logging
 from typing import Dict, List, NamedTuple, Sequence, TypedDict, Union, cast
 
 from datadog_checks.base import ConfigurationError
@@ -31,8 +31,8 @@ ParseMetricsResult = TypedDict(
 )
 
 
-def parse_metrics(metrics, resolver, logger, bulk_threshold=0):
-    # type: (List[Metric], OIDResolver, Logger, int) -> ParseMetricsResult
+def parse_metrics(metrics, resolver, bulk_threshold=0):
+    # type: (List[Metric], OIDResolver, int) -> ParseMetricsResult
     """
     Parse the `metrics` section of a config file, and return OIDs to fetch and metrics to submit.
     """
@@ -42,7 +42,7 @@ def parse_metrics(metrics, resolver, logger, bulk_threshold=0):
     parsed_metrics = []  # type: List[ParsedMetric]
 
     for metric in metrics:
-        result = _parse_metric(metric, logger)
+        result = _parse_metric(metric)
 
         for oid in result.oids_to_fetch:
             oids.append(oid)
@@ -89,8 +89,8 @@ MetricParseResult = NamedTuple(
 )
 
 
-def _parse_metric(metric, logger):
-    # type: (Metric, Logger) -> MetricParseResult
+def _parse_metric(metric):
+    # type: (Metric) -> MetricParseResult
     """
     Parse a single metric in the `metrics` section of a config file.
 
@@ -143,7 +143,7 @@ def _parse_metric(metric, logger):
         if 'symbols' not in metric:
             raise ConfigurationError('When specifying a table, you must specify a list of symbols')
         metric = cast(TableMetric, metric)
-        return _parse_table_metric(metric, logger)
+        return _parse_table_metric(metric)
 
     raise ConfigurationError('When specifying a MIB, you must specify either a table or a symbol')
 
@@ -239,8 +239,8 @@ def _parse_symbol(mib, symbol):
     return ParsedSymbol(name=name, oid=oid, oids_to_resolve={name: oid})
 
 
-def _parse_table_metric(metric, logger):
-    # type: (TableMetric, Logger) -> MetricParseResult
+def _parse_table_metric(metric):
+    # type: (TableMetric) -> MetricParseResult
     mib = metric['MIB']
 
     parsed_table = _parse_symbol(mib, metric['table'])
@@ -276,6 +276,7 @@ def _parse_table_metric(metric, logger):
                             tag = cast(ColumnTableMetricTag, tag)
                             index_mappings.append(IndexMapping(tag['column']['name'], index=index, mapping=mapping))
     else:
+        logger = logging.getLogger('snmp')
         logger.warning(
             "%s table has not metric_tags section, all its metrics will use the same tags."
             "If the table has multiple rows, only one row will be submitted."

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -277,8 +277,8 @@ def _parse_table_metric(metric, logger):
                             index_mappings.append(IndexMapping(tag['column']['name'], index=index, mapping=mapping))
     elif logger:
         logger.warning(
-            "%s table doesn't have a 'metric_tags' section, all its metrics will use the same tags."
-            "If the table has multiple rows, only one row will be submitted."
+            "%s table doesn't have a 'metric_tags' section, all its metrics will use the same tags. "
+            "If the table has multiple rows, only one row will be submitted. "
             "Please add at least one discriminating metric tag (such as a row index) "
             "to ensure metrics of all rows are submitted.",
             str(metric['table']),

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -5,7 +5,7 @@
 Helpers for parsing the `metrics` section of a config file.
 """
 from logging import Logger
-from typing import Dict, List, NamedTuple, Sequence, TypedDict, Union, cast
+from typing import Dict, List, NamedTuple, Optional, Sequence, TypedDict, Union, cast
 
 from datadog_checks.base import ConfigurationError
 
@@ -32,7 +32,7 @@ ParseMetricsResult = TypedDict(
 
 
 def parse_metrics(metrics, resolver, logger, bulk_threshold=0):
-    # type: (List[Metric], OIDResolver, Logger, int) -> ParseMetricsResult
+    # type: (List[Metric], OIDResolver, Optional[Logger], int) -> ParseMetricsResult
     """
     Parse the `metrics` section of a config file, and return OIDs to fetch and metrics to submit.
     """
@@ -90,7 +90,7 @@ MetricParseResult = NamedTuple(
 
 
 def _parse_metric(metric, logger):
-    # type: (Metric, Logger) -> MetricParseResult
+    # type: (Metric, Optional[Logger]) -> MetricParseResult
     """
     Parse a single metric in the `metrics` section of a config file.
 
@@ -240,7 +240,7 @@ def _parse_symbol(mib, symbol):
 
 
 def _parse_table_metric(metric, logger):
-    # type: (TableMetric, Logger) -> MetricParseResult
+    # type: (TableMetric, Optional[Logger]) -> MetricParseResult
     mib = metric['MIB']
 
     parsed_table = _parse_symbol(mib, metric['table'])
@@ -275,7 +275,7 @@ def _parse_table_metric(metric, logger):
                         if 'column' in tag:
                             tag = cast(ColumnTableMetricTag, tag)
                             index_mappings.append(IndexMapping(tag['column']['name'], index=index, mapping=mapping))
-    else:
+    elif logger:
         logger.warning(
             "%s table has not metric_tags section, all its metrics will use the same tags."
             "If the table has multiple rows, only one row will be submitted."

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -277,7 +277,7 @@ def _parse_table_metric(metric, logger):
                             index_mappings.append(IndexMapping(tag['column']['name'], index=index, mapping=mapping))
     elif logger:
         logger.warning(
-            "%s table has not metric_tags section, all its metrics will use the same tags."
+            "%s table doesn't have 'metric_tags' section, all its metrics will use the same tags."
             "If the table has multiple rows, only one row will be submitted."
             "Please add at least one discriminating metric tag (such as a row index) "
             "to ensure metrics of all rows are submitted.",

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -134,7 +134,6 @@ class SnmpCheck(AgentCheck):
             profiles=self.profiles,
             profiles_by_oid=self.profiles_by_oid,
             loader=loader,
-            logger=self.log,
         )
 
     def _build_autodiscovery_config(self, source_instance, ip_address):

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -304,6 +304,7 @@ class SnmpCheck(AgentCheck):
         cache = read_persistent_cache(self.check_id)
         if cache:
             hosts = json.loads(cache)
+            print('Cached hosts len {}'.format(len(hosts)))
             for host in hosts:
                 try:
                     ipaddress.ip_address(host)
@@ -320,6 +321,8 @@ class SnmpCheck(AgentCheck):
             raise ConfigurationError(message)
 
         # Pass a weakref to the discovery function to not have a reference cycle
+        print(self._config.discovered_instances)
+        print(list(self._config.network_hosts()))
         self._thread = self._thread_factory(
             target=discover_instances, args=(self._config, discovery_interval, weakref.ref(self)), name=self.name
         )

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -134,6 +134,7 @@ class SnmpCheck(AgentCheck):
             profiles=self.profiles,
             profiles_by_oid=self.profiles_by_oid,
             loader=loader,
+            logger=self.log,
         )
 
     def _build_autodiscovery_config(self, source_instance, ip_address):

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -304,7 +304,6 @@ class SnmpCheck(AgentCheck):
         cache = read_persistent_cache(self.check_id)
         if cache:
             hosts = json.loads(cache)
-            print('Cached hosts len {}'.format(len(hosts)))
             for host in hosts:
                 try:
                     ipaddress.ip_address(host)
@@ -321,8 +320,6 @@ class SnmpCheck(AgentCheck):
             raise ConfigurationError(message)
 
         # Pass a weakref to the discovery function to not have a reference cycle
-        print(self._config.discovered_instances)
-        print(list(self._config.network_hosts()))
         self._thread = self._thread_factory(
             target=discover_instances, args=(self._config, discovery_interval, weakref.ref(self)), name=self.name
         )

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -151,10 +151,18 @@ BULK_TABULAR_OBJECTS = [
             "ipSystemStatsHCOutOctets",
             "ipSystemStatsInMcastPkts",
         ],
+        'metric_tags': [{'tag': "dumbindex", 'index': 1}],
     },
 ]
 
-INVALID_METRICS = [{'MIB': "IF-MIB", 'table': "noIdeaWhatIAmDoingHere", 'symbols': ["ImWrong", "MeToo"]}]
+INVALID_METRICS = [
+    {
+        'MIB': "IF-MIB",
+        'table': "noIdeaWhatIAmDoingHere",
+        'symbols': ["ImWrong", "MeToo"],
+        'metric_tags': [{'tag': "dumbindex", 'index': 1}],
+    }
+]
 
 PLAY_WITH_GET_NEXT_METRICS = [
     {"OID": "1.3.6.1.2.1.4.31.3.1.3.2", "name": "needFallback"},

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -59,7 +59,7 @@ def test_load_profiles(caplog):
             check._config.refresh_with_profile(profile)
         except ConfigurationError as e:
             pytest.fail("Profile `{}` is not configured correctly: {}".format(name, e))
-        assert 'table has not metric_tags section.' not in caplog.text
+        assert 'table has not metric_tags section' not in caplog.text
         caplog.clear()
 
 

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import logging
+
 import pytest
 
 from datadog_checks.base import ConfigurationError
@@ -48,14 +50,17 @@ from .metrics import (
 )
 
 
-def test_load_profiles():
+def test_load_profiles(caplog):
     instance = common.generate_instance_config([])
     check = SnmpCheck('snmp', {}, [instance])
+    caplog.at_level(logging.WARNING)
     for name, profile in check.profiles.items():
         try:
             check._config.refresh_with_profile(profile)
         except ConfigurationError as e:
             pytest.fail("Profile `{}` is not configured correctly: {}".format(name, e))
+        assert 'table has not metric_tags section.' not in caplog.text
+        caplog.clear()
 
 
 def run_profile_check(recording_name):

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -59,7 +59,7 @@ def test_load_profiles(caplog):
             check._config.refresh_with_profile(profile)
         except ConfigurationError as e:
             pytest.fail("Profile `{}` is not configured correctly: {}".format(name, e))
-        assert 'table has not metric_tags section' not in caplog.text
+        assert "table doesn't have a 'metric_tags' section" not in caplog.text
         caplog.clear()
 
 

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -87,10 +87,7 @@ def test_parse_metrics(lcd_mock, caplog):
     assert foo.name == 'foo'
     assert isinstance(foo, ParsedTableMetric)
     assert bar.name == 'bar'
-    assert (
-        'foo_table table has not metric_tags section. If the table has multiple rows, metrics may be missing.'
-        in caplog.text
-    )
+    assert 'foo_table table has not metric_tags section, all its metrics will use the same tags.' in caplog.text
 
     # MIB with table, symbols, bad metrics_tags
     metrics = [{"MIB": "foo_mib", "table": "foo_table", "symbols": ["foo", "bar"], "metric_tags": [{}]}]

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -117,7 +117,9 @@ def test_parse_metrics(lcd_mock, caplog):
     foo = parsed_metrics[0]
     assert isinstance(foo, ParsedTableMetric)
     assert foo.name == 'foo'
-    assert foo.index_tags == [('test', '1')]
+    index_tag = foo.index_tags[0]
+    assert index_tag.index == '1'
+    assert index_tag.parsed_metric_tag.name == 'test'
 
     # MIB with table, symbols, metrics_tags index
     metrics = [

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -75,16 +75,10 @@ def test_parse_metrics(lcd_mock):
     with pytest.raises(Exception):
         config.parse_metrics(metrics)
 
-    # MIB with table and symbols
+    # MIB with table and symbols but no metric_tags
     metrics = [{"MIB": "foo_mib", "table": "foo_table", "symbols": ["foo", "bar"]}]
-    _, next_oids, _, parsed_metrics = config.parse_metrics(metrics)
-    assert len(next_oids) == 2
-    assert len(parsed_metrics) == 2
-    foo, bar = parsed_metrics
-    assert isinstance(foo, ParsedTableMetric)
-    assert foo.name == 'foo'
-    assert isinstance(foo, ParsedTableMetric)
-    assert bar.name == 'bar'
+    with pytest.raises(Exception):
+        config.parse_metrics(metrics)
 
     # MIB with table, symbols, bad metrics_tags
     metrics = [{"MIB": "foo_mib", "table": "foo_table", "symbols": ["foo", "bar"], "metric_tags": [{}]}]
@@ -97,13 +91,21 @@ def test_parse_metrics(lcd_mock):
         config.parse_metrics(metrics)
 
     # Table with manual OID
-    metrics = [{"MIB": "foo_mib", "table": "foo_table", "symbols": [{"OID": "1.2.3", "name": "foo"}]}]
+    metrics = [
+        {
+            "MIB": "foo_mib",
+            "table": "foo_table",
+            "symbols": [{"OID": "1.2.3", "name": "foo"}],
+            "metric_tags": [{"tag": "test", "index": "1"}],
+        }
+    ]
     _, next_oids, _, parsed_metrics = config.parse_metrics(metrics)
     assert len(next_oids) == 1
     assert len(parsed_metrics) == 1
     foo = parsed_metrics[0]
     assert isinstance(foo, ParsedTableMetric)
     assert foo.name == 'foo'
+    assert foo.index_tags == [('test', '1')]
 
     # MIB with table, symbols, metrics_tags index
     metrics = [

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -87,7 +87,9 @@ def test_parse_metrics(lcd_mock, caplog):
     assert foo.name == 'foo'
     assert isinstance(foo, ParsedTableMetric)
     assert bar.name == 'bar'
-    assert 'foo_table table has not metric_tags section, all its metrics will use the same tags.' in caplog.text
+    assert (
+        "foo_table table doesn't have a 'metric_tags' section, all its metrics will use the same tags." in caplog.text
+    )
 
     # MIB with table, symbols, bad metrics_tags
     metrics = [{"MIB": "foo_mib", "table": "foo_table", "symbols": ["foo", "bar"], "metric_tags": [{}]}]

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -77,7 +77,7 @@ def test_parse_metrics(lcd_mock):
 
     # MIB with table and symbols but no metric_tags
     metrics = [{"MIB": "foo_mib", "table": "foo_table", "symbols": ["foo", "bar"]}]
-    with pytest.raises(Exception):
+    with pytest.raises(ConfigurationError):
         config.parse_metrics(metrics)
 
     # MIB with table, symbols, bad metrics_tags

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -382,6 +382,8 @@ def test_cache_building(write_mock, read_mock):
     check._config.discovered_instances['192.168.0.1'] = InstanceConfig(discovered_instance)
     check._start_discovery()
 
+    print(write_mock.call_count)
+
     try:
         for _ in range(30):
             if write_mock.call_count:
@@ -390,6 +392,7 @@ def test_cache_building(write_mock, read_mock):
     finally:
         check._running = False
 
+    print(write_mock.call_count)
     write_mock.assert_called_once_with('', '["192.168.0.1"]')
 
 

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -382,7 +382,11 @@ def test_cache_building(write_mock, read_mock):
     check._config.discovered_instances['192.168.0.1'] = InstanceConfig(discovered_instance)
     check._start_discovery()
 
+    if len(check._config.discovered_instances) > 0:
+        print(check._config.discovered_instances)
+
     print(write_mock.call_count)
+    write_mock.reset_mock()
 
     try:
         for _ in range(30):

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -88,7 +88,7 @@ def test_parse_metrics(lcd_mock, caplog):
     assert isinstance(foo, ParsedTableMetric)
     assert bar.name == 'bar'
     assert (
-        'foo_table table has not metric_tags section. If the table has multiple rows, metrics will be missing.'
+        'foo_table table has not metric_tags section. If the table has multiple rows, metrics may be missing.'
         in caplog.text
     )
 

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -382,12 +382,6 @@ def test_cache_building(write_mock, read_mock):
     check._config.discovered_instances['192.168.0.1'] = InstanceConfig(discovered_instance)
     check._start_discovery()
 
-    if len(check._config.discovered_instances) > 0:
-        print(check._config.discovered_instances)
-
-    print(write_mock.call_count)
-    write_mock.reset_mock()
-
     try:
         for _ in range(30):
             if write_mock.call_count:
@@ -396,7 +390,6 @@ def test_cache_building(write_mock, read_mock):
     finally:
         check._running = False
 
-    print(write_mock.call_count)
     write_mock.assert_called_once_with('', '["192.168.0.1"]')
 
 


### PR DESCRIPTION
### What does this PR do?
~Raise a `ConfigurationError` when a table metric does not have an additional tag.~
Add a warning when a table metric does not have an additional tag. Since the problem can be harmless if the table have only one row, a breaking change (raising an error) may not be necessary.

### Motivation
https://github.com/DataDog/integrations-core/pull/6765

### Additional Notes
Also update the load profile test to fail if a table metric does not have an additional tag.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
