### PR TITLE
Remove deprecated isort recursive option

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -77,7 +77,7 @@ def add_style_checker(config, sections, make_envconfig, reader):
     commands = [
         'flake8 --config=../.flake8 .',
         'black --check --diff .',
-        'isort --check-only --diff --recursive .',
+        'isort --check-only --diff .',
     ]
 
     if sections['testenv'].get(TYPES_FLAG, 'false').lower() == 'true':
@@ -125,7 +125,7 @@ def add_style_formatter(config, sections, make_envconfig, reader):
         # Run formatter AFTER sorting imports
         'commands': '\n'.join(
             [
-                'isort --recursive .',
+                'isort .',
                 'black .',
                 'python -c "print(\'\\n[NOTE] flake8 may still report style errors for things black cannot fix, '
                 'these will need to be fixed manually.\')"',

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/jmx.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/jmx.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-
 import click
 
 from ..console import CONTEXT_SETTINGS
@@ -19,8 +18,7 @@ def jmx():
 @click.pass_context
 def query_endpoint(ctx, host, port, domain):
     import jpype
-    from jpype import java
-    from jpype import javax
+    from jpype import java, javax
 
     url = "service:jmx:rmi:///jndi/rmi://{}:{}/jmxrmi".format(host, port)
     jpype.startJVM(convertStrings=False)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
@@ -42,7 +42,7 @@ def make(ctx, checks, version, initial_release, skip_sign, sign_only, exclude):
       - Ensure you did `gpg --import <YOUR_KEY_ID>.gpg.pub`
     """
     # Import lazily since in-toto runs a subprocess to check for gpg2 on load
-    from ...signing import update_link_metadata, YubikeyException
+    from ...signing import YubikeyException, update_link_metadata
 
     releasing_all = 'all' in checks
 


### PR DESCRIPTION
The option has been remove since 5.0.0 Penny - July 4, 2020 

>   - `--recursive` option has been removed. Directories passed in are now automatically sorted recursive.


https://github.com/timothycrosley/isort/blame/develop/CHANGELOG.md#L31


### Motivation

Error:

> isort: error: unrecognized arguments: --recursive