### PR TITLE
Use isort black profile

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -38,6 +38,7 @@ from ..utils.secrets import SecretsSanitizer
 
 try:
     import datadog_agent
+
     from ..log import CheckLoggingAdapter, init_logging
 
     init_logging()

--- a/datadog_checks_base/datadog_checks/base/checks/win/winpdh_base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/winpdh_base.py
@@ -11,9 +11,9 @@ from ... import AgentCheck, is_affirmative
 from ...utils.containers import hash_mutable
 
 try:
-    from .winpdh import WinPDHCounter, DATA_TYPE_INT, DATA_TYPE_DOUBLE
+    from .winpdh import DATA_TYPE_DOUBLE, DATA_TYPE_INT, WinPDHCounter
 except ImportError:
-    from .winpdh_stub import WinPDHCounter, DATA_TYPE_INT, DATA_TYPE_DOUBLE
+    from .winpdh_stub import DATA_TYPE_DOUBLE, DATA_TYPE_INT, WinPDHCounter
 
 
 RESOURCETYPE_ANY = 0

--- a/datadog_checks_base/datadog_checks/base/ddyaml.py
+++ b/datadog_checks_base/datadog_checks/base/ddyaml.py
@@ -8,12 +8,12 @@ import yaml
 from six import string_types
 
 try:
-    from yaml import CSafeLoader as yLoader
     from yaml import CSafeDumper as yDumper
+    from yaml import CSafeLoader as yLoader
 except ImportError:
     # On source install C Extensions might have not been built
-    from yaml import SafeLoader as yLoader  # noqa, imported from here elsewhere
     from yaml import SafeDumper as yDumper  # noqa, imported from here elsewhere
+    from yaml import SafeLoader as yLoader  # noqa, imported from here elsewhere
 
 log = logging.getLogger(__name__)
 

--- a/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
@@ -8,12 +8,12 @@ from six import string_types
 from .. import ensure_unicode
 
 try:
-    from _util import get_subprocess_output as subprocess_output
     from _util import SubprocessOutputEmptyError  # noqa
+    from _util import get_subprocess_output as subprocess_output
 except ImportError:
     # No agent
-    from ..stubs._util import subprocess_output
     from ..stubs._util import SubprocessOutputEmptyError  # noqa
+    from ..stubs._util import subprocess_output
 
 
 log = logging.getLogger(__name__)

--- a/datadog_checks_base/tests/test_kube_leader.py
+++ b/datadog_checks_base/tests/test_kube_leader.py
@@ -1,17 +1,16 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
 import json
 from datetime import datetime, timedelta
 
 import mock
 import pytest
-from kubernetes.config.dateutil import format_rfc3339
 from six import iteritems, string_types
 
 from datadog_checks.base import AgentCheck, KubeLeaderElectionBaseCheck
 from datadog_checks.base.checks.kube_leader import ElectionRecord
+from kubernetes.config.dateutil import format_rfc3339
 
 # Trigger lazy imports
 try:

--- a/datadog_checks_base/tests/test_pdhbasecheck.py
+++ b/datadog_checks_base/tests/test_pdhbasecheck.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
 import copy
 
 import pytest
@@ -9,8 +8,9 @@ import pytest
 from .utils import requires_windows
 
 try:
-    from datadog_checks.checks.win.winpdh_base import PDHBaseCheck
     from datadog_test_libs.win.pdh_mocks import initialize_pdh_tests, pdh_mocks_fixture  # noqa: F401
+
+    from datadog_checks.checks.win.winpdh_base import PDHBaseCheck
 except ImportError:
     pass
 

--- a/datadog_checks_base/tests/test_winpdh.py
+++ b/datadog_checks_base/tests/test_winpdh.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
 import logging
 from collections import defaultdict
 
@@ -10,12 +9,13 @@ import pytest
 from .utils import requires_windows
 
 try:
-    from datadog_checks.checks.win.winpdh import WinPDHCounter, SINGLE_INSTANCE_KEY
     from datadog_test_libs.win.pdh_mocks import (  # noqa: F401
         initialize_pdh_tests,
-        pdh_mocks_fixture_bad_perf_strings,
         pdh_mocks_fixture,
+        pdh_mocks_fixture_bad_perf_strings,
     )
+
+    from datadog_checks.checks.win.winpdh import SINGLE_INSTANCE_KEY, WinPDHCounter
 except ImportError:
     import platform
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -8,16 +8,16 @@ import shutil
 
 # How long ddev will wait for GPG to finish, especially when asking dev for signature.
 import securesystemslib.settings
+
 securesystemslib.settings.SUBPROCESS_TIMEOUT = 60
 
+from in_toto import runlib, util
 from securesystemslib.gpg.constants import GPG_COMMAND
 
-from in_toto import runlib, util
-
-from .constants import get_root
-from .git import ignored_by_git, tracked_by_git
 from ..subprocess import run_command
 from ..utils import chdir, ensure_dir_exists, path_join, stream_file_lines
+from .constants import get_root
+from .git import ignored_by_git, tracked_by_git
 
 LINK_DIR = '.in-toto'
 STEP_NAME = 'tag'

--- a/datadog_checks_tests_helper/datadog_test_libs/win/pdh_mocks.py
+++ b/datadog_checks_tests_helper/datadog_test_libs/win/pdh_mocks.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 
 import mock
 import pytest
-
 from six import PY3
 from six.moves import winreg
 

--- a/datadog_checks_tests_helper/setup.py
+++ b/datadog_checks_tests_helper/setup.py
@@ -1,10 +1,10 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from setuptools import setup, find_packages
 from codecs import open  # To use a consistent encoding
 from os import path
 
+from setuptools import find_packages, setup
 
 HERE = path.abspath(path.dirname(__file__))
 

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -6,7 +6,7 @@ from __future__ import division
 import os
 import platform
 import re
-import xml.etree.ElementTree as ET
+from xml.etree import ElementTree as ET
 
 import psutil
 from six import iteritems, string_types

--- a/docs/developer/.scripts/33_render_status.py
+++ b/docs/developer/.scripts/33_render_status.py
@@ -7,7 +7,11 @@ from datadog_checks.dev.tooling.utils import (
     get_readme_file,
     get_valid_checks,
     get_valid_integrations,
-    is_tile_only, has_e2e, has_dashboard)
+    has_dashboard,
+    has_e2e,
+    is_tile_only,
+)
+
 MARKER = '<docs-insert-status>'
 
 

--- a/go-metro/setup.py
+++ b/go-metro/setup.py
@@ -1,9 +1,10 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from setuptools import setup
 from codecs import open  # To use a consistent encoding
 from os import path
+
+from setuptools import setup
 
 HERE = path.dirname(path.abspath(__file__))
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -4,13 +4,13 @@
 from collections import defaultdict
 from time import time
 
+from six import string_types
+
+from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from kafka import KafkaAdminClient, KafkaClient
 from kafka import errors as kafka_errors
 from kafka.protocol.offset import OffsetRequest, OffsetResetStrategy, OffsetResponse
 from kafka.structs import TopicPartition
-from six import string_types
-
-from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 
 from .constants import CONTEXT_UPPER_BOUND, DEFAULT_KAFKA_TIMEOUT, KAFKA_INTERNAL_TOPICS
 from .legacy_0_10_2 import LegacyKafkaCheck_0_10_2

--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -6,15 +6,15 @@ from __future__ import division
 from collections import defaultdict
 from time import time
 
-from kafka import KafkaClient
-from kafka import errors as kafka_errors
-from kafka.protocol.commit import GroupCoordinatorRequest, OffsetFetchRequest
-from kafka.protocol.offset import OffsetRequest, OffsetResetStrategy, OffsetResponse
 from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeError
 from six import string_types
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
+from kafka import KafkaClient
+from kafka import errors as kafka_errors
+from kafka.protocol.commit import GroupCoordinatorRequest, OffsetFetchRequest
+from kafka.protocol.offset import OffsetRequest, OffsetResetStrategy, OffsetResponse
 
 from .constants import CONTEXT_UPPER_BOUND, DEFAULT_KAFKA_TIMEOUT, KAFKA_INTERNAL_TOPICS
 

--- a/kafka_consumer/tests/conftest.py
+++ b/kafka_consumer/tests/conftest.py
@@ -5,9 +5,9 @@ import os
 import time
 
 import pytest
-from kafka import KafkaConsumer
 
 from datadog_checks.dev import WaitFor, docker_run
+from kafka import KafkaConsumer
 
 from .common import HERE, HOST_IP, KAFKA_CONNECT_STR, PARTITIONS, TOPICS, ZK_CONNECT_STR
 from .runners import KConsumer, Producer, ZKConsumer

--- a/kafka_consumer/tests/runners.py
+++ b/kafka_consumer/tests/runners.py
@@ -5,9 +5,10 @@ import os
 import threading
 import time
 
-from kafka import KafkaConsumer, KafkaProducer
 from kazoo.client import KazooClient
 from six import binary_type, iteritems
+
+from kafka import KafkaConsumer, KafkaProducer
 
 from .common import KAFKA_CONNECT_STR, PARTITIONS, ZK_CONNECT_STR
 

--- a/kubernetes/datadog_checks/kubernetes/kubernetes.py
+++ b/kubernetes/datadog_checks/kubernetes/kubernetes.py
@@ -5,23 +5,23 @@
 """kubernetes check
 Collects metrics from cAdvisor instance
 """
-# stdlib
-from collections import defaultdict
-from fnmatch import fnmatch
+import calendar
 import numbers
 import re
 import time
-import calendar
 
-# 3p
-from requests.exceptions import ConnectionError
+# stdlib
+from collections import defaultdict
+from fnmatch import fnmatch
 
 # project
 from checks import AgentCheck
 from config import _is_affirmative
+
+# 3p
+from requests.exceptions import ConnectionError
 from utils.kubernetes import KubeUtil
 from utils.service_discovery.sd_backend import get_sd_backend
-
 
 NAMESPACE = "kubernetes"
 DEFAULT_MAX_DEPTH = 10

--- a/kubernetes/setup.py
+++ b/kubernetes/setup.py
@@ -1,9 +1,10 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from setuptools import setup
 from codecs import open  # To use a consistent encoding
 from os import path
+
+from setuptools import setup
 
 HERE = path.dirname(path.abspath(__file__))
 

--- a/kubernetes/test/test_kubernetes.py
+++ b/kubernetes/test/test_kubernetes.py
@@ -2,18 +2,19 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+import os
+import unittest
+
 # stdlib
 import mock
-import unittest
-import os
 
 # 3p
 import simplejson as json
+from checks import AgentCheck
 from nose.plugins.attrib import attr
 
 # project
 from tests.checks.common import AgentCheckTest, Fixtures
-from checks import AgentCheck
 from utils.kubernetes.kubeutil import KubeUtil, detect_is_k8s
 
 CPU = "CPU"

--- a/openstack_controller/datadog_checks/openstack_controller/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api.py
@@ -5,8 +5,9 @@ from os import environ
 
 import requests
 import simplejson as json
-from openstack import connection
 from six.moves.urllib.parse import urljoin
+
+from openstack import connection
 
 from .exceptions import (
     AuthenticationNeeded,

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -7,12 +7,12 @@ from collections import defaultdict
 from datetime import datetime
 
 import requests
-from openstack.config.loader import OpenStackConfig
 from six import iteritems, itervalues
 
 from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.common import pattern_filter
 from datadog_checks.base.utils.tracing import traced
+from openstack.config.loader import OpenStackConfig
 
 from .api import ApiFactory
 from .exceptions import (

--- a/openstack_controller/tests/test_openstack_sdk_api.py
+++ b/openstack_controller/tests/test_openstack_sdk_api.py
@@ -1,6 +1,5 @@
 import mock
 import pytest
-from openstack.exceptions import SDKException
 
 from datadog_checks.openstack_controller.api import OpenstackSDKApi
 from datadog_checks.openstack_controller.exceptions import (
@@ -9,6 +8,7 @@ from datadog_checks.openstack_controller.exceptions import (
     MissingNeutronEndpoint,
     MissingNovaEndpoint,
 )
+from openstack.exceptions import SDKException
 
 from . import common
 

--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -4,7 +4,7 @@
 import re
 
 import psycopg2 as pg
-import psycopg2.extras as pgextras
+from psycopg2 import extras as pgextras
 from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -309,8 +309,8 @@ def test_check_real_process_regex(aggregator):
 
 
 def test_relocated_procfs(aggregator):
-    import tempfile
     import shutil
+    import tempfile
     import uuid
 
     unique_process_name = str(uuid.uuid4())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,8 @@ py36 = false
 skip-string-normalization = true
 
 [tool.isort]
+profile = 'black'
 default_section = 'THIRDPARTY'
-force_grid_wrap = 0
-include_trailing_comma = true
 known_first_party = 'datadog_checks'
 line_length = 120
-multi_line_output = 3
 skip_glob = 'datadog_checks/dev/tooling/signing.py,datadog_checks/dev/tooling/templates/*,datadog_checks/*/vendor/*'
-use_parentheses = true

--- a/rethinkdb/datadog_checks/rethinkdb/check.py
+++ b/rethinkdb/datadog_checks/rethinkdb/check.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from typing import Any, Callable, Iterator, Sequence, cast
 
 import rethinkdb
-
 from datadog_checks.base import AgentCheck
 
 from . import operations, queries

--- a/rethinkdb/tests/cluster.py
+++ b/rethinkdb/tests/cluster.py
@@ -6,10 +6,9 @@ from contextlib import contextmanager
 from typing import Iterator, List
 
 import rethinkdb
-from rethinkdb import r
-
 from datadog_checks.dev.conditions import WaitFor
 from datadog_checks.dev.docker import temporarily_stop_service
+from rethinkdb import r
 
 from .common import (
     AGENT_PASSWORD,

--- a/rethinkdb/tests/test_integration.py
+++ b/rethinkdb/tests/test_integration.py
@@ -6,8 +6,8 @@ from typing import ContextManager, Set
 
 import mock
 import pytest
-import rethinkdb
 
+import rethinkdb
 from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.base.stubs.datadog_agent import DatadogAgentStub
 from datadog_checks.base.types import ServiceCheckStatus


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Use https://timothycrosley.github.io/isort/docs/configuration/profiles/#black
Then run `isort <check>` on all checks.

Refs #7060 

### Motivation
<!-- What inspired you to submit this pull request? -->
Use defaults to reduce configuration options.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Used this script to apply `isort` (using `ddev test -fs <check>` would have taken too long):

```python
from pathlib import Path
from subprocess import call

from tqdm import tqdm

checks = [
    path for path in Path('.').iterdir()
    if path.is_dir() and not path.name.startswith(('.', '_')) and path.name != 'venv'
]

for check in tqdm(checks):
    command = ['isort', check]
    call(command)
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
