### PR TITLE
Create tmp directories in `/tmp` instead of compose dir

### DIFF
--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -32,7 +32,7 @@ E2E_METADATA = {
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    with TempDir('snmprec', COMPOSE_DIR) as tmp_dir:
+    with TempDir('snmprec') as tmp_dir:
         data_dir = os.path.join(tmp_dir, 'data')
         env = {'DATA_DIR': data_dir}
         if not os.path.exists(data_dir):


### PR DESCRIPTION
### What does this PR do?

Create tmp directories in /tmp instead of compose dir

### Motivation

Avoids polluting development dir.

![image](https://user-images.githubusercontent.com/49917914/87543151-7cdcc200-c6a4-11ea-9087-f3075a14f84f.png)
