### PR TITLE
Option to skip semver version validation in changelog command when specifying old version

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -30,8 +30,11 @@ ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, autho
 @click.option('--dry-run', '-n', is_flag=True)
 @click.option('--output-file', '-o', default='CHANGELOG.md', show_default=True)
 @click.option('--tag-prefix', '-tp', default='v', show_default=True)
+@click.option('--no-semver', '-ns', default=False, is_flag=True)
 @click.pass_context
-def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_file, tag_prefix, organization):
+def changelog(
+    ctx, check, version, old_version, initial, quiet, dry_run, output_file, tag_prefix, no_semver, organization
+):
     """Perform the operations needed to update the changelog.
 
     This method is supposed to be used by other tasks and not directly.
@@ -46,7 +49,8 @@ def changelog(ctx, check, version, old_version, initial, quiet, dry_run, output_
             'Failed to retrieve the latest version. Please ensure your project or check has a proper set of tags '
             'following SemVer and matches the provided tag_prefix and/or tag_pattern.'
         )
-    if parse_version_info(version.replace(tag_prefix, '', 1)) <= parse_version_info(
+
+    if not no_semver and parse_version_info(version.replace(tag_prefix, '', 1)) <= parse_version_info(
         cur_version.replace(tag_prefix, '', 1)
     ):
         abort(f'Current version is {cur_version}, cannot bump to {version}')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Option to skip semver version validation in changelog command when specifying old version

### Motivation
<!-- What inspired you to submit this pull request? -->
This is so the changelog command works even with non semver versions, such as our https://github.com/Datadog/datadog-firehose-nozzle-release repo.


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
