### PR TITLE
mysql support other events_statement tables with sampling

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -80,3 +80,26 @@ class ConstantRateLimiter:
         sleep_amount = max(self.period_s - elapsed_s, 0)
         time.sleep(sleep_amount)
         self.last_event = time.time()
+
+
+class ExpiringCache(dict):
+    """
+    Simple expiring key-value cache. Not thread safe.
+    """
+
+    def __init__(self):
+        self.cache = {}
+
+    def set(self, key, val, expire_seconds):
+        """
+        set key=value, expiring after expire_seconds
+        """
+        expire_at = time.time() + expire_seconds
+        self.cache[key] = (val, expire_at)
+
+    def get(self, key):
+        val, expire_at = self.cache.get(key, (None, -1))
+        if 0 < expire_at < time.time():
+            del self.cache[key]
+            return None
+        return val

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -97,9 +97,9 @@ class ExpiringCache(dict):
         expire_at = time.time() + expire_seconds
         self.cache[key] = (val, expire_at)
 
-    def get(self, key):
-        val, expire_at = self.cache.get(key, (None, -1))
+    def get(self, key, default=None):
+        val, expire_at = self.cache.get(key, (default, -1))
         if 0 < expire_at < time.time():
             del self.cache[key]
-            return None
+            return default
         return val

--- a/mysql/datadog_checks/mysql/execution_plans.py
+++ b/mysql/datadog_checks/mysql/execution_plans.py
@@ -192,9 +192,9 @@ class ExecutionPlansMixin(object):
             except pymysql.err.DatabaseError as e:
                 if e.args[0] == 1290:
                     # --read-only mode failure is expected so log at debug level
-                    self.log.debug('failed to enable performance_schema consumer %s: %s', name, str(e))
+                    self.log.debug('failed to enable performance_schema consumer %s: %s', name, e)
                     return False
-                self.log.warning('failed to enable performance_schema consumer %s: %s', name, str(e))
+                self.log.warning('failed to enable performance_schema consumer %s: %s', name, e)
         return False
 
     def _get_plan_collection_strategy(self, db, options, min_collection_interval):

--- a/mysql/datadog_checks/mysql/execution_plans.py
+++ b/mysql/datadog_checks/mysql/execution_plans.py
@@ -1,11 +1,11 @@
 import json
+import time
 from contextlib import closing
 
 import pymysql
 
 import datadog_agent
 import pymysql
-import time
 from datadog import statsd
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.db.statement_metrics import is_dbm_enabled

--- a/mysql/datadog_checks/mysql/execution_plans.py
+++ b/mysql/datadog_checks/mysql/execution_plans.py
@@ -260,12 +260,13 @@ class ExecutionPlansMixin(object):
         )
 
         if chosen_table:
-            # cache only successful strategies, 10 minute expiry
-            # 10 minutes is short enough that we'll reflect updates "relatively quickly"
-            # i.e., an aurora replica becomes a master (or vice versa)
+            # cache only successful strategies
+            # should be short enough that we'll reflect updates "relatively quickly"
+            # i.e., an aurora replica becomes a master (or vice versa).
             self.log.debug("found plan collection strategy. chosen_table=%s, time_limit=%s, rate_limit=%s",
                            chosen_table, collect_exec_plans_time_limit, collect_exec_plans_rate_limit)
-            self._expiring_cache.set("plan_collection_strategy", strategy, 10 * 60)
+            self._expiring_cache.set("plan_collection_strategy", strategy,
+                                     options.get('plan_collection_strategy_cache_time', 10 * 60))
         else:
             self.log.warning(
                 "no valid performance_schema.events_statements table found. cannot collect execution plans.")

--- a/mysql/datadog_checks/mysql/execution_plans.py
+++ b/mysql/datadog_checks/mysql/execution_plans.py
@@ -3,6 +3,10 @@ from contextlib import closing
 
 import pymysql
 
+import datadog_agent
+import pymysql
+import time
+from datadog import statsd
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.db.statement_metrics import is_dbm_enabled
 from datadog_checks.base.utils.db.sql import compute_sql_signature, compute_exec_plan_signature, submit_exec_plan_events
@@ -12,14 +16,16 @@ try:
 except ImportError:
     from ..stubs import datadog_agent
 
+from datadog_checks.base.utils.db.statement_metrics import is_dbm_enabled
+from datadog_checks.base.utils.db.utils import ConstantRateLimiter
 
 VALID_EXPLAIN_STATEMENTS = frozenset({
-  'select',
-  'table',
-  'delete',
-  'insert',
-  'replace',
-  'update',
+    'select',
+    'table',
+    'delete',
+    'insert',
+    'replace',
+    'update',
 })
 
 
@@ -29,13 +35,13 @@ class ExecutionPlansMixin(object):
     """
 
     def __init__(self, *args, **kwargs):
-        # TODO: Make this a configurable limit
-        self.query_limit = 500
-        self._checkpoint = None
+        # checkpoint at zero so we pull the whole history table on the first run
+        self._checkpoint = 0
         self._auto_enable_eshl = None
-    
+
     def _enable_performance_schema_consumers(self, db):
-        query = """UPDATE performance_schema.setup_consumers SET enabled = 'YES' WHERE name = 'events_statements_history_long'"""
+        query = """UPDATE performance_schema.setup_consumers SET enabled = 'YES' WHERE name = 
+        'events_statements_history_long'"""
         with closing(db.cursor()) as cursor:
             try:
                 cursor.execute(query)
@@ -53,23 +59,9 @@ class ExecutionPlansMixin(object):
             else:
                 self.log.info('Successfully enabled events_statements_history_long consumers')
 
-    def _collect_execution_plans(self, db, tags, options):
-        if self._auto_enable_eshl is None:
-            self._auto_enable_eshl = is_affirmative(options.get('auto_enable_events_statements_history_long', False))
-        if not (is_dbm_enabled() and is_affirmative(options.get('collect_execution_plans', True))):
-            return False
+    def _get_events_statements_by_digest(self, db, events_statements_table, row_limit):
+        start = time.time()
 
-        tags = list(set(self.service_check_tags + tags))
-        if self._checkpoint is None:
-            with closing(db.cursor()) as cursor:
-                cursor.execute('SELECT MAX(timer_start) FROM performance_schema.events_statements_history_long')
-                result = cursor.fetchone()
-            if not result or not all(result):
-                self.log.debug('Unable to fetch from performance_schema.events_statements_history_long')
-                if self._auto_enable_eshl:
-                    self._enable_performance_schema_consumers(db)
-                return False
-            self._checkpoint = result[0]
         # Select the most recent events with a bias towards events which have higher wait times
         query = """
             SELECT current_schema AS current_schema,
@@ -92,7 +84,7 @@ class ExecutionPlansMixin(object):
                    sort_scan,
                    no_index_used,
                    no_good_index_used
-              FROM performance_schema.events_statements_history_long
+              FROM performance_schema.{}
              WHERE sql_text IS NOT NULL
                AND event_name like %s
                AND digest_text NOT LIKE %s
@@ -100,13 +92,23 @@ class ExecutionPlansMixin(object):
           GROUP BY digest
           ORDER BY timer_wait DESC
               LIMIT %s
-            """
+            """.format(events_statements_table)
 
         with closing(db.cursor(pymysql.cursors.DictCursor)) as cursor:
-            cursor.execute(query, ('statement/%', 'EXPLAIN %', self._checkpoint, self.query_limit))
+            params = ('statement/%', 'EXPLAIN %', self._checkpoint, row_limit)
+            self.log.debug("running query. " + query, *params)
+            cursor.execute(query, params)
             rows = cursor.fetchall()
+            if not rows:
+                self.log.debug("no statements found in performance_schema.%s", events_statements_table)
+                return rows
+            self._checkpoint = max(r['timer_start'] for r in rows)
             cursor.execute('SET @@SESSION.sql_notes = 0')
+            statsd.increment("dd.mysql.events_statements_by_digest.rows", len(rows))
+            statsd.timing("dd.mysql.events_statements_by_digest.time", (time.time() - start) * 1000)
+            return rows
 
+    def _collect_plans_for_statements(self, db, rows, seen_statement_plan_sigs, instance_tags):
         events = []
         num_truncated = 0
 
@@ -117,7 +119,6 @@ class ExecutionPlansMixin(object):
             schema = row['current_schema']
             sql_text = row['sql_text']
             digest_text = row['digest_text']
-            self._checkpoint = max(row['timer_start'], self._checkpoint)
             duration_ns = row['max_timer_wait_ns']
 
             if not sql_text:
@@ -131,10 +132,16 @@ class ExecutionPlansMixin(object):
 
             with closing(db.cursor()) as cursor:
                 # TODO: run these asynchronously / do some benchmarking to optimize
-                plan = self._run_explain(cursor, sql_text, schema)
+                plan = self._run_explain(cursor, sql_text, schema, instance_tags)
+                if not plan:
+                    continue
                 normalized_plan = datadog_agent.obfuscate_sql_exec_plan(plan, normalize=True) if plan else None
                 obfuscated_statement = datadog_agent.obfuscate_sql(sql_text)
-                if plan:
+                query_signature = compute_sql_signature(obfuscated_statement)
+                plan_signature = compute_exec_plan_signature(normalized_plan)
+                statement_plan_sig = (query_signature, plan_signature)
+                if statement_plan_sig not in seen_statement_plan_sigs:
+                    seen_statement_plan_sigs.add(statement_plan_sig)
                     events.append({
                         'duration': duration_ns,
                         'db': {
@@ -143,7 +150,7 @@ class ExecutionPlansMixin(object):
                             'query_signature': compute_sql_signature(obfuscated_statement),
                             'plan': plan,
                             'plan_cost': self._parse_execution_plan_cost(plan),
-                            'plan_signature': compute_exec_plan_signature(normalized_plan),
+                            'plan_signature': plan_signature,
                             'debug': {
                                 'normalized_plan': normalized_plan,
                                 'obfuscated_plan': datadog_agent.obfuscate_sql_exec_plan(plan),
@@ -169,7 +176,6 @@ class ExecutionPlansMixin(object):
                         }
                     })
 
-        submit_exec_plan_events(events, tags, "mysql")
         if num_truncated > 0:
             self.log.warning(
                 'Unable to collect %d/%d execution plans due to truncated SQL text. Consider raising '
@@ -178,20 +184,70 @@ class ExecutionPlansMixin(object):
                 num_truncated + len(events)
             )
 
-    def _run_explain(self, cursor, statement, schema):
+        return events
+
+    def _collect_execution_plans(self, db, tags, options, min_collection_interval):
+        if self._auto_enable_eshl is None:
+            self._auto_enable_eshl = is_affirmative(options.get('auto_enable_events_statements_history_long', False))
+        if not (is_dbm_enabled() and is_affirmative(options.get('collect_execution_plans', True))):
+            return False
+
+        stmt_row_limit = options.get('events_statements_row_limit', 5000)
+
+        events_statements_table = options.get('events_statements_table', 'events_statements_history_long')
+        supported_tables = {'events_statements_history_long', 'events_statements_history', 'events_statements_current'}
+        if events_statements_table not in supported_tables:
+            self.log.warning("invalid 'events_statements_table' config for instance: %s. must be one of %s.",
+                             events_statements_table, ', '.join(sorted(supported_tables)))
+            events_statements_table = 'events_statements_history_long'
+        is_history_long = events_statements_table == 'events_statements_history_long'
+
+        collect_exec_plans_rate_limit = options.get('collect_exec_plans_rate_limit', -1)
+        collect_exec_plans_time_limit = options.get('collect_exec_plans_time_limit', -1)
+        if collect_exec_plans_rate_limit < 0:
+            collect_exec_plans_rate_limit = 0 if is_history_long else 1
+        if collect_exec_plans_time_limit < 0:
+            # default time limit for history long is 1ms, meaning it'll run only once
+            collect_exec_plans_time_limit = 1 / 1000 if is_history_long else max(1, min_collection_interval - 1)
+        stmt_sample_rate_limiter = ConstantRateLimiter(collect_exec_plans_rate_limit)
+
+        instance_tags = list(set(self.service_check_tags + tags))
+
+        start_time = time.time()
+        # avoid reprocessing the exact same statements
+        seen_digests = set()
+        # ingest only one sample per unique (query, plan)
+        seen_statement_plan_sigs = set()
+        while time.time() - start_time < collect_exec_plans_time_limit:
+            stmt_sample_rate_limiter.sleep()
+            rows = self._get_events_statements_by_digest(db, events_statements_table, stmt_row_limit)
+            events = self._collect_plans_for_statements(db, rows, seen_statement_plan_sigs, instance_tags)
+            if events:
+                submit_exec_plan_events(events, instance_tags, "mysql")
+
+        statsd.gauge("dd.mysql.collect_execution_plans.total.time", (time.time() - start_time) * 1000,
+                     tags=instance_tags)
+        statsd.gauge("dd.mysql.collect_execution_plans.seen_statements", len(seen_digests), tags=instance_tags)
+        statsd.gauge("dd.mysql.collect_execution_plans.seen_statement_plan_sigs", len(seen_statement_plan_sigs),
+                     tags=instance_tags)
+
+    def _run_explain(self, cursor, statement, schema, instance_tags):
         # TODO: cleaner query cleaning to strip comments, etc.
         if statement.strip().split(' ', 1)[0].lower() not in VALID_EXPLAIN_STATEMENTS:
             return
 
         try:
+            start_time = time.time()
             if schema is not None:
                 cursor.execute('USE `{}`'.format(schema))
             cursor.execute('EXPLAIN FORMAT=json {statement}'.format(statement=statement))
+            statsd.timing("dd.mysql.run_explain.time", (time.time() - start_time) * 1000, tags=instance_tags)
         except (pymysql.err.InternalError, pymysql.err.ProgrammingError) as e:
             if len(e.args) != 2:
                 raise
             if e.args[0] in (1046,):
-                self.log.warning('Failed to collect EXPLAIN due to a permissions error: %s, Statement: %s', e.args, statement)
+                self.log.warning('Failed to collect EXPLAIN due to a permissions error: %s, Statement: %s', e.args,
+                                 statement)
                 return None
             elif e.args[0] == 1064:
                 self.log.warning('Programming error when collecting EXPLAIN: %s, Statement: %s', e.args, statement)

--- a/mysql/datadog_checks/mysql/execution_plans.py
+++ b/mysql/datadog_checks/mysql/execution_plans.py
@@ -121,8 +121,12 @@ class ExecutionPlansMixin(object):
 
             with closing(db.cursor()) as cursor:
                 # TODO: run these asynchronously / do some benchmarking to optimize
-                plan = self._run_explain(cursor, sql_text, schema, instance_tags)
-                if not plan:
+                try:
+                    plan = self._run_explain(cursor, sql_text, schema, instance_tags)
+                    if not plan:
+                        continue
+                except Exception:
+                    self.log.exception("failed to run explain on query %s", sql_text)
                     continue
                 normalized_plan = datadog_agent.obfuscate_sql_exec_plan(plan, normalize=True) if plan else None
                 obfuscated_statement = datadog_agent.obfuscate_sql(sql_text)

--- a/mysql/datadog_checks/mysql/execution_plans.py
+++ b/mysql/datadog_checks/mysql/execution_plans.py
@@ -3,12 +3,8 @@ import time
 from contextlib import closing
 
 import pymysql
-
-import datadog_agent
-import pymysql
 from datadog import statsd
 from datadog_checks.base import is_affirmative
-from datadog_checks.base.utils.db.statement_metrics import is_dbm_enabled
 from datadog_checks.base.utils.db.sql import compute_sql_signature, compute_exec_plan_signature, submit_exec_plan_events
 
 try:

--- a/mysql/datadog_checks/mysql/execution_plans.py
+++ b/mysql/datadog_checks/mysql/execution_plans.py
@@ -260,7 +260,7 @@ class ExecutionPlansMixin(object):
         )
 
         if chosen_table:
-            # cache only successful plans, 10 minute expiry
+            # cache only successful strategies, 10 minute expiry
             # 10 minutes is short enough that we'll reflect updates "relatively quickly"
             # i.e., an aurora replica becomes a master (or vice versa)
             self.log.debug("found plan collection strategy. chosen_table=%s, time_limit=%s, rate_limit=%s",

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -373,6 +373,7 @@ class MySql(ExecutionPlansMixin, AgentCheck):
             ssl,
             connect_timeout,
             max_custom_queries,
+            min_collection_interval
         ) = self._get_config(instance)
 
         self._set_qcache_stats()
@@ -392,7 +393,7 @@ class MySql(ExecutionPlansMixin, AgentCheck):
                 self._collect_metrics(db, tags, options, queries, max_custom_queries)
                 self._collect_system_metrics(host, db, tags)
                 self._collect_statement_metrics(db, tags)
-                self._collect_execution_plans(db, tags, options)
+                self._collect_execution_plans(db, tags, options, min_collection_interval)
 
                 # keeping track of these:
                 self._put_qcache_stats()
@@ -419,6 +420,7 @@ class MySql(ExecutionPlansMixin, AgentCheck):
         ssl = instance.get('ssl', {})
         connect_timeout = instance.get('connect_timeout', 10)
         max_custom_queries = instance.get('max_custom_queries', self.DEFAULT_MAX_CUSTOM_QUERIES)
+        min_collection_interval = instance.get('min_collection_interval', 15)
 
         if queries or 'max_custom_queries' in instance:
             self.warning(
@@ -439,6 +441,7 @@ class MySql(ExecutionPlansMixin, AgentCheck):
             ssl,
             connect_timeout,
             max_custom_queries,
+            min_collection_interval
         )
 
     def _set_qcache_stats(self):


### PR DESCRIPTION
* add sampling strategy like postgres for events_statements_history or events_statements_current.
* add similar internal metrics like we have for postgres

Logs if try to set an invalid table:

```
(execution_plans.py:215) | invalid events_statements_table fake. must be one of events_statements_history_long, events_statements_history, events_statements_current
(execution_plans.py:190) | failed to enable performance_schema consumer events_statements_history_long: (1290, 'The MySQL server is running with the --read-only option so it cannot execute this statement')
(execution_plans.py:261) | found plan collection strategy. chosen_table=events_statements_history, time_limit=14, rate_limit=1
```
