### PR TITLE
[HOLD] Leverage pysnmp concurrent queries for GET command

### DIFF
--- a/snmp/datadog_checks/snmp/commands.py
+++ b/snmp/datadog_checks/snmp/commands.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 from logging import Logger
-from typing import Any, Dict, Generator, List, cast
+from typing import Any, Dict, Generator, cast
 
 from pyasn1.type.univ import Null
 from pysnmp import hlapi

--- a/snmp/datadog_checks/snmp/commands.py
+++ b/snmp/datadog_checks/snmp/commands.py
@@ -46,12 +46,12 @@ def snmp_get_async(config, oids_batches, lookup_mib):
 
         cbCtx['error'] = errorIndication
         cum_var_binds.extend(var_binds)
-        config.logger.debug('Returned vars: %s', OIDPrinter(var_binds, with_values=True))
+        config.logger_ref().debug('Returned vars: %s', OIDPrinter(var_binds, with_values=True))
 
     ctx = {}  # type: Dict[str, Any]
 
     for oids in oids_batches:
-        config.logger.debug('Running SNMP command get on OIDS: %s', OIDPrinter(oids, with_values=False))
+        config.logger_ref().debug('Running SNMP command get on OIDS: %s', OIDPrinter(oids, with_values=False))
         var_binds = vbProcessor.makeVarBinds(config._snmp_engine, oids)
 
         cmdgen.GetCommandGenerator().sendVarBinds(

--- a/snmp/datadog_checks/snmp/commands.py
+++ b/snmp/datadog_checks/snmp/commands.py
@@ -12,7 +12,6 @@ from pysnmp.proto.rfc1905 import endOfMibView
 from twisted.python.log import Logger
 
 from datadog_checks.base.errors import CheckException
-from datadog_checks.snmp.models import OID
 from datadog_checks.snmp.utils import OIDPrinter
 
 from .config import InstanceConfig
@@ -27,13 +26,13 @@ def _handle_error(ctx, config):
 
 
 def snmp_get(config, oids, lookup_mib):
-    # type: (InstanceConfig, List[OID], bool) -> list
+    # type: (InstanceConfig, List[Any], bool) -> list
     """Call SNMP GET on a list of oids."""
-    return snmp_get_async(config, iter(list(oids)), lookup_mib)
+    return snmp_get_async(config, iter([oids]), lookup_mib)
 
 
 def snmp_get_async(config, oids_batches, lookup_mib):
-    # type: (InstanceConfig, Iterator[List[OID]], bool) -> list
+    # type: (InstanceConfig, Iterator[List[Any]], bool) -> list
     """Call SNMP GET on batches of oids concurrently."""
 
     if config.device is None:
@@ -76,7 +75,7 @@ def snmp_get_async(config, oids_batches, lookup_mib):
 
 
 def snmp_getnext(config, oids, lookup_mib, ignore_nonincreasing_oid):
-    # type: (InstanceConfig, list, bool, bool) -> Generator
+    # type: (InstanceConfig, List[Any], bool, bool) -> Generator
     """Call SNMP GETNEXT on a list of oids. It will iterate on the results if it happens to be under the same prefix."""
 
     if config.device is None:

--- a/snmp/datadog_checks/snmp/commands.py
+++ b/snmp/datadog_checks/snmp/commands.py
@@ -74,7 +74,7 @@ def snmp_get(config, oids, lookup_mib, oid_batch_size=None):
 
 
 def snmp_getnext(config, oids, lookup_mib, ignore_nonincreasing_oid):
-    # type: (InstanceConfig, List[Any], bool, bool) -> Generator
+    # type: (InstanceConfig, list, bool, bool) -> Generator
     """Call SNMP GETNEXT on a list of oids. It will iterate on the results if it happens to be under the same prefix."""
 
     if config.device is None:

--- a/snmp/datadog_checks/snmp/commands.py
+++ b/snmp/datadog_checks/snmp/commands.py
@@ -37,7 +37,7 @@ def snmp_get_async(config, oids_batches, lookup_mib):
     if config.device is None:
         raise RuntimeError('No device set')  # pragma: no cover
 
-    res_var_binds = []
+    cum_var_binds = []
 
     def callback(  # type: ignore
         snmpEngine, sendRequestHandle, errorIndication, errorStatus, errorIndex, varBinds, cbCtx
@@ -45,7 +45,7 @@ def snmp_get_async(config, oids_batches, lookup_mib):
         var_binds = vbProcessor.unmakeVarBinds(snmpEngine, varBinds, lookup_mib)
 
         cbCtx['error'] = errorIndication
-        res_var_binds.extend(var_binds)
+        cum_var_binds.extend(var_binds)
         config.logger.debug('Returned vars: %s', OIDPrinter(var_binds, with_values=True))
 
     ctx = {}  # type: Dict[str, Any]
@@ -68,7 +68,7 @@ def snmp_get_async(config, oids_batches, lookup_mib):
 
     _handle_error(ctx, config)
 
-    return res_var_binds
+    return cum_var_binds
 
 
 def snmp_getnext(config, oids, lookup_mib, ignore_nonincreasing_oid):

--- a/snmp/datadog_checks/snmp/commands.py
+++ b/snmp/datadog_checks/snmp/commands.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+from logging import Logger
 from typing import Any, Dict, Generator, Iterator, List, cast
 
 from pyasn1.type.univ import Null
@@ -9,7 +10,6 @@ from pysnmp.entity.rfc3413 import cmdgen
 from pysnmp.hlapi.asyncore.cmdgen import vbProcessor
 from pysnmp.proto import errind
 from pysnmp.proto.rfc1905 import endOfMibView
-from twisted.python.log import Logger
 
 from datadog_checks.base.errors import CheckException
 from datadog_checks.snmp.utils import OIDPrinter

--- a/snmp/datadog_checks/snmp/commands.py
+++ b/snmp/datadog_checks/snmp/commands.py
@@ -11,6 +11,7 @@ from pysnmp.proto import errind
 from pysnmp.proto.rfc1905 import endOfMibView
 
 from datadog_checks.base.errors import CheckException
+from datadog_checks.snmp.utils import OIDPrinter
 
 from .config import InstanceConfig
 
@@ -45,10 +46,12 @@ def snmp_get_async(config, oids_batches, lookup_mib):
 
         cbCtx['error'] = errorIndication
         res_var_binds.extend(var_binds)
+        config.logger.debug('Returned vars: %s', OIDPrinter(var_binds, with_values=True))
 
     ctx = {}  # type: Dict[str, Any]
 
     for oids in oids_batches:
+        config.logger.debug('Running SNMP command get on OIDS: %s', OIDPrinter(oids, with_values=False))
         var_binds = vbProcessor.makeVarBinds(config._snmp_engine, oids)
 
         cmdgen.GetCommandGenerator().sendVarBinds(

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -92,7 +92,6 @@ class InstanceConfig:
             self.metrics.extend(global_metrics)
 
         self.enforce_constraints = is_affirmative(instance.get('enforce_mib_constraints', True))
-        self.use_async = is_affirmative(instance.get('use_async', False))
         self._snmp_engine = loader.create_snmp_engine(mibs_path)
         mib_view_controller = loader.get_mib_view_controller(mibs_path)
         self._resolver = OIDResolver(mib_view_controller, self.enforce_constraints)

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -79,7 +79,7 @@ class InstanceConfig:
             if value in (None, ""):
                 instance.pop(key)
 
-        self.logger = weakref.ref(local_logger) if logger is None else weakref.ref(logger)
+        self.logger_ref = weakref.ref(local_logger) if logger is None else weakref.ref(logger)
 
         self.instance = instance
         self.tags = instance.get('tags', [])
@@ -285,7 +285,7 @@ class InstanceConfig:
         """Parse configuration and returns data to be used for SNMP queries."""
         # Use bulk for SNMP version > 1 only.
         bulk_threshold = self.bulk_threshold if self._auth_data.mpModel else 0
-        result = parse_metrics(metrics, resolver=self._resolver, logger=self.logger(), bulk_threshold=bulk_threshold)
+        result = parse_metrics(metrics, resolver=self._resolver, logger=self.logger_ref(), bulk_threshold=bulk_threshold)
         return result['oids'], result['next_oids'], result['bulk_oids'], result['parsed_metrics']
 
     def parse_metric_tags(self, metric_tags):

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -285,7 +285,9 @@ class InstanceConfig:
         """Parse configuration and returns data to be used for SNMP queries."""
         # Use bulk for SNMP version > 1 only.
         bulk_threshold = self.bulk_threshold if self._auth_data.mpModel else 0
-        result = parse_metrics(metrics, resolver=self._resolver, logger=self.logger_ref(), bulk_threshold=bulk_threshold)
+        result = parse_metrics(
+            metrics, resolver=self._resolver, logger=self.logger_ref(), bulk_threshold=bulk_threshold
+        )
         return result['oids'], result['next_oids'], result['bulk_oids'], result['parsed_metrics']
 
     def parse_metric_tags(self, metric_tags):

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -92,6 +92,7 @@ class InstanceConfig:
             self.metrics.extend(global_metrics)
 
         self.enforce_constraints = is_affirmative(instance.get('enforce_mib_constraints', True))
+        self.use_async = is_affirmative(instance.get('use_async', False))
         self._snmp_engine = loader.create_snmp_engine(mibs_path)
         mib_view_controller = loader.get_mib_view_controller(mibs_path)
         self._resolver = OIDResolver(mib_view_controller, self.enforce_constraints)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -18,7 +18,7 @@ from six import iteritems
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.errors import CheckException
 
-from .commands import snmp_bulk, snmp_get, snmp_getnext, snmp_get_async
+from .commands import snmp_bulk, snmp_get, snmp_get_async, snmp_getnext
 from .compat import read_persistent_cache, write_persistent_cache
 from .config import InstanceConfig
 from .discovery import discover_instances
@@ -224,59 +224,33 @@ class SnmpCheck(AgentCheck):
         next_oids = [oid.as_object_type() for oid in next_oids]
         all_binds = []
 
-        if config.use_async:
-            try:
-                # self.log.debug('Running SNMP command get on OIDS: %s', OIDPrinter(oids_batch, with_values=False))
+        try:
+            # self.log.debug('Running SNMP command get on OIDS: %s', OIDPrinter(oids_batch, with_values=False))
 
-                var_binds = snmp_get_async(config, batches(scalar_oids, size=self.oid_batch_size), lookup_mib=enforce_constraints)
-                self.log.debug('Returned vars: %s', OIDPrinter(var_binds, with_values=True))
+            var_binds = snmp_get_async(
+                config, batches(scalar_oids, size=self.oid_batch_size), lookup_mib=enforce_constraints
+            )
+            self.log.debug('Returned vars: %s', OIDPrinter(var_binds, with_values=True))
 
-                missing_results = []
+            missing_results = []
 
-                for var in var_binds:
-                    result_oid, value = var
-                    if reply_invalid(value):
-                        oid_tuple = result_oid.asTuple()
-                        missing_results.append(ObjectType(ObjectIdentity(oid_tuple)))
-                    else:
-                        all_binds.append(var)
+            for var in var_binds:
+                result_oid, value = var
+                if reply_invalid(value):
+                    oid_tuple = result_oid.asTuple()
+                    missing_results.append(ObjectType(ObjectIdentity(oid_tuple)))
+                else:
+                    all_binds.append(var)
 
-                if missing_results:
-                    # If we didn't catch the metric using snmpget, try snmpnext
-                    next_oids.extend(missing_results)
+            if missing_results:
+                # If we didn't catch the metric using snmpget, try snmpnext
+                next_oids.extend(missing_results)
 
-            except (PySnmpError, CheckException) as e:
-                message = 'Failed to collect some metrics: {}'.format(e)
-                if not error:
-                    error = message
-                self.warning(message)
-        else:
-            for oids_batch in batches(scalar_oids, size=self.oid_batch_size):
-                try:
-                    self.log.debug('Running SNMP command get on OIDS: %s', OIDPrinter(oids_batch, with_values=False))
-
-                    var_binds = snmp_get(config, oids_batch, lookup_mib=enforce_constraints)
-                    self.log.debug('Returned vars: %s', OIDPrinter(var_binds, with_values=True))
-
-                    missing_results = []
-
-                    for var in var_binds:
-                        result_oid, value = var
-                        if reply_invalid(value):
-                            oid_tuple = result_oid.asTuple()
-                            missing_results.append(ObjectType(ObjectIdentity(oid_tuple)))
-                        else:
-                            all_binds.append(var)
-
-                    if missing_results:
-                        # If we didn't catch the metric using snmpget, try snmpnext
-                        next_oids.extend(missing_results)
-
-                except (PySnmpError, CheckException) as e:
-                    message = 'Failed to collect some metrics: {}'.format(e)
-                    if not error:
-                        error = message
-                    self.warning(message)
+        except (PySnmpError, CheckException) as e:
+            message = 'Failed to collect some metrics: {}'.format(e)
+            if not error:
+                error = message
+            self.warning(message)
 
         for oids_batch in batches(next_oids, size=self.oid_batch_size):
             try:

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -18,7 +18,7 @@ from six import iteritems
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from datadog_checks.base.errors import CheckException
 
-from .commands import snmp_bulk, snmp_get, snmp_get_async, snmp_getnext
+from .commands import snmp_bulk, snmp_get, snmp_getnext
 from .compat import read_persistent_cache, write_persistent_cache
 from .config import InstanceConfig
 from .discovery import discover_instances
@@ -225,8 +225,8 @@ class SnmpCheck(AgentCheck):
         all_binds = []
 
         try:
-            var_binds = snmp_get_async(
-                config, batches(scalar_oids, size=self.oid_batch_size), lookup_mib=enforce_constraints
+            var_binds = snmp_get(
+                config, scalar_oids, lookup_mib=enforce_constraints, oid_batch_size=self.oid_batch_size
             )
 
             missing_results = []

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -225,12 +225,9 @@ class SnmpCheck(AgentCheck):
         all_binds = []
 
         try:
-            # self.log.debug('Running SNMP command get on OIDS: %s', OIDPrinter(oids_batch, with_values=False))
-
             var_binds = snmp_get_async(
                 config, batches(scalar_oids, size=self.oid_batch_size), lookup_mib=enforce_constraints
             )
-            self.log.debug('Returned vars: %s', OIDPrinter(var_binds, with_values=True))
 
             missing_results = []
 

--- a/snmp/tests/test_bench.py
+++ b/snmp/tests/test_bench.py
@@ -53,33 +53,14 @@ def test_profile_f5_with_oids_cache(oid_batch_size, benchmark):
     benchmark.pedantic(check.check, args=(instance,), iterations=1, rounds=5, warmup_rounds=1)
 
 
-@pytest.mark.parametrize('refresh_oids_cache_interval,oid_batch_size,use_async', [
-    (0, 10, False),
-    (0, 32, False),
-    (0, 64, False),
-    (0, 128, False),
-    (0, 256, False),
-    (3600, 10, False),
-    (3600, 32, False),
-    (3600, 64, False),
-    (3600, 128, False),
-    (3600, 256, False),
-    (0, 10, True),
-    (0, 32, True),
-    (0, 64, True),
-    (0, 128, True),
-    (0, 256, True),
-    (3600, 10, True),
-    (3600, 32, True),
-    (3600, 64, True),
-    (3600, 128, True),
-    (3600, 256, True),
-])
-def test_oids_cache_bench(refresh_oids_cache_interval, oid_batch_size, benchmark, use_async):
+@pytest.mark.parametrize(
+    'refresh_oids_cache_interval,oid_batch_size',
+    [(0, 10), (0, 32), (0, 64), (0, 128), (0, 256), (3600, 10), (3600, 32), (3600, 64), (3600, 128), (3600, 256)],
+)
+def test_oids_cache_bench(refresh_oids_cache_interval, oid_batch_size, benchmark):
     instance = generate_instance_config([])
     instance['community_string'] = 'f5'
     instance['refresh_oids_cache_interval'] = refresh_oids_cache_interval
-    instance['use_async'] = use_async
     check = SnmpCheck('snmp', {'oid_batch_size': oid_batch_size}, [instance])
 
     benchmark.pedantic(check.check, args=(instance,), iterations=1, rounds=5, warmup_rounds=1)

--- a/snmp/tests/test_bench.py
+++ b/snmp/tests/test_bench.py
@@ -55,7 +55,7 @@ def test_profile_f5_with_oids_cache(oid_batch_size, benchmark):
 
 
 @pytest.mark.parametrize(
-    'refresh_oids_cache_interval,oid_batch_size', [itertools.product([0, 3600], [10, 32, 64, 128, 256])],
+    'refresh_oids_cache_interval,oid_batch_size', itertools.product([0, 3600], [10, 32, 64, 128, 256]),
 )
 def test_oids_cache_bench(refresh_oids_cache_interval, oid_batch_size, benchmark):
     instance = generate_instance_config([])

--- a/snmp/tests/test_bench.py
+++ b/snmp/tests/test_bench.py
@@ -55,8 +55,7 @@ def test_profile_f5_with_oids_cache(oid_batch_size, benchmark):
 
 
 @pytest.mark.parametrize(
-    'refresh_oids_cache_interval,oid_batch_size',
-    [itertools.product([0, 3600], [10, 32, 64, 128, 256])],
+    'refresh_oids_cache_interval,oid_batch_size', [itertools.product([0, 3600], [10, 32, 64, 128, 256])],
 )
 def test_oids_cache_bench(refresh_oids_cache_interval, oid_batch_size, benchmark):
     instance = generate_instance_config([])

--- a/snmp/tests/test_bench.py
+++ b/snmp/tests/test_bench.py
@@ -53,11 +53,33 @@ def test_profile_f5_with_oids_cache(oid_batch_size, benchmark):
     benchmark.pedantic(check.check, args=(instance,), iterations=1, rounds=5, warmup_rounds=1)
 
 
-@pytest.mark.parametrize('refresh_oids_cache_interval,oid_batch_size', [(0, 10), (0, 256), (3600, 10), (3600, 256)])
-def test_oids_cache_bench(refresh_oids_cache_interval, oid_batch_size, benchmark):
+@pytest.mark.parametrize('refresh_oids_cache_interval,oid_batch_size,use_async', [
+    (0, 10, False),
+    (0, 32, False),
+    (0, 64, False),
+    (0, 128, False),
+    (0, 256, False),
+    (3600, 10, False),
+    (3600, 32, False),
+    (3600, 64, False),
+    (3600, 128, False),
+    (3600, 256, False),
+    (0, 10, True),
+    (0, 32, True),
+    (0, 64, True),
+    (0, 128, True),
+    (0, 256, True),
+    (3600, 10, True),
+    (3600, 32, True),
+    (3600, 64, True),
+    (3600, 128, True),
+    (3600, 256, True),
+])
+def test_oids_cache_bench(refresh_oids_cache_interval, oid_batch_size, benchmark, use_async):
     instance = generate_instance_config([])
     instance['community_string'] = 'f5'
     instance['refresh_oids_cache_interval'] = refresh_oids_cache_interval
+    instance['use_async'] = use_async
     check = SnmpCheck('snmp', {'oid_batch_size': oid_batch_size}, [instance])
 
     benchmark.pedantic(check.check, args=(instance,), iterations=1, rounds=5, warmup_rounds=1)

--- a/snmp/tests/test_bench.py
+++ b/snmp/tests/test_bench.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import itertools
 
 import pytest
 
@@ -55,7 +56,7 @@ def test_profile_f5_with_oids_cache(oid_batch_size, benchmark):
 
 @pytest.mark.parametrize(
     'refresh_oids_cache_interval,oid_batch_size',
-    [(0, 10), (0, 32), (0, 64), (0, 128), (0, 256), (3600, 10), (3600, 32), (3600, 64), (3600, 128), (3600, 256)],
+    [itertools.product([0, 3600], [10, 32, 64, 128, 256])],
 )
 def test_oids_cache_bench(refresh_oids_cache_interval, oid_batch_size, benchmark):
     instance = generate_instance_config([])

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -37,4 +37,4 @@ commands =
 [testenv:bench]
 commands =
     pip install -r requirements.in
-    pytest -v {posargs}
+    pytest -v {posargs} --benchmark-only --benchmark-histogram --benchmark-cprofile=tottime

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -37,4 +37,4 @@ commands =
 [testenv:bench]
 commands =
     pip install -r requirements.in
-    pytest -v {posargs} --benchmark-only --benchmark-histogram --benchmark-cprofile=tottime
+    pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?

`pysnmp` concurrent queries for GET cmd brings some performance gain. 

1-20% performance gain (comparing `3600-32-True` to `3600-128-False` cases)

[details here](https://github.com/DataDog/integrations-core/pull/7307)

The performance gain is negligible if OID caching is not used (see Benchmark without OID Caching section) since we don't make as much GET cmd calls.

See benchmark data here: https://github.com/DataDog/integrations-core/pull/7307

### Motivation

Better performance

### Additional notes

Async doesn't work well for GETNEXT/GETBULK since multiple **synchronous** calls need to be made (For each column, the previous oid is needed to retrieve the next one).

This PR only focus on GET command.