### PR TITLE
Fix wrong indentation of `table` key in column metric tags

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/_cisco-generic.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_cisco-generic.yaml
@@ -212,12 +212,12 @@ metrics:
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.9.1.10
           name: rttMonCtrlOperState
-          table: rttMonCtrlOperTable
+        table: rttMonCtrlOperTable
         tag: rtt_state
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.1.1.4
           name: rttMonCtrlAdminRttType
-          table: rttMonCtrlAdminTable
+        table: rttMonCtrlAdminTable
         tag: rtt_type
       - index: 1
         tag: rtt_index
@@ -237,7 +237,7 @@ metrics:
       - column:
           OID: 1.3.6.1.4.1.9.9.42.1.2.1.1.4
           name: rttMonCtrlAdminRttType
-          table: rttMonCtrlAdminTable
+        table: rttMonCtrlAdminTable
         tag: rtt_type
       - index: 1
         tag: rtt_index

--- a/snmp/datadog_checks/snmp/data/profiles/_cisco-voice.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_cisco-voice.yaml
@@ -14,7 +14,7 @@ metrics:
       - column:
           name: hrSWRunIndex
           OID: 1.3.6.1.2.1.25.4.2.1.1
-          table: hrSWRunTable
+        table: hrSWRunTable
         tag: run_index
   - MIB: HOST-RESOURCES-MIB
     table:
@@ -27,7 +27,7 @@ metrics:
       - column:
           name: hrSWRunIndex
           OID: 1.3.6.1.2.1.25.4.2.1.1
-          table: hrSWRunTable
+        table: hrSWRunTable
         tag: run_index
   - MIB: CISCO-CVP-MIB
     table:
@@ -50,7 +50,7 @@ metrics:
       - column:
           name: ccvpServiceIndex
           OID: 1.3.6.1.4.1.9.9.590.1.5.1.1.1
-          table: ccvpServiceTable
+        table: ccvpServiceTable
         tag: service_index
 
   - MIB: CISCO-CVP-MIB

--- a/snmp/datadog_checks/snmp/data/profiles/_generic-router-if.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-router-if.yaml
@@ -19,7 +19,7 @@ metrics:
   - column:
       OID: 1.3.6.1.2.1.31.1.1.1.1
       name: ifName
-      table: ifXTable
+    table: ifXTable
     tag: interface
 - MIB: IF-MIB
   table:
@@ -36,7 +36,7 @@ metrics:
   - column:
       OID: 1.3.6.1.2.1.31.1.1.1.1
       name: ifName
-      table: ifXTable
+    table: ifXTable
     tag: interface
 - MIB: IF-MIB
   table:

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -417,7 +417,16 @@ def _parse_table_metric_tag(mib, parsed_table, metric_tag):
 
 def _parse_column_metric_tag(mib, parsed_table, metric_tag):
     # type: (str, ParsedSymbol, ColumnTableMetricTag) -> ParsedColumnMetricTag
-    parsed_column = _parse_symbol(mib, metric_tag['column'])
+    column = metric_tag['column']
+
+    if isinstance(column, dict) and 'table' in column:
+        # Prevent a common error due to bad indentation...
+        raise ConfigurationError(
+            'found unexpected "table" key in column {} '
+            '("table" should be set on the `metric_tag` - this is probably an indentation issue)'.format(column)
+        )
+
+    parsed_column = _parse_symbol(mib, column)
 
     batches = {TableBatchKey(mib, table=parsed_table.name): TableBatch(parsed_table.oid, oids=[parsed_column.oid])}
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix mis-indented `table` keys in profiles.

Also adds an extra validation step in the profile parsing logic to prevent this from happening again.

### Motivation
<!-- What inspired you to submit this pull request? -->
QAing https://github.com/DataDog/integrations-core/pull/6765 led me to see that it introduced a few `column` metric tags where the `table` key was misplaced (on the `column` instead of the `metric_tag`).

This also fixes the collection of the related metric tags, since before the check would have tried to get them from the same table as the symbols (and fail to find them).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
