### PR TITLE
Clean up of unused extends in meraki cloud profile

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/meraki-cloud-controller.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/meraki-cloud-controller.yaml
@@ -3,11 +3,6 @@
 # We don't extend from base for now, as sysName is useless for meraki.
 extends:
   - _base.yaml
-  - _generic-router-bgp4.yaml
-  - _generic-router-udp.yaml
-  - _generic-router-tcp.yaml
-  - _generic-router-ospf.yaml
-  - _generic-router-ip.yaml
   - _generic-router-if.yaml
   
 sysobjectid: 1.3.6.1.4.1.29671.*


### PR DESCRIPTION
### What does this PR do?
Clean up of unused extends in the meraki-cloud-controller config as suggested in this other [PR](https://github.com/DataDog/integrations-core/pull/6905).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
