### PR TITLE
Add minimum length to required strings in manifest validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -30,14 +30,18 @@ def get_manifest_schema():
             "description": "Defines the various components of an integration",
             "type": "object",
             "properties": {
-                "display_name": {"description": "The human readable name of this integration", "type": "string"},
+                "display_name": {
+                    "description": "The human readable name of this integration",
+                    "type": "string",
+                    "minLength": 1,
+                },
                 "maintainer": {
                     "description": "The email address for the maintainer of this integration",
                     "type": "string",
                     "format": "email",
                 },
                 "manifest_version": {"description": "The schema version of this manifest", "type": "string"},
-                "name": {"description": "The name of this integration", "type": "string"},
+                "name": {"description": "The name of this integration", "type": "string", "minLength": 1},
                 "metric_prefix": {
                     "description": "The prefix for metrics being emitted from this integration",
                     "type": "string",
@@ -50,9 +54,10 @@ def get_manifest_schema():
                 "short_description": {
                     "description": "Brief description of this integration",
                     "type": "string",
+                    "minLength": 1,
                     "maxLength": 80,
                 },
-                "guid": {"description": "A GUID for this integration", "type": "string"},
+                "guid": {"description": "A GUID for this integration", "type": "string", "minLength": 1},
                 "support": {
                     "description": "The support type for this integration, one of `core`, `contrib`, or `partner`",
                     "type": "string",
@@ -63,7 +68,11 @@ def get_manifest_schema():
                     "type": "array",
                     "items": {"type": "string", "enum": ["linux", "mac_os", "windows"]},
                 },
-                "public_title": {"description": "A human readable public title of this integration", "type": "string"},
+                "public_title": {
+                    "description": "A human readable public title of this integration",
+                    "type": "string",
+                    "minLength": 1,
+                },
                 "categories": {
                     "description": "The categories of this integration",
                     "type": "array",
@@ -204,6 +213,7 @@ def get_manifest_schema():
                                         "description": "Email of the partner company to use for subscription purposes",
                                         "type": "string",
                                         "format": "email",
+                                        "minLength": 1,
                                     },
                                 },
                                 "required": ["eula", "legal_email"],


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds `minLength: 1` to the fields in the manifest jsonschema that are string and required. Required means they must exist, but allows the strings to be empty. For our purposes, required and nonempty are the same. 

JSONSchema ref: https://json-schema.org/understanding-json-schema/reference/string.html#id5

### Additional Notes
Another approach here would be to create a definition that is `string` and `minLength: 1` and use this as a ref, however we then wouldn't be able to use different patterns for each string where needed. So instead I added this field to each required string individually. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
