### PR TITLE
Add tag for Scylla monitor query

### DIFF
--- a/scylla/assets/monitors/instance_down.json
+++ b/scylla/assets/monitors/instance_down.json
@@ -1,7 +1,7 @@
 {
 	"name": "[Scylla] Server is shutting down",
 	"type": "metric alert",
-	"query": "avg(last_1m):max:scylla.node.operation_mode{*} > 3",
+	"query": "avg(last_1m):max:scylla.node.operation_mode{*} by {server} > 3",
 	"message": "{{server.name}} is shutting down. Current value of {{value}} \n\nThe operation mode of the current nodes can have values of UNKNOWN = 0; STARTING = 1; JOINING = 2; NORMAL = 3; LEAVING = 4; DECOMMISSIONED = 5; DRAINING = 6; DRAINED = 7; MOVING = 8",
 	"tags": [
 		"integration:scylla"


### PR DESCRIPTION
### What does this PR do?
Adds the "server" tag scope for the monitor query