### PR TITLE
Fix NoSuchProcess log message level

### DIFF
--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -167,7 +167,10 @@ class ProcessCheck(AgentCheck):
                                 if re.search(string, ' '.join(cmdline)):
                                     found = True
                     except psutil.NoSuchProcess:
-                        self.log.warning('Process disappeared while scanning')
+                        # As the process list isn't necessarily scanned right after it's created
+                        # (since we're using a shared cache), there can be cases where processes
+                        # in the list are dead when an instance of the check tries to scan them.
+                        self.log.debug('Process disappeared while scanning')
                     except psutil.AccessDenied as e:
                         ad_error_logger('Access denied to process with PID {}'.format(proc.pid))
                         ad_error_logger('Error: {}'.format(e))


### PR DESCRIPTION
### What does this PR do?

Lowers the message level of the `psutil.NoSuchProcess` exception while scanning the process list, to debug.

### Motivation

With the logic introduced in #5920, it's more likely to get this exception (as an instance will not necessarily scan the list right after it's created, since we use a shared list ; eg. it could scan the list 10 or 20s after it's created). Thus, there's a much higher chance of there being dead processes when scanning the list. As this is expected, we shouldn't log a warning-level message.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
