### PR TITLE
[ddev] Add missing dependency

### DIFF
--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -36,6 +36,7 @@ REQUIRES = [
     "shutilwhich==1.1.0; python_version < '3.0'",
     "subprocess32==3.5.4; python_version < '3.0'",
     'tenacity',
+    'jsonschema>=3.2.0',
 ]
 
 


### PR DESCRIPTION
### What does this PR do?
Adds `jsonschema` to the list of dependencies

### Motivation
```
Traceback (most recent call last):
  File "/usr/local/bin/ddev", line 11, in <module>
    load_entry_point('datadog-checks-dev', 'console_scripts', 'ddev')()
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 490, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2855, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2446, in load
    return self.resolve()
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2452, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Users/albert.cintora/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/cli.py", line 6, in <module>
    from .commands import ALL_COMMANDS
  File "/Users/albert.cintora/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/__init__.py", line 16, in <module>
    from .validate import validate
  File "/Users/albert.cintora/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py", line 15, in <module>
    from .manifest import manifest
  File "/Users/albert.cintora/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py", line 9, in <module>
    import jsonschema
ModuleNotFoundError: No module named 'jsonschema'
```
