### PR TITLE
Better logging for submit_metric

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -534,12 +534,18 @@ class SnmpCheck(AgentCheck):
             try:
                 metric = as_metric_with_forced_type(snmp_value, forced_type, options)
             except Exception as e:
-                self.log.error('Unable to coerce %s to %s: %s', name, forced_type, e)
+                self.log.error(
+                    'Unable to coerce `%s` to `%s` for metric `%s`: %s', snmp_value, forced_type, metric_name, e
+                )
                 return
             if metric is None:
                 raise ConfigurationError('Invalid forced-type {!r} for metric {!r}'.format(forced_type, name))
         else:
-            metric = as_metric_with_inferred_type(snmp_value)
+            try:
+                metric = as_metric_with_inferred_type(snmp_value)
+            except Exception as e:
+                self.log.error('Unable to parse value `%s` for metric `%s`: %s', snmp_value, metric_name, e)
+                return
 
         if metric is None:
             self.log.warning('Unsupported metric type %s for %s', snmp_value.__class__.__name__, metric_name)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -544,7 +544,9 @@ class SnmpCheck(AgentCheck):
             try:
                 metric = as_metric_with_inferred_type(snmp_value)
             except Exception as e:
-                self.log.error('Unable to parse value `%s` for metric `%s`: %s', snmp_value, metric_name, e)
+                self.log.error(
+                    'Unable to parse value for inferred type `%s` for metric `%s`: %s', snmp_value, metric_name, e
+                )
                 return
 
         if metric is None:

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -523,8 +523,11 @@ class SnmpCheck(AgentCheck):
         try:
             self.do_submit_metric(name, snmp_value, forced_type, tags, options)
         except Exception as e:
-            msg = 'Unable to submit metric=`{}`, value=`{}`, forced_type=`{}`, tags=`{}`, options=`{}`: {}'.format(
-                name, snmp_value, forced_type, tags, options, e
+            msg = (
+                'Unable to submit metric `{}` with '
+                'value=`{}` ({}), forced_type=`{}`, tags=`{}`, options=`{}`: {}'.format(
+                    name, snmp_value, type(snmp_value), forced_type, tags, options, e
+                )
             )
             self.log.warning(msg)
             self.log.debug(msg, exc_info=True)
@@ -548,7 +551,7 @@ class SnmpCheck(AgentCheck):
             metric = as_metric_with_inferred_type(snmp_value)
 
         if metric is None:
-            raise RuntimeError('Unsupported metric type {} for {}'.format(snmp_value.__class__.__name__, metric_name))
+            raise RuntimeError('Unsupported metric type {} for {}'.format(type(snmp_value), metric_name))
 
         submit_func = getattr(self, metric['type'])
         submit_func(metric_name, metric['value'], tags=tags)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -523,8 +523,9 @@ class SnmpCheck(AgentCheck):
         try:
             self.do_submit_metric(name, snmp_value, forced_type, tags, options)
         except Exception as e:
-            value_class = 'None' if snmp_value is None else snmp_value.__class__.__name__
-            msg = 'Unable to submit metric=`{}`, value=`{}` ({}}, forced_type=`{}`, tags=`{}`, options=`{}`: {}'.format(name, snmp_value, value_class, forced_type, tags, options, e)
+            msg = 'Unable to submit metric=`{}`, value=`{}`, forced_type=`{}`, tags=`{}`, options=`{}`: {}'.format(
+                name, snmp_value, forced_type, tags, options, e
+            )
             self.log.warning(msg)
             self.log.debug(msg, exc_info=True)
 
@@ -547,7 +548,7 @@ class SnmpCheck(AgentCheck):
             metric = as_metric_with_inferred_type(snmp_value)
 
         if metric is None:
-            raise RuntimeError('Unsupported metric type %s for %s'.format(snmp_value.__class__.__name__, metric_name))
+            raise RuntimeError('Unsupported metric type {} for {}'.format(snmp_value.__class__.__name__, metric_name))
 
         submit_func = getattr(self, metric['type'])
         submit_func(metric_name, metric['value'], tags=tags)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -521,7 +521,7 @@ class SnmpCheck(AgentCheck):
         report them to the aggregator.
         """
         try:
-            self.do_submit_metric(name, snmp_value, forced_type, tags, options)
+            self._do_submit_metric(name, snmp_value, forced_type, tags, options)
         except Exception as e:
             msg = (
                 'Unable to submit metric `{}` with '
@@ -532,7 +532,7 @@ class SnmpCheck(AgentCheck):
             self.log.warning(msg)
             self.log.debug(msg, exc_info=True)
 
-    def do_submit_metric(self, name, snmp_value, forced_type, tags, options):
+    def _do_submit_metric(self, name, snmp_value, forced_type, tags, options):
         # type: (str, Any, Optional[str], List[str], dict) -> None
 
         if reply_invalid(snmp_value):

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -501,7 +501,7 @@ def test_invalid_forcedtype_metric(aggregator, caplog):
     # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
-    assert "Unable to submit metricx" in caplog.text
+    assert "Unable to submit metric" in caplog.text
 
 
 def test_scalar_with_tags(aggregator):

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -488,7 +488,7 @@ def test_forcedtype_metric(aggregator):
     aggregator.all_metrics_asserted()
 
 
-def test_invalid_forcedtype_metric(aggregator):
+def test_invalid_forcedtype_metric(aggregator, caplog):
     """
     If a forced type is invalid a warning should be issued + a service check
     should be available
@@ -499,7 +499,9 @@ def test_invalid_forcedtype_metric(aggregator):
     check.check(instance)
 
     # Test service check
-    aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.WARNING, tags=common.CHECK_TAGS, at_least=1)
+    aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
+
+    assert "Unable to submit metricx" in caplog.text
 
 
 def test_scalar_with_tags(aggregator):

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -490,15 +490,14 @@ def test_forcedtype_metric(aggregator):
 
 def test_invalid_forcedtype_metric(aggregator, caplog):
     """
-    If a forced type is invalid a warning should be issued + a service check
-    should be available
+    If a forced type is invalid a warning should be issued
+    but the check should continue processing the remaining metrics.
     """
     instance = common.generate_instance_config(common.INVALID_FORCED_METRICS)
     check = common.create_check(instance)
 
     check.check(instance)
 
-    # Test service check
     aggregator.assert_service_check("snmp.can_check", status=SnmpCheck.OK, tags=common.CHECK_TAGS, at_least=1)
 
     assert "Unable to submit metric" in caplog.text


### PR DESCRIPTION
Better logging for submit_metric

- Catch all exceptions from  `do_submit_metric`, cleaner than multiple low level  try/except.
- Log all `submit_metric` arguments so we can easily reproduce issues
- Log stracktrace in debug mode with exc_info.
- Let's not raise `ConfigurationError` so that the check continue to work even if there is an issue with one of the metrics
