### PR TITLE
Add function to parse RDS tags from the endpoint

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/aws.py
+++ b/datadog_checks_base/datadog_checks/base/utils/aws.py
@@ -34,10 +34,6 @@ def rds_parse_tags_from_endpoint(endpoint):
     
     identifier, cluster, region, _ = parts
     if cluster.startswith('cluster-'):
-        # Provided URI is an aurora cluster endpoint, not an instance.
-        # This is the case when the agent is configured to connect to the
-        # reader/writer endpoint in an aurora cluster or if the cluster is
-        # a serverless Aurora cluster.
         tags.append('dbclusteridentifier:' + identifier)
     else:
         tags.append('dbinstanceidentifier:' + identifier)

--- a/datadog_checks_base/datadog_checks/base/utils/aws.py
+++ b/datadog_checks_base/datadog_checks/base/utils/aws.py
@@ -16,7 +16,8 @@ def rds_parse_tags_from_endpoint(endpoint):
     Examples:
 
     >>> rds_parse_tags_from_endpoint('customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com')
-    ['dbinstanceidentifier:customers-04', 'hostname:customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com', 'region:us-west-2']
+    ['dbinstanceidentifier:customers-04', 'hostname:customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com',
+     'region:us-west-2']
 
     >>> rds_parse_tags_from_endpoint('dd-metrics.cluster-ro-cfxdfe8cpixl.ap-east-1.rds.amazonaws.com')
     ['dbclusteridentifier:dd-metrics', 'region:ap-east-1']

--- a/datadog_checks_base/datadog_checks/base/utils/aws.py
+++ b/datadog_checks_base/datadog_checks/base/utils/aws.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+
 def rds_parse_tags_from_endpoint(endpoint):
     """
     Given the URI for an AWS RDS / Aurora endpoint, parse supplemental tags
@@ -31,7 +32,7 @@ def rds_parse_tags_from_endpoint(endpoint):
         return tags
     if parts[3] != 'rds.amazonaws.com':
         return tags
-    
+
     identifier, cluster, region, _ = parts
     if cluster.startswith('cluster-'):
         tags.append('dbclusteridentifier:' + identifier)

--- a/datadog_checks_base/datadog_checks/base/utils/aws.py
+++ b/datadog_checks_base/datadog_checks/base/utils/aws.py
@@ -1,0 +1,46 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+def rds_parse_tags_from_endpoint(endpoint):
+    """
+    Given the URI for an AWS RDS / Aurora endpoint, parse supplemental tags
+    from the parts. The possible tags are:
+
+    * `dbinstanceidentifier` - The instance's unique identifier for RDS and Aurora clusters
+    * `dbclusteridentifier` - The cluster identifier in the case of Aurora cluster endpoints and serverless
+    * `hostname` - The full endpoint if the endpoint points to a specific instance
+    * `region` - The AWS region of the endpoint
+
+    Examples:
+
+    >>> rds_parse_tags_from_endpoint('customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com')
+    ['dbinstanceidentifier:customers-04', 'hostname:customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com', 'region:us-west-2']
+
+    >>> rds_parse_tags_from_endpoint('dd-metrics.cluster-ro-cfxdfe8cpixl.ap-east-1.rds.amazonaws.com')
+    ['dbclusteridentifier:dd-metrics', 'region:ap-east-1']
+    """
+    tags = []
+
+    if not endpoint:
+        return tags
+
+    endpoint = endpoint.strip()
+    parts = endpoint.split('.', 3)
+    if len(parts) != 4:
+        return tags
+    if parts[3] != 'rds.amazonaws.com':
+        return tags
+    
+    identifier, cluster, region, _ = parts
+    if cluster.startswith('cluster-'):
+        # Provided URI is an aurora cluster endpoint, not an instance.
+        # This is the case when the agent is configured to connect to the
+        # reader/writer endpoint in an aurora cluster or if the cluster is
+        # a serverless Aurora cluster.
+        tags.append('dbclusteridentifier:' + identifier)
+    else:
+        tags.append('dbinstanceidentifier:' + identifier)
+        tags.append('hostname:' + endpoint)
+    tags.append('region:' + region)
+    return tags

--- a/datadog_checks_base/tests/test_aws.py
+++ b/datadog_checks_base/tests/test_aws.py
@@ -1,0 +1,24 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.base.utils.aws import rds_parse_tags_from_endpoint
+
+
+pytestmark = pytest.mark.aws
+
+
+class TestRDS:
+    @pytest.mark.parametrize('test_case,expected', [
+        (None, []),
+        ('', []),
+        ('localhost', []),
+        ('/var/run/postgres.sock', []),
+        (' my_db.cfxdfe8cpixl.us-east-2.rds.amazonaws.com ', ['dbinstanceidentifier:my_db', 'hostname:my_db.cfxdfe8cpixl.us-east-2.rds.amazonaws.com', 'region:us-east-2']),
+        ('customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com', ['dbinstanceidentifier:customers-04', 'hostname:customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com', 'region:us-west-2']),
+        ('dd-metrics.cluster-ro-cfxdfe8cpixl.ap-east-1.rds.amazonaws.com', ['dbclusteridentifier:dd-metrics', 'region:ap-east-1']),
+        ('dd-metrics.cluster-cfxdfe8cpixl.ap-east-1.rds.amazonaws.com', ['dbclusteridentifier:dd-metrics', 'region:ap-east-1']),
+    ])
+    def test_parse_tags_from_endpoint_instance(self, test_case, expected):
+        assert rds_parse_tags_from_endpoint(test_case) == expected

--- a/datadog_checks_base/tests/test_aws.py
+++ b/datadog_checks_base/tests/test_aws.py
@@ -5,20 +5,42 @@ import pytest
 
 from datadog_checks.base.utils.aws import rds_parse_tags_from_endpoint
 
-
 pytestmark = pytest.mark.aws
 
 
 class TestRDS:
-    @pytest.mark.parametrize('test_case,expected', [
-        (None, []),
-        ('', []),
-        ('localhost', []),
-        ('/var/run/postgres.sock', []),
-        (' my_db.cfxdfe8cpixl.us-east-2.rds.amazonaws.com ', ['dbinstanceidentifier:my_db', 'hostname:my_db.cfxdfe8cpixl.us-east-2.rds.amazonaws.com', 'region:us-east-2']),
-        ('customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com', ['dbinstanceidentifier:customers-04', 'hostname:customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com', 'region:us-west-2']),
-        ('dd-metrics.cluster-ro-cfxdfe8cpixl.ap-east-1.rds.amazonaws.com', ['dbclusteridentifier:dd-metrics', 'region:ap-east-1']),
-        ('dd-metrics.cluster-cfxdfe8cpixl.ap-east-1.rds.amazonaws.com', ['dbclusteridentifier:dd-metrics', 'region:ap-east-1']),
-    ])
+    @pytest.mark.parametrize(
+        'test_case,expected',
+        [
+            (None, []),
+            ('', []),
+            ('localhost', []),
+            ('/var/run/postgres.sock', []),
+            (
+                ' my_db.cfxdfe8cpixl.us-east-2.rds.amazonaws.com ',
+                [
+                    'dbinstanceidentifier:my_db',
+                    'hostname:my_db.cfxdfe8cpixl.us-east-2.rds.amazonaws.com',
+                    'region:us-east-2',
+                ],
+            ),
+            (
+                'customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com',
+                [
+                    'dbinstanceidentifier:customers-04',
+                    'hostname:customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com',
+                    'region:us-west-2',
+                ],
+            ),
+            (
+                'dd-metrics.cluster-ro-cfxdfe8cpixl.ap-east-1.rds.amazonaws.com',
+                ['dbclusteridentifier:dd-metrics', 'region:ap-east-1'],
+            ),
+            (
+                'dd-metrics.cluster-cfxdfe8cpixl.ap-east-1.rds.amazonaws.com',
+                ['dbclusteridentifier:dd-metrics', 'region:ap-east-1'],
+            ),
+        ],
+    )
     def test_parse_tags_from_endpoint(self, test_case, expected):
         assert rds_parse_tags_from_endpoint(test_case) == expected

--- a/datadog_checks_base/tests/test_aws.py
+++ b/datadog_checks_base/tests/test_aws.py
@@ -20,5 +20,5 @@ class TestRDS:
         ('dd-metrics.cluster-ro-cfxdfe8cpixl.ap-east-1.rds.amazonaws.com', ['dbclusteridentifier:dd-metrics', 'region:ap-east-1']),
         ('dd-metrics.cluster-cfxdfe8cpixl.ap-east-1.rds.amazonaws.com', ['dbclusteridentifier:dd-metrics', 'region:ap-east-1']),
     ])
-    def test_parse_tags_from_endpoint_instance(self, test_case, expected):
+    def test_parse_tags_from_endpoint(self, test_case, expected):
         assert rds_parse_tags_from_endpoint(test_case) == expected


### PR DESCRIPTION
### What does this PR do?

Exposes a utility function for parsing AWS RDS metadata to tag database integrations with when they are connecting to an RDS / Aurora instance.

### Motivation

This improves the experience for customers because it will provide a common tag set they can use to link Cloudwatch integration metrics with database integration metrics. This common tagging will be used in database monitoring dashboards so customers need only toggle a single tag instead of multiple tags on dashboards.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
