### PR TITLE
Refactor to make encoding more consistent

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -4,7 +4,7 @@
 
 from six import iteritems
 
-from datadog_checks.base import AgentCheck, ensure_bytes, ensure_unicode
+from datadog_checks.base import AgentCheck, to_native_string
 
 from .. import metrics
 
@@ -45,7 +45,7 @@ class ChannelMetricCollector(object):
         self.gauge = gauge
 
     def get_pcf_channel_metrics(self, queue_manager):
-        args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: ensure_bytes('*')}
+        args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ensure_bytes('*')}
         try:
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_CHANNEL(args)
@@ -57,7 +57,7 @@ class ChannelMetricCollector(object):
             self.gauge(mname, channels, tags=self.config.tags_no_channel)
 
             for channel_info in response:
-                channel_name = ensure_unicode(channel_info[pymqi.CMQCFC.MQCACH_CHANNEL_NAME]).strip()
+                channel_name = to_native_string(channel_info[pymqi.CMQCFC.MQCACH_CHANNEL_NAME]).strip()
                 channel_tags = self.config.tags_no_channel + ["channel:{}".format(channel_name)]
 
                 self._submit_metrics_from_properties(channel_info, metrics.channel_metrics(), channel_tags)
@@ -83,7 +83,7 @@ class ChannelMetricCollector(object):
         channels_to_skip = channels_to_skip or []
         search_channel_tags = tags + ["channel:{}".format(search_channel_name)]
         try:
-            args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: ensure_bytes(search_channel_name)}
+            args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ensure_bytes(search_channel_name)}
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(args)
             self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.OK, search_channel_tags)
@@ -95,7 +95,7 @@ class ChannelMetricCollector(object):
                 self.log.warning("Error getting CHANNEL status for channel %s: %s", search_channel_name, e)
         else:
             for channel_info in response:
-                channel_name = ensure_unicode(channel_info[pymqi.CMQCFC.MQCACH_CHANNEL_NAME]).strip()
+                channel_name = to_native_string(channel_info[pymqi.CMQCFC.MQCACH_CHANNEL_NAME]).strip()
                 if channel_name in channels_to_skip:
                     continue
                 channel_tags = tags + ["channel:{}".format(channel_name)]

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
@@ -4,7 +4,7 @@
 
 from six import iteritems
 
-from datadog_checks.base import AgentCheck, ensure_bytes, ensure_unicode
+from datadog_checks.base import AgentCheck, to_native_string
 from datadog_checks.ibm_mq.metrics import GAUGE
 
 from .. import metrics
@@ -80,7 +80,7 @@ class QueueMetricCollector(object):
         queues = []
 
         for queue_type in SUPPORTED_QUEUE_TYPES:
-            args = {pymqi.CMQC.MQCA_Q_NAME: ensure_bytes(mq_pattern_filter), pymqi.CMQC.MQIA_Q_TYPE: queue_type}
+            args = {pymqi.CMQC.MQCA_Q_NAME: pymqi.ensure_bytes(mq_pattern_filter), pymqi.CMQC.MQIA_Q_TYPE: queue_type}
             try:
                 pcf = pymqi.PCFExecute(queue_manager)
                 response = pcf.MQCMD_INQUIRE_Q(args)
@@ -89,7 +89,7 @@ class QueueMetricCollector(object):
             else:
                 for queue_info in response:
                     queue = queue_info[pymqi.CMQC.MQCA_Q_NAME]
-                    queues.append(ensure_unicode(queue).strip())
+                    queues.append(to_native_string(queue).strip())
 
         return queues
 
@@ -112,7 +112,7 @@ class QueueMetricCollector(object):
         Grab stats from queues
         """
         try:
-            args = {pymqi.CMQC.MQCA_Q_NAME: ensure_bytes(queue_name), pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_ALL}
+            args = {pymqi.CMQC.MQCA_Q_NAME: pymqi.ensure_bytes(queue_name), pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_ALL}
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_INQUIRE_Q(args)
         except pymqi.MQMIError as e:
@@ -141,7 +141,7 @@ class QueueMetricCollector(object):
     def get_pcf_queue_status_metrics(self, queue_manager, queue_name, tags):
         try:
             args = {
-                pymqi.CMQC.MQCA_Q_NAME: ensure_bytes(queue_name),
+                pymqi.CMQC.MQCA_Q_NAME: pymqi.ensure_bytes(queue_name),
                 pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_ALL,
                 pymqi.CMQCFC.MQIACF_Q_STATUS_ATTRS: pymqi.CMQCFC.MQIACF_ALL,
             }
@@ -167,7 +167,7 @@ class QueueMetricCollector(object):
 
     def get_pcf_queue_reset_metrics(self, queue_manager, queue_name, tags):
         try:
-            args = {pymqi.CMQC.MQCA_Q_NAME: ensure_bytes(queue_name)}
+            args = {pymqi.CMQC.MQCA_Q_NAME: pymqi.ensure_bytes(queue_name)}
             pcf = pymqi.PCFExecute(queue_manager)
             response = pcf.MQCMD_RESET_Q_STATS(args)
         except pymqi.MQMIError as e:


### PR DESCRIPTION
### What does this PR do?

1. Use `pymqi.ensure_bytes` for better consistency with pymqi own internal use of `pymqi.ensure_bytes`.

Details: 

https://github.com/DataDog/integrations-core/pull/6913#discussion_r446124869

2. `to_native_string` is more appropriate than `ensure_unicode`.

Currently, in Python2 the code might actually break if there is a unicode in the channel name (unlikely though):

This code fails:
```
python2 -c 'tag = "abc: {}".format(u"12\xe1")'
```

### Motivation

- Consistency
- Use native strings in majority of the code, and convert appropriately at the edge e.g. when interfacing with pymqi that require bytes.