### PR TITLE
Add log_source to manifest.json

### DIFF
--- a/active_directory/manifest.json
+++ b/active_directory/manifest.json
@@ -27,6 +27,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/active_directory/manifest.json
+++ b/active_directory/manifest.json
@@ -28,8 +28,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -34,8 +34,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -33,6 +33,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/activemq_xml/manifest.json
+++ b/activemq_xml/manifest.json
@@ -30,8 +30,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/activemq_xml/manifest.json
+++ b/activemq_xml/manifest.json
@@ -29,6 +29,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/aerospike/manifest.json
+++ b/aerospike/manifest.json
@@ -30,8 +30,6 @@
       "Aerospike Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/aerospike/manifest.json
+++ b/aerospike/manifest.json
@@ -22,13 +22,16 @@
   "is_public": true,
   "integration_id": "aerospike",
   "assets": {
-     "configuration": {
+    "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {},
     "dashboards": {
       "Aerospike Overview": "assets/dashboards/overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/agent_metrics/manifest.json
+++ b/agent_metrics/manifest.json
@@ -24,6 +24,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/agent_metrics/manifest.json
+++ b/agent_metrics/manifest.json
@@ -25,8 +25,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/airflow/manifest.json
+++ b/airflow/manifest.json
@@ -31,6 +31,9 @@
     },
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/airflow/manifest.json
+++ b/airflow/manifest.json
@@ -32,8 +32,6 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/amazon_eks/manifest.json
+++ b/amazon_eks/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/amazon_eks/manifest.json
+++ b/amazon_eks/manifest.json
@@ -25,6 +25,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/amazon_msk/manifest.json
+++ b/amazon_msk/manifest.json
@@ -29,6 +29,9 @@
     },
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/amazon_msk/manifest.json
+++ b/amazon_msk/manifest.json
@@ -30,8 +30,6 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/ambari/manifest.json
+++ b/ambari/manifest.json
@@ -31,8 +31,6 @@
       "Ambari base dashboard": "assets/dashboards/base_dashboard.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/ambari/manifest.json
+++ b/ambari/manifest.json
@@ -30,6 +30,9 @@
     "dashboards": {
       "Ambari base dashboard": "assets/dashboards/base_dashboard.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -44,6 +44,9 @@
       "status_code_overview": "assets/saved_views/status_code_overview.json",
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -45,8 +45,6 @@
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/aspdotnet/manifest.json
+++ b/aspdotnet/manifest.json
@@ -23,6 +23,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/aspdotnet/manifest.json
+++ b/aspdotnet/manifest.json
@@ -24,8 +24,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/azure_active_directory/manifest.json
+++ b/azure_active_directory/manifest.json
@@ -27,6 +27,9 @@
     "dashboards": {},
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/azure_active_directory/manifest.json
+++ b/azure_active_directory/manifest.json
@@ -28,8 +28,6 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/btrfs/manifest.json
+++ b/btrfs/manifest.json
@@ -26,6 +26,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/btrfs/manifest.json
+++ b/btrfs/manifest.json
@@ -27,8 +27,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/cacti/manifest.json
+++ b/cacti/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/cacti/manifest.json
+++ b/cacti/manifest.json
@@ -21,10 +21,13 @@
   "integration_id": "cacti",
   "assets": {
     "configuration": {
-       "spec": "assets/configuration/spec.yaml"
+      "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -30,8 +30,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -29,6 +29,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/cassandra_nodetool/manifest.json
+++ b/cassandra_nodetool/manifest.json
@@ -24,6 +24,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/cassandra_nodetool/manifest.json
+++ b/cassandra_nodetool/manifest.json
@@ -25,8 +25,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -34,8 +34,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -33,6 +33,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/cilium/manifest.json
+++ b/cilium/manifest.json
@@ -29,8 +29,6 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/cilium/manifest.json
+++ b/cilium/manifest.json
@@ -28,6 +28,9 @@
       "Cilium Overview": "assets/dashboards/overview.json"
     },
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -28,6 +28,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -29,8 +29,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/clickhouse/manifest.json
+++ b/clickhouse/manifest.json
@@ -27,6 +27,9 @@
       "ClickHouse Overview": "assets/dashboards/overview.json"
     },
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/clickhouse/manifest.json
+++ b/clickhouse/manifest.json
@@ -28,8 +28,6 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/cloud_foundry_api/manifest.json
+++ b/cloud_foundry_api/manifest.json
@@ -30,8 +30,6 @@
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/cloud_foundry_api/manifest.json
+++ b/cloud_foundry_api/manifest.json
@@ -29,6 +29,9 @@
     "dashboards": {},
     "monitors": {},
     "saved_views": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/cockroachdb/manifest.json
+++ b/cockroachdb/manifest.json
@@ -29,8 +29,6 @@
       "CockroachDB Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/cockroachdb/manifest.json
+++ b/cockroachdb/manifest.json
@@ -28,6 +28,9 @@
     "dashboards": {
       "CockroachDB Overview": "assets/dashboards/overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/confluent_platform/manifest.json
+++ b/confluent_platform/manifest.json
@@ -34,8 +34,6 @@
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/confluent_platform/manifest.json
+++ b/confluent_platform/manifest.json
@@ -33,6 +33,9 @@
     },
     "monitors": {},
     "saved_views": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -38,8 +38,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -37,6 +37,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/containerd/manifest.json
+++ b/containerd/manifest.json
@@ -22,6 +22,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/containerd/manifest.json
+++ b/containerd/manifest.json
@@ -23,8 +23,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/coredns/manifest.json
+++ b/coredns/manifest.json
@@ -26,6 +26,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/coredns/manifest.json
+++ b/coredns/manifest.json
@@ -27,8 +27,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -36,6 +36,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -37,8 +37,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/couchbase/manifest.json
+++ b/couchbase/manifest.json
@@ -28,6 +28,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/couchbase/manifest.json
+++ b/couchbase/manifest.json
@@ -29,8 +29,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/cri/manifest.json
+++ b/cri/manifest.json
@@ -22,6 +22,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/cri/manifest.json
+++ b/cri/manifest.json
@@ -23,8 +23,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/crio/manifest.json
+++ b/crio/manifest.json
@@ -24,6 +24,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/crio/manifest.json
+++ b/crio/manifest.json
@@ -25,8 +25,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -93,7 +93,7 @@ def get_manifest_schema():
                                     "type": "string",
                                     "description": "The log pipeline identifier corresponding to this integration",
                                 }
-                            }
+                            },
                         },
                     },
                     "required": ["monitors", "dashboards", "service_checks", "logs"],

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -86,8 +86,17 @@ def get_manifest_schema():
                             "type": "string",
                             "description": "Relative path to the json file containing service check metadata",
                         },
+                        "logs": {
+                            "type": "object",
+                            "properties": {
+                                "source": {
+                                    "type": "string",
+                                    "description": "The log pipeline identifier corresponding to this integration",
+                                }
+                            }
+                        },
                     },
-                    "required": ["monitors", "dashboards", "service_checks"],
+                    "required": ["monitors", "dashboards", "service_checks", "logs"],
                 },
             },
             "allOf": [

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
@@ -28,6 +28,9 @@
     "dashboards": {{}},
     "monitors": {{}},
     "saved_views": {{}},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
@@ -29,8 +29,6 @@
     "monitors": {{}},
     "saved_views": {{}},
     "service_checks": "assets/service_checks.json",
-    "logs": {{
-      "source": ""
-    }}
+    "logs": {{}}
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
@@ -29,8 +29,8 @@
     "monitors": {{}},
     "saved_views": {{}},
     "service_checks": "assets/service_checks.json",
-    "logs": {
+    "logs": {{
       "source": ""
-    }
+    }}
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
@@ -21,7 +21,6 @@
   "type": "check",
   "is_public": false,
   "integration_id": "{check_name_kebab}",
-  "log_source": "",
   "assets": {{
     "configuration": {{
       "spec": "assets/configuration/spec.yaml"

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
@@ -21,6 +21,7 @@
   "type": "check",
   "is_public": false,
   "integration_id": "{check_name_kebab}",
+  "log_source": "",
   "assets": {{
     "configuration": {{
       "spec": "assets/configuration/spec.yaml"
@@ -28,6 +29,9 @@
     "dashboards": {{}},
     "monitors": {{}},
     "saved_views": {{}},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
@@ -29,8 +29,6 @@
     "monitors": {{}},
     "saved_views": {{}},
     "service_checks": "assets/service_checks.json",
-    "logs": {{
-      "source": ""
-    }}
+    "logs": {{}}
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
@@ -30,8 +30,8 @@
     "monitors": {{}},
     "saved_views": {{}},
     "service_checks": "assets/service_checks.json",
-    "logs": {
+    "logs": {{
       "source": ""
-    }
+    }}
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
@@ -30,8 +30,8 @@
     "saved_views": {{}},
     "monitors": {{}},
     "service_checks": "assets/service_checks.json",
-    "logs": {
+    "logs": {{
       "source": ""
-    }
+    }}
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
@@ -29,8 +29,6 @@
     "saved_views": {{}},
     "monitors": {{}},
     "service_checks": "assets/service_checks.json",
-    "logs": {{
-      "source": ""
-    }}
+    "logs": {{}}
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
@@ -21,7 +21,6 @@
   "type": "check",
   "is_public": false,
   "integration_id": "{check_name_kebab}",
-  "log_source": "",
   "assets": {{
     "configuration": {{
       "spec":"assets/configuration/spec.yaml"

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
@@ -21,6 +21,7 @@
   "type": "check",
   "is_public": false,
   "integration_id": "{check_name_kebab}",
+  "log_source": "",
   "assets": {{
     "configuration": {{
       "spec":"assets/configuration/spec.yaml"
@@ -28,6 +29,9 @@
     "dashboards": {{}},
     "saved_views": {{}},
     "monitors": {{}},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
@@ -21,7 +21,6 @@
   "type": "check",
   "is_public": false,
   "integration_id": "{check_name_kebab}",
-  "log_source": "",
   "assets": {{
     "dashboards": {{}},
     "saved_views": {{}},

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
@@ -21,10 +21,14 @@
   "type": "check",
   "is_public": false,
   "integration_id": "{check_name_kebab}",
+  "log_source": "",
   "assets": {{
     "dashboards": {{}},
     "saved_views": {{}},
     "monitors": {{}},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
@@ -27,8 +27,8 @@
     "saved_views": {{}},
     "monitors": {{}},
     "service_checks": "assets/service_checks.json",
-    "logs": {
+    "logs": {{
       "source": ""
-    }
+    }}
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
@@ -26,8 +26,6 @@
     "saved_views": {{}},
     "monitors": {{}},
     "service_checks": "assets/service_checks.json",
-    "logs": {{
-      "source": ""
-    }}
+    "logs": {{}}
   }}
 }}

--- a/directory/manifest.json
+++ b/directory/manifest.json
@@ -24,6 +24,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/directory/manifest.json
+++ b/directory/manifest.json
@@ -25,8 +25,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -22,11 +22,14 @@
   "type": "check",
   "integration_id": "system",
   "assets": {
-     "configuration": {
-        "spec": "assets/configuration/spec.yaml"
-     },
+    "configuration": {
+      "spec": "assets/configuration/spec.yaml"
+    },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -28,8 +28,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/dns_check/manifest.json
+++ b/dns_check/manifest.json
@@ -32,8 +32,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/dns_check/manifest.json
+++ b/dns_check/manifest.json
@@ -31,6 +31,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/dotnetclr/manifest.json
+++ b/dotnetclr/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/dotnetclr/manifest.json
+++ b/dotnetclr/manifest.json
@@ -25,6 +25,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/druid/manifest.json
+++ b/druid/manifest.json
@@ -31,6 +31,9 @@
       "Druid Overview": "assets/dashboards/overview.json"
     },
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/druid/manifest.json
+++ b/druid/manifest.json
@@ -32,8 +32,6 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/ecs_fargate/manifest.json
+++ b/ecs_fargate/manifest.json
@@ -28,6 +28,9 @@
     "dashboards": {
       "Amazon Fargate": "assets/dashboards/amazon_fargate_overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/ecs_fargate/manifest.json
+++ b/ecs_fargate/manifest.json
@@ -29,8 +29,6 @@
       "Amazon Fargate": "assets/dashboards/amazon_fargate_overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/eks_fargate/manifest.json
+++ b/eks_fargate/manifest.json
@@ -30,6 +30,9 @@
   "assets": {
     "dashboards": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/eks_fargate/manifest.json
+++ b/eks_fargate/manifest.json
@@ -31,8 +31,6 @@
     "dashboards": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -36,8 +36,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -35,6 +35,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/envoy/manifest.json
+++ b/envoy/manifest.json
@@ -25,13 +25,16 @@
   "type": "check",
   "integration_id": "envoy",
   "assets": {
-     "configuration": {
+    "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {},
     "dashboards": {
       "Envoy - Overview": "assets/dashboards/envoy_overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/envoy/manifest.json
+++ b/envoy/manifest.json
@@ -33,8 +33,6 @@
       "Envoy - Overview": "assets/dashboards/envoy_overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/etcd/manifest.json
+++ b/etcd/manifest.json
@@ -36,6 +36,9 @@
     "dashboards": {
       "Etcd Overview": "assets/dashboards/etcd_overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/etcd/manifest.json
+++ b/etcd/manifest.json
@@ -37,8 +37,6 @@
       "Etcd Overview": "assets/dashboards/etcd_overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/exchange_server/manifest.json
+++ b/exchange_server/manifest.json
@@ -24,6 +24,9 @@
     "dashboards": {
       "Exchange Server Overview": "assets/dashboards/overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/exchange_server/manifest.json
+++ b/exchange_server/manifest.json
@@ -25,8 +25,6 @@
       "Exchange Server Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/external_dns/manifest.json
+++ b/external_dns/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/external_dns/manifest.json
+++ b/external_dns/manifest.json
@@ -25,6 +25,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/flink/manifest.json
+++ b/flink/manifest.json
@@ -31,6 +31,9 @@
     },
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/flink/manifest.json
+++ b/flink/manifest.json
@@ -32,8 +32,6 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/fluentd/manifest.json
+++ b/fluentd/manifest.json
@@ -36,6 +36,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/fluentd/manifest.json
+++ b/fluentd/manifest.json
@@ -37,8 +37,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/gearmand/manifest.json
+++ b/gearmand/manifest.json
@@ -32,8 +32,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/gearmand/manifest.json
+++ b/gearmand/manifest.json
@@ -31,6 +31,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/gitlab/manifest.json
+++ b/gitlab/manifest.json
@@ -13,7 +13,10 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "gitlab.",
-  "metric_to_check": ["gitlab.process_max_fds", "gitlab.ruby.process_start_time_seconds"],
+  "metric_to_check": [
+    "gitlab.process_max_fds",
+    "gitlab.ruby.process_start_time_seconds"
+  ],
   "name": "gitlab",
   "public_title": "Datadog-Gitlab Integration",
   "short_description": "Track all your Gitlab metrics with Datadog",
@@ -33,6 +36,9 @@
     "dashboards": {
       "Gitlab Overview": "assets/dashboards/overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/gitlab/manifest.json
+++ b/gitlab/manifest.json
@@ -37,8 +37,6 @@
       "Gitlab Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/gitlab_runner/manifest.json
+++ b/gitlab_runner/manifest.json
@@ -26,6 +26,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/gitlab_runner/manifest.json
+++ b/gitlab_runner/manifest.json
@@ -27,8 +27,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/go-metro/manifest.json
+++ b/go-metro/manifest.json
@@ -22,6 +22,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/go-metro/manifest.json
+++ b/go-metro/manifest.json
@@ -23,8 +23,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/go_expvar/manifest.json
+++ b/go_expvar/manifest.json
@@ -28,6 +28,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/go_expvar/manifest.json
+++ b/go_expvar/manifest.json
@@ -29,8 +29,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/gunicorn/manifest.json
+++ b/gunicorn/manifest.json
@@ -33,6 +33,9 @@
       "status_code_overview": "assets/saved_views/status_code_overview.json",
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/gunicorn/manifest.json
+++ b/gunicorn/manifest.json
@@ -34,8 +34,6 @@
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -40,8 +40,6 @@
       "response_time_overview": "assets/saved_views/response_time.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -39,6 +39,9 @@
       "bot_errors": "assets/saved_views/bot_errors.json",
       "response_time_overview": "assets/saved_views/response_time.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/harbor/manifest.json
+++ b/harbor/manifest.json
@@ -29,8 +29,6 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/harbor/manifest.json
+++ b/harbor/manifest.json
@@ -25,9 +25,12 @@
   "integration_id": "harbor",
   "assets": {
     "dashboards": {
-        "Harbor Overview": "assets/dashboards/overview.json"
+      "Harbor Overview": "assets/dashboards/overview.json"
     },
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/hazelcast/manifest.json
+++ b/hazelcast/manifest.json
@@ -35,6 +35,9 @@
     },
     "monitors": {},
     "saved_views": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/hazelcast/manifest.json
+++ b/hazelcast/manifest.json
@@ -36,8 +36,6 @@
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/hdfs_datanode/manifest.json
+++ b/hdfs_datanode/manifest.json
@@ -30,8 +30,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/hdfs_datanode/manifest.json
+++ b/hdfs_datanode/manifest.json
@@ -29,6 +29,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -30,8 +30,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -29,6 +29,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/hive/manifest.json
+++ b/hive/manifest.json
@@ -31,6 +31,9 @@
     "dashboards": {
       "Hive Overview": "assets/dashboards/overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/hive/manifest.json
+++ b/hive/manifest.json
@@ -32,8 +32,6 @@
       "Hive Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/hivemq/manifest.json
+++ b/hivemq/manifest.json
@@ -32,6 +32,9 @@
     },
     "monitors": {},
     "saved_views": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/hivemq/manifest.json
+++ b/hivemq/manifest.json
@@ -33,8 +33,6 @@
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -28,6 +28,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -29,8 +29,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/hyperv/manifest.json
+++ b/hyperv/manifest.json
@@ -23,11 +23,14 @@
   "is_public": true,
   "integration_id": "hyper-v",
   "assets": {
-     "configuration": {
+    "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/hyperv/manifest.json
+++ b/hyperv/manifest.json
@@ -29,8 +29,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/ibm_db2/manifest.json
+++ b/ibm_db2/manifest.json
@@ -28,6 +28,9 @@
     "dashboards": {
       "IBM Db2 Overview": "assets/dashboards/overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/ibm_db2/manifest.json
+++ b/ibm_db2/manifest.json
@@ -29,8 +29,6 @@
       "IBM Db2 Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/ibm_mq/manifest.json
+++ b/ibm_mq/manifest.json
@@ -30,8 +30,6 @@
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/ibm_mq/manifest.json
+++ b/ibm_mq/manifest.json
@@ -29,6 +29,9 @@
     "service_checks": "assets/service_checks.json",
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
+    },
+    "logs": {
+      "source": ""
     }
   }
 }

--- a/ibm_was/manifest.json
+++ b/ibm_was/manifest.json
@@ -28,8 +28,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/ibm_was/manifest.json
+++ b/ibm_was/manifest.json
@@ -27,6 +27,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/ignite/manifest.json
+++ b/ignite/manifest.json
@@ -33,8 +33,6 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/ignite/manifest.json
+++ b/ignite/manifest.json
@@ -32,6 +32,9 @@
     },
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -31,6 +31,9 @@
       "bot_errors": "assets/saved_views/bot_errors.json",
       "response_time_overview": "assets/saved_views/response_time.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -32,8 +32,6 @@
       "response_time_overview": "assets/saved_views/response_time.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/istio/manifest.json
+++ b/istio/manifest.json
@@ -36,6 +36,9 @@
       "Istio base dashboard": "assets/dashboards/istio_overview.json",
       "Istio Overview 1.5": "assets/dashboards/istio_1_5_overview"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/istio/manifest.json
+++ b/istio/manifest.json
@@ -37,8 +37,6 @@
       "Istio Overview 1.5": "assets/dashboards/istio_1_5_overview"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/jboss_wildfly/manifest.json
+++ b/jboss_wildfly/manifest.json
@@ -30,8 +30,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/jboss_wildfly/manifest.json
+++ b/jboss_wildfly/manifest.json
@@ -29,6 +29,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -36,8 +36,6 @@
       "logger_overview": "assets/saved_views/logger_overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -35,6 +35,9 @@
       "kafka_patterns": "assets/saved_views/kafka_patterns.json",
       "logger_overview": "assets/saved_views/logger_overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -25,6 +25,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -40,6 +40,9 @@
       "status_code_overview": "assets/saved_views/status_code_overview.json",
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -41,8 +41,6 @@
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/kube_apiserver_metrics/manifest.json
+++ b/kube_apiserver_metrics/manifest.json
@@ -27,9 +27,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   },
   "is_public": true
 }

--- a/kube_apiserver_metrics/manifest.json
+++ b/kube_apiserver_metrics/manifest.json
@@ -1,32 +1,35 @@
 {
-    "display_name": "Kubernetes API server metrics",
-    "maintainer": "help@datadoghq.com",
-    "manifest_version": "1.0.0",
-    "name": "kube_apiserver_metrics",
-    "metric_prefix": "kube_apiserver.",
-    "metric_to_check": "kube_apiserver.go_goroutines",
-    "creates_events": false,
-    "short_description": "Collect metrics from the Kubernetes APIserver",
-    "guid": "406b274b-c44d-4499-a329-efd053b3f538",
-    "support": "core",
-    "supported_os": [
-        "linux",
-        "mac_os",
-        "windows"
-    ],
-    "public_title": "Datadog-Kubernetes API server metrics Integration",
-    "categories": [
-        "containers"
-    ],
-    "type": "check",
-    "integration_id": "kube-apiserver-metrics",
-    "assets": {
-        "configuration": {
-            "spec": "assets/configuration/spec.yaml"
-        },
-        "monitors": {},
-        "dashboards": {},
-        "service_checks": "assets/service_checks.json"
+  "display_name": "Kubernetes API server metrics",
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "1.0.0",
+  "name": "kube_apiserver_metrics",
+  "metric_prefix": "kube_apiserver.",
+  "metric_to_check": "kube_apiserver.go_goroutines",
+  "creates_events": false,
+  "short_description": "Collect metrics from the Kubernetes APIserver",
+  "guid": "406b274b-c44d-4499-a329-efd053b3f538",
+  "support": "core",
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "public_title": "Datadog-Kubernetes API server metrics Integration",
+  "categories": [
+    "containers"
+  ],
+  "type": "check",
+  "integration_id": "kube-apiserver-metrics",
+  "assets": {
+    "configuration": {
+      "spec": "assets/configuration/spec.yaml"
     },
-    "is_public": true
+    "monitors": {},
+    "dashboards": {},
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
+  },
+  "is_public": true
 }

--- a/kube_controller_manager/manifest.json
+++ b/kube_controller_manager/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/kube_controller_manager/manifest.json
+++ b/kube_controller_manager/manifest.json
@@ -25,6 +25,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/kube_dns/manifest.json
+++ b/kube_dns/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/kube_dns/manifest.json
+++ b/kube_dns/manifest.json
@@ -25,6 +25,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/kube_metrics_server/manifest.json
+++ b/kube_metrics_server/manifest.json
@@ -27,6 +27,9 @@
     "dashboards": {
       "Kubernetes Metrics Server - Overview": "assets/dashboards/overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/kube_metrics_server/manifest.json
+++ b/kube_metrics_server/manifest.json
@@ -28,8 +28,6 @@
       "Kubernetes Metrics Server - Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/kube_proxy/manifest.json
+++ b/kube_proxy/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/kube_proxy/manifest.json
+++ b/kube_proxy/manifest.json
@@ -25,6 +25,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/kube_scheduler/manifest.json
+++ b/kube_scheduler/manifest.json
@@ -26,6 +26,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/kube_scheduler/manifest.json
+++ b/kube_scheduler/manifest.json
@@ -27,8 +27,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/kubelet/manifest.json
+++ b/kubelet/manifest.json
@@ -24,6 +24,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/kubelet/manifest.json
+++ b/kubelet/manifest.json
@@ -25,8 +25,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -29,6 +29,9 @@
       "Kubernetes Nodes Overview": "assets/dashboards/kubernetes_nodes.json",
       "Kubernetes Deployments Overview": "assets/dashboards/kubernetes_deployments.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -30,8 +30,6 @@
       "Kubernetes Deployments Overview": "assets/dashboards/kubernetes_deployments.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/kubernetes_state/manifest.json
+++ b/kubernetes_state/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/kubernetes_state/manifest.json
+++ b/kubernetes_state/manifest.json
@@ -25,6 +25,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/kyototycoon/manifest.json
+++ b/kyototycoon/manifest.json
@@ -28,8 +28,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/kyototycoon/manifest.json
+++ b/kyototycoon/manifest.json
@@ -27,6 +27,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/lighttpd/manifest.json
+++ b/lighttpd/manifest.json
@@ -32,8 +32,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/lighttpd/manifest.json
+++ b/lighttpd/manifest.json
@@ -31,6 +31,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/linkerd/manifest.json
+++ b/linkerd/manifest.json
@@ -28,8 +28,6 @@
       "Linkerd - Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/linkerd/manifest.json
+++ b/linkerd/manifest.json
@@ -27,6 +27,9 @@
     "dashboards": {
       "Linkerd - Overview": "assets/dashboards/overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/linux_proc_extras/manifest.json
+++ b/linux_proc_extras/manifest.json
@@ -22,6 +22,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/linux_proc_extras/manifest.json
+++ b/linux_proc_extras/manifest.json
@@ -23,8 +23,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/mapr/manifest.json
+++ b/mapr/manifest.json
@@ -28,8 +28,6 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/mapr/manifest.json
+++ b/mapr/manifest.json
@@ -27,6 +27,9 @@
       "MapR - Overview": "assets/dashboards/mapr_overview.json"
     },
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/mapreduce/manifest.json
+++ b/mapreduce/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/mapreduce/manifest.json
+++ b/mapreduce/manifest.json
@@ -25,6 +25,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/marathon/manifest.json
+++ b/marathon/manifest.json
@@ -30,8 +30,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/marathon/manifest.json
+++ b/marathon/manifest.json
@@ -29,6 +29,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/mcache/manifest.json
+++ b/mcache/manifest.json
@@ -33,8 +33,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/mcache/manifest.json
+++ b/mcache/manifest.json
@@ -32,6 +32,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -33,6 +33,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -34,8 +34,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/mesos_slave/manifest.json
+++ b/mesos_slave/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/mesos_slave/manifest.json
+++ b/mesos_slave/manifest.json
@@ -25,6 +25,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -42,8 +42,6 @@
       "slow_queries": "assets/saved_views/slow_queries.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -41,6 +41,9 @@
       "queries_by_type_overview": "assets/saved_views/queries_by_type_overview.json",
       "slow_queries": "assets/saved_views/slow_queries.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -41,8 +41,6 @@
       "slow_operations": "assets/saved_views/slow_operations.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -40,6 +40,9 @@
       "operations_overview": "assets/saved_views/operations_overview.json",
       "slow_operations": "assets/saved_views/slow_operations.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/nagios/manifest.json
+++ b/nagios/manifest.json
@@ -28,8 +28,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/nagios/manifest.json
+++ b/nagios/manifest.json
@@ -27,6 +27,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/network/manifest.json
+++ b/network/manifest.json
@@ -28,6 +28,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/network/manifest.json
+++ b/network/manifest.json
@@ -29,8 +29,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/nfsstat/manifest.json
+++ b/nfsstat/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/nfsstat/manifest.json
+++ b/nfsstat/manifest.json
@@ -25,6 +25,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -39,6 +39,9 @@
       "status_code_overview": "assets/saved_views/status_code_overview.json",
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -40,8 +40,6 @@
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/nginx_ingress_controller/manifest.json
+++ b/nginx_ingress_controller/manifest.json
@@ -38,8 +38,6 @@
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/nginx_ingress_controller/manifest.json
+++ b/nginx_ingress_controller/manifest.json
@@ -37,6 +37,9 @@
       "status_code_overview": "assets/saved_views/status_code_overview.json",
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/ntp/manifest.json
+++ b/ntp/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/ntp/manifest.json
+++ b/ntp/manifest.json
@@ -25,6 +25,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/oom_kill/manifest.json
+++ b/oom_kill/manifest.json
@@ -24,8 +24,6 @@
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/oom_kill/manifest.json
+++ b/oom_kill/manifest.json
@@ -23,6 +23,9 @@
     "dashboards": {},
     "monitors": {},
     "saved_views": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/openldap/manifest.json
+++ b/openldap/manifest.json
@@ -28,8 +28,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/openldap/manifest.json
+++ b/openldap/manifest.json
@@ -27,6 +27,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/openmetrics/manifest.json
+++ b/openmetrics/manifest.json
@@ -26,6 +26,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/openmetrics/manifest.json
+++ b/openmetrics/manifest.json
@@ -27,8 +27,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/openshift/manifest.json
+++ b/openshift/manifest.json
@@ -23,6 +23,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/openshift/manifest.json
+++ b/openshift/manifest.json
@@ -24,8 +24,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/openstack/manifest.json
+++ b/openstack/manifest.json
@@ -29,6 +29,9 @@
     "dashboards": {
       "OpenStack Controller Overview": "assets/dashboards/openstack-controller.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/openstack/manifest.json
+++ b/openstack/manifest.json
@@ -30,8 +30,6 @@
       "OpenStack Controller Overview": "assets/dashboards/openstack-controller.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/openstack_controller/manifest.json
+++ b/openstack_controller/manifest.json
@@ -24,6 +24,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/openstack_controller/manifest.json
+++ b/openstack_controller/manifest.json
@@ -25,8 +25,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/oracle/manifest.json
+++ b/oracle/manifest.json
@@ -27,6 +27,9 @@
     "dashboards": {
       "oracle": "assets/dashboards/oracle_overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/oracle/manifest.json
+++ b/oracle/manifest.json
@@ -28,8 +28,6 @@
       "oracle": "assets/dashboards/oracle_overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/pdh_check/manifest.json
+++ b/pdh_check/manifest.json
@@ -25,8 +25,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/pdh_check/manifest.json
+++ b/pdh_check/manifest.json
@@ -24,6 +24,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/pgbouncer/manifest.json
+++ b/pgbouncer/manifest.json
@@ -34,8 +34,6 @@
       "user_overview": "assets/saved_views/user_overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/pgbouncer/manifest.json
+++ b/pgbouncer/manifest.json
@@ -33,6 +33,9 @@
       "instance_overview": "assets/saved_views/instance_overview.json",
       "user_overview": "assets/saved_views/user_overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/php_fpm/manifest.json
+++ b/php_fpm/manifest.json
@@ -38,6 +38,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/php_fpm/manifest.json
+++ b/php_fpm/manifest.json
@@ -39,8 +39,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/pivotal_pks/manifest.json
+++ b/pivotal_pks/manifest.json
@@ -22,6 +22,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/pivotal_pks/manifest.json
+++ b/pivotal_pks/manifest.json
@@ -23,8 +23,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -28,6 +28,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -29,8 +29,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -46,6 +46,9 @@
       "postgres_pattern": "assets/saved_views/postgres_pattern.json",
       "sessions_by_host": "assets/saved_views/sessions_by_host.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -47,8 +47,6 @@
       "sessions_by_host": "assets/saved_views/sessions_by_host.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/powerdns_recursor/manifest.json
+++ b/powerdns_recursor/manifest.json
@@ -33,6 +33,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/powerdns_recursor/manifest.json
+++ b/powerdns_recursor/manifest.json
@@ -34,8 +34,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/presto/manifest.json
+++ b/presto/manifest.json
@@ -35,8 +35,6 @@
       "response_time_overview": "assets/saved_views/response_time.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/presto/manifest.json
+++ b/presto/manifest.json
@@ -34,6 +34,9 @@
       "error_patterns": "assets/saved_views/error_patterns.json",
       "response_time_overview": "assets/saved_views/response_time.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/process/manifest.json
+++ b/process/manifest.json
@@ -27,6 +27,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/process/manifest.json
+++ b/process/manifest.json
@@ -28,8 +28,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/prometheus/manifest.json
+++ b/prometheus/manifest.json
@@ -22,6 +22,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/prometheus/manifest.json
+++ b/prometheus/manifest.json
@@ -23,8 +23,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/proxysql/manifest.json
+++ b/proxysql/manifest.json
@@ -33,8 +33,6 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/proxysql/manifest.json
+++ b/proxysql/manifest.json
@@ -32,6 +32,9 @@
     },
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -33,6 +33,9 @@
       "pid_overview": "assets/saved_views/status_overview.json",
       "rabbitmq_pattern": "assets/saved_views/rabbitmq_pattern.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -34,8 +34,6 @@
       "rabbitmq_pattern": "assets/saved_views/rabbitmq_pattern.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -41,8 +41,6 @@
       "redis_pattern": "assets/saved_views/redis_pattern.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -31,7 +31,7 @@
   "integration_id": "redis",
   "assets": {
     "configuration": {
-       "spec": "assets/configuration/spec.yaml"
+      "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {},
     "dashboards": {},
@@ -40,6 +40,9 @@
       "pid_overview": "assets/saved_views/pid_overview.json",
       "redis_pattern": "assets/saved_views/redis_pattern.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/rethinkdb/manifest.json
+++ b/rethinkdb/manifest.json
@@ -35,8 +35,6 @@
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/rethinkdb/manifest.json
+++ b/rethinkdb/manifest.json
@@ -34,6 +34,9 @@
     },
     "monitors": {},
     "saved_views": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/riak/manifest.json
+++ b/riak/manifest.json
@@ -30,8 +30,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/riak/manifest.json
+++ b/riak/manifest.json
@@ -29,6 +29,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/riakcs/manifest.json
+++ b/riakcs/manifest.json
@@ -28,8 +28,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/riakcs/manifest.json
+++ b/riakcs/manifest.json
@@ -27,6 +27,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/sap_hana/manifest.json
+++ b/sap_hana/manifest.json
@@ -26,6 +26,9 @@
       "SAP HANA Overview": "assets/dashboards/overview.json"
     },
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/sap_hana/manifest.json
+++ b/sap_hana/manifest.json
@@ -27,8 +27,6 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/scylla/manifest.json
+++ b/scylla/manifest.json
@@ -28,6 +28,9 @@
     },
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/scylla/manifest.json
+++ b/scylla/manifest.json
@@ -29,8 +29,6 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/sidekiq/manifest.json
+++ b/sidekiq/manifest.json
@@ -31,8 +31,6 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/sidekiq/manifest.json
+++ b/sidekiq/manifest.json
@@ -30,6 +30,9 @@
     },
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -30,8 +30,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -29,6 +29,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -32,8 +32,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -31,6 +31,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/spark/manifest.json
+++ b/spark/manifest.json
@@ -30,8 +30,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/spark/manifest.json
+++ b/spark/manifest.json
@@ -29,6 +29,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -28,6 +28,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -29,8 +29,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/squid/manifest.json
+++ b/squid/manifest.json
@@ -28,8 +28,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/squid/manifest.json
+++ b/squid/manifest.json
@@ -27,6 +27,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/ssh_check/manifest.json
+++ b/ssh_check/manifest.json
@@ -38,8 +38,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/ssh_check/manifest.json
+++ b/ssh_check/manifest.json
@@ -37,6 +37,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/statsd/manifest.json
+++ b/statsd/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/statsd/manifest.json
+++ b/statsd/manifest.json
@@ -25,6 +25,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/supervisord/manifest.json
+++ b/supervisord/manifest.json
@@ -33,8 +33,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/supervisord/manifest.json
+++ b/supervisord/manifest.json
@@ -32,6 +32,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/system_core/manifest.json
+++ b/system_core/manifest.json
@@ -28,8 +28,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/system_core/manifest.json
+++ b/system_core/manifest.json
@@ -27,6 +27,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/system_swap/manifest.json
+++ b/system_swap/manifest.json
@@ -24,6 +24,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/system_swap/manifest.json
+++ b/system_swap/manifest.json
@@ -25,8 +25,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/systemd/manifest.json
+++ b/systemd/manifest.json
@@ -25,8 +25,6 @@
       "Systemd Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/systemd/manifest.json
+++ b/systemd/manifest.json
@@ -24,6 +24,9 @@
     "dashboards": {
       "Systemd Overview": "assets/dashboards/overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/tcp_check/manifest.json
+++ b/tcp_check/manifest.json
@@ -30,8 +30,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/tcp_check/manifest.json
+++ b/tcp_check/manifest.json
@@ -29,6 +29,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/teamcity/manifest.json
+++ b/teamcity/manifest.json
@@ -28,6 +28,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/teamcity/manifest.json
+++ b/teamcity/manifest.json
@@ -29,8 +29,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/tenable/manifest.json
+++ b/tenable/manifest.json
@@ -28,6 +28,9 @@
     "dashboards": {},
     "saved_views": {},
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/tenable/manifest.json
+++ b/tenable/manifest.json
@@ -29,8 +29,6 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/tls/manifest.json
+++ b/tls/manifest.json
@@ -27,7 +27,10 @@
     "monitors": {},
     "dashboards": {
       "TLS Overview": "assets/dashboards/overview.json"
-     },
-    "service_checks": "assets/service_checks.json"
+    },
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/tls/manifest.json
+++ b/tls/manifest.json
@@ -29,8 +29,6 @@
       "TLS Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/tokumx/manifest.json
+++ b/tokumx/manifest.json
@@ -32,8 +32,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/tokumx/manifest.json
+++ b/tokumx/manifest.json
@@ -31,6 +31,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -33,8 +33,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -32,6 +32,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/twemproxy/manifest.json
+++ b/twemproxy/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/twemproxy/manifest.json
+++ b/twemproxy/manifest.json
@@ -25,6 +25,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/twistlock/manifest.json
+++ b/twistlock/manifest.json
@@ -30,8 +30,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/twistlock/manifest.json
+++ b/twistlock/manifest.json
@@ -29,6 +29,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -36,6 +36,9 @@
       "status_code_overview": "assets/saved_views/status_code_overview.json",
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -37,8 +37,6 @@
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/vault/manifest.json
+++ b/vault/manifest.json
@@ -38,8 +38,6 @@
       "vault_patern": "assets/saved_views/vault_patern.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/vault/manifest.json
+++ b/vault/manifest.json
@@ -37,6 +37,9 @@
       "service_name_overview": "assets/saved_views/service_name_overview.json",
       "vault_patern": "assets/saved_views/vault_patern.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/vertica/manifest.json
+++ b/vertica/manifest.json
@@ -28,8 +28,6 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/vertica/manifest.json
+++ b/vertica/manifest.json
@@ -27,6 +27,9 @@
       "Vertica Overview": "assets/dashboards/overview.json"
     },
     "monitors": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/vsphere/manifest.json
+++ b/vsphere/manifest.json
@@ -29,6 +29,9 @@
     "dashboards": {
       "vsphere-overview": "assets/dashboards/vsphere_overview.json"
     },
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/vsphere/manifest.json
+++ b/vsphere/manifest.json
@@ -30,8 +30,6 @@
       "vsphere-overview": "assets/dashboards/vsphere_overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/win32_event_log/manifest.json
+++ b/win32_event_log/manifest.json
@@ -26,6 +26,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/win32_event_log/manifest.json
+++ b/win32_event_log/manifest.json
@@ -27,8 +27,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/windows_service/manifest.json
+++ b/windows_service/manifest.json
@@ -24,6 +24,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/windows_service/manifest.json
+++ b/windows_service/manifest.json
@@ -25,8 +25,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/wmi_check/manifest.json
+++ b/wmi_check/manifest.json
@@ -27,6 +27,9 @@
     },
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/wmi_check/manifest.json
+++ b/wmi_check/manifest.json
@@ -28,8 +28,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/yarn/manifest.json
+++ b/yarn/manifest.json
@@ -26,8 +26,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }

--- a/yarn/manifest.json
+++ b/yarn/manifest.json
@@ -25,6 +25,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -33,6 +33,9 @@
   "assets": {
     "monitors": {},
     "dashboards": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "logs": {
+      "source": ""
+    }
   }
 }

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -34,8 +34,6 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {
-      "source": ""
-    }
+    "logs": {}
   }
 }


### PR DESCRIPTION
Mapping an integration name to it's log source is becoming harder.
Let's add a field to the manifest.json for this