### PR TITLE
Remove validation on formatting of public title

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -362,20 +362,6 @@ def manifest(ctx, fix, include_extras, repo_url):
                 if not public_title or not isinstance(public_title, str):
                     file_failures += 1
                     display_queue.append((echo_failure, '  required non-null string: public_title'))
-                else:
-                    title_start = 'Datadog-'
-                    title_end = ' Integration'
-                    section_char_set = set(public_title[len(title_start) : -len(title_end)].lower())
-                    check_name_char_set = set(check_name.lower())
-                    character_overlap = check_name_char_set & section_char_set
-
-                    correct_start = public_title.startswith(title_start)
-                    correct_end = public_title.endswith(title_end)
-                    overlap_enough = len(character_overlap) > int(len(check_name_char_set) * 0.5)
-
-                    if not (correct_start and correct_end and overlap_enough):
-                        file_failures += 1
-                        display_queue.append((echo_failure, f'  invalid `public_title`: {public_title}'))
 
                 # categories
                 categories = decoded.get('categories')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-{integration_name} Integration",
+  "public_title": "{integration_name}",
   "categories": [
     ""
   ],

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-{integration_name} Integration",
+  "public_title": "{integration_name}",
   "categories": [
     ""
   ],

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-{integration_name} Integration",
+  "public_title": "{integration_name}",
   "categories": [
     "log collection"
   ],

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-{integration_name} Integration",
+  "public_title": "{integration_name}",
   "categories": [
     ""
   ],


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove the validation surrounding the `Datadog-` and `Integration` formatting of public titles in the manifest.json

### Motivation
<!-- What inspired you to submit this pull request? -->
The consumers of this used to require that they were formatted in this way, but thats no longer the case. For example, https://github.com/DataDog/documentation/blob/d0fbfdcf034150802e477120eaba7257fd9c119f/local/bin/py/build/actions/integrations.py#L564 replaces out the `Datadog-` prefix and `Integration` suffix.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
