### PR TITLE
Update query and require_full_window for MYSQL mon

### DIFF
--- a/mysql/assets/recommended_monitors/mysql_replication_slave.json
+++ b/mysql/assets/recommended_monitors/mysql_replication_slave.json
@@ -1,7 +1,7 @@
 {
     "name": "[MySQL] Replication slave not running",
     "type": "query alert",
-    "query": "sum(last_1m):avg:mysql.replication.seconds_behind_master{*} by {host} < 0.99",
+    "query": "avg(last_1m):avg:mysql.replication.seconds_behind_master{*} by {host} > 0.99",
     "message": "Check MySQL replication thread on {{host.name}}",
     "tags": [
         "service:mysql"
@@ -14,7 +14,7 @@
         "include_tags": false,
         "no_data_timeframe": 10,
         "new_host_delay": 300,
-        "require_full_window": true,
+        "require_full_window": false,
         "notify_no_data": false,
         "renotify_interval": 0,
         "escalation_message": "",


### PR DESCRIPTION
### What does this PR do?
We want to alert if the value is too high but the threshold is currently `< 0.99`

require_full_window should be false or this monitor will likely skip quite a bit.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
