### PR TITLE
Don't document class constants

### DIFF
--- a/docs/developer/base/prometheus.md
+++ b/docs/developer/base/prometheus.md
@@ -14,6 +14,11 @@ All functionality is exposed by the `OpenMetricsBaseCheck` and `OpenMetricsScrap
 ::: datadog_checks.base.checks.openmetrics.OpenMetricsBaseCheck
     rendering:
       heading_level: 4
+    selection:
+      members:
+        - __init__
+        - check
+        - get_scraper_config
 
 ::: datadog_checks.base.checks.openmetrics.mixins.OpenMetricsScraperMixin
     rendering:


### PR DESCRIPTION
### What does this PR do?
Explicitly list relevant functions so we don't autodocument the class constants that are listed.

### Motivation
Brought up during QA, the fields that are autodocumented are not helpful as they do not have docstrings.

### Additional Notes
Before: 
<img width="744" alt="Screen Shot 2020-06-29 at 4 59 58 PM" src="https://user-images.githubusercontent.com/15065007/86055809-5a06a880-ba2a-11ea-929c-3e26644c7076.png">


After: 
<img width="761" alt="Screen Shot 2020-06-29 at 4 59 42 PM" src="https://user-images.githubusercontent.com/15065007/86055688-2cb9fa80-ba2a-11ea-9cee-6880cb0577e2.png">

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
