### PR TITLE
Add shell subcommand to ddev env

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/__init__.py
@@ -8,11 +8,12 @@ from .check import check_run
 from .ls import ls
 from .prune import prune
 from .reload import reload_env
+from .shell import shell
 from .start import start
 from .stop import stop
 from .test import test
 
-ALL_COMMANDS = (check_run, ls, prune, reload_env, start, stop, test)
+ALL_COMMANDS = (check_run, ls, prune, reload_env, shell, start, stop, test)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Manage environments')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
@@ -5,7 +5,7 @@ import click
 
 from ...e2e import create_interface, get_configured_envs
 from ...testing import complete_active_checks, complete_configured_envs
-from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info
 
 
 @click.command('shell', context_settings=CONTEXT_SETTINGS, short_help='Run a shell inside agent container')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
@@ -43,8 +43,8 @@ def shell(check, env, install_vim, install_tools):
         tools = list(install_tools)
         if install_vim:
             tools.extend(('less', 'vim'))
-        echo_info('Installing helper tools ..')
-        environment.exec_command(f'apt update && apt install -y {" ".join(tools)}')
+        echo_info(f'Installing helper tools: {", ".join(tools)}')
+        environment.exec_command('/bin/bash -c "apt update && apt install -y {}"'.format(" ".join(tools)))
 
     result = environment.shell()
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2019-present
+# (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import click

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
@@ -1,0 +1,40 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import click
+
+from ...e2e import create_interface, get_configured_envs
+from ...testing import complete_active_checks, complete_configured_envs
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
+
+
+@click.command('shell', context_settings=CONTEXT_SETTINGS, short_help='Run a shell inside agent container')
+@click.argument('check', autocompletion=complete_active_checks)
+@click.argument('env', autocompletion=complete_configured_envs, required=False)
+def shell(check, env):
+    """Restart an Agent to detect environment changes."""
+    envs = get_configured_envs(check)
+    if not envs:
+        echo_failure(f'No active environments found for `{check}`.')
+        echo_info(f'See what is available to start via `ddev env ls {check}`.')
+        abort()
+
+    if not env:
+        if len(envs) > 1:
+            echo_failure(f'Multiple active environments found for `{check}`, please specify one.')
+            echo_info('See what is active via `ddev env ls`.')
+            abort()
+
+        env = envs[0]
+
+    if env not in envs:
+        echo_failure(f'`{env}` is not an active environment.')
+        echo_info('See what is active via `ddev env ls`.')
+        abort()
+
+    environment = create_interface(check, env)
+
+    result = environment.shell()
+
+    if result.code:
+        abort(result.stdout + result.stderr, code=result.code)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
@@ -40,10 +40,11 @@ def shell(check, env, install_vim, install_tools):
         abort('Shell subcommand only available for docker e2e environments')
 
     if install_vim or install_tools:
-        tools = 'less vim ' if install_vim else ' '
-        tools += ' '.join(install_tools)
+        tools = list(install_tools)
+        if install_vim:
+            tools.extend(('less', 'vim'))
         echo_info('Installing helper tools ..')
-        environment.exec_command('/bin/bash -c "apt update && apt install -y {}"'.format(tools))
+        environment.exec_command(f'apt update && apt install -y {" ".join(tools)}')
 
     result = environment.shell()
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
@@ -34,6 +34,9 @@ def shell(check, env):
 
     environment = create_interface(check, env)
 
+    if environment.ENV_TYPE == 'local':
+        abort('Shell subcommand only available for docker e2e environments')
+
     result = environment.shell()
 
     if result.code:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -285,6 +285,9 @@ class DockerInterface(object):
     def restart_agent(self):
         return run_command(['docker', 'restart', self.container_name], capture=True)
 
+    def shell(self):
+        return self.exec_command('/bin/bash', interactive=True)
+
 
 def get_docker_networks():
     command = ['docker', 'network', 'ls', '--format', '{{.Name}}']


### PR DESCRIPTION
### What does this PR do?
Add shortcut to execute a bash shell within the agent container via: `ddev env shell <CHECK>`

Examples:

```
$ ddev env shell snmp -v
$ ddev env shell snmp -v -i ripgrep
$ ddev env shell snmp -i ripgrep
$ ddev env shell snmp -i ripgrep -i tig
```

### Motivation
Tired of manually typing container name.

### Additional Notes
Only works for Docker interface, not local agent.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
