### PR TITLE
Add dependencies to setup.py

### DIFF
--- a/datadog_checks_downloader/setup.py
+++ b/datadog_checks_downloader/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
     packages=['datadog_checks.downloader'],
     # Run-time dependencies
-    install_requires=get_dependencies(),
+    extras_require={'deps': get_dependencies()},
     # NOTE: Copy over TUF directories, and root metadata.
     package_data={
         'datadog_checks.downloader': [

--- a/datadog_checks_downloader/setup.py
+++ b/datadog_checks_downloader/setup.py
@@ -51,6 +51,8 @@ setup(
         'Programming Language :: Python :: 3.8',
     ],
     packages=['datadog_checks.downloader'],
+    # Run-time dependencies
+    install_requires=get_dependencies(),
     # NOTE: Copy over TUF directories, and root metadata.
     package_data={
         'datadog_checks.downloader': [


### PR DESCRIPTION
### What does this PR do?
Adds `install_requires` to setup.py

### Motivation
Installed the package locally, but didn't get the associated dependencies along with it.
