### PR TITLE
Fix release-hash-check git diff

### DIFF
--- a/.github/workflows/release-hash-check.yml
+++ b/.github/workflows/release-hash-check.yml
@@ -22,7 +22,7 @@ jobs:
     - id: files
       run: |
         git fetch origin master
-        FILES=$(git --no-pager diff --name-only HEAD...FETCH_HEAD 2>/dev/null | tr "\n" " ")
+        FILES=$(git --no-pager diff --name-only master .in-toto | xargs echo)
         echo "::set-output name=all::$FILES"
 
     - run: python .github/workflows/release-hash-check.py ${{ steps.files.outputs.all }}


### PR DESCRIPTION
### What does this PR do?

Fix release-hash-check.yml 

### Motivation

```
##[debug]/bin/bash -e /home/runner/work/_temp/bc9ca637-9be8-4b57-9208-f0bdc50b65c8.sh
Traceback (most recent call last):
  File ".github/workflows/release-hash-check.py", line 27, in <module>
    link_file = updated_link_files[0]
IndexError: list index out of range
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->
