### PR TITLE
Parse batch-index read latency metrics

### DIFF
--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -279,6 +279,10 @@ class AerospikeCheck(AgentCheck):
             if ns_metric_name_match:
                 ns = ns_metric_name_match.groups()[0]
                 metric_name = ns_metric_name_match.groups()[1]
+            elif line.startswith("batch-index"):
+                # https://www.aerospike.com/docs/operations/monitor/latency/#batch-index
+                ns = None
+                metric_name = "batch-index"
             else:
                 self.log.warning("Invalid data. Namespace and/or metric name not found in line: `%s`", line)
                 # Since the data come by pair and the order matters it's safer to return right away than submitting
@@ -303,7 +307,7 @@ class AerospikeCheck(AgentCheck):
         for ns, v in iteritems(ns_latencies):
             metric_names = v.get("metric_names", [])
             metric_values = v.get("metric_values", [])
-            namespace_tags = ['namespace:{}'.format(ns)]
+            namespace_tags = ['namespace:{}'.format(ns)] if ns else []
             namespace_tags.extend(self._tags)
             if len(metric_names) == len(metric_values):
                 for i in range(len(metric_names)):

--- a/aerospike/metadata.csv
+++ b/aerospike/metadata.csv
@@ -587,6 +587,10 @@ aerospike.namespace.latency.write_ops_sec,gauge,,transaction,,The write operatio
 aerospike.namespace.latency.write_over_1ms,gauge,,transaction,,The write latency over 1ms.,-1,aerospike,write latency 1ms
 aerospike.namespace.latency.write_over_64ms,gauge,,transaction,,The write latency over 64ms.,-1,aerospike,write latency 64ms
 aerospike.namespace.latency.write_over_8ms,gauge,,transaction,,The write latency over 8ms.,-1,aerospike,write latency 8ms
+aerospike.namespace.latency.batch_index_ops_sec,gauge,,transaction,,The batch read operations per sec.,-1,aerospike,batch read ops sec
+aerospike.namespace.latency.batch_index_over_1ms,gauge,,transaction,,The batch read latency over 1ms.,-1,aerospike,batch read latency 1ms
+aerospike.namespace.latency.batch_index_over_64ms,gauge,,transaction,,The batch read latency over 64ms.,-1,aerospike,batch read latency 64ms
+aerospike.namespace.latency.batch_index_over_8ms,gauge,,transaction,,The batch read latency over 8ms.,-1,aerospike,batch read latency 8ms
 aerospike.namespace.migrate_order,gauge,,,,The number between 1 and 10 which determines the order namespaces are to be processed when migrating.,0,aerospike,
 aerospike.namespace.geo2dsphere_within.strict,gauge,,,,"An additional sanity check from Aerospike to validate whether the points returned by S2 falls under the user's query region. When set to false, Aerospike does not do this additional check and send the results as it is.",0,aerospike,
 aerospike.namespace.geo2dsphere_within.earth_radius_meters,gauge,,,,"Earth's radius in meters, since the workspace here is the complete earth.",0,aerospike,

--- a/aerospike/tests/common.py
+++ b/aerospike/tests/common.py
@@ -45,6 +45,10 @@ LAZY_METRICS = [
     'aerospike.namespace.latency.read_over_8ms',
     'aerospike.namespace.latency.read_over_1ms',
     'aerospike.namespace.latency.read_ops_sec',
+    'aerospike.namespace.latency.batch_index_over_64ms',
+    'aerospike.namespace.latency.batch_index_over_8ms',
+    'aerospike.namespace.latency.batch_index_over_1ms',
+    'aerospike.namespace.latency.batch_index_ops_sec',
 ]
 
 INSTANCE = {

--- a/aerospike/tests/conftest.py
+++ b/aerospike/tests/conftest.py
@@ -40,8 +40,12 @@ def init_db():
     }
     client.put(key, bins)
 
-    for _ in range(10):
+    batch_keys = []
+    for i in range(10):
         client.get(key)
+        batch_key = ('test', 'demo', 'key' + str(i))
+        batch_keys.append(batch_key)
+    client.get_many(batch_keys)
 
     client.close()
 

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -57,6 +57,8 @@ def test_collect_latency_parser(aggregator):
     check.get_info = mock.MagicMock(
         return_value=[
             'error-no-data-yet-or-back-too-small',
+            'batch-index:11:53:47-GMT,ops/sec,>1ms,>8ms,>64ms',
+            '11:53:57,0.0,0.00,0.00,0.00',
             '{ns-1}-read:11:53:47-GMT,ops/sec,>1ms,>8ms,>64ms',
             '11:53:57,0.0,0.00,0.00,0.00',
             '{ns-1}-write:11:53:47-GMT,ops/sec,>1ms,>8ms,>64ms',
@@ -73,7 +75,10 @@ def test_collect_latency_parser(aggregator):
 
     for ns in ['ns-1', 'ns-2_foo']:
         for metric in common.LAZY_METRICS:
-            aggregator.assert_metric(metric, tags=['namespace:{}'.format(ns), 'tag:value'])
+            if "batch_index" in metric:
+                aggregator.assert_metric(metric, tags=['tag:value'])
+            else:
+                aggregator.assert_metric(metric, tags=['namespace:{}'.format(ns), 'tag:value'])
 
     aggregator.assert_all_metrics_covered()
 


### PR DESCRIPTION
### What does this PR do?
Parse `batch-index` which is not namespace specific instead of below and not send any latency metrics at all.

```
 Invalid data. Namespace and/or metric name not found in line: `batch-index:06:10:32-GMT,ops/sec,>1ms,>8ms,>64ms`
```

### Motivation
- AGENT-1673

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
