### PR TITLE
Revert Fix wrong indentation of `table` key in column metric tags #7024

### DIFF
--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -438,16 +438,7 @@ def _parse_table_metric_tag(mib, parsed_table, metric_tag):
 
 def _parse_column_metric_tag(mib, parsed_table, metric_tag):
     # type: (str, ParsedSymbol, ColumnTableMetricTag) -> ParsedColumnMetricTag
-    column = metric_tag['column']
-
-    if isinstance(column, dict) and 'table' in column:
-        # Prevent a common error due to bad indentation...
-        raise ConfigurationError(
-            'found unexpected "table" key in column {} '
-            '("table" should be set on the `metric_tag` - this is probably an indentation issue)'.format(column)
-        )
-
-    parsed_column = _parse_symbol(mib, column)
+    parsed_column = _parse_symbol(mib, metric_tag['column'])
 
     batches = {TableBatchKey(mib, table=parsed_table.name): TableBatch(parsed_table.oid, oids=[parsed_column.oid])}
 


### PR DESCRIPTION
### What does this PR do?

Revert Fix wrong indentation of `table` key in column metric tags #7024

We keep the profiles indent fixes made in #7024

### Motivation

Need more investigation about the consequence of raising an ConfigurationError at this location.

Currently, the check will fail on startup with `Warning: found unexpected "table" key in column`.