### PR TITLE
Spark integration default param

### DIFF
--- a/spark/README.md
+++ b/spark/README.md
@@ -35,7 +35,7 @@ Follow the instructions below to configure this check for an Agent running on a 
        #   spark_url: http://<Mesos_master>:5050 # Mesos master web UI
        #   spark_url: http://<YARN_ResourceManager_address>:8088 # YARN ResourceManager address
 
-       spark_cluster_mode: spark_standalone_mode # default
+       spark_cluster_mode: spark_yarn_mode # default
        #   spark_cluster_mode: spark_mesos_mode
        #   spark_cluster_mode: spark_yarn_mode
        #   spark_cluster_mode: spark_driver_mode


### PR DESCRIPTION
### What does this PR do?
Changes the param default in the docs to match the param default in the [conf.yaml file](https://github.com/DataDog/integrations-core/blob/master/spark/datadog_checks/spark/data/conf.yaml.example#L76).

### Motivation
Jira request

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached