### PR TITLE
[kubernetes] [dashboard-nodes] OOTB dasboard

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_nodes.json
+++ b/kubernetes/assets/dashboards/kubernetes_nodes.json
@@ -1,0 +1,1445 @@
+{
+  "author_info": {
+    "author_name": "Datadog"
+  },
+  "board_title": "Kubernetes Nodes Overview",
+  "created_by": {
+    "access_role": "st",
+    "disabled": false,
+    "email": "support@datadoghq.com",
+    "handle": "support@datadoghq.com",
+    "is_admin": false,
+    "name": "Datadog",
+    "role": null,
+    "title": null,
+    "verified": true
+  },
+  "description": "Our Kubernetes dashboard gives you broad visibility into the scale, status, and resource usage of your cluster and its containers. Further reading for Kubernetes monitoring:\n\n- [Autoscale Kubernetes workloads with any Datadog metric](https://www.datadoghq.com/blog/autoscale-kubernetes-datadog/)\n\n- [How to monitor Kubernetes + Docker with Datadog](https://www.datadoghq.com/blog/monitor-kubernetes-docker/)\n\n- [Monitoring in the Kubernetes era](https://www.datadoghq.com/blog/monitoring-kubernetes-era/)\n\n- [Monitoring Kubernetes performance metrics](https://www.datadoghq.com/blog/monitoring-kubernetes-performance-metrics/)\n\n- [Collecting metrics with built-in Kubernetes monitoring tools](https://www.datadoghq.com/blog/how-to-collect-and-graph-kubernetes-metrics/)\n\n- [Monitoring Kubernetes with Datadog](https://www.datadoghq.com/blog/monitoring-kubernetes-with-datadog/)\n\n- [Datadog's Kubernetes integration docs](https://docs.datadoghq.com/integrations/kubernetes/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
+  "widgets": [
+    {
+      "id": 1,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "top(sum:kubernetes_state.nodes.by_condition{$cluster,status:true,!condition:ready,$host} by {status,condition,cluster_name}, 10, 'last', 'desc')",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "right_yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Number of Not ready Nodes",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false
+      },
+      "layout": {
+        "x": 40,
+        "y": 36,
+        "width": 39,
+        "height": 16
+      }
+    },
+    {
+      "id": 2,
+      "definition": {
+        "type": "check_status",
+        "title": "Kubelets up",
+        "title_size": "16",
+        "title_align": "center",
+        "check": "kubernetes.kubelet.check",
+        "grouping": "cluster",
+        "group_by": [],
+        "tags": [
+          "$cluster",
+          "$host"
+        ],
+        "time": {
+          "live_span": "10m"
+        }
+      },
+      "layout": {
+        "x": 0,
+        "y": 22,
+        "width": 20,
+        "height": 7
+      }
+    },
+    {
+      "id": 3,
+      "definition": {
+        "type": "check_status",
+        "title": "Kubelet Ping",
+        "title_size": "16",
+        "title_align": "center",
+        "check": "kubernetes.kubelet.check.ping",
+        "grouping": "cluster",
+        "group_by": [],
+        "tags": [
+          "$cluster",
+          "$host"
+        ],
+        "time": {
+          "live_span": "10m"
+        }
+      },
+      "layout": {
+        "x": 0,
+        "y": 14,
+        "width": 20,
+        "height": 7
+      }
+    },
+    {
+      "id": 4,
+      "definition": {
+        "type": "note",
+        "content": "Nodes Utilization",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 0,
+        "y": 53,
+        "width": 115,
+        "height": 5
+      }
+    },
+    {
+      "id": 5,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:kubernetes.memory.usage{$cluster,$host} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Memory usage per node",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
+      },
+      "layout": {
+        "x": 58,
+        "y": 76,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 6,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:kubernetes.cpu.requests{$cluster,$host} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Sum Kubernetes CPU requests per node",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {
+          "live_span": "4h"
+        },
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 0,
+        "y": 93,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 7,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:kubernetes.memory.requests{$cluster,$host} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Sum Kubernetes memory requests per node",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {
+          "live_span": "4h"
+        },
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 58,
+        "y": 93,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 8,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:kubernetes.cpu.usage.total{$cluster,$host} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "CPU usage per node",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
+      },
+      "layout": {
+        "x": 0,
+        "y": 76,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 9,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "top(sum:kubernetes.pods.running{$cluster,$host} by {host}, 50, 'mean', 'desc')",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Sum of Pods per Node ",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
+      },
+      "layout": {
+        "x": 58,
+        "y": 173,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 10,
+      "definition": {
+        "type": "note",
+        "content": "Disk I/O & Network",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 0,
+        "y": 319,
+        "width": 115,
+        "height": 5
+      }
+    },
+    {
+      "id": 11,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:kubernetes.network.rx_bytes{$cluster,$host} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Network in per node",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {
+          "live_span": "4h"
+        },
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 0,
+        "y": 325,
+        "width": 57,
+        "height": 15
+      }
+    },
+    {
+      "id": 12,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:kubernetes.network.tx_bytes{$cluster,$host} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "green",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Network out per node",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {
+          "live_span": "4h"
+        },
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 0,
+        "y": 341,
+        "width": 57,
+        "height": 15
+      }
+    },
+    {
+      "id": 13,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:kubernetes.io.read_bytes{$cluster,$host} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "grey",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Disk reads per node",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {
+          "live_span": "4h"
+        },
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 58,
+        "y": 341,
+        "width": 57,
+        "height": 15
+      }
+    },
+    {
+      "id": 14,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:kubernetes.io.write_bytes{$cluster,$host} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "grey",
+              "line_type": "solid",
+              "line_width": "thick"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Disk writes per node",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {
+          "live_span": "4h"
+        },
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 58,
+        "y": 325,
+        "width": 57,
+        "height": 15
+      }
+    },
+    {
+      "id": 19,
+      "definition": {
+        "type": "toplist",
+        "requests": [
+          {
+            "q": "top(sum:kubernetes_state.nodes.by_condition{$cluster,status:true,$host} by {condition,status}, 10, 'mean', 'desc')"
+          }
+        ],
+        "custom_links": [],
+        "title": "Node active conditions overview ",
+        "title_size": "16",
+        "title_align": "left"
+      },
+      "layout": {
+        "x": 80,
+        "y": 36,
+        "width": 35,
+        "height": 16
+      }
+    },
+    {
+      "id": 21,
+      "definition": {
+        "type": "event_timeline",
+        "query": "sources:kubernetes $host $cluster",
+        "tags_execution": "and",
+        "title": "",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {
+          "live_span": "4h"
+        }
+      },
+      "layout": {
+        "x": 0,
+        "y": 230,
+        "width": 57,
+        "height": 9
+      }
+    },
+    {
+      "id": 22,
+      "definition": {
+        "type": "note",
+        "content": "[Events](https://www.datadoghq.com/blog/monitoring-kubernetes-performance-metrics/#toc-correlate-with-events10)\nand certificates",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 0,
+        "y": 224,
+        "width": 115,
+        "height": 5
+      }
+    },
+    {
+      "id": 23,
+      "definition": {
+        "type": "event_stream",
+        "query": "sources:kubernetes $host $cluster",
+        "tags_execution": "and",
+        "event_size": "s",
+        "title": "",
+        "title_size": "16",
+        "title_align": "left"
+      },
+      "layout": {
+        "x": 58,
+        "y": 230,
+        "width": 57,
+        "height": 34
+      }
+    },
+    {
+      "id": 24,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}, avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}*100",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "include_zero": false
+        },
+        "markers": [
+          {
+            "value": "y = 100",
+            "display_type": "error dashed"
+          }
+        ],
+        "title": "Memory utilization per node",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 58,
+        "y": 59,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 26,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:kubernetes_state.node.cpu_allocatable{$cluster,$host} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Allocatable cpu cores per node",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true
+      },
+      "layout": {
+        "x": 58,
+        "y": 271,
+        "width": 57,
+        "height": 15
+      }
+    },
+    {
+      "id": 27,
+      "definition": {
+        "type": "note",
+        "content": "Allocatable resources per Node",
+        "background_color": "gray",
+        "font_size": "16",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      },
+      "layout": {
+        "x": 0,
+        "y": 265,
+        "width": 115,
+        "height": 5
+      }
+    },
+    {
+      "id": 28,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:kubernetes_state.node.pods_allocatable{$cluster,$host} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Allocatable pods per node",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true
+      },
+      "layout": {
+        "x": 0,
+        "y": 271,
+        "width": 57,
+        "height": 15
+      }
+    },
+    {
+      "id": 29,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:kubernetes_state.node.memory_allocatable{$cluster,$host} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Allocatable memory per node",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true
+      },
+      "layout": {
+        "x": 0,
+        "y": 173,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 30,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:kubernetes.containers.running{$cluster,$host} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Sum of containers per node",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
+      },
+      "layout": {
+        "x": 58,
+        "y": 190,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 31,
+      "definition": {
+        "type": "query_table",
+        "requests": [
+          {
+            "q": "avg:kubernetes_state.node.cpu_allocatable{$host, $cluster} by {host}",
+            "aggregator": "avg",
+            "limit": 25,
+            "order": "asc"
+          }
+        ],
+        "custom_links": [],
+        "title": "Allocatable CPU sort ASC",
+        "title_size": "16",
+        "title_align": "left"
+      },
+      "layout": {
+        "x": 0,
+        "y": 287,
+        "width": 57,
+        "height": 15
+      }
+    },
+    {
+      "id": 32,
+      "definition": {
+        "type": "query_table",
+        "requests": [
+          {
+            "q": "avg:kubernetes_state.node.pods_allocatable{$cluster,$host} by {host}",
+            "aggregator": "avg",
+            "limit": 25,
+            "order": "asc"
+          }
+        ],
+        "custom_links": [],
+        "title": "Allocatable Pods sort ASC",
+        "title_size": "16",
+        "title_align": "left"
+      },
+      "layout": {
+        "x": 58,
+        "y": 287,
+        "width": 57,
+        "height": 15
+      }
+    },
+    {
+      "id": 33,
+      "definition": {
+        "type": "query_table",
+        "requests": [
+          {
+            "q": "avg:kubernetes_state.node.memory_allocatable{$cluster,$host} by {host}",
+            "aggregator": "avg",
+            "limit": 25,
+            "order": "asc"
+          }
+        ],
+        "custom_links": [],
+        "title": "Allocatable Memory sort ASC",
+        "title_size": "16",
+        "title_align": "left"
+      },
+      "layout": {
+        "x": 0,
+        "y": 303,
+        "width": 57,
+        "height": 15
+      }
+    },
+    {
+      "id": 35,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:kubernetes_state.nodes.by_condition{$cluster,$host,condition:ready,status:true} by {condition,status,cluster_name}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "right_yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Number of Ready Nodes",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
+      },
+      "layout": {
+        "x": 0,
+        "y": 36,
+        "width": 39,
+        "height": 16
+      }
+    },
+    {
+      "id": 36,
+      "definition": {
+        "type": "toplist",
+        "requests": [
+          {
+            "q": "top(max:tls.seconds_left{kubelet:server,$cluster,$host} by {host}, 25, 'last', 'asc')",
+            "conditional_formats": [
+              {
+                "comparator": ">",
+                "value": 3600,
+                "palette": "white_on_green"
+              },
+              {
+                "comparator": ">",
+                "value": 0,
+                "palette": "white_on_yellow"
+              },
+              {
+                "comparator": "<",
+                "value": 0,
+                "palette": "white_on_red"
+              }
+            ]
+          }
+        ],
+        "custom_links": [],
+        "title": "Kubelet certificate close to expirations",
+        "title_size": "16",
+        "title_align": "left"
+      },
+      "layout": {
+        "x": 0,
+        "y": 242,
+        "width": 57,
+        "height": 22
+      }
+    },
+    {
+      "id": 42,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:kubernetes_state.node.count{$cluster,$host}",
+            "aggregator": "avg"
+          }
+        ],
+        "title": "Number of nodes",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "autoscale": false,
+        "precision": 0
+      },
+      "layout": {
+        "x": 0,
+        "y": 6,
+        "width": 20,
+        "height": 7
+      }
+    },
+    {
+      "id": 48,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:kubernetes.memory.usage_pct{$cluster,$host} by {cluster_name}, avg:kubernetes.memory.usage_pct{$cluster,$host} by {cluster_name}*100",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "right_yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "markers": [
+          {
+            "value": "y = 100",
+            "display_type": "error dashed"
+          }
+        ],
+        "title": "Memory utilization per cluster",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false
+      },
+      "layout": {
+        "x": 0,
+        "y": 150,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 49,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:kubernetes.filesystem.usage_pct{$cluster,$host} by {cluster_name}, sum:kubernetes.filesystem.usage_pct{$cluster,$host} by {cluster_name}*100",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "right_yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Filesystem utilization per cluster",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false
+      },
+      "layout": {
+        "x": 58,
+        "y": 133,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 1833525595095066,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:kubernetes.cpu.requests{$cluster,$host} by {cluster_name}/sum:kubernetes.cpu.capacity{$cluster,$host} by {cluster_name}*100",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "markers": [
+          {
+            "value": "y = 100",
+            "display_type": "error dashed"
+          }
+        ],
+        "title": "CPU Allocation (requests / capacity) per cluster",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
+      },
+      "layout": {
+        "x": 0,
+        "y": 133,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 135174260481642,
+      "definition": {
+        "type": "note",
+        "content": "Cluster Utilization",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 0,
+        "y": 127,
+        "width": 115,
+        "height": 5
+      }
+    },
+    {
+      "id": 1118205270069402,
+      "definition": {
+        "type": "note",
+        "content": "Pods and Containers",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 0,
+        "y": 167,
+        "width": 115,
+        "height": 5
+      }
+    },
+    {
+      "id": 7551774071077938,
+      "definition": {
+        "type": "note",
+        "content": "Conditions of Nodes in a Cluster",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 0,
+        "y": 30,
+        "width": 115,
+        "height": 5
+      }
+    },
+    {
+      "id": 4742670376252076,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "100-avg:system.cpu.idle{$host,$cluster} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "markers": [
+          {
+            "value": "y = 100",
+            "display_type": "error dashed"
+          }
+        ],
+        "title": "CPU utilization per node",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 0,
+        "y": 59,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 3768427411010756,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "100-avg:system.cpu.idle{$host,$cluster} by {cluster_name}",
+            "display_type": "line",
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "right_yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "markers": [
+          {
+            "value": "y = 100",
+            "display_type": "error dashed"
+          }
+        ],
+        "title": "CPU utilization per cluster",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 58,
+        "y": 150,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 4158410061564864,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:kubernetes.cpu.requests{$cluster,$host} by {host}/sum:kubernetes.cpu.capacity{$cluster,$host} by {host}*100",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "markers": [
+          {
+            "value": "y = 100",
+            "display_type": "error dashed"
+          }
+        ],
+        "title": "Kubernetes (requests / capacity) per node",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 0,
+        "y": 110,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 3255661318461102,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:kubernetes_state.node.cpu_capacity{$cluster,$host}",
+            "aggregator": "avg"
+          }
+        ],
+        "custom_links": [],
+        "title": "Sum of CPU",
+        "title_size": "16",
+        "title_align": "left",
+        "autoscale": false,
+        "precision": 0
+      },
+      "layout": {
+        "x": 21,
+        "y": 6,
+        "width": 18,
+        "height": 7
+      }
+    },
+    {
+      "id": 4991369247392468,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:kubernetes_state.node.memory_capacity{$cluster,$host}",
+            "aggregator": "avg"
+          }
+        ],
+        "custom_links": [],
+        "title": "Sum of Memory",
+        "title_size": "16",
+        "title_align": "left",
+        "autoscale": true,
+        "precision": 0
+      },
+      "layout": {
+        "x": 21,
+        "y": 14,
+        "width": 18,
+        "height": 7
+      }
+    },
+    {
+      "id": 1924552417927878,
+      "definition": {
+        "type": "note",
+        "content": "Overview",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": -3,
+        "y": 0,
+        "width": 115,
+        "height": 5
+      }
+    },
+    {
+      "id": 7651716585819792,
+      "definition": {
+        "type": "toplist",
+        "requests": [
+          {
+            "q": "top(sum:kubernetes_state.pod.ready{$cluster,condition:true,$host} by {host,pod_name}, 10, 'last', 'desc')"
+          }
+        ],
+        "custom_links": [],
+        "title": "Pods in Ready State per Node",
+        "title_size": "16",
+        "title_align": "left"
+      },
+      "layout": {
+        "x": 0,
+        "y": 190,
+        "width": 57,
+        "height": 16
+      }
+    },
+    {
+      "id": 7485538399693614,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "100-avg:system.cpu.idle{$host,$cluster} by {host}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "markers": [
+          {
+            "value": "y = 100",
+            "display_type": "error dashed"
+          }
+        ],
+        "title": "CPU % utilization per node",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 80,
+        "y": 6,
+        "width": 35,
+        "height": 23
+      }
+    },
+    {
+      "id": 1166393040596032,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}, avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}*100",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "include_zero": false
+        },
+        "markers": [
+          {
+            "value": "y = 100",
+            "display_type": "error dashed"
+          }
+        ],
+        "title": "Memory utilization % per node",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 40,
+        "y": 6,
+        "width": 39,
+        "height": 23
+      }
+    }
+  ],
+  "template_variables": [
+    {
+      "name": "cluster",
+      "default": "*",
+      "prefix": "cluster_name"
+    },
+    {
+      "name": "host",
+      "default": "*",
+      "prefix": "host"
+    }
+  ],
+  "layout_type": "free",
+  "is_read_only": false,
+  "notify_list": [],
+  "id": "vmw-jbm-ewe"
+}

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -25,7 +25,8 @@
   "assets": {
     "monitors": {},
     "dashboards": {
-      "Kubernetes - Pods": "assets/dashboards/kubernetes_pods.json"
+      "Kubernetes - Pods": "assets/dashboards/kubernetes_pods.json",
+      "Kubernetes - Nodes": "assets/dashboards/kubernetes_nodes.json"
     },
     "service_checks": "assets/service_checks.json"
   }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a new OOTB dashboard for Nodes that is part of the Kubernetes integration

### Motivation
<!-- What inspired you to submit this pull request? -->
- Users would like additional dashboards to monitor different workloads in Kubernetes, like nodes.
- Customers would like to have fewer template var. for specific dashboards like nodes.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Staging URL: https://dd.datad0g.com/dashboard/ixg-wq2-h3v/kubernetes-nodes-overview?from_ts=1594206126800&live=true&to_ts=1594209726800


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
