### PR TITLE
capitalise name of check in tutorial's spec.yaml

### DIFF
--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -284,7 +284,7 @@ For this example, those files would have the following form:
 The `awesome/assets/configuration/spec.yaml` used to generate `awesome/datadog_checks/awesome/data/conf.yaml.example`:
 
 ```yaml
-name: awesome
+name: Awesome
 files:
 - name: awesome.yaml
   options:


### PR DESCRIPTION
### What does this PR do?
Capitalises the name of the check in the tutorial's `spec.yaml`.

### Motivation
Dash 2020 workshop.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] ~~Feature or bugfix MUST have appropriate tests (unit, integration, e2e)~~
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
