### PR TITLE
Add coverage param to test-all

### DIFF
--- a/.azure-pipelines/templates/test-all.yml
+++ b/.azure-pipelines/templates/test-all.yml
@@ -3,17 +3,19 @@ parameters:
   repo: 'core'
   pip_cache_config: null
   run_py2_tests: true
+  coverage: true
 
 jobs:
 - ${{ each check in parameters.checks }}:
   - template: './test-single-${{ check.os }}.yml'
     parameters:
       check: ${{ check.checkName }}
+      coverage: ${{ parameters.coverage }}
       display: ${{ check.displayName }}
       repo: ${{ parameters.repo }}
       pip_cache_config: ${{ parameters.pip_cache_config }}
       run_py2_tests: ${{ parameters.run_py2_tests }}
-
+      
       # Avoid max step limits
       ${{ if eq(check.checkName, 'datadog_checks_base') }}:
         validate: true

--- a/.azure-pipelines/templates/test-all.yml
+++ b/.azure-pipelines/templates/test-all.yml
@@ -15,7 +15,7 @@ jobs:
       repo: ${{ parameters.repo }}
       pip_cache_config: ${{ parameters.pip_cache_config }}
       run_py2_tests: ${{ parameters.run_py2_tests }}
-      
+
       # Avoid max step limits
       ${{ if eq(check.checkName, 'datadog_checks_base') }}:
         validate: true


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds the `coverage` parameter to the test-all.yml template to get passed down to the test-single job. 

### Motivation
<!-- What inspired you to submit this pull request? -->
The parameter seemed to be propagating down for the test changes pipeline in external repos, but not for the test all pipeline. This should resolve that. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
