### PR TITLE
Document the name argument

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -93,7 +93,7 @@ def display_path_tree(path_tree):
 def create(ctx, name, integration_type, location, non_interactive, quiet, dry_run):
     """
         Create scaffolding for a new integration.
-        
+
         NAME: Use the display name as the integration would appear in documentation.
     """
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -94,7 +94,7 @@ def create(ctx, name, integration_type, location, non_interactive, quiet, dry_ru
     """
         Create scaffolding for a new integration.
 
-        NAME: Use the display name as the integration would appear in documentation.
+        NAME: The display name of the integration that will appear in documentation.
     """
 
     if name.islower():

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -91,7 +91,11 @@ def display_path_tree(path_tree):
 @click.option('--dry-run', '-n', is_flag=True, help='Only show what would be created')
 @click.pass_context
 def create(ctx, name, integration_type, location, non_interactive, quiet, dry_run):
-    """Create scaffolding for a new integration."""
+    """
+        Create scaffolding for a new integration.
+        
+        NAME: use the display name as the integration would appear in documentation.
+    """
 
     if name.islower():
         echo_warning('Make sure to use the display name. e.g. MapR, Ambari, IBM MQ, vSphere, ...')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -94,7 +94,7 @@ def create(ctx, name, integration_type, location, non_interactive, quiet, dry_ru
     """
         Create scaffolding for a new integration.
         
-        NAME: use the display name as the integration would appear in documentation.
+        NAME: Use the display name as the integration would appear in documentation.
     """
 
     if name.islower():


### PR DESCRIPTION
### What does this PR do?
This PR specifies that the NAME argument for `ddev create` should be using the display name. 
The command only prints a warning after running the command.

### Motivation
I've noticed a few contrib PRs with the naming issue which requires updating many fields. The `display_name` field in manifest.json cannot be updated after syncing, this addition prevents uncaught errors for the future.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
