### PR TITLE
Add monitor validation on allowed types and more friendly error messages

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import json
+import os
 
 import click
 
@@ -12,6 +13,7 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
 
 REQUIRED_ATTRIBUTES = {'name', 'type', 'query', 'message', 'tags', 'options', 'recommended_monitor_metadata'}
 EXTRA_NOT_ALLOWED_FIELDS = ['id']
+ALLOWED_MONITOR_TYPES = ['metric alert', 'query alert', 'event alert']
 
 
 @click.command(
@@ -37,6 +39,7 @@ def recommended_monitors():
             failed_checks += 1
 
         for monitor_file in monitors_relative_locations:
+            monitor_filename = os.path.basename(monitor_file)
             try:
                 decoded = json.loads(read_file(monitor_file).strip())
             except json.JSONDecodeError as e:
@@ -51,18 +54,31 @@ def recommended_monitors():
                 missing_fields = REQUIRED_ATTRIBUTES.difference(all_keys)
                 file_failed = True
                 display_queue.append(
-                    (echo_failure, f"    {monitor_file} does not contain the required fields: {missing_fields}"),
+                    (echo_failure, f"    {monitor_filename} does not contain the required fields: {missing_fields}"),
                 )
             elif any([item for item in all_keys if item in EXTRA_NOT_ALLOWED_FIELDS]):
                 file_failed = True
                 display_queue.append(
                     (
                         echo_failure,
-                        f"    {monitor_file} contains extra unallowed field, one of: {EXTRA_NOT_ALLOWED_FIELDS}",
+                        f"    {monitor_filename} contains unsupported field(s). Please ensure none of the following are"
+                        f" in the file: {EXTRA_NOT_ALLOWED_FIELDS}",
                     ),
                 )
             else:
                 # If all required keys exist, validate values
+
+                monitor_type = decoded.get('type')
+                if monitor_type not in ALLOWED_MONITOR_TYPES:
+                    file_failed = True
+                    display_queue.append(
+                        (
+                            echo_failure,
+                            f"    {monitor_filename} is of unsupported type: \"{monitor_type}\". Only"
+                            f" the following types are allowed: {ALLOWED_MONITOR_TYPES}",
+                        )
+                    )
+
                 description = decoded.get('recommended_monitor_metadata').get('description')
                 if description is not None:
                     if len(description) > 300:
@@ -70,20 +86,22 @@ def recommended_monitors():
                         display_queue.append(
                             (
                                 echo_failure,
-                                f"    {monitor_file} has a description field that is too long, must be < 300 chars",
+                                f"    {monitor_filename} has a description field that is too long, must be < 300 chars",
                             ),
                         )
 
                 result = [i for i in decoded.get('tags') if i.startswith('integration:')]
                 if len(result) < 1:
                     file_failed = True
-                    display_queue.append((echo_failure, f"    {monitor_file} must have an `integration` tag"),)
+                    display_queue.append((echo_failure, f"    {monitor_filename} must have an `integration` tag"),)
 
                 display_name = manifest.get("display_name").lower()
                 monitor_name = decoded.get('name').lower()
                 if not (check_name in monitor_name or display_name in monitor_name):
                     file_failed = True
-                    display_queue.append((echo_failure, f"    {monitor_file} name must contain the integration name"),)
+                    display_queue.append(
+                        (echo_failure, f"    {monitor_filename} name must contain the integration name"),
+                    )
 
         if file_failed:
             failed_checks += 1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Recommended monitors currently allow `metric alert`, `query alert` and `event alert` types, so this PR adds a validation for that. 

I also modified the error messaging a bit to try and make the recommended solution a bit more clear. 
I also only print the filename instead of the file path at the beginning of the error. Since the errors are nested under the integration name anyway, it makes the error line shorter. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
