### PR TITLE
Limit the number of reported contexts

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -87,14 +87,14 @@ class KafkaCheck(AgentCheck):
 
         # Fetch Kafka consumer offsets
         try:
-            self._get_consumer_offsets()
+            self._get_consumer_offsets(self._context_limit)
         except Exception:
             self.log.exception("There was a problem collecting consumer offsets from Kafka.")
             # don't raise because we might get valid broker offsets
 
         # Fetch the broker highwater offsets
         try:
-            self._get_highwater_offsets()
+            self._get_highwater_offsets(self._context_limit - len(self._consumer_offsets))
         except Exception:
             self.log.exception("There was a problem collecting the highwater mark offsets.")
             # Unlike consumer offsets, fail immediately because we can't calculate consumer lag w/o highwater_offsets
@@ -110,9 +110,10 @@ class KafkaCheck(AgentCheck):
                 self._context_limit,
             )
 
-        # Report the metics
-        self._report_highwater_offsets()
-        self._report_consumer_offsets_and_lag()
+        # Report the metrics
+        context_available = self._context_limit
+        context_available -= self._report_highwater_offsets(context_available)
+        self._report_consumer_offsets_and_lag(context_available)
 
     def _create_kafka_admin_client(self, api_version):
         """Return a KafkaAdminClient."""
@@ -150,7 +151,7 @@ class KafkaCheck(AgentCheck):
             raise RuntimeError("Local cluster metadata cache did not populate.")
         return kafka_admin_client
 
-    def _get_highwater_offsets(self):
+    def _get_highwater_offsets(self, contexts_to_fetch):
         """Fetch highwater offsets for topic_partitions in the Kafka cluster.
 
         Do this for all partitions in the cluster because even if it has no consumers, we may want to measure whether
@@ -246,22 +247,34 @@ class KafkaCheck(AgentCheck):
                         "partition: %s." % (topic, partition)
                     )
 
-    def _report_highwater_offsets(self):
+    def _report_highwater_offsets(self, contexts_available):
         """Report the broker highwater offsets."""
+        reported_contexts = 0
+
         for (topic, partition), highwater_offset in self._highwater_offsets.items():
+            if reported_contexts >= contexts_available:
+                self.log.debug("Skipping remaining highwater offsets because context limit has been reached")
+                break
             broker_tags = ['topic:%s' % topic, 'partition:%s' % partition]
             broker_tags.extend(self._custom_tags)
             self.gauge('broker_offset', highwater_offset, tags=broker_tags)
+            reported_contexts += 1
+        return reported_contexts
 
-    def _report_consumer_offsets_and_lag(self):
+    def _report_consumer_offsets_and_lag(self, contexts_available):
         """Report the consumer offsets and consumer lag."""
+        reported_contexts = 0
         for (consumer_group, topic, partition), consumer_offset in self._consumer_offsets.items():
+            if reported_contexts >= contexts_available:
+                self.log.debug("Skipping remaining consumer and lag offsets because context limit has been reached")
+                break
             consumer_group_tags = ['topic:%s' % topic, 'partition:%s' % partition, 'consumer_group:%s' % consumer_group]
             consumer_group_tags.extend(self._custom_tags)
             if partition in self._kafka_client._client.cluster.partitions_for_topic(topic):
                 # report consumer offset if the partition is valid because even if leaderless the consumer offset will
                 # be valid once the leader failover completes
                 self.gauge('consumer_offset', consumer_offset, tags=consumer_group_tags)
+                reported_contexts += 1
                 if (topic, partition) not in self._highwater_offsets:
                     self.log.warning(
                         "Consumer group: %s has offsets for topic: %s partition: %s, but no stored highwater offset "
@@ -273,7 +286,9 @@ class KafkaCheck(AgentCheck):
                     continue
 
                 consumer_lag = self._highwater_offsets[(topic, partition)] - consumer_offset
-                self.gauge('consumer_lag', consumer_lag, tags=consumer_group_tags)
+                if reported_contexts < contexts_available:
+                    self.gauge('consumer_lag', consumer_lag, tags=consumer_group_tags)
+                    reported_contexts += 1
 
                 if consumer_lag < 0:
                     # this will effectively result in data loss, so emit an event for max visibility
@@ -296,8 +311,9 @@ class KafkaCheck(AgentCheck):
                     partition,
                 )
                 self._kafka_client._client.cluster.request_update()  # force metadata update on next poll()
+        return reported_contexts
 
-    def _get_consumer_offsets(self):
+    def _get_consumer_offsets(self, contexts_to_fetch):
         """Fetch Consumer Group offsets from Kafka.
 
         Also fetch consumer_groups, topics, and partitions if not already specified.
@@ -322,12 +338,18 @@ class KafkaCheck(AgentCheck):
 
         if self._monitor_unlisted_consumer_groups:
             for broker in self._kafka_client._client.cluster.brokers():
+                if len(self._consumer_offsets) >= contexts_to_fetch:
+                    self.log.debug("Context limit reached, skipping further fetching")
+                    break
                 list_groups_future = self._kafka_client._list_consumer_groups_send_request(broker.nodeId)
                 list_groups_future.add_callback(self._list_groups_callback, broker.nodeId)
                 self._consumer_futures.append(list_groups_future)
         elif self._consumer_groups:
             self._validate_listed_consumer_groups()
             for consumer_group in self._consumer_groups:
+                if len(self._consumer_offsets) >= contexts_to_fetch:
+                    self.log.debug("Context limit reached, skipping further fetching")
+                    break
                 find_coordinator_future = self._kafka_client._find_coordinator_id_send_request(consumer_group)
                 find_coordinator_future.add_callback(self._find_coordinator_callback, consumer_group)
                 self._consumer_futures.append(find_coordinator_future)

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -111,9 +111,8 @@ class KafkaCheck(AgentCheck):
             )
 
         # Report the metrics
-        context_available = self._context_limit
-        context_available -= self._report_highwater_offsets(context_available)
-        self._report_consumer_offsets_and_lag(context_available)
+        self._report_highwater_offsets()
+        self._report_consumer_offsets_and_lag()
 
     def _create_kafka_admin_client(self, api_version):
         """Return a KafkaAdminClient."""
@@ -247,34 +246,22 @@ class KafkaCheck(AgentCheck):
                         "partition: %s." % (topic, partition)
                     )
 
-    def _report_highwater_offsets(self, contexts_available):
+    def _report_highwater_offsets(self):
         """Report the broker highwater offsets."""
-        reported_contexts = 0
-
         for (topic, partition), highwater_offset in self._highwater_offsets.items():
-            if reported_contexts >= contexts_available:
-                self.log.debug("Skipping remaining highwater offsets because context limit has been reached")
-                break
             broker_tags = ['topic:%s' % topic, 'partition:%s' % partition]
             broker_tags.extend(self._custom_tags)
             self.gauge('broker_offset', highwater_offset, tags=broker_tags)
-            reported_contexts += 1
-        return reported_contexts
 
-    def _report_consumer_offsets_and_lag(self, contexts_available):
+    def _report_consumer_offsets_and_lag(self):
         """Report the consumer offsets and consumer lag."""
-        reported_contexts = 0
         for (consumer_group, topic, partition), consumer_offset in self._consumer_offsets.items():
-            if reported_contexts >= contexts_available:
-                self.log.debug("Skipping remaining consumer and lag offsets because context limit has been reached")
-                break
             consumer_group_tags = ['topic:%s' % topic, 'partition:%s' % partition, 'consumer_group:%s' % consumer_group]
             consumer_group_tags.extend(self._custom_tags)
             if partition in self._kafka_client._client.cluster.partitions_for_topic(topic):
                 # report consumer offset if the partition is valid because even if leaderless the consumer offset will
                 # be valid once the leader failover completes
                 self.gauge('consumer_offset', consumer_offset, tags=consumer_group_tags)
-                reported_contexts += 1
                 if (topic, partition) not in self._highwater_offsets:
                     self.log.warning(
                         "Consumer group: %s has offsets for topic: %s partition: %s, but no stored highwater offset "
@@ -286,9 +273,7 @@ class KafkaCheck(AgentCheck):
                     continue
 
                 consumer_lag = self._highwater_offsets[(topic, partition)] - consumer_offset
-                if reported_contexts < contexts_available:
-                    self.gauge('consumer_lag', consumer_lag, tags=consumer_group_tags)
-                    reported_contexts += 1
+                self.gauge('consumer_lag', consumer_lag, tags=consumer_group_tags)
 
                 if consumer_lag < 0:
                     # this will effectively result in data loss, so emit an event for max visibility
@@ -311,7 +296,6 @@ class KafkaCheck(AgentCheck):
                     partition,
                 )
                 self._kafka_client._client.cluster.request_update()  # force metadata update on next poll()
-        return reported_contexts
 
     def _get_consumer_offsets(self, contexts_to_fetch):
         """Fetch Consumer Group offsets from Kafka.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -87,21 +87,24 @@ class KafkaCheck(AgentCheck):
 
         # Fetch Kafka consumer offsets
         try:
-            self._get_consumer_offsets(self._context_limit)
+            self._get_consumer_offsets()
         except Exception:
             self.log.exception("There was a problem collecting consumer offsets from Kafka.")
             # don't raise because we might get valid broker offsets
 
         # Fetch the broker highwater offsets
         try:
-            self._get_highwater_offsets(self._context_limit - len(self._consumer_offsets))
+            if len(self._consumer_offsets) < self._context_limit:
+                self._get_highwater_offsets()
+            else:
+                self.log.warning("Contex limit reached. Skipping highwater collection")
         except Exception:
             self.log.exception("There was a problem collecting the highwater mark offsets.")
             # Unlike consumer offsets, fail immediately because we can't calculate consumer lag w/o highwater_offsets
             raise
 
         total_contexts = len(self._consumer_offsets) + len(self._highwater_offsets)
-        if total_contexts > self._context_limit:
+        if total_contexts >= self._context_limit:
             self.warning(
                 """Discovered %s metric contexts - this exceeds the maximum number of %s contexts permitted by the
                 check. Please narrow your target by specifying in your kafka_consumer.yaml the consumer groups, topics
@@ -111,8 +114,8 @@ class KafkaCheck(AgentCheck):
             )
 
         # Report the metrics
-        self._report_highwater_offsets()
-        self._report_consumer_offsets_and_lag()
+        self._report_highwater_offsets(self._context_limit)
+        self._report_consumer_offsets_and_lag(self._context_limit - len(self._highwater_offsets))
 
     def _create_kafka_admin_client(self, api_version):
         """Return a KafkaAdminClient."""
@@ -150,7 +153,7 @@ class KafkaCheck(AgentCheck):
             raise RuntimeError("Local cluster metadata cache did not populate.")
         return kafka_admin_client
 
-    def _get_highwater_offsets(self, contexts_to_fetch):
+    def _get_highwater_offsets(self):
         """Fetch highwater offsets for topic_partitions in the Kafka cluster.
 
         Do this for all partitions in the cluster because even if it has no consumers, we may want to measure whether
@@ -246,22 +249,31 @@ class KafkaCheck(AgentCheck):
                         "partition: %s." % (topic, partition)
                     )
 
-    def _report_highwater_offsets(self):
+    def _report_highwater_offsets(self, contexts_limit):
         """Report the broker highwater offsets."""
+        reported_contexts = 0
         for (topic, partition), highwater_offset in self._highwater_offsets.items():
             broker_tags = ['topic:%s' % topic, 'partition:%s' % partition]
             broker_tags.extend(self._custom_tags)
             self.gauge('broker_offset', highwater_offset, tags=broker_tags)
+            reported_contexts += 1
+            if reported_contexts == contexts_limit:
+                return
 
-    def _report_consumer_offsets_and_lag(self):
+    def _report_consumer_offsets_and_lag(self, contexts_limit):
         """Report the consumer offsets and consumer lag."""
+        reported_contexts = 0
         for (consumer_group, topic, partition), consumer_offset in self._consumer_offsets.items():
+            if reported_contexts >= contexts_limit:
+                return
             consumer_group_tags = ['topic:%s' % topic, 'partition:%s' % partition, 'consumer_group:%s' % consumer_group]
             consumer_group_tags.extend(self._custom_tags)
             if partition in self._kafka_client._client.cluster.partitions_for_topic(topic):
                 # report consumer offset if the partition is valid because even if leaderless the consumer offset will
                 # be valid once the leader failover completes
                 self.gauge('consumer_offset', consumer_offset, tags=consumer_group_tags)
+                reported_contexts += 1
+
                 if (topic, partition) not in self._highwater_offsets:
                     self.log.warning(
                         "Consumer group: %s has offsets for topic: %s partition: %s, but no stored highwater offset "
@@ -273,7 +285,9 @@ class KafkaCheck(AgentCheck):
                     continue
 
                 consumer_lag = self._highwater_offsets[(topic, partition)] - consumer_offset
-                self.gauge('consumer_lag', consumer_lag, tags=consumer_group_tags)
+                if reported_contexts < contexts_limit:
+                    self.gauge('consumer_lag', consumer_lag, tags=consumer_group_tags)
+                    reported_contexts += 1
 
                 if consumer_lag < 0:
                     # this will effectively result in data loss, so emit an event for max visibility
@@ -297,7 +311,7 @@ class KafkaCheck(AgentCheck):
                 )
                 self._kafka_client._client.cluster.request_update()  # force metadata update on next poll()
 
-    def _get_consumer_offsets(self, contexts_to_fetch):
+    def _get_consumer_offsets(self):
         """Fetch Consumer Group offsets from Kafka.
 
         Also fetch consumer_groups, topics, and partitions if not already specified.
@@ -322,18 +336,12 @@ class KafkaCheck(AgentCheck):
 
         if self._monitor_unlisted_consumer_groups:
             for broker in self._kafka_client._client.cluster.brokers():
-                if len(self._consumer_offsets) >= contexts_to_fetch:
-                    self.log.debug("Context limit reached, skipping further fetching")
-                    break
                 list_groups_future = self._kafka_client._list_consumer_groups_send_request(broker.nodeId)
                 list_groups_future.add_callback(self._list_groups_callback, broker.nodeId)
                 self._consumer_futures.append(list_groups_future)
         elif self._consumer_groups:
             self._validate_listed_consumer_groups()
             for consumer_group in self._consumer_groups:
-                if len(self._consumer_offsets) >= contexts_to_fetch:
-                    self.log.debug("Context limit reached, skipping further fetching")
-                    break
                 find_coordinator_future = self._kafka_client._find_coordinator_id_send_request(consumer_group)
                 find_coordinator_future.add_callback(self._find_coordinator_callback, consumer_group)
                 self._consumer_futures.append(find_coordinator_future)

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -97,7 +97,7 @@ class KafkaCheck(AgentCheck):
             if len(self._consumer_offsets) < self._context_limit:
                 self._get_highwater_offsets()
             else:
-                self.log.warning("Contex limit reached. Skipping highwater collection")
+                self.log.debug("Context limit reached. Skipping highwater offset collection.")
         except Exception:
             self.log.exception("There was a problem collecting the highwater mark offsets.")
             # Unlike consumer offsets, fail immediately because we can't calculate consumer lag w/o highwater_offsets

--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -224,7 +224,7 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
             response = self._make_blocking_req(request, node_id=broker.nodeId)
             self._process_highwater_offsets(response)
             if len(self._highwater_offsets) >= contexts_limit:
-                self.log.debug("Context limit reached, not collecting more highwater offsets")
+                self.log.debug("Context limit reached. Skipping highwater offsets collection.")
                 return
 
     def _process_highwater_offsets(self, response):
@@ -374,7 +374,7 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
                         gathered_contexts += 1
 
                         if gathered_contexts >= contexts_limit:
-                            self.log.debug("Context limit reached, not collecting more zk consumer offsets")
+                            self.log.debug("Context limit reached. Skipping zk consumer offsets collection.")
                             return
                     except NoNodeError:
                         self.log.info('No zookeeper node at %s', zk_path)
@@ -426,7 +426,7 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
                             gathered_contexts += 1
 
                             if gathered_contexts >= contexts_limit:
-                                self.log.debug("Context limit reached, not collecting more kafka consumer offsets")
+                                self.log.debug("Context limit reached. Skipping kafka consumer offsets collection.")
                                 return
                 else:
                     self.log.info("unable to find group coordinator for %s", consumer_group)

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -17,6 +17,7 @@ BROKER_METRICS = ['kafka.broker_offset']
 CONSUMER_METRICS = ['kafka.consumer_offset', 'kafka.consumer_lag']
 
 
+@pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_check_kafka(aggregator, kafka_instance):
     """
@@ -26,6 +27,18 @@ def test_check_kafka(aggregator, kafka_instance):
     kafka_consumer_check.check(kafka_instance)
 
     assert_check_kafka(aggregator, kafka_instance['consumer_groups'])
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_check_kafka_metrics_limit(aggregator, kafka_instance):
+    """
+    Testing Kafka_consumer check.
+    """
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {'max_partition_contexts': 1}, [kafka_instance])
+    kafka_consumer_check.check(kafka_instance)
+
+    assert len(aggregator._metrics) == 1
 
 
 @pytest.mark.e2e
@@ -48,6 +61,7 @@ def assert_check_kafka(aggregator, consumer_groups):
     aggregator.assert_all_metrics_covered()
 
 
+@pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_consumer_config_error(caplog):
     instance = {'kafka_connect_str': KAFKA_CONNECT_STR, 'kafka_consumer_offsets': True, 'tags': ['optional:tag1']}
@@ -60,6 +74,7 @@ def test_consumer_config_error(caplog):
     assert 'monitor_unlisted_consumer_groups is False' in caplog.text
 
 
+@pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_no_topics(aggregator, kafka_instance):
     kafka_instance['consumer_groups'] = {'my_consumer': {}}
@@ -72,6 +87,7 @@ def test_no_topics(aggregator, kafka_instance):
     assert_check_kafka(aggregator, {'my_consumer': {'marvel': [0]}})
 
 
+@pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_no_partitions(aggregator, kafka_instance):
     kafka_instance['consumer_groups'] = {'my_consumer': {'marvel': []}}


### PR DESCRIPTION
The Kafka consumer checks counts the total number of submitted context and displays a warning when the check submits too many metrics.
But the check still collects all metrics, this is a regression introduced here: https://github.com/DataDog/integrations-core/commit/c4a29b1d62165017204a1cc96cf54a293bf3e16f

On the legacy implementation the limit is applied at collection time. However, as the new implementation uses futures to perform the collection this strategy can only be partially applied and so the limit is applied on submission time.