### PR TITLE
Allow "noqa" for long spec descriptions

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
@@ -78,13 +78,15 @@ def write_description(option, writer, indent, option_type):
     for line in description.splitlines():
         if line:
             line = f'{indent}## {line}'
-            if len(line) > DESCRIPTION_LINE_LENGTH_LIMIT:
+            if len(line) > DESCRIPTION_LINE_LENGTH_LIMIT and ' /noqa' not in line:
                 extra_characters = len(line) - DESCRIPTION_LINE_LENGTH_LIMIT
                 writer.new_error(
                     'Description line length of {} `{}` was over the limit by {} character{}'.format(
                         option_type, option['name'], extra_characters, 's' if extra_characters > 1 else ''
                     )
                 )
+            elif ' /noqa' in line:
+                line = line.replace(' /noqa', '')
             writer.write(line)
         else:
             writer.write(indent, '##')

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -854,7 +854,9 @@ def test_option_description_length_limit_with_noqa():
             value:
               type: string
               example: something
-        """.format('a' * DESCRIPTION_LINE_LENGTH_LIMIT + ' /noqa')
+        """.format(
+            'a' * DESCRIPTION_LINE_LENGTH_LIMIT + ' /noqa'
+        )
     )
 
     files = consumer.render()
@@ -863,10 +865,12 @@ def test_option_description_length_limit_with_noqa():
     assert contents == normalize_yaml(
         """
         ## @param foo - string - optional - default: something
-        ## aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        ## {}
         #
         # foo: something
-        """
+        """.format(
+            'a' * DESCRIPTION_LINE_LENGTH_LIMIT
+        )
     )
 
 

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -840,6 +840,36 @@ def test_option_description_length_limit():
     assert 'Description line length of option `foo` was over the limit by 3 characters' in errors
 
 
+def test_option_description_length_limit_with_noqa():
+    consumer = get_example_consumer(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - name: foo
+            description: {}
+            value:
+              type: string
+              example: something
+        """.format('a' * DESCRIPTION_LINE_LENGTH_LIMIT + ' /noqa')
+    )
+
+    files = consumer.render()
+    contents, errors = files['test.yaml.example']
+    assert not errors
+    assert contents == normalize_yaml(
+        """
+        ## @param foo - string - optional - default: something
+        ## aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        #
+        # foo: something
+        """
+    )
+
+
 @pytest.mark.skipif(PY2, reason='Dictionary key order is not guaranteed in Python 2')
 def test_deprecation():
     consumer = get_example_consumer(


### PR DESCRIPTION
### What does this PR do?
Allows for bypassing line restrictions in config spec descriptions.

### Motivation
The `mapreduce` check has a really long URL for documenting APIs, and the spec won't validate as a result: `https://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapredAppMasterRest.html#Job_Counters_API`


This change allows for appending ` /noqa` to the end of a line in the `spec.yaml` file to bypass the restriction.  That bit will also get removed in the resulting `conf.yaml.example` file.

### Additional Notes
Note that "#noqa" doesn't work as it gets interpreted as a comment and gets stripped when the YAML is read in but before processing begins.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
