### PR TITLE
Rename all_oids to scalar_oids

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -151,10 +151,10 @@ class InstanceConfig:
         if not self.metrics and not profiles_by_oid and not profile:
             raise ConfigurationError('Instance should specify at least one metric or profiles should be defined')
 
-        self.all_oids, self.next_oids, self.bulk_oids, self.parsed_metrics = self.parse_metrics(self.metrics)
+        self.scalar_oids, self.next_oids, self.bulk_oids, self.parsed_metrics = self.parse_metrics(self.metrics)
         tag_oids, self.parsed_metric_tags = self.parse_metric_tags(metric_tags)
         if tag_oids:
-            self.all_oids.extend(tag_oids)
+            self.scalar_oids.extend(tag_oids)
 
         if profile:
             if profile not in profiles:
@@ -171,7 +171,7 @@ class InstanceConfig:
     def refresh_with_profile(self, profile):
         # type: (Dict[str, Any]) -> None
         metrics = profile['definition'].get('metrics', [])
-        all_oids, next_oids, bulk_oids, parsed_metrics = self.parse_metrics(metrics)
+        scalar_oids, next_oids, bulk_oids, parsed_metrics = self.parse_metrics(metrics)
 
         metric_tags = profile['definition'].get('metric_tags', [])
         tag_oids, parsed_metric_tags = self.parse_metric_tags(metric_tags)
@@ -182,12 +182,12 @@ class InstanceConfig:
         # In the future we'll probably want to implement de-duplication.
 
         self.metrics.extend(metrics)
-        self.all_oids.extend(all_oids)
+        self.scalar_oids.extend(scalar_oids)
         self.next_oids.extend(next_oids)
         self.bulk_oids.extend(bulk_oids)
         self.parsed_metrics.extend(parsed_metrics)
         self.parsed_metric_tags.extend(parsed_metric_tags)
-        self.all_oids.extend(tag_oids)
+        self.scalar_oids.extend(tag_oids)
 
     def add_profile_tag(self, profile_name):
         # type: (str) -> None
@@ -297,7 +297,7 @@ class InstanceConfig:
             return
         # Reference sysUpTimeInstance directly, see http://oidref.com/1.3.6.1.2.1.1.3.0
         uptime_oid = OID('1.3.6.1.2.1.1.3.0')
-        self.all_oids.append(uptime_oid)
+        self.scalar_oids.append(uptime_oid)
         self._resolver.register(uptime_oid, 'sysUpTimeInstance')
 
         parsed_metric = ParsedSymbolMetric('sysUpTimeInstance', forced_type='gauge')

--- a/snmp/datadog_checks/snmp/discovery.py
+++ b/snmp/datadog_checks/snmp/discovery.py
@@ -45,7 +45,7 @@ def discover_instances(config, interval, check_ref):
             try:
                 profile = check._profile_for_sysobject_oid(sys_object_oid)
             except ConfigurationError:
-                if not (host_config.all_oids or host_config.bulk_oids):
+                if not (host_config.scalar_oids or host_config.bulk_oids):
                     check.log.warning("Host %s didn't match a profile for sysObjectID %s", host, sys_object_oid)
                     del check
                     continue


### PR DESCRIPTION
`scalar_oids` is more suitable since all_oids are scalar oids.

Extracted from: https://github.com/DataDog/integrations-core/pull/7110