### PR TITLE
[BENCHMARK] Leverage pysnmp concurrent queries 

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -92,6 +92,7 @@ class InstanceConfig:
             self.metrics.extend(global_metrics)
 
         self.enforce_constraints = is_affirmative(instance.get('enforce_mib_constraints', True))
+        self.use_async = is_affirmative(instance.get('use_async', False))
         self._snmp_engine = loader.create_snmp_engine(mibs_path)
         mib_view_controller = loader.get_mib_view_controller(mibs_path)
         self._resolver = OIDResolver(mib_view_controller, self.enforce_constraints)

--- a/snmp/tests/test_bench.py
+++ b/snmp/tests/test_bench.py
@@ -53,11 +53,33 @@ def test_profile_f5_with_oids_cache(oid_batch_size, benchmark):
     benchmark.pedantic(check.check, args=(instance,), iterations=1, rounds=5, warmup_rounds=1)
 
 
-@pytest.mark.parametrize('refresh_oids_cache_interval,oid_batch_size', [(0, 10), (0, 256), (3600, 10), (3600, 256)])
-def test_oids_cache_bench(refresh_oids_cache_interval, oid_batch_size, benchmark):
+@pytest.mark.parametrize('refresh_oids_cache_interval,oid_batch_size,use_async', [
+    (0, 10, False),
+    (0, 32, False),
+    (0, 64, False),
+    (0, 128, False),
+    (0, 256, False),
+    (3600, 10, False),
+    (3600, 32, False),
+    (3600, 64, False),
+    (3600, 128, False),
+    (3600, 256, False),
+    (0, 10, True),
+    (0, 32, True),
+    (0, 64, True),
+    (0, 128, True),
+    (0, 256, True),
+    (3600, 10, True),
+    (3600, 32, True),
+    (3600, 64, True),
+    (3600, 128, True),
+    (3600, 256, True),
+])
+def test_oids_cache_bench(refresh_oids_cache_interval, oid_batch_size, benchmark, use_async):
     instance = generate_instance_config([])
     instance['community_string'] = 'f5'
     instance['refresh_oids_cache_interval'] = refresh_oids_cache_interval
+    instance['use_async'] = use_async
     check = SnmpCheck('snmp', {'oid_batch_size': oid_batch_size}, [instance])
 
     benchmark.pedantic(check.check, args=(instance,), iterations=1, rounds=5, warmup_rounds=1)

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -37,4 +37,4 @@ commands =
 [testenv:bench]
 commands =
     pip install -r requirements.in
-    pytest -v {posargs}
+    pytest -v {posargs} --benchmark-only --benchmark-histogram --benchmark-cprofile=tottime


### PR DESCRIPTION
Benchmark for https://github.com/DataDog/integrations-core/pull/7309

Goal: measure how pysnmp concurrent queries for GET cmd affect performance.

Summary: 20-35% performance gain, when using OID caching.

The performance gain is much lower if OID caching is not used (see Benchmark without OID Caching section) since we don't make as much GET cmd calls.

## Benchmark details

In `test_oids_cache_bench[3600-32-True]`:
- the first number is oid cache interval (0 means disabled)
- the second number is the oid batch size
- the third bool is weather we use async or not (see PR code change)

![image](https://user-images.githubusercontent.com/49917914/89532182-abf0da00-d7f1-11ea-83a1-360f4534f10c.png)


```
------------------------------------------------------------------------------------------------- benchmark: 20 tests --------------------------------------------------------------------------------------------------
Name (time in ms)                                Min                   Max                  Mean              StdDev                Median                 IQR            Outliers     OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_oids_cache_bench[3600-32-True]         222.6887 (1.0)        288.7350 (1.0)        246.7952 (1.0)       24.8203 (3.63)       241.8361 (1.0)       20.8401 (3.52)          1;1  4.0519 (1.0)           5           1
test_oids_cache_bench[3600-64-True]         229.7761 (1.03)       293.4530 (1.02)       249.0688 (1.01)      26.0744 (3.81)       242.2191 (1.00)      29.5039 (4.98)          1;0  4.0150 (0.99)          5           1
test_oids_cache_bench[3600-128-False]       277.4040 (1.25)       314.4812 (1.09)       298.3497 (1.21)      15.2748 (2.23)       296.6352 (1.23)      24.6425 (4.16)          2;0  3.3518 (0.83)          5           1
test_oids_cache_bench[3600-128-True]        278.8495 (1.25)       344.9328 (1.19)       301.7672 (1.22)      26.1656 (3.82)       294.5363 (1.22)      32.0027 (5.40)          1;0  3.3138 (0.82)          5           1
test_oids_cache_bench[3600-256-False]       285.3083 (1.28)       332.8596 (1.15)       303.4753 (1.23)      17.8907 (2.61)       300.9528 (1.24)      18.8155 (3.17)          2;0  3.2952 (0.81)          5           1
test_oids_cache_bench[3600-64-False]        292.9542 (1.32)       310.0676 (1.07)       298.1352 (1.21)       6.8462 (1.0)        295.2290 (1.22)       5.9271 (1.0)           1;1  3.3542 (0.83)          5           1
test_oids_cache_bench[3600-10-True]         304.5259 (1.37)       363.2780 (1.26)       332.0368 (1.35)      23.5876 (3.45)       321.8904 (1.33)      35.0658 (5.92)          2;0  3.0117 (0.74)          5           1
test_oids_cache_bench[3600-256-True]        326.7760 (1.47)       395.7920 (1.37)       345.9479 (1.40)      28.2501 (4.13)       337.2952 (1.39)      22.3393 (3.77)          1;1  2.8906 (0.71)          5           1
test_oids_cache_bench[3600-32-False]        330.8409 (1.49)       360.6182 (1.25)       344.1382 (1.39)      10.9807 (1.60)       343.7462 (1.42)      13.2385 (2.23)          2;0  2.9058 (0.72)          5           1
test_oids_cache_bench[3600-10-False]        460.2782 (2.07)       524.2919 (1.82)       483.8220 (1.96)      30.5275 (4.46)       463.6496 (1.92)      51.5538 (8.70)          1;0  2.0669 (0.51)          5           1
test_oids_cache_bench[0-256-False]          702.1386 (3.15)     1,240.2888 (4.30)       845.0503 (3.42)     224.9437 (32.86)      754.5497 (3.12)     205.5089 (34.67)         1;1  1.1834 (0.29)          5           1
test_oids_cache_bench[0-128-False]          735.2160 (3.30)       807.2229 (2.80)       782.2122 (3.17)      28.2226 (4.12)       794.3269 (3.28)      31.2663 (5.28)          1;0  1.2784 (0.32)          5           1
test_oids_cache_bench[0-64-False]           770.4026 (3.46)       792.7881 (2.75)       783.6901 (3.18)       8.9016 (1.30)       782.4875 (3.24)      12.4405 (2.10)          2;0  1.2760 (0.31)          5           1
test_oids_cache_bench[0-128-True]           781.1614 (3.51)       878.3106 (3.04)       835.0164 (3.38)      34.7660 (5.08)       839.3229 (3.47)      29.2447 (4.93)          2;0  1.1976 (0.30)          5           1
test_oids_cache_bench[0-256-True]           806.4033 (3.62)     1,024.4645 (3.55)       898.6864 (3.64)      82.6123 (12.07)      882.0669 (3.65)     108.0160 (18.22)         2;0  1.1127 (0.27)          5           1
test_oids_cache_bench[0-32-False]           844.0499 (3.79)       906.7948 (3.14)       864.7981 (3.50)      24.4740 (3.57)       858.8667 (3.55)      23.1268 (3.90)          1;0  1.1563 (0.29)          5           1
test_oids_cache_bench[0-64-True]            855.3918 (3.84)       951.6743 (3.30)       890.7652 (3.61)      36.4965 (5.33)       884.9045 (3.66)      36.5703 (6.17)          1;0  1.1226 (0.28)          5           1
test_oids_cache_bench[0-32-True]            932.0634 (4.19)     1,083.0928 (3.75)     1,029.0321 (4.17)      59.1264 (8.64)     1,047.3967 (4.33)      71.6289 (12.08)         1;0  0.9718 (0.24)          5           1
test_oids_cache_bench[0-10-False]         1,062.1702 (4.77)     1,188.6338 (4.12)     1,110.6606 (4.50)      52.7596 (7.71)     1,083.4410 (4.48)      78.5697 (13.26)         1;0  0.9004 (0.22)          5           1
test_oids_cache_bench[0-10-True]          1,263.2961 (5.67)     1,378.7012 (4.77)     1,314.9835 (5.33)      43.6647 (6.38)     1,315.8284 (5.44)      59.0623 (9.96)          2;0  0.7605 (0.19)          5           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```


### Benchmark with OID Caching

![image](https://user-images.githubusercontent.com/49917914/89532332-ec505800-d7f1-11ea-9050-9ba498e12191.png)


```
-------------------------------------------------------------------------------------------- benchmark: 10 tests ---------------------------------------------------------------------------------------------
Name (time in ms)                              Min                 Max                Mean             StdDev              Median                IQR            Outliers     OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_oids_cache_bench[3600-64-True]       222.1871 (1.0)      253.1651 (1.01)     232.7907 (1.0)      12.2822 (1.65)     231.1515 (1.0)      14.4622 (1.47)          1;0  4.2957 (1.0)           5           1
test_oids_cache_bench[3600-32-True]       227.5568 (1.02)     249.7591 (1.0)      235.8209 (1.01)      9.0885 (1.22)     232.7904 (1.01)     13.4278 (1.37)          1;0  4.2405 (0.99)          5           1
test_oids_cache_bench[3600-128-True]      260.8214 (1.17)     309.6727 (1.24)     278.8613 (1.20)     23.0830 (3.09)     263.0909 (1.14)     38.2651 (3.90)          1;0  3.5860 (0.83)          5           1
test_oids_cache_bench[3600-10-True]       279.5710 (1.26)     295.3416 (1.18)     288.7393 (1.24)      7.4652 (1.0)      292.6148 (1.27)     13.3934 (1.36)          1;0  3.4633 (0.81)          5           1
test_oids_cache_bench[3600-256-True]      294.9603 (1.33)     346.1948 (1.39)     314.9455 (1.35)     20.7995 (2.79)     304.8312 (1.32)     29.6322 (3.02)          1;0  3.1752 (0.74)          5           1
test_oids_cache_bench[3600-256-False]     300.2101 (1.35)     326.7276 (1.31)     311.8804 (1.34)     11.4204 (1.53)     306.5733 (1.33)     18.9364 (1.93)          2;0  3.2064 (0.75)          5           1
test_oids_cache_bench[3600-128-False]     310.5080 (1.40)     335.4276 (1.34)     318.5702 (1.37)      9.8533 (1.32)     314.4963 (1.36)      9.8170 (1.0)           1;0  3.1390 (0.73)          5           1
test_oids_cache_bench[3600-64-False]      318.3189 (1.43)     347.7627 (1.39)     333.6387 (1.43)     12.7665 (1.71)     334.1962 (1.45)     22.9938 (2.34)          2;0  2.9973 (0.70)          5           1
test_oids_cache_bench[3600-32-False]      336.4488 (1.51)     371.1810 (1.49)     347.3270 (1.49)     14.1901 (1.90)     341.8034 (1.48)     16.8854 (1.72)          1;0  2.8791 (0.67)          5           1
test_oids_cache_bench[3600-10-False]      464.7760 (2.09)     508.8289 (2.04)     485.7735 (2.09)     15.7646 (2.11)     483.3394 (2.09)     15.2088 (1.55)          2;0  2.0586 (0.48)          5           1
------------
```

### Benchmark without OID Caching

![image](https://user-images.githubusercontent.com/49917914/89532887-cd05fa80-d7f2-11ea-811f-582234d63b45.png)


```

----------------------------------------------------------------------------------------------- benchmark: 10 tests -----------------------------------------------------------------------------------------------
Name (time in ms)                             Min                   Max                  Mean             StdDev                Median                IQR            Outliers     OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_oids_cache_bench[0-128-True]        697.4371 (1.0)        844.1143 (1.16)       768.4875 (1.07)     58.9841 (7.62)       746.7786 (1.05)     90.0290 (7.30)          2;0  1.3013 (0.93)          5           1
test_oids_cache_bench[0-256-False]       711.5141 (1.02)       729.3424 (1.0)        718.5331 (1.0)       7.7422 (1.0)        714.2539 (1.0)      12.3395 (1.0)           1;0  1.3917 (1.0)           5           1
test_oids_cache_bench[0-256-True]        720.9498 (1.03)       781.0235 (1.07)       743.7483 (1.04)     22.4473 (2.90)       741.1077 (1.04)     20.7587 (1.68)          2;0  1.3445 (0.97)          5           1
test_oids_cache_bench[0-64-True]         735.2095 (1.05)       876.9922 (1.20)       790.8798 (1.10)     57.4444 (7.42)       774.1162 (1.08)     86.4274 (7.00)          1;0  1.2644 (0.91)          5           1
test_oids_cache_bench[0-128-False]       757.6328 (1.09)       836.4576 (1.15)       783.4128 (1.09)     31.3635 (4.05)       779.2413 (1.09)     33.6275 (2.73)          1;0  1.2765 (0.92)          5           1
test_oids_cache_bench[0-64-False]        775.3369 (1.11)       870.1026 (1.19)       821.1923 (1.14)     33.7712 (4.36)       822.4742 (1.15)     31.6290 (2.56)          2;0  1.2177 (0.87)          5           1
test_oids_cache_bench[0-32-True]         830.4699 (1.19)       868.1664 (1.19)       849.1821 (1.18)     13.4493 (1.74)       847.7336 (1.19)     12.8106 (1.04)          2;0  1.1776 (0.85)          5           1
test_oids_cache_bench[0-32-False]        837.8091 (1.20)       907.0226 (1.24)       854.7614 (1.19)     29.4510 (3.80)       844.4446 (1.18)     23.3111 (1.89)          1;1  1.1699 (0.84)          5           1
test_oids_cache_bench[0-10-True]       1,024.4232 (1.47)     1,095.7785 (1.50)     1,059.5681 (1.47)     25.7168 (3.32)     1,059.8911 (1.48)     28.3383 (2.30)          2;0  0.9438 (0.68)          5           1
test_oids_cache_bench[0-10-False]      1,075.0335 (1.54)     1,151.6417 (1.58)     1,104.5908 (1.54)     28.9783 (3.74)     1,098.1012 (1.54)     32.9358 (2.67)          2;0  0.9053 (0.65)          5           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```


```