### PR TITLE
Fix ssh check on master

### DIFF
--- a/ssh_check/tox.ini
+++ b/ssh_check/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{8.1-latest}
+    py{27,38}-{8.1,latest}
 
 [testenv]
 ensure_default_envdir = true


### PR DESCRIPTION
The tox envs for ssh check was invalid. `8.1-latest` was a single env that was pulling the `latest` docker image.