### PR TITLE
add counterset validation in pdh check

### DIFF
--- a/pdh_check/datadog_checks/pdh_check/pdh_check.py
+++ b/pdh_check/datadog_checks/pdh_check/pdh_check.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2013-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-
+from datadog_checks.base import ConfigurationError
 from datadog_checks.base.checks.win import PDHBaseCheck
 
 
@@ -15,7 +15,9 @@ class PDHCheck(PDHBaseCheck):
     def __init__(self, name, init_config, instances=None):
         counter_list = []
         for instance in instances:
-            counterset = instance['countersetname']
+            counterset = instance.get('countersetname')
+            if not counterset:
+                raise ConfigurationError('Counterset is a required instance field')
 
             counter_list.extend(
                 (counterset, None, inst_name, dd_name, mtype) for inst_name, dd_name, mtype in instance['metrics']

--- a/pdh_check/tests/test_pdh_check.py
+++ b/pdh_check/tests/test_pdh_check.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import pytest
+from datadog_checks.base import ConfigurationError
 from datadog_test_libs.win.pdh_mocks import initialize_pdh_tests, pdh_mocks_fixture  # noqa: F401
 
 from datadog_checks.pdh_check import PDHCheck
@@ -10,6 +11,7 @@ from datadog_checks.pdh_check import PDHCheck
 from .common import CHECK_NAME, INSTANCE, INSTANCE_METRICS
 
 
+@pytest.mark.unit
 @pytest.mark.usefixtures('pdh_mocks_fixture')
 def test_basic_check(aggregator):
     """
@@ -25,3 +27,9 @@ def test_basic_check(aggregator):
         aggregator.assert_metric(metric, tags=None, count=1)
 
     aggregator.assert_all_metrics_covered()
+
+
+@pytest.mark.unit
+def test_raises_configuration_error():
+    with pytest.raises(ConfigurationError):
+        PDHCheck(CHECK_NAME, {}, [{}])

--- a/pdh_check/tests/test_pdh_check.py
+++ b/pdh_check/tests/test_pdh_check.py
@@ -3,9 +3,9 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import pytest
-from datadog_checks.base import ConfigurationError
 from datadog_test_libs.win.pdh_mocks import initialize_pdh_tests, pdh_mocks_fixture  # noqa: F401
 
+from datadog_checks.base import ConfigurationError
 from datadog_checks.pdh_check import PDHCheck
 
 from .common import CHECK_NAME, INSTANCE, INSTANCE_METRICS


### PR DESCRIPTION
Raises ConfigurationError if required config option is missing