### PR TITLE
Fix gunicorn tests

### DIFF
--- a/gunicorn/tests/conftest.py
+++ b/gunicorn/tests/conftest.py
@@ -46,11 +46,12 @@ def setup_gunicorn(request):
         proc = start_gunicorn(gunicorn_bin_path, conf_file)
 
         def fin():
-            proc.terminate()
+            proc.kill()
+            time.sleep(5)
 
         request.addfinalizer(fin)
 
-        time.sleep(15)
+        time.sleep(5)
 
         yield {'gunicorn_bin_path': gunicorn_bin_path}
 


### PR DESCRIPTION
Sandbox here with 20 runs: https://github.com/DataDog/integrations-core/pull/7288

Unsure why tests started to fail in Azure (new VM maybe?), but the gunicorn process was not cleaned correctly and the port was still in use.