### PR TITLE
DOCS 1160 - ddev needs pip3

### DIFF
--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -39,7 +39,7 @@ git clone https://github.com/DataDog/integrations-extras.git
 The [Developer Toolkit][4] is comprehensive and includes a lot of functionality. Here's what you need to get started:
 
 ```bash
-pip install "datadog-checks-dev[cli]"
+pip3 install "datadog-checks-dev[cli]"
 ```
 
 If you chose to clone this repository to somewhere other than `$HOME/dd/`, you'll need to adjust the configuration file:


### PR DESCRIPTION
### What does this PR do?

updates `pip` to `pip3` in new check doc. confirmed ddev needs to be installed with pip3

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
