### PR TITLE
Improve collection of library logs for debug flares

### DIFF
--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -152,8 +152,8 @@ instances:
     ## Vertica library log level.
     ## This option exists because vertica-python logging is disabled by default
     ## and must be enabled it with an explicit option.
-    ## By default library logging is disabled, or set to DEBUG when the Agent log level is DEBUG.
-    ## Valid values: null (default behavior), CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG
+    ## When this option is not set, library logging is disabled, or set to DEBUG when the Agent log level is DEBUG.
+    ## Valid values: CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG
     #
     # client_lib_log_level: <CLIENT_LIB_LOG_LEVEL>
 

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -148,11 +148,12 @@ instances:
     #     tags:
     #       - test:vertica
 
-    ## @param client_lib_log_level - string - optional - default: Agent log level
+    ## @param client_lib_log_level - string - optional
     ## Vertica library log level.
     ## This option exists because vertica-python logging is disabled by default
     ## and must be enabled it with an explicit option.
-    ## Valid values: null (use Agent log level), CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG
+    ## By default library logging is disabled, or set to DEBUG when the Agent log level is DEBUG.
+    ## Valid values: null (default behavior), CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG
     #
     # client_lib_log_level: <CLIENT_LIB_LOG_LEVEL>
 

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -148,10 +148,9 @@ instances:
     #     tags:
     #       - test:vertica
 
-    ## @param client_lib_log_level - string - optional
+    ## @param client_lib_log_level - string - optional - default: DEBUG
     ## Vertica library log level.
-    ## By default the vertica library logging is disabled.
-    ## Valid values: CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG
+    ## Valid values: CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG, null (disable logging).
     #
     # client_lib_log_level: DEBUG
 

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -151,7 +151,7 @@ instances:
     ## @param client_lib_log_level - string - optional
     ## Vertica library log level.
     ## This option exists because vertica-python logging is disabled by default
-    ## and must be enabled it with an explicit option.
+    ## and must be enabled explicitly.
     ## When this option is not set, library logging is disabled, or set to DEBUG when the Agent log level is DEBUG.
     ## Valid values: CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG
     #

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -150,8 +150,9 @@ instances:
 
     ## @param client_lib_log_level - string - optional - default: Agent log level
     ## Vertica library log level.
-    ## This option exists because python-vertica disables logging by default, requiring to enable it with an explicit option.
-    ## Valid values: null (use Agent log level), CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG.
+    ## This option exists because vertica-python logging is disabled by default
+    ## and must be enabled it with an explicit option.
+    ## Valid values: null (use Agent log level), CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG
     #
     # client_lib_log_level: <CLIENT_LIB_LOG_LEVEL>
 

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -148,11 +148,12 @@ instances:
     #     tags:
     #       - test:vertica
 
-    ## @param client_lib_log_level - string - optional - default: DEBUG
+    ## @param client_lib_log_level - string - optional - default: Agent log level
     ## Vertica library log level.
-    ## Valid values: CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG, null (disable logging).
+    ## This option exists because python-vertica disables logging by default, requiring to enable it with an explicit option.
+    ## Valid values: null (use Agent log level), CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG.
     #
-    # client_lib_log_level: DEBUG
+    # client_lib_log_level: <CLIENT_LIB_LOG_LEVEL>
 
 ## Log Section (Available for Agent >=6.0)
 ##

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -46,7 +46,7 @@ class VerticaCheck(AgentCheck):
         self._tags = self.instance.get('tags', [])
 
         self._client_lib_log_level = self.instance.get(
-            'client_lib_log_level', logging.getLevelName(self.log.getEffectiveLevel())
+            'client_lib_log_level', logging.getLevelName(self.log.logger.getEffectiveLevel())
         )
 
         self._tls_verify = is_affirmative(self.instance.get('tls_verify', False))

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
+import logging
 import ssl
 from collections import defaultdict
 from datetime import datetime
@@ -18,12 +19,6 @@ from datadog_checks.base.utils.containers import iter_unique
 
 from . import views
 from .utils import kilobytes_to_bytes, node_state_to_service_check
-
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 
 # Python 3 only
 PROTOCOL_TLS_CLIENT = getattr(ssl, 'PROTOCOL_TLS_CLIENT', ssl.PROTOCOL_TLS)
@@ -50,7 +45,9 @@ class VerticaCheck(AgentCheck):
         self._timeout = float(self.instance.get('timeout', 10))
         self._tags = self.instance.get('tags', [])
 
-        self._client_lib_log_level = self.instance.get('client_lib_log_level', datadog_agent.get_config('log_level'))
+        self._client_lib_log_level = self.instance.get(
+            'client_lib_log_level', logging.getLevelName(self.log.getEffectiveLevel())
+        )
 
         self._tls_verify = is_affirmative(self.instance.get('tls_verify', False))
         self._validate_hostname = is_affirmative(self.instance.get('validate_hostname', True))

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -19,6 +19,12 @@ from datadog_checks.base.utils.containers import iter_unique
 from . import views
 from .utils import kilobytes_to_bytes, node_state_to_service_check
 
+try:
+    import datadog_agent
+except ImportError:
+    from datadog_checks.base.stubs import datadog_agent
+
+
 # Python 3 only
 PROTOCOL_TLS_CLIENT = getattr(ssl, 'PROTOCOL_TLS_CLIENT', ssl.PROTOCOL_TLS)
 
@@ -44,7 +50,7 @@ class VerticaCheck(AgentCheck):
         self._timeout = float(self.instance.get('timeout', 10))
         self._tags = self.instance.get('tags', [])
 
-        self._client_lib_log_level = self.instance.get('client_lib_log_level')
+        self._client_lib_log_level = self.instance.get('client_lib_log_level', datadog_agent.get_config('log_level'))
 
         self._tls_verify = is_affirmative(self.instance.get('tls_verify', False))
         self._validate_hostname = is_affirmative(self.instance.get('validate_hostname', True))

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -95,7 +95,7 @@ class VerticaCheck(AgentCheck):
     def _get_default_client_lib_log_level(self):
         if self.log.logger.getEffectiveLevel() == logging.DEBUG:
             # Automatically collect library logs for debug flares.
-            return logging.DEBUG
+            return 'DEBUG'
         # Default to no library logs, since they're too verbose even at the INFO level.
         return None
 

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
-import logging
 import ssl
 from collections import defaultdict
 from datetime import datetime
@@ -45,9 +44,7 @@ class VerticaCheck(AgentCheck):
         self._timeout = float(self.instance.get('timeout', 10))
         self._tags = self.instance.get('tags', [])
 
-        self._client_lib_log_level = self.instance.get(
-            'client_lib_log_level', logging.getLevelName(self.log.logger.getEffectiveLevel())
-        )
+        self._client_lib_log_level = self.instance.get('client_lib_log_level', self.log.logger.getEffectiveLevel())
 
         self._tls_verify = is_affirmative(self.instance.get('tls_verify', False))
         self._validate_hostname = is_affirmative(self.instance.get('validate_hostname', True))

--- a/vertica/tests/common.py
+++ b/vertica/tests/common.py
@@ -20,5 +20,4 @@ CONFIG = {
     'password': 'monitor',
     'timeout': 10,
     'tags': ['foo:bar'],
-    'client_lib_log_level': 'DEBUG',
 }

--- a/vertica/tests/test_unit.py
+++ b/vertica/tests/test_unit.py
@@ -116,3 +116,28 @@ def test_client_logging_enabled_debug_if_agent_uses_debug(aggregator, instance):
             log_level='DEBUG',
             log_path='',
         )
+
+
+def test_client_logging_disabled_if_agent_uses_info(aggregator, instance):
+    """
+    Library logs should be disabled by default, in particular under normal Agent operation (INFO level).
+    """
+    instance.pop('client_lib_log_level', None)
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+
+    check = VerticaCheck('vertica', {}, [instance])
+
+    with mock.patch('datadog_checks.vertica.vertica.vertica') as vertica:
+        check.check(instance)
+
+        vertica.connect.assert_called_with(
+            database=mock.ANY,
+            host=mock.ANY,
+            port=mock.ANY,
+            user=mock.ANY,
+            password=mock.ANY,
+            backup_server_node=mock.ANY,
+            connection_load_balance=mock.ANY,
+            connection_timeout=mock.ANY,
+        )

--- a/vertica/tests/test_unit.py
+++ b/vertica/tests/test_unit.py
@@ -113,6 +113,6 @@ def test_client_logging_enabled_debug_if_agent_uses_debug(aggregator, instance):
             backup_server_node=mock.ANY,
             connection_load_balance=mock.ANY,
             connection_timeout=mock.ANY,
-            log_level=logging.DEBUG,
+            log_level='DEBUG',
             log_path='',
         )

--- a/vertica/tests/test_unit.py
+++ b/vertica/tests/test_unit.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
 import os
 
 import mock
@@ -87,4 +88,31 @@ def test_client_logging_disabled(aggregator, instance):
             backup_server_node=mock.ANY,
             connection_load_balance=mock.ANY,
             connection_timeout=mock.ANY,
+        )
+
+
+def test_client_logging_enabled_debug_if_agent_uses_debug(aggregator, instance):
+    """
+    Improve collection of debug flares by automatically enabling client DEBUG logs when the Agent uses DEBUG logs.
+    """
+    instance.pop('client_lib_log_level', None)
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)
+
+    check = VerticaCheck('vertica', {}, [instance])
+
+    with mock.patch('datadog_checks.vertica.vertica.vertica') as vertica:
+        check.check(instance)
+
+        vertica.connect.assert_called_with(
+            database=mock.ANY,
+            host=mock.ANY,
+            port=mock.ANY,
+            user=mock.ANY,
+            password=mock.ANY,
+            backup_server_node=mock.ANY,
+            connection_load_balance=mock.ANY,
+            connection_timeout=mock.ANY,
+            log_level=logging.DEBUG,
+            log_path='',
         )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Make `client_lib_log_level` option default to DEBUG when the Agent uses DEBUG logs.

### Motivation
<!-- What inspired you to submit this pull request? -->
Facilitate collection of debug flare for support cases. (By default Vertica logging is disabled, so even if the Agent log level is DEBUG we won't get any library-level debug logs unless the option is set.)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
