### PR TITLE
Update logs config service field to optional

### DIFF
--- a/active_directory/datadog_checks/active_directory/data/conf.yaml.example
+++ b/active_directory/datadog_checks/active_directory/data/conf.yaml.example
@@ -94,7 +94,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -179,7 +179,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -330,7 +330,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/ambari/datadog_checks/ambari/data/conf.yaml.example
+++ b/ambari/datadog_checks/ambari/data/conf.yaml.example
@@ -359,7 +359,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -330,7 +330,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/ceph/datadog_checks/ceph/data/conf.yaml.example
+++ b/ceph/datadog_checks/ceph/data/conf.yaml.example
@@ -95,7 +95,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+++ b/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
@@ -190,7 +190,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -393,7 +393,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/couch/datadog_checks/couch/data/conf.yaml.example
+++ b/couch/datadog_checks/couch/data/conf.yaml.example
@@ -366,7 +366,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/logs.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/logs.yaml
@@ -7,7 +7,7 @@ description: |
                                           Set path if type is file.
                                           Set channel_path if type is windows_event.
   source  - required - Attribute that defines which Integration sent the logs.
-  service - required - The name of the service that generates the log.
+  service - optional - The name of the service that generates the log.
                        Overrides any `service` defined in the `init_config` section.
   tags - optional - Add tags to the collected logs.
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/assets/configuration/spec.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/assets/configuration/spec.yaml
@@ -7,4 +7,3 @@ files:
     - type: file
       path: /var/log/{check_name}.log
       source: {check_name}
-      service: <SERVICE>

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -319,7 +319,7 @@ def test_section_example_indent():
         ##                                         Set path if type is file.
         ##                                         Set channel_path if type is windows_event.
         ## source  - required - Attribute that defines which Integration sent the logs.
-        ## service - required - The name of the service that generates the log.
+        ## service - optional - The name of the service that generates the log.
         ##                      Overrides any `service` defined in the `init_config` section.
         ## tags - optional - Add tags to the collected logs.
         ##
@@ -381,7 +381,7 @@ def test_section_example_indent_required():
         ##                                         Set path if type is file.
         ##                                         Set channel_path if type is windows_event.
         ## source  - required - Attribute that defines which Integration sent the logs.
-        ## service - required - The name of the service that generates the log.
+        ## service - optional - The name of the service that generates the log.
         ##                      Overrides any `service` defined in the `init_config` section.
         ## tags - optional - Add tags to the collected logs.
         ##

--- a/druid/datadog_checks/druid/data/conf.yaml.example
+++ b/druid/datadog_checks/druid/data/conf.yaml.example
@@ -330,7 +330,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -384,7 +384,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -379,7 +379,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/flink/datadog_checks/flink/data/conf.yaml.example
+++ b/flink/datadog_checks/flink/data/conf.yaml.example
@@ -5,7 +5,7 @@
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -557,7 +557,7 @@ init_config:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
+++ b/gunicorn/datadog_checks/gunicorn/data/conf.yaml.example
@@ -69,7 +69,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -195,7 +195,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
@@ -336,7 +336,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
@@ -336,7 +336,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -179,7 +179,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/hivemq/datadog_checks/hivemq/data/conf.yaml.example
+++ b/hivemq/datadog_checks/hivemq/data/conf.yaml.example
@@ -179,7 +179,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -183,7 +183,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/ignite/datadog_checks/ignite/data/conf.yaml.example
+++ b/ignite/datadog_checks/ignite/data/conf.yaml.example
@@ -179,7 +179,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -185,7 +185,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/kafka/datadog_checks/kafka/data/conf.yaml.example
+++ b/kafka/datadog_checks/kafka/data/conf.yaml.example
@@ -179,7 +179,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -330,7 +330,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/marathon/datadog_checks/marathon/data/conf.yaml.example
+++ b/marathon/datadog_checks/marathon/data/conf.yaml.example
@@ -346,7 +346,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -199,7 +199,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -265,7 +265,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/nginx/datadog_checks/nginx/data/conf.yaml.example
+++ b/nginx/datadog_checks/nginx/data/conf.yaml.example
@@ -359,7 +359,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -182,7 +182,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/redisdb/datadog_checks/redisdb/data/conf.yaml.example
+++ b/redisdb/datadog_checks/redisdb/data/conf.yaml.example
@@ -158,7 +158,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/rethinkdb/datadog_checks/rethinkdb/data/conf.yaml.example
+++ b/rethinkdb/datadog_checks/rethinkdb/data/conf.yaml.example
@@ -75,7 +75,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/riak/datadog_checks/riak/data/conf.yaml.example
+++ b/riak/datadog_checks/riak/data/conf.yaml.example
@@ -330,7 +330,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/sidekiq/datadog_checks/sidekiq/data/conf.yaml.example
+++ b/sidekiq/datadog_checks/sidekiq/data/conf.yaml.example
@@ -5,7 +5,7 @@
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/solr/datadog_checks/solr/data/conf.yaml.example
+++ b/solr/datadog_checks/solr/data/conf.yaml.example
@@ -179,7 +179,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -389,7 +389,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -114,7 +114,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/tenable/datadog_checks/tenable/data/conf.yaml.example
+++ b/tenable/datadog_checks/tenable/data/conf.yaml.example
@@ -5,7 +5,7 @@
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/tomcat/datadog_checks/tomcat/data/conf.yaml.example
+++ b/tomcat/datadog_checks/tomcat/data/conf.yaml.example
@@ -179,7 +179,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/vault/datadog_checks/vault/data/conf.yaml.example
+++ b/vault/datadog_checks/vault/data/conf.yaml.example
@@ -351,7 +351,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/yarn/datadog_checks/yarn/data/conf.yaml.example
+++ b/yarn/datadog_checks/yarn/data/conf.yaml.example
@@ -399,7 +399,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##

--- a/zk/datadog_checks/zk/data/conf.yaml.example
+++ b/zk/datadog_checks/zk/data/conf.yaml.example
@@ -79,7 +79,7 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
-## service - required - The name of the service that generates the log.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
 ##


### PR DESCRIPTION
### What does this PR do?
This PR makes:
- logs config service `optional`
- sync integration configs
- update logs check template

### Motivation
<!-- What inspired you to submit this pull request? -->
By default, the service should be the one in init_config/instance level. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
