### PR TITLE
Add setup section to readme

### DIFF
--- a/kube_proxy/README.md
+++ b/kube_proxy/README.md
@@ -20,7 +20,7 @@ Note: If you edit the namespace & metrics name, or add any other metric they are
 
 Contribute to the integration if you want to add a relevant metric.
 
-## Validation
+### Validation
 
 [Run the Agent's `status` subcommand][1] and look for `kube_proxy` under the Checks section.
 

--- a/kube_proxy/README.md
+++ b/kube_proxy/README.md
@@ -7,7 +7,9 @@ Get metrics from kube_proxy service in real time to:
 - Visualize and monitor kube_proxy states
 - Be notified about kube_proxy failovers and events.
 
-## Configuration
+## Setup
+
+### Configuration
 
 The integration relies on the `--metrics-bind-address` option of the kube-proxy, by default it's bound to `127.0.0.1:10249`.
 Either start the agent on the host network if the kube-proxy is also on the host network (default) or start the kube-proxy with the `--metrics-bind-address=0.0.0.0:10249`


### PR DESCRIPTION
### What does this PR do?
- Adds a setup section to a readme- all integrations should have one.
### Motivation
https://github.com/DataDog/integrations-core/pull/7088
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
