### PR TITLE
Allow list of sysoids in profiles

### DIFF
--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -39,7 +39,7 @@ or a wildcard pattern to address multiple device models:
 sysobjectid: 1.3.6.1.131.12.4.*
 ```
 
-or even a list of those:
+or a list of fully-defined OID / wildcard patterns:
 
 ```yaml
 sysobjectid:

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -39,6 +39,14 @@ or a wildcard pattern to address multiple device models:
 sysobjectid: 1.3.6.1.131.12.4.*
 ```
 
+or even a list of those:
+
+```yaml
+sysobjectid:
+  - 1.3.6.1.131.12.4.*
+  - 1.3.6.1.4.1.232.9.4.10
+```
+
 ### `extends`
 
 _(Optional)_

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -108,15 +108,18 @@ class SnmpCheck(AgentCheck):
         """
         profiles_by_oid = {}  # type: Dict[str, str]
         for name, profile in self.profiles.items():
-            sys_object_oid = profile['definition'].get('sysobjectid')
-            if sys_object_oid is not None:
-                profile_match = profiles_by_oid.get(sys_object_oid)
-                if profile_match:
-                    raise ConfigurationError(
-                        "Profile {} has the same sysObjectID ({}) as {}".format(name, sys_object_oid, profile_match)
-                    )
-                else:
-                    profiles_by_oid[sys_object_oid] = name
+            sys_object_oids = profile['definition'].get('sysobjectid')
+            if sys_object_oids is not None:
+                if isinstance(sys_object_oids, str):
+                    sys_object_oids = [sys_object_oids]
+                for sys_object_oid in sys_object_oids:
+                    profile_match = profiles_by_oid.get(sys_object_oid)
+                    if profile_match:
+                        raise ConfigurationError(
+                            "Profile {} has the same sysObjectID ({}) as {}".format(name, sys_object_oid, profile_match)
+                        )
+                    else:
+                        profiles_by_oid[sys_object_oid] = name
         return profiles_by_oid
 
     def _build_config(self, instance):
@@ -283,14 +286,14 @@ class SnmpCheck(AgentCheck):
         """
         Return the most specific profile that matches the given sysObjectID.
         """
-        profiles = [profile for oid, profile in self.profiles_by_oid.items() if fnmatch.fnmatch(sys_object_oid, oid)]
+        matched_oids = [
+            (oid, profile) for oid, profile in self.profiles_by_oid.items() if fnmatch.fnmatch(sys_object_oid, oid)
+        ]
 
-        if not profiles:
+        if not matched_oids:
             raise ConfigurationError('No profile matching sysObjectID {}'.format(sys_object_oid))
 
-        return max(
-            profiles, key=lambda profile: oid_pattern_specificity(self.profiles[profile]['definition']['sysobjectid'])
-        )
+        return max(matched_oids, key=lambda oid: oid_pattern_specificity(oid[0]))[1]
 
     def _start_discovery(self):
         # type: () -> None

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -294,7 +294,9 @@ class SnmpCheck(AgentCheck):
         if not matched_profiles_by_oid:
             raise ConfigurationError('No profile matching sysObjectID {}'.format(sys_object_oid))
 
-        return max(matched_profiles_by_oid.keys(), key=lambda oid: oid_pattern_specificity(oid[0]))[1]
+        oid = max(matched_profiles_by_oid.keys(), key=lambda oid: oid_pattern_specificity(oid))
+
+        return matched_profiles_by_oid[oid]
 
     def _start_discovery(self):
         # type: () -> None

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -625,8 +625,6 @@ def test_profile_sysoid_list(aggregator, caplog):
     }
     init_config = {'profiles': {'profile1': {'definition': definition}}}
 
-    caplog.at_level(logging.WARNING)
-
     devices_matched = [
         {'community_string': 'hpe-proliant', 'sysobjectid': '1.3.6.1.4.1.232.1.2'},
         {'community_string': 'network', 'sysobjectid': '1.3.6.1.4.1.1.2.1.3.4'},
@@ -646,6 +644,7 @@ def test_profile_sysoid_list(aggregator, caplog):
 
         aggregator.reset()
 
+    caplog.at_level(logging.WARNING)
     devices_not_matched = [
         {'community_string': '3850', 'sysobjectid': '1.3.6.1.4.1.9.1.1745'},
     ]
@@ -661,6 +660,7 @@ def test_profile_sysoid_list(aggregator, caplog):
         aggregator.assert_all_metrics_covered()
 
         aggregator.reset()
+        caplog.clear()
 
 
 @pytest.mark.parametrize(

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -640,6 +640,7 @@ def test_profile_sysoid_list(aggregator, caplog):
 
         tags = common_tags + ['snmp_oid:{}'.format(device['sysobjectid'])]
         aggregator.assert_metric('snmp.IAmACounter32', tags=tags, count=1)
+        aggregator.assert_metric('snmp.devices_monitored', tags=tags, count=1, value=1)
 
         aggregator.assert_all_metrics_covered()
 
@@ -655,6 +656,7 @@ def test_profile_sysoid_list(aggregator, caplog):
         check.check(instance)
 
         assert 'No profile matching sysObjectID 1.3.6.1.4.1.9.1.1745' in caplog.text
+        aggregator.assert_metric('snmp.devices_monitored', tags=common.CHECK_TAGS, count=1, value=1)
 
         aggregator.assert_all_metrics_covered()
 

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -241,7 +241,7 @@ def test_duplicate_sysobjectid_error():
     SnmpCheck('snmp', init_config, [instance])
 
 
-def test_mapping_sysobjectids():
+def test_sysobjectid_list():
     profile_multiple = {'sysobjectid': ['1.3.6.1.4.1.9.1.241', '1.3.6.1.4.1.9.1.1790']}
     profile_single = {'sysobjectid': '1.3.6.1.4.1.9.1.3450'}
 
@@ -249,11 +249,11 @@ def test_mapping_sysobjectids():
     init_config = {'profiles': {'multiple': {'definition': profile_multiple}, 'single': {'definition': profile_single}}}
     check = SnmpCheck('snmp', init_config, [instance])
 
-    assert check.profiles_by_oid['1.3.6.1.4.1.9.1.241'] == 'multiple'
-    assert check.profiles_by_oid['1.3.6.1.4.1.9.1.1790'] == 'multiple'
-    assert check.profiles_by_oid['1.3.6.1.4.1.9.1.3450'] == 'single'
-
-    assert len(check.profiles_by_oid) == 3
+    assert check.profiles_by_oid = {
+        '1.3.6.1.4.1.9.1.241': 'multiple',
+        '1.3.6.1.4.1.9.1.1790': 'multiple',
+        '1.3.6.1.4.1.9.1.3450': 'single',
+    }
 
 
 def test_no_address():

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -249,7 +249,7 @@ def test_sysobjectid_list():
     init_config = {'profiles': {'multiple': {'definition': profile_multiple}, 'single': {'definition': profile_single}}}
     check = SnmpCheck('snmp', init_config, [instance])
 
-    assert check.profiles_by_oid = {
+    assert check.profiles_by_oid == {
         '1.3.6.1.4.1.9.1.241': 'multiple',
         '1.3.6.1.4.1.9.1.1790': 'multiple',
         '1.3.6.1.4.1.9.1.3450': 'single',

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -241,6 +241,21 @@ def test_duplicate_sysobjectid_error():
     SnmpCheck('snmp', init_config, [instance])
 
 
+def test_mapping_sysobjectids():
+    profile_multiple = {'sysobjectid': ['1.3.6.1.4.1.9.1.241', '1.3.6.1.4.1.9.1.1790']}
+    profile_single = {'sysobjectid': '1.3.6.1.4.1.9.1.3450'}
+
+    instance = common.generate_instance_config([])
+    init_config = {'profiles': {'multiple': {'definition': profile_multiple}, 'single': {'definition': profile_single}}}
+    check = SnmpCheck('snmp', init_config, [instance])
+
+    assert check.profiles_by_oid['1.3.6.1.4.1.9.1.241'] == 'multiple'
+    assert check.profiles_by_oid['1.3.6.1.4.1.9.1.1790'] == 'multiple'
+    assert check.profiles_by_oid['1.3.6.1.4.1.9.1.3450'] == 'single'
+
+    assert len(check.profiles_by_oid) == 3
+
+
 def test_no_address():
     instance = common.generate_instance_config([])
     instance.pop('ip_address')


### PR DESCRIPTION
### What does this PR do?
Allow list of sysobjectids in profiles like this:
```yaml
sysobjectid:
  - 1.3.6.1.4.1.9.1.241
  - 1.3.6.1.4.1.9.1.1790
```

### Motivation
Preparing #6925 

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
