### PR TITLE
Fix namespace default value

### DIFF
--- a/wmi_check/assets/configuration/spec.yaml
+++ b/wmi_check/assets/configuration/spec.yaml
@@ -63,7 +63,7 @@ files:
       description: The optional WMI namespace to connect to.
       value:
         type: string
-        example: cimv2
+        example: 'root\cimv2'
     - name: filters
       description: |
         A list of filters on the WMI query you may want.

--- a/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
+++ b/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
@@ -54,10 +54,10 @@ instances:
     #
     # password: <PASSWORD>
 
-    ## @param namespace - string - optional - default: cimv2
+    ## @param namespace - string - optional - default: root\cimv2
     ## The optional WMI namespace to connect to.
     #
-    # namespace: cimv2
+    # namespace: 'root\cimv2'
 
     ## @param filters - list of mappings - optional
     ## A list of filters on the WMI query you may want.

--- a/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
+++ b/wmi_check/datadog_checks/wmi_check/data/conf.yaml.example
@@ -57,7 +57,7 @@ instances:
     ## @param namespace - string - optional - default: root\cimv2
     ## The optional WMI namespace to connect to.
     #
-    # namespace: 'root\cimv2'
+    # namespace: root\cimv2
 
     ## @param filters - list of mappings - optional
     ## A list of filters on the WMI query you may want.


### PR DESCRIPTION
### What does this PR do?

Fix namespace default value

### Motivation

Doc does not match impl. The `root\` prefix is missing:

https://github.com/DataDog/integrations-core/blob/cc027387c9e2911dcf957b7d282e434fe6d8ae22/datadog_checks_base/datadog_checks/base/checks/win/wmi/__init__.py#L50