### PR TITLE
remove mention of custom metrics for agent check

### DIFF
--- a/agent_metrics/README.md
+++ b/agent_metrics/README.md
@@ -23,13 +23,9 @@ The Agent Metrics check is included in the [Datadog Agent][3] package, so you do
 
 2. [Restart the Agent][6].
 
-#### Metrics collection
-
-The Agent Metrics integration can potentially emit [custom metrics][7], which may impact your [billing][8].
-
 ### Validation
 
-[Run the Agent's status subcommand][9] and look for `agent_metrics` under the Checks section.
+[Run the Agent's status subcommand][7] and look for `agent_metrics` under the Checks section.
 
 ## Data Collected
 
@@ -37,7 +33,7 @@ All data collected are only available for Agent v5.
 
 ### Metrics
 
-See [metadata.csv][10] for a list of metrics provided by this integration.
+See [metadata.csv][8] for a list of metrics provided by this integration.
 
 ### Events
 
@@ -49,7 +45,7 @@ The Agent Metrics check does not include any service checks.
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][11].
+Need help? Contact [Datadog support][9].
 
 [1]: https://docs.datadoghq.com/integrations/go_expvar/
 [2]: https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
@@ -57,8 +53,6 @@ Need help? Contact [Datadog support][11].
 [4]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [5]: https://github.com/DataDog/integrations-core/blob/agent-v5/agent_metrics/datadog_checks/agent_metrics/data/conf.yaml.default
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[7]: https://docs.datadoghq.com/developers/metrics/custom_metrics/
-[8]: https://docs.datadoghq.com/account_management/billing/custom_metrics/
-[9]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[10]: https://github.com/DataDog/integrations-core/blob/master/agent_metrics/metadata.csv
-[11]: https://docs.datadoghq.com/help/
+[7]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[8]: https://github.com/DataDog/integrations-core/blob/master/agent_metrics/metadata.csv
+[9]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
agent metrics check doesn't have any custom metrics: https://datadoghq.atlassian.net/browse/DOCS-496
