### PR TITLE
azure_active_directory is just a tile

### DIFF
--- a/.gitlab/validate-logs-intgs/validate_log_intgs.py
+++ b/.gitlab/validate-logs-intgs/validate_log_intgs.py
@@ -22,9 +22,10 @@ EXCEPTIONS = {
         ERR_UNEXPECTED_LOG_COLLECTION_CAT,  # cilium does not need a pipeline to automatically parse the logs
         ERR_UNEXPECTED_LOG_DOC  # The documentation says to use 'source: cilium'
     ],
-    'mesos_master': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # We do support log collection for mesos environments
-    'amazon_eks': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # eks is just a tile
-    'eks_fargate': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # Log collection but not from the agent
+    'mesos_master': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # We do support log collection for mesos environments
+    'amazon_eks': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # eks is just a tile
+    'azure_active_directory': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # azure_active_directory is just a tile
+    'eks_fargate': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # Log collection but not from the agent
     'fluentd': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # Fluentd is about log collection but we don't collect fluentd logs
     'kubernetes': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # The agent collects logs from kubernetes environment but there is no pipeline per se
     'win32_event_log': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # win32_event_log is about log collection but we don't collect win32_event_log logs


### PR DESCRIPTION
### What does this PR do?

azure_active_directory is just a tile

### Motivation

It's breaking CI validation.

```
Logs pipelines don't pass validation steps:
 - azure_active_directory: The check does not have a log pipeline but defines 'log collection' in its manifest file.
```