### PR TITLE
Update Sidekiq documentation link

### DIFF
--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -45,7 +45,7 @@ No additional installation is needed on your server.
           end
    ```
 
-    See the Sidekiq [Pro][6] and [Enterprise][7] documentation for more information, and the [Datadog Ruby][7] documentation for further configuration options.
+    See the Sidekiq [Pro][6] and [Enterprise][7] documentation for more information, and the [Datadog Ruby][14] documentation for further configuration options.
 
 3. Update the [Datadog Agent main configuration file][13] `datadog.yaml` by adding the following configs:
 
@@ -132,3 +132,4 @@ Need help? Contact [Datadog support][1].
 [11]: https://github.com/mperham/sidekiq/wiki/Ent-Historical-Metrics#custom
 [12]: https://github.com/DataDog/integrations-core/blob/master/sidekiq/metadata.csv
 [13]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/
+[14]: https://docs.datadoghq.com/integrations/ruby/

--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -132,4 +132,3 @@ Need help? Contact [Datadog support][1].
 [11]: https://github.com/mperham/sidekiq/wiki/Ent-Historical-Metrics#custom
 [12]: https://github.com/DataDog/integrations-core/blob/master/sidekiq/metadata.csv
 [13]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/
-[14]: https://docs.datadoghq.com/integrations/ruby/

--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -45,7 +45,7 @@ No additional installation is needed on your server.
           end
    ```
 
-    See the Sidekiq [Pro][6] and [Enterprise][7] documentation for more information, and the [Datadog Ruby][14] documentation for further configuration options.
+    See the Sidekiq [Pro][6] and [Enterprise][7] documentation for more information, and the [Dogstatsd Ruby][4] documentation for further configuration options.
 
 3. Update the [Datadog Agent main configuration file][13] `datadog.yaml` by adding the following configs:
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update `Datadog Ruby` link in sidekiq configuration docs to point to https://docs.datadoghq.com/integrations/ruby/ instead of https://github.com/mperham/sidekiq/wiki/Ent-Historical-Metrics

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
I'm not positive this is the destination the original author intended to link to, but seems closer than the sidekiq wiki

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
