### PR TITLE
Add self.instance comment to check template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/check.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/check.py
@@ -6,4 +6,5 @@ from datadog_checks.base import AgentCheck
 class {check_class}(AgentCheck):
     def check(self, _):
         # type: (Any) -> None
+        # Use self.instance to read the check configuration
         pass


### PR DESCRIPTION
Since we remove the `instance` argument in the check method, it's not clear how to read the integration configuration.
This PR adds a small documentation comment in the check method.