### PR TITLE
Add `Inbox` column in ddev release trello status

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/status.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/status.py
@@ -28,8 +28,8 @@ def status(ctx: click.Context, as_json: bool, clipboard: bool) -> None:
 
     counts = trello.count_by_columns()
 
-    row_format = '{:15} | {:<8} | {:<8} | {:<8} | {:<8} | {}'
-    headers = ('Total', 'In Progress', 'Issues Found', 'Awaiting Build', 'Done')
+    row_format = '{:15} | {:<8} | {:<8} | {:<8} | {:<8} | {:<8} | {}'
+    headers = ('Total', 'Inbox', 'In Progress', 'Issues Found', 'Awaiting Build', 'Done')
 
     if as_json:
         print(json.dumps(counts, indent=2))
@@ -38,8 +38,8 @@ def status(ctx: click.Context, as_json: bool, clipboard: bool) -> None:
     totals = dict(zip(headers, [0] * len(headers)))
 
     output = []
-    output.append(row_format.format('', '', 'In', 'Issues', 'Awaiting', ''))
-    output.append(row_format.format('Team', 'Total', 'Progress', 'Found', 'Build', 'Done'))
+    output.append(row_format.format('', '', '', 'In', 'Issues', 'Awaiting', ''))
+    output.append(row_format.format('Team', 'Total', 'Inbox', 'Progress', 'Found', 'Build', 'Done'))
     output.append(row_format.format('--', *['--' for _ in headers]))
 
     for team, data in counts.items():

--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -111,7 +111,7 @@ class TrelloClient:
                 if label['name'] in self.label_map:
                     team = label['name']
                     id_list = card['idList']
-                    
+
                     if id_list in map_team_list:
                         counts[team]['Total'] += 1
                         counts[team]['Inbox'] += 1

--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -48,7 +48,7 @@ class TrelloClient:
             'Networks': '5e79109821620a60014fc016',
             'Processes': '5e7910789f92a918152b700d',
             'Trace': '5c050640ecb34f0915ec589a',
-            'Tools and Libraries': '5ab12740841642c2a8829053',
+            'Tools and Libs': '5ab12740841642c2a8829053',
         }
         self.progress_columns = {
             '55d1fe4cd3192ab85fa0f7ea': 'In Progress',  # INPROGRESS
@@ -100,7 +100,7 @@ class TrelloClient:
         map_team_list = {v: k for k, v in self.team_list_map.items()}
 
         counts = {
-            k: {'Total': 0, 'In Progress': 0, 'Issues Found': 0, 'Awaiting Build': 0, 'Done': 0}
+            k: {'Total': 0, 'Inbox': 0, 'In Progress': 0, 'Issues Found': 0, 'Awaiting Build': 0, 'Done': 0}
             for k in map_label.values()
         }
 
@@ -110,13 +110,13 @@ class TrelloClient:
             for label in labels:
                 if label['name'] in self.label_map:
                     team = label['name']
-                    counts[team]['Total'] += 1
                     id_list = card['idList']
+                    
                     if id_list in map_team_list:
-                        # Team's Inbox
-                        # NOTE: This is "In Progress" but not technically started, yet
-                        counts[team]['In Progress'] += 1
+                        counts[team]['Total'] += 1
+                        counts[team]['Inbox'] += 1
                     elif id_list in self.progress_columns:
+                        counts[team]['Total'] += 1
                         counts[team][self.progress_columns[id_list]] += 1
 
         return counts


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add `Inbox` column for command `ddev release trello status`.
Total count does not count cards in a column not available in the report.
Replace `Tools and Libraries` by `Tools and Libs` for a better alignment.

Example of output:

```
Trello Status Report:

                |          |          | In       | Issues   | Awaiting | 
Team            | Total    | Inbox    | Progress | Found    | Build    | Done
--              | --       | --       | --       | --       | --       | --
Containers      | 46       | 40       | 1        | 0        | 0        | 5
Container App   | 1        | 1        | 0        | 0        | 0        | 0
Core            | 41       | 17       | 5        | 0        | 1        | 18
Integrations    | 137      | 53       | 6        | 1        | 3        | 74
Logs            | 0        | 0        | 0        | 0        | 0        | 0
Platform        | 77       | 36       | 1        | 1        | 1        | 38
Networks        | 16       | 15       | 1        | 0        | 0        | 0
Processes       | 3        | 3        | 0        | 0        | 0        | 0
Trace           | 8        | 6        | 0        | 0        | 0        | 2
Tools and Libs  | 0        | 0        | 0        | 0        | 0        | 0
--              | --       | --       | --       | --       | --       | --
TOTALS          | 329      | 171      | 14       | 2        | 5        | 137
```
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
