### PR TITLE
[Test CI] Use pip 2020 resolver for all integrations

### DIFF
--- a/active_directory/tox.ini
+++ b/active_directory/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt

--- a/activemq/tox.ini
+++ b/activemq/tox.ini
@@ -15,6 +15,7 @@ usedevelop = true
 dd_check_style = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/activemq_xml/tox.ini
+++ b/activemq_xml/tox.ini
@@ -15,6 +15,7 @@ usedevelop = true
 dd_check_style = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/aerospike/tox.ini
+++ b/aerospike/tox.ini
@@ -16,6 +16,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/airflow/tox.ini
+++ b/airflow/tox.ini
@@ -16,6 +16,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/amazon_msk/tox.ini
+++ b/amazon_msk/tox.ini
@@ -14,6 +14,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/ambari/tox.ini
+++ b/ambari/tox.ini
@@ -14,6 +14,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/apache/tox.ini
+++ b/apache/tox.ini
@@ -15,6 +15,7 @@ usedevelop = true
 dd_check_style = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv = APACHE_VERSION=2.4.27

--- a/aspdotnet/tox.ini
+++ b/aspdotnet/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt

--- a/btrfs/tox.ini
+++ b/btrfs/tox.ini
@@ -13,6 +13,7 @@ usedevelop = true
 dd_check_style = true
 platform = linux|darwin
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/cacti/tox.ini
+++ b/cacti/tox.ini
@@ -15,6 +15,7 @@ usedevelop = true
 dd_check_style = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/cassandra/tox.ini
+++ b/cassandra/tox.ini
@@ -15,6 +15,7 @@ usedevelop = true
 dd_check_style = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/cassandra_nodetool/tox.ini
+++ b/cassandra_nodetool/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =

--- a/ceph/tox.ini
+++ b/ceph/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =

--- a/cilium/tox.ini
+++ b/cilium/tox.ini
@@ -16,6 +16,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/cisco_aci/tox.ini
+++ b/cisco_aci/tox.ini
@@ -12,6 +12,7 @@ envdir =
 usedevelop = true
 dd_check_style = true
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/clickhouse/tox.ini
+++ b/clickhouse/tox.ini
@@ -16,6 +16,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/cloud_foundry_api/tox.ini
+++ b/cloud_foundry_api/tox.ini
@@ -12,6 +12,7 @@ dd_mypy_args = --py2 datadog_checks/ tests/
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/cockroachdb/tox.ini
+++ b/cockroachdb/tox.ini
@@ -17,6 +17,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/confluent_platform/tox.ini
+++ b/confluent_platform/tox.ini
@@ -16,6 +16,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/consul/tox.ini
+++ b/consul/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/coredns/tox.ini
+++ b/coredns/tox.ini
@@ -21,6 +21,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/couch/tox.ini
+++ b/couch/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/couchbase/tox.ini
+++ b/couchbase/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv = COUCHBASE_VERSION=5.5.3

--- a/crio/tox.ini
+++ b/crio/tox.ini
@@ -14,6 +14,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
      -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/datadog_checks_base/tox.ini
+++ b/datadog_checks_base/tox.ini
@@ -20,6 +20,7 @@ dd_mypy_args =
     datadog_checks/base/checks/win/wmi/__init__.py
 usedevelop = true
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_tests_helper
     -rrequirements-dev.txt
 passenv =

--- a/datadog_checks_dev/tox.ini
+++ b/datadog_checks_dev/tox.ini
@@ -20,6 +20,7 @@ usedevelop = true
 skip_install = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/datadog_checks_downloader/tox.ini
+++ b/datadog_checks_downloader/tox.ini
@@ -12,6 +12,7 @@ envdir =
 dd_check_style = true
 usedevelop = true
 deps =
+    --use-feature=2020-resolver
   -e../datadog_checks_base[deps]
   -rrequirements-dev.txt
 commands =

--- a/directory/tox.ini
+++ b/directory/tox.ini
@@ -17,6 +17,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/disk/tox.ini
+++ b/disk/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/dns_check/tox.ini
+++ b/dns_check/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/dotnetclr/tox.ini
+++ b/dotnetclr/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt

--- a/druid/tox.ini
+++ b/druid/tox.ini
@@ -16,6 +16,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/ecs_fargate/tox.ini
+++ b/ecs_fargate/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/eks_fargate/tox.ini
+++ b/eks_fargate/tox.ini
@@ -14,6 +14,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/elastic/tox.ini
+++ b/elastic/tox.ini
@@ -17,6 +17,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/envoy/tox.ini
+++ b/envoy/tox.ini
@@ -17,6 +17,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/etcd/tox.ini
+++ b/etcd/tox.ini
@@ -16,6 +16,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/exchange_server/tox.ini
+++ b/exchange_server/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt

--- a/external_dns/tox.ini
+++ b/external_dns/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/fluentd/tox.ini
+++ b/fluentd/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/gearmand/tox.ini
+++ b/gearmand/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|winn32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/gitlab/tox.ini
+++ b/gitlab/tox.ini
@@ -22,6 +22,7 @@ setenv =
     13: GITLAB_VERSION=13.0.6-ce.0
     bench: GITLAB_VERSION=13.0.6-ce.0
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/gitlab_runner/tox.ini
+++ b/gitlab_runner/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/go_expvar/tox.ini
+++ b/go_expvar/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = darwin|linux|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/gunicorn/tox.ini
+++ b/gunicorn/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =

--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =

--- a/harbor/tox.ini
+++ b/harbor/tox.ini
@@ -16,6 +16,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/hazelcast/tox.ini
+++ b/hazelcast/tox.ini
@@ -15,6 +15,7 @@ usedevelop = true
 dd_check_style = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/hdfs_datanode/tox.ini
+++ b/hdfs_datanode/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/hdfs_namenode/tox.ini
+++ b/hdfs_namenode/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/hive/tox.ini
+++ b/hive/tox.ini
@@ -15,6 +15,7 @@ usedevelop = true
 dd_check_style = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/hivemq/tox.ini
+++ b/hivemq/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/http_check/tox.ini
+++ b/http_check/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/hyperv/tox.ini
+++ b/hyperv/tox.ini
@@ -17,6 +17,7 @@ description =
 usedevelop = true
 platform = win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/ibm_db2/tox.ini
+++ b/ibm_db2/tox.ini
@@ -17,6 +17,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/ibm_mq/tox.ini
+++ b/ibm_mq/tox.ini
@@ -17,6 +17,7 @@ dd_check_types = true
 dd_mypy_args = --py2 datadog_checks/ tests/
 platform = linux|darwin
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv = *

--- a/ibm_was/tox.ini
+++ b/ibm_was/tox.ini
@@ -16,6 +16,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/ignite/tox.ini
+++ b/ignite/tox.ini
@@ -15,6 +15,7 @@ usedevelop = true
 dd_check_style = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/iis/tox.ini
+++ b/iis/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt

--- a/istio/tox.ini
+++ b/istio/tox.ini
@@ -21,6 +21,7 @@ passenv =
     USERNAME
     HOME
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/jboss_wildfly/tox.ini
+++ b/jboss_wildfly/tox.ini
@@ -15,6 +15,7 @@ usedevelop = true
 dd_check_style = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/kafka/tox.ini
+++ b/kafka/tox.ini
@@ -17,6 +17,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -19,6 +19,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/kong/tox.ini
+++ b/kong/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =

--- a/kube_apiserver_metrics/tox.ini
+++ b/kube_apiserver_metrics/tox.ini
@@ -14,6 +14,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/kube_controller_manager/tox.ini
+++ b/kube_controller_manager/tox.ini
@@ -14,6 +14,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps,kube]
     -rrequirements-dev.txt
 passenv =

--- a/kube_dns/tox.ini
+++ b/kube_dns/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/kube_metrics_server/tox.ini
+++ b/kube_metrics_server/tox.ini
@@ -14,6 +14,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/kube_proxy/tox.ini
+++ b/kube_proxy/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/kube_scheduler/tox.ini
+++ b/kube_scheduler/tox.ini
@@ -14,6 +14,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps,kube]
     -rrequirements-dev.txt
 passenv =

--- a/kubelet/tox.ini
+++ b/kubelet/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/kubernetes_state/tox.ini
+++ b/kubernetes_state/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/kyototycoon/tox.ini
+++ b/kyototycoon/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/lighttpd/tox.ini
+++ b/lighttpd/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =

--- a/linkerd/tox.ini
+++ b/linkerd/tox.ini
@@ -20,6 +20,7 @@ passenv =
     TF_VAR*
     USERNAME
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/linux_proc_extras/tox.ini
+++ b/linux_proc_extras/tox.ini
@@ -14,6 +14,7 @@ description =
     py{27,38}: e2e ready
 usedevelop = true
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/mapr/tox.ini
+++ b/mapr/tox.ini
@@ -14,6 +14,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/mapreduce/tox.ini
+++ b/mapreduce/tox.ini
@@ -15,6 +15,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/marathon/tox.ini
+++ b/marathon/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/mcache/tox.ini
+++ b/mcache/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/mesos_master/tox.ini
+++ b/mesos_master/tox.ini
@@ -15,6 +15,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/mesos_slave/tox.ini
+++ b/mesos_slave/tox.ini
@@ -19,6 +19,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =

--- a/mongo/tox.ini
+++ b/mongo/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/nagios/tox.ini
+++ b/nagios/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/network/tox.ini
+++ b/network/tox.ini
@@ -15,6 +15,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/nfsstat/tox.ini
+++ b/nfsstat/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/nginx/tox.ini
+++ b/nginx/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/nginx_ingress_controller/tox.ini
+++ b/nginx_ingress_controller/tox.ini
@@ -13,6 +13,7 @@ envdir =
 dd_check_style = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/openldap/tox.ini
+++ b/openldap/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =

--- a/openmetrics/tox.ini
+++ b/openmetrics/tox.ini
@@ -16,6 +16,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
      -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/openstack/tox.ini
+++ b/openstack/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/openstack_controller/tox.ini
+++ b/openstack_controller/tox.ini
@@ -15,6 +15,7 @@ description =
 dd_check_style = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e ../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/oracle/tox.ini
+++ b/oracle/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = darwin|linux|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/pdh_check/tox.ini
+++ b/pdh_check/tox.ini
@@ -15,6 +15,7 @@ description =
 usedevelop = true
 platform = win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     ../datadog_checks_tests_helper
     -rrequirements-dev.txt

--- a/pgbouncer/tox.ini
+++ b/pgbouncer/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/php_fpm/tox.ini
+++ b/php_fpm/tox.ini
@@ -19,6 +19,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/postfix/tox.ini
+++ b/postfix/tox.ini
@@ -20,6 +20,7 @@ passenv =
     COMPOSE*
     USERNAME
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/postgres/tox.ini
+++ b/postgres/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/powerdns_recursor/tox.ini
+++ b/powerdns_recursor/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =

--- a/presto/tox.ini
+++ b/presto/tox.ini
@@ -15,6 +15,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/process/tox.ini
+++ b/process/tox.ini
@@ -15,6 +15,7 @@ description =
 usedevelop = true
 platform = linux|darwin|windows
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/prometheus/tox.ini
+++ b/prometheus/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/proxysql/tox.ini
+++ b/proxysql/tox.ini
@@ -16,6 +16,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/rabbitmq/tox.ini
+++ b/rabbitmq/tox.ini
@@ -15,6 +15,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/redisdb/tox.ini
+++ b/redisdb/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/rethinkdb/tox.ini
+++ b/rethinkdb/tox.ini
@@ -18,6 +18,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/riak/tox.ini
+++ b/riak/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/riakcs/tox.ini
+++ b/riakcs/tox.ini
@@ -19,6 +19,7 @@ passenv =
     COMPOSE*
     BOTO_CONFIG
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/sap_hana/tox.ini
+++ b/sap_hana/tox.ini
@@ -16,6 +16,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/scylla/tox.ini
+++ b/scylla/tox.ini
@@ -16,6 +16,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -22,6 +22,7 @@ dd_mypy_args =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/solr/tox.ini
+++ b/solr/tox.ini
@@ -15,6 +15,7 @@ usedevelop = true
 dd_check_style = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/spark/tox.ini
+++ b/spark/tox.ini
@@ -16,6 +16,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -15,6 +15,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/squid/tox.ini
+++ b/squid/tox.ini
@@ -15,6 +15,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/ssh_check/tox.ini
+++ b/ssh_check/tox.ini
@@ -19,6 +19,7 @@ setenv =
     8.1: SSH_SERVER_VERSION=SSH-2.0-OpenSSH_8.1
     latest: SSH_SERVER_IMAGE=latest
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/statsd/tox.ini
+++ b/statsd/tox.ini
@@ -15,6 +15,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/supervisord/tox.ini
+++ b/supervisord/tox.ini
@@ -20,6 +20,7 @@ passenv =
 setenv =
     3.3: SUPERVISOR_VERSION=3_3_3
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/system_core/tox.ini
+++ b/system_core/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/system_swap/tox.ini
+++ b/system_swap/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/tcp_check/tox.ini
+++ b/tcp_check/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/teamcity/tox.ini
+++ b/teamcity/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/tls/tox.ini
+++ b/tls/tox.ini
@@ -16,6 +16,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/tokumx/tox.ini
+++ b/tokumx/tox.ini
@@ -14,6 +14,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/tomcat/tox.ini
+++ b/tomcat/tox.ini
@@ -15,6 +15,7 @@ usedevelop = true
 dd_check_style = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/twemproxy/tox.ini
+++ b/twemproxy/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/twistlock/tox.ini
+++ b/twistlock/tox.ini
@@ -14,6 +14,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/varnish/tox.ini
+++ b/varnish/tox.ini
@@ -18,6 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =

--- a/vault/tox.ini
+++ b/vault/tox.ini
@@ -16,6 +16,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv =

--- a/vertica/tox.ini
+++ b/vertica/tox.ini
@@ -16,6 +16,7 @@ description =
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 passenv = *

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -28,6 +28,7 @@ platform = linux|darwin
 passenv =
     TEST_VSPHERE_*
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/win32_event_log/tox.ini
+++ b/win32_event_log/tox.ini
@@ -13,6 +13,7 @@ dd_check_style = true
 usedevelop = true
 platform = win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/windows_service/tox.ini
+++ b/windows_service/tox.ini
@@ -17,6 +17,7 @@ description =
 usedevelop = true
 platform = win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/wmi_check/tox.ini
+++ b/wmi_check/tox.ini
@@ -19,6 +19,7 @@ dd_mypy_args =
     --follow-imports silent
     datadog_checks/wmi_check/wmi_check.py
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =

--- a/yarn/tox.ini
+++ b/yarn/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv = YARN_VERSION=2.7.1

--- a/zk/tox.ini
+++ b/zk/tox.ini
@@ -15,6 +15,7 @@ dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
 deps =
+    --use-feature=2020-resolver
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 commands =


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update tox configuration to use the new pip resolver: https://blog.python.org/2020/07/upgrade-pip-20-2-changes-20-3.html

### Motivation
<!-- What inspired you to submit this pull request? -->
The pip resolver is off-by-default in pip 20.2 and will be turned on in the upcoming pip 20.3.

We need to make sure this won't cause major breakage to our tooling when his happens.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
I batch-updated the tox config of integrations using this script:

```python
from pathlib import Path


def get_tox_paths():
    for d in Path(".").iterdir():
        if (
            d.is_dir()
            and not d.name.startswith((".", "_"))
            and d.name not in ("env", "venv")
            and (path := d / "tox.ini").exists()
        ):
            yield path


for toxpath in get_tox_paths():
    lines = toxpath.read_text().splitlines()

    lineno = 0
    while lineno < len(lines):
        line = lines[lineno]
        if line.strip() == "deps =":
            lines.insert(lineno + 1, "    --use-feature=2020-resolver")
        lineno += 1

    toxpath.write_text("\n".join(lines) + "\n")
```


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
