### PR TITLE
add conntrack binary step in network README

### DIFF
--- a/network/README.md
+++ b/network/README.md
@@ -50,7 +50,7 @@ Linux: Configure the following sudoers rule for this to work:
 dd-agent ALL=NOPASSWD: /usr/sbin/conntrack -S
 ```
 
-Kubernetes: Conntrack metrics are available by default in Kubernetes < v1.11 or when using the `host` networking mode in Kubernetes v1.11+.
+Kubernetes: Conntrack metrics are available by default in Kubernetes < v1.11 or when using the `host` networking mode in Kubernetes v1.11+. The conntrack binary may need to be installed to the agent image. 
 
 ### Validation
 


### PR DESCRIPTION
### What does this PR do?
Specifies that certain users may need to install conntrack binary in the Datadog image

### Motivation
https://datadog.zendesk.com/agent/tickets/379516