### PR TITLE
Fix mysql metric for innodb row lock time

### DIFF
--- a/mysql/datadog_checks/mysql/innodb_metrics.py
+++ b/mysql/datadog_checks/mysql/innodb_metrics.py
@@ -126,9 +126,6 @@ class InnoDBMetrics(object):
                 results['Innodb_current_transactions'] += 1
                 if line.find('ACTIVE') > 0:
                     results['Innodb_active_transactions'] += 1
-            elif txn_seen and line.find('------- TRX HAS BEEN') == 0:
-                # ------- TRX HAS BEEN WAITING 32 SEC FOR THIS LOCK TO BE GRANTED:
-                results['Innodb_row_lock_time'] += long(row[5]) * 1000
             elif line.find('read views open inside InnoDB') > 0:
                 # 1 read views open inside InnoDB
                 results['Innodb_read_views'] = long(row[0])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Previously, the code retrieved the internal innodb metric returned by
`SHOW STATUS` first, and then tried to add the row lock time from any
in-flight query on top of it, based on `SHOW ENGINE INNODB STATUS`.

The intention was probably to make the metric more accurate, because
the internal innodb metric for row lock time will only be incremented
once a query has completed (either successfully or after exceeding
`innodb_lock_wait_timeout`).

However, the addition actually didn't work, because we are just merging
2 python dictionaries. So, we would end up with either the accumulating
counter value from `SHOW STATUS` when there is no in-flight query
waiting for row lock, or the manually calculated value from parsing
`SHOW ENGINE INNODB STATUS` otherwise. Flipping between these 2 values,
the rate calculated by datadog agent would be useless and confusing.

This is fixed by returning the internal innodb metric as-is. Trying to
add the row lock time from in-flight queries would introduce complexity
without adding much benefit, as the default `innodb_lock_wait_timeout`
is only 50 seconds anyway.

### Motivation
<!-- What inspired you to submit this pull request? -->
The wrong metric made the graph looks confusing, and also prevented us from setting the alert threshold.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
