### PR TITLE
Update the Istio 1.5+ dashboard.

### DIFF
--- a/istio/assets/dashboards/istio_1_5_overview.json
+++ b/istio/assets/dashboards/istio_1_5_overview.json
@@ -2,8 +2,8 @@
     "author_info": {
         "author_name": "Datadog"
     },
-    "board_title": "Istio Overview (v1.5+)",
-    "created": "2020-06-09T17:58:26.082012+00:00",
+    "board_title": "Istio overview (v1.5+)",
+    "created": "2020-08-17T14:59:00.345556+00:00",
     "created_by": {
         "access_role": "adm",
         "disabled": false,
@@ -16,9 +16,9 @@
         "verified": true
     },
     "description": "### Istio\n\nNote: This dashboard outlines new metrics from Istio `v1.5+.\n\n- [What is Istio](https://istio.io/docs/concepts/what-is-istio/)?\n- [Istiod](https://istio.io/docs/ops/deployment/architecture/)\n- [Envoy](https://istio.io/docs/concepts/what-is-istio/#envoy), a high performance proxy.\n    - XDS = Envoy management APIs that can be implemented by backend servers. \n        - These APIs support:\n            - Cluster discovery service (CDS)\n            - Route discovery service (RDS)\n            - Endpoint discovery service (EDS)\n            - Listener discovery service (LDS)",
-    "id": 1171035,
-    "modified": "2020-06-09T17:59:33.768417+00:00",
-    "new_id": "t59-b5k-r6s",
+    "id": 1285907,
+    "modified": "2020-08-17T15:50:21.941036+00:00",
+    "new_id": "p8q-mi5-mks",
     "read_only": false,
     "template_variables": [
         {
@@ -32,8 +32,7 @@
             "bgcolor": "gray",
             "font_size": "18",
             "height": 5,
-            "html": "Istiod resource usage",
-            "id": 0,
+            "html": "istiod resource usage",
             "text_align": "center",
             "tick": true,
             "tick_edge": "bottom",
@@ -47,8 +46,7 @@
             "bgcolor": "gray",
             "font_size": "18",
             "height": 5,
-            "html": "Mesh throughput",
-            "id": 1,
+            "html": "Mesh metrics",
             "text_align": "center",
             "tick": true,
             "tick_edge": "bottom",
@@ -60,7 +58,6 @@
         },
         {
             "height": 12,
-            "id": 2,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
@@ -96,7 +93,6 @@
         },
         {
             "height": 12,
-            "id": 3,
             "tile_def": {
                 "custom_links": [],
                 "requests": [
@@ -117,7 +113,6 @@
         },
         {
             "height": 12,
-            "id": 4,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
@@ -146,7 +141,6 @@
         },
         {
             "height": 12,
-            "id": 5,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
@@ -182,7 +176,6 @@
         },
         {
             "height": 12,
-            "id": 6,
             "legend": false,
             "tile_def": {
                 "custom_links": [],
@@ -217,7 +210,6 @@
         },
         {
             "height": 12,
-            "id": 7,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
@@ -253,7 +245,6 @@
         },
         {
             "height": 12,
-            "id": 8,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
@@ -289,7 +280,6 @@
         },
         {
             "height": 12,
-            "id": 9,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
@@ -325,7 +315,6 @@
         },
         {
             "height": 5,
-            "id": 10,
             "sizing": "fit",
             "type": "image",
             "url": "https://s3.amazonaws.com/dd-integrations/istio/configuration/tile/logo.png",
@@ -335,7 +324,6 @@
         },
         {
             "height": 12,
-            "id": 11,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
@@ -371,16 +359,15 @@
         },
         {
             "height": 12,
-            "id": 12,
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
-                        "q": "top(avg:istio.go.gc_duration_seconds.sum{$cluster}, 10, 'mean', 'desc')"
+                        "q": "top(avg:istio.go.gc_duration_seconds.sum{$cluster} by {host}, 10, 'mean', 'desc')"
                     }
                 ],
                 "viz": "toplist"
             },
+            "time": {},
             "title": true,
             "title_align": "center",
             "title_size": 16,
@@ -394,8 +381,7 @@
             "bgcolor": "gray",
             "font_size": "18",
             "height": 5,
-            "html": "Pilot Traffic Management",
-            "id": 13,
+            "html": "xDS metrics",
             "text_align": "center",
             "tick": true,
             "tick_edge": "bottom",
@@ -407,11 +393,9 @@
         },
         {
             "height": 12,
-            "id": 14,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
                         "q": "sum:istio.pilot.xds{$cluster}",
@@ -423,12 +407,20 @@
                         "type": "area"
                     }
                 ],
-                "viz": "timeseries"
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
             },
+            "time": {},
             "title": true,
             "title_align": "center",
             "title_size": 16,
-            "title_text": "XDS connected endpoints",
+            "title_text": "xDS connected endpoints",
             "type": "timeseries",
             "width": 26,
             "x": 55,
@@ -436,28 +428,35 @@
         },
         {
             "height": 12,
-            "id": 15,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
-                        "q": "sum:istio.pilot.xds.pushes{$cluster}",
+                        "on_right_yaxis": false,
+                        "q": "sum:istio.pilot.xds.pushes{$cluster} by {type}",
                         "style": {
                             "palette": "dog_classic",
                             "type": "solid",
                             "width": "normal"
                         },
-                        "type": "line"
+                        "type": "bars"
                     }
                 ],
-                "viz": "timeseries"
+                "viz": "timeseries",
+                "yaxis": {
+                    "includeZero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
             },
+            "time": {},
             "title": true,
             "title_align": "center",
             "title_size": 16,
-            "title_text": "LDS/EDS/RDS/CDS Build,Send Errors",
+            "title_text": "xDS pushes per API (including errors)",
             "type": "timeseries",
             "width": 26,
             "x": 82,
@@ -467,8 +466,7 @@
             "bgcolor": "gray",
             "font_size": "18",
             "height": 5,
-            "html": "Galley  Configuration Validation",
-            "id": 16,
+            "html": "Configuration validation metrics",
             "text_align": "center",
             "tick": true,
             "tick_edge": "bottom",
@@ -480,7 +478,6 @@
         },
         {
             "height": 12,
-            "id": 17,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
@@ -509,11 +506,9 @@
         },
         {
             "height": 12,
-            "id": 18,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
                         "q": "sum:istio.process.max_fds{$cluster}",
@@ -534,10 +529,11 @@
                     "scale": "linear"
                 }
             },
+            "time": {},
             "title": true,
             "title_align": "center",
             "title_size": 16,
-            "title_text": "Max # of File Descriptors",
+            "title_text": "Max # of file descriptors",
             "type": "timeseries",
             "width": 26,
             "x": 163,
@@ -545,11 +541,9 @@
         },
         {
             "height": 12,
-            "id": 19,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
                         "q": "sum:istio.process.virtual_memory_bytes{$cluster}",
@@ -570,10 +564,11 @@
                     "scale": "linear"
                 }
             },
+            "time": {},
             "title": true,
             "title_align": "center",
             "title_size": 16,
-            "title_text": "Virtual Memory Size",
+            "title_text": "Virtual memory size",
             "type": "timeseries",
             "width": 26,
             "x": 163,
@@ -581,13 +576,11 @@
         },
         {
             "height": 12,
-            "id": 20,
             "legend": false,
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
-                        "q": "avg:istio.pilot.xds.eds_all_locality_endpoints{$cluster}",
+                        "q": "avg:istio.pilot.proxy_convergence_time.sum{$cluster}",
                         "style": {
                             "palette": "dog_classic",
                             "type": "solid",
@@ -605,10 +598,11 @@
                     "scale": "linear"
                 }
             },
+            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
-            "title_text": "Network endpoints for each cluster (all localities)",
+            "title_text": "xDS proxy convergence time",
             "type": "timeseries",
             "width": 26,
             "x": 55,
@@ -616,20 +610,19 @@
         },
         {
             "height": 12,
-            "id": 21,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
+                        "on_right_yaxis": false,
                         "q": "avg:istio.sidecar_injection.requests_total{$cluster}.as_count()",
                         "style": {
                             "palette": "dog_classic",
                             "type": "solid",
                             "width": "normal"
                         },
-                        "type": "line"
+                        "type": "bars"
                     }
                 ],
                 "viz": "timeseries",
@@ -641,10 +634,11 @@
                     "scale": "linear"
                 }
             },
+            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
-            "title_text": "Total Sidecar Injection Requests",
+            "title_text": "Total sidecar injection requests",
             "type": "timeseries",
             "width": 26,
             "x": 1,
@@ -652,11 +646,9 @@
         },
         {
             "height": 12,
-            "id": 22,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
                         "q": "avg:istio.galley.validation.failed{$cluster}.as_count()",
@@ -677,10 +669,11 @@
                     "scale": "linear"
                 }
             },
+            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
-            "title_text": "Total failed Galley Validation",
+            "title_text": "Total failed configuration validations",
             "type": "timeseries",
             "width": 26,
             "x": 82,
@@ -688,20 +681,19 @@
         },
         {
             "height": 12,
-            "id": 23,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
-                        "q": "avg:istio.sidecar_injection.requests_total{$cluster}.as_count(), avg:istio.sidecar_injection.success_total{$cluster}.as_count(), avg:istio.sidecar_injection.requests_total{$cluster}.as_count()-avg:istio.sidecar_injection.success_total{$cluster}.as_count()",
+                        "on_right_yaxis": false,
+                        "q": "avg:istio.sidecar_injection.requests_total{$cluster}.as_count()-avg:istio.sidecar_injection.success_total{$cluster}.as_count()",
                         "style": {
                             "palette": "dog_classic",
                             "type": "solid",
                             "width": "normal"
                         },
-                        "type": "line"
+                        "type": "bars"
                     }
                 ],
                 "viz": "timeseries",
@@ -713,10 +705,11 @@
                     "scale": "linear"
                 }
             },
+            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
-            "title_text": "Total Failed Sidecar Injection Requests",
+            "title_text": "Failed or skipped sidecar injection requests",
             "type": "timeseries",
             "width": 26,
             "x": 28,
@@ -724,7 +717,6 @@
         },
         {
             "height": 12,
-            "id": 24,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
@@ -760,14 +752,12 @@
         },
         {
             "height": 12,
-            "id": 25,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
-                        "q": "avg:istio.grpc.server.handling_seconds.sum{$cluster}, avg:istio.grpc.server.handling_seconds.count{$cluster}, avg:istio.grpc.server.handling_seconds.sum{$cluster}/avg:istio.grpc.server.handling_seconds.count{$cluster}",
+                        "q": "avg:istio.grpc.server.handling_seconds.sum{$cluster}/avg:istio.grpc.server.handling_seconds.count{$cluster}",
                         "style": {
                             "palette": "dog_classic",
                             "type": "solid",
@@ -785,6 +775,7 @@
                     "scale": "linear"
                 }
             },
+            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
@@ -798,8 +789,7 @@
             "bgcolor": "gray",
             "font_size": "18",
             "height": 5,
-            "html": "Sidecar Injection",
-            "id": 26,
+            "html": "Sidecar injection",
             "text_align": "center",
             "tick": true,
             "tick_edge": "bottom",
@@ -811,7 +801,6 @@
         },
         {
             "height": 12,
-            "id": 27,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
@@ -847,7 +836,6 @@
         },
         {
             "height": 12,
-            "id": 28,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
@@ -883,11 +871,9 @@
         },
         {
             "height": 12,
-            "id": 29,
             "legend": false,
             "legend_size": "0",
             "tile_def": {
-                "custom_links": [],
                 "requests": [
                     {
                         "q": "avg:istio.pilot.services{$cluster}",
@@ -908,10 +894,11 @@
                     "scale": "linear"
                 }
             },
+            "time": {},
             "title": true,
             "title_align": "left",
             "title_size": 16,
-            "title_text": "Total pilot services",
+            "title_text": "Services known to istiod",
             "type": "timeseries",
             "width": 26,
             "x": 55,
@@ -919,7 +906,6 @@
         },
         {
             "height": 12,
-            "id": 30,
             "legend": false,
             "legend_size": "0",
             "tile_def": {

--- a/istio/manifest.json
+++ b/istio/manifest.json
@@ -34,7 +34,7 @@
     "monitors": {},
     "dashboards": {
       "Istio base dashboard": "assets/dashboards/istio_overview.json",
-      "Istio Overview 1.5": "assets/dashboards/istio_1_5_overview"
+      "Istio overview (v1.5+)": "assets/dashboards/istio_1_5_overview.json"
     },
     "service_checks": "assets/service_checks.json",
     "logs": {


### PR DESCRIPTION
### What does this PR do?
Update the Istio 1.5+ OOB dashboard

![The edited dashboard](https://user-images.githubusercontent.com/25250668/90435582-33b1d080-e09d-11ea-96ba-7c25863a8e4f.png)


- Make capitalization consistent
- Change "Mesh throughput" to the more accurate "Mesh metrics"
- Aggregate by host in the "Hosts with the highest GC time toplist"
- Remove names of deprecated Istio microservices
- Aggregate the xDS pushes widget by push type
- Rename "LDS/EDS/RDS/CDS Build,Send Errors" since the metric
  no longer includes build errors in recent versions of Istio.
  See:
  https://github.com/istio/istio/commit/e97b19756df06bf04784e2cf1cd6f1176c9ef64d
- Remove the istio.pilot.xds.eds_all_locality_endpoints widget
  since the metric has been removed from recent versions of
  Istio. See:
  https://github.com/istio/istio/commit/eb4178a79ad31dd63e901c2902af65354afc2e26
- Replace the all locality endpoints widget with one for
  istio.pilot.proxy_convergence_time
- Where a series shows a sum/count derived metric, remove possibly
  misleading series for the sum and count, showing only
  the derived metric.

### Motivation
Writing a dashboard page for Istio 1.5+ and noticed that we needed to update certain aspects of the dashboard before we could describe them within the dashboard page.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
