### PR TITLE
Deprecate all_metrics_asserted

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -14,6 +14,7 @@ from .similar import build_similar_elements_msg
 
 log = logging.getLogger(__name__)
 
+
 def normalize_tags(tags, sort=False):
     # The base class ensures the Agent receives bytes in PY2 and unicode in PY3.
     # This function makes sure strings are compared with the same type.

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
+import logging
 from collections import OrderedDict, defaultdict
 
 from six import iteritems
@@ -11,6 +12,7 @@ from ..utils.common import ensure_unicode, to_native_string
 from .common import HistogramBucketStub, MetricStub, ServiceCheckStub
 from .similar import build_similar_elements_msg
 
+log = logging.getLogger(__name__)
 
 def normalize_tags(tags, sort=False):
     # The base class ensures the Agent receives bytes in PY2 and unicode in PY3.
@@ -419,6 +421,10 @@ class AggregatorStub(object):
         self._events = []
 
     def all_metrics_asserted(self):
+        """
+        Deprecated, use `assert_all_metrics_covered` instead.
+        """
+        log.warning("`AggregatorStub.all_metrics_asserted` is deprecated. Used `assert_all_metrics_covered` instead.")
         assert self.metrics_asserted_pct >= 100.0
 
     def not_asserted(self):

--- a/kong/tests/test_integration_e2e.py
+++ b/kong/tests/test_integration_e2e.py
@@ -57,7 +57,7 @@ def _assert_check(aggregator):
             'kong.can_connect', status=Kong.OK, tags=['kong_host:localhost', 'kong_port:8001'] + expected_tags, count=1
         )
 
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 @pytest.mark.usefixtures('dd_environment')
@@ -68,4 +68,4 @@ def test_connection_failure(aggregator, check):
         'kong.can_connect', status=Kong.CRITICAL, tags=['kong_host:localhost', 'kong_port:1111'], count=1
     )
 
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()

--- a/php_fpm/tests/test_php_fpm.py
+++ b/php_fpm/tests/test_php_fpm.py
@@ -15,7 +15,7 @@ def test_bad_ping_reply(check, instance, aggregator, ping_url_tag):
     check.check(instance)
 
     aggregator.assert_service_check('php_fpm.can_ping', status=check.CRITICAL, tags=expected_tags)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_status(check, instance, aggregator, ping_url_tag):

--- a/php_fpm/tests/test_unit.py
+++ b/php_fpm/tests/test_unit.py
@@ -30,7 +30,7 @@ def test_bad_ping(aggregator):
     aggregator.assert_service_check(
         'php_fpm.can_ping', status=check.CRITICAL, tags=['ping_url:http://foo:9001/ping', 'some_tag']
     )
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_should_not_retry(check, instance):

--- a/riak/tests/test_e2e.py
+++ b/riak/tests/test_e2e.py
@@ -23,4 +23,4 @@ def test_check(dd_agent_check, instance):
     for gauge in common.GAUGE_OTHER:
         aggregator.assert_metric(gauge, count=1)
 
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()

--- a/riak/tests/test_riak.py
+++ b/riak/tests/test_riak.py
@@ -26,7 +26,7 @@ def test_check(aggregator, check, instance):
     for gauge in common.GAUGE_OTHER:
         aggregator.assert_metric(gauge, count=1)
 
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 @pytest.mark.usefixtures('dd_environment')

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -63,7 +63,7 @@ def test_type_support(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_transient_error(aggregator):
@@ -103,7 +103,7 @@ def test_snmpget(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_custom_mib(aggregator):
@@ -141,7 +141,7 @@ def test_scalar(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_enforce_constraint(aggregator):
@@ -176,7 +176,7 @@ def test_unenforce_constraint(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_table(aggregator):
@@ -203,7 +203,7 @@ def test_table(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_resolved_table(aggregator):
@@ -225,7 +225,7 @@ def test_resolved_table(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_table_v3_MD5_DES(aggregator):
@@ -265,7 +265,7 @@ def test_table_v3_MD5_DES(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_table_v3_MD5_AES(aggregator):
@@ -305,7 +305,7 @@ def test_table_v3_MD5_AES(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_table_v3_SHA_DES(aggregator):
@@ -344,7 +344,7 @@ def test_table_v3_SHA_DES(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_table_v3_SHA_AES(aggregator):
@@ -383,7 +383,7 @@ def test_table_v3_SHA_AES(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_bulk_table(aggregator):
@@ -413,7 +413,7 @@ def test_bulk_table(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_invalid_metric(aggregator):
@@ -449,7 +449,7 @@ def test_forcedtype_metric(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_invalid_forcedtype_metric(aggregator):
@@ -486,7 +486,7 @@ def test_scalar_with_tags(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_network_failure(aggregator):
@@ -505,7 +505,7 @@ def test_network_failure(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.CRITICAL, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_cast_metrics(aggregator):
@@ -518,7 +518,7 @@ def test_cast_metrics(aggregator):
     aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_profile(aggregator):
@@ -640,7 +640,7 @@ def test_profile_sys_object_unknown(aggregator, caplog):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.CRITICAL, tags=common.CHECK_TAGS, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
     # Via network discovery...
 
@@ -817,7 +817,7 @@ def test_metric_tag_symbol(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_metric_tag_oid(aggregator):
@@ -839,7 +839,7 @@ def test_metric_tag_oid(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_metric_tag_profile_manual(aggregator):
@@ -866,7 +866,7 @@ def test_metric_tag_profile_manual(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_metric_tag_profile_sysoid(aggregator):
@@ -893,7 +893,7 @@ def test_metric_tag_profile_sysoid(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_metric_tags_misconfiguration():
@@ -975,7 +975,7 @@ def test_metric_tag_matching(aggregator):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
 
 def test_timeout(aggregator, caplog):
@@ -997,7 +997,7 @@ def test_timeout(aggregator, caplog):
     aggregator.assert_metric('snmp.sysUpTimeInstance', count=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()
 
     for record in caplog.records:
         if "No SNMP response received before timeout" in record.message:

--- a/snmp/tests/test_e2e.py
+++ b/snmp/tests/test_e2e.py
@@ -26,4 +26,4 @@ def test_e2e(dd_agent_check):
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=tags, at_least=1)
 
     common.assert_common_metrics(aggregator)
-    aggregator.all_metrics_asserted()
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

Deprecate all_metrics_asserted

### Motivation

`all_metrics_asserted` is a duplicate of `assert_all_metrics_covered`
