### PR TITLE
Continue check execution when only a few vhosts are unhealthy

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -674,7 +674,12 @@ class RabbitMQ(AgentCheck):
             # We need to urlencode the vhost because it can be '/'.
             path = u'aliveness-test/{}'.format(quote_plus(vhost))
             aliveness_url = urljoin(base_url, path)
-            aliveness_response = self._get_data(aliveness_url)
+            aliveness_response = {}
+            try:
+                aliveness_response = self._get_data(aliveness_url)
+            except Exception as e:
+                self.log.debug("Couldn't get aliveness status from vhost, %s: %s", vhost, e)
+
             message = u"Response from aliveness API: {}".format(aliveness_response)
 
             if aliveness_response.get('status') == 'ok':

--- a/rabbitmq/tests/test_unit.py
+++ b/rabbitmq/tests/test_unit.py
@@ -72,12 +72,12 @@ def test__check_aliveness(check, aggregator):
     check._get_data = mock.MagicMock()
 
     # only one vhost should be OK
-    check._get_data.side_effect = [{"status": "ok"}, {}]
-    check._check_aliveness('', vhosts=['foo', 'bar'], custom_tags=[])
+    check._get_data.side_effect = [{"status": "ok"}, {}, {"status": "not_ok"}, Exception("foo")]
+    check._check_aliveness('', vhosts=['foo', 'bar', 'baz', 'xyz'], custom_tags=[])
     sc = aggregator.service_checks('rabbitmq.aliveness')
-    assert len(sc) == 2
+    assert len(sc) == 4
     aggregator.assert_service_check('rabbitmq.aliveness', status=RabbitMQ.OK)
-    aggregator.assert_service_check('rabbitmq.aliveness', status=RabbitMQ.CRITICAL)
+    aggregator.assert_service_check('rabbitmq.aliveness', status=RabbitMQ.CRITICAL, count=3)
 
     # in case of connection errors, this check should stay silent
     check._get_data.side_effect = RabbitMQException


### PR DESCRIPTION
Currently the check for aliveness-test was failing the whole check whenever a single vhost was reporting unhealthy (a non 2xx status code).

This PR fixes that behavior by gracefully handling the error, marking that vhost unhealthy but continuing the rest of the execution.