### PR TITLE
Split config out

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -24,11 +24,11 @@ files:
 
       - template: instances
         options:
-          - name: server
+          - name: host
             required: true
             description: |
-              MySQL server to connect to.
-              NOTE: Even if the server name is "localhost", the agent connects to MySQL using TCP/IP, unless you also
+              MySQL host to connect to.
+              NOTE: Even if the host is "localhost", the agent connects to MySQL using TCP/IP, unless you also
               provide a value for the sock key (below).
             value:
               type: string

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -10,7 +10,7 @@ DEFAULT_MAX_CUSTOM_QUERIES = 20
 class MySQLConfig(object):
     def __init__(self, instance):
         self.log = get_check_logger()
-        self.host = instance.get('server', '')
+        self.host = instance.get('host', instance.get('server', ''))
         self.port = int(instance.get('port', 0))
         self.tags = list(instance.get('tags', []))
         self.mysql_sock = instance.get('sock', '')

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -1,0 +1,34 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from datadog_checks.base import ConfigurationError
+from datadog_checks.base.log import get_check_logger
+
+DEFAULT_MAX_CUSTOM_QUERIES = 20
+
+
+class MySQLConfig(object):
+    def __init__(self, instance):
+        self.log = get_check_logger()
+        self.host = instance.get('server', '')
+        self.port = int(instance.get('port', 0))
+        self.tags = list(instance.get('tags', []))
+        self.mysql_sock = instance.get('sock', '')
+        self.defaults_file = instance.get('defaults_file', '')
+        self.user = instance.get('user', '')
+        self.password = str(instance.get('pass', ''))
+        self.tags = instance.get('tags', [])
+        self.options = instance.get('options', {}) or {}  # options could be None if empty in the YAML
+        self.queries = instance.get('queries', [])
+        self.ssl = instance.get('ssl', {})
+        self.connect_timeout = instance.get('connect_timeout', 10)
+        self.max_custom_queries = instance.get('max_custom_queries', DEFAULT_MAX_CUSTOM_QUERIES)
+
+        if self.queries or 'max_custom_queries' in instance:
+            self.log.warning(
+                'The options `queries` and `max_custom_queries` are deprecated and will be '
+                'removed in a future release. Use the `custom_queries` option instead.'
+            )
+
+        if not (self.host and self.user) and not self.defaults_file:
+            raise ConfigurationError("Mysql host and user are needed.")

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -23,8 +23,10 @@ class MySQLConfig(object):
         self.ssl = instance.get('ssl', {})
         self.connect_timeout = instance.get('connect_timeout', 10)
         self.max_custom_queries = instance.get('max_custom_queries', DEFAULT_MAX_CUSTOM_QUERIES)
+        self.configuration_checks()
 
-        if self.queries or 'max_custom_queries' in instance:
+    def configuration_checks(self):
+        if self.queries or self.max_custom_queries != DEFAULT_MAX_CUSTOM_QUERIES:
             self.log.warning(
                 'The options `queries` and `max_custom_queries` are deprecated and will be '
                 'removed in a future release. Use the `custom_queries` option instead.'

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -25,12 +25,12 @@ init_config:
 #
 instances:
 
-    ## @param server - string - required
-    ## MySQL server to connect to.
-    ## NOTE: Even if the server name is "localhost", the agent connects to MySQL using TCP/IP, unless you also
+    ## @param host - string - required
+    ## MySQL host to connect to.
+    ## NOTE: Even if the host is "localhost", the agent connects to MySQL using TCP/IP, unless you also
     ## provide a value for the sock key (below).
     #
-  - server: localhost
+  - host: localhost
 
     ## @param user - string - required
     ## Username used to connect to MySQL.

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -16,6 +16,7 @@ from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.db import QueryManager
 
 from .collection_utils import collect_all_scalars, collect_scalar, collect_string, collect_type
+from .config import MySQLConfig
 from .const import (
     BINLOG_VARS,
     BUILDS,
@@ -69,13 +70,12 @@ class MySql(AgentCheck):
         super(MySql, self).__init__(name, init_config, instances)
         self.qcache_stats = {}
         self.metadata = None
-
-        self._tags = list(self.instance.get('tags', []))
+        self.config = MySQLConfig(self.instance)
 
         # Create a new connection on every check run
         self._conn = None
 
-        self._query_manager = QueryManager(self, self.execute_query_raw, queries=[], tags=self._tags)
+        self._query_manager = QueryManager(self, self.execute_query_raw, queries=[], tags=self.config.tags)
         self.check_initializations.append(self._query_manager.compile_queries)
         self.innodb_stats = InnoDBMetrics()
 
@@ -119,27 +119,18 @@ class MySql(AgentCheck):
         return {'pymysql': pymysql.__version__}
 
     def check(self, instance):
-        (
-            host,
-            port,
-            user,
-            password,
-            mysql_sock,
-            defaults_file,
-            tags,
-            options,
-            queries,
-            ssl,
-            connect_timeout,
-            max_custom_queries,
-        ) = self._get_config(instance)
-
         self._set_qcache_stats()
-
-        if not (host and user) and not defaults_file:
-            raise Exception("Mysql host and user are needed.")
-
-        with self._connect(host, port, mysql_sock, user, password, defaults_file, ssl, connect_timeout, tags) as db:
+        with self._connect(
+            self.config.host,
+            self.config.port,
+            self.config.mysql_sock,
+            self.config.user,
+            self.config.password,
+            self.config.defaults_file,
+            self.config.ssl,
+            self.config.connect_timeout,
+            self.config.tags,
+        ) as db:
             try:
                 self._conn = db
 
@@ -148,8 +139,10 @@ class MySql(AgentCheck):
                 self._send_metadata()
 
                 # Metric collection
-                self._collect_metrics(db, tags, options, queries, max_custom_queries)
-                self._collect_system_metrics(host, db, tags)
+                self._collect_metrics(
+                    db, self.config.tags, self.config.options, self.config.queries, self.config.max_custom_queries
+                )
+                self._collect_system_metrics(self.config.host, db, self.config.tags)
 
                 # keeping track of these:
                 self._put_qcache_stats()
@@ -162,41 +155,6 @@ class MySql(AgentCheck):
                 raise e
             finally:
                 self._conn = None
-
-    def _get_config(self, instance):
-        self.host = instance.get('server', '')
-        self.port = int(instance.get('port', 0))
-        self.mysql_sock = instance.get('sock', '')
-        self.defaults_file = instance.get('defaults_file', '')
-        user = instance.get('user', '')
-        password = str(instance.get('pass', ''))
-        tags = instance.get('tags', [])
-        options = instance.get('options', {}) or {}  # options could be None if empty in the YAML
-        queries = instance.get('queries', [])
-        ssl = instance.get('ssl', {})
-        connect_timeout = instance.get('connect_timeout', 10)
-        max_custom_queries = instance.get('max_custom_queries', self.DEFAULT_MAX_CUSTOM_QUERIES)
-
-        if queries or 'max_custom_queries' in instance:
-            self.warning(
-                'The options `queries` and `max_custom_queries` are deprecated and will be '
-                'removed in a future release. Use the `custom_queries` option instead.'
-            )
-
-        return (
-            self.host,
-            self.port,
-            user,
-            password,
-            self.mysql_sock,
-            self.defaults_file,
-            tags,
-            options,
-            queries,
-            ssl,
-            connect_timeout,
-            max_custom_queries,
-        )
 
     def _set_qcache_stats(self):
         host_key = self._get_host_key()
@@ -211,14 +169,14 @@ class MySql(AgentCheck):
         self.qcache_stats[host_key] = (self._qcache_hits, self._qcache_inserts, self._qcache_not_cached)
 
     def _get_host_key(self):
-        if self.defaults_file:
-            return self.defaults_file
+        if self.config.defaults_file:
+            return self.config.defaults_file
 
-        hostkey = self.host
-        if self.mysql_sock:
-            hostkey = "{0}:{1}".format(hostkey, self.mysql_sock)
-        elif self.port:
-            hostkey = "{0}:{1}".format(hostkey, self.port)
+        hostkey = self.config.host
+        if self.config.mysql_sock:
+            hostkey = "{0}:{1}".format(hostkey, self.config.mysql_sock)
+        elif self.config.port:
+            hostkey = "{0}:{1}".format(hostkey, self.config.port)
 
         return hostkey
 

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -78,6 +78,7 @@ class MySql(AgentCheck):
         self._query_manager = QueryManager(self, self.execute_query_raw, queries=[], tags=self.config.tags)
         self.check_initializations.append(self._query_manager.compile_queries)
         self.innodb_stats = InnoDBMetrics()
+        self.check_initializations.append(self.config.configuration_checks)
 
     def execute_query_raw(self, query):
         with closing(self._conn.cursor(pymysql.cursors.SSCursor)) as cursor:

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -119,7 +119,7 @@ class MySql(AgentCheck):
     def get_library_versions(cls):
         return {'pymysql': pymysql.__version__}
 
-    def check(self, instance):
+    def check(self, _):
         self._set_qcache_stats()
         with self._connect(
             self.config.host,

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -23,7 +23,7 @@ def config_e2e():
 
     return {
         'init_config': {},
-        'instances': [{'server': common.HOST, 'user': common.USER, 'pass': common.PASS, 'port': common.PORT}],
+        'instances': [{'host': common.HOST, 'user': common.USER, 'pass': common.PASS, 'port': common.PORT}],
         'logs': [
             {'type': 'file', 'path': '{}/mysql.log'.format(logs_path), 'source': 'mysql', 'service': 'local_mysql'},
             {
@@ -75,7 +75,7 @@ def instance_basic(config_e2e):
 @pytest.fixture
 def instance_complex():
     return {
-        'server': common.HOST,
+        'host': common.HOST,
         'user': common.USER,
         'pass': common.PASS,
         'port': common.PORT,
@@ -107,7 +107,7 @@ def instance_complex():
 @pytest.fixture
 def instance_custom_queries():
     return {
-        'server': common.HOST,
+        'host': common.HOST,
         'user': common.USER,
         'pass': common.PASS,
         'port': common.PORT,
@@ -127,7 +127,7 @@ def instance_custom_queries():
 
 @pytest.fixture(scope='session')
 def instance_error():
-    return {'server': common.HOST, 'user': 'unknown', 'pass': common.PASS}
+    return {'host': common.HOST, 'user': 'unknown', 'pass': common.PASS}
 
 
 @pytest.fixture(scope='session')

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -222,7 +222,7 @@ def test__get_server_pid():
     """
     Test the logic looping through the processes searching for `mysqld`
     """
-    mysql_check = MySql(common.CHECK_NAME, {}, instances=[{}])
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[{'server': 'localhost', 'user': 'datadog'}])
     mysql_check._get_pid_file_variable = mock.MagicMock(return_value=None)
     mysql_check.log = mock.MagicMock()
     dummy_proc = subprocess.Popen(["python"])

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -137,9 +137,10 @@ def test_connection_failure(aggregator, instance_error):
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_complex_config_replica(aggregator, instance_complex):
-    mysql_check = MySql(common.CHECK_NAME, {}, instances=[instance_complex])
     config = copy.deepcopy(instance_complex)
     config['port'] = common.SLAVE_PORT
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[config])
+
     mysql_check.check(config)
 
     # self.assertMetricTag('mysql.replication.seconds_behind_master', 'channel:default')


### PR DESCRIPTION
Split of https://github.com/DataDog/integrations-core/pull/7169

It moves the config loading to a new file, it also moves it to `__init__` and changes regular `Exception` error to a `ConfigurationError`
It renames `server` config option to `host` while keeping retrocompatibility for consistency with the rest of integrations