### PR TITLE
Clean before building wheel

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/release.py
@@ -114,6 +114,12 @@ def update_agent_requirements(req_file, check, newline):
 
 def build_package(package_path, sdist):
     with chdir(package_path):
+        # Clean up needed before build. Files built previously and now delete might still persist in build directory
+        # and will be included in the final wheel. This is not desired.
+        result = run_command([sys.executable, 'setup.py', 'clean', '--all'], capture='out')
+        if result.code != 0:
+            return result
+
         result = run_command([sys.executable, 'setup.py', 'bdist_wheel', '--universal'], capture='out')
         if result.code != 0:
             return result

--- a/datadog_checks_dev/datadog_checks/dev/tooling/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/release.py
@@ -114,8 +114,8 @@ def update_agent_requirements(req_file, check, newline):
 
 def build_package(package_path, sdist):
     with chdir(package_path):
-        # Clean up needed before build. Files built previously and now delete might still persist in build directory
-        # and will be included in the final wheel. This is not desired.
+        # Clean up: Files built previously and now deleted might still persist in build directory
+        # and will be included in the final wheel. Cleaning up before avoids that.
         result = run_command([sys.executable, 'setup.py', 'clean', '--all'], capture='out')
         if result.code != 0:
             return result


### PR DESCRIPTION
### What does this PR do?

Clean up needed before build. Files built previously and now deleted might still persist in build directory and will be included in the final wheel. This is not desired.

### Example (before this PR)

```
$ rm -rf datadog_checks_dev/build

$ ddev release build datadog_checks_dev

$ ls datadog_checks_dev/build//lib/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/
__about__.py  __init__.py  check.py  data

$ mv datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/check.py datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/check_abc.py

$ ddev release build datadog_checks_dev

# the build directory contain both old and new file
$ ls datadog_checks_dev/build//lib/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/
__about__.py  __init__.py  check.py  check_abc.py  data

# As you can see, the wheel contain the old and new file
$ unzip -l datadog_checks_dev/dist/datadog_checks_dev-3.13.0-py2.py3-none-any.whl | grep datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}
       38  06-19-2020 09:15   datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/__about__.py
      128  06-19-2020 09:15   datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/__init__.py
      185  07-02-2020 16:40   datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/check.py
      185  07-02-2020 16:40   datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/check_abc.py
     1493  06-19-2020 09:15   datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/data/conf.yaml.example
```
