### PR TITLE
Allow the validation of the newer dashboard payload in integration bo…

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dashboards.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dashboards.py
@@ -69,10 +69,7 @@ def dashboards():
             if not _is_dashboard_format(decoded):
                 file_old_format = True
                 display_queue.append(
-                    (
-                        echo_warning,
-                        f'    {dashboard_file} is not using the new /dashboard payload format.'
-                    ),
+                    (echo_warning, f'    {dashboard_file} is not using the new /dashboard payload format.'),
                 )
 
             if file_failed:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dashboards.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dashboards.py
@@ -7,21 +7,21 @@ import click
 
 from ....utils import read_file
 from ...utils import get_assets_from_manifest, get_valid_integrations
-from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning
 
-REQUIRED_ATTRIBUTES = {"board_title", "description", "template_variables", "widgets"}
-DASH_ONLY_FIELDS = {"layout_type", "title", "created_at"}
-DASH_ONLY_WIDGET_FIELDS = {"definition", "layout"}
+REQUIRED_ATTRIBUTES = {"description", "template_variables", "widgets"}
+DASHBOARD_ONLY_FIELDS = {"layout_type", "title", "created_at"}
+DASHBOARD_ONLY_WIDGET_FIELDS = {"definition", "layout"}
 
 
-def _is_dash_format(payload):
-    for field in DASH_ONLY_FIELDS:
+def _is_dashboard_format(payload):
+    for field in DASHBOARD_ONLY_FIELDS:
         if field in payload:
             return True
 
     # Also checks if any specified widget in the dashboard defines a dash only field
     for widget in payload["widgets"]:
-        for field in DASH_ONLY_WIDGET_FIELDS:
+        for field in DASHBOARD_ONLY_WIDGET_FIELDS:
             if field in widget:
                 return True
     return False
@@ -32,11 +32,13 @@ def dashboards():
     """Validate all Dashboard definition files."""
     echo_info("Validating all Dashboard definition files...")
     failed_checks = 0
+    old_payloads = 0
     ok_checks = 0
 
     for check_name in sorted(get_valid_integrations()):
         display_queue = []
         file_failed = False
+        file_old_format = False
 
         dashboard_relative_locations, invalid_files = get_assets_from_manifest(check_name, 'dashboards')
         for invalid in invalid_files:
@@ -64,13 +66,12 @@ def dashboards():
                 )
 
             # Confirm the dashboard payload comes from the old API for now
-            if _is_dash_format(decoded):
-                file_failed = True
+            if not _is_dashboard_format(decoded):
+                file_old_format = True
                 display_queue.append(
                     (
-                        echo_failure,
-                        f'    {dashboard_file} is using the new /dash payload format which isn\'t currently supported.'
-                        ' Please use the format from the /screen or /time API endpoints instead.',
+                        echo_warning,
+                        f'    {dashboard_file} is not using the new /dashboard payload format.'
                     ),
                 )
 
@@ -81,11 +82,23 @@ def dashboards():
                 echo_failure(' FAILED')
                 for display_func, message in display_queue:
                     display_func(message)
+                display_queue = []
             else:
                 ok_checks += 1
 
+            if file_old_format:
+                old_payloads += 1
+                # Display detailed info if file is using the old screen/time payloads
+                echo_info(f'{check_name}... ', nl=False)
+                echo_warning(' WARNING')
+                for display_func, message in display_queue:
+                    display_func(message)
+                display_queue = []
+
     if ok_checks:
         echo_success(f"{ok_checks} valid files")
+    if old_payloads:
+        echo_warning(f"{old_payloads} using the old screen/time payloads and should be migrated")
     if failed_checks:
         echo_failure(f"{failed_checks} invalid files")
         abort()


### PR DESCRIPTION
…ards

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We can now allow Integration Dashboards to have their payload be exported via the button in the UI or the `api/v1/dashboards` endpoint. This PR removes the restriction in the validation to not fail in this case. 

It also prints a warning for all dashboards that are currently using the old format, so we can easily check which ones need to be migrated. 

### Motivation
<!-- What inspired you to submit this pull request? -->
New payloads 🎉 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
For now I log a warning when the old payload is detected, though we'll want to move this to an error and fail the check once all boards are migrated.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
