### PR TITLE
Support "*" wildcard in type_overrides configuration

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -76,6 +76,7 @@
     Type override allows you to override a type in the prometheus payload
     or type an untyped metrics (they're ignored by default).
     Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, `summary`
+    The "*" wildcard can be used to match multiple metric names.
   value:
     example:
       <METRIC_NAME>: <METRIC_TYPE>

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -57,6 +57,7 @@ instances:
     ## Type override allows you to override a type in the prometheus payload
     ## or type an untyped metrics (they're ignored by default).
     ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, `summary`
+    ## The "*" wildcard can be used to match multiple metric names.
     #
     # type_overrides:
     #   <METRIC_NAME>: <METRIC_TYPE>

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -126,6 +126,7 @@ instances:
     ## Type override allows you to override a type in the prometheus payload
     ## or type an untyped metrics (they're ignored by default).
     ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, `summary`
+    ## The "*" wildcard can be used to match multiple metric names.
     #
     # type_overrides:
     #   <METRIC_NAME>: <METRIC_TYPE>

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -94,6 +94,7 @@ instances:
     ## Type override allows you to override a type in the prometheus payload
     ## or type an untyped metrics (they're ignored by default).
     ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, `summary`
+    ## The "*" wildcard can be used to match multiple metric names.
     #
     # type_overrides:
     #   <METRIC_NAME>: <METRIC_TYPE>

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -95,6 +95,7 @@ instances:
     ## Type override allows you to override a type in the prometheus payload
     ## or type an untyped metrics (they're ignored by default).
     ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, `summary`
+    ## The "*" wildcard can be used to match multiple metric names.
     #
     # type_overrides:
     #   <METRIC_NAME>: <METRIC_TYPE>

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -101,6 +101,7 @@ instances:
     ## Type override allows you to override a type in the prometheus payload
     ## or type an untyped metrics (they're ignored by default).
     ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, `summary`
+    ## The "*" wildcard can be used to match multiple metric names.
     #
     # type_overrides:
     #   <METRIC_NAME>: <METRIC_TYPE>


### PR DESCRIPTION
### What does this PR do?
Make it possible to use the wildcard `*` to match metric names when configuring `type_overrides` 

fixes https://github.com/DataDog/integrations-core/issues/6091

### Motivation
FR

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
