### PR TITLE
Remove references to `use_psycopg2`

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -75,9 +75,6 @@ Follow the instructions below to configure this check for an Agent running on a 
      ## The hostname to connect to.
      ## NOTE: Even if the server name is "localhost", the agent connects to
      ## PostgreSQL using TCP/IP, unless you also provide a value for the sock key.
-     ## If `use_psycopg2` is enabled, use the directory containing
-     ## the UNIX socket (ex: `/run/postgresql/`) otherwise, use the full path to
-     ##  the socket file (ex: `/run/postgresql/.s.PGSQL.5433`).
      #
      - host: localhost
 

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -13,8 +13,6 @@ files:
         The hostname to connect to.
         NOTE: Even if the server name is `localhost`, the Agent connects to PostgreSQL using TCP/IP unless you also
         provide a value for the sock key.
-        If `use_psycopg2` is enabled, use the directory containing the UNIX socket (ex: `/run/postgresql/`)
-        otherwise, use the full path to the socket file (ex: `/run/postgresql/.s.PGSQL.5433`).
       value:
         example: localhost
         type: string

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -17,8 +17,6 @@ instances:
     ## The hostname to connect to.
     ## NOTE: Even if the server name is `localhost`, the Agent connects to PostgreSQL using TCP/IP unless you also
     ## provide a value for the sock key.
-    ## If `use_psycopg2` is enabled, use the directory containing the UNIX socket (ex: `/run/postgresql/`)
-    ## otherwise, use the full path to the socket file (ex: `/run/postgresql/.s.PGSQL.5433`).
     #
   - host: localhost
 


### PR DESCRIPTION
### What does this PR do?
Removes references to a deprecated config option when support for `psycopg2` was added https://github.com/DataDog/integrations-core/pull/4096.

### Motivation
Resolves https://github.com/DataDog/integrations-core/issues/6974
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
