### PR TITLE
ddev for extras must not rewrite line endings

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -82,8 +82,6 @@ def run_in_toto(products, **kwargs):
         product_list=products,
         # Keep file size down
         compact_json=True,
-        # Cross-platform support
-        normalize_line_endings=True,
         # Extra options
         **kwargs,
     )
@@ -107,7 +105,8 @@ def update_link_metadata(checks, core_workflow=True):
         key_id_prefix = key_id[:8].lower()
 
         tag_link = f'{STEP_NAME}.{key_id_prefix}.link'
-        options = {'gpg_keyid': key_id}
+        # Normalize line endings, particularly on Windows, to deal with git.
+        options = {'gpg_keyid': key_id, 'normalize_line_endings': True}
     else:
         signing_key_path = os.getenv('IN_TOTO_SIGNING_KEY_PATH', '')
         signing_key = util.import_rsa_key_from_file(signing_key_path, os.getenv('IN_TOTO_SIGNING_KEY_PASSWORD'))
@@ -117,7 +116,9 @@ def update_link_metadata(checks, core_workflow=True):
         key_id_prefix = signing_key['keyid'][:8].lower()
 
         tag_link = f'{STEP_NAME}.{key_id_prefix}.link'
-        options = {'signing_key': signing_key}
+        # Do not allow machine to normalize line endings, because it is not on Windows,
+        # for which git might rewrite line endings in files.
+        options = {'signing_key': signing_key, 'normalize_line_endings': False}
 
     # Final location of metadata file.
     metadata_file = path_join(LINK_DIR, tag_link)


### PR DESCRIPTION
### What does this PR do?

Prevents in-toto from normalizing line endings when hashing files.

### Motivation

That works for developers on Windows (where they must hash files that end up being normalized in git), but not for extras on Linux.

### Additional Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
