### PR TITLE
[skip ci] capitalise check name when created via ddev

### DIFF
--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -69,7 +69,7 @@ One of the developer toolkit features is the `create` command, which creates the
 Let's try a dry-run using the `-n/--dry-run` flag, which won't write anything to disk.
 
 ```bash
-ddev create -n awesome
+ddev create -n Awesome
 ```
 
 This displays the path where the files would have been written, as well as the structure itself. For now, just make sure that the path in the _first line_ of output matches your Extras repository.
@@ -79,7 +79,7 @@ This displays the path where the files would have been written, as well as the s
 The interactive mode is a wizard for creating new integrations. By answering a handful of questions, the scaffolding will be set up and lightly pre-configured for you.
 
 ```bash
-ddev create awesome
+ddev create Awesome
 ```
 
 After answering the questions, the output matches that of the dry-run above, except in this case the scaffolding for your new integration actually exists!


### PR DESCRIPTION
### What does this PR do?
In the documentation, capitalise the name of the check in the `ddev` command line.

### Motivation
Avoiding this warning message:
![image](https://user-images.githubusercontent.com/625232/87533843-7f83eb00-c695-11ea-98b2-647b6bcb985e.png)


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
