### PR TITLE
Update dash export command to use newer api

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
@@ -11,11 +11,11 @@ import requests
 from ....utils import ensure_dir_exists, path_join, write_file
 from ...constants import get_root
 from ...utils import get_valid_integrations, load_manifest, write_manifest
-from ..console import CONTEXT_SETTINGS, abort
+from ..console import CONTEXT_SETTINGS, abort, echo_success
 
-BOARD_ID_PATTERN = r'{site}/[^/]+/([^/]+)/.+'
-SCREEN_API = 'https://api.{site}/api/v1/screen/{board_id}'
-REQUIRED_FIELDS = ["board_title", "description", "template_variables", "widgets"]
+BOARD_ID_PATTERN = r'{site}/[^/]+/([^/]+)/.*'
+DASHBOARD_API = 'https://api.{site}/api/v1/dashboard/{board_id}'
+REQUIRED_FIELDS = ["layout_type", "title", "description", "template_variables", "widgets"]
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Dashboard utilities')
@@ -25,7 +25,7 @@ def dash():
 
 @dash.command(context_settings=CONTEXT_SETTINGS, short_help='Export a Dashboard as JSON')
 @click.argument('url')
-@click.argument('integration', required=False)
+@click.argument('integration', required=True)
 @click.option(
     '--author',
     '-a',
@@ -67,7 +67,7 @@ def export(ctx, url, integration, author):
 
     try:
         response = requests.get(
-            SCREEN_API.format(site=site, board_id=board_id), params={'api_key': api_key, 'application_key': app_key}
+            DASHBOARD_API.format(site=site, board_id=board_id), params={'api_key': api_key, 'application_key': app_key}
         )
         response.raise_for_status()
     except Exception as e:
@@ -80,7 +80,7 @@ def export(ctx, url, integration, author):
 
     output = json.dumps(new_payload, indent=4, sort_keys=True)
 
-    file_name = new_payload['board_title'].strip().lower()
+    file_name = new_payload['title'].strip().lower()
     if integration:
         manifest = load_manifest(integration)
 
@@ -101,7 +101,7 @@ def export(ctx, url, integration, author):
         location = path_join(get_root(), integration, 'assets', 'dashboards')
         ensure_dir_exists(location)
 
-        manifest['assets']['dashboards'][new_payload['board_title']] = f'assets/dashboards/{file_name}'
+        manifest['assets']['dashboards'][new_payload['title']] = f'assets/dashboards/{file_name}'
         write_manifest(manifest, integration)
     else:
         file_name = f"{file_name.replace(' ', '_')}.json"
@@ -109,3 +109,4 @@ def export(ctx, url, integration, author):
 
     file_path = path_join(location, file_name)
     write_file(file_path, output)
+    echo_success(f"Successfully wrote dashboard: `{file_name}` for integration: `{integration}`")


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR updates the `ddev meta dash export` command to support the newer `dashboard` api instead of the older apis.
I also updated the regex to allow you to paste in a URL that just ends with the dash id
I added a success message at the end if the CLI completed properly. 
I also made the integration argument required, it looks like with the way the board_id regex was, this was being required anyway. 

### Motivation
<!-- What inspired you to submit this pull request? -->
An effort to start using the newer dashboard payloads and migrate existing dashboards away from the old format. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
