### PR TITLE
Update docstring to use trello subcommand 

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -164,23 +164,23 @@ def testable(ctx: click.Context, base_ref: str, target_ref: str, milestone: str,
 
     * Create cards for changes between a previous Agent release and `master` (useful when preparing an initial RC):
 
-        `$ ddev release testable 7.16.1 origin/master`
+        `$ ddev release trello testable 7.16.1 origin/master`
 
     * Create cards for changes between a previous RC and `master` (useful when preparing a new RC, and a separate
     release branch was not created yet):
 
-        `$ ddev release testable 7.17.0-rc.2 origin/master`
+        `$ ddev release trello testable 7.17.0-rc.2 origin/master`
 
     * Create cards for changes between a previous RC and a release branch (useful to only review changes in a
     release branch that has diverged from `master`):
 
-        `$ ddev release testable 7.17.0-rc.4 7.17.x`
+        `$ ddev release trello testable 7.17.0-rc.4 7.17.x`
 
     * Create cards for changes between two arbitrary tags, e.g. between RCs:
 
-        `$ ddev release testable 7.17.0-rc.4 7.17.0-rc.5`
+        `$ ddev release trello testable 7.17.0-rc.4 7.17.0-rc.5`
 
-    TIP: run with `ddev -x release testable` to force the use of the current directory.
+    TIP: run with `ddev -x release trello testable` to force the use of the current directory.
     To avoid GitHub's public API rate limits, you need to set
     `github.user`/`github.token` in your config file or use the
     `DD_GITHUB_USER`/`DD_GITHUB_TOKEN` environment variables.


### PR DESCRIPTION
### What does this PR do?

Update docstring of release command to use trello subcommand 

### Motivation
The command is now: ddev release trello testable

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
