### PR TITLE
Remove latest from tox

### DIFF
--- a/clickhouse/tox.ini
+++ b/clickhouse/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py{27,38}-{18,19,latest}
+    py{27,38}-{18,19}
 
 [testenv]
 ensure_default_envdir = true
@@ -23,7 +23,6 @@ passenv =
     COMPOSE*
     USERNAME
 setenv =
-    CLICKHOUSE_VERSION=latest
     18: CLICKHOUSE_VERSION=18
     19: CLICKHOUSE_VERSION=19
 commands =


### PR DESCRIPTION
### What does this PR do?

Remove clickhouse latest from tox

### Motivation

Fix CI. More stable CI. 

### Additional Notes

Ticket created (AI-992) for supporting latest docker image changes:

```
tests/test_clickhouse.py::test_check FAILED                              [  7%]
tests/test_clickhouse.py::test_can_connect PASSED                        [ 15%]
tests/test_clickhouse.py::test_custom_queries PASSED                     [ 23%]
tests/test_clickhouse.py::test_version_metadata SKIPPED                  [ 30%]
tests/test_e2e.py::test_check SKIPPED                                    [ 38%]
tests/test_unit.py::test_config PASSED                                   [ 46%]
tests/test_unit.py::test_config_error PASSED                             [ 53%]
tests/test_unit.py::test_error_query PASSED                              [ 61%]
tests/test_unit.py::test_latest_metrics_supported[SystemMetrics] SKIPPED [ 69%]
tests/test_unit.py::test_latest_metrics_supported[SystemEvents] SKIPPED  [ 76%]
tests/test_utils.py::TestErrorSanitizer::test_clean PASSED               [ 84%]
tests/test_utils.py::TestErrorSanitizer::test_scrub PASSED               [ 92%]
tests/test_utils.py::TestErrorSanitizer::test_scrub_no_password PASSED   [100%]

=================================== FAILURES ===================================
__________________________________ test_check __________________________________
tests/test_clickhouse.py:24: in test_check
    aggregator.assert_metric_has_tag(metric, server_tag)
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:161: in assert_metric_has_tag
    assert len(candidates) >= at_least, msg
E   AssertionError: Candidates size assertion for `clickhouse.replica.leader.election`, count: None, at_least: 1) failed
E   assert 0 >= 1
E    +  where 0 = len([])

```