### PR TITLE
Test tcp_check against local server

### DIFF
--- a/tcp_check/tests/common.py
+++ b/tcp_check/tests/common.py
@@ -1,17 +1,21 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+
 from datadog_checks.tcp_check import TCPCheck
+
+HERE = os.path.dirname(os.path.abspath(__file__))
 
 CHECK_NAME = "tcp_check"
 
-INSTANCE = {'host': 'datadoghq.com', 'port': 80, 'timeout': 1.5, 'name': 'UpService', 'tags': ["foo:bar"]}
+INSTANCE = {'host': '127.0.0.1', 'port': 8000, 'timeout': 1.5, 'name': 'UpService', 'tags': ['foo:bar']}
 
 INSTANCE_KO = {'host': '127.0.0.1', 'port': 65530, 'timeout': 1.5, 'name': 'DownService', 'tags': ["foo:bar"]}
 
 
 def _test_check(aggregator):
-    expected_tags = ['foo:bar', 'target_host:datadoghq.com', 'port:80', 'instance:UpService']
+    expected_tags = ['foo:bar', 'target_host:127.0.0.1', 'port:8000', 'instance:UpService']
     aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags)
     aggregator.assert_service_check('tcp.can_connect', status=TCPCheck.OK, tags=expected_tags)
     aggregator.assert_all_metrics_covered()

--- a/tcp_check/tests/compose/docker-compose.yml
+++ b/tcp_check/tests/compose/docker-compose.yml
@@ -3,6 +3,6 @@ version: '3'
 services:
   nginx:
     container_name: nginx
-    image: nginx:alpine
+    image: nginx
     ports:
       - "8000:80"

--- a/tcp_check/tests/compose/docker-compose.yml
+++ b/tcp_check/tests/compose/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  nginx:
+    container_name: nginx
+    image: nginx:alpine
+    ports:
+      - "8000:80"

--- a/tcp_check/tests/conftest.py
+++ b/tcp_check/tests/conftest.py
@@ -1,10 +1,12 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import os
 from copy import deepcopy
 
 import pytest
 
+from datadog_checks.dev import docker_run
 from datadog_checks.tcp_check import TCPCheck
 
 from . import common
@@ -12,7 +14,8 @@ from . import common
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    yield common.INSTANCE
+    with docker_run(os.path.join(common.HERE, 'compose', 'docker-compose.yml')):
+        yield common.INSTANCE
 
 
 @pytest.fixture

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -46,7 +46,7 @@ def test_up(aggregator, check):
     Service expected to be up
     """
     check.check(deepcopy(common.INSTANCE))
-    expected_tags = ["instance:UpService", "target_host:datadoghq.com", "port:80", "foo:bar"]
+    expected_tags = ["instance:UpService", "target_host:127.0.0.1", "port:8000", "foo:bar"]
     aggregator.assert_service_check('tcp.can_connect', status=check.OK, tags=expected_tags)
     aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags)
     aggregator.assert_all_metrics_covered()
@@ -64,12 +64,12 @@ def test_response_time(aggregator):
     check.check(instance)
 
     # service check
-    expected_tags = ['foo:bar', 'target_host:datadoghq.com', 'port:80', 'instance:instance:response_time']
+    expected_tags = ['foo:bar', 'target_host:127.0.0.1', 'port:8000', 'instance:instance:response_time']
     aggregator.assert_service_check('tcp.can_connect', status=check.OK, tags=expected_tags)
     aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags)
 
     # response time metric
-    expected_tags = ['url:datadoghq.com:80', 'instance:instance:response_time', 'foo:bar']
+    expected_tags = ['url:127.0.0.1:8000', 'instance:instance:response_time', 'foo:bar']
     aggregator.assert_metric('network.tcp.response_time', tags=expected_tags)
     aggregator.assert_all_metrics_covered()
     assert len(aggregator.service_checks('tcp.can_connect')) == 1


### PR DESCRIPTION
### What does this PR do?
Use a local Nginx server instead of `datadoghq.com` in `tcp_check` tests.

### Motivation
<!-- What inspired you to submit this pull request? -->
Lower the barrier to entry for tweaking the local server when debugging support cases (right now we have to do this every time since we can't change the behaviour of `datadoghq.com`).

Other tiny benefits, but they're not really relevant tbh (eg allow tests to run offline, don't make tests depend on availability of a live endpoint).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
