### PR TITLE
Enable histogram for pytest-benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ wheelhouse/
 # By default, ignore in-toto metadata from the command line:
 .in-toto/
 *.link
+
+# Benchmark histograms
+benchmark_*.svg

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -28,7 +28,7 @@ REQUIRES = [
     'psutil',
     'PyYAML>=5.3',
     'pytest',
-    'pytest-benchmark>=3.2.1',
+    'pytest-benchmark[histogram]>=3.2.1',
     'pytest-cov>=2.6.1',
     'pytest-mock',
     'requests>=2.22.0',


### PR DESCRIPTION
### What does this PR do?

Enable histogram for pytest-benchmark

### Motivation

Histograms are easier to read/understand and share with teams.

Example:

![image](https://user-images.githubusercontent.com/49917914/87221125-fb1a2b00-c369-11ea-87bc-31737c8fb6f6.png)

From this data:

```
------------------------------------------------------------------------------------- benchmark: 5 tests -------------------------------------------------------------------------------------
Name (time in ms)             Min                 Max                Mean             StdDev              Median                 IQR            Outliers     OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_profile_f5[128]     275.4361 (1.0)      347.8396 (1.05)     313.8686 (1.03)     25.6864 (2.48)     315.7393 (1.03)      19.2686 (2.13)          2;1  3.1860 (0.97)          5           1
test_profile_f5[256]     286.0071 (1.04)     331.2724 (1.0)      305.8882 (1.0)      17.5271 (1.69)     305.7626 (1.0)       25.3360 (2.80)          2;0  3.2692 (1.0)           5           1
test_profile_f5[64]      287.8199 (1.04)     528.3658 (1.59)     373.7749 (1.22)     95.1384 (9.19)     373.7813 (1.22)     113.8305 (12.58)         1;0  2.6754 (0.82)          5           1
test_profile_f5[32]      327.1754 (1.19)     352.2649 (1.06)     334.0993 (1.09)     10.3484 (1.0)      331.3403 (1.08)       9.0451 (1.0)           1;1  2.9931 (0.92)          5           1
test_profile_f5[10]      459.6404 (1.67)     579.4572 (1.75)     510.8282 (1.67)     52.3034 (5.05)     501.2674 (1.64)      92.6139 (10.24)         1;0  1.9576 (0.60)          5           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```


### Usage

Add `--benchmark-histogram` to pytest options in bench section in the integration's `tox.ini`.

```
 [testenv:bench]
 commands =
     pip install -r requirements.in
     pytest -v {posargs} --benchmark-histogram
```
