### PR TITLE
Add note about running multiple JMX checks

### DIFF
--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -4,6 +4,9 @@ init_config:
 
     ## @param is_jmx - boolean - required
     ## Whether or not this file is a configuration for a JMX integration.
+    ##
+    ## NOTE: To run more than one JMX check, create configuration files with the format jmx_<INDEX>.d/conf.yaml. Each
+    ## folder should be stored in the conf.d directory. Include this option set to true in each configuration file.
     #
     is_jmx: true
 

--- a/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+++ b/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
@@ -4,6 +4,9 @@ init_config:
 
     ## @param is_jmx - boolean - required
     ## Whether or not this file is a configuration for a JMX integration.
+    ##
+    ## NOTE: To run more than one JMX check, create configuration files with the format jmx_<INDEX>.d/conf.yaml. Each
+    ## folder should be stored in the conf.d directory. Include this option set to true in each configuration file.
     #
     is_jmx: true
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
@@ -1,6 +1,10 @@
 - name: is_jmx
   required: true
-  description: Whether or not this file is a configuration for a JMX integration.
+  description: |
+    Whether or not this file is a configuration for a JMX integration.
+
+    NOTE: To run more than one JMX check, create configuration files with the format jmx_<INDEX>.d/conf.yaml. Each
+    folder should be stored in the conf.d directory. Include this option set to true in each configuration file.
   value:
     example: true
     type: boolean

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -4,6 +4,9 @@ init_config:
 
     ## @param is_jmx - boolean - required
     ## Whether or not this file is a configuration for a JMX integration.
+    ##
+    ## NOTE: To run more than one JMX check, create configuration files with the format jmx_<INDEX>.d/conf.yaml. Each
+    ## folder should be stored in the conf.d directory. Include this option set to true in each configuration file.
     #
     is_jmx: false
 

--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -4,6 +4,9 @@ init_config:
 
     ## @param is_jmx - boolean - required
     ## Whether or not this file is a configuration for a JMX integration.
+    ##
+    ## NOTE: To run more than one JMX check, create configuration files with the format jmx_<INDEX>.d/conf.yaml. Each
+    ## folder should be stored in the conf.d directory. Include this option set to true in each configuration file.
     #
     is_jmx: true
 

--- a/hivemq/datadog_checks/hivemq/data/conf.yaml.example
+++ b/hivemq/datadog_checks/hivemq/data/conf.yaml.example
@@ -4,6 +4,9 @@ init_config:
 
     ## @param is_jmx - boolean - required
     ## Whether or not this file is a configuration for a JMX integration.
+    ##
+    ## NOTE: To run more than one JMX check, create configuration files with the format jmx_<INDEX>.d/conf.yaml. Each
+    ## folder should be stored in the conf.d directory. Include this option set to true in each configuration file.
     #
     is_jmx: true
 

--- a/ignite/datadog_checks/ignite/data/conf.yaml.example
+++ b/ignite/datadog_checks/ignite/data/conf.yaml.example
@@ -4,6 +4,9 @@ init_config:
 
     ## @param is_jmx - boolean - required
     ## Whether or not this file is a configuration for a JMX integration.
+    ##
+    ## NOTE: To run more than one JMX check, create configuration files with the format jmx_<INDEX>.d/conf.yaml. Each
+    ## folder should be stored in the conf.d directory. Include this option set to true in each configuration file.
     #
     is_jmx: true
 

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -4,6 +4,9 @@ init_config:
 
     ## @param is_jmx - boolean - required
     ## Whether or not this file is a configuration for a JMX integration.
+    ##
+    ## NOTE: To run more than one JMX check, create configuration files with the format jmx_<INDEX>.d/conf.yaml. Each
+    ## folder should be stored in the conf.d directory. Include this option set to true in each configuration file.
     #
     is_jmx: true
 

--- a/solr/datadog_checks/solr/data/conf.yaml.example
+++ b/solr/datadog_checks/solr/data/conf.yaml.example
@@ -4,6 +4,9 @@ init_config:
 
     ## @param is_jmx - boolean - required
     ## Whether or not this file is a configuration for a JMX integration.
+    ##
+    ## NOTE: To run more than one JMX check, create configuration files with the format jmx_<INDEX>.d/conf.yaml. Each
+    ## folder should be stored in the conf.d directory. Include this option set to true in each configuration file.
     #
     is_jmx: true
 

--- a/tomcat/datadog_checks/tomcat/data/conf.yaml.example
+++ b/tomcat/datadog_checks/tomcat/data/conf.yaml.example
@@ -4,6 +4,9 @@ init_config:
 
     ## @param is_jmx - boolean - required
     ## Whether or not this file is a configuration for a JMX integration.
+    ##
+    ## NOTE: To run more than one JMX check, create configuration files with the format jmx_<INDEX>.d/conf.yaml. Each
+    ## folder should be stored in the conf.d directory. Include this option set to true in each configuration file.
     #
     is_jmx: true
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Copy the `NOTE` from the [JMX: Configuration](https://docs.datadoghq.com/integrations/java/?tab=host#configuration docs about how JMX checks should be configured to run multiple "instances".

### Motivation
<!-- What inspired you to submit this pull request? -->
_It seems_ JMX-based checks don't support multiple `instances`, but instead should be configured with one folder with a single-instance `conf.yaml` each.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Things I'm not quite sure about yet:

- Does this actually apply to all JMX-based checks (eg Confluent Platform, HiveMQ…), or is this specific to the JMX integration (`java` in dogweb)?
- Will `confluent_platform_1.d` and `confluent_platform_2.d` (as suggested in the note) work as expected? Or should users use `confluent_platform.d/conf_1.yaml`, `confluent_platform/conf_2.yaml`, etc?

Need to confirm these points with local testing, which is why I'm marking this as draft for the moment.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
