### PR TITLE
Cap psutil for windows

### DIFF
--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -25,7 +25,8 @@ REQUIRES = [
     "contextlib2; python_version < '3.0'",
     'coverage>=5.0.3',
     'mock',
-    'psutil',
+    "psutil; sys_platform != 'win32'",
+    "psutil<=5.7.0; sys_platform == 'win32'",  # cap psutil due to https://github.com/giampaolo/psutil/issues/1790
     'PyYAML>=5.3',
     'pytest',
     'pytest-benchmark>=3.2.1',


### PR DESCRIPTION
Cap psutil due to https://github.com/giampaolo/psutil/issues/1790

### Motivation
This is currently breaking Py27 windows test on CI