### PR TITLE
Use OID instead of MIB for sysName

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/_base.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_base.yaml
@@ -1,6 +1,6 @@
 # Base profile that should only contain any items we want to provide for all profiles.
 
 metric_tags:
-  - MIB: SNMPv2-MIB
+  - OID: 1.3.6.1.2.1.1.5.0
     symbol: sysName
     tag: snmp_host


### PR DESCRIPTION
### What does this PR do?

Use OID instead of MIB for sysName.

Note: let's use `1.3.6.1.2.1.1.5.0` instead of `1.3.6.1.2.1.1.5`. That will avoid having to call both snmp get (will fail for `1.3.6.1.2.1.1.5`)  and snmp next

### Motivation

Avoids having to resolve by mib: https://github.com/DataDog/integrations-core/blob/917c0bcad5e08108bf733f5f4180659531cf3866/snmp/datadog_checks/snmp/resolver.py#L162
