### PR TITLE
Use DEBUG log level for Vertica when Agent log level is DEBUG or TRACE

### DIFF
--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -152,7 +152,8 @@ instances:
     ## Vertica library log level.
     ## This option exists because vertica-python logging is disabled by default
     ## and must be enabled explicitly.
-    ## When this option is not set, library logging is disabled, or set to DEBUG when the Agent log level is DEBUG.
+    ## When this option is not set, library logging is disabled, or set to DEBUG
+    ## when the Agent log level is DEBUG or lower (TRACE).
     ## Valid values: CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG
     #
     # client_lib_log_level: <CLIENT_LIB_LOG_LEVEL>

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -93,9 +93,9 @@ class VerticaCheck(AgentCheck):
         self._view = defaultdict(list)
 
     def _get_default_client_lib_log_level(self):
-        if self.log.logger.getEffectiveLevel() == logging.DEBUG:
+        if self.log.logger.getEffectiveLevel() <= logging.DEBUG:
             # Automatically collect library logs for debug flares.
-            return 'DEBUG'
+            return logging.DEBUG
         # Default to no library logs, since they're too verbose even at the INFO level.
         return None
 

--- a/vertica/tests/test_unit.py
+++ b/vertica/tests/test_unit.py
@@ -5,8 +5,10 @@ import logging
 import os
 
 import mock
+import pytest
 
 from datadog_checks.base import AgentCheck
+from datadog_checks.base.log import TRACE_LEVEL
 from datadog_checks.vertica import VerticaCheck
 
 CERTIFICATE_DIR = os.path.join(os.path.dirname(__file__), 'certificate')
@@ -91,13 +93,18 @@ def test_client_logging_disabled(aggregator, instance):
         )
 
 
-def test_client_logging_enabled_debug_if_agent_uses_debug(aggregator, instance):
+@pytest.mark.parametrize(
+    'agent_log_level, expected_vertica_log_level', [(logging.DEBUG, logging.DEBUG), (TRACE_LEVEL, logging.DEBUG)]
+)
+def test_client_logging_enabled_debug_if_agent_uses_lower_than_debug(
+    aggregator, instance, agent_log_level, expected_vertica_log_level
+):
     """
     Improve collection of debug flares by automatically enabling client DEBUG logs when the Agent uses DEBUG logs.
     """
     instance.pop('client_lib_log_level', None)
     root_logger = logging.getLogger()
-    root_logger.setLevel(logging.DEBUG)
+    root_logger.setLevel(agent_log_level)
 
     check = VerticaCheck('vertica', {}, [instance])
 
@@ -113,7 +120,7 @@ def test_client_logging_enabled_debug_if_agent_uses_debug(aggregator, instance):
             backup_server_node=mock.ANY,
             connection_load_balance=mock.ANY,
             connection_timeout=mock.ANY,
-            log_level='DEBUG',
+            log_level=expected_vertica_log_level,
             log_path='',
         )
 

--- a/vertica/tests/test_unit.py
+++ b/vertica/tests/test_unit.py
@@ -96,7 +96,7 @@ def test_client_logging_disabled(aggregator, instance):
 @pytest.mark.parametrize(
     'agent_log_level, expected_vertica_log_level', [(logging.DEBUG, logging.DEBUG), (TRACE_LEVEL, logging.DEBUG)]
 )
-def test_client_logging_enabled_debug_if_agent_uses_lower_than_debug(
+def test_client_logging_enabled_debug_if_agent_uses_debug_or_trace(
     aggregator, instance, agent_log_level, expected_vertica_log_level
 ):
     """


### PR DESCRIPTION
### What does this PR do?

Use DEBUG log level for Vertica when Agent log level is DEBUG or TRACE

Improve to https://github.com/DataDog/integrations-core/pull/7252

### Motivation

Also use DEBUG log level for vertica if Agent log level is TRACE