### PR TITLE
exclude explain plans

### DIFF
--- a/mysql/datadog_checks/mysql/execution_plans.py
+++ b/mysql/datadog_checks/mysql/execution_plans.py
@@ -86,6 +86,7 @@ class ExecutionPlansMixin(object):
               FROM performance_schema.events_statements_history_long
              WHERE sql_text IS NOT NULL
                AND event_name like %s
+               AND digest_text NOT LIKE %s
                AND timer_start > %s
           GROUP BY digest
           ORDER BY timer_wait DESC
@@ -93,7 +94,7 @@ class ExecutionPlansMixin(object):
             """
 
         with closing(db.cursor(pymysql.cursors.DictCursor)) as cursor:
-            cursor.execute(query, ('statement/%', self._checkpoint, self.query_limit))
+            cursor.execute(query, ('statement/%', 'EXPLAIN %', self._checkpoint, self.query_limit))
             rows = cursor.fetchall()
 
         events = []

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -1438,6 +1438,7 @@ class MySql(ExecutionPlansMixin, AgentCheck):
                 `sum_no_index_used` as `no_index_used`,
                 `sum_no_good_index_used` as `no_good_index_used`
             FROM performance_schema.events_statements_summary_by_digest
+            WHERE `digest_text` NOT LIKE 'EXPLAIN %'
             ORDER BY `avg_timer_wait` DESC"""
 
         METRICS = {


### PR DESCRIPTION
We don't need statistics or samples for the explain plans we run against the database.
