### PR TITLE
Out-of-the-box Dashboard for Kubernetes Deployments

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_deployments.json
+++ b/kubernetes/assets/dashboards/kubernetes_deployments.json
@@ -17,7 +17,7 @@
     },
     "description": "Our Kubernetes dashboard gives you broad visibility into the scale, status, and resource usage of your cluster and its containers. Further reading for Kubernetes monitoring:\n\n- [Autoscale Kubernetes workloads with any Datadog metric](https://www.datadoghq.com/blog/autoscale-kubernetes-datadog/)\n\n- [How to monitor Kubernetes + Docker with Datadog](https://www.datadoghq.com/blog/monitor-kubernetes-docker/)\n\n- [Monitoring in the Kubernetes era](https://www.datadoghq.com/blog/monitoring-kubernetes-era/)\n\n- [Monitoring Kubernetes performance metrics](https://www.datadoghq.com/blog/monitoring-kubernetes-performance-metrics/)\n\n- [Collecting metrics with built-in Kubernetes monitoring tools](https://www.datadoghq.com/blog/how-to-collect-and-graph-kubernetes-metrics/)\n\n- [Monitoring Kubernetes with Datadog](https://www.datadoghq.com/blog/monitoring-kubernetes-with-datadog/)\n\n- [Datadog's Kubernetes integration docs](https://docs.datadoghq.com/integrations/kubernetes/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
     "id": 1227732,
-    "modified": "2020-07-14T17:33:36.134840+00:00",
+    "modified": "2020-07-19T17:46:45.196308+00:00",
     "new_id": "yn5-ms6-w87",
     "read_only": false,
     "template_variables": [
@@ -47,6 +47,7 @@
             "height": 12,
             "tile_def": {
                 "autoscale": true,
+                "custom_links": [],
                 "precision": 0,
                 "requests": [
                     {
@@ -63,14 +64,13 @@
                 ],
                 "viz": "query_value"
             },
-            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
             "title_text": "Available",
             "type": "query_value",
             "width": 14,
-            "x": 30,
+            "x": 45,
             "y": 6
         },
         {
@@ -124,7 +124,7 @@
                                 "value": "0"
                             }
                         ],
-                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
                     }
                 ],
                 "viz": "query_value"
@@ -136,7 +136,7 @@
             "title_text": "Replicas",
             "type": "query_value",
             "width": 14,
-            "x": 0,
+            "x": 15,
             "y": 6
         },
         {
@@ -144,10 +144,9 @@
             "legend": false,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace} by {deployment}",
+                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace} by {deployment}",
                         "style": {
                             "palette": "dog_classic",
                             "type": "solid",
@@ -156,13 +155,6 @@
                         "type": "area"
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
                 "viz": "timeseries",
                 "yaxis": {
                     "includeZero": true,
@@ -172,10 +164,11 @@
                     "scale": "linear"
                 }
             },
+            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
-            "title_text": "Replicas per Deployment",
+            "title_text": "Replicas",
             "type": "timeseries",
             "width": 59,
             "x": 0,
@@ -185,6 +178,7 @@
             "height": 12,
             "tile_def": {
                 "autoscale": true,
+                "custom_links": [],
                 "precision": 0,
                 "requests": [
                     {
@@ -206,14 +200,13 @@
                 ],
                 "viz": "query_value"
             },
-            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
             "title_text": "Unavailable",
             "type": "query_value",
             "width": 14,
-            "x": 60,
+            "x": 75,
             "y": 6
         },
         {
@@ -273,7 +266,7 @@
                                 "value": "0"
                             }
                         ],
-                        "q": "sum:kubernetes_state.deployment.replicas_available{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
                     }
                 ],
                 "viz": "query_value"
@@ -285,7 +278,7 @@
             "title_text": "Desired",
             "type": "query_value",
             "width": 14,
-            "x": 15,
+            "x": 30,
             "y": 6
         },
         {
@@ -293,7 +286,6 @@
             "legend": false,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
@@ -305,13 +297,6 @@
                         "type": "area"
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
                 "viz": "timeseries",
                 "yaxis": {
                     "includeZero": true,
@@ -321,10 +306,11 @@
                     "scale": "linear"
                 }
             },
+            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
-            "title_text": "Replicas Desired per Deployment",
+            "title_text": "Replicas Desired",
             "type": "timeseries",
             "width": 59,
             "x": 60,
@@ -334,6 +320,7 @@
             "height": 12,
             "tile_def": {
                 "autoscale": true,
+                "custom_links": [],
                 "precision": 0,
                 "requests": [
                     {
@@ -350,14 +337,13 @@
                 ],
                 "viz": "query_value"
             },
-            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
             "title_text": "Updated",
             "type": "query_value",
             "width": 14,
-            "x": 45,
+            "x": 60,
             "y": 6
         },
         {
@@ -407,7 +393,6 @@
             "legend": false,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.deployment.rollingupdate.max_unavailable{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
@@ -419,13 +404,6 @@
                         "type": "area"
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
                 "viz": "timeseries",
                 "yaxis": {
                     "includeZero": true,
@@ -435,49 +413,15 @@
                     "scale": "linear"
                 }
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Replicas Unavailable During Rolling Update",
-            "type": "timeseries",
-            "width": 59,
-            "x": 60,
-            "y": 72
-        },
-        {
-            "height": 12,
-            "tile_def": {
-                "autoscale": true,
-                "precision": 0,
-                "requests": [
-                    {
-                        "aggregator": "last",
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "red_on_white",
-                                "value": "0"
-                            },
-                            {
-                                "comparator": "<=",
-                                "palette": "green_on_white",
-                                "value": "0"
-                            }
-                        ],
-                        "q": "sum:kubernetes_state.deployment.rollingupdate.max_unavailable{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
-                    }
-                ],
-                "viz": "query_value"
-            },
             "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
-            "title_text": "Rolling Update",
-            "type": "query_value",
-            "width": 14,
-            "x": 75,
-            "y": 6
+            "title_text": "Max Unavailable Replicas in Rolling Update (spec strategy)",
+            "type": "timeseries",
+            "width": 59,
+            "x": 60,
+            "y": 87
         },
         {
             "height": 12,
@@ -526,10 +470,16 @@
             "legend": false,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
+                "markers": [
+                    {
+                        "label": "y = 0",
+                        "type": "ok dashed",
+                        "value": "y = 0"
+                    }
+                ],
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}-sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}, sum:kubernetes_state.deployment.replicas{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}-sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}-sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
                         "style": {
                             "palette": "orange",
                             "type": "solid",
@@ -538,13 +488,6 @@
                         "type": "area"
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
                 "viz": "timeseries",
                 "yaxis": {
                     "includeZero": true,
@@ -554,6 +497,7 @@
                     "scale": "linear"
                 }
             },
+            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
@@ -561,12 +505,13 @@
             "type": "timeseries",
             "width": 59,
             "x": 60,
-            "y": 87
+            "y": 72
         },
         {
             "height": 12,
             "tile_def": {
                 "autoscale": true,
+                "custom_links": [],
                 "precision": 0,
                 "requests": [
                     {
@@ -583,7 +528,6 @@
                 ],
                 "viz": "query_value"
             },
-            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
@@ -597,6 +541,7 @@
             "height": 12,
             "tile_def": {
                 "autoscale": true,
+                "custom_links": [],
                 "precision": 0,
                 "requests": [
                     {
@@ -618,7 +563,6 @@
                 ],
                 "viz": "query_value"
             },
-            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
@@ -797,7 +741,7 @@
             "bgcolor": "gray",
             "font_size": "18",
             "height": 5,
-            "html": "Replicas",
+            "html": "Replicas by Deployment",
             "text_align": "center",
             "tick": false,
             "tick_edge": "bottom",
@@ -1118,7 +1062,6 @@
             "legend": true,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
                         "q": "sum:kubernetes.network.rx_bytes{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}, sum:kubernetes.network.tx_bytes{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}",
@@ -1130,13 +1073,6 @@
                         "type": "line"
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
                 "viz": "timeseries",
                 "yaxis": {
                     "includeZero": true,
@@ -1146,10 +1082,11 @@
                     "scale": "linear"
                 }
             },
+            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
-            "title_text": "Network Rate",
+            "title_text": "Network Usage (Rx / Tx rate)",
             "type": "timeseries",
             "width": 59,
             "x": 60,
@@ -1340,6 +1277,35 @@
             "width": 59,
             "x": 60,
             "y": 245
+        },
+        {
+            "height": 12,
+            "tile_def": {
+                "precision": 0,
+                "requests": [
+                    {
+                        "aggregator": "avg",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "white_on_green",
+                                "value": "0"
+                            }
+                        ],
+                        "q": "count_nonzero(sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace} by {kube_deployment})"
+                    }
+                ],
+                "viz": "query_value"
+            },
+            "time": {},
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Deployments",
+            "type": "query_value",
+            "width": 14,
+            "x": 0,
+            "y": 6
         }
     ]
 }

--- a/kubernetes/assets/dashboards/kubernetes_deployments.json
+++ b/kubernetes/assets/dashboards/kubernetes_deployments.json
@@ -1,0 +1,1345 @@
+{
+    "author_info": {
+        "author_name": "Datadog"
+    },
+    "board_title": "Kubernetes Deployments Overview",
+    "created": "2020-07-14T17:23:45.442889+00:00",
+    "created_by": {
+        "access_role": "st",
+        "disabled": false,
+        "email": "support@datadoghq.com",
+        "handle": "support@datadoghq.com",
+        "is_admin": false,
+        "name": "Datadog",
+        "role": null,
+        "title": null,
+        "verified": true
+    },
+    "description": "Our Kubernetes dashboard gives you broad visibility into the scale, status, and resource usage of your cluster and its containers. Further reading for Kubernetes monitoring:\n\n- [Autoscale Kubernetes workloads with any Datadog metric](https://www.datadoghq.com/blog/autoscale-kubernetes-datadog/)\n\n- [How to monitor Kubernetes + Docker with Datadog](https://www.datadoghq.com/blog/monitor-kubernetes-docker/)\n\n- [Monitoring in the Kubernetes era](https://www.datadoghq.com/blog/monitoring-kubernetes-era/)\n\n- [Monitoring Kubernetes performance metrics](https://www.datadoghq.com/blog/monitoring-kubernetes-performance-metrics/)\n\n- [Collecting metrics with built-in Kubernetes monitoring tools](https://www.datadoghq.com/blog/how-to-collect-and-graph-kubernetes-metrics/)\n\n- [Monitoring Kubernetes with Datadog](https://www.datadoghq.com/blog/monitoring-kubernetes-with-datadog/)\n\n- [Datadog's Kubernetes integration docs](https://docs.datadoghq.com/integrations/kubernetes/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
+    "id": 1227732,
+    "modified": "2020-07-14T17:33:36.134840+00:00",
+    "new_id": "yn5-ms6-w87",
+    "read_only": false,
+    "template_variables": [
+        {
+            "default": "*",
+            "name": "scope",
+            "prefix": null
+        },
+        {
+            "default": "*",
+            "name": "kube_cluster_name",
+            "prefix": "kube_cluster_name"
+        },
+        {
+            "default": "*",
+            "name": "kube_namespace",
+            "prefix": "kube_namespace"
+        },
+        {
+            "default": "*",
+            "name": "kube_deployment",
+            "prefix": "kube_deployment"
+        }
+    ],
+    "widgets": [
+        {
+            "height": 12,
+            "tile_def": {
+                "autoscale": true,
+                "precision": 0,
+                "requests": [
+                    {
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "green_on_white",
+                                "value": "0"
+                            }
+                        ],
+                        "q": "sum:kubernetes_state.deployment.replicas_available{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                    }
+                ],
+                "viz": "query_value"
+            },
+            "time": {},
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Available",
+            "type": "query_value",
+            "width": 14,
+            "x": 30,
+            "y": 6
+        },
+        {
+            "height": 12,
+            "legend": false,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas_available{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "style": {
+                            "palette": "green",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "area"
+                    }
+                ],
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Replicas Available",
+            "type": "timeseries",
+            "width": 59,
+            "x": 0,
+            "y": 57
+        },
+        {
+            "height": 12,
+            "tile_def": {
+                "autoscale": true,
+                "precision": 0,
+                "requests": [
+                    {
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "custom_fg_color": "#6a53a1",
+                                "palette": "green_on_white",
+                                "value": "0"
+                            }
+                        ],
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                    }
+                ],
+                "viz": "query_value"
+            },
+            "time": {},
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Replicas",
+            "type": "query_value",
+            "width": 14,
+            "x": 0,
+            "y": 6
+        },
+        {
+            "height": 12,
+            "legend": false,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace} by {deployment}",
+                        "style": {
+                            "palette": "dog_classic",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "area"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Replicas per Deployment",
+            "type": "timeseries",
+            "width": 59,
+            "x": 0,
+            "y": 42
+        },
+        {
+            "height": 12,
+            "tile_def": {
+                "autoscale": true,
+                "precision": 0,
+                "requests": [
+                    {
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "red_on_white",
+                                "value": "0"
+                            },
+                            {
+                                "comparator": "<=",
+                                "palette": "green_on_white",
+                                "value": "0"
+                            }
+                        ],
+                        "q": "sum:kubernetes_state.deployment.replicas_unavailable{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                    }
+                ],
+                "viz": "query_value"
+            },
+            "time": {},
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Unavailable",
+            "type": "query_value",
+            "width": 14,
+            "x": 60,
+            "y": 6
+        },
+        {
+            "height": 12,
+            "legend": false,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas_unavailable{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {kube_cluster_name,kube_namespace,kube_deployment}",
+                        "style": {
+                            "palette": "orange",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "area"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Replicas Unavailable",
+            "type": "timeseries",
+            "width": 59,
+            "x": 0,
+            "y": 72
+        },
+        {
+            "height": 12,
+            "tile_def": {
+                "autoscale": true,
+                "precision": 0,
+                "requests": [
+                    {
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "green_on_white",
+                                "value": "0"
+                            }
+                        ],
+                        "q": "sum:kubernetes_state.deployment.replicas_available{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                    }
+                ],
+                "viz": "query_value"
+            },
+            "time": {},
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Desired",
+            "type": "query_value",
+            "width": 14,
+            "x": 15,
+            "y": 6
+        },
+        {
+            "height": 12,
+            "legend": false,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "style": {
+                            "palette": "cool",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "area"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Replicas Desired per Deployment",
+            "type": "timeseries",
+            "width": 59,
+            "x": 60,
+            "y": 42
+        },
+        {
+            "height": 12,
+            "tile_def": {
+                "autoscale": true,
+                "precision": 0,
+                "requests": [
+                    {
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "green_on_white",
+                                "value": "0"
+                            }
+                        ],
+                        "q": "sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                    }
+                ],
+                "viz": "query_value"
+            },
+            "time": {},
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Updated",
+            "type": "query_value",
+            "width": 14,
+            "x": 45,
+            "y": 6
+        },
+        {
+            "height": 12,
+            "legend": false,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "style": {
+                            "palette": "dog_classic",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "area"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Replicas Updated",
+            "type": "timeseries",
+            "width": 59,
+            "x": 60,
+            "y": 57
+        },
+        {
+            "height": 12,
+            "legend": false,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.rollingupdate.max_unavailable{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "style": {
+                            "palette": "warm",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "area"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Replicas Unavailable During Rolling Update",
+            "type": "timeseries",
+            "width": 59,
+            "x": 60,
+            "y": 72
+        },
+        {
+            "height": 12,
+            "tile_def": {
+                "autoscale": true,
+                "precision": 0,
+                "requests": [
+                    {
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "red_on_white",
+                                "value": "0"
+                            },
+                            {
+                                "comparator": "<=",
+                                "palette": "green_on_white",
+                                "value": "0"
+                            }
+                        ],
+                        "q": "sum:kubernetes_state.deployment.rollingupdate.max_unavailable{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                    }
+                ],
+                "viz": "query_value"
+            },
+            "time": {},
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Rolling Update",
+            "type": "query_value",
+            "width": 14,
+            "x": 75,
+            "y": 6
+        },
+        {
+            "height": 12,
+            "legend": false,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment,kube_cluster_name,kube_namespace}-sum:kubernetes_state.deployment.replicas_available{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment,kube_cluster_name,kube_namespace}",
+                        "style": {
+                            "palette": "warm",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "area"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Replicas Desired but Not Available",
+            "type": "timeseries",
+            "width": 59,
+            "x": 0,
+            "y": 87
+        },
+        {
+            "height": 12,
+            "legend": false,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}-sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}, sum:kubernetes_state.deployment.replicas{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}-sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "style": {
+                            "palette": "orange",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "area"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Replicas Outdated",
+            "type": "timeseries",
+            "width": 59,
+            "x": 60,
+            "y": 87
+        },
+        {
+            "height": 12,
+            "tile_def": {
+                "autoscale": true,
+                "precision": 0,
+                "requests": [
+                    {
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">=",
+                                "palette": "yellow_on_white",
+                                "value": "0"
+                            }
+                        ],
+                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}-sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                    }
+                ],
+                "viz": "query_value"
+            },
+            "time": {},
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Outdated",
+            "type": "query_value",
+            "width": 14,
+            "x": 105,
+            "y": 6
+        },
+        {
+            "height": 12,
+            "tile_def": {
+                "autoscale": true,
+                "precision": 0,
+                "requests": [
+                    {
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "red_on_white",
+                                "value": "0"
+                            },
+                            {
+                                "comparator": "<=",
+                                "palette": "green_on_white",
+                                "value": "0"
+                            }
+                        ],
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}-sum:kubernetes_state.deployment.replicas_available{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                    }
+                ],
+                "viz": "query_value"
+            },
+            "time": {},
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Desired Not Available",
+            "type": "query_value",
+            "width": 14,
+            "x": 90,
+            "y": 6
+        },
+        {
+            "bgcolor": "gray",
+            "font_size": "18",
+            "height": 5,
+            "html": "Overview",
+            "text_align": "center",
+            "tick": false,
+            "tick_edge": "bottom",
+            "tick_pos": "50%",
+            "type": "note",
+            "width": 119,
+            "x": 0,
+            "y": 0
+        },
+        {
+            "height": 12,
+            "legend": false,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "count_nonzero(avg:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_namespace,$kube_cluster_name} by {kube_cluster_name,kube_namespace,kube_deployment})",
+                        "style": {
+                            "palette": "dog_classic",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "line"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Deployments",
+            "type": "timeseries",
+            "width": 29,
+            "x": 0,
+            "y": 21
+        },
+        {
+            "height": 12,
+            "legend": false,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_namespace,$kube_cluster_name} by {kube_cluster_name,kube_namespace,kube_deployment}",
+                        "style": {
+                            "palette": "dog_classic",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "area"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Replicas per Deployments",
+            "type": "timeseries",
+            "width": 29,
+            "x": 30,
+            "y": 21
+        },
+        {
+            "height": 12,
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "change_type": "absolute",
+                        "compare_to": "week_before",
+                        "increase_good": true,
+                        "order_by": "change",
+                        "order_dir": "desc",
+                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_namespace,$kube_cluster_name} by {kube_cluster_name,kube_namespace,kube_deployment}"
+                    }
+                ],
+                "viz": "change"
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Replicas per Deployments",
+            "type": "change",
+            "width": 29,
+            "x": 60,
+            "y": 21
+        },
+        {
+            "height": 12,
+            "legend": false,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}-sum:kubernetes_state.deployment.replicas_available{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "style": {
+                            "palette": "dog_classic",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "area"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Replicas Desired but Not Available",
+            "type": "timeseries",
+            "width": 29,
+            "x": 90,
+            "y": 21
+        },
+        {
+            "bgcolor": "gray",
+            "font_size": "18",
+            "height": 5,
+            "html": "Replicas",
+            "text_align": "center",
+            "tick": false,
+            "tick_edge": "bottom",
+            "tick_pos": "50%",
+            "type": "note",
+            "width": 119,
+            "x": 0,
+            "y": 36
+        },
+        {
+            "bgcolor": "gray",
+            "font_size": "18",
+            "height": 5,
+            "html": "Resources",
+            "text_align": "center",
+            "tick": false,
+            "tick_edge": "bottom",
+            "tick_pos": "50%",
+            "type": "note",
+            "width": 119,
+            "x": 0,
+            "y": 102
+        },
+        {
+            "height": 22,
+            "legend": true,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.cpu.usage.total{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_cluster_name,kube_namespace,kube_deployment}",
+                        "style": {
+                            "palette": "dog_classic",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "line"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "CPU Usage by Deployment",
+            "type": "timeseries",
+            "width": 59,
+            "x": 0,
+            "y": 114
+        },
+        {
+            "height": 22,
+            "legend": true,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "avg:kubernetes.memory.usage{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}",
+                        "style": {
+                            "palette": "dog_classic",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "line"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Memory Usage by Deployment",
+            "type": "timeseries",
+            "width": 59,
+            "x": 60,
+            "y": 114
+        },
+        {
+            "height": 22,
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "top(sum:kubernetes.memory.usage{$scope,$kube_namespace,$kube_deployment,!pod_name:no_pod,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}, 10, 'mean', 'desc')"
+                    }
+                ],
+                "viz": "toplist"
+            },
+            "time": {
+                "live_span": "4h"
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Most memory-intensive Deployments",
+            "type": "toplist",
+            "width": 59,
+            "x": 60,
+            "y": 139
+        },
+        {
+            "height": 22,
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "top(sum:kubernetes.cpu.usage.total{$scope,$kube_namespace,$kube_deployment,!pod_name:no_pod,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}, 10, 'mean', 'desc')"
+                    }
+                ],
+                "viz": "toplist"
+            },
+            "time": {
+                "live_span": "4h"
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Most CPU-intensive Deployments",
+            "type": "toplist",
+            "width": 59,
+            "x": 0,
+            "y": 139
+        },
+        {
+            "height": 22,
+            "legend": true,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "metadata": {
+                            "sum:kubernetes.cpu.limits{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}": {
+                                "alias": "Limits"
+                            },
+                            "sum:kubernetes.cpu.requests{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}": {
+                                "alias": "Requests"
+                            },
+                            "sum:kubernetes.cpu.usage.total{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}": {
+                                "alias": "Usage"
+                            }
+                        },
+                        "q": "sum:kubernetes.cpu.requests{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}, sum:kubernetes.cpu.usage.total{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}, sum:kubernetes.cpu.limits{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}",
+                        "style": {
+                            "palette": "dog_classic",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "line"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "CPU requests, limits and usage",
+            "type": "timeseries",
+            "width": 59,
+            "x": 0,
+            "y": 164
+        },
+        {
+            "height": 22,
+            "legend": true,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "metadata": {
+                            "sum:kubernetes.memory.limits{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}": {
+                                "alias": "Limits"
+                            },
+                            "sum:kubernetes.memory.requests{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}": {
+                                "alias": "Requests"
+                            },
+                            "sum:kubernetes.memory.rss{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}": {
+                                "alias": "Usage"
+                            }
+                        },
+                        "q": "sum:kubernetes.memory.requests{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}, sum:kubernetes.memory.rss{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}, sum:kubernetes.memory.limits{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}",
+                        "style": {
+                            "palette": "dog_classic",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "line"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Memory requests, limits and usage",
+            "type": "timeseries",
+            "width": 59,
+            "x": 60,
+            "y": 164
+        },
+        {
+            "bgcolor": "gray",
+            "font_size": "18",
+            "height": 5,
+            "html": "CPU",
+            "text_align": "center",
+            "tick": false,
+            "tick_edge": "bottom",
+            "tick_pos": "50%",
+            "type": "note",
+            "width": 59,
+            "x": 0,
+            "y": 108
+        },
+        {
+            "bgcolor": "gray",
+            "font_size": "18",
+            "height": 5,
+            "html": "Memory",
+            "text_align": "center",
+            "tick": false,
+            "tick_edge": "bottom",
+            "tick_pos": "50%",
+            "type": "note",
+            "width": 59,
+            "x": 60,
+            "y": 108
+        },
+        {
+            "bgcolor": "gray",
+            "font_size": "18",
+            "height": 5,
+            "html": "Disk",
+            "text_align": "center",
+            "tick": false,
+            "tick_edge": "bottom",
+            "tick_pos": "50%",
+            "type": "note",
+            "width": 59,
+            "x": 0,
+            "y": 189
+        },
+        {
+            "bgcolor": "gray",
+            "font_size": "18",
+            "height": 5,
+            "html": "Network",
+            "text_align": "center",
+            "tick": false,
+            "tick_edge": "bottom",
+            "tick_pos": "50%",
+            "type": "note",
+            "width": 59,
+            "x": 60,
+            "y": 189
+        },
+        {
+            "height": 22,
+            "legend": true,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.network.rx_bytes{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}, sum:kubernetes.network.tx_bytes{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}",
+                        "style": {
+                            "palette": "dog_classic",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "line"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Network Rate",
+            "type": "timeseries",
+            "width": 59,
+            "x": 60,
+            "y": 195
+        },
+        {
+            "height": 22,
+            "legend": true,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "markers": [
+                    {
+                        "label": "y = 0",
+                        "type": "ok dashed",
+                        "value": "y = 0"
+                    }
+                ],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.network.rx_errors{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}, sum:kubernetes.network.tx_errors{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}",
+                        "style": {
+                            "palette": "dog_classic",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "line"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Network Errors",
+            "type": "timeseries",
+            "width": 59,
+            "x": 60,
+            "y": 220
+        },
+        {
+            "height": 22,
+            "legend": true,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.filesystem.usage{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}",
+                        "style": {
+                            "palette": "dog_classic",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "line"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Disk Usage",
+            "type": "timeseries",
+            "width": 59,
+            "x": 0,
+            "y": 195
+        },
+        {
+            "height": 22,
+            "legend": true,
+            "legend_size": "0",
+            "tile_def": {
+                "custom_links": [],
+                "markers": [
+                    {
+                        "label": "\u00a0100%\u00a0",
+                        "type": "error dashed",
+                        "value": "y = 100"
+                    }
+                ],
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.filesystem.usage_pct{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}*100",
+                        "style": {
+                            "palette": "dog_classic",
+                            "type": "solid",
+                            "width": "normal"
+                        },
+                        "type": "line"
+                    }
+                ],
+                "right_yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                },
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Disk Usage %",
+            "type": "timeseries",
+            "width": 59,
+            "x": 0,
+            "y": 220
+        },
+        {
+            "height": 22,
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "top(sum:kubernetes.filesystem.usage{$scope,$kube_namespace,$kube_deployment,!pod_name:no_pod,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}, 10, 'mean', 'desc')"
+                    }
+                ],
+                "viz": "toplist"
+            },
+            "time": {
+                "live_span": "4h"
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Most Disk-intensive Deployments",
+            "type": "toplist",
+            "width": 59,
+            "x": -1,
+            "y": 245
+        },
+        {
+            "height": 22,
+            "tile_def": {
+                "custom_links": [],
+                "requests": [
+                    {
+                        "q": "top(sum:kubernetes.network.tx_bytes{$scope,$kube_namespace,$kube_deployment,!pod_name:no_pod,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}, 10, 'mean', 'desc')"
+                    }
+                ],
+                "viz": "toplist"
+            },
+            "time": {
+                "live_span": "4h"
+            },
+            "title": true,
+            "title_align": "left",
+            "title_size": 16,
+            "title_text": "Most Network-intensive Deployments",
+            "type": "toplist",
+            "width": 59,
+            "x": 60,
+            "y": 245
+        }
+    ]
+}

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -26,7 +26,8 @@
     "monitors": {},
     "dashboards": {
       "Kubernetes - Pods": "assets/dashboards/kubernetes_pods.json",
-      "Kubernetes Nodes Overview": "assets/dashboards/kubernetes_nodes.json"
+      "Kubernetes Nodes Overview": "assets/dashboards/kubernetes_nodes.json",
+      "Kubernetes Deployments Overview": "assets/dashboards/kubernetes_deployments.json"
     },
     "service_checks": "assets/service_checks.json"
   }


### PR DESCRIPTION
### What does this PR do?
Adds a new OOTB dashboard for Deployments that is part of the Kubernetes integration

### Motivation
* Users would like additional dashboards to monitor different workloads in Kubernetes, like Deployments.
* Customers would like to have fewer template var. for specific dashboards like deployments.

### Additional Notes
Staging URL: https://dd.datad0g.com/screen/integration/30340/kubernetes-deployments-overview

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
