### PR TITLE
Add snmp.devices_monitored metric

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -104,6 +104,10 @@ class InstanceConfig:
         ip_address = instance.get('ip_address')
         network_address = instance.get('network_address')
 
+        autodiscovery_subnet = instance.get('autodiscovery_subnet')
+        if autodiscovery_subnet:
+            self.tags.append('autodiscovery_subnet:{}'.format(autodiscovery_subnet))
+
         if not ip_address and not network_address:
             raise ConfigurationError('An IP address or a network address needs to be specified')
 

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -104,10 +104,6 @@ class InstanceConfig:
         ip_address = instance.get('ip_address')
         network_address = instance.get('network_address')
 
-        autodiscovery_subnet = instance.get('autodiscovery_subnet')
-        if autodiscovery_subnet:
-            self.tags.append('autodiscovery_subnet:{}'.format(autodiscovery_subnet))
-
         if not ip_address and not network_address:
             raise ConfigurationError('An IP address or a network address needs to be specified')
 

--- a/snmp/datadog_checks/snmp/data/auto_conf.yaml
+++ b/snmp/datadog_checks/snmp/data/auto_conf.yaml
@@ -73,3 +73,9 @@ instances:
     ## Name of your context (optional SNMP v3-only parameter).
     #
     context_name: "%%extra_context_name%%"
+
+    ## @param autodiscovery_subnet - string - optional
+    ## The autodiscovery subnet the device is part of.
+    ## Used by Agent autodiscovery to pass subnet name.
+    #
+    autodiscovery_subnet: "%%autodiscovery_subnet%%"

--- a/snmp/datadog_checks/snmp/data/auto_conf.yaml
+++ b/snmp/datadog_checks/snmp/data/auto_conf.yaml
@@ -74,8 +74,12 @@ instances:
     #
     context_name: "%%extra_context_name%%"
 
-    ## @param autodiscovery_subnet - string - optional
-    ## The autodiscovery subnet the device is part of.
-    ## Used by Agent autodiscovery to pass subnet name.
+    ## @param tags - list of key:value element - optional
+    ## List of tags to attach to every metric, event and service check emitted by this integration.
+    ##
+    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
     #
-    autodiscovery_subnet: "%%autodiscovery_subnet%%"
+    tags:
+      # The autodiscovery subnet the device is part of.
+      # Used by Agent autodiscovery to pass subnet name.
+      - "autodiscovery_subnet:%%autodiscovery_subnet%%"

--- a/snmp/datadog_checks/snmp/discovery.py
+++ b/snmp/datadog_checks/snmp/discovery.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-import copy
 import json
 import time
 import weakref
@@ -33,11 +32,8 @@ def discover_instances(config, interval, check_ref):
             check = check_ref()
             if check is None or not check._running:
                 return
-            instance = copy.deepcopy(config.instance)
-            instance.pop('network_address')
-            instance['ip_address'] = host
 
-            host_config = check._build_config(instance)
+            host_config = check._build_autodiscovery_config(config.instance, host)
 
             try:
                 sys_object_oid = check.fetch_sysobject_oid(host_config)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -381,7 +381,7 @@ class SnmpCheck(AgentCheck):
                 error = 'Failed to collect metrics for {} - {}'.format(self._get_instance_name(instance), e)
             self.warning(error)
         finally:
-            # At this point, `tags` include extra tags added in try clause
+            # At this point, `tags` might includes some extra tags added in try clause
             self.gauge('snmp.devices_monitored', 1, tags=tags)
 
             # Report service checks

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -295,7 +295,9 @@ class SnmpCheck(AgentCheck):
                 instance = copy.deepcopy(self.instance)
                 network_address = instance.pop('network_address')
                 instance['ip_address'] = host
-                instance['autodiscovery_subnet'] = network_address
+
+                instance.setdefault('tags', [])
+                instance['tags'].append('autodiscovery_subnet:{}'.format(network_address))
 
                 host_config = self._build_config(instance)
                 self._config.discovered_instances[host] = host_config

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -384,6 +384,9 @@ class SnmpCheck(AgentCheck):
             self.warning(error)
         finally:
             # At this point, `tags` might include some extra tags added in try clause
+
+            # Sending `snmp.devices_monitored` with value 1 will allow users to count devices
+            # by using `sum by {X}` queries in UI. X being a tag like `autodiscovery_subnet`, `snmp_profile`, etc
             self.gauge('snmp.devices_monitored', 1, tags=tags)
 
             # Report service checks

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -381,7 +381,7 @@ class SnmpCheck(AgentCheck):
                 error = 'Failed to collect metrics for {} - {}'.format(self._get_instance_name(instance), e)
             self.warning(error)
         finally:
-            # At this point, `tags` might includes some extra tags added in try clause
+            # At this point, `tags` might include some extra tags added in try clause
             self.gauge('snmp.devices_monitored', 1, tags=tags)
 
             # Report service checks

--- a/snmp/metadata.csv
+++ b/snmp/metadata.csv
@@ -1,4 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+snmp.devices_monitored,gauge,,,,Devices monitored count. Make 'sum by {X}' queries to count all the Devices with the tag X.,0,snmp,
 snmp.adapterCollisions,count,,,,[Dell iDRAC] Total number of single collisions.,0,snmp,
 snmp.adapterRxBytes,count,,byte,,[Dell iDRAC] Total number of bytes received.,0,snmp,
 snmp.adapterRxDropped,count,,packet,,[Dell iDRAC] Total number of receive packets dropped due to overrun.,0,snmp,

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -212,3 +212,7 @@ def generate_v3_instance_config(metrics, name=None, user=None, auth=None, auth_k
 
 def create_check(instance):
     return SnmpCheck('snmp', {}, [instance])
+
+
+def assert_common_metrics(aggregator, tags=None):
+    aggregator.assert_metric('snmp.devices_monitored', metric_type=aggregator.GAUGE, tags=tags)

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -62,6 +62,7 @@ def test_type_support(aggregator):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -101,6 +102,7 @@ def test_snmpget(aggregator):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -138,6 +140,7 @@ def test_scalar(aggregator):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -172,6 +175,7 @@ def test_unenforce_constraint(aggregator):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -198,6 +202,7 @@ def test_table(aggregator):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -219,6 +224,7 @@ def test_resolved_table(aggregator):
 
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -258,6 +264,7 @@ def test_table_v3_MD5_DES(aggregator):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -297,6 +304,7 @@ def test_table_v3_MD5_AES(aggregator):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -335,6 +343,7 @@ def test_table_v3_SHA_DES(aggregator):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -373,6 +382,7 @@ def test_table_v3_SHA_AES(aggregator):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -402,6 +412,7 @@ def test_bulk_table(aggregator):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -437,6 +448,7 @@ def test_forcedtype_metric(aggregator):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -473,6 +485,7 @@ def test_scalar_with_tags(aggregator):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -491,6 +504,7 @@ def test_network_failure(aggregator):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.CRITICAL, tags=common.CHECK_TAGS, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -503,6 +517,7 @@ def test_cast_metrics(aggregator):
     aggregator.assert_metric('snmp.cpuload2', value=0.06)
     aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -518,6 +533,8 @@ def test_profile(aggregator):
         metric_name = "snmp." + metric['name']
         aggregator.assert_metric(metric_name, tags=common_tags, count=1)
     aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)
+
+    common.assert_common_metrics(aggregator)
     aggregator.assert_all_metrics_covered()
 
 
@@ -537,6 +554,8 @@ def test_profile_by_file(aggregator):
         metric_name = "snmp." + metric['name']
         aggregator.assert_metric(metric_name, tags=common_tags, count=1)
     aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)
+
+    common.assert_common_metrics(aggregator)
     aggregator.assert_all_metrics_covered()
 
 
@@ -557,6 +576,8 @@ def test_profile_sys_object(aggregator):
         metric_name = "snmp." + metric['name']
         aggregator.assert_metric(metric_name, tags=common_tags, count=1)
     aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)
+
+    common.assert_common_metrics(aggregator)
     aggregator.assert_all_metrics_covered()
 
 
@@ -594,6 +615,8 @@ def test_profile_sys_object_prefix(aggregator, most_specific_oid, least_specific
         aggregator.assert_metric(metric_name, tags=ignored_profile_tags, count=0)
 
     aggregator.assert_metric('snmp.sysUpTimeInstance', tags=matching_profile_tags, count=1)
+
+    common.assert_common_metrics(aggregator)
     aggregator.assert_all_metrics_covered()
 
 
@@ -615,6 +638,8 @@ def test_profile_sys_object_unknown(aggregator, caplog):
     check.check(instance)
 
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.CRITICAL, tags=common.CHECK_TAGS, at_least=1)
+
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
     # Via network discovery...
@@ -687,6 +712,8 @@ def test_discovery(aggregator):
 
     aggregator.assert_metric('snmp.sysUpTimeInstance')
     aggregator.assert_metric('snmp.discovered_devices_count', tags=['network:{}'.format(network)])
+
+    common.assert_common_metrics(aggregator)
     aggregator.assert_all_metrics_covered()
 
 
@@ -750,6 +777,7 @@ def test_metric_tag_symbol(aggregator):
 
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -771,6 +799,7 @@ def test_metric_tag_oid(aggregator):
 
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -797,6 +826,7 @@ def test_metric_tag_profile_manual(aggregator):
 
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -823,6 +853,7 @@ def test_metric_tag_profile_sysoid(aggregator):
 
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -904,6 +935,7 @@ def test_metric_tag_matching(aggregator):
 
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
 
@@ -924,6 +956,8 @@ def test_timeout(aggregator, caplog):
     aggregator.assert_metric('snmp.ifOutDiscards', count=4)
     aggregator.assert_metric('snmp.ifOutErrors', count=4)
     aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)
+
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()
 
     for record in caplog.records:

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -721,6 +721,41 @@ def test_discovery(aggregator):
     aggregator.assert_all_metrics_covered()
 
 
+@mock.patch("datadog_checks.snmp.snmp.read_persistent_cache")
+def test_discovery_devices_monitored_count(read_mock, aggregator):
+    read_mock.return_value = '["192.168.0.1","192.168.0.2"]'
+
+    host = socket.gethostbyname(common.HOST)
+    network = ipaddress.ip_network(u'{}/29'.format(host), strict=False).with_prefixlen
+    check_tags = [
+        'autodiscovery_subnet:{}'.format(to_native_string(network)),
+    ]
+    instance = {
+        'name': 'snmp_conf',
+        # Make sure the check handles bytes
+        'network_address': to_native_string(network),
+        'port': common.PORT,
+        'community_string': 'public',
+        'retries': 0,
+        'discovery_interval': 0,
+    }
+    init_config = {
+        'profiles': {
+            'profile1': {'definition': {'metrics': common.SUPPORTED_METRIC_TYPES, 'sysobjectid': '1.3.6.1.4.1.8072.*'}}
+        }
+    }
+    check = SnmpCheck('snmp', init_config, [instance])
+    check.check(instance)
+    check._running = False
+
+    aggregator.assert_metric('snmp.discovered_devices_count', tags=['network:{}'.format(network)])
+
+    for device_ip in ['192.168.0.1', '192.168.0.2']:
+        tags = check_tags + ['snmp_device:{}'.format(device_ip)]
+        aggregator.assert_metric('snmp.devices_monitored', metric_type=aggregator.GAUGE, value=1, count=1, tags=tags)
+    aggregator.assert_all_metrics_covered()
+
+
 def test_different_mibs(aggregator):
     metrics = [
         {

--- a/snmp/tests/test_e2e.py
+++ b/snmp/tests/test_e2e.py
@@ -25,4 +25,5 @@ def test_e2e(dd_agent_check):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
 
+    common.assert_common_metrics(aggregator)
     aggregator.all_metrics_asserted()

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -106,6 +106,8 @@ def test_cisco_voice(aggregator):
 
     resources = ["hrSWRunPerfMem", "hrSWRunPerfCPU"]
 
+    common.assert_common_metrics(aggregator, tags)
+
     for resource in resources:
         aggregator.assert_metric('snmp.{}'.format(resource), metric_type=aggregator.GAUGE, tags=tags)
 
@@ -231,6 +233,8 @@ def test_f5(aggregator):
     tags = ['snmp_profile:f5-big-ip', 'snmp_host:f5-big-ip-adc-good-byol-1-vm.c.datadog-integrations-lab.internal']
     tags += common.CHECK_TAGS
 
+    common.assert_common_metrics(aggregator, tags)
+
     for metric in gauges:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
     for metric in counts:
@@ -330,6 +334,9 @@ def test_f5(aggregator):
 def test_router(aggregator):
     run_profile_check('network')
     common_tags = common.CHECK_TAGS + ['snmp_profile:generic-router']
+
+    common.assert_common_metrics(aggregator, common_tags)
+
     for interface in ['eth0', 'eth1']:
         tags = ['interface:{}'.format(interface)] + common_tags
         for metric in IF_COUNTS:
@@ -381,6 +388,9 @@ def test_f5_router(aggregator):
     interfaces = ['1.0', 'mgmt', '/Common/internal', '/Common/http-tunnel', '/Common/socks-tunnel']
     common_tags = ['snmp_profile:router', 'snmp_host:f5-big-ip-adc-good-byol-1-vm.c.datadog-integrations-lab.internal']
     common_tags.extend(common.CHECK_TAGS)
+
+    common.assert_common_metrics(aggregator, common_tags)
+
     for interface in interfaces:
         tags = ['interface:{}'.format(interface)] + common_tags
         for metric in IF_COUNTS:
@@ -408,6 +418,9 @@ def test_cisco_3850(aggregator):
     # We're not covering all interfaces
     interfaces = ["Gi1/0/{}".format(i) for i in range(1, 48)]
     common_tags = common.CHECK_TAGS + ['snmp_host:Cat-3850-4th-Floor.companyname.local', 'snmp_profile:cisco-3850']
+
+    common.assert_common_metrics(aggregator, common_tags)
+
     for interface in interfaces:
         tags = ['interface:{}'.format(interface)] + common_tags
         for metric in IF_COUNTS:
@@ -511,6 +524,9 @@ def test_meraki_cloud_controller(aggregator):
     run_profile_check('meraki-cloud-controller')
 
     common_tags = common.CHECK_TAGS + ['snmp_profile:meraki-cloud-controller', 'snmp_host:dashboard.meraki.com']
+
+    common.assert_common_metrics(aggregator, common_tags)
+
     dev_metrics = ['devStatus', 'devClientCount']
     dev_tags = ['device:Gymnasium', 'product:MR16-HW', 'network:L_NETWORK'] + common_tags
     for metric in dev_metrics:
@@ -544,6 +560,8 @@ def test_idrac(aggregator):
 
     interfaces = ['eth0', 'en1']
     common_tags = common.CHECK_TAGS + ['snmp_profile:idrac']
+
+    common.assert_common_metrics(aggregator, common_tags)
 
     for interface in interfaces:
         tags = ['adapter:{}'.format(interface)] + common_tags
@@ -641,6 +659,8 @@ def test_cisco_nexus(aggregator):
     interfaces = ["GigabitEthernet1/0/{}".format(i) for i in range(1, 9)]
 
     common_tags = common.CHECK_TAGS + ['snmp_host:Nexus-eu1.companyname.managed', 'snmp_profile:cisco-nexus']
+
+    common.assert_common_metrics(aggregator, common_tags)
 
     for interface in interfaces:
         tags = ['interface:{}'.format(interface)] + common_tags
@@ -755,6 +775,8 @@ def test_dell_poweredge(aggregator):
     )
 
     common_tags = common.CHECK_TAGS + ['snmp_profile:dell-poweredge']
+
+    common.assert_common_metrics(aggregator, common_tags)
 
     chassis_indexes = [29, 31]
     for chassis_index in chassis_indexes:
@@ -893,6 +915,8 @@ def test_hp_ilo4(aggregator):
 
     common_tags = common.CHECK_TAGS + ['snmp_profile:hp-ilo4']
 
+    common.assert_common_metrics(aggregator, common_tags)
+
     for metric in status_gauges:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=common_tags, count=1)
 
@@ -941,6 +965,8 @@ def test_proliant(aggregator):
     run_profile_check('hpe-proliant')
 
     common_tags = common.CHECK_TAGS + ['snmp_profile:hpe-proliant']
+
+    common.assert_common_metrics(aggregator, common_tags)
 
     for metric in TCP_COUNTS:
         aggregator.assert_metric(
@@ -1094,6 +1120,8 @@ def test_generic_host_resources(aggregator):
 
     common_tags = common.CHECK_TAGS + ['snmp_profile:generic']
 
+    common.assert_common_metrics(aggregator, common_tags)
+
     sys_metrics = [
         'snmp.hrSystemUptime',
         'snmp.hrSystemNumUsers',
@@ -1118,6 +1146,8 @@ def test_palo_alto(aggregator):
     run_profile_check('pan-common')
 
     common_tags = common.CHECK_TAGS + ['snmp_profile:palo-alto']
+
+    common.assert_common_metrics(aggregator, common_tags)
 
     session = [
         'panSessionUtilization',
@@ -1162,6 +1192,8 @@ def test_cisco_asa_5525(aggregator):
     run_profile_check('cisco_asa_5525')
 
     common_tags = common.CHECK_TAGS + ['snmp_profile:cisco-asa-5525', 'snmp_host:kept']
+
+    common.assert_common_metrics(aggregator, common_tags)
 
     for metric in TCP_COUNTS:
         aggregator.assert_metric(
@@ -1299,6 +1331,8 @@ def test_cisco_csr(aggregator):
 
     common_tags = common.CHECK_TAGS + ['snmp_profile:cisco-csr1000v']
 
+    common.assert_common_metrics(aggregator, common_tags)
+
     tags = ['neighbor:244.12.239.177'] + common_tags
     for metric in PEER_GAUGES:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags)
@@ -1315,6 +1349,8 @@ def test_checkpoint_firewall(aggregator):
     run_profile_check('checkpoint-firewall')
 
     common_tags = common.CHECK_TAGS + ['snmp_profile:checkpoint-firewall']
+
+    common.assert_common_metrics(aggregator, common_tags)
 
     cpu_metrics = [
         'multiProcUserTime',
@@ -1377,6 +1413,8 @@ def test_arista(aggregator):
 
     common_tags = common.CHECK_TAGS + ['snmp_profile:arista']
 
+    common.assert_common_metrics(aggregator, common_tags)
+
     aggregator.assert_metric(
         'snmp.aristaEgressQueuePktsDropped',
         metric_type=aggregator.MONOTONIC_COUNT,
@@ -1415,6 +1453,8 @@ def test_aruba(aggregator):
     run_profile_check('aruba')
 
     common_tags = common.CHECK_TAGS + ['snmp_profile:aruba']
+
+    common.assert_common_metrics(aggregator, common_tags)
 
     for fan in [18, 28]:
         fan_tags = common_tags + ['fan_index:{}'.format(fan)]
@@ -1482,6 +1522,8 @@ def test_chatsworth(aggregator):
         'legacy_pdu_version:1.2.3',
     ]
     common_tags = common.CHECK_TAGS + legacy_global_tags + ['snmp_profile:chatsworth_pdu']
+
+    common.assert_common_metrics(aggregator, common_tags)
 
     # Legacy metrics
     legacy_pdu_tags = common_tags
@@ -1618,6 +1660,9 @@ def test_isilon(aggregator):
         (1232918362, 1),
         (1383990869, 1),
     ]
+
+    common.assert_common_metrics(aggregator, common_tags)
+
     for metric in quota_metrics:
         for qid, qtype in quota_ids_types:
             tags = ['quota_id:{}'.format(qid), 'quota_type:{}'.format(qtype)] + common_tags
@@ -1675,6 +1720,8 @@ def test_apc_ups(aggregator):
         'upsAdvTestDiagnosticsResults',
     ]
 
+    common.assert_common_metrics(aggregator, tags)
+
     for metric in metrics:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
     aggregator.assert_metric(
@@ -1729,6 +1776,8 @@ def test_fortinet_fortigate(aggregator):
     ]
     vd_tags = common_tags + ['virtualdomain_index:4', 'virtualdomain_name:their oxen quaintly']
 
+    common.assert_common_metrics(aggregator, common_tags)
+
     for metric in common_gauge_metrics:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=common_tags, count=1)
 
@@ -1772,6 +1821,8 @@ def test_netapp(aggregator):
     ]
 
     common_tags = common.CHECK_TAGS + profile_tags
+
+    common.assert_common_metrics(aggregator, common_tags)
 
     gauges = [
         'cfInterconnectStatus',

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -488,7 +488,7 @@ def test_cache_loading_tags(thread_mock, read_mock):
     check._start_discovery()
 
     config = check._config.discovered_instances['192.168.0.2']
-    assert set(config.tags) == {'snmp_device:192.168.0.2', 'test:check'}
+    assert set(config.tags) == {'autodiscovery_subnet:192.168.0.0/29', 'test:check', 'snmp_device:192.168.0.2'}
 
 
 def test_failed_to_collect_metrics():

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -469,7 +469,12 @@ def test_discovery_tags():
     discover_instances(check._config, 0, weakref.ref(check))
 
     config = check._config.discovered_instances['192.168.0.2']
-    assert set(config.tags) == {'snmp_device:192.168.0.2', 'test:check', 'snmp_profile:generic-router'}
+    assert set(config.tags) == {
+        'snmp_device:192.168.0.2',
+        'test:check',
+        'snmp_profile:generic-router',
+        'autodiscovery_subnet:192.168.0.0/29',
+    }
 
 
 @mock.patch("datadog_checks.snmp.snmp.read_persistent_cache")


### PR DESCRIPTION
Depend on https://github.com/DataDog/datadog-agent/pull/5790

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Add snmp.devices_monitored metric.
- Add `autodiscovery_subnet` to autodiscovery template

### Motivation
<!-- What inspired you to submit this pull request? -->

The initial purpose of `snmp.devices_monitored` is to be able to count device per subnet since `snmp.discovered_devices_count` metric is not available for instances scheduled by Agent audiscovery.

But `snmp.devices_monitored` metric can also be used for counting the number of devices summed by any available base tag. 


### Additional notes

Since `autodiscovery_subnet` is for now only used for Agent autodiscovery, I think there is no need to add it to `conf.yaml.example`.