### PR TITLE
Add validation for link file content

### DIFF
--- a/.github/workflows/release-hash-check.py
+++ b/.github/workflows/release-hash-check.py
@@ -28,7 +28,7 @@ link_file = updated_link_files[0]
 with open(link_file, 'r') as f:
     content = json.load(f)
 
-products = link_file['signed']['products']
+products = content['signed']['products']
 
 for product, signatures in products.items():
     expected_sha = signatures['sha256']

--- a/.github/workflows/release-hash-check.py
+++ b/.github/workflows/release-hash-check.py
@@ -1,0 +1,41 @@
+from fnmatch import fnmatch
+import sys
+import json
+import hashlib
+
+
+def compute_sha256(filename):
+    sha256_hash = hashlib.sha256()
+    with open(filename, "rb") as f:
+        # Read and update hash string value in blocks of 4K
+        for byte_block in iter(lambda: f.read(4096), b""):
+            sha256_hash.update(byte_block)
+    return sha256_hash.hexdigest()
+
+
+def error(*args):
+    print(*args, file=sys.stderr)
+    sys.exit(1)
+
+
+updated_link_files = [f for f in sys.argv[1:] if fnmatch(f, '.in-toto/tag.*.link')]
+if len(updated_link_files) < 0:
+    error("The release-hash-check should only run upon modification of a link file.")
+if len(updated_link_files) > 1:
+    error("There should never be two different link files modified at the same time.")
+
+link_file = updated_link_files[0]
+with open(link_file, 'r') as f:
+    content = json.load(f)
+
+products = link_file['signed']['products']
+
+for product, signatures in products.items():
+    expected_sha = signatures['sha256']
+    if expected_sha != compute_sha256(product):
+        error(
+            f"File {product} currently has a different sha than what has been signed. "
+            f"Is your branch up to date with master?"
+        )
+
+print(f"Link file {link_file} has valid signatures.")

--- a/.github/workflows/release-hash-check.yml
+++ b/.github/workflows/release-hash-check.yml
@@ -1,0 +1,28 @@
+name: release-hash-check
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .in-toto/*.link
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - id: files
+      run: |
+        git fetch origin master
+        FILES=$(git --no-pager diff --name-only HEAD...FETCH_HEAD 2>/dev/null | tr "\n" " ")
+        echo "::set-output name=all::$FILES"
+
+    - run: python .github/workflows/release-hash-check.py ${{ steps.files.outputs.all }}


### PR DESCRIPTION
### What does this PR do?
Adds a new github action that looks for updated tag.*.link file and validates the content of the files.

### Motivation
If the hashes in the link files are wrong, the release won't happen. This happens every now and then, when the local copy of the master branch is outdated.
This validation step should smooth the release process. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
