### PR TITLE
Validate the monitor id isn't in the payload

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -11,6 +11,7 @@ from ...utils import get_assets_from_manifest, get_valid_integrations, load_mani
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
 
 REQUIRED_ATTRIBUTES = {'name', 'type', 'query', 'message', 'tags', 'options', 'recommended_monitor_metadata'}
+EXTRA_NOT_ALLOWED_FIELDS = ['id']
 
 
 @click.command(
@@ -51,6 +52,11 @@ def recommended_monitors():
                 file_failed = True
                 display_queue.append(
                     (echo_failure, f"    {monitor_file} does not contain the required fields: {missing_fields}"),
+                )
+            elif any([item for item in all_keys if item in EXTRA_NOT_ALLOWED_FIELDS]):
+                file_failed = True
+                display_queue.append(
+                    (echo_failure, f"    {monitor_file} contains extra unallowed field, one of: {EXTRA_NOT_ALLOWED_FIELDS}"),
                 )
             else:
                 # If all required keys exist, validate values

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -56,7 +56,10 @@ def recommended_monitors():
             elif any([item for item in all_keys if item in EXTRA_NOT_ALLOWED_FIELDS]):
                 file_failed = True
                 display_queue.append(
-                    (echo_failure, f"    {monitor_file} contains extra unallowed field, one of: {EXTRA_NOT_ALLOWED_FIELDS}"),
+                    (
+                        echo_failure,
+                        f"    {monitor_file} contains extra unallowed field, one of: {EXTRA_NOT_ALLOWED_FIELDS}",
+                    ),
                 )
             else:
                 # If all required keys exist, validate values


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds an extra piece to the recommended monitor validations to fail if there is a monitor id in the json. 

### Motivation
<!-- What inspired you to submit this pull request? -->
When exporting a monitor to get the json, there will be an `id` that shouldn't be in the final payload. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
