### PR TITLE
Fix PostgreSQL connection string when using ident authentication

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -290,7 +290,7 @@ class PostgreSql(AgentCheck):
         else:
             if self.config.host == 'localhost' and self.config.password == '':
                 # Use ident method
-                connection_string = "user=%s dbname=%s, application_name=%s" % (
+                connection_string = "user=%s dbname=%s application_name=%s" % (
                     self.config.user,
                     self.config.dbname,
                     "datadog-agent",


### PR DESCRIPTION
### What does this PR do?
Remove extra comma in PostgreSQL connection string when using ident authentication.

### Motivation

I was getting the following error:
```
Jul 27 22:56:29 HOST agent[13961]: 2020-07-27 22:56:29 CEST | CORE | ERROR | (pkg/collector/runner/runner.go:292 in work) |
Error running check postgres: [
  {
    "message": "FATAL:  database \"mydb,\" does not exist\n",
    "traceback": "Traceback (most recent call last):\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py\", line 841, in run\n    self.check(instance)\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/postgres/postgres.py\", line 431, in check\n    )\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/postgres/postgres.py\", line 415, in check\n    # Check version\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/postgres/postgres.py\", line 298, in _connect\n    connection_string += \" options='-c statement_timeout=%s'\" % self.config.query_timeout\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/psycopg2/__init__.py\", line 126, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\npsycopg2.OperationalError: FATAL:  database \"mydb,\" does not exist\n\n"
  }
]
````

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
