### PR TITLE
Fixing the Pods Overview widgets for OOMKill and CrashLoopBackOff

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -260,7 +260,7 @@
             "tile_def": {
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.container.waiting{$cluster,$namespace,$deployment,reason:crashloopbackoff,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "q": "sum:kubernetes.containers.state.waiting{$cluster,$namespace,$deployment,reason:crashloopbackoff,$scope,$statefulset,$daemonset,$job} by {pod_name}",
                         "style": {
                             "palette": "dog_classic",
                             "type": "solid",
@@ -295,7 +295,7 @@
             "tile_def": {
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.container.terminated{$cluster,$namespace,$deployment,reason:OOMKilled,$statefulset,$daemonset,$job} by {pod_name}",
+                        "q": "sum:kubernetes.containers.state.terminated{$cluster,$namespace,$deployment,reason:oomkilled,$statefulset,$daemonset,$job} by {pod_name}",
                         "style": {
                             "palette": "dog_classic",
                             "type": "solid",


### PR DESCRIPTION
### What does this PR do?
Fixing the Pods Overview widgets for OOMKill and CrashLoopBackOff

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
