### PR TITLE
Fix httplib2 version in changelog

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ## 11.9.0 / 2020-05-20
 
-* [Added] Upgrade httplib2 to 0.18.0. See [#6702](https://github.com/DataDog/integrations-core/pull/6702).
+* [Added] Upgrade httplib2 to 0.18.1. See [#6702](https://github.com/DataDog/integrations-core/pull/6702).
 * [Fixed] Fix time utilities. See [#6692](https://github.com/DataDog/integrations-core/pull/6692).
 
 ## 11.8.0 / 2020-05-17

--- a/riak/CHANGELOG.md
+++ b/riak/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.9.0 / 2020-05-20
 
-* [Added] Upgrade httplib2 to 0.18.0. See [#6702](https://github.com/DataDog/integrations-core/pull/6702).
+* [Added] Upgrade httplib2 to 0.18.1. See [#6702](https://github.com/DataDog/integrations-core/pull/6702).
 
 ## 1.8.0 / 2020-05-17
 


### PR DESCRIPTION
### What does this PR do?
Fix changelog httplib2 version `0.18.0` to `0.18.1`
See #6702  

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
