### PR TITLE
Use the log source attribute

### DIFF
--- a/active_directory/manifest.json
+++ b/active_directory/manifest.json
@@ -28,6 +28,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "ruby"
+    }
   }
 }

--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -34,6 +34,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "activemq"
+    }
   }
 }

--- a/airflow/manifest.json
+++ b/airflow/manifest.json
@@ -32,6 +32,8 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "airflow"
+    }
   }
 }

--- a/ambari/manifest.json
+++ b/ambari/manifest.json
@@ -31,6 +31,8 @@
       "Ambari base dashboard": "assets/dashboards/base_dashboard.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "ambari"
+    }
   }
 }

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -45,6 +45,8 @@
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "apache"
+    }
   }
 }

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -30,6 +30,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "cassandra"
+    }
   }
 }

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -34,6 +34,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "ceph"
+    }
   }
 }

--- a/clickhouse/manifest.json
+++ b/clickhouse/manifest.json
@@ -28,6 +28,8 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "clickhouse"
+    }
   }
 }

--- a/confluent_platform/manifest.json
+++ b/confluent_platform/manifest.json
@@ -34,6 +34,8 @@
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "confluent_platform"
+    }
   }
 }

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -38,6 +38,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "consul"
+    }
   }
 }

--- a/coredns/manifest.json
+++ b/coredns/manifest.json
@@ -27,6 +27,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "coredns"
+    }
   }
 }

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -37,6 +37,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "couchdb"
+    }
   }
 }

--- a/druid/manifest.json
+++ b/druid/manifest.json
@@ -32,6 +32,8 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "druid"
+    }
   }
 }

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -36,6 +36,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "elasticsearch"
+    }
   }
 }

--- a/envoy/manifest.json
+++ b/envoy/manifest.json
@@ -33,6 +33,8 @@
       "Envoy - Overview": "assets/dashboards/envoy_overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "envoy"
+    }
   }
 }

--- a/flink/manifest.json
+++ b/flink/manifest.json
@@ -32,6 +32,8 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "flink"
+    }
   }
 }

--- a/gitlab/manifest.json
+++ b/gitlab/manifest.json
@@ -37,6 +37,8 @@
       "Gitlab Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "gitlab"
+    }
   }
 }

--- a/gunicorn/manifest.json
+++ b/gunicorn/manifest.json
@@ -34,6 +34,8 @@
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "gunicorn"
+    }
   }
 }

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -40,6 +40,8 @@
       "response_time_overview": "assets/saved_views/response_time.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "haproxy"
+    }
   }
 }

--- a/harbor/manifest.json
+++ b/harbor/manifest.json
@@ -29,6 +29,8 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "harbor"
+    }
   }
 }

--- a/hazelcast/manifest.json
+++ b/hazelcast/manifest.json
@@ -36,6 +36,8 @@
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "hazelcast"
+    }
   }
 }

--- a/hdfs_datanode/manifest.json
+++ b/hdfs_datanode/manifest.json
@@ -30,6 +30,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "hdfs_datanode"
+    }
   }
 }

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -30,6 +30,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "hdfs_namenode"
+    }
   }
 }

--- a/hive/manifest.json
+++ b/hive/manifest.json
@@ -32,6 +32,8 @@
       "Hive Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "hive"
+    }
   }
 }

--- a/hivemq/manifest.json
+++ b/hivemq/manifest.json
@@ -33,6 +33,8 @@
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "hivemq"
+    }
   }
 }

--- a/ibm_db2/manifest.json
+++ b/ibm_db2/manifest.json
@@ -29,6 +29,8 @@
       "IBM Db2 Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "ibm_db2"
+    }
   }
 }

--- a/ibm_mq/manifest.json
+++ b/ibm_mq/manifest.json
@@ -30,6 +30,8 @@
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
-    "logs": {}
+    "logs": {
+      "source": "ibm_mq"
+    }
   }
 }

--- a/ibm_was/manifest.json
+++ b/ibm_was/manifest.json
@@ -28,6 +28,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "ibm_was"
+    }
   }
 }

--- a/ignite/manifest.json
+++ b/ignite/manifest.json
@@ -33,6 +33,8 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "ignite"
+    }
   }
 }

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -32,6 +32,8 @@
       "response_time_overview": "assets/saved_views/response_time.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "iis"
+    }
   }
 }

--- a/istio/manifest.json
+++ b/istio/manifest.json
@@ -37,6 +37,8 @@
       "Istio Overview 1.5": "assets/dashboards/istio_1_5_overview"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "istio"
+    }
   }
 }

--- a/jboss_wildfly/manifest.json
+++ b/jboss_wildfly/manifest.json
@@ -30,6 +30,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "jboss_wildfly"
+    }
   }
 }

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -36,6 +36,8 @@
       "logger_overview": "assets/saved_views/logger_overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "kafka"
+    }
   }
 }

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -41,6 +41,8 @@
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "kong"
+    }
   }
 }

--- a/kube_scheduler/manifest.json
+++ b/kube_scheduler/manifest.json
@@ -27,6 +27,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "kube_scheduler"
+    }
   }
 }

--- a/mapr/manifest.json
+++ b/mapr/manifest.json
@@ -28,6 +28,8 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "mapr"
+    }
   }
 }

--- a/marathon/manifest.json
+++ b/marathon/manifest.json
@@ -30,6 +30,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "marathon"
+    }
   }
 }

--- a/mcache/manifest.json
+++ b/mcache/manifest.json
@@ -33,6 +33,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "memcached"
+    }
   }
 }

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -42,6 +42,8 @@
       "slow_queries": "assets/saved_views/slow_queries.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "mongodb"
+    }
   }
 }

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -41,6 +41,8 @@
       "slow_operations": "assets/saved_views/slow_operations.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "mysql"
+    }
   }
 }

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -40,6 +40,8 @@
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "nginx"
+    }
   }
 }

--- a/nginx_ingress_controller/manifest.json
+++ b/nginx_ingress_controller/manifest.json
@@ -38,6 +38,8 @@
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "nginx-ingress-controller"
+    }
   }
 }

--- a/openldap/manifest.json
+++ b/openldap/manifest.json
@@ -28,6 +28,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "openldap"
+    }
   }
 }

--- a/pgbouncer/manifest.json
+++ b/pgbouncer/manifest.json
@@ -34,6 +34,8 @@
       "user_overview": "assets/saved_views/user_overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "pgbouncer"
+    }
   }
 }

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -29,6 +29,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "postfix"
+    }
   }
 }

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -47,6 +47,8 @@
       "sessions_by_host": "assets/saved_views/sessions_by_host.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "postgresql"
+    }
   }
 }

--- a/presto/manifest.json
+++ b/presto/manifest.json
@@ -35,6 +35,8 @@
       "response_time_overview": "assets/saved_views/response_time.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "presto"
+    }
   }
 }

--- a/proxysql/manifest.json
+++ b/proxysql/manifest.json
@@ -33,6 +33,8 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "proxysql"
+    }
   }
 }

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -34,6 +34,8 @@
       "rabbitmq_pattern": "assets/saved_views/rabbitmq_pattern.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "rabbitmq"
+    }
   }
 }

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -41,6 +41,8 @@
       "redis_pattern": "assets/saved_views/redis_pattern.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "redis"
+    }
   }
 }

--- a/rethinkdb/manifest.json
+++ b/rethinkdb/manifest.json
@@ -35,6 +35,8 @@
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "rethinkdb"
+    }
   }
 }

--- a/riak/manifest.json
+++ b/riak/manifest.json
@@ -30,6 +30,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "riak"
+    }
   }
 }

--- a/scylla/manifest.json
+++ b/scylla/manifest.json
@@ -29,6 +29,8 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "scylla"
+    }
   }
 }

--- a/sidekiq/manifest.json
+++ b/sidekiq/manifest.json
@@ -31,6 +31,8 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "sidekiq"
+    }
   }
 }

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -33,6 +33,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "solr"
+    }
   }
 }

--- a/spark/manifest.json
+++ b/spark/manifest.json
@@ -30,6 +30,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "spark"
+    }
   }
 }

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -29,6 +29,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "sqlserver"
+    }
   }
 }

--- a/squid/manifest.json
+++ b/squid/manifest.json
@@ -28,6 +28,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "squid"
+    }
   }
 }

--- a/tenable/manifest.json
+++ b/tenable/manifest.json
@@ -29,6 +29,8 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "tenable"
+    }
   }
 }

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -33,6 +33,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "tomcat"
+    }
   }
 }

--- a/twistlock/manifest.json
+++ b/twistlock/manifest.json
@@ -30,6 +30,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "twistlock"
+    }
   }
 }

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -37,6 +37,8 @@
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "varnish"
+    }
   }
 }

--- a/vault/manifest.json
+++ b/vault/manifest.json
@@ -38,6 +38,8 @@
       "vault_patern": "assets/saved_views/vault_patern.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "vault"
+    }
   }
 }

--- a/vertica/manifest.json
+++ b/vertica/manifest.json
@@ -28,6 +28,8 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "vertica"
+    }
   }
 }

--- a/yarn/manifest.json
+++ b/yarn/manifest.json
@@ -24,12 +24,14 @@
   "type": "check",
   "integration_id": "yarn",
   "assets": {
-     "configuration": {
+    "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "yarn"
+    }
   }
 }

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -34,6 +34,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {
+      "source": "zookeeper"
+    }
   }
 }


### PR DESCRIPTION
Update all manifests to use the new "assets/logs/source" attribute.
NO-OP yet but will be used by the logs pipeline validation test in the short term.