### PR TITLE
Fix default value in example configuration file

### DIFF
--- a/kube_apiserver_metrics/assets/configuration/spec.yaml
+++ b/kube_apiserver_metrics/assets/configuration/spec.yaml
@@ -19,6 +19,8 @@ files:
       overrides:
         prometheus_url.value.example: https://localhost:443/metrics
         prometheus_url.display_priority: 1
+        bearer_token_auth.value.default: true
+        bearer_token_auth.value.example: true
 
 - name: auto_conf.yaml
   options:

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -133,11 +133,11 @@ instances:
     # exclude_labels:
     #   - timestamp
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean - optional - default: True
     ## Set bearer_token_auth to true to add bearer token authentication header.
     ## Note: if bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
-    # bearer_token_auth: false
+    # bearer_token_auth: true
 
     ## @param bearer_token_path - string - optional
     ## The path to a kubernetes service account bearer token file, make sure the file exists and mounted correctly.


### PR DESCRIPTION
### What does this PR do?
Change default value to `true` for `bearer_token_auth` for the `conf.yaml.example` file.
It is `true` by default in this integration (https://github.com/DataDog/integrations-core/blob/master/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py#L41)

### Motivation
QA #6831 

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
