### PR TITLE
Fix tag names

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/cisco-asa-5525.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/cisco-asa-5525.yaml
@@ -19,9 +19,9 @@ metrics:
         name: cfwConnectionStatValue
     metric_tags:
       - index: 1
-        tag: stat_type
-      - index: 2
         tag: service_type
+      - index: 2
+        tag: stat_type
 
   - MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
     symbol:

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -1236,7 +1236,7 @@ def test_cisco_asa_5525(aggregator):
     sensor_tags = ['sensor_id:31', 'sensor_type:9'] + common_tags
     aggregator.assert_metric('snmp.entPhySensorValue', metric_type=aggregator.GAUGE, tags=sensor_tags, count=1)
 
-    stat_tags = [(2, 20), (5, 5)]
+    stat_tags = [(20, 2), (5, 5)]
     for (svc, stat) in stat_tags:
         aggregator.assert_metric(
             'snmp.cfwConnectionStatValue',


### PR DESCRIPTION
### What does this PR do?
The tag names were inverted in #6897 according to the doc http://www.circitor.fr/Mibs/Mib/C/CISCO-FIREWALL-MIB.mib
`INDEX { cfwConnectionStatService, cfwConnectionStatType }`

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
