### PR TITLE
add min_collection_interval param to conf.yaml.example for http check 

### DIFF
--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -359,8 +359,8 @@ instances:
     #
     # log_requests: false
 
-    ## @param min_collection_interval - integer - optional
-    ## Specifies the minimum time elapsed between http calls from this instance, in seconds
-    ## See https://docs.datadoghq.com/developers/write_agent_check/?tab=agentv6v7#collection-interval for more details
-
-    # min_collection_interval: 30
+    ## @param min_collection_interval - number - optional - default: 15
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    # min_collection_interval: 15

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -359,7 +359,7 @@ instances:
     #
     # log_requests: false
 
-    ## @param min_collection_interval - number - optional - default: 15
+    ## @param min_collection_interval - integer - optional - default: 15
     ## This changes the collection interval of the check. For more information, see:
     ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
     #

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -306,7 +306,7 @@ instances:
     ## If `tls_verify` is disabled, security warnings are logged by the check.
     ## Disable these by setting `tls_ignore_warning` to true.
     ##
-    ## Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration. 
+    ## Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration.
     ## If enabled for multiple instances, spurious warnings might still appear even if `tls_ignore_warning` is set
     ## to true.
     #
@@ -358,3 +358,9 @@ instances:
     ## Whether or not to debug log the HTTP(S) requests made, including the method and URL.
     #
     # log_requests: false
+
+    ## @param min_collection_interval - integer - optional
+    ## Specifies the minimum time elapsed between http calls from this instance, in seconds
+    ## See https://docs.datadoghq.com/developers/write_agent_check/?tab=agentv6v7#collection-interval for more details
+
+    # min_collection_interval: 30


### PR DESCRIPTION
### What does this PR do?
Adds the min_collection_interval parameter to the conf.yaml.example for the http check 

### Motivation
Requests from customers 

### Additional Notes
It appears that we only discuss min_collection_interval in the docs [here](https://docs.datadoghq.com/developers/write_agent_check/?tab=agentv6v7#collection-interval), but two customers have asked me questions about including it with the http check, so I thought I would make a PR to add it 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
