### PR TITLE
Add benchmark-histogram option

### DIFF
--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -37,4 +37,4 @@ commands =
 [testenv:bench]
 commands =
     pip install -r requirements.in
-    pytest -v {posargs}
+    pytest -v {posargs} --benchmark-histogram

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -37,4 +37,4 @@ commands =
 [testenv:bench]
 commands =
     pip install -r requirements.in
-    pytest -v {posargs} --benchmark-histogram
+    pytest -v {posargs} --benchmark-only --benchmark-histogram --benchmark-cprofile=tottime


### PR DESCRIPTION
### What does this PR do?

Add benchmark-histogram option to SNMP bench.

Usage:

```
ddev test --bench snmp -k test_oids_cache_bench
```

Output:

```
tests/test_bench.py::test_oids_cache_bench[0-10] PASSED                                                                                                                                                                                                                                                                                                              [ 25%]
tests/test_bench.py::test_oids_cache_bench[0-256] PASSED                                                                                                                                                                                                                                                                                                             [ 50%]
tests/test_bench.py::test_oids_cache_bench[3600-10] PASSED                                                                                                                                                                                                                                                                                                           [ 75%]
tests/test_bench.py::test_oids_cache_bench[3600-256] PASSED                                                                                                                                                                                                                                                                                                          [100%]


--------------------------------------------------------------------------------------------------------- benchmark: 4 tests --------------------------------------------------------------------------------------------------------
Name (time in ms)                                               Min                   Max                  Mean             StdDev                Median                IQR            Outliers     OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
tests/test_bench.py::test_oids_cache_bench[3600-256]       268.0524 (1.0)        298.4373 (1.0)        280.0445 (1.0)      11.9965 (1.0)        281.0498 (1.0)      16.1554 (1.0)           1;0  3.5709 (1.0)           5           1
tests/test_bench.py::test_oids_cache_bench[3600-10]        476.4124 (1.78)       519.4286 (1.74)       490.2312 (1.75)     17.3872 (1.45)       487.5145 (1.73)     20.1383 (1.25)          1;0  2.0399 (0.57)          5           1
tests/test_bench.py::test_oids_cache_bench[0-256]          698.7286 (2.61)       798.6502 (2.68)       750.2096 (2.68)     38.2811 (3.19)       758.0433 (2.70)     54.8324 (3.39)          2;0  1.3330 (0.37)          5           1
tests/test_bench.py::test_oids_cache_bench[0-10]         1,036.9643 (3.87)     1,077.3360 (3.61)     1,055.6761 (3.77)     17.9013 (1.49)     1,055.4873 (3.76)     32.8096 (2.03)          2;0  0.9473 (0.27)          5           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Generated histogram: .../integrations-core/snmp/benchmark_20200806_095838.svg
```

Open `.../integrations-core/snmp/benchmark_20200806_095838.svg` in your browser.

You will see:

![image](https://user-images.githubusercontent.com/49917914/89519880-5a3e5480-d7dd-11ea-8e39-864ae84c7ac4.png)


### Motivation

Histograms are easier to read.

