### PR TITLE
Ignore empty label_to_hostname label value

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -785,7 +785,7 @@ class OpenMetricsScraperMixin(object):
         if (
             hostname is None
             and scraper_config['label_to_hostname'] is not None
-            and scraper_config['label_to_hostname'] in sample[self.SAMPLE_LABELS]
+            and sample[self.SAMPLE_LABELS].get(scraper_config['label_to_hostname'])
         ):
             hostname = sample[self.SAMPLE_LABELS][scraper_config['label_to_hostname']]
             suffix = scraper_config['label_to_hostname_suffix']

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -271,6 +271,29 @@ def test_submit_gauge_with_labels_and_hostname_override(
     )
 
 
+def test_submit_gauge_with_labels_and_hostname_override_empty_label(
+    aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config
+):
+    """ submitting metrics that contain empty label_to_hostname """
+    ref_gauge = GaugeMetricFamily(
+        'process_virtual_memory_bytes', 'Virtual memory size in bytes.', labels=['my_1st_label', 'node']
+    )
+    ref_gauge.add_metric(['my_1st_label_value', ''], 54927360.0)
+
+    check = mocked_prometheus_check
+    mocked_prometheus_scraper_config['label_to_hostname'] = 'node'
+    mocked_prometheus_scraper_config['label_to_hostname_suffix'] = '-cluster-name'
+    metric_name = mocked_prometheus_scraper_config['metrics_mapper'][ref_gauge.name]
+    check.submit_openmetric(metric_name, ref_gauge, mocked_prometheus_scraper_config)
+    aggregator.assert_metric(
+        'prometheus.process.vm.bytes',
+        54927360.0,
+        tags=['my_1st_label:my_1st_label_value', 'node:'],
+        hostname="",
+        count=1,
+    )
+
+
 def test_submit_gauge_with_labels_and_hostname_already_overridden(
     aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config
 ):


### PR DESCRIPTION
### What does this PR do?
- Do not add a host tag when `hostname` is `None` and the `label_to_hostname` label's value is `""` 

### Motivation
- Avoid having incomplete and incorrect host tags with `label_to_hostname_suffix` only (`host:-<cluster-name>` in case of KSM)
-  When `hostname` is `None` and the `label_to_hostname` label's value is `""` we shouldn't add a `host` tag

### Additional Notes
Could be QAed using KSM and the metric `kube_pod_status_unschedulable`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
