### PR TITLE
Auto assign card

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/rc_build_cards_updater.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/rc_build_cards_updater.py
@@ -22,12 +22,12 @@ class RCBuildCardsUpdater:
                 f'A valid version is for example `7.21.0-rc.3`. '
                 f'You can disable the update of cards in RC builds column by removing --update-rc-builds-cards'
             )
+        else:
+            groups = match.groups()
+            if len(groups) != 6:
+                raise Exception('Regex in RCBuildCardsUpdater is not correct')
 
-        groups = match.groups()
-        if len(groups) != 6:
-            raise Exception('Regex in RCBuildCardsUpdater is not correct')
-
-        (_, self.__minor, self.__patch, _, _, self.__rc) = groups
+            (_, self.__minor, self.__patch, _, _, self.__rc) = groups
 
     def update_cards(self):
         rc_build_cards = [

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -461,5 +461,5 @@ def show_card_assigments(testerSelector: TesterSelector):
     for team, v in stat.items():
         echo_info(team)
         for user, prs in v.items():
-            prs_str = ".".join([str(pr) for pr in prs])
+            prs_str = ", ".join([str(pr) for pr in prs])
             echo_info(f"\t- {user}: {prs_str}")

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -9,8 +9,8 @@ import click
 
 from .....subprocess import SubprocessError, run_command
 from .....utils import basepath, chdir, get_next
-from ....constants import CHANGELOG_LABEL_PREFIX, CHANGELOG_TYPE_NONE, get_root
 from ....config import APP_DIR
+from ....constants import CHANGELOG_LABEL_PREFIX, CHANGELOG_TYPE_NONE, get_root
 from ....github import get_pr, get_pr_from_hash, get_pr_labels, get_pr_milestone, parse_pr_number
 from ....trello import TrelloClient
 from ....utils import format_commit_id

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -10,13 +10,13 @@ import click
 from .....subprocess import SubprocessError, run_command
 from .....utils import basepath, chdir, get_next
 from ....constants import CHANGELOG_LABEL_PREFIX, CHANGELOG_TYPE_NONE, get_root
+from ....config import APP_DIR
 from ....github import get_pr, get_pr_from_hash, get_pr_labels, get_pr_milestone, parse_pr_number
 from ....trello import TrelloClient
 from ....utils import format_commit_id
 from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_waiting, echo_warning
-from ....config import APP_DIR
 from .rc_build_cards_updater import RCBuildCardsUpdater
-from .tester_selector.tester_selector import TesterSelector, create_tester_selector, TrelloUser
+from .tester_selector.tester_selector import TesterSelector, TrelloUser, create_tester_selector
 
 
 def create_trello_card(
@@ -452,6 +452,7 @@ def testable(
 
     if dry_run:
         show_card_assigments(testerSelector)
+
 
 def show_card_assigments(testerSelector: TesterSelector):
     echo_info('Cards assignments')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/cache.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/cache.py
@@ -1,0 +1,61 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import json
+import os
+import time
+from typing import Dict, List, Optional
+from datetime import datetime
+
+from ....console import echo_info
+
+
+class Cache:
+    """
+    Cache data expensive to compute. Use JSON format.
+    """
+
+    def __init__(self, app_dir: str, cache_name: str, expiration: datetime):
+        cache_path = os.path.join(app_dir, '.cache')
+        self.__path = os.path.join(cache_path, cache_name)
+        try:
+            os.mkdir(cache_path)
+        except FileExistsError:
+            pass
+        try:
+            creation_time = datetime.utcfromtimestamp(
+                os.path.getctime(self.__path))
+            if creation_time < expiration:
+                echo_info(f'Cache expired. Removing cache {self.__path}')
+                os.remove(self.__path)
+        except OSError:
+            # file does not exist
+            pass
+
+    def get_value(self) -> Optional[object]:
+        try:
+            with open(self.__path) as f:
+                echo_info(f'Load from {self.__path}')
+                value_json = f.read()
+                return json.loads(value_json)
+        except FileNotFoundError:
+            return None
+        except Exception as e:
+            raise Exception(
+                f'Invalid cache object in {self.__path} {type(e)}') from e
+
+    def set_value(self, value: object):
+        value_json = json.dumps(value)
+        stat = None
+        
+        try:
+            stat = os.stat(self.__path)
+        except FileNotFoundError:
+            pass
+
+        with open(self.__path, 'w') as f:
+            f.write(value_json)
+        if stat:
+            # restore file dates for cache expiration
+            os.utime(self.__path, (stat.st_atime, stat.st_mtime))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/cache.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/cache.py
@@ -4,16 +4,15 @@
 
 import json
 import os
-import time
-from typing import Dict, List, Optional
 from datetime import datetime
+from typing import Optional
 
 from ....console import echo_info
 
 
 class Cache:
     """
-    Cache data expensive to compute. Use JSON format.
+    Cache data that is expensive to compute. Use JSON format.
     """
 
     def __init__(self, app_dir: str, cache_name: str, expiration: datetime):
@@ -24,8 +23,7 @@ class Cache:
         except FileExistsError:
             pass
         try:
-            creation_time = datetime.utcfromtimestamp(
-                os.path.getctime(self.__path))
+            creation_time = datetime.utcfromtimestamp(os.path.getctime(self.__path))
             if creation_time < expiration:
                 echo_info(f'Cache expired. Removing cache {self.__path}')
                 os.remove(self.__path)
@@ -42,13 +40,12 @@ class Cache:
         except FileNotFoundError:
             return None
         except Exception as e:
-            raise Exception(
-                f'Invalid cache object in {self.__path} {type(e)}') from e
+            raise Exception(f'Invalid cache object in {self.__path} {type(e)}') from e
 
     def set_value(self, value: object):
         value_json = json.dumps(value)
         stat = None
-        
+
         try:
             stat = os.stat(self.__path)
         except FileNotFoundError:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_trello_user_matcher.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_trello_user_matcher.py
@@ -2,23 +2,18 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import json
-import os
 import string
 import unicodedata
-from collections import namedtuple
-from dataclasses import dataclass
-from typing import Dict, NamedTuple, Optional
+from typing import Dict, Optional
 
-from ....console import echo_info
-from .trello_users import TrelloUsers, TrelloUser
+from .trello_users import TrelloUser, TrelloUsers
 
 
 class GithubTrelloUserMatcher:
     """
     Find the Trello user from a Github user using heuristics
 
-    See `__normalize_github_name` for Github name normalization and     
+    See `__normalize_github_name` for Github name normalization and
     `__normalize_trello_name` for Trello name normalization
     """
 
@@ -51,16 +46,14 @@ class GithubTrelloUserMatcher:
         return name
 
     def __strip_accents(self, text: str):
-        text = unicodedata.normalize('NFD', text).encode(
-            'ascii', 'ignore').decode("utf-8")
+        text = unicodedata.normalize('NFD', text).encode('ascii', 'ignore').decode("utf-8")
         return str(text)
 
     def __normalize_trello_name(self, name: str):
         """
         Remove space, `@datadoghq.com`, `.`, postfix digits and convert the result to lower case
         """
-        name = name.replace(" ", "").replace(
-            "@datadoghq.com", "").replace(".", "")
+        name = name.replace(" ", "").replace("@datadoghq.com", "").replace(".", "")
         name = name.lower().rstrip(string.digits)
         return name
 
@@ -71,5 +64,4 @@ class GithubTrelloUserMatcher:
         else:
             existing_user = self.__normalized_trello_users[normalize_name]
             if existing_user != user:
-                raise Exception(
-                    f'Normalized name is the same for {existing_user} and {user}')
+                raise Exception(f'Normalized name is the same for {existing_user} and {user}')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_trello_user_matcher.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_trello_user_matcher.py
@@ -1,0 +1,75 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import json
+import os
+import string
+import unicodedata
+from collections import namedtuple
+from dataclasses import dataclass
+from typing import Dict, NamedTuple, Optional
+
+from ....console import echo_info
+from .trello_users import TrelloUsers, TrelloUser
+
+
+class GithubTrelloUserMatcher:
+    """
+    Find the Trello user from a Github user using heuristics
+
+    See `__normalize_github_name` for Github name normalization and     
+    `__normalize_trello_name` for Trello name normalization
+    """
+
+    def __init__(self, trello_users: TrelloUsers):
+        users = trello_users.get_users()
+        self.__normalized_trello_users: Dict[str, TrelloUser] = {}
+        for user in users:
+            self.__add_trello_user(user.full_name, user)
+            self.__add_trello_user(user.username, user)
+
+    def get_trello_user(self, github_login: str, github_username: str) -> Optional[TrelloUser]:
+        names = [github_login]
+        if github_username:
+            names.append(github_username)
+        for name in names:
+            normalized_name = self.__normalize_github_name(name)
+            if normalized_name in self.__normalized_trello_users:
+                return self.__normalized_trello_users[normalized_name]
+        return None
+
+    def __normalize_github_name(self, name: str) -> str:
+        """
+        Remove spaces and `-dd` suffix, replace accents and convert the result to lower case.
+        """
+        name = name.replace(" ", "")
+        name = self.__strip_accents(name).lower()
+        suffix = "-dd"
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+        return name
+
+    def __strip_accents(self, text: str):
+        text = unicodedata.normalize('NFD', text).encode(
+            'ascii', 'ignore').decode("utf-8")
+        return str(text)
+
+    def __normalize_trello_name(self, name: str):
+        """
+        Remove space, `@datadoghq.com`, `.`, postfix digits and convert the result to lower case
+        """
+        name = name.replace(" ", "").replace(
+            "@datadoghq.com", "").replace(".", "")
+        name = name.lower().rstrip(string.digits)
+        return name
+
+    def __add_trello_user(self, name: str, user: TrelloUser):
+        normalize_name = self.__normalize_trello_name(name)
+        if normalize_name not in self.__normalized_trello_users:
+            self.__normalized_trello_users[normalize_name] = user
+        else:
+            existing_user = self.__normalized_trello_users[normalize_name]
+            if existing_user != user:
+                raise Exception(
+                    f'Normalized name is the same for {existing_user} and {user}')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_users.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_users.py
@@ -1,0 +1,62 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import json
+import os
+import time
+from datetime import datetime
+from typing import cast, Dict, List, Optional
+
+from .....github import Github
+from ....console import echo_info
+from .cache import Cache
+
+
+class GithubUser:
+    def __init__(self, data: Dict[str, object]):
+        self.login = cast(str, data['login'])
+        self.name = cast(str, data['name'])
+        self.last_pr_date_str = ''
+        last_pr_date_str = data['last_pr_date_str']
+        if last_pr_date_str:
+            self.last_pr_date_str = cast(str, last_pr_date_str)
+        self.team = cast(str, data['team'])
+
+
+class GithubUsers:
+    """
+    Store a collection of Github users
+    """
+    def __init__(self, github: Github, app_dir: str, cache_expiration: datetime):
+        self.__github = github
+        # Use a cache to avoid API Rate Limits
+        self.__user_cache = Cache(app_dir, 'github_user', cache_expiration)
+
+    def get_users(self, teams: List[str]) -> List[GithubUser]:
+        github_users = cast(Dict[str, Dict[str, object]],
+                            self.__user_cache.get_value())
+        if not github_users:
+            github_users = {}
+        for team in teams:
+            echo_info(f'Get team members for {team}')
+            for member in self.__github.get_team_members(team):
+                login = member['login']
+                if login not in github_users:
+                    user = self.__github.get_user(login)
+                    date = self.get_last_pr_date(login)
+                    github_users[login] = {
+                        'login': login, 'name': user['name'], 'last_pr_date_str': date, 'team': team}
+                    time.sleep(1)  # to avoid timeout
+
+        self.__user_cache.set_value(github_users)
+        return [GithubUser(user) for user in github_users.values()]
+
+    def get_last_pr_date(self, login: str) -> Optional[str]:
+        last_prs = self.__github.get_last_prs(login)
+        last_prs_items = last_prs['items']
+        if len(last_prs_items) == 0:
+            return None
+        last_pr = last_prs_items[0]
+        created_at = last_pr['created_at']
+        return created_at

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_users.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_users.py
@@ -2,11 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import json
-import os
 import time
 from datetime import datetime
-from typing import cast, Dict, List, Optional
+from typing import Dict, List, Optional, cast
 
 from .....github import Github
 from ....console import echo_info
@@ -28,14 +26,14 @@ class GithubUsers:
     """
     Store a collection of Github users
     """
+
     def __init__(self, github: Github, app_dir: str, cache_expiration: datetime):
         self.__github = github
         # Use a cache to avoid API Rate Limits
         self.__user_cache = Cache(app_dir, 'github_user', cache_expiration)
 
     def get_users(self, teams: List[str]) -> List[GithubUser]:
-        github_users = cast(Dict[str, Dict[str, object]],
-                            self.__user_cache.get_value())
+        github_users = cast(Dict[str, Dict[str, object]], self.__user_cache.get_value())
         if not github_users:
             github_users = {}
         for team in teams:
@@ -45,8 +43,7 @@ class GithubUsers:
                 if login not in github_users:
                     user = self.__github.get_user(login)
                     date = self.get_last_pr_date(login)
-                    github_users[login] = {
-                        'login': login, 'name': user['name'], 'last_pr_date_str': date, 'team': team}
+                    github_users[login] = {'login': login, 'name': user['name'], 'last_pr_date_str': date, 'team': team}
                     time.sleep(1)  # to avoid timeout
 
         self.__user_cache.set_value(github_users)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector.py
@@ -3,19 +3,20 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from datetime import datetime, timedelta
-from typing import Dict, Optional, Set, List
+from typing import Dict, List, Optional
 
 from .....github import Github
 from .....trello import TrelloClient
 from ....console import echo_info, echo_warning
-from .trello_users import TrelloUsers, TrelloUser
 from .github_trello_user_matcher import GithubTrelloUserMatcher
-from .github_users import GithubUsers, GithubUser
+from .github_users import GithubUser, GithubUsers
 from .tester_selector_team import TesterSelectorTeam
+from .trello_users import TrelloUser, TrelloUsers
+
 
 def create_tester_selector(trello: TrelloClient, github_teams: List[str], user_config, app_dir: str):
     github = Github(user_config, 5, 'datadog-agent', 'DataDog')
-    now = datetime.utcnow() 
+    now = datetime.utcnow()
     user_cache_expiration = now + timedelta(days=-7)
     trello_users = TrelloUsers(trello, app_dir, user_cache_expiration)
     github_users = GithubUsers(github, app_dir, user_cache_expiration)
@@ -32,20 +33,22 @@ class TesterSelector:
     Only users who created a pull request after `inactivity_date` are
     considered.
     """
+
     def __init__(
         self,
         team_names: List[str],
         github_users: GithubUsers,
         matcher: GithubTrelloUserMatcher,
         github: Github,
-        inactivity_date: datetime):
+        inactivity_date: datetime,
+    ):
 
-        self.__teams: Dict[str, TesterSelectorTeam]={}
-        self.__trello_user_from_github_login: Dict[str, TrelloUser]={}
+        self.__teams: Dict[str, TesterSelectorTeam] = {}
+        self.__trello_user_from_github_login: Dict[str, TrelloUser] = {}
 
         for user in github_users.get_users(team_names):
-            last_activity_date=self.__get_last_user_activity(user)
-            login=user.login
+            last_activity_date = self.__get_last_user_activity(user)
+            login = user.login
             if last_activity_date and last_activity_date > inactivity_date:
                 self.__add_user(user, matcher, github)
             else:
@@ -54,38 +57,38 @@ class TesterSelector:
     def get_next_tester(self, author: str, team_name: str, pr_num: int) -> Optional[TrelloUser]:
         if team_name not in self.__teams:
             return None
-        team=self.__teams[team_name]
-        github_login=team.get_next_tester(author, pr_num)
+        team = self.__teams[team_name]
+        github_login = team.get_next_tester(author, pr_num)
 
         if github_login in self.__trello_user_from_github_login:
             return self.__trello_user_from_github_login[github_login]
         return None
 
     def get_stats(self):
-        stats={}
+        stats = {}
         for team in self.__teams.values():
-            stats[team.get_name()]=team.get_stats()
+            stats[team.get_name()] = team.get_stats()
         return stats
 
     def __add_user(self, github_user: GithubUser, matcher: GithubTrelloUserMatcher, github: Github):
-        team=self.__get_or_create_team(github_user, github)
-        login=github_user.login
+        team = self.__get_or_create_team(github_user, github)
+        login = github_user.login
         team.add(login)
 
-        trello_user=matcher.get_trello_user(login, github_user.name)
+        trello_user = matcher.get_trello_user(login, github_user.name)
         if not trello_user:
             echo_warning(f'No trello user found for {login}')
         else:
-            self.__trello_user_from_github_login[login]=trello_user
+            self.__trello_user_from_github_login[login] = trello_user
 
     def __get_or_create_team(self, github_user: GithubUser, github: Github):
-        team_name=github_user.team
+        team_name = github_user.team
         if team_name not in self.__teams:
-            self.__teams[team_name]=TesterSelectorTeam(github, team_name)
+            self.__teams[team_name] = TesterSelectorTeam(github, team_name)
         return self.__teams[team_name]
 
     def __get_last_user_activity(self, user: GithubUser) -> Optional[datetime]:
-        last_pr_date=user.last_pr_date_str
+        last_pr_date = user.last_pr_date_str
         if last_pr_date:
             return datetime.strptime(last_pr_date, "%Y-%m-%dT%H:%M:%SZ")
         return None

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector.py
@@ -1,0 +1,91 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from datetime import datetime, timedelta
+from typing import Dict, Optional, Set, List
+
+from .....github import Github
+from .....trello import TrelloClient
+from ....console import echo_info, echo_warning
+from .trello_users import TrelloUsers, TrelloUser
+from .github_trello_user_matcher import GithubTrelloUserMatcher
+from .github_users import GithubUsers, GithubUser
+from .tester_selector_team import TesterSelectorTeam
+
+def create_tester_selector(trello: TrelloClient, github_teams: List[str], user_config, app_dir: str):
+    github = Github(user_config, 5, 'datadog-agent', 'DataDog')
+    now = datetime.utcnow() 
+    user_cache_expiration = now + timedelta(days=-7)
+    trello_users = TrelloUsers(trello, app_dir, user_cache_expiration)
+    github_users = GithubUsers(github, app_dir, user_cache_expiration)
+    userMatcher = GithubTrelloUserMatcher(trello_users)
+
+    inactivity_date = now + timedelta(days=-(6 * 7))  # Duration of the release
+    return TesterSelector(github_teams, github_users, userMatcher, github, inactivity_date)
+
+
+class TesterSelector:
+    """
+    Select a teammmate for QAing a trello card from github author.
+    The algorithm is described in TesterSelectorTeam.
+    Only users who created a pull request after `inactivity_date` are
+    considered.
+    """
+    def __init__(
+        self,
+        team_names: List[str],
+        github_users: GithubUsers,
+        matcher: GithubTrelloUserMatcher,
+        github: Github,
+        inactivity_date: datetime):
+
+        self.__teams: Dict[str, TesterSelectorTeam]={}
+        self.__trello_user_from_github_login: Dict[str, TrelloUser]={}
+
+        for user in github_users.get_users(team_names):
+            last_activity_date=self.__get_last_user_activity(user)
+            login=user.login
+            if last_activity_date and last_activity_date > inactivity_date:
+                self.__add_user(user, matcher, github)
+            else:
+                echo_info(f'Skip inactive user {login} {last_activity_date}')
+
+    def get_next_tester(self, author: str, team_name: str, pr_num: int) -> Optional[TrelloUser]:
+        if team_name not in self.__teams:
+            return None
+        team=self.__teams[team_name]
+        github_login=team.get_next_tester(author, pr_num)
+
+        if github_login in self.__trello_user_from_github_login:
+            return self.__trello_user_from_github_login[github_login]
+        return None
+
+    def get_stats(self):
+        stats={}
+        for team in self.__teams.values():
+            stats[team.get_name()]=team.get_stats()
+        return stats
+
+    def __add_user(self, github_user: GithubUser, matcher: GithubTrelloUserMatcher, github: Github):
+        team=self.__get_or_create_team(github_user, github)
+        login=github_user.login
+        team.add(login)
+
+        trello_user=matcher.get_trello_user(login, github_user.name)
+        if not trello_user:
+            echo_warning(f'No trello user found for {login}')
+        else:
+            self.__trello_user_from_github_login[login]=trello_user
+
+    def __get_or_create_team(self, github_user: GithubUser, github: Github):
+        team_name=github_user.team
+        if team_name not in self.__teams:
+            self.__teams[team_name]=TesterSelectorTeam(github, team_name)
+        return self.__teams[team_name]
+
+    def __get_last_user_activity(self, user: GithubUser) -> Optional[datetime]:
+        last_pr_date=user.last_pr_date_str
+        if last_pr_date:
+            return datetime.strptime(last_pr_date, "%Y-%m-%dT%H:%M:%SZ")
+        return None

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector_team.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector_team.py
@@ -3,8 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import random
+from typing import Dict, List, Optional, Set
+
 from .....github import Github
-from typing import List, Set, Dict, Optional
+
 
 class TesterSelectorTeam:
     """
@@ -12,13 +14,14 @@ class TesterSelectorTeam:
 
     The algorithm is the following:
         1 Consider teammates who are neither the author of the PR nor a reviewer.
-        2 Select the teammate with the least number of assigned cards. If several 
+        2 Select the teammate with the least number of assigned cards. If several
           teammates meet these criterion, select one randomly.
-        
-        If a tester cannot be find, use 2 but consider teammates that review the PR. 
+
+        If a tester cannot be find, use 2 but consider teammates that review the PR.
 
         Note: If someone review all the PRs of her team, the algorithm never select her.
     """
+
     def __init__(self, github: Github, team_name: str):
         self.__prs_by_tester: Dict[str, List[int]] = {}
         self.__name = team_name
@@ -38,7 +41,7 @@ class TesterSelectorTeam:
             tester = self.__select_testers(lambda t: t != author)
 
         if tester is not None:
-            self.__prs_by_tester[tester].append(pr_num)        
+            self.__prs_by_tester[tester].append(pr_num)
         return tester
 
     def get_stats(self):
@@ -53,7 +56,7 @@ class TesterSelectorTeam:
         for user, prs in self.__prs_by_tester.items():
             if not user_excluded_fct(user):
                 if len(candidates) == 0 or len(prs) <= minAssignedCards:
-                    # if a user has less reviews than minAssignedCards, then 
+                    # if a user has less reviews than minAssignedCards, then
                     # she becomes the current best candidate.
                     if len(prs) < minAssignedCards:
                         candidates.clear()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector_team.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector_team.py
@@ -1,0 +1,69 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import random
+from .....github import Github
+from typing import List, Set, Dict, Optional
+
+class TesterSelectorTeam:
+    """
+    Select a teammmate for QAing a trello card from a github PR author.
+
+    The algorithm is the following:
+        1 Consider teammates who are neither the author of the PR nor a reviewer.
+        2 Select the teammate with the least number of assigned cards. If several 
+          teammates meet these criterion, select one randomly.
+        
+        If a tester cannot be find, use 2 but consider teammates that review the PR. 
+
+        Note: If someone review all the PRs of her team, the algorithm never select her.
+    """
+    def __init__(self, github: Github, team_name: str):
+        self.__prs_by_tester: Dict[str, List[int]] = {}
+        self.__name = team_name
+        self.__github = github
+
+    def add(self, user: str):
+        self.__prs_by_tester[user] = []
+
+    def get_next_tester(self, author: str, pr_num: int) -> Optional[str]:
+        exclude_testers = self.__get_reviewers(pr_num)
+        exclude_testers.add(author)
+
+        # find a tester who is neither the author nor a reviewer
+        tester = self.__select_testers(lambda t: t in exclude_testers)
+        if tester is None:
+            # find a tester who is not the author
+            tester = self.__select_testers(lambda t: t != author)
+
+        if tester is not None:
+            self.__prs_by_tester[tester].append(pr_num)        
+        return tester
+
+    def get_stats(self):
+        return self.__prs_by_tester
+
+    def get_name(self):
+        return self.__name
+
+    def __select_testers(self, user_excluded_fct) -> Optional[str]:
+        candidates: List[str] = []
+        minAssignedCards = 0
+        for user, prs in self.__prs_by_tester.items():
+            if not user_excluded_fct(user):
+                if len(candidates) == 0 or len(prs) <= minAssignedCards:
+                    # if a user has less reviews than minAssignedCards, then 
+                    # she becomes the current best candidate.
+                    if len(prs) < minAssignedCards:
+                        candidates.clear()
+                    candidates.append(user)
+                    minAssignedCards = len(prs)
+
+        if len(candidates) > 0:
+            return candidates[random.randint(0, len(candidates) - 1)]
+        return None
+
+    def __get_reviewers(self, pr_num: int) -> Set[str]:
+        reviews = self.__github.get_reviews(pr_num)
+        return set([r["user"]["login"] for r in reviews])

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/trello_users.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/trello_users.py
@@ -2,13 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import json
-import os
-import time
 from datetime import datetime
-from typing import cast, Dict, List, Optional
+from typing import Dict, List, cast
 
-from .....github import Github
 from .....trello import TrelloClient
 from ....console import echo_info
 from .cache import Cache
@@ -25,14 +21,14 @@ class TrelloUsers:
     """
     Store a collection of Trello users
     """
+
     def __init__(self, trello: TrelloClient, app_dir: str, cache_expiration: datetime):
         self.__trello = trello
         # Use a cache to avoid API Rate Limits
         self.__user_cache = Cache(app_dir, 'trello_user', cache_expiration)
 
     def get_users(self) -> List[TrelloUser]:
-        trello_users = cast(Dict[str, Dict[str, object]],
-                            self.__user_cache.get_value())
+        trello_users = cast(Dict[str, Dict[str, object]], self.__user_cache.get_value())
         if not trello_users:
             trello_users = {}
         membership = self.__trello.get_membership()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/trello_users.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/trello_users.py
@@ -1,0 +1,52 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import json
+import os
+import time
+from datetime import datetime
+from typing import cast, Dict, List, Optional
+
+from .....github import Github
+from .....trello import TrelloClient
+from ....console import echo_info
+from .cache import Cache
+
+
+class TrelloUser:
+    def __init__(self, data: Dict[str, object]):
+        self.id = cast(str, data['id_member'])
+        self.full_name = cast(str, data['full_name'])
+        self.username = cast(str, data['username'])
+
+
+class TrelloUsers:
+    """
+    Store a collection of Trello users
+    """
+    def __init__(self, trello: TrelloClient, app_dir: str, cache_expiration: datetime):
+        self.__trello = trello
+        # Use a cache to avoid API Rate Limits
+        self.__user_cache = Cache(app_dir, 'trello_user', cache_expiration)
+
+    def get_users(self) -> List[TrelloUser]:
+        trello_users = cast(Dict[str, Dict[str, object]],
+                            self.__user_cache.get_value())
+        if not trello_users:
+            trello_users = {}
+        membership = self.__trello.get_membership()
+        for m in membership:
+            if not m['deactivated']:
+                id_member = m['idMember']
+                if id_member not in trello_users:
+                    member = self.__trello.get_member(id_member)
+                    fullname = member['fullName']
+                    echo_info(f'Getting information for user {fullname}')
+                    trello_users[id_member] = {
+                        'id_member': id_member,
+                        'full_name': fullname,
+                        'username': member['username'],
+                    }
+        self.__user_cache.set_value(trello_users)
+        return [TrelloUser(user) for user in trello_users.values()]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/github.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/github.py
@@ -170,12 +170,12 @@ class Github:
         return self.__get_request_retry(f'{API_URL}/orgs/{self.__org}/teams/{team}/members')
 
     def get_reviews(self, pr_num):
-        return self.__get_request_retry(
-            f'{API_URL}/repos/{self.__org}/{self.__repo}/pulls/{pr_num}/reviews')
+        return self.__get_request_retry(f'{API_URL}/repos/{self.__org}/{self.__repo}/pulls/{pr_num}/reviews')
 
     def get_last_prs(self, user):
         return self.__get_request_retry(
-            f'{API_URL}/search/issues?q=repo:{self.__org}/{self.__repo}+author:{user}+is:pr+sort:created')
+            f'{API_URL}/search/issues?q=repo:{self.__org}/{self.__repo}+author:{user}+is:pr+sort:created'
+        )
 
     def __get_request_retry(self, url):
         wait = 3
@@ -191,7 +191,6 @@ class Github:
         raise Exception(f'Error: {url}')
 
     def __get_request(self, url):
-        repo = basepath(get_root())
         response = requests.get(url, auth=self.__auth)
 
         response.raise_for_status()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/github.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/github.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 import re
+import time
 from typing import Optional
 
 import requests
@@ -153,3 +154,45 @@ def parse_pr_numbers(git_log_lines):
         if pr_number:
             prs.append(pr_number)
     return prs
+
+
+class Github:
+    def __init__(self, config, retry_count: int, repo: str, org: str):
+        self.__auth = get_auth_info(config)
+        self.__org = org
+        self.__repo = repo
+        self.__retry_count = retry_count
+
+    def get_user(self, login):
+        return self.__get_request_retry(f'{API_URL}/users/{login}')
+
+    def get_team_members(self, team):
+        return self.__get_request_retry(f'{API_URL}/orgs/{self.__org}/teams/{team}/members')
+
+    def get_reviews(self, pr_num):
+        return self.__get_request_retry(
+            f'{API_URL}/repos/{self.__org}/{self.__repo}/pulls/{pr_num}/reviews')
+
+    def get_last_prs(self, user):
+        return self.__get_request_retry(
+            f'{API_URL}/search/issues?q=repo:{self.__org}/{self.__repo}+author:{user}+is:pr+sort:created')
+
+    def __get_request_retry(self, url):
+        wait = 3
+        for _ in range(self.__retry_count):
+            try:
+                return self.__get_request(url)
+            except requests.exceptions.HTTPError as e:
+                if e.response.status_code == 403:
+                    time.sleep(wait)
+                    wait *= 2
+                else:
+                    raise e
+        raise Exception(f'Error: {url}')
+
+    def __get_request(self, url):
+        repo = basepath(get_root())
+        response = requests.get(url, auth=self.__auth)
+
+        response.raise_for_status()
+        return response.json()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -53,6 +53,7 @@ class TrelloClient:
             'team/integrations': 'agent-integrations',
             'team/logs': 'logs-intake',
             'team/intg-tools-libs': 'integrations-tools-and-libraries',
+            'team/agent-security': 'agent-security',
         }
 
         self.label_map = {

--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -12,6 +12,8 @@ class TrelloClient:
     LISTS_ENDPOINT = API_URL + '/1/boards/ICjijxr4/lists'
     LABELS_ENDPOINT = API_URL + '/1/boards/ICjijxr4/labels'
     CARDS_ENDPOINT = API_URL + '/1/cards'
+    MEMBERSHIP_ENDPOINT = API_URL + '/1/boards/ICjijxr4/memberships'
+    MEMBER_ENPOINT = API_URL + '/1/members'
 
     def __init__(self, config):
         self.auth = {'key': config['trello']['key'] or None, 'token': config['trello']['token'] or None}
@@ -39,6 +41,20 @@ class TrelloClient:
             'team/logs': 'Logs',
             'team/tools-and-libraries': 'Tools and Libraries',
         }
+
+        self.label_github_team_map = {
+            'team/agent-apm': 'agent-apm',
+            'team/agent-core': 'agent-core',
+            'team/agent-platform': 'agent-platform',
+            'team/networks': 'networks',
+            'team/processes': 'processes',
+            'team/containers': 'container-integrations',
+            'team/container-app': 'container-app',
+            'team/integrations': 'agent-integrations',
+            'team/logs': 'logs-intake',
+            'team/intg-tools-libs': 'integrations-tools-and-libraries',
+        }
+
         self.label_map = {
             'Containers': '5e7910856f8e4363e3b51708',
             'Container App': '5e8b36f72f642272e75edd34',
@@ -132,3 +148,26 @@ class TrelloClient:
         response = requests.put(f'{self.CARDS_ENDPOINT}/{card_id}', headers=headers, data=data, params=self.auth)
         response.raise_for_status()
         return response.json()
+
+    def get_membership(self):
+        """
+        Get the members.
+        """
+        membership = requests.get(self.MEMBERSHIP_ENDPOINT, params=self.auth)
+        membership.raise_for_status()
+        return membership.json()
+
+    def get_member(self, id_member):
+        """
+        Get the member.
+        """
+        try:
+            membership = requests.get(f'{self.MEMBER_ENPOINT}/{id_member}', params=self.auth)
+            membership.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 429:
+                raise Exception('Timeout, please try in 900 secondes') from e
+            else:
+                raise e
+
+        return membership.json()


### PR DESCRIPTION
### What does this PR do?

This PR assign a tester to the Trello cards created by `ddev release trello testable` 

The algorithm is the following:
1. Consider teammates who are neither the author of the PR nor a reviewer.
2. Select the teammate with the least number of assigned cards. If several teammates meet these criterion, select one randomly.

If a tester cannot be find, use 2. but consider teammates that reviewed the PR.

A user is not considered if she did not open a pull request on DataDog/datadog-agent during the last 6 weeks.

Note: If someone review all the PRs of her team, the algorithm never select her.

Algorithm is implemented in `tester_selector_team.py`

### Motivation
<!-- What inspired you to submit this pull request? -->

Assigning a tester that is neither the author nor a review is time consuming

### Additional Notes
<!-- Anything else we should know when reviewing? -->

To match Trello users and Github users, the code uses heuristics as I was not aware of https://github.com/DataDog/devops/wiki/GitHub-usernames-and-Trello-IDs.

Pros:
- There is no need to maintain GitHub-usernames-and-Trello-IDs. As the agent team is quite big, `GitHub-usernames-and-Trello-IDs` should probably need to be updated for each release.
- It works for any teams

Cons:
- There is less control on excluded users (1).
- 2 users need to update their trello fullname or Trello name.

(1): It is possible to used a new trello card, all users assigned on this specific card received Trello cards to QA. 

For reviewer: I would love to hear your thoughts on using heuristics VS GitHub-usernames-and-Trello-IDs.

Note:
I have used `mypy` to check typing.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
