### PR TITLE
Revert the board_title dashboard name for HiveMQ

### DIFF
--- a/hivemq/assets/dashboards/hivemq.json
+++ b/hivemq/assets/dashboards/hivemq.json
@@ -1,5 +1,5 @@
 {
-  "board_title": "HiveMQ",
+  "board_title": "HiveMQ Overview",
   "read_only": false,
   "description": "The default dashboard for monitoring HiveMQ brokers including connections, subscriptions, and messages.",
   "created": "2020-07-07T18:59:17.091896+00:00",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Uses the original `board_title` for the hiveMQ dashboard

### Motivation
<!-- What inspired you to submit this pull request? -->
The name change caused a backend change, reverting to the original board title fixes this. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
