### PR TITLE
Send more useful metrics for wsrep flow control

### DIFF
--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -230,6 +230,9 @@ GALERA_VARS = {
     'wsrep_cluster_size': ('mysql.galera.wsrep_cluster_size', GAUGE),
     'wsrep_local_recv_queue_avg': ('mysql.galera.wsrep_local_recv_queue_avg', GAUGE),
     'wsrep_flow_control_paused': ('mysql.galera.wsrep_flow_control_paused', GAUGE),
+    'wsrep_flow_control_paused_ns': ('mysql.galera.wsrep_flow_control_paused_ns', MONOTONIC),
+    'wsrep_flow_control_recv': ('mysql.galera.wsrep_flow_control_recv', MONOTONIC),
+    'wsrep_flow_control_sent': ('mysql.galera.wsrep_flow_control_sent', MONOTONIC),
     'wsrep_cert_deps_distance': ('mysql.galera.wsrep_cert_deps_distance', GAUGE),
     'wsrep_local_send_queue_avg': ('mysql.galera.wsrep_local_send_queue_avg', GAUGE),
 }

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -170,6 +170,9 @@ mysql.innodb.x_lock_spin_rounds,gauge,,,,"As shown in the SEMAPHORES section of 
 mysql.innodb.x_lock_spin_waits,gauge,,wait,,"As shown in the SEMAPHORES section of the SHOW ENGINE INNODB STATUS output.",0,mysql,mysql innodb x_lock_spin_waits
 mysql.galera.wsrep_local_recv_queue_avg,gauge,,,,"Shows the average size of the local received queue since the last status query.",0,mysql,mysql galera wsrep_local_recv_queue_avg
 mysql.galera.wsrep_flow_control_paused,gauge,,fraction,,"Shows the fraction of the time, since FLUSH STATUS was last called, that the node paused due to Flow Control.",0,mysql,mysql galera wsrep_flow_control_paused
+mysql.galera.wsrep_flow_control_paused_ns,count,,nanosecond,,"Shows the pause time due to Flow Control, in nanoseconds.",0,mysql,mysql galera wsrep_flow_control_paused_ns
+mysql.galera.wsrep_flow_control_recv,count,,,,"Shows the number of times the galera node has received a pausing Flow Control message from others",0,mysql,mysql galera wsrep_flow_control_recv
+mysql.galera.wsrep_flow_control_sent,count,,,,"Shows the number of times the galera node has sent a pausing Flow Control message to others",0,mysql,mysql galera wsrep_flow_control_sent
 mysql.galera.wsrep_cert_deps_distance,gauge,,,,"Shows the average distance between the lowest and highest sequence number, or seqno, values that the node can possibly apply in parallel.",0,mysql,mysql galera wsrep_cert_deps_distance
 mysql.galera.wsrep_local_send_queue_avg,gauge,,,,"Show an average for the send queue length since the last FLUSH STATUS query.",0,mysql,mysql galera wsrep_local_send_queue_avg
 mysql.performance.qcache.utilization,gauge,,fraction,,Fraction of the query cache memory currently being used.,0,mysql,mysql performance qcache utilization


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The metric `wsrep_flow_control_paused` is not that useful, as it just
tracks the fraction of the time where flow control pause happens over
the lifetime of the process. So, if mysqld has been up for 180 days and
has been paused for 107 seconds, the value would be 107 / (180 * 86400)
or 0.0000069. At this point, if something bad happens and causes a 5
seconds flow control pause, the value would only increase to 0.0000072.
It is difficult to visualize such tiny change, and impossible to set
any alert threshold.

On the other hand, the metric `wsrep_flow_control_paused_ns`, as a
counter for the total flow control paused time in nanoseconds, is more
useful for both graphing and alerting.

Next, the metric `wsrep_flow_control_sent` is important to tell which
is the slow galera node that couldn't keep up, while the metric
`wsrep_flow_control_recv` is just included for completeness.

Note that these 3 added metrics are sent as monotonic counters, similar
to `innodb_buffer_pool_wait_free`. They are sparse metrics that should
mostly stay at 0, and should be visualized with bar graphs.

### Motivation
<!-- What inspired you to submit this pull request? -->
Able to visualize the wsrep flow control metrics, and also to setup alerts for them.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
