### PR TITLE
Allow codeowner validation to fail on CI 

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
@@ -72,3 +72,5 @@ def codeowners():
 
     if not has_failed:
         echo_success("All integrations have valid codeowners.")
+    else:
+        abort()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
@@ -6,7 +6,7 @@ import re
 import click
 
 from ...utils import get_codeowners, get_valid_integrations
-from ..console import CONTEXT_SETTINGS, echo_failure, echo_success, abort
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_success
 
 DIRECTORY_REGEX = re.compile(r"\/(.*)\/$")
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
@@ -6,7 +6,7 @@ import re
 import click
 
 from ...utils import get_codeowners, get_valid_integrations
-from ..console import CONTEXT_SETTINGS, echo_failure, echo_success
+from ..console import CONTEXT_SETTINGS, echo_failure, echo_success, abort
 
 DIRECTORY_REGEX = re.compile(r"\/(.*)\/$")
 


### PR DESCRIPTION
### What does this PR do?
- allows codeowners validation to fail when run on the CI

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
