### PR TITLE
Fix e2e tests with gitlab 13+

### DIFF
--- a/gitlab/tests/common.py
+++ b/gitlab/tests/common.py
@@ -94,7 +94,7 @@ METRICS = [
 ]
 
 METRICS_TO_TEST = [
-    "unicorn.workers",
+    "puma.workers",
     "rack.http_requests_total",
     "ruby.process_start_time_seconds",
     "rack.http_request_duration_seconds.sum",

--- a/gitlab/tests/compose/docker-compose.yml
+++ b/gitlab/tests/compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   gitlab:
-    image: gitlab/gitlab-ce:latest
+    image: gitlab/gitlab-ce:${GITLAB_VERSION}
     volumes:
       - ./config/gitlab.rb:/etc/gitlab/gitlab.rb
     ports:

--- a/gitlab/tests/compose/docker-compose.yml
+++ b/gitlab/tests/compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   gitlab:
-    image: gitlab/gitlab-ce:${GITLAB_VERSION}
+    image: gitlab/gitlab-ce:latest
     volumes:
       - ./config/gitlab.rb:/etc/gitlab/gitlab.rb
     ports:

--- a/gitlab/tox.ini
+++ b/gitlab/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}
+    py{27,38}-{13}
     bench
 
 [testenv]
@@ -18,6 +18,9 @@ platform = linux|darwin|win32
 passenv =
     DOCKER*
     COMPOSE*
+setenv =
+    13: GITLAB_VERSION=13.0.6-ce.0
+    bench: GITLAB_VERSION=13.0.6-ce.0
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt

--- a/gitlab/tox.ini
+++ b/gitlab/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{12}
+    py{27,38}
     bench
 
 [testenv]
@@ -18,9 +18,6 @@ platform = linux|darwin|win32
 passenv =
     DOCKER*
     COMPOSE*
-setenv =
-    12: GITLAB_VERSION=12.10.6-ce.0
-    bench: GITLAB_VERSION=12.10.6-ce.0
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt


### PR DESCRIPTION
With version 13, gitlab officialy switched from unicorn to puma as their default webserver: https://docs.gitlab.com/ee/administration/operations/puma.html

Because of that some metrics have changed, for example "gitlab.unicorn.workers" is now "gitlab.puma.workers".
Beside naming, the change is minimal and we're already compatible with the puma metrics (they are collected and documented in the metadata.csv).

This PR only fixes the gitlab tests to use the "latest" image and check for "puma.workers" instead of "unicorn.workers".

### Alternative design

We could instead test against both gitlab 12 and gitlab 13 and check for "unicorn" in v12 and "puma" in v13.
Because starting a gitlab environment is already time consuming and because the change really is minimal between 12 and 13, we only test puma. Note that the "unicorn" metrics are still tested with the fixture data.