### PR TITLE
[Refactor] Add SubNet abstraction

### DIFF
--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -178,6 +178,7 @@ def test_ignore_ip_addresses():
 
     instance = common.generate_instance_config(common.SUPPORTED_METRIC_TYPES)
     string_not_in_a_list = '192.168.1.0/29'
+    instance['network_address'] = '192.168.1.0/29'
     instance['ignored_ip_addresses'] = string_not_in_a_list
     with pytest.raises(ConfigurationError):
         SnmpCheck('snmp', {}, [instance])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Similar to #6953, add a `SubNet` model class to manipulate in the "autodiscovery" parts of the code.

### Motivation
<!-- What inspired you to submit this pull request? -->
Increase readability by manipulating real-world concepts

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Other follow-up refactor ideas:
- Separate out the discovery code even more - eg by more clearly separating device vs subnet config, by extracting out a `DiscoveryManager` that holds a reference to a `SubNet` and the threadpool, etc.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
