### PR TITLE
Fix release-hash-check git diff

### DIFF
--- a/.github/workflows/release-hash-check.yml
+++ b/.github/workflows/release-hash-check.yml
@@ -22,7 +22,7 @@ jobs:
     - id: files
       run: |
         git fetch origin master
-        FILES=$(git --no-pager diff --name-only master .in-toto | xargs echo)
+        FILES=$(git --no-pager diff --name-only origin/master -- .in-toto | xargs echo)
         echo "::set-output name=all::$FILES"
 
     - run: python .github/workflows/release-hash-check.py ${{ steps.files.outputs.all }}


### PR DESCRIPTION
### What does this PR do?

Fix release-hash-check git diff

### Motivation

```
fatal: ambiguous argument 'master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
```
