### PR TITLE
Fix flaky test

### DIFF
--- a/datadog_checks_base/tests/test_db.py
+++ b/datadog_checks_base/tests/test_db.py
@@ -1501,7 +1501,7 @@ class TestColumnTransformers:
         assert len(aggregator._metrics['test.foo']) == 1
         m = aggregator._metrics['test.foo'][0]
 
-        assert 3599 < m.value < 3601
+        assert abs(m.value - 3600) < 2
         assert m.type == aggregator.GAUGE
         assert m.tags == ['test:foo', 'test:bar', 'test:tag1']
 


### PR DESCRIPTION
Sometimes azure is slower than usual and that timing test was flaky. 

Example: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=21244&view=logs&j=762a2123-1c7c-5bf0-0e62-04885c3ecd74

```
tests/test_db.py:1504: in test_time_elapsed_format
    assert 3599 < m.value < 3601
E   AssertionError: assert 3601.000489 < 3601
E    +  where 3601.000489 = MetricStub(name='test.foo', type=0, value=3601.000489, tags=['test:foo', 'test:bar', 'test:tag1'], hostname='', device=None).value
```