### PR TITLE
Add validation for recommended monitors

### DIFF
--- a/.azure-pipelines/templates/run-validations.yml
+++ b/.azure-pipelines/templates/run-validations.yml
@@ -33,6 +33,9 @@ steps:
 - script: ddev validate readmes
   displayName: 'Validate README files'
 
+- script: ddev validate recommended-monitors
+  displayName: 'Validate monitors files'
+
 - script: ddev validate saved-views
   displayName: 'Validate saved views data'
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
@@ -15,6 +15,7 @@ from .imports import imports
 from .manifest import manifest
 from .metadata import metadata
 from .readmes import readmes
+from .recommended_monitors import recommended_monitors
 from .saved_views import saved_views
 from .service_checks import service_checks
 
@@ -30,6 +31,7 @@ ALL_COMMANDS = (
     manifest,
     metadata,
     readmes,
+    recommended_monitors,
     saved_views,
     service_checks,
 )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -79,16 +79,16 @@ def recommended_monitors():
                     file_failed = True
                     display_queue.append((echo_failure, f"    {monitor_file} name contain the integration name"),)
 
-            if file_failed:
-                failed_checks += 1
-                # Display detailed info if file is invalid
-                echo_info(f'{check_name}... ', nl=False)
-                echo_failure(' FAILED')
-                for display_func, message in display_queue:
-                    display_func(message)
-                display_queue = []
-            else:
-                ok_checks += 1
+        if file_failed:
+            failed_checks += 1
+            # Display detailed info if file is invalid
+            echo_info(f'{check_name}... ', nl=False)
+            echo_failure(' FAILED')
+            for display_func, message in display_queue:
+                display_func(message)
+            display_queue = []
+        else:
+            ok_checks += 1
 
     if ok_checks:
         echo_success(f"{ok_checks} valid files")

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -60,8 +60,9 @@ def recommended_monitors():
                 )
             else:
                 # If all required keys exist, validate values
-                if decoded.get('recommended_monitor_metadata').get('description') is not None:
-                    if len(decoded.get('recommended_monitor_metadata').get('description')) > 300:
+                description = decoded.get('recommended_monitor_metadata').get('description')
+                if description is not None:
+                    if len(description) > 300:
                         file_failed = True
                         display_queue.append(
                             (
@@ -75,7 +76,9 @@ def recommended_monitors():
                     file_failed = True
                     display_queue.append((echo_failure, f"    {monitor_file} must have an `integration` tag"),)
 
-                if check_name not in decoded.get('name').lower():
+                display_name = manifest.get("display_name").lower()
+                monitor_name = decoded.get('name').lower()
+                if not (check_name in monitor_name or display_name in monitor_name):
                     file_failed = True
                     display_queue.append((echo_failure, f"    {monitor_file} name must contain the integration name"),)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -58,14 +58,27 @@ def recommended_monitors():
                     (echo_failure, f"    {monitor_file} does not contain the required fields: {missing_fields}"),
                 )
             else:
-                if decoded.get(decoded.get('recommended_monitor_metadata').get('description')) is not None:
-                    if len(decoded.get(decoded.get('recommended_monitor_metadata').get('description'))) < 300:
+                ## If all required keys exist, validate values
+                if decoded.get('recommended_monitor_metadata').get('description') is not None:
+                    if len(decoded.get('recommended_monitor_metadata').get('description')) > 300:
                         file_failed = True
                         display_queue.append(
                             (echo_failure, f"    {monitor_file} has a description field that is too long, must be <300 chars"),
                         )
 
-                # if decoded.get('tags'):
+                result = [i for i in decoded.get('tags') if i.startswith('integration:')]
+                if len(result) < 1:
+                    file_failed = True
+                    display_queue.append(
+                        (echo_failure,
+                         f"    {monitor_file} must have an integration tag"),
+                    )
+                if check_name not in decoded.get('name').lower():
+                    display_queue.append(
+                        (echo_failure,
+                         f"    {monitor_file} name contain the integration name"),
+                    )
+
 
             if file_failed:
                 failed_checks += 1
@@ -74,6 +87,7 @@ def recommended_monitors():
                 echo_failure(' FAILED')
                 for display_func, message in display_queue:
                     display_func(message)
+                display_queue = []
             else:
                 ok_checks += 1
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -14,9 +14,6 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
 
 REQUIRED_ATTRIBUTES = {'name', 'type', 'query', 'message', 'tags', 'options', 'recommended_monitor_metadata'}
 
-## Questions
-## 1 monitor per file
-
 
 @click.command('recommended-monitors', context_settings=CONTEXT_SETTINGS, short_help='Validate recommended monitor definition JSON files')
 def recommended_monitors():
@@ -73,12 +70,12 @@ def recommended_monitors():
                         (echo_failure,
                          f"    {monitor_file} must have an integration tag"),
                     )
+
                 if check_name not in decoded.get('name').lower():
                     display_queue.append(
                         (echo_failure,
                          f"    {monitor_file} name contain the integration name"),
                     )
-
 
             if file_failed:
                 failed_checks += 1

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -1,0 +1,28 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import json
+import os
+
+import click
+
+from ....utils import file_exists, read_file, write_file
+from ...constants import get_root
+from ...utils import get_valid_integrations, load_manifest, parse_version_parts
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
+
+REQUIRED_ATTRIBUTES = {'name', 'type', 'query', 'message', 'tags', 'options', 'recommended_monitor_metadata'}
+
+## Questions
+## 1 monitor per file
+## File must be mentioned in manifest.json
+
+
+@click.command('recommended-monitors', context_settings=CONTEXT_SETTINGS, short_help='Validate recommended monitor files')
+def recommended_monitors():
+    """Validate all `service_checks.json` files."""
+    root = get_root()
+    echo_info("Validating all service_checks.json files...")
+    failed_checks = 0
+    ok_checks = 0

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -57,6 +57,15 @@ def recommended_monitors():
                 display_queue.append(
                     (echo_failure, f"    {monitor_file} does not contain the required fields: {missing_fields}"),
                 )
+            else:
+                if decoded.get(decoded.get('recommended_monitor_metadata').get('description')) is not None:
+                    if len(decoded.get(decoded.get('recommended_monitor_metadata').get('description'))) < 300:
+                        file_failed = True
+                        display_queue.append(
+                            (echo_failure, f"    {monitor_file} has a description field that is too long, must be <300 chars"),
+                        )
+
+                # if decoded.get('tags'):
 
             if file_failed:
                 failed_checks += 1

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -15,7 +15,11 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
 REQUIRED_ATTRIBUTES = {'name', 'type', 'query', 'message', 'tags', 'options', 'recommended_monitor_metadata'}
 
 
-@click.command('recommended-monitors', context_settings=CONTEXT_SETTINGS, short_help='Validate recommended monitor definition JSON files')
+@click.command(
+    'recommended-monitors',
+    context_settings=CONTEXT_SETTINGS,
+    short_help='Validate recommended monitor definition JSON files',
+)
 def recommended_monitors():
     """Validate all recommended monitors definition files."""
     root = get_root()
@@ -55,27 +59,24 @@ def recommended_monitors():
                     (echo_failure, f"    {monitor_file} does not contain the required fields: {missing_fields}"),
                 )
             else:
-                ## If all required keys exist, validate values
+                # If all required keys exist, validate values
                 if decoded.get('recommended_monitor_metadata').get('description') is not None:
                     if len(decoded.get('recommended_monitor_metadata').get('description')) > 300:
                         file_failed = True
                         display_queue.append(
-                            (echo_failure, f"    {monitor_file} has a description field that is too long, must be <300 chars"),
+                            (
+                                echo_failure,
+                                f"    {monitor_file} has a description field that is too long, must be <300 chars",
+                            ),
                         )
 
                 result = [i for i in decoded.get('tags') if i.startswith('integration:')]
                 if len(result) < 1:
                     file_failed = True
-                    display_queue.append(
-                        (echo_failure,
-                         f"    {monitor_file} must have an integration tag"),
-                    )
+                    display_queue.append((echo_failure, f"    {monitor_file} must have an integration tag"),)
 
                 if check_name not in decoded.get('name').lower():
-                    display_queue.append(
-                        (echo_failure,
-                         f"    {monitor_file} name contain the integration name"),
-                    )
+                    display_queue.append((echo_failure, f"    {monitor_file} name contain the integration name"),)
 
             if file_failed:
                 failed_checks += 1

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -76,6 +76,7 @@ def recommended_monitors():
                     display_queue.append((echo_failure, f"    {monitor_file} must have an integration tag"),)
 
                 if check_name not in decoded.get('name').lower():
+                    file_failed = True
                     display_queue.append((echo_failure, f"    {monitor_file} name contain the integration name"),)
 
             if file_failed:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -73,11 +73,11 @@ def recommended_monitors():
                 result = [i for i in decoded.get('tags') if i.startswith('integration:')]
                 if len(result) < 1:
                     file_failed = True
-                    display_queue.append((echo_failure, f"    {monitor_file} must have an integration tag"),)
+                    display_queue.append((echo_failure, f"    {monitor_file} must have an `integration` tag"),)
 
                 if check_name not in decoded.get('name').lower():
                     file_failed = True
-                    display_queue.append((echo_failure, f"    {monitor_file} name contain the integration name"),)
+                    display_queue.append((echo_failure, f"    {monitor_file} name must contain the integration name"),)
 
         if file_failed:
             failed_checks += 1

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -7,22 +7,69 @@ import os
 
 import click
 
-from ....utils import file_exists, read_file, write_file
+from ....utils import file_exists, read_file
 from ...constants import get_root
-from ...utils import get_valid_integrations, load_manifest, parse_version_parts
+from ...utils import get_valid_integrations, load_manifest
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
 
 REQUIRED_ATTRIBUTES = {'name', 'type', 'query', 'message', 'tags', 'options', 'recommended_monitor_metadata'}
 
 ## Questions
 ## 1 monitor per file
-## File must be mentioned in manifest.json
 
 
-@click.command('recommended-monitors', context_settings=CONTEXT_SETTINGS, short_help='Validate recommended monitor files')
+@click.command('recommended-monitors', context_settings=CONTEXT_SETTINGS, short_help='Validate recommended monitor definition JSON files')
 def recommended_monitors():
-    """Validate all `service_checks.json` files."""
+    """Validate all recommended monitors definition files."""
     root = get_root()
-    echo_info("Validating all service_checks.json files...")
+    echo_info("Validating all recommended monitors...")
     failed_checks = 0
     ok_checks = 0
+
+    for check_name in sorted(get_valid_integrations()):
+        display_queue = []
+        file_failed = False
+        manifest = load_manifest(check_name)
+        monitors_relative_locations = manifest.get('assets', {}).get('monitors', {}).values()
+        for monitor_relative_location in monitors_relative_locations:
+
+            monitor_file = os.path.join(root, check_name, *monitor_relative_location.split('/'))
+            if not file_exists(monitor_file):
+                echo_info(f'{check_name}... ', nl=False)
+                echo_info(' FAILED')
+                echo_failure(f'  {monitor_file} does not exist')
+                failed_checks += 1
+                continue
+
+            try:
+                decoded = json.loads(read_file(monitor_file).strip())
+            except json.JSONDecodeError as e:
+                failed_checks += 1
+                echo_info(f'{check_name}... ', nl=False)
+                echo_failure(' FAILED')
+                echo_failure(f'  invalid json: {e}')
+                continue
+
+            all_keys = set(decoded.keys())
+            if not REQUIRED_ATTRIBUTES.issubset(all_keys):
+                missing_fields = REQUIRED_ATTRIBUTES.difference(all_keys)
+                file_failed = True
+                display_queue.append(
+                    (echo_failure, f"    {monitor_file} does not contain the required fields: {missing_fields}"),
+                )
+
+            if file_failed:
+                failed_checks += 1
+                # Display detailed info if file is invalid
+                echo_info(f'{check_name}... ', nl=False)
+                echo_failure(' FAILED')
+                for display_func, message in display_queue:
+                    display_func(message)
+            else:
+                ok_checks += 1
+
+    if ok_checks:
+        echo_success(f"{ok_checks} valid files")
+    if failed_checks:
+        echo_failure(f"{failed_checks} invalid files")
+        abort()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -28,7 +28,12 @@ def recommended_monitors():
         display_queue = []
         file_failed = False
         manifest = load_manifest(check_name)
-        monitors_relative_locations = get_assets_from_manifest(check_name, 'monitors')
+        monitors_relative_locations, invalid_files = get_assets_from_manifest(check_name, 'monitors')
+        for file in invalid_files:
+                echo_info(f'{check_name}... ', nl=False)
+                echo_info(' FAILED')
+                echo_failure(f'  {file} does not exist')
+                failed_checks += 1
 
         for monitor_file in monitors_relative_locations:
             try:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -30,10 +30,10 @@ def recommended_monitors():
         manifest = load_manifest(check_name)
         monitors_relative_locations, invalid_files = get_assets_from_manifest(check_name, 'monitors')
         for file in invalid_files:
-                echo_info(f'{check_name}... ', nl=False)
-                echo_info(' FAILED')
-                echo_failure(f'  {file} does not exist')
-                failed_checks += 1
+            echo_info(f'{check_name}... ', nl=False)
+            echo_info(' FAILED')
+            echo_failure(f'  {file} does not exist')
+            failed_checks += 1
 
         for monitor_file in monitors_relative_locations:
             try:


### PR DESCRIPTION
### What does this PR do?
Validates the expected keys in the monitors payload.

Warns if:
- integration tag is missing
- description is too long
- name does not contain integration name

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
