### PR TITLE
Add `get_check_logger`

### DIFF
--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
+import sys
 from typing import Callable
 
 from six import PY2, text_type
@@ -165,7 +166,6 @@ def get_check_logger(default_logger=None):
     """
     Search the current AgentCheck log starting from closest stack frame.
     """
-    import sys
     from datadog_checks.base import AgentCheck
 
     for i in range(MAX_LOGGER_FRAME_SEARCH):

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -21,7 +21,7 @@ TRACE_LEVEL = 7
 LOGGER_FRAME_SEARCH_MAX_DEPTH = 50
 
 
-default_fallback_logger = logging.getLogger(__name__)
+DEFAULT_FALLBACK_LOGGER = logging.getLogger(__name__)
 
 
 class AgentLogger(logging.getLoggerClass()):
@@ -169,11 +169,14 @@ def get_check_logger(default_logger=None):
     from datadog_checks.base import AgentCheck
 
     for i in range(LOGGER_FRAME_SEARCH_MAX_DEPTH):
-        frame = sys._getframe(i)
+        try:
+            frame = sys._getframe(i)
+        except ValueError:
+            break
         if 'self' in frame.f_locals:
             check = frame.f_locals['self']
             if isinstance(check, AgentCheck):
                 return check.log
     if default_logger is not None:
         return default_logger
-    return default_fallback_logger
+    return DEFAULT_FALLBACK_LOGGER

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -18,7 +18,7 @@ except ImportError:
 # Arbitrary number less than 10 (DEBUG)
 TRACE_LEVEL = 7
 
-MAX_LOGGER_FRAME_SEARCH = 50
+LOGGER_FRAME_SEARCH_MAX_DEPTH = 50
 
 
 default_fallback_logger = logging.getLogger(__name__)
@@ -168,7 +168,7 @@ def get_check_logger(default_logger=None):
     """
     from datadog_checks.base import AgentCheck
 
-    for i in range(MAX_LOGGER_FRAME_SEARCH):
+    for i in range(LOGGER_FRAME_SEARCH_MAX_DEPTH):
         frame = sys._getframe(i)
         if 'self' in frame.f_locals:
             check = frame.f_locals['self']

--- a/datadog_checks_base/tests/test_log.py
+++ b/datadog_checks_base/tests/test_log.py
@@ -10,7 +10,7 @@ import mock
 
 from datadog_checks import log
 from datadog_checks.base import AgentCheck
-from datadog_checks.base.log import get_check_logger, init_logging
+from datadog_checks.base.log import DEFAULT_FALLBACK_LOGGER, get_check_logger, init_logging
 
 
 def test_get_py_loglevel():
@@ -49,7 +49,7 @@ def test_get_check_logger(caplog):
 
     class MyCheck(AgentCheck):
         def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
+            super(MyCheck, self).__init__(*args, **kwargs)
             self.config = FooConfig()
 
         def check(self, _):
@@ -59,4 +59,23 @@ def test_get_check_logger(caplog):
     check.check({})
 
     assert check.log is check.config.log
+    assert "This is a warning" in caplog.text
+
+
+def test_get_check_logger_fallback(caplog):
+    log = get_check_logger()
+
+    log.warning("This is a warning")
+
+    assert log is DEFAULT_FALLBACK_LOGGER
+    assert "This is a warning" in caplog.text
+
+
+def test_get_check_logger_argument_fallback(caplog):
+    logger = logging.getLogger()
+    log = get_check_logger(default_logger=logger)
+
+    log.warning("This is a warning")
+
+    assert log is logger
     assert "This is a warning" in caplog.text


### PR DESCRIPTION
### What does this PR do?

Add get_check_logger

### Motivation

Avoids having to pass the log object from AgentCheck to other classes. See test example.
