### PR TITLE
Support updating Agent /etc/hosts in E2E envs

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -258,6 +258,11 @@ class DockerInterface(object):
         for key, value in sorted(env_vars.items()):
             command.extend(['-e', f'{key}={value}'])
 
+        # The docker `--add-host` command will reliably create entries in the `/etc/hosts` file,
+        # otherwise, edits to that file will be overwritten on container restarts
+        for host, ip in self.metadata.get('custom_hosts', []):
+            command.extend(['--add-host', f'{host}:{ip}'])
+
         if self.dogstatsd:
             command.extend(['-p', f'{DEFAULT_DOGSTATSD_PORT}:{DEFAULT_DOGSTATSD_PORT}/udp'])
 


### PR DESCRIPTION
### What does this PR do?
Adds E2E support for adding custom hosts to the Agent `/etc/hosts` file.

This could be used in place of the functionality provided by `mock_e2e_agent` in #7106.

Example usage:

```python
MOCKED_E2E_HOSTS = ('namenode', 'datanode', 'resourcemanager', 'nodemanager', 'historyserver')

def get_custom_hosts():
    # creat a mapping of mapreduce hostnames to localhost for DNS resolution
    custom_hosts = [(host, '127.0.0.1') for host in MOCKED_E2E_HOSTS]
    return custom_hosts


@pytest.fixture(scope="session")
def dd_environment():
    env = {'HOSTNAME': HOST}
    with docker_run(
        compose_file=os.path.join(HERE, "compose", "docker-compose.yaml"),
        conditions=[
            WaitFor(setup_mapreduce, attempts=240, wait=5)
        ],
        mount_logs=True,
        env_vars=env,
    ):
        yield INSTANCE_INTEGRATION, {'custom_hosts': get_custom_hosts()}
```

This ends up appending the following options to the `docker run` command: `'--add-host', 'namenode:127.0.0.1', '--add-host', 'datanode:127.0.0.1', '--add-host', 'resourcemanager:127.0.0.1', '--add-host', 'nodemanager:127.0.0.1', '--add-host', 'historyserver:127.0.0.1'`.

And results in the following `/etc/hosts` file:
```
root@docker-desktop:/# cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::0	ip6-localnet
ff00::0	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
127.0.0.1	namenode
127.0.0.1	datanode
127.0.0.1	resourcemanager
127.0.0.1	nodemanager
127.0.0.1	historyserver
```

### Motivation
Docker is very unforgiving with its hosts file and will rewrite any manual edits after every restart of the container.  Using the `--ad-host` option preserves these changes across restarts.

One key benefit of this approach, it avoids the need for explicit tests to perform the setup/tear down.  This means commands like `ddev env check mapreduce py38` can still work.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
