### PR TITLE
Fix empty result case

### DIFF
--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -231,6 +231,8 @@ class AerospikeCheck(AgentCheck):
 
         if not separator:
             return data
+        if not data:
+            return []
 
         return data.split(separator)
 

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -109,6 +109,6 @@ def test_collect_empty_data(aggregator):
     check = AerospikeCheck('aerospike', {}, [common.INSTANCE])
 
     check._client = mock.MagicMock()
-    check._client.info_node.return_value = 'sets/test/ci	'
+    check._client.info_node.return_value = 'sets/test/ci	'  # from real data, there is a tab after the command
     check.log = mock.MagicMock()
     assert [] == check.get_info('sets/test/ci')

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -103,3 +103,12 @@ def test_collect_latency_invalid_data(aggregator):
     )
 
     aggregator.assert_all_metrics_covered()  # no metric
+
+
+def test_collect_empty_data(aggregator):
+    check = AerospikeCheck('aerospike', {}, [common.INSTANCE])
+
+    check._client = mock.MagicMock()
+    check._client.info_node.return_value = 'sets/test/ci	'
+    check.log = mock.MagicMock()
+    assert [] == check.get_info('sets/test/ci')


### PR DESCRIPTION
### What does this PR do?

Fix empty result case. Results might be an empty, we should return en empty list `[]` instead of `['']`

### Motivation

Results might be an empty.

```
2020-07-22 22:59:24 EDT | CORE | DEBUG | (pkg/collector/python/datadog_agent.go:122 in LogMessage) | aerospike:2bcea5d037c1a7ac | (aerospike.py:226) | Get info results for command=`sets/example/ci`, host=`('localhost', 3000)`, policies=`{'timeout': 10000}`: sets/example/ci	
2020-07-22 22:59:24 EDT | CORE | ERROR | (pkg/collector/runner/runner.go:292 in work) | Error running check aerospike: [{"message": "dictionary update sequence element #0 has length 1; 2 is required", "traceback": "Traceback (most recent call last):
  File \"/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/base/checks/base.py\", line 673, in run
    self.check(instance)
  File \"/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/aerospike/aerospike.py\", line 142, in check
    self.collect_info('sets/{}/{}'.format(ns, s), SET_METRIC_TYPE, separator=':', tags=set_tags)
  File \"/opt/datadog-agent/embedded/lib/python3.7/site-packages/datadog_checks/aerospike/aerospike.py\", line 177, in collect_info
    required_data = dict(entry.split('=', 1) for entry in entries)
    ValueError: dictionary update sequence element #0 has length 1; 2 is required
"}]
```
