### PR TITLE
[Dev] Move MySQL statement metrics to its own class/file and improve metric coverage

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
@@ -9,6 +9,9 @@ except ImportError:
     from ..stubs import datadog_agent
 
 
+def is_dbm_enabled():
+    return is_affirmative(datadog_agent.get_config('deep_database_monitoring'))
+
 class StatementMetrics:
     """
     This class supports normalized statement-level metrics, which are collected from the database's
@@ -22,14 +25,11 @@ class StatementMetrics:
 
     These tables are monotonically increasing.
     """
-    def __init__(self):
+    def __init__(self, log):
+        self.log = log
         self.previous_statements = dict()
 
-    @staticmethod
-    def is_enabled():
-        return is_affirmative(datadog_agent.get_config('deep_database_monitoring'))
-
-    def _compute_derivative_rows(self, rows, metrics, key):
+    def compute_derivative_rows(self, rows, metrics, key):
         """
         Compute the first derivative of column-based metrics for a given set of rows. This also resets the
         statement cache so should only be called once per check run.
@@ -41,65 +41,71 @@ class StatementMetrics:
         """
         result = []
         new_cache = {}
+        metrics = set(metrics)
+        dropped_metrics = set()
         for row in rows:
             row_key = key(row)
             new_cache[row_key] = row
             prev = self.previous_statements.get(row_key)
             if prev is None:
                 continue
-            if any([row[k] - prev[k] < 0 for k in metrics]):
+            metric_columns = metrics & set(row.keys())
+            dropped_metrics.update(metrics - metric_columns)
+            if any([row[k] - prev[k] < 0 for k in metric_columns]):
                 # The table was truncated or stats reset; begin tracking again from this point
                 continue
-            if all([row[k] - prev[k] == 0 for k in metrics]):
+            if all([row[k] - prev[k] == 0 for k in metric_columns]):
                 # No metrics to report; query did not run
                 continue
-            result.append({k: row[k] - prev[k] if k in metrics else row[k] 
+            result.append({k: row[k] - prev[k] if k in metric_columns else row[k]
                            for k in row})
 
         self.previous_statements = new_cache
+        if dropped_metrics:
+            self.log.warning('Some metrics not available from table: %s', ','.join(m for m in dropped_metrics))
         return result
 
-    @staticmethod
-    def _apply_limits(rows, metric_limits, tiebreaker_metric, tiebreaker_reverse, key):
-        """
-        Given a list of query rows, apply limits ensuring that the top k and bottom k of each metric (columns)
-        are present. To increase the overlap of rows across metics with the same values (such as 0), the tiebreaker metric
-        is used as a second sort dimension.
 
-        - **rows** (_List[dict]_) - rows with columns as metrics
-        - **metric_limits** (_Dict[str,Tuple[int,int]]_) - dict of the top k and bottom k limits for each metric
-                ex:
-                >>> metrics = {
-                >>>     'count': (200, 50),
-                >>>     'time': (200, 100),
-                >>>     'lock_time': (50, 50),
-                >>>     ...
-                >>>     'rows_sent': (100, 0),
-                >>> }
-        - **tiebreaker_metric** (_str_) - metric used to resolve ties, intended to increase row overlap in different metrics
-        - **tiebreaker_reverse** (_bool_) - whether the tiebreaker metric should in reverse order (descending)
-        - **key** (_callable_) - function for an ID which uniquely identifies a row
-        """
-        if len(rows) == 0:
-            return rows
+def apply_row_limits(rows, metric_limits, tiebreaker_metric, tiebreaker_reverse, key):
+    """
+    Given a list of query rows, apply limits ensuring that the top k and bottom k of each metric (columns)
+    are present. To increase the overlap of rows across metics with the same values (such as 0), the tiebreaker metric
+    is used as a second sort dimension.
 
-        limited = dict()
+    - **rows** (_List[dict]_) - rows with columns as metrics
+    - **metric_limits** (_Dict[str,Tuple[int,int]]_) - dict of the top k and bottom k limits for each metric
+            ex:
+            >>> metrics = {
+            >>>     'count': (200, 50),
+            >>>     'time': (200, 100),
+            >>>     'lock_time': (50, 50),
+            >>>     ...
+            >>>     'rows_sent': (100, 0),
+            >>> }
+    - **tiebreaker_metric** (_str_) - metric used to resolve ties, intended to increase row overlap in different metrics
+    - **tiebreaker_reverse** (_bool_) - whether the tiebreaker metric should in reverse order (descending)
+    - **key** (_callable_) - function for an ID which uniquely identifies a row
+    """
+    if len(rows) == 0:
+        return rows
 
-        for metric, (top_k, bottom_k) in metric_limits.items():
-            # sort_key uses a secondary sort dimension so that if there are a lot of
-            # the same values (like 0), then there will be more overlap in selected rows
-            # over time
-            if tiebreaker_reverse:
-                sort_key = lambda row: (row[metric], -row[tiebreaker_metric])
-            else:
-                sort_key = lambda row: (row[metric], row[tiebreaker_metric])
-            sorted_rows = sorted(rows, key=sort_key)
+    limited = dict()
 
-            top = sorted_rows[len(sorted_rows)-top_k:]
-            bottom = sorted_rows[:bottom_k]
-            for row in top:
-                limited[key(row)] = row
-            for row in bottom:
-                limited[key(row)] = row
+    for metric, (top_k, bottom_k) in metric_limits.items():
+        # sort_key uses a secondary sort dimension so that if there are a lot of
+        # the same values (like 0), then there will be more overlap in selected rows
+        # over time
+        if tiebreaker_reverse:
+            sort_key = lambda row: (row[metric], -row[tiebreaker_metric])
+        else:
+            sort_key = lambda row: (row[metric], row[tiebreaker_metric])
+        sorted_rows = sorted(rows, key=sort_key)
 
-        return list(limited.values())
+        top = sorted_rows[len(sorted_rows)-top_k:]
+        bottom = sorted_rows[:bottom_k]
+        for row in top:
+            limited[key(row)] = row
+        for row in bottom:
+            limited[key(row)] = row
+
+    return list(limited.values())

--- a/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
@@ -1,0 +1,105 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.base import is_affirmative
+
+try:
+    import datadog_agent
+except ImportError:
+    from ..stubs import datadog_agent
+
+
+class StatementMetrics:
+    """
+    This class supports normalized statement-level metrics, which are collected from the database's
+    statistics tables, ex:
+
+        - Postgres: pg_stat_statements
+        - MySQL: performance_schema.events_statements_summary_by_digest
+        - Oracle: V$SQLAREA
+        - SQL Server: sys.dm_exec_query_stats
+        - DB2: mon_db_summary
+
+    These tables are monotonically increasing.
+    """
+    def __init__(self):
+        self.previous_statements = dict()
+
+    @staticmethod
+    def is_enabled():
+        return is_affirmative(datadog_agent.get_config('deep_database_monitoring'))
+
+    def _compute_derivative_rows(self, rows, metrics, key):
+        """
+        Compute the first derivative of column-based metrics for a given set of rows. This also resets the
+        statement cache so should only be called once per check run.
+
+        - **rows** (_List[dict]_) - rows from current check run
+        - **previous** (_List[dict]_) - rows from the previous check run
+        - **metrics** (_List[str]_) - the metrics to compute for each row
+        - **key** (_callable_) - function for an ID which uniquely identifies a row across runs
+        """
+        result = []
+        new_cache = {}
+        for row in rows:
+            row_key = key(row)
+            new_cache[row_key] = row
+            prev = self.previous_statements.get(row_key)
+            if prev is None:
+                continue
+            if any([row[k] - prev[k] < 0 for k in metrics]):
+                # The table was truncated or stats reset; begin tracking again from this point
+                continue
+            if all([row[k] - prev[k] == 0 for k in metrics]):
+                # No metrics to report; query did not run
+                continue
+            result.append({k: row[k] - prev[k] if k in metrics else row[k] 
+                           for k in row})
+
+        self.previous_statements = new_cache
+        return result
+
+    @staticmethod
+    def _apply_limits(rows, metric_limits, tiebreaker_metric, tiebreaker_reverse, key):
+        """
+        Given a list of query rows, apply limits ensuring that the top k and bottom k of each metric (columns)
+        are present. To increase the overlap of rows across metics with the same values (such as 0), the tiebreaker metric
+        is used as a second sort dimension.
+
+        - **rows** (_List[dict]_) - rows with columns as metrics
+        - **metric_limits** (_Dict[str,Tuple[int,int]]_) - dict of the top k and bottom k limits for each metric
+                ex:
+                >>> metrics = {
+                >>>     'count': (200, 50),
+                >>>     'time': (200, 100),
+                >>>     'lock_time': (50, 50),
+                >>>     ...
+                >>>     'rows_sent': (100, 0),
+                >>> }
+        - **tiebreaker_metric** (_str_) - metric used to resolve ties, intended to increase row overlap in different metrics
+        - **tiebreaker_reverse** (_bool_) - whether the tiebreaker metric should in reverse order (descending)
+        - **key** (_callable_) - function for an ID which uniquely identifies a row
+        """
+        if len(rows) == 0:
+            return rows
+
+        limited = dict()
+
+        for metric, (top_k, bottom_k) in metric_limits.items():
+            # sort_key uses a secondary sort dimension so that if there are a lot of
+            # the same values (like 0), then there will be more overlap in selected rows
+            # over time
+            if tiebreaker_reverse:
+                sort_key = lambda row: (row[metric], -row[tiebreaker_metric])
+            else:
+                sort_key = lambda row: (row[metric], row[tiebreaker_metric])
+            sorted_rows = sorted(rows, key=sort_key)
+
+            top = sorted_rows[len(sorted_rows)-top_k:]
+            bottom = sorted_rows[:bottom_k]
+            for row in top:
+                limited[key(row)] = row
+            for row in bottom:
+                limited[key(row)] = row
+
+        return list(limited.values())

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -18,6 +18,7 @@ from six import PY3, iteritems, itervalues, text_type
 from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.db import QueryManager
 
+from .statements import MySQLStatementMetrics
 from .execution_plans import ExecutionPlansMixin
 from datadog_checks.base.utils.db.sql import compute_sql_signature
 
@@ -308,8 +309,6 @@ class MySql(ExecutionPlansMixin, AgentCheck):
         ExecutionPlansMixin.__init__(self)
         self.qcache_stats = {}
         self.metadata = None
-        # Cache to compare the statement metrics to the previous collection
-        self.statement_cache = {}
 
         self._tags = list(self.instance.get('tags', []))
 
@@ -318,8 +317,8 @@ class MySql(ExecutionPlansMixin, AgentCheck):
 
         self._query_manager = QueryManager(self, self.execute_query_raw, queries=[], tags=self._tags)
         self.check_initializations.append(self._query_manager.compile_queries)
-        self.max_query_metrics = int(self.instance.get('options', {}).get('max_query_metrics', 300))
-        self.escape_query_commas_hack = self.instance.get('options', {}).get('escape_query_commas_hack', False)
+
+        self._statement_metrics = MySQLStatementMetrics(self.instance)
 
     def execute_query_raw(self, query):
         with closing(self._conn.cursor(pymysql.cursors.SSCursor)) as cursor:
@@ -392,7 +391,7 @@ class MySql(ExecutionPlansMixin, AgentCheck):
                 # Metric collection
                 self._collect_metrics(db, tags, options, queries, max_custom_queries)
                 self._collect_system_metrics(host, db, tags)
-                self._collect_queries(db, tags, options)
+                self._collect_statement_metrics(db, tags, options)
                 self._collect_execution_plans(db, tags, options)
 
                 # keeping track of these:
@@ -709,15 +708,12 @@ class MySql(ExecutionPlansMixin, AgentCheck):
             if len(queries) > max_custom_queries:
                 self.warning("Maximum number (%s) of custom queries reached.  Skipping the rest.", max_custom_queries)
 
-    def _collect_queries(self, db, tags, options):
-        if not(is_affirmative(options.get('extra_performance_queries', False))):
-            return False
-
+    def _collect_statement_metrics(self, db, tags, options):
         tags = list(set(self.service_check_tags + tags))
-        summary_metrics = self._query_summary_per_statement(db)
+        summary_metrics = self._statement_metrics.get_per_statement_metrics(db)
 
         for metric_name, value, fn, metric_tags in summary_metrics:
-            fn(metric_name, value, tags=metric_tags + tags)
+            fn(self, metric_name, value, tags=metric_tags + tags)
 
     def _is_master(self, slaves, results):
         # master uuid only collected in slaves
@@ -1421,107 +1417,6 @@ class MySql(ExecutionPlansMixin, AgentCheck):
         except (pymysql.err.InternalError, pymysql.err.OperationalError) as e:
             self.warning("Avg exec time performance metrics unavailable at this time: %s", e)
             return None
-
-    def _query_summary_per_statement(self, db):
-        """
-        Collects per-statement metrics from performance schema. Because the statement sums are
-        cumulative, the results of the previous run are stored and subtracted from the current
-        values to get the counts for the elapsed period. This is similar to monotonic_count, but
-        several fields must be further processed from the delta values.
-        """
-
-        sql_statement_summary ="""\
-            SELECT `schema_name` as `schema`,
-                `digest` as `digest`,
-                `digest_text` as `query`,
-                `count_star` as `count`,
-                `sum_timer_wait` / 1000 as `time`,
-                `sum_lock_time` / 1000 as `lock_time`,
-                `sum_errors` as `errors`,
-                `sum_rows_affected` as `rows_affected`,
-                `sum_rows_sent` as `rows_sent`,
-                `sum_rows_examined` as `rows_examined`,
-                `sum_select_scan` as `select_scan`,
-                `sum_select_full_join` as `select_full_join`,
-                `sum_no_index_used` as `no_index_used`,
-                `sum_no_good_index_used` as `no_good_index_used`
-            FROM performance_schema.events_statements_summary_by_digest
-            WHERE `digest_text` NOT LIKE 'EXPLAIN %'
-            ORDER BY `avg_timer_wait` DESC"""
-
-        METRICS = {
-            'count': ('mysql.queries.count', self.count),
-            'errors': ('mysql.queries.errors', self.count),
-            'time': ('mysql.queries.time', self.count),
-            'select_scan': ('mysql.queries.select_scan', self.count),
-            'select_full_join': ('mysql.queries.select_full_join', self.count),
-            'no_index_used': ('mysql.queries.no_index_used', self.count),
-            'no_good_index_used': ('mysql.queries.no_good_index_used', self.count),
-            'lock_time': ('mysql.queries.lock_time', self.count),
-            'rows_affected': ('mysql.queries.rows_affected', self.count),
-            'rows_sent': ('mysql.queries.rows_sent', self.count),
-            'rows_examined': ('mysql.queries.rows_examined', self.count),
-        }
-
-        try:
-            with closing(db.cursor(pymysql.cursors.DictCursor)) as cursor:
-                cursor.execute(sql_statement_summary)
-
-                rows = cursor.fetchall()
-        except (pymysql.err.InternalError, pymysql.err.OperationalError) as e:
-            self.warning("Statement summary metrics are unavailable at this time: %s", e)
-            return []
-
-        # # TODO: apply a limit
-        # In the event the row count exceeds the limit, select the most "interesting" statements
-        # which are slow, have errors, no good index, etc.
-        # - avg duration
-        # - high lock time
-
-        rows = rows[:self.max_query_metrics]
-
-
-        # Given the queried rows, each row must be checked against its previous result
-        # to derive the values in the elapsed period. Statements which appeared first this
-        # run will emit no metrics. If the table was truncated or cumulative counts were
-        # lost since the last run, this run will emit no metrics.
-
-        metrics = dict()
-
-        new_cache = {}
-        for row in rows:
-            key = (row['schema'], row['digest'])
-            new_cache[key] = row
-            if key not in self.statement_cache:
-                continue
-            prev = self.statement_cache[key]
-
-            # Table was truncated or no new queries; start tracking from this point
-            if row['count'] - prev['count'] <= 0:
-                continue
-
-            for col, (name, fn) in METRICS.items():
-                tags = []
-                if row['schema'] is not None:
-                    tags.append('schema:' + row['schema'])
-                obfuscated_statement = datadog_agent.obfuscate_sql(row['query'])
-                query_signature = compute_sql_signature(obfuscated_statement)
-                tags.append('query_signature:' + query_signature)
-                if self.escape_query_commas_hack:
-                    obfuscated_statement = obfuscated_statement.replace(', ', '，').replace(',', '，')
-                tags.append('query:' + obfuscated_statement[:200])
-
-                # Merge metrics in cases where the query signature differs from the DB digest
-                key = '|'.join([name] + sorted(tags))
-                value = row[col] - prev[col]
-                if key in metrics:
-                    self.log.warning(f'Query Collision: {key}')
-                    _, prev_value, _, _ = metrics[key]
-                    value += prev_value
-                metrics[key] = (name, value, fn, tags)
-
-        self.statement_cache = new_cache
-        return list(metrics.values())
 
     def _query_size_per_schema(self, db):
         # Fetches the avg query execution time per schema and returns the

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -318,7 +318,7 @@ class MySql(ExecutionPlansMixin, AgentCheck):
         self._query_manager = QueryManager(self, self.execute_query_raw, queries=[], tags=self._tags)
         self.check_initializations.append(self._query_manager.compile_queries)
 
-        self._statement_metrics = MySQLStatementMetrics(self.instance)
+        self._statement_metrics = MySQLStatementMetrics(self.instance, self.log)
 
     def execute_query_raw(self, query):
         with closing(self._conn.cursor(pymysql.cursors.SSCursor)) as cursor:

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -136,8 +136,11 @@ class MySQLStatementMetrics:
             prev = self.statement_cache.get(row_key)
             if prev is None:
                 continue
-            if any([row[k] - prev[k] <= 0 for k in metrics]):
+            if any([row[k] - prev[k] < 0 for k in metrics]):
                 # The table was truncated or stats reset; begin tracking again from this point
+                continue
+            if all([row[k] - prev[k] == 0 for k in metrics]):
+                # No metrics to report; query did not run
                 continue
             result.append({k: row[k] - prev[k] if k in metrics else row[k] 
                            for k in row})

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -64,17 +64,18 @@ class MySQLStatementMetrics:
         rows = self._apply_row_limits(rows, self.query_metric_limits, 'count', True, key=lambda row: (row['schema'], row['digest']))
 
         metrics = dict()
-        for row in rows:
-            for col, (name, metric_type) in METRICS.items():
-                tags = []
-                if row['schema'] is not None:
-                    tags.append('schema:' + row['schema'])
-                obfuscated_statement = datadog_agent.obfuscate_sql(row['query'])
-                if self.escape_query_commas_hack:
-                    obfuscated_statement = obfuscated_statement.replace(', ', '，').replace(',', '，')
-                tags.append('query:' + obfuscated_statement[:200])
-                tags.append('query_signature:' + compute_sql_signature(obfuscated_statement))
 
+        for row in rows:
+            tags = []
+            if row['schema'] is not None:
+                tags.append('schema:' + row['schema'])
+            obfuscated_statement = datadog_agent.obfuscate_sql(row['query'])
+            if self.escape_query_commas_hack:
+                obfuscated_statement = obfuscated_statement.replace(', ', '，').replace(',', '，')
+            tags.append('query:' + obfuscated_statement[:200])
+            tags.append('query_signature:' + compute_sql_signature(obfuscated_statement))
+
+            for col, (name, metric_type) in METRICS.items():
                 # Merge metrics in cases where the query signature differs from the DB digest
                 value = row[col]
                 key = '|'.join([name] + sorted(tags))

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -1,0 +1,173 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from contextlib import closing
+
+import pymysql
+
+from datadog_checks.base import AgentCheck, is_affirmative
+from datadog_checks.base.utils.db.sql import compute_sql_signature
+
+try:
+    import datadog_agent
+except ImportError:
+    from ..stubs import datadog_agent
+
+
+class MySQLStatementMetrics:
+    """
+    MySQLStatementMetrics collects database metrics per normalized MySQL statement
+    """
+
+    def __init__(self, instance):
+        self.statement_cache = dict()
+
+        dbm_enabled = is_affirmative(datadog_agent.get_config('deep_database_monitoring'))
+        self.enabled = dbm_enabled and not instance.get('options', {}).get('disable_query_metrics', False)
+        self.max_query_metrics = int(instance.get('options', {}).get('max_query_metrics', 500))
+        self.max_query_metrics_sort = int(instance.get('options', {}).get('max_query_metrics_sort', 100))
+        self.escape_query_commas_hack = instance.get('options', {}).get('escape_query_commas_hack', False)
+    
+    def get_per_statement_metrics(self, db):
+        if not self.enabled:
+            return []
+
+        METRICS = {
+            'count': ('mysql.queries.count', AgentCheck.count),
+            'errors': ('mysql.queries.errors', AgentCheck.count),
+            'time': ('mysql.queries.time', AgentCheck.count),
+            'select_scan': ('mysql.queries.select_scan', AgentCheck.count),
+            'select_full_join': ('mysql.queries.select_full_join', AgentCheck.count),
+            'no_index_used': ('mysql.queries.no_index_used', AgentCheck.count),
+            'no_good_index_used': ('mysql.queries.no_good_index_used', AgentCheck.count),
+            'lock_time': ('mysql.queries.lock_time', AgentCheck.count),
+            'rows_affected': ('mysql.queries.rows_affected', AgentCheck.count),
+            'rows_sent': ('mysql.queries.rows_sent', AgentCheck.count),
+            'rows_examined': ('mysql.queries.rows_examined', AgentCheck.count),
+        }
+        rows = self._query_summary_per_statement(db)
+        rows = self._compute_derivative_rows(rows, METRICS.keys(), key=lambda row: (row['schema'], row['digest']))
+        rows = self._apply_row_limit(rows, 'count', True, METRICS.keys(), self.max_query_metrics, 
+                                     top_k=self.max_query_metrics_sort, bottom_k=self.max_query_metrics_sort)
+
+        metrics = dict()
+        for row in rows:
+            for col, (name, metric_type) in METRICS.items():
+                tags = []
+                if row['schema'] is not None:
+                    tags.append('schema:' + row['schema'])
+                obfuscated_statement = datadog_agent.obfuscate_sql(row['query'])
+                if self.escape_query_commas_hack:
+                    obfuscated_statement = obfuscated_statement.replace(', ', '，').replace(',', '，')
+                tags.append('query:' + obfuscated_statement[:200])
+                tags.append('query_signature:' + compute_sql_signature(obfuscated_statement))
+
+                # Merge metrics in cases where the query signature differs from the DB digest
+                value = row[col]
+                key = '|'.join([name] + sorted(tags))
+                if key in metrics:
+                    _, prev_value, _, _ = metrics[key]
+                    value += prev_value
+                metrics[key] = (name, value, metric_type, tags)
+        return list(metrics.values())
+
+    def _query_summary_per_statement(self, db):
+        """
+        Collects per-statement metrics from performance schema. Because the statement sums are
+        cumulative, the results of the previous run are stored and subtracted from the current
+        values to get the counts for the elapsed period. This is similar to monotonic_count, but
+        several fields must be further processed from the delta values.
+        """
+
+        sql_statement_summary ="""\
+            SELECT `schema_name` as `schema`,
+                `digest` as `digest`,
+                `digest_text` as `query`,
+                `count_star` as `count`,
+                `sum_timer_wait` / 1000 as `time`,
+                `sum_lock_time` / 1000 as `lock_time`,
+                `sum_errors` as `errors`,
+                `sum_rows_affected` as `rows_affected`,
+                `sum_rows_sent` as `rows_sent`,
+                `sum_rows_examined` as `rows_examined`,
+                `sum_select_scan` as `select_scan`,
+                `sum_select_full_join` as `select_full_join`,
+                `sum_no_index_used` as `no_index_used`,
+                `sum_no_good_index_used` as `no_good_index_used`
+            FROM performance_schema.events_statements_summary_by_digest
+            WHERE `digest_text` NOT LIKE 'EXPLAIN %'
+            ORDER BY `count_star` DESC
+            LIMIT 10000"""
+
+        try:
+            with closing(db.cursor(pymysql.cursors.DictCursor)) as cursor:
+                cursor.execute(sql_statement_summary)
+
+                rows = cursor.fetchall()
+        except (pymysql.err.InternalError, pymysql.err.OperationalError) as e:
+            self.warning("Statement summary metrics are unavailable at this time: %s", e)
+            return []
+        
+        return rows
+
+    def _compute_derivative_rows(self, rows, metrics, key):
+        """
+        Given a list of rows, compute the derivative from the previous run for each row
+        using the `key` function.
+        """
+        result = []
+        new_cache = {}
+        for row in rows:
+            row_key = key(row)
+            new_cache[row_key] = row
+            prev = self.statement_cache.get(row_key)
+            if prev is None:
+                continue
+            if any([row[k] - prev[k] < 0 for k in metrics]):
+                # The table was truncated or stats reset; begin tracking again from this point
+                continue
+            result.append({k: row[k] - prev[k] if k in metrics else row[k] 
+                           for k in row})
+
+        self.statement_cache = new_cache
+        return result
+
+    @staticmethod
+    def _apply_row_limit(rows, metric, metric_descending, secondary_metrics, limit, top_k, bottom_k):
+        """
+        Limits the number of rows while trying to ensure coverage across metrics. To ensure coverage of each 
+        available metric when sorted, this function selects the top K and bottom K rows of each metric targeted. 
+        However the resulting row count can be lower or higher than the target limit; in these cases, the
+        primary metric will be used to truncate or fill rows which are below or above the query metric limit.
+
+        The primary metric assumes ascending or descending are the most "interesting" values. For instance the
+        'count' metric is more valuable descending since the most frequent queries should be kept over the less
+        frequent queries.
+        """
+        if len(rows) < limit or len(rows) == 0:
+            return rows
+
+        limited = dict()
+        row_key = lambda row: '|'.join([str(item[1]) for item in sorted(row.items(), key=lambda x: x[0])])
+        for m in secondary_metrics:
+            sorted_rows = sorted(rows, key=lambda row: row[m])
+            top = sorted_rows[0:top_k]
+            bottom = sorted_rows[bottom_k:]
+
+            for row in top + bottom:
+                key = row_key(row)
+                limited[key] = row
+
+        # Once the top and bottom of secondary metrics are all accounted for, 
+        # fill the list by primary metric (if necessary) or truncate by primary metric (if necessary)
+        if len(limited) < limit:
+            for row in sorted(rows, key=lambda row: row[metric], reverse=metric_descending):
+                key = row_key(row)
+                limited[row] = row
+                if len(limited) == limit:
+                    break
+            return list(limited.values())
+        else:
+            limited = list(limited.values())
+            limited.sort(key=lambda row: row[metric], reverse=metric_descending)
+            return limited[:limit]


### PR DESCRIPTION
### What does this PR do?

NOTE: this should not be merged into master, only a development branch.

This PR cleans up statement metrics and moves much of the logic to another file. It also fixes a couple of bugs:

1. Per statement metrics do not currently reflect the true values when sorted by count, rows, lock time, etc. because the query currently applies a limit by only one metric (avg query time). So the top 200 queries by avg query time may exclude the top query by rows returned. The new logic goes through each metric and selects the top k and bottom k rows for that metric (with logic to truncate or fill by a primary metric, count).

2. Queries which produce different digests (according to MySQL normalization) but the same query signature (according to Datadog's normalization) will produce different metrics. This aligns on Datadog's normalization instead of the digest. It also removes digest as a tag because it is ambiguous and was only used for debugging purposes.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
