### PR TITLE
Add space_id and org_id tags in addition to space_guid and org_guid

### DIFF
--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/cloud_foundry_api.py
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/cloud_foundry_api.py
@@ -405,15 +405,22 @@ class CloudFoundryApiCheck(AgentCheck):
         org_guid,
     ):
         # type: (str, str, int, str, str, str, str, str, str, str, str) -> Event
+        space_id = space_guid if space_guid else "none"
+        org_id = org_guid if org_guid else "none"
+        # we include both space_guid+space_id and org_guid+org_id; the *_guid are kept for
+        # backwards compatibility, the *_id are added to maintain consistency with
+        # https://github.com/DataDog/datadog-firehose-nozzle
         tags = [
             "event_type:{}".format(event_type),
             "{}_name:{}".format(target_type, target_name),
             "{}_guid:{}".format(target_type, target_guid),
             "{}_name:{}".format(actor_type, actor_name),
             "{}_guid:{}".format(actor_type, actor_guid),
-            "space_guid:{}".format(space_guid if space_guid else "none"),
+            "space_guid:{}".format(space_id),
+            "space_id:{}".format(space_id),
             "space_name:{}".format(self.get_space_name(space_guid) if space_guid else "none"),
-            "org_guid:{}".format(org_guid if org_guid else "none"),
+            "org_guid:{}".format(org_id),
+            "org_id:{}".format(org_id),
             "org_name:{}".format(self.get_org_name(org_guid) if org_guid else "none"),
         ] + self._tags
         dd_event = {

--- a/cloud_foundry_api/tests/test_cloud_foundry_api.py
+++ b/cloud_foundry_api/tests/test_cloud_foundry_api.py
@@ -440,8 +440,10 @@ def test_build_dd_event(_, __, ___, instance):
         "actor_type_name:actor_name",
         "actor_type_guid:actor_guid",
         "space_guid:space_guid",
+        "space_id:space_guid",
         "space_name:space_name",
         "org_guid:org_guid",
+        "org_id:org_guid",
         "org_name:org_name",
         "foo:bar",
     ]
@@ -478,8 +480,10 @@ def test_build_dd_event(_, __, ___, instance):
         "actor_type_name:actor_name",
         "actor_type_guid:actor_guid",
         "space_guid:none",
+        "space_id:none",
         "space_name:none",
         "org_guid:none",
+        "org_id:none",
         "org_name:none",
         "foo:bar",
     ]


### PR DESCRIPTION
### What does this PR do?

Adds `space_id` and `org_id` tags in addition to `space_guid` and `org_guid` to make sure users can use the same set of tags as they use for the datadog-firehose-nozzle.

### Motivation

We should provide usage consistency with https://github.com/DataDog/datadog-firehose-nozzle which submits `org_id` and `space_id` tags.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
