### PR TITLE
Use EC2 instance_id for consul latency metrics instead of hostname

### DIFF
--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
+import socket
 from collections import defaultdict, namedtuple
 from datetime import datetime, timedelta
 from itertools import islice
@@ -483,6 +484,14 @@ class ConsulCheck(AgentCheck):
         if len(nodes) == 1:
             self.log.debug("Only 1 node in cluster, skipping network latency metrics.")
         else:
+            socket_hostname = socket.gethostname()
+            if self.hostname != socket_hostname:
+                # Replace hostname references to use the agent determined hostname
+                # In EC2 environments, this will be `instance_id` instead, for example
+                for node in nodes:
+                    if node['Node'] == socket_hostname:
+                        node['Node'] = self.hostname
+
             for node in nodes:
                 node_name = node['Node']
                 latencies = []


### PR DESCRIPTION
### What does this PR do?
Normalizes on the Agent defined `hostname` value which can differ depending on the environment the Agent is running in.

For EC2 environments, the Agent will choose to use the `instance_id` over the socket hostname.  The `consul` check returns a map of latencies based on the socket hostnames, however.  As the check calculates the latencies, it will use the `hostname` in the metric call, and if this differs from the Agent hostname, then it will create a separate instance in the Datadog Infrastructure list.

This PR instead checks if `self.hostname` differs from `socket.gethostname()`, and overrides any values in the consul responses with the `self.hostname` values.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
