### PR TITLE
Fix autodiscovery_subnet var in auto_conf.yaml

### DIFF
--- a/snmp/datadog_checks/snmp/data/auto_conf.yaml
+++ b/snmp/datadog_checks/snmp/data/auto_conf.yaml
@@ -82,4 +82,4 @@ instances:
     tags:
       # The autodiscovery subnet the device is part of.
       # Used by Agent autodiscovery to pass subnet name.
-      - "autodiscovery_subnet:%%autodiscovery_subnet%%"
+      - "autodiscovery_subnet:%%extra_autodiscovery_subnet%%"


### PR DESCRIPTION
The var `autodiscovery_subnet` should be `extra_autodiscovery_subnet`

But introduced here: https://github.com/DataDog/integrations-core/pull/6941