### PR TITLE
Add assert_metrics_using_metadata to template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tests/test_{check_name}.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tests/test_{check_name}.py
@@ -1,6 +1,7 @@
 {license_header}from typing import Any, Dict
 
 from datadog_checks.base.stubs.aggregator import AggregatorStub
+from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.{check_name} import {check_class}
 
 
@@ -10,3 +11,4 @@ def test_check(aggregator, instance):
     check.check(instance)
 
     aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())


### PR DESCRIPTION
### What does this PR do?

Add assert_metrics_using_metadata to template

### Motivation

Helps ensuring that metrics submitted are present in `metadata.csv`.
