### PR TITLE
Expand user paths correctly for legacy E2E config

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -131,7 +131,7 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, org_name, profile
     env_type = metadata['env_type']
 
     # TODO: remove this legacy fallback lookup in any future major version bump
-    legacy_fallback = ctx.obj.get('agent', '')
+    legacy_fallback = os.path.expanduser(ctx.obj.get('agent', ''))
     if os.path.isdir(legacy_fallback):
         legacy_fallback = ''
 


### PR DESCRIPTION
Context: https://github.com/DataDog/integrations-core/pull/6771
The previous PR kepts a legacy path for old-style ddev configs. The legacy branch was not handling user paths like "~/dd/datadog-agent" correctly.