### PR TITLE
Send latency metrics node_name as tag instead of hostname

### DIFF
--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -471,9 +471,9 @@ class ConsulCheck(AgentCheck):
                         median = latencies[half_n]
                     else:
                         median = (latencies[half_n - 1] + latencies[half_n]) / 2
-                    self.gauge('consul.net.dc.latency.min', latencies[0], hostname='', tags=tags)
-                    self.gauge('consul.net.dc.latency.median', median, hostname='', tags=tags)
-                    self.gauge('consul.net.dc.latency.max', latencies[-1], hostname='', tags=tags)
+                    self.gauge('consul.net.dc.latency.min', latencies[0], tags=tags)
+                    self.gauge('consul.net.dc.latency.median', median, tags=tags)
+                    self.gauge('consul.net.dc.latency.max', latencies[-1], tags=tags)
 
                 # We've found ourselves, we can move on
                 break
@@ -498,24 +498,15 @@ class ConsulCheck(AgentCheck):
                     median = latencies[half_n]
                 else:
                     median = (latencies[half_n - 1] + latencies[half_n]) / 2
-                self.gauge('consul.net.node.latency.min', latencies[0], hostname=node_name, tags=main_tags)
-                self.gauge(
-                    'consul.net.node.latency.p25', latencies[ceili(n * 0.25) - 1], hostname=node_name, tags=main_tags
-                )
-                self.gauge('consul.net.node.latency.median', median, hostname=node_name, tags=main_tags)
-                self.gauge(
-                    'consul.net.node.latency.p75', latencies[ceili(n * 0.75) - 1], hostname=node_name, tags=main_tags
-                )
-                self.gauge(
-                    'consul.net.node.latency.p90', latencies[ceili(n * 0.90) - 1], hostname=node_name, tags=main_tags
-                )
-                self.gauge(
-                    'consul.net.node.latency.p95', latencies[ceili(n * 0.95) - 1], hostname=node_name, tags=main_tags
-                )
-                self.gauge(
-                    'consul.net.node.latency.p99', latencies[ceili(n * 0.99) - 1], hostname=node_name, tags=main_tags
-                )
-                self.gauge('consul.net.node.latency.max', latencies[-1], hostname=node_name, tags=main_tags)
+                tags = main_tags + ['node_name:{}'.format(node_name)]
+                self.gauge('consul.net.node.latency.min', latencies[0], tags=tags)
+                self.gauge('consul.net.node.latency.p25', latencies[ceili(n * 0.25) - 1], tags=tags)
+                self.gauge('consul.net.node.latency.median', median, tags=tags)
+                self.gauge('consul.net.node.latency.p75', latencies[ceili(n * 0.75) - 1], tags=tags)
+                self.gauge('consul.net.node.latency.p90', latencies[ceili(n * 0.90) - 1], tags=tags)
+                self.gauge('consul.net.node.latency.p95', latencies[ceili(n * 0.95) - 1], tags=tags)
+                self.gauge('consul.net.node.latency.p99', latencies[ceili(n * 0.99) - 1], tags=tags)
+                self.gauge('consul.net.node.latency.max', latencies[-1], tags=tags)
 
     def _get_all_nodes(self):
         return self.consul_request('v1/catalog/nodes')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
For consideration…

For latency metrics, send the `node_name` as a `node_name` tag, instead of using it to set the metric `hostname`.

### Motivation
<!-- What inspired you to submit this pull request? -->
- Prevent duplicate hosts, for example in case the Agent-detected hostname is different from the `node_name`.
- Prevent ghost hosts, i.e. hosts where an Agent is not installed (but that would previously show up in the host map because of these metrics).

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Alternative to https://github.com/DataDog/integrations-core/pull/7235, prompted by https://github.com/DataDog/integrations-core/pull/7235#pullrequestreview-459115227:

> I believe we could improve the consul check by simply stop trying to match the hostname of remote hosts in order to prevent duplicates. We could attach the remote node name as a new tag like node_name instead of using it as the host name. WDYT?

### Testing

Right now the consul tests setup cannot pick up latency metrics. I've debugged locally and it looks like the nodes take a while (~2min) to show up in the `/v1/coordinate/nodes` we use to collect these metrics. Once all 3 nodes are showing up, the ACL test is failing (no 403 response error), and I don't understand why/ There are strange logs in the leader and follower nodes, such as below, which might indicate there's something up with how ACLs are configured in our setup.

```console
$ docker logs -f consul-follower-1
    ...
    2020/08/04 13:27:16 [INFO] consul: New leader elected: consul-leader
    2020/08/04 13:27:16 [DEBUG] serf: messageUserEventType: consul:new-leader
    2020/08/04 13:27:16 [DEBUG] serf: messageUserEventType: consul:new-leader
    2020/08/04 13:27:17 [WARN] agent: Coordinate update blocked by ACLs
    2020/08/04 13:27:19 [WARN] agent: Node info update blocked by ACLs
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
