### PR TITLE
Allow coverage to be optional for CI

### DIFF
--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -15,7 +15,7 @@ steps:
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
 
-- ${{ if and(eq(parameters.test, 'true'), not(eq(parameters.coverage, 'true')) }}:
+- ${{ if and(eq(parameters.test, 'true'), not(eq(parameters.coverage, 'true'))) }}:
     - script: ddev test --junit ${{ parameters.check }}
       displayName: 'Run Unit/Integration tests (no coverage)'
       env:

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -18,8 +18,6 @@ steps:
 - ${{ if and(eq(parameters.test, 'true'), not(eq(parameters.coverage, 'true'))) }}:
     - script: ddev test --junit ${{ parameters.check }}
       displayName: 'Run Unit/Integration tests (no coverage)'
-      env:
-        CODECOV_TOKEN: $(CODECOV_TOKEN)
 
 - ${{ if eq(parameters.test_e2e, 'true') }}:
   - script: |

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -9,7 +9,7 @@ parameters:
   coverage: true
 
 steps:
-- ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true') }}:
+- ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true')) }}:
   - script: ddev test --cov --junit ${{ parameters.check }}
     displayName: 'Run Unit/Integration tests'
     env:

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -6,13 +6,20 @@ parameters:
   benchmark: false
   latest_metrics: false
   repo: ''
+  coverage: true
 
 steps:
-- ${{ if eq(parameters.test, 'true') }}:
+- ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true') }}:
   - script: ddev test --cov --junit ${{ parameters.check }}
     displayName: 'Run Unit/Integration tests'
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
+
+- ${{ if and(eq(parameters.test, 'true'), not(eq(parameters.coverage, 'true')) }}:
+    - script: ddev test --junit ${{ parameters.check }}
+      displayName: 'Run Unit/Integration tests (no coverage)'
+      env:
+        CODECOV_TOKEN: $(CODECOV_TOKEN)
 
 - ${{ if eq(parameters.test_e2e, 'true') }}:
   - script: |

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -9,6 +9,7 @@ parameters:
   validate: false
   repo: 'core'
   pip_cache_config: null
+  coverage: true
 
 jobs:
 - job: '${{ coalesce(parameters.job_name, parameters.check) }}_Linux'
@@ -43,3 +44,4 @@ jobs:
       benchmark: ${{ parameters.benchmark }}
       latest_metrics: ${{ parameters.latest_metrics }}
       repo: ${{ parameters.repo }}
+      coverage: ${{ parameters.coverage }}

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -9,6 +9,7 @@ parameters:
   validate: false
   repo: 'core'
   pip_cache_config: null
+  coverage: true
 
 jobs:
 - job: '${{ coalesce(parameters.job_name, parameters.check) }}_Windows'
@@ -45,3 +46,4 @@ jobs:
       benchmark: ${{ parameters.benchmark }}
       latest_metrics: ${{ parameters.latest_metrics }}
       repo: ${{ parameters.repo }}
+      coverage: ${{ parameters.coverage }}


### PR DESCRIPTION
### What does this PR do?
Adds CI variable `coverage` to determine whether coverage tests should be run as part of the `ddev test` operation.  It defaults to `true`, but this now allows other repos which leverage our config to optionally turn that feature off in their environments.
