### PR TITLE
Update RC build cards when running `ddev release trello testable`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/rc_build_cards_updater.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/rc_build_cards_updater.py
@@ -2,8 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import re
 import json
+import re
+
 from ....trello import TrelloClient
 from ...console import abort, echo_info
 
@@ -16,7 +17,8 @@ class RCBuildCardsUpdater:
         match = re.fullmatch(self.version_regex, release_version)
         if not match:
             abort(
-                f'{release_version} is an invalid release version. A valid release version is for example 7.21.0-rc.3')
+                f'{release_version} is an invalid release version. A valid release version is for example 7.21.0-rc.3'
+            )
 
         groups = match.groups()
         if len(groups) != 6:
@@ -30,17 +32,14 @@ class RCBuildCardsUpdater:
             'DyjjKkZD',  # [A6] Windows
             'BOvSs9Le',  # [IOT] Linux
             'hu1JXJ18',  # [A7] Linux + Docker
-            'E7bHwa14']  # [A6] Linux + Docker
+            'E7bHwa14',
+        ]  # [A6] Linux + Docker
 
         for card_id in rc_build_cards:
             card = self.__trello.get_card(card_id)
             description = card['desc']
             new_version = f'\\g<1>.{self.__minor}.{self.__patch}\\g<4>rc\\g<5>{self.__rc}'
-            new_description = re.sub(
-                self.version_regex, new_version, description)
-            updated_card = {
-                'desc': new_description
-            }
+            new_description = re.sub(self.version_regex, new_version, description)
+            updated_card = {'desc': new_description}
             echo_info(f'updating release version for the card {card["name"]}')
-            self.__trello.update_card(
-                card_id, json.dumps(updated_card))
+            self.__trello.update_card(card_id, json.dumps(updated_card))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/rc_build_cards_updater.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/rc_build_cards_updater.py
@@ -9,7 +9,7 @@ from ...console import abort, echo_info
 
 
 class RCBuildCardsUpdater:
-    version_regex = r'(\d*)\.(\d*)\.(\d*)([-~])rc\.(\d*)'
+    version_regex = r'(\d*)\.(\d*)\.(\d*)([-~])rc([\.-])(\d*)'
 
     def __init__(self, trello: TrelloClient, release_version: str):
         self.__trello = trello
@@ -19,10 +19,10 @@ class RCBuildCardsUpdater:
                 f'{release_version} is an invalid release version. A valid release version is for example 7.21.0-rc.3')
 
         groups = match.groups()
-        if len(groups) != 5:
+        if len(groups) != 6:
             raise Exception('Regex in RCBuildCardsUpdater is not correct')
 
-        (_, self.__minor, self.__patch, _, self.__rc) = groups
+        (_, self.__minor, self.__patch, _, _, self.__rc) = groups
 
     def update_cards(self):
         rc_build_cards = [
@@ -30,13 +30,12 @@ class RCBuildCardsUpdater:
             'DyjjKkZD',  # [A6] Windows
             'BOvSs9Le',  # [IOT] Linux
             'hu1JXJ18',  # [A7] Linux + Docker
-            'E7bHwa14',  # [A6] Linux + Docker
-            'dYrSpOLW']  # macOS
-        
+            'E7bHwa14']  # [A6] Linux + Docker
+
         for card_id in rc_build_cards:
             card = self.__trello.get_card(card_id)
             description = card['desc']
-            new_version = f'\\g<1>.{self.__minor}.{self.__patch}\\g<4>rc.{self.__rc}'
+            new_version = f'\\g<1>.{self.__minor}.{self.__patch}\\g<4>rc\\g<5>{self.__rc}'
             new_description = re.sub(
                 self.version_regex, new_version, description)
             updated_card = {

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/rc_build_cards_updater.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/rc_build_cards_updater.py
@@ -17,7 +17,10 @@ class RCBuildCardsUpdater:
         match = re.fullmatch(self.version_regex, release_version)
         if not match:
             abort(
-                f'{release_version} is an invalid release version. A valid release version is for example 7.21.0-rc.3'
+                f'Cannot update cards in RC builds columnn. '
+                f'`{release_version}` is an invalid release candidate version. '
+                f'A valid version is for example `7.21.0-rc.3`. '
+                f'You can disable the update of cards in RC builds column by removing --update-rc-builds-cards'
             )
 
         groups = match.groups()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/rc_build_cards_updater.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/rc_build_cards_updater.py
@@ -1,0 +1,47 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import re
+import json
+from ....trello import TrelloClient
+from ...console import abort, echo_info
+
+
+class RCBuildCardsUpdater:
+    version_regex = r'(\d*)\.(\d*)\.(\d*)([-~])rc\.(\d*)'
+
+    def __init__(self, trello: TrelloClient, release_version: str):
+        self.__trello = trello
+        match = re.fullmatch(self.version_regex, release_version)
+        if not match:
+            abort(
+                f'{release_version} is an invalid release version. A valid release version is for example 7.21.0-rc.3')
+
+        groups = match.groups()
+        if len(groups) != 5:
+            raise Exception('Regex in RCBuildCardsUpdater is not correct')
+
+        (_, self.__minor, self.__patch, _, self.__rc) = groups
+
+    def update_cards(self):
+        rc_build_cards = [
+            'Rrn1Y0yU',  # [A7] Windows + Docker + Chocolatey
+            'DyjjKkZD',  # [A6] Windows
+            'BOvSs9Le',  # [IOT] Linux
+            'hu1JXJ18',  # [A7] Linux + Docker
+            'E7bHwa14',  # [A6] Linux + Docker
+            'dYrSpOLW']  # macOS
+        
+        for card_id in rc_build_cards:
+            card = self.__trello.get_card(card_id)
+            description = card['desc']
+            new_version = f'\\g<1>.{self.__minor}.{self.__patch}\\g<4>rc.{self.__rc}'
+            new_description = re.sub(
+                self.version_regex, new_version, description)
+            updated_card = {
+                'desc': new_description
+            }
+            echo_info(f'updating release version for the card {card["name"]}')
+            self.__trello.update_card(
+                card_id, json.dumps(updated_card))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -145,16 +145,13 @@ def pick_card_member(config: dict, author: str, team: str) -> Optional[str]:
 @click.argument('target_ref')
 @click.option('--milestone', help='The PR milestone to filter by')
 @click.option('--dry-run', '-n', is_flag=True, help='Only show the changes')
-@click.option('--release-version', help='If specified, cards in RC builds column will be updated with this'
-                                        'release version. For example 7.21.0-rc.3')
+@click.option(
+    '--release-version',
+    help='If specified, cards in RC builds column will be updated with this' 'release version. For example 7.21.0-rc.3',
+)
 @click.pass_context
 def testable(
-    ctx: click.Context,
-    base_ref: str,
-    target_ref: str,
-    milestone: str,
-    dry_run: bool,
-    release_version: str
+    ctx: click.Context, base_ref: str, target_ref: str, milestone: str, dry_run: bool, release_version: str
 ) -> None:
     """
     Create a Trello card for changes since a previous release (referenced by `BASE_REF`)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -146,12 +146,11 @@ def pick_card_member(config: dict, author: str, team: str) -> Optional[str]:
 @click.option('--milestone', help='The PR milestone to filter by')
 @click.option('--dry-run', '-n', is_flag=True, help='Only show the changes')
 @click.option(
-    '--release-version',
-    help='If specified, cards in RC builds column will be updated with this' 'release version. For example 7.21.0-rc.3',
+    '--update-rc-builds-cards', is_flag=True, help='Update cards in RC builds column with `target_ref` version',
 )
 @click.pass_context
 def testable(
-    ctx: click.Context, base_ref: str, target_ref: str, milestone: str, dry_run: bool, release_version: str
+    ctx: click.Context, base_ref: str, target_ref: str, milestone: str, dry_run: bool, update_rc_builds_cards: bool
 ) -> None:
     """
     Create a Trello card for changes since a previous release (referenced by `BASE_REF`)
@@ -242,8 +241,8 @@ def testable(
     user_config = ctx.obj
     trello = TrelloClient(user_config)
     rc_build_cards_updater = None
-    if release_version:
-        rc_build_cards_updater = RCBuildCardsUpdater(trello, release_version)
+    if update_rc_builds_cards:
+        rc_build_cards_updater = RCBuildCardsUpdater(trello, target_ref)
 
     for i, (commit_hash, commit_subject) in enumerate(commits, 1):
         commit_id = parse_pr_number(commit_subject)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -14,6 +14,7 @@ from ....github import get_pr, get_pr_from_hash, get_pr_labels, get_pr_milestone
 from ....trello import TrelloClient
 from ....utils import format_commit_id
 from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_waiting, echo_warning
+from .rc_build_cards_updater import RCBuildCardsUpdater
 
 
 def create_trello_card(
@@ -144,8 +145,17 @@ def pick_card_member(config: dict, author: str, team: str) -> Optional[str]:
 @click.argument('target_ref')
 @click.option('--milestone', help='The PR milestone to filter by')
 @click.option('--dry-run', '-n', is_flag=True, help='Only show the changes')
+@click.option('--release-version', help='If specified, cards in RC builds column will be updated with this'
+                                        'release version. For example 7.21.0-rc.3')
 @click.pass_context
-def testable(ctx: click.Context, base_ref: str, target_ref: str, milestone: str, dry_run: bool) -> None:
+def testable(
+    ctx: click.Context,
+    base_ref: str,
+    target_ref: str,
+    milestone: str,
+    dry_run: bool,
+    release_version: str
+) -> None:
     """
     Create a Trello card for changes since a previous release (referenced by `BASE_REF`)
     that need to be tested for the next release (referenced by `TARGET_REF`).
@@ -234,6 +244,9 @@ def testable(ctx: click.Context, base_ref: str, target_ref: str, milestone: str,
     commit_ids: Set[str] = set()
     user_config = ctx.obj
     trello = TrelloClient(user_config)
+    rc_build_cards_updater = None
+    if release_version:
+        rc_build_cards_updater = RCBuildCardsUpdater(trello, release_version)
 
     for i, (commit_hash, commit_subject) in enumerate(commits, 1):
         commit_id = parse_pr_number(commit_subject)
@@ -375,3 +388,5 @@ def testable(ctx: click.Context, base_ref: str, target_ref: str, milestone: str,
                 )
 
             finished = True
+    if rc_build_cards_updater and not dry_run:
+        rc_build_cards_updater.update_cards()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -11,6 +11,7 @@ class TrelloClient:
     BOARD_ENDPOINT = API_URL + '/1/boards/ICjijxr4/cards'
     LISTS_ENDPOINT = API_URL + '/1/boards/ICjijxr4/lists'
     LABELS_ENDPOINT = API_URL + '/1/boards/ICjijxr4/labels'
+    CARDS_ENDPOINT = API_URL + '/1/cards'
 
     def __init__(self, config):
         self.auth = {'key': config['trello']['key'] or None, 'token': config['trello']['token'] or None}
@@ -120,3 +121,14 @@ class TrelloClient:
                         counts[team][self.progress_columns[id_list]] += 1
 
         return counts
+
+    def get_card(self, card_id):
+        response = requests.get(f'{self.CARDS_ENDPOINT}/{card_id}', params=self.auth)
+        response.raise_for_status()
+        return response.json()
+
+    def update_card(self, card_id, data):
+        headers = {'Content-Type': 'application/json'}
+        response = requests.put(f'{self.CARDS_ENDPOINT}/{card_id}', headers=headers, data=data, params=self.auth)
+        response.raise_for_status()
+        return response.json()


### PR DESCRIPTION
### What does this PR do?

This PR update the release version for cards in RC build column when running `ddev release trello testable`, 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
