### PR TITLE
Sync example config with JMX template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
@@ -121,17 +121,17 @@ instances:
     #
     # rmi_registry_ssl: false
 
-    ## @param rmi_connection_timeout - number - optional - default: 30
-    ## The connection timeout, in seconds, when connecting to a remote JVM.
+    ## @param rmi_connection_timeout - number - optional - default: 20000
+    ## The connection timeout, in milliseconds, when connecting to a remote JVM.
     #
-    # rmi_connection_timeout: 30
+    # rmi_connection_timeout: 20000
 
-    ## @param rmi_client_timeout - number - optional - default: 30
+    ## @param rmi_client_timeout - number - optional - default: 15000
     ## The timeout to consider a remote connection, already successfully established, as lost.
-    ## If a connected remote JVM does not reply after `rmi_client_timeout` seconds jmxfetch
+    ## If a connected remote JVM does not reply after `rmi_client_timeout` milliseconds jmxfetch
     ## will give up on that connection and retry.
     #
-    # rmi_client_timeout: 30
+    # rmi_client_timeout: 15000
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.


### PR DESCRIPTION
### What does this PR do?
Sync the `conf.yaml.example` file in the JMX integration template

### Motivation
https://github.com/DataDog/integrations-core/pull/6864 updated the jmx spec but not the jmx config file template used for `ddev create -t jmx stuff`.
```
$ ddev create -t jmx stuff
$ ddev validate config stuff
stuff:
    File `conf.yaml.example` needs to be synced

Files with errors: 1
Files valid: 1
```

### Additional Notes
Discovered while QAing #6676 
We probably want to automate this in the futur

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
