### PR TITLE
postgres rate limiting updates

### DIFF
--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -48,9 +48,12 @@ class PostgresConfig:
         self.collect_default_db = is_affirmative(instance.get('collect_default_database', False))
         self.collect_statement_metrics = is_dbm_enabled() and is_affirmative(instance.get('collect_query_metrics', True))
         self.collect_execution_plans = is_dbm_enabled() and is_affirmative(instance.get('collect_execution_plans', True))
-        self.collect_exec_plan_sample_sleep = instance.get('collect_exec_plan_sample_sleep', 0)
-        self.collect_exec_plan_time_limit = instance.get('collect_exec_plan_time_limit', 5)
-        self.collect_exec_plan_event_limit = instance.get('collect_exec_plan_event_limit', 1000)
+        self.collect_exec_plans_rate_limit = instance.get('collect_exec_plans_rate_limit', 10)
+        # plan collection time limit defaults to taking up most of the regular collection interval, leaving a one
+        # second buffer between each interval
+        self.collect_exec_plans_time_limit = instance.get('collect_exec_plans_time_limit',
+                                                          max(1, instance.get('min_collection_interval', 15) - 1))
+        self.collect_exec_plans_event_limit = instance.get('collect_exec_plans_event_limit', 100000)
         self.collect_exec_plan_function = instance.get('collect_exec_plan_function', 'public.explain_statement')
         self.custom_queries = instance.get('custom_queries', [])
         # default for both pg_stat_functions is to query the default views

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -315,12 +315,12 @@ class PgStatementsMixin(object):
         while time.time() - start_time < self.config.collect_exec_plans_time_limit:
             if len(seen_statement_plan_sigs) > self.config.collect_exec_plans_event_limit:
                 break
+            self._activity_sample_rate_limiter.sleep()
             samples = self._get_new_pg_stat_activity(instance_tags=instance_tags)
             events = self._explain_new_pg_stat_activity(samples, seen_statements, seen_statement_plan_sigs,
                                                         instance_tags)
             if events:
                 submit_exec_plan_events(events, instance_tags, "postgres")
-            self._activity_sample_rate_limiter.sleep()
 
         statsd.gauge("dd.postgres.collect_execution_plans.total.time", (time.time() - start_time) * 1000,
                      tags=instance_tags)


### PR DESCRIPTION
* more precise rate limit control using a basic rate-limiter instead of a constant sleep like before
* simplified config so sampling time limit is derived from min_collection_interval by default

