### PR TITLE
Add new_gc_metrics to all jmx integrations

### DIFF
--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -12,6 +12,16 @@ init_config:
     #
     collect_default_metrics: true
 
+    ## @param new_gc_metrics - boolean - optional - default: False
+    ## Set to true to use better metric names for garbage collection metrics.
+    ## jvm.gc.cms.count   => jvm.gc.minor_collection_count
+    ##                       jvm.gc.major_collection_count
+    ## jvm.gc.parnew.time => jvm.gc.minor_collection_time
+    ##                       jvm.gc.major_collection_time
+    ## The default value is false to ensure backward compatibility.
+    #
+    # new_gc_metrics: false
+
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.
     ## If not set, the default service check used is the integration name.

--- a/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+++ b/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
@@ -12,6 +12,16 @@ init_config:
     #
     collect_default_metrics: true
 
+    ## @param new_gc_metrics - boolean - optional - default: False
+    ## Set to true to use better metric names for garbage collection metrics.
+    ## jvm.gc.cms.count   => jvm.gc.minor_collection_count
+    ##                       jvm.gc.major_collection_count
+    ## jvm.gc.parnew.time => jvm.gc.minor_collection_time
+    ##                       jvm.gc.major_collection_time
+    ## The default value is false to ensure backward compatibility.
+    #
+    # new_gc_metrics: false
+
     ## @param service_check_prefix - string - required
     ## Service check prefix to use.
     #

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
@@ -10,6 +10,18 @@
   value:
     example: true
     type: boolean
+- name: new_gc_metrics
+  description: |
+    Set to true to use better metric names for garbage collection metrics.
+    jvm.gc.cms.count   => jvm.gc.minor_collection_count
+                          jvm.gc.major_collection_count
+    jvm.gc.parnew.time => jvm.gc.minor_collection_time
+                          jvm.gc.major_collection_time
+    The default value is false to ensure backward compatibility.
+  value:
+    type: boolean
+    example: false
+    default: false
 - name: service_check_prefix
   description: |
     Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -12,6 +12,16 @@ init_config:
     #
     collect_default_metrics: true
 
+    ## @param new_gc_metrics - boolean - optional - default: False
+    ## Set to true to use better metric names for garbage collection metrics.
+    ## jvm.gc.cms.count   => jvm.gc.minor_collection_count
+    ##                       jvm.gc.major_collection_count
+    ## jvm.gc.parnew.time => jvm.gc.minor_collection_time
+    ##                       jvm.gc.major_collection_time
+    ## The default value is false to ensure backward compatibility.
+    #
+    # new_gc_metrics: false
+
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.
     ## If not set, the default service check used is the integration name.

--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -12,6 +12,16 @@ init_config:
     #
     collect_default_metrics: true
 
+    ## @param new_gc_metrics - boolean - optional - default: False
+    ## Set to true to use better metric names for garbage collection metrics.
+    ## jvm.gc.cms.count   => jvm.gc.minor_collection_count
+    ##                       jvm.gc.major_collection_count
+    ## jvm.gc.parnew.time => jvm.gc.minor_collection_time
+    ##                       jvm.gc.major_collection_time
+    ## The default value is false to ensure backward compatibility.
+    #
+    # new_gc_metrics: false
+
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.
     ## If not set, the default service check used is the integration name.

--- a/hivemq/datadog_checks/hivemq/data/conf.yaml.example
+++ b/hivemq/datadog_checks/hivemq/data/conf.yaml.example
@@ -12,6 +12,16 @@ init_config:
     #
     collect_default_metrics: true
 
+    ## @param new_gc_metrics - boolean - optional - default: False
+    ## Set to true to use better metric names for garbage collection metrics.
+    ## jvm.gc.cms.count   => jvm.gc.minor_collection_count
+    ##                       jvm.gc.major_collection_count
+    ## jvm.gc.parnew.time => jvm.gc.minor_collection_time
+    ##                       jvm.gc.major_collection_time
+    ## The default value is false to ensure backward compatibility.
+    #
+    # new_gc_metrics: false
+
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.
     ## If not set, the default service check used is the integration name.

--- a/ignite/datadog_checks/ignite/data/conf.yaml.example
+++ b/ignite/datadog_checks/ignite/data/conf.yaml.example
@@ -12,6 +12,16 @@ init_config:
     #
     collect_default_metrics: true
 
+    ## @param new_gc_metrics - boolean - optional - default: False
+    ## Set to true to use better metric names for garbage collection metrics.
+    ## jvm.gc.cms.count   => jvm.gc.minor_collection_count
+    ##                       jvm.gc.major_collection_count
+    ## jvm.gc.parnew.time => jvm.gc.minor_collection_time
+    ##                       jvm.gc.major_collection_time
+    ## The default value is false to ensure backward compatibility.
+    #
+    # new_gc_metrics: false
+
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.
     ## If not set, the default service check used is the integration name.

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -12,6 +12,16 @@ init_config:
     #
     collect_default_metrics: true
 
+    ## @param new_gc_metrics - boolean - optional - default: False
+    ## Set to true to use better metric names for garbage collection metrics.
+    ## jvm.gc.cms.count   => jvm.gc.minor_collection_count
+    ##                       jvm.gc.major_collection_count
+    ## jvm.gc.parnew.time => jvm.gc.minor_collection_time
+    ##                       jvm.gc.major_collection_time
+    ## The default value is false to ensure backward compatibility.
+    #
+    # new_gc_metrics: false
+
     ## @param service_check_prefix - string - required
     ## Service check prefix to use.
     #

--- a/solr/datadog_checks/solr/data/conf.yaml.example
+++ b/solr/datadog_checks/solr/data/conf.yaml.example
@@ -12,6 +12,16 @@ init_config:
     #
     collect_default_metrics: true
 
+    ## @param new_gc_metrics - boolean - optional - default: False
+    ## Set to true to use better metric names for garbage collection metrics.
+    ## jvm.gc.cms.count   => jvm.gc.minor_collection_count
+    ##                       jvm.gc.major_collection_count
+    ## jvm.gc.parnew.time => jvm.gc.minor_collection_time
+    ##                       jvm.gc.major_collection_time
+    ## The default value is false to ensure backward compatibility.
+    #
+    # new_gc_metrics: false
+
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.
     ## If not set, the default service check used is the integration name.

--- a/tomcat/datadog_checks/tomcat/data/conf.yaml.example
+++ b/tomcat/datadog_checks/tomcat/data/conf.yaml.example
@@ -12,6 +12,16 @@ init_config:
     #
     collect_default_metrics: true
 
+    ## @param new_gc_metrics - boolean - optional - default: False
+    ## Set to true to use better metric names for garbage collection metrics.
+    ## jvm.gc.cms.count   => jvm.gc.minor_collection_count
+    ##                       jvm.gc.major_collection_count
+    ## jvm.gc.parnew.time => jvm.gc.minor_collection_time
+    ##                       jvm.gc.major_collection_time
+    ## The default value is false to ensure backward compatibility.
+    #
+    # new_gc_metrics: false
+
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.
     ## If not set, the default service check used is the integration name.


### PR DESCRIPTION
JMXfetch reads a flag named `new_gc_metrics` in `init_config` that makes it produce different GC metrics. But it's not documented it in integrations.

New metrics are documented in `java/metadata.csv`
![image](https://user-images.githubusercontent.com/611228/86768887-88017380-c04e-11ea-9db6-a633b6428868.png)

Agent changelog notice: https://github.com/DataDog/datadog-agent/blob/afb595fa7567e5c006ab84ee03a33aaf49d8567b/CHANGELOG.rst#upgrade-notes-10

Usage example: https://github.com/DataDog/datadog-agent/blob/41be52cc63a629f7a18e94fc6e36733e0ff967dd/cmd/agent/dist/conf.d/jmx.d/conf.yaml.example#L11


