### PR TITLE
[DRAFT/POC] Use WeakRef

### DIFF
--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -25,10 +25,10 @@ class AgentLogger(logging.getLoggerClass()):
 
 
 class CheckLoggingAdapter(logging.LoggerAdapter):
-    def __init__(self, logger, check):
+    def __init__(self, logger, check_ref):
         super(CheckLoggingAdapter, self).__init__(logger, {})
-        self.check = check
-        self.check_id = self.check.check_id
+        self.check_ref = check_ref
+        self.check_id = check_ref().check_id
 
     def setup_sanitization(self, sanitize):
         # type: (Callable[[str], str]) -> None
@@ -39,13 +39,10 @@ class CheckLoggingAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):
         # Cache for performance
         if not self.check_id:
-            self.check_id = self.check.check_id
+            self.check_id = self.check_ref().check_id
             # Default to `unknown` for checks that log during
             # `__init__` and therefore have no `check_id` yet
             self.extra['_check_id'] = self.check_id or 'unknown'
-            if self.check_id:
-                # Break the reference cycle, once we resolved check_id we don't need the check anymore
-                self.check = None
 
         kwargs.setdefault('extra', self.extra)
         return msg, kwargs

--- a/datadog_checks_base/datadog_checks/base/utils/weakref.py
+++ b/datadog_checks_base/datadog_checks/base/utils/weakref.py
@@ -1,0 +1,29 @@
+import weakref
+from collections import deque
+
+
+class WeakDeque(deque):
+    def __init__(self, iterable):
+        super(WeakDeque, self).__init__(weakref.ref(i) for i in iterable)
+
+    def append(self, x):
+        super(WeakDeque, self).append(weakref.ref(x))
+
+    def appendleft(self, x):
+        super(WeakDeque, self).appendleft(weakref.ref(x))
+
+    def extend(self, iterable):
+        super(WeakDeque, self).extend(weakref.ref(i) for i in iterable)
+
+    def extendleft(self, iterable):
+        super(WeakDeque, self).extendleft(weakref.ref(i) for i in iterable)
+
+    def pop(self, *args):
+        return super(WeakDeque, self).pop(*args)()
+
+    def popleft(self):
+        return super(WeakDeque, self).popleft()()
+
+    def remove(self, *args):
+        raise NotImplemented('Method not implemented')
+

--- a/datadog_checks_base/datadog_checks/base/utils/weakref.py
+++ b/datadog_checks_base/datadog_checks/base/utils/weakref.py
@@ -2,28 +2,39 @@ import weakref
 from collections import deque
 
 
-class WeakDeque(deque):
+class WeakDeque(object):
+    """
+    Weakref implementation of Deque
+
+    Caveat:
+        - Some deque methods are not implemented.
+    """
     def __init__(self, iterable):
-        super(WeakDeque, self).__init__(weakref.ref(i) for i in iterable)
+        self.deq = deque(weakref.ref(i) for i in iterable)
 
     def append(self, x):
-        super(WeakDeque, self).append(weakref.ref(x))
+        self.deq.append(weakref.ref(x))
 
     def appendleft(self, x):
-        super(WeakDeque, self).appendleft(weakref.ref(x))
+        self.deq.appendleft(weakref.ref(x))
 
     def extend(self, iterable):
-        super(WeakDeque, self).extend(weakref.ref(i) for i in iterable)
+        self.deq.extend(weakref.ref(i) for i in iterable)
 
     def extendleft(self, iterable):
-        super(WeakDeque, self).extendleft(weakref.ref(i) for i in iterable)
+        self.deq.extendleft(weakref.ref(i) for i in iterable)
 
     def pop(self, *args):
-        return super(WeakDeque, self).pop(*args)()
+        while True:
+            val = self.deq.pop(*args)()
+            if val is not None:
+                return val
 
     def popleft(self):
-        return super(WeakDeque, self).popleft()()
+        while True:
+            val = self.deq.popleft()()
+            if val is not None:
+                return val
 
-    def remove(self, *args):
-        raise NotImplemented('Method not implemented')
-
+    def __len__(self):
+        return len(self.deq)

--- a/datadog_checks_base/tests/test_weakref.py
+++ b/datadog_checks_base/tests/test_weakref.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+from collections import OrderedDict
+from typing import Any
+
+import mock
+import pytest
+from six import PY3
+
+from datadog_checks.base import AgentCheck
+from datadog_checks.base import __version__ as base_package_version
+from datadog_checks.base import to_native_string
+from datadog_checks.base.checks.base import datadog_agent
+from datadog_checks.base.utils.weakref import WeakDeque
+
+
+class Foo(object):
+    def __init__(self, val):
+        self.val = val
+
+
+def test_weak_deque_append_del_pop():
+    a,b,c = Foo("a"), Foo("b"), Foo("c")
+
+    deq = WeakDeque([a])
+    deq.append(b)
+    deq.append(c)
+
+    del b
+
+    assert len(deq) == 3
+    assert deq.pop().val == "c"
+    assert deq.pop().val == "a"
+    assert len(deq) == 0
+
+
+def test_weak_deque_appendleft():
+    a,b,c = Foo("a"), Foo("b"), Foo("c")
+
+    deq = WeakDeque([a])
+    deq.appendleft(b)
+    deq.appendleft(c)
+
+    assert deq.pop().val == "a"
+    assert deq.pop().val == "b"
+    assert deq.pop().val == "c"
+
+
+def test_weak_deque_extend():
+    a,b,c = Foo("a"), Foo("b"), Foo("c")
+
+    deq = WeakDeque([a])
+    deq.extend([b, c])
+
+    assert deq.pop().val == "c"
+    assert deq.pop().val == "b"
+    assert deq.pop().val == "a"
+
+
+def test_weak_deque_extendleft():
+    a,b,c = Foo("a"), Foo("b"), Foo("c")
+
+    deq = WeakDeque([a])
+    deq.extendleft([b, c])
+
+    assert deq.popleft().val == "c"
+    assert deq.popleft().val == "b"
+    assert deq.popleft().val == "a"
+
+
+def test_weak_deque_popleft():
+    a,b,c = Foo("a"), Foo("b"), Foo("c")
+
+    deq = WeakDeque([a])
+    deq.append(b)
+    deq.append(c)
+
+    assert deq.popleft().val == "a"
+    assert deq.popleft().val == "b"
+    assert deq.popleft().val == "c"
+
+
+
+


### PR DESCRIPTION
TODO
- [ ] avoid WeakDeque if possible
- [ ] write doc about it
  - [ ] why
  - [ ] impacts (auto discovery, cluster agent)
  - [ ] how prevent in the future
  - [ ] might worth having tests/tooling/process to check for such cases for actual integrations.

### What does this PR do?

Use WeakRef to circular references for
- CheckLoggingAdapter referencing AgentCheck
-  self.check_initializations deque referencing AgentCheck methods

### Motivation

Currently due to circular dependencies, AgentCheck instances cannot be freed using ref counting.

This PR will fix that issue and avoid having GC to resolve circular deps.


