### PR TITLE
Migrate Integration Dashboards to new payload structure

### DIFF
--- a/linkerd/assets/dashboards/overview.json
+++ b/linkerd/assets/dashboards/overview.json
@@ -1,769 +1,605 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_bgtype": "board_graph",
-    "board_title": "Linkerd - Overview",
-    "created": "2020-01-06T22:20:03.614862+00:00",
-    "created_by": {
-        "access_role": "adm",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": true,
-        "name": "Datadog",
-        "role": null,
-        "verified": true
-    },
+    "title": "Linkerd - Overview",
     "description": "## Linkerd\n\nThis dashboard provides a high-level overview of your Linkerd cluster so you can monitor its performance and route, control, and connection metrics.\n\nFor further reading on monitoring Envoy, see:\n\n- [Official Linkerd integration docs](https://docs.datadoghq.com/integrations/linkerd/)\n\nClone this template to make changes and add your own graphs and widgets.",
-    "disableCog": false,
-    "disableEditing": false,
-    "id": 938369,
-    "isIntegration": false,
-    "isShared": false,
-    "modified": "2020-01-07T05:49:26.054024+00:00",
-    "new_id": "6rm-u47-hp2",
-    "originalHeight": 80,
-    "originalWidth": "calc(100% - 32px)",
-    "read_only": false,
-    "template_variables": [],
     "widgets": [
-        {
-            "add_timeframe": true,
-            "board_id": 592110,
-            "generated_title": "",
-            "globalTimeframe": {
-                "end": 1552069110000,
-                "isLive": true,
-                "start": 1552068210000
-            },
-            "height": 8,
-            "isShared": false,
-            "margin": "",
-            "scaleFactor": 1,
-            "sizing": "fit",
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "",
-            "type": "image",
-            "url": "https://static.datadoghq.com/static/images/saas_logos/bot/linkerd@2x.png",
-            "width": 12,
-            "x": 1,
-            "y": 2
+      {
+        "id": 0,
+        "definition": {
+          "type": "image",
+          "url": "https://static.datadoghq.com/static/images/saas_logos/bot/linkerd@2x.png",
+          "sizing": "fit"
         },
-        {
-            "add_timeframe": true,
-            "board_id": "6rm-u47-hp2",
-            "error": null,
-            "generated_title": "Timeseries",
-            "height": 15,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "sum:linkerd.request_total{*} by {direction}.as_rate()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Request rate",
-            "type": "timeseries",
-            "width": 26,
-            "x": 65,
-            "y": 8
-        },
-        {
-            "add_timeframe": true,
-            "board_id": "6rm-u47-hp2",
-            "error": null,
-            "generated_title": "Timeseries",
-            "height": 15,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "top(avg:linkerd.response_latency.sum{*} by {direction}/avg:linkerd.response_latency.count{*} by {direction},10,'mean','desc')",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Average response latency by host",
-            "type": "timeseries",
-            "width": 24,
-            "x": 40,
-            "y": 8
-        },
-        {
-            "add_timeframe": true,
-            "board_id": "6rm-u47-hp2",
-            "error": null,
-            "generated_title": "Timeseries",
-            "height": 15,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "sum:linkerd.response_total{*} by {classification}.as_count()/sum:linkerd.response_total{*}.as_count()*100",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "max": "100",
-                    "min": "0"
-                }
-            },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Success rate of requests",
-            "type": "timeseries",
-            "width": 25,
-            "x": 14,
-            "y": 8
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "background_color": "gray",
-            "bgcolor": "gray",
-            "content": "Mesh throughput",
-            "font_size": "18",
-            "height": 5,
-            "html": "Throughput",
-            "legend": false,
-            "legend_size": "0",
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "viz": "note",
-            "width": 77,
-            "x": 14,
-            "y": 2
-        },
-        {
-            "add_timeframe": true,
-            "board_id": "6rm-u47-hp2",
-            "check": "linkerd.prometheus.health",
-            "error": null,
-            "group": null,
-            "group_by": [],
-            "grouping": "cluster",
-            "height": 13,
-            "isShared": false,
-            "scaleFactor": 1,
-            "tags": [
-                "*"
-            ],
-            "text_align": "center",
-            "text_size": "auto",
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Health",
-            "type": "check_status",
-            "width": 12,
-            "x": 1,
-            "y": 12
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 15,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:linkerd.tcp.connection_duration.sum{*} by {direction}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Average connection lifetime",
-            "type": "timeseries",
-            "width": 22,
-            "x": 92,
-            "y": 8
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "background_color": "gray",
-            "bgcolor": "gray",
-            "content": "Throughput",
-            "font_size": "18",
-            "height": 5,
-            "html": "Connections",
-            "legend": false,
-            "legend_size": "0",
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "viz": "note",
-            "width": 32,
-            "x": 92,
-            "y": 2
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 9,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "preTemplateQuery": "max:linkerd.tcp.open_connections{*}",
-                        "q": "max:linkerd.tcp.open_connections{*}"
-                    }
-                ],
-                "title_align": "center",
-                "title_size": "13",
-                "viz": "query_value"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Open Connections",
-            "type": "query_value",
-            "width": 9,
-            "x": 115,
-            "y": 8
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "background_color": "gray",
-            "bgcolor": "gray",
-            "content": "Throughput",
-            "font_size": "18",
-            "height": 5,
-            "html": "Linkerd V1 Only",
-            "legend": false,
-            "legend_size": "0",
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "viz": "note",
-            "width": 118,
-            "x": 1,
-            "y": 53
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "preTemplateQuery": "count_not_null(avg:linkerd.jvm.uptime{*})",
-                        "q": "count_not_null(avg:linkerd.jvm.uptime{*})"
-                    }
-                ],
-                "time": {
-                    "live_span": "1h"
-                },
-                "title_align": "left",
-                "title_size": "16",
-                "viz": "query_value"
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Linkerd instances",
-            "type": "query_value",
-            "width": 14,
-            "x": 1,
-            "y": 59
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "preTemplateQuery": "count_not_null(sum:linkerd.rt.client.requests_s{$router} by {client})",
-                        "q": "count_not_null(sum:linkerd.rt.client.requests_s{*} by {client})"
-                    }
-                ],
-                "time": {
-                    "live_span": "1h"
-                },
-                "title_align": "left",
-                "title_size": "16",
-                "viz": "query_value"
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Services monitored",
-            "type": "query_value",
-            "width": 14,
-            "x": 16,
-            "y": 59
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "preTemplateQuery": "sum:linkerd.rt.client.requests_s{$router}",
-                        "q": "sum:linkerd.rt.client.requests_s{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "time": {
-                    "live_span": "1h"
-                },
-                "title_align": "left",
-                "title_size": "16",
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Req/S",
-            "type": "timeseries",
-            "width": 28,
-            "x": 31,
-            "y": 59
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "preTemplateQuery": "avg:linkerd.rt.client.status.1XX_s{$router}",
-                        "q": "avg:linkerd.rt.client.status.1XX_s{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "preTemplateQuery": "avg:linkerd.rt.client.status.2XX_s{$router}",
-                        "q": "avg:linkerd.rt.client.status.2XX_s{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "preTemplateQuery": "avg:linkerd.rt.client.status.3XX_s{$router}",
-                        "q": "avg:linkerd.rt.client.status.3XX_s{*}",
-                        "style": {
-                            "palette": "grey",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "preTemplateQuery": "avg:linkerd.rt.client.status.4XX_s{$router}",
-                        "q": "avg:linkerd.rt.client.status.4XX_s{*}",
-                        "style": {
-                            "palette": "orange",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "preTemplateQuery": "avg:linkerd.rt.client.status.5XX_s{$router}",
-                        "q": "avg:linkerd.rt.client.status.5XX_s{*}",
-                        "style": {
-                            "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "time": {
-                    "live_span": "1h"
-                },
-                "title_align": "left",
-                "title_size": "16",
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Status Code/Sec",
-            "type": "timeseries",
-            "width": 29,
-            "x": 90,
-            "y": 59
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "preTemplateQuery": "max:linkerd.rt.client.request_latency_ms.quantile{$router,$service,$instance,quantile:0.95}",
-                        "q": "max:linkerd.rt.client.request_latency_ms.quantile{quantile:0.95}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "preTemplateQuery": "max:linkerd.rt.client.request_latency_ms.quantile{$router,$service,$instance,quantile:0.99}",
-                        "q": "max:linkerd.rt.client.request_latency_ms.quantile{quantile:0.99}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "preTemplateQuery": "max:linkerd.rt.client.request_latency_ms.quantile{$router,$service,$instance,quantile:1.0}",
-                        "q": "max:linkerd.rt.client.request_latency_ms.quantile{quantile:1.0}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "time": {
-                    "live_span": "1h"
-                },
-                "title_align": "left",
-                "title_size": "16",
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Latency",
-            "type": "timeseries",
-            "width": 29,
-            "x": 60,
-            "y": 59
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "background_color": "gray",
-            "bgcolor": "gray",
-            "content": "Connections",
-            "font_size": "18",
-            "height": 5,
-            "html": "Route Metrics",
-            "legend": false,
-            "legend_size": "0",
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "viz": "note",
-            "width": 58,
-            "x": 1,
-            "y": 26
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 15,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "top(avg:linkerd.route.response_latency.sum{*} by {direction}/avg:linkerd.route.response_latency.count{*} by {direction},10,'mean','desc')",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "title_align": "center",
-                "title_size": "16",
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average route response latency",
-            "type": "timeseries",
-            "width": 28,
-            "x": 1,
-            "y": 32
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 15,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "sum:linkerd.route.request_total{*} by {direction}.as_rate()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "title_align": "center",
-                "title_size": "16",
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Route request rate",
-            "type": "timeseries",
-            "width": 28,
-            "x": 31,
-            "y": 32
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 15,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "sum:linkerd.control.request_total{*} by {direction}.as_rate()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "title_align": "center",
-                "title_size": "16",
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Control request rate",
-            "type": "timeseries",
-            "width": 28,
-            "x": 91,
-            "y": 32
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "background_color": "gray",
-            "bgcolor": "gray",
-            "content": "Route Metrics",
-            "font_size": "18",
-            "height": 5,
-            "html": "Control Metrics",
-            "legend": false,
-            "legend_size": "0",
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "viz": "note",
-            "width": 58,
-            "x": 61,
-            "y": 26
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 15,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "top(avg:linkerd.control.response_latency.sum{*} by {direction}/avg:linkerd.control.response_latency.count{*} by {direction},10,'mean','desc')",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "title_align": "center",
-                "title_size": "16",
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average control response latency",
-            "type": "timeseries",
-            "width": 28,
-            "x": 61,
-            "y": 32
+        "layout": {
+          "x": 1,
+          "y": 2,
+          "width": 12,
+          "height": 8
         }
-    ]
-}
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:linkerd.request_total{*} by {direction}.as_rate()",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Request rate",
+          "title_size": "16",
+          "title_align": "center",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 65,
+          "y": 8,
+          "width": 26,
+          "height": 17
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "top(avg:linkerd.response_latency.sum{*} by {direction}/avg:linkerd.response_latency.count{*} by {direction},10,'mean','desc')",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average response latency by host",
+          "title_size": "16",
+          "title_align": "center",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 40,
+          "y": 8,
+          "width": 24,
+          "height": 17
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:linkerd.response_total{*} by {classification}.as_count()/sum:linkerd.response_total{*}.as_count()*100",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "min": "0",
+            "max": "100"
+          },
+          "title": "Success rate of requests",
+          "title_size": "16",
+          "title_align": "center",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 14,
+          "y": 8,
+          "width": 25,
+          "height": 17
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "note",
+          "content": "Throughput",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 14,
+          "y": 2,
+          "width": 77,
+          "height": 5
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "check_status",
+          "title": "Health",
+          "title_size": "16",
+          "title_align": "center",
+          "check": "linkerd.prometheus.health",
+          "grouping": "cluster",
+          "group_by": [],
+          "tags": [
+            "*"
+          ]
+        },
+        "layout": {
+          "x": 1,
+          "y": 12,
+          "width": 12,
+          "height": 13
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:linkerd.tcp.connection_duration.sum{*} by {direction}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average connection lifetime",
+          "title_size": "16",
+          "title_align": "center",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 92,
+          "y": 8,
+          "width": 22,
+          "height": 17
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "note",
+          "content": "Connections",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 92,
+          "y": 2,
+          "width": 32,
+          "height": 5
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "max:linkerd.tcp.open_connections{*}",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Open Connections",
+          "title_size": "16",
+          "title_align": "left",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 115,
+          "y": 8,
+          "width": 9,
+          "height": 11
+        }
+      },
+      {
+        "id": 9,
+        "definition": {
+          "type": "note",
+          "content": "Linkerd V1 Only",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 1,
+          "y": 53,
+          "width": 118,
+          "height": 5
+        }
+      },
+      {
+        "id": 10,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "count_not_null(avg:linkerd.jvm.uptime{*})",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Linkerd instances",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 1,
+          "y": 59,
+          "width": 14,
+          "height": 14
+        }
+      },
+      {
+        "id": 11,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "count_not_null(sum:linkerd.rt.client.requests_s{*} by {client})",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Services monitored",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 16,
+          "y": 59,
+          "width": 14,
+          "height": 14
+        }
+      },
+      {
+        "id": 12,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:linkerd.rt.client.requests_s{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Req/S",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 31,
+          "y": 59,
+          "width": 28,
+          "height": 14
+        }
+      },
+      {
+        "id": 13,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:linkerd.rt.client.status.1XX_s{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:linkerd.rt.client.status.2XX_s{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:linkerd.rt.client.status.3XX_s{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "grey",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:linkerd.rt.client.status.4XX_s{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "orange",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:linkerd.rt.client.status.5XX_s{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "warm",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Status Code/Sec",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 90,
+          "y": 59,
+          "width": 29,
+          "height": 14
+        }
+      },
+      {
+        "id": 14,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "max:linkerd.rt.client.request_latency_ms.quantile{quantile:0.95}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "max:linkerd.rt.client.request_latency_ms.quantile{quantile:0.99}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "max:linkerd.rt.client.request_latency_ms.quantile{quantile:1.0}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Latency",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 60,
+          "y": 59,
+          "width": 29,
+          "height": 14
+        }
+      },
+      {
+        "id": 15,
+        "definition": {
+          "type": "note",
+          "content": "Route Metrics",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 1,
+          "y": 26,
+          "width": 58,
+          "height": 5
+        }
+      },
+      {
+        "id": 16,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "top(avg:linkerd.route.response_latency.sum{*} by {direction}/avg:linkerd.route.response_latency.count{*} by {direction},10,'mean','desc')",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average route response latency",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 1,
+          "y": 32,
+          "width": 28,
+          "height": 17
+        }
+      },
+      {
+        "id": 17,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:linkerd.route.request_total{*} by {direction}.as_rate()",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Route request rate",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 31,
+          "y": 32,
+          "width": 28,
+          "height": 17
+        }
+      },
+      {
+        "id": 18,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:linkerd.control.request_total{*} by {direction}.as_rate()",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Control request rate",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 91,
+          "y": 32,
+          "width": 28,
+          "height": 17
+        }
+      },
+      {
+        "id": 19,
+        "definition": {
+          "type": "note",
+          "content": "Control Metrics",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 61,
+          "y": 26,
+          "width": 58,
+          "height": 5
+        }
+      },
+      {
+        "id": 20,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "top(avg:linkerd.control.response_latency.sum{*} by {direction}/avg:linkerd.control.response_latency.count{*} by {direction},10,'mean','desc')",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average control response latency",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 61,
+          "y": 32,
+          "width": 28,
+          "height": 17
+        }
+      }
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30302
+  }

--- a/mapr/assets/dashboards/mapr_overview.json
+++ b/mapr/assets/dashboards/mapr_overview.json
@@ -1,1351 +1,952 @@
 {
-    "board_title": "MapR - Overview",
-    "read_only": false,
-    "author_info": {
-      "author_name": "Datadog"
-    },
-    "description": "This dashboard provides a high-level overview of your MapR 6.1+ deployment so you can monitor its performance and resource usage. For further reading on monitoring MapR:\n\n- [Monitoring the cluster (MapR)](https://mapr.com/docs/61/AdministratorGuide/Monitoring-the-Cluster.html)\n- [Metric collection (MapR)](https://mapr.com/docs/61/AdministratorGuide/MetricsCollections.html)\n- [Datadog's MapR integration docs](https://docs.datadoghq.com/integrations/mapr)\n\nClone this template dashboard to make changes and add your own graphs and widgets.",
-    "board_bgtype": "board_graph",
-    "created": "2019-09-23T17:38:22.356539+00:00",
-    "created_by": {
-      "disabled": false,
-      "handle": "support@datadoghq.com",
-      "name": "Datadog",
-      "is_admin": false,
-      "role": null,
-      "access_role": "st",
-      "verified": true,
-      "email": "support@datadoghq.com"
-    },
-    "new_id": "2db-kqp-3h5",
-    "modified": "2019-10-24T20:24:30.028165+00:00",
-    "originalHeight": 80,
-    "template_variables": [
-      {
-        "default": "*",
-        "prefix": "clustername",
-        "name": "clustername"
-      },
-      {
-        "default": "*",
-        "prefix": null,
-        "name": "scope"
-      }
-    ],
-    "isIntegration": false,
-    "disableEditing": false,
-    "originalWidth": "calc(100% - 32px)",
-    "widgets": [
-      {
-        "board_id": "mcg-3zy-6ru",
-        "title_align": "left",
-        "title_size": 16,
-        "time": {},
-        "title": true,
+  "title": "MapR - Overview",
+  "description": "This dashboard provides a high-level overview of your MapR 6.1+ deployment so you can monitor its performance and resource usage. For further reading on monitoring MapR:\n\n- [Monitoring the cluster (MapR)](https://mapr.com/docs/61/AdministratorGuide/Monitoring-the-Cluster.html)\n- [Metric collection (MapR)](https://mapr.com/docs/61/AdministratorGuide/MetricsCollections.html)\n- [Datadog's MapR integration docs](https://docs.datadoghq.com/integrations/mapr)\n\nClone this template dashboard to make changes and add your own graphs and widgets.",
+  "widgets": [
+    {
+      "id": 0,
+      "definition": {
         "type": "timeseries",
-        "generated_title": "Timeseries",
-        "title_text": "Remote reads & writes",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:mapr.fs.writes{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "purple",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
-            },
-            {
-              "q": "avg:mapr.fs.reads{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "green",
-                "type": "solid"
-              },
-              "type": "line"
+        "requests": [
+          {
+            "q": "avg:mapr.fs.writes{$clustername,$scope}.as_count()",
+            "display_type": "line",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
             }
-          ],
-          "autoscale": true
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
+          },
+          {
+            "q": "avg:mapr.fs.reads{$clustername,$scope}.as_count()",
+            "display_type": "line",
+            "style": {
+              "palette": "green",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Remote reads & writes",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 122,
         "y": 9,
-        "x": 122,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "board_id": "mcg-3zy-6ru",
-        "title_align": "left",
-        "title_size": 16,
-        "time": {},
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "Timeseries",
-        "title_text": "Local reads & writes",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:mapr.fs.local_reads{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "green",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
-            },
-            {
-              "q": "avg:mapr.fs.local_writes{$clustername,$scope}.as_count()",
-              "style": {
-                "width": "normal",
-                "palette": "purple",
-                "type": "solid"
-              },
-              "type": "line"
-            }
-          ],
-          "autoscale": true
-        },
         "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
+        "height": 20
+      }
+    },
+    {
+      "id": 1,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.fs.local_reads{$clustername,$scope}.as_count()",
+            "display_type": "line",
+            "style": {
+              "palette": "green",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.fs.local_writes{$clustername,$scope}.as_count()",
+            "display_type": "line",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Local reads & writes",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 122,
         "y": 30,
-        "x": 122,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "board_id": "mcg-3zy-6ru",
-        "title_align": "left",
-        "title_size": 16,
-        "time": {},
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "mapr.fs.kvstore_scan, mapr.fs.kvstore_delete, mapr.fs.kvstore_insert, mapr.fs.kvstore_lookup",
-        "title_text": "KVStore (scan/delete/insert/lookup)",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:mapr.fs.kvstore_scan{$clustername,$scope}",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
-            },
-            {
-              "q": "avg:mapr.fs.kvstore_delete{$clustername,$scope}",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line"
-            },
-            {
-              "q": "avg:mapr.fs.kvstore_insert{$clustername,$scope}",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line"
-            },
-            {
-              "q": "avg:mapr.fs.kvstore_lookup{$clustername,$scope}",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line"
-            }
-          ],
-          "autoscale": true
-        },
         "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 51,
+        "height": 20
+      }
+    },
+    {
+      "id": 2,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.fs.kvstore_scan{$clustername,$scope}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.fs.kvstore_delete{$clustername,$scope}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.fs.kvstore_insert{$clustername,$scope}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.fs.kvstore_lookup{$clustername,$scope}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "KVStore (scan/delete/insert/lookup)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
         "x": 163,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "board_id": "2db-kqp-3h5",
-        "title_align": "left",
-        "title_size": 16,
-        "time": {},
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "mapr.fs.statstype_create, mapr.fs.statstype_write, mapr.fs.statstype_read, mapr.fs.statstype_lookup",
-        "title_text": "Statstype (read/write/create/lookup)",
-        "height": 18,
-        "tile_def": {
-          "autoscale": true,
-          "yaxis": {
-            "min": "auto",
-            "max": "auto",
-            "scale": "linear",
-            "label": "",
-            "includeZero": true
-          },
-          "color_by_groups": [],
-          "xaxis": {
-            "min": "auto",
-            "max": "auto",
-            "scale": "linear",
-            "label": "",
-            "includeZero": true
-          },
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:mapr.fs.statstype_create{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
-            },
-            {
-              "q": "avg:mapr.fs.statstype_write{$clustername,$scope}.as_count()",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line"
-            },
-            {
-              "q": "avg:mapr.fs.statstype_read{$clustername,$scope}.as_count()",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line"
-            },
-            {
-              "q": "avg:mapr.fs.statstype_lookup{$clustername,$scope}.as_count()",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line"
-            }
-          ]
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
         "y": 51,
-        "x": 122,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 3,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.fs.statstype_create{$clustername,$scope}.as_count()",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.fs.statstype_write{$clustername,$scope}.as_count()",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.fs.statstype_read{$clustername,$scope}.as_count()",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.fs.statstype_lookup{$clustername,$scope}.as_count()",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Statstype (read/write/create/lookup)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      {
-        "board_id": "2db-kqp-3h5",
-        "sizing": "zoom",
-        "title": false,
-        "url": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iNDIwcHgi%0D%0AIGhlaWdodD0iMTE0cHgiIHZpZXdCb3g9IjAgMCA0MjAgMTE0IiB2ZXJzaW9uPSIxLjEiIHhtbG5z%0D%0APSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMu%0D%0Ab3JnLzE5OTkveGxpbmsiPgogICAgPCEtLSBHZW5lcmF0b3I6IFNrZXRjaCA1OCAoODQ2NjMpIC0g%0D%0AaHR0cHM6Ly9za2V0Y2guY29tIC0tPgogICAgPHRpdGxlPm1hcHJAM3g8L3RpdGxlPgogICAgPGRl%0D%0Ac2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+CiAgICA8ZyBpZD0ibWFwciIgc3Ryb2tlPSJu%0D%0Ab25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAg%0D%0AICAgICAgPGcgaWQ9Ikdyb3VwLTExIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLjAwMDAwMCwgLTE1%0D%0ALjAwMDAwMCkiPgogICAgICAgICAgICA8ZyBpZD0iR3JvdXAtMTAiIHRyYW5zZm9ybT0idHJhbnNs%0D%0AYXRlKDMyLjUwMDAwMCwgMzAuNTI1ODYzKSI+PC9nPgogICAgICAgICAgICA8cmVjdCBpZD0iUmVj%0D%0AdGFuZ2xlIiBmaWxsPSIjRkZGRkZGIiBvcGFjaXR5PSIwLjUiIHg9IjAiIHk9IjE1IiB3aWR0aD0i%0D%0ANDIwIiBoZWlnaHQ9IjExNCI+PC9yZWN0PgogICAgICAgICAgICA8cGF0aCBkPSJNNDIwLC0wLjAw%0D%0AMDI2MjUgTDQyMCwxNDMuNDAwODYzIEwwLDE0My40MDA4NjMgTDAsLTAuMDAwMjYyNSBMNDIwLC0w%0D%0ALjAwMDI2MjUgWiBNMTkwLjY1Mzc1LDMxLjAzNjk4NzIgQzE4NS4wMzM2MjUsMzEuMTA4NjEyNSAx%0D%0AODEuNzc2LDM0LjM4OTg2MjUgMTc5LjAwMTM3NSw0MC44MjYzNjI1IEwxNDkuNDgzMjUsMTAwLjQy%0D%0ANDM2MyBMMTM0LjIzNDYyNSw0MC44MjYzNjI1IEMxMzIuNDg2Mzc1LDMzLjkyNzg2MjUgMTI3Ljg3%0D%0AMTYyNSwzMS4wMzY5ODcyIDEyMi41ODIyNSwzMS4wMzY5ODcyIEMxMTcuMjkyODc1LDMxLjAzNjk4%0D%0ANzIgMTEzLjI1ODI1LDMzLjc2NTExMjUgMTEwLjgzNTM3NSw0MC44MjYzNjI1IEw5Mi4zNzExMjUs%0D%0AMTAwLjcwNzg2MyBMNzQuMjE5MjUsNDAuODI2MzYyNSBDNzEuOTY5NjI1LDMzLjc2NTExMjUgNjcu%0D%0AODExNjI1LDMxLjAzNjk4NzIgNjIuNDkwNzUsMzEuMDM2OTg3MiBDNTcuMTcyNSwzMS4wMzY5ODcy%0D%0AIDUyLjY2Mjc1LDMzLjkyNzg2MjUgNTAuOTExODc1LDQwLjgyNjM2MjUgTDMyLjY4OTEyNSwxMTIu%0D%0AMDA1ODYzIEw0NC44Mjk3NSwxMTIuMDA1ODYzIEw2Mi41MTQzNzUsNDIuNjY5MTEyNSBMODAuOTYy%0D%0AODc1LDEwMy40NTg4NjMgQzgyLjg4NDM3NSwxMDkuNzE2ODYzIDg3LjczMjc1LDExMi42MDY5ODgg%0D%0AOTIuMzk0NzUsMTEyLjQ0NDIzOCBDOTcuMDU2NzUsMTEyLjYwNjk4OCAxMDEuODM5NSwxMDkuNzE2%0D%0AODYzIDEwMy45MzE2MjUsMTAzLjQ1ODg2MyBMMTIyLjU4MjI1LDQyLjQ4MjczNzUgTDEzNy44MzA4%0D%0ANzUsMTAxLjg2Mjg2MyBDMTM5LjU3OTEyNSwxMDkuMjQ0MzYzIDE0My45NDE4NzUsMTEyLjQ2MjYx%0D%0AMyAxNDkuMzg2MTI1LDExMi40NjI2MTMgQzE1NC41MzExMjUsMTEyLjQ2MjYxMyAxNTguMjI0NSwx%0D%0AMDguNTcyMzYzIDE2MC45MDk4NzUsMTAzLjQ3NzIzOCBMMTkwLjcyNDYyNSw0My4yMTUxMTI1IEwy%0D%0AMDQuNTQ1MjUsNzAuODU4OTg3NSBMMTg0LjMwOTEyNSw3MC44NTg5ODc1IEwxNzguNDg0MjUsODIu%0D%0ANDQ1NzM3NSBMMjEwLjIyMDUsODIuNDQ1NzM3NSBMMjIwLjgyNTUsMTAzLjQ5Mjk4NyBDMjI0LjI3%0D%0ANDc1LDEwOS43NTg4NjMgMjI2LjUyNDM3NSwxMTIuNDc4MzYzIDIzMi43OTU1LDExMi40NzgzNjMg%0D%0AQzIzOS4yMDMxMjUsMTEyLjQ3ODM2MyAyNDQuMzc3LDEwOS45NTU3MzcgMjQ0LjM3Nyw5NS45MzU2%0D%0AMTI1IEwyNDQuNDI0MjUsNDMuNzg3MzYyNSBMMjcwLjA2LDQzLjc4NzM2MjUgQzI4NC4xODUxMjUs%0D%0ANDMuNzg3MzYyNSAyODYuODEyNzUsNTEuMDcxNzM3NSAyODYuODEyNzUsNTYuODU3MjM3NSBDMjg2%0D%0ALjgxMjc1LDYyLjY0MjczNzUgMjgzLjg5OSw3MC43MzAzNjI1IDI2OS43OTIyNSw3MC43OTU5ODc1%0D%0AIEwyNTAuNzY4ODc1LDcwLjc5NTk4NzUgTDI1MC43Njg4NzUsODIuMjU0MTEyNSBMMjY4Ljk3MDYy%0D%0ANSw4Mi4yOTA4NjI1IEMyOTEuMjgzMTI1LDgyLjI5MDg2MjUgMjk5LjYzMzI1LDcxLjc2MTk4NzUg%0D%0AMjk5LjYzMzI1LDU2LjgyODM2MjUgQzI5OS42MzMyNSw0MS44OTQ3Mzc1IDI5MS4xMTc3NSwzMi4w%0D%0ANTg4NjI1IDI2OS4yODAzNzUsMzIuMDU4ODYyNSBMMjQ0LjYzNDI1LDMyLjA1ODg2MjUgQzIzNC42%0D%0AODgxMjUsMzIuMDU4ODYyNSAyMzIuNDM4NSwzNS4xNTg5ODc1IDIzMi40Mzg1LDQzLjUwNjQ4NzUg%0D%0ATDIzMi40Mzg1LDEwMC42NDQ4NjMgTDIwMi43OTcsNDAuODI2MzYyNSBDMTk5LjI2MTEyNSwzNC4y%0D%0ANTU5ODc1IDE5NS44Njk2MjUsMzAuOTc5OTg3NSAxOTAuNjUzNzUsMzEuMDM2OTg3MiBaIE0zNDMu%0D%0ANzMyNzI1LDMyLjEwMDYgTDMwOC44Nzc5NzUsMzIuMTAwNiBDMzAwLjY4Nzk3NSwzMi4xMDA2IDMw%0D%0AMC42ODc5NzUsNDMuODA1NDc1IDMwOC44Nzc5NzUsNDMuODA1NDc1IEwzNDQuMzkxNiw0My44MDU0%0D%0ANzUgQzM1OC41MjE5NzUsNDMuODA1NDc1IDM2MS40MTIxLDUxLjIxNTg1IDM2MS40MTIxLDU3LjAw%0D%0AMTM1IEMzNjEuNDEyMSw2Mi43ODY4NSAzNTguNDk4MzUsNzAuMzI4NDc1IDM0NC4zOTE2LDcwLjMy%0D%0AODQ3NSBMMzA2LjE3NDIyNSw3MC40NjIzNSBMMzA2LjMxMDcyNSwxMTEuOTI0MjI1IEwzMTguMTY3%0D%0AODUsMTExLjkyNDIyNSBMMzE4LjA2ODEsODEuODk0MjI1IEwzNDIuMTQ5ODUsODEuODk0MjI1IEwz%0D%0ANjMuMTc4NzI1LDExMS43Nzk4NSBMMzc3LjQ5Mjg1LDExMS43Nzk4NSBMMzU1LjY1MDIyNSw4MC43%0D%0AMTAzNSBDMzY3Ljg4NTM1LDc4LjE0MzEgMzc0LjI0ODM1LDY4LjU3NDk3NSAzNzQuMjQ4MzUsNTcu%0D%0AMDAxMzUgQzM3NC4yNDgzNSw0Mi4wNjI0NzUgMzY1Ljc0ODYsMzIuMTAwNiAzNDMuNzMyNzI1LDMy%0D%0ALjEwMDYgWiBNMzg3LjEzMjksMTAxLjY2Mzg4OCBMMzg3LjExNDUyNSwxMDEuNjYzODg4IEMzODQu%0D%0AMzk3NjUsMTAxLjcxNjM4OCAzODIuMjM5OSwxMDMuOTU4MTM4IDM4Mi4yODk3NzUsMTA2LjY3NTAx%0D%0AMyBDMzgyLjM0MjI3NSwxMDkuMzg5MjYzIDM4NC41ODY2NSwxMTEuNTQ5NjM4IDM4Ny4zMDA5LDEx%0D%0AMS40OTcxMzggQzM4OS45OTE1MjUsMTExLjQ0NzI2MyAzOTIuMTQxNCwxMDkuMjQyMjYzIDM5Mi4x%0D%0AMjU3MzYsMTA2LjU1NDI2MyBDMzkyLjA5Njc3NSwxMDMuODI0MjYzIDM4OS44NjAyNzUsMTAxLjYz%0D%0ANTAxMyAzODcuMTMyOSwxMDEuNjYzODg4IFogTTM5MC44NDQ2NSwxMDYuMzc1NzYzIEMzOTAuODQ3%0D%0AMjc1LDEwNi40NDY2MzggMzkwLjg0OTksMTA2LjUxMjI2MyAzOTAuODQ5OSwxMDYuNTgwNTEzIEMz%0D%0AOTAuOTIwNzc1LDEwOC42NTE2MzggMzg5LjMwMTE1LDExMC4zODQxMzggMzg3LjIzMjY1LDExMC40%0D%0ANTUwMTMgTDM4Ny4xMTQ1MjUsMTEwLjQ1NzYzOCBDMzg0Ljk1Njc3NSwxMTAuNTUyMTM4IDM4My4x%0D%0AMjk3NzUsMTA4Ljg4MjYzOCAzODMuMDMyNjUsMTA2LjcyNDg4OCBDMzgyLjkzODE1LDEwNC41Njk3%0D%0ANjMgMzg0LjYwNzY1LDEwMi43NDI3NjMgMzg2Ljc2NTQsMTAyLjY0MzAxMyBDMzg4LjkyMDUyNSwx%0D%0AMDIuNTQ4NTEzIDM5MC43NDc1MjUsMTA0LjIxODAxMyAzOTAuODQ0NjUsMTA2LjM3NTc2MyBaIE0z%0D%0AODcuMDY3NTM4LDEwNC4wNDEwODcgQzM4Ni40NDI3ODgsMTA0LjAzMzIxMiAzODUuODE4MDM4LDEw%0D%0ANC4wODU3MTIgMzg1LjIwMzc4OCwxMDQuMTkzMzM3IEwzODUuMjAzNzg4LDEwOS4wODEwODcgTDM4%0D%0ANi4zMzUxNjMsMTA5LjA4MTA4NyBMMzg2LjMzNTE2MywxMDcuMTE3NTg3IEwzODYuODcwNjYzLDEw%0D%0ANy4xMTc1ODcgQzM4Ny41MDMyODgsMTA3LjExNzU4NyAzODcuNzk3Mjg4LDEwNy4zNTY0NjIgMzg3%0D%0ALjg4MzkxMywxMDcuODk0NTg3IEMzODcuOTU3NDEzLDEwOC4yOTg4MzcgMzg4LjA4ODY2MywxMDgu%0D%0ANjkyNTg3IDM4OC4yNzI0MTMsMTA5LjA1NzQ2MiBMMzg5LjQ5ODI4OCwxMDkuMDU3NDYyIEMzODku%0D%0AMzE0NTM4LDEwOC42NzQyMTIgMzg5LjE5Mzc4OCwxMDguMjYyMDg3IDM4OS4xMzYwMzgsMTA3Ljgz%0D%0AOTQ2MiBDMzg5LjA2NTE2MywxMDcuMzI0OTYyIDM4OC43MjEyODgsMTA2Ljg4OTIxMiAzODguMjM4%0D%0AMjg4LDEwNi43MDAyMTIgTDM4OC4yMzgyODgsMTA2LjY0NTA4NyBDMzg4LjgwMDAzOCwxMDYuNTI5%0D%0ANTg3IDM4OS4yMTc0MTMsMTA2LjA1NDQ2MiAzODkuMjUxNTM4LDEwNS40ODIyMTIgQzM4OS4yNjIw%0D%0AMzgsMTA1LjA3MDA4NyAzODkuMDg2MTYzLDEwNC42NzM3MTIgMzg4Ljc3Mzc4OCwxMDQuNDAzMzM3%0D%0AIEMzODguMjUxNDEzLDEwNC4xMTk4MzcgMzg3LjY1ODE2MywxMDMuOTkzODM3IDM4Ny4wNjc1Mzgs%0D%0AMTA0LjA0MTA4NyBaIE0zODYuOTg2MTYzLDEwNC44NzMyMTIgQzM4Ny42OTIyODgsMTA0Ljg3MzIx%0D%0AMiAzODguMDI4Mjg4LDEwNS4xNzc3MTIgMzg4LjAyODI4OCwxMDUuNjIxMzM3IEMzODguMDI4Mjg4%0D%0ALDEwNi4wNjQ5NjIgMzg3LjUyMTY2MywxMDYuMzQzMjEyIDM4Ni44ODY0MTMsMTA2LjM0MzIxMiBM%0D%0AMzg2LjM1MDkxMywxMDYuMzQzMjEyIEwzODYuMzUwOTEzLDEwNC45NDQwODcgQzM4Ni41NTgyODgs%0D%0AMTA0Ljg5NDIxMiAzODYuNzczNTM4LDEwNC44NzA1ODcgMzg2Ljk4NjE2MywxMDQuODczMjEyIFoi%0D%0AIGlkPSJDb21iaW5lZC1TaGFwZSIgZmlsbD0iI0M4MTAyRSI+PC9wYXRoPgogICAgICAgIDwvZz4K%0D%0AICAgIDwvZz4KPC9zdmc+",
-        "scaleFactor": 1,
-        "margin": "",
-        "height": 10,
-        "width": 35,
-        "y": 1,
-        "x": 2,
-        "add_timeframe": true,
+      "layout": {
+        "x": 122,
+        "y": 51,
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 4,
+      "definition": {
         "type": "image",
-        "isShared": false
+        "url": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iNDIwcHgi%0D%0AIGhlaWdodD0iMTE0cHgiIHZpZXdCb3g9IjAgMCA0MjAgMTE0IiB2ZXJzaW9uPSIxLjEiIHhtbG5z%0D%0APSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMu%0D%0Ab3JnLzE5OTkveGxpbmsiPgogICAgPCEtLSBHZW5lcmF0b3I6IFNrZXRjaCA1OCAoODQ2NjMpIC0g%0D%0AaHR0cHM6Ly9za2V0Y2guY29tIC0tPgogICAgPHRpdGxlPm1hcHJAM3g8L3RpdGxlPgogICAgPGRl%0D%0Ac2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+CiAgICA8ZyBpZD0ibWFwciIgc3Ryb2tlPSJu%0D%0Ab25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAg%0D%0AICAgICAgPGcgaWQ9Ikdyb3VwLTExIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLjAwMDAwMCwgLTE1%0D%0ALjAwMDAwMCkiPgogICAgICAgICAgICA8ZyBpZD0iR3JvdXAtMTAiIHRyYW5zZm9ybT0idHJhbnNs%0D%0AYXRlKDMyLjUwMDAwMCwgMzAuNTI1ODYzKSI+PC9nPgogICAgICAgICAgICA8cmVjdCBpZD0iUmVj%0D%0AdGFuZ2xlIiBmaWxsPSIjRkZGRkZGIiBvcGFjaXR5PSIwLjUiIHg9IjAiIHk9IjE1IiB3aWR0aD0i%0D%0ANDIwIiBoZWlnaHQ9IjExNCI+PC9yZWN0PgogICAgICAgICAgICA8cGF0aCBkPSJNNDIwLC0wLjAw%0D%0AMDI2MjUgTDQyMCwxNDMuNDAwODYzIEwwLDE0My40MDA4NjMgTDAsLTAuMDAwMjYyNSBMNDIwLC0w%0D%0ALjAwMDI2MjUgWiBNMTkwLjY1Mzc1LDMxLjAzNjk4NzIgQzE4NS4wMzM2MjUsMzEuMTA4NjEyNSAx%0D%0AODEuNzc2LDM0LjM4OTg2MjUgMTc5LjAwMTM3NSw0MC44MjYzNjI1IEwxNDkuNDgzMjUsMTAwLjQy%0D%0ANDM2MyBMMTM0LjIzNDYyNSw0MC44MjYzNjI1IEMxMzIuNDg2Mzc1LDMzLjkyNzg2MjUgMTI3Ljg3%0D%0AMTYyNSwzMS4wMzY5ODcyIDEyMi41ODIyNSwzMS4wMzY5ODcyIEMxMTcuMjkyODc1LDMxLjAzNjk4%0D%0ANzIgMTEzLjI1ODI1LDMzLjc2NTExMjUgMTEwLjgzNTM3NSw0MC44MjYzNjI1IEw5Mi4zNzExMjUs%0D%0AMTAwLjcwNzg2MyBMNzQuMjE5MjUsNDAuODI2MzYyNSBDNzEuOTY5NjI1LDMzLjc2NTExMjUgNjcu%0D%0AODExNjI1LDMxLjAzNjk4NzIgNjIuNDkwNzUsMzEuMDM2OTg3MiBDNTcuMTcyNSwzMS4wMzY5ODcy%0D%0AIDUyLjY2Mjc1LDMzLjkyNzg2MjUgNTAuOTExODc1LDQwLjgyNjM2MjUgTDMyLjY4OTEyNSwxMTIu%0D%0AMDA1ODYzIEw0NC44Mjk3NSwxMTIuMDA1ODYzIEw2Mi41MTQzNzUsNDIuNjY5MTEyNSBMODAuOTYy%0D%0AODc1LDEwMy40NTg4NjMgQzgyLjg4NDM3NSwxMDkuNzE2ODYzIDg3LjczMjc1LDExMi42MDY5ODgg%0D%0AOTIuMzk0NzUsMTEyLjQ0NDIzOCBDOTcuMDU2NzUsMTEyLjYwNjk4OCAxMDEuODM5NSwxMDkuNzE2%0D%0AODYzIDEwMy45MzE2MjUsMTAzLjQ1ODg2MyBMMTIyLjU4MjI1LDQyLjQ4MjczNzUgTDEzNy44MzA4%0D%0ANzUsMTAxLjg2Mjg2MyBDMTM5LjU3OTEyNSwxMDkuMjQ0MzYzIDE0My45NDE4NzUsMTEyLjQ2MjYx%0D%0AMyAxNDkuMzg2MTI1LDExMi40NjI2MTMgQzE1NC41MzExMjUsMTEyLjQ2MjYxMyAxNTguMjI0NSwx%0D%0AMDguNTcyMzYzIDE2MC45MDk4NzUsMTAzLjQ3NzIzOCBMMTkwLjcyNDYyNSw0My4yMTUxMTI1IEwy%0D%0AMDQuNTQ1MjUsNzAuODU4OTg3NSBMMTg0LjMwOTEyNSw3MC44NTg5ODc1IEwxNzguNDg0MjUsODIu%0D%0ANDQ1NzM3NSBMMjEwLjIyMDUsODIuNDQ1NzM3NSBMMjIwLjgyNTUsMTAzLjQ5Mjk4NyBDMjI0LjI3%0D%0ANDc1LDEwOS43NTg4NjMgMjI2LjUyNDM3NSwxMTIuNDc4MzYzIDIzMi43OTU1LDExMi40NzgzNjMg%0D%0AQzIzOS4yMDMxMjUsMTEyLjQ3ODM2MyAyNDQuMzc3LDEwOS45NTU3MzcgMjQ0LjM3Nyw5NS45MzU2%0D%0AMTI1IEwyNDQuNDI0MjUsNDMuNzg3MzYyNSBMMjcwLjA2LDQzLjc4NzM2MjUgQzI4NC4xODUxMjUs%0D%0ANDMuNzg3MzYyNSAyODYuODEyNzUsNTEuMDcxNzM3NSAyODYuODEyNzUsNTYuODU3MjM3NSBDMjg2%0D%0ALjgxMjc1LDYyLjY0MjczNzUgMjgzLjg5OSw3MC43MzAzNjI1IDI2OS43OTIyNSw3MC43OTU5ODc1%0D%0AIEwyNTAuNzY4ODc1LDcwLjc5NTk4NzUgTDI1MC43Njg4NzUsODIuMjU0MTEyNSBMMjY4Ljk3MDYy%0D%0ANSw4Mi4yOTA4NjI1IEMyOTEuMjgzMTI1LDgyLjI5MDg2MjUgMjk5LjYzMzI1LDcxLjc2MTk4NzUg%0D%0AMjk5LjYzMzI1LDU2LjgyODM2MjUgQzI5OS42MzMyNSw0MS44OTQ3Mzc1IDI5MS4xMTc3NSwzMi4w%0D%0ANTg4NjI1IDI2OS4yODAzNzUsMzIuMDU4ODYyNSBMMjQ0LjYzNDI1LDMyLjA1ODg2MjUgQzIzNC42%0D%0AODgxMjUsMzIuMDU4ODYyNSAyMzIuNDM4NSwzNS4xNTg5ODc1IDIzMi40Mzg1LDQzLjUwNjQ4NzUg%0D%0ATDIzMi40Mzg1LDEwMC42NDQ4NjMgTDIwMi43OTcsNDAuODI2MzYyNSBDMTk5LjI2MTEyNSwzNC4y%0D%0ANTU5ODc1IDE5NS44Njk2MjUsMzAuOTc5OTg3NSAxOTAuNjUzNzUsMzEuMDM2OTg3MiBaIE0zNDMu%0D%0ANzMyNzI1LDMyLjEwMDYgTDMwOC44Nzc5NzUsMzIuMTAwNiBDMzAwLjY4Nzk3NSwzMi4xMDA2IDMw%0D%0AMC42ODc5NzUsNDMuODA1NDc1IDMwOC44Nzc5NzUsNDMuODA1NDc1IEwzNDQuMzkxNiw0My44MDU0%0D%0ANzUgQzM1OC41MjE5NzUsNDMuODA1NDc1IDM2MS40MTIxLDUxLjIxNTg1IDM2MS40MTIxLDU3LjAw%0D%0AMTM1IEMzNjEuNDEyMSw2Mi43ODY4NSAzNTguNDk4MzUsNzAuMzI4NDc1IDM0NC4zOTE2LDcwLjMy%0D%0AODQ3NSBMMzA2LjE3NDIyNSw3MC40NjIzNSBMMzA2LjMxMDcyNSwxMTEuOTI0MjI1IEwzMTguMTY3%0D%0AODUsMTExLjkyNDIyNSBMMzE4LjA2ODEsODEuODk0MjI1IEwzNDIuMTQ5ODUsODEuODk0MjI1IEwz%0D%0ANjMuMTc4NzI1LDExMS43Nzk4NSBMMzc3LjQ5Mjg1LDExMS43Nzk4NSBMMzU1LjY1MDIyNSw4MC43%0D%0AMTAzNSBDMzY3Ljg4NTM1LDc4LjE0MzEgMzc0LjI0ODM1LDY4LjU3NDk3NSAzNzQuMjQ4MzUsNTcu%0D%0AMDAxMzUgQzM3NC4yNDgzNSw0Mi4wNjI0NzUgMzY1Ljc0ODYsMzIuMTAwNiAzNDMuNzMyNzI1LDMy%0D%0ALjEwMDYgWiBNMzg3LjEzMjksMTAxLjY2Mzg4OCBMMzg3LjExNDUyNSwxMDEuNjYzODg4IEMzODQu%0D%0AMzk3NjUsMTAxLjcxNjM4OCAzODIuMjM5OSwxMDMuOTU4MTM4IDM4Mi4yODk3NzUsMTA2LjY3NTAx%0D%0AMyBDMzgyLjM0MjI3NSwxMDkuMzg5MjYzIDM4NC41ODY2NSwxMTEuNTQ5NjM4IDM4Ny4zMDA5LDEx%0D%0AMS40OTcxMzggQzM4OS45OTE1MjUsMTExLjQ0NzI2MyAzOTIuMTQxNCwxMDkuMjQyMjYzIDM5Mi4x%0D%0AMjU3MzYsMTA2LjU1NDI2MyBDMzkyLjA5Njc3NSwxMDMuODI0MjYzIDM4OS44NjAyNzUsMTAxLjYz%0D%0ANTAxMyAzODcuMTMyOSwxMDEuNjYzODg4IFogTTM5MC44NDQ2NSwxMDYuMzc1NzYzIEMzOTAuODQ3%0D%0AMjc1LDEwNi40NDY2MzggMzkwLjg0OTksMTA2LjUxMjI2MyAzOTAuODQ5OSwxMDYuNTgwNTEzIEMz%0D%0AOTAuOTIwNzc1LDEwOC42NTE2MzggMzg5LjMwMTE1LDExMC4zODQxMzggMzg3LjIzMjY1LDExMC40%0D%0ANTUwMTMgTDM4Ny4xMTQ1MjUsMTEwLjQ1NzYzOCBDMzg0Ljk1Njc3NSwxMTAuNTUyMTM4IDM4My4x%0D%0AMjk3NzUsMTA4Ljg4MjYzOCAzODMuMDMyNjUsMTA2LjcyNDg4OCBDMzgyLjkzODE1LDEwNC41Njk3%0D%0ANjMgMzg0LjYwNzY1LDEwMi43NDI3NjMgMzg2Ljc2NTQsMTAyLjY0MzAxMyBDMzg4LjkyMDUyNSwx%0D%0AMDIuNTQ4NTEzIDM5MC43NDc1MjUsMTA0LjIxODAxMyAzOTAuODQ0NjUsMTA2LjM3NTc2MyBaIE0z%0D%0AODcuMDY3NTM4LDEwNC4wNDEwODcgQzM4Ni40NDI3ODgsMTA0LjAzMzIxMiAzODUuODE4MDM4LDEw%0D%0ANC4wODU3MTIgMzg1LjIwMzc4OCwxMDQuMTkzMzM3IEwzODUuMjAzNzg4LDEwOS4wODEwODcgTDM4%0D%0ANi4zMzUxNjMsMTA5LjA4MTA4NyBMMzg2LjMzNTE2MywxMDcuMTE3NTg3IEwzODYuODcwNjYzLDEw%0D%0ANy4xMTc1ODcgQzM4Ny41MDMyODgsMTA3LjExNzU4NyAzODcuNzk3Mjg4LDEwNy4zNTY0NjIgMzg3%0D%0ALjg4MzkxMywxMDcuODk0NTg3IEMzODcuOTU3NDEzLDEwOC4yOTg4MzcgMzg4LjA4ODY2MywxMDgu%0D%0ANjkyNTg3IDM4OC4yNzI0MTMsMTA5LjA1NzQ2MiBMMzg5LjQ5ODI4OCwxMDkuMDU3NDYyIEMzODku%0D%0AMzE0NTM4LDEwOC42NzQyMTIgMzg5LjE5Mzc4OCwxMDguMjYyMDg3IDM4OS4xMzYwMzgsMTA3Ljgz%0D%0AOTQ2MiBDMzg5LjA2NTE2MywxMDcuMzI0OTYyIDM4OC43MjEyODgsMTA2Ljg4OTIxMiAzODguMjM4%0D%0AMjg4LDEwNi43MDAyMTIgTDM4OC4yMzgyODgsMTA2LjY0NTA4NyBDMzg4LjgwMDAzOCwxMDYuNTI5%0D%0ANTg3IDM4OS4yMTc0MTMsMTA2LjA1NDQ2MiAzODkuMjUxNTM4LDEwNS40ODIyMTIgQzM4OS4yNjIw%0D%0AMzgsMTA1LjA3MDA4NyAzODkuMDg2MTYzLDEwNC42NzM3MTIgMzg4Ljc3Mzc4OCwxMDQuNDAzMzM3%0D%0AIEMzODguMjUxNDEzLDEwNC4xMTk4MzcgMzg3LjY1ODE2MywxMDMuOTkzODM3IDM4Ny4wNjc1Mzgs%0D%0AMTA0LjA0MTA4NyBaIE0zODYuOTg2MTYzLDEwNC44NzMyMTIgQzM4Ny42OTIyODgsMTA0Ljg3MzIx%0D%0AMiAzODguMDI4Mjg4LDEwNS4xNzc3MTIgMzg4LjAyODI4OCwxMDUuNjIxMzM3IEMzODguMDI4Mjg4%0D%0ALDEwNi4wNjQ5NjIgMzg3LjUyMTY2MywxMDYuMzQzMjEyIDM4Ni44ODY0MTMsMTA2LjM0MzIxMiBM%0D%0AMzg2LjM1MDkxMywxMDYuMzQzMjEyIEwzODYuMzUwOTEzLDEwNC45NDQwODcgQzM4Ni41NTgyODgs%0D%0AMTA0Ljg5NDIxMiAzODYuNzczNTM4LDEwNC44NzA1ODcgMzg2Ljk4NjE2MywxMDQuODczMjEyIFoi%0D%0AIGlkPSJDb21iaW5lZC1TaGFwZSIgZmlsbD0iI0M4MTAyRSI+PC9wYXRoPgogICAgICAgIDwvZz4K%0D%0AICAgIDwvZz4KPC9zdmc+",
+        "sizing": "zoom"
       },
-      {
-        "board_id": "2db-kqp-3h5",
+      "layout": {
         "x": 2,
-        "title_align": "left",
-        "title_size": 16,
-        "time": {},
-        "title": true,
-        "type": "query_value",
-        "generated_title": "Query Value",
-        "title_text": "CPU count",
-        "height": 10,
-        "tile_def": {
-          "viz": "query_value",
-          "requests": [
-            {
-              "q": "avg:mapr.cldb.cluster_cpu_total{$clustername,$scope}",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": null,
-              "conditional_formats": [
-                {
-                  "palette": "white_on_red",
-                  "comparator": ">",
-                  "value": null
-                },
-                {
-                  "palette": "white_on_yellow",
-                  "comparator": ">=",
-                  "value": null
-                },
-                {
-                  "palette": "white_on_green",
-                  "comparator": "<",
-                  "value": null
-                }
-              ]
-            }
-          ],
-          "autoscale": true,
-          "custom_unit": "CPUs"
-        },
-        "width": 17,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 21,
-        "autoscale": true,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "x": 20,
-        "autoscale": true,
-        "time": {},
-        "title": true,
-        "type": "query_value",
-        "title_align": "left",
-        "title_text": "Node count",
-        "height": 10,
-        "tile_def": {
-          "title_size": "16",
-          "title_align": "left",
-          "custom_unit": null,
-          "precision": "2",
-          "viz": "query_value",
-          "autoscale": true,
-          "requests": [
-            {
-              "q": "avg:mapr.cldb.nodes_in_cluster{$clustername,$scope}",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": null,
-              "conditional_formats": []
-            }
-          ]
-        },
-        "width": 17,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 21,
-        "title_size": 16,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "x": 20,
-        "autoscale": true,
-        "time": {},
-        "title": true,
-        "type": "query_value",
-        "title_align": "left",
-        "title_text": "Available memory",
-        "height": 10,
-        "tile_def": {
-          "title_size": "16",
-          "title_align": "left",
-          "custom_unit": "%",
-          "precision": "2",
-          "viz": "query_value",
-          "autoscale": true,
-          "requests": [
-            {
-              "q": "(avg:mapr.cldb.cluster_memory_capacity{$scope,$clustername}-avg:mapr.cldb.cluster_memory_used{$scope,$clustername})/avg:mapr.cldb.cluster_memory_capacity{$scope,$clustername}*100",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": null,
-              "conditional_formats": [
-                {
-                  "palette": "white_on_red",
-                  "comparator": "<",
-                  "value": "15"
-                }
-              ]
-            }
-          ]
-        },
-        "width": 17,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 47,
-        "title_size": 16,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "board_id": "2db-kqp-3h5",
-        "title_align": "left",
-        "title_size": 16,
-        "time": {},
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "Query Value",
-        "title_text": "Disk space utilization",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:mapr.cldb.cluster_disk_capacity{$scope,$clustername}",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "cool",
-                "type": "solid"
-              },
-              "type": "area",
-              "conditional_formats": [
-                {
-                  "palette": "white_on_red",
-                  "comparator": ">",
-                  "value": null
-                },
-                {
-                  "palette": "white_on_yellow",
-                  "comparator": ">=",
-                  "value": null
-                },
-                {
-                  "palette": "white_on_green",
-                  "comparator": "<",
-                  "value": null
-                }
-              ]
-            },
-            {
-              "q": "avg:mapr.cldb.cluster_diskspace_used{$scope,$clustername}",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "cool",
-                "type": "solid"
-              },
-              "type": "area"
-            }
-          ],
-          "autoscale": true
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 9,
-        "x": 39,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "error": null,
-        "title_size": 16,
-        "title": true,
-        "type": "timeseries",
-        "title_align": "left",
-        "title_text": "Memory utilization",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "title_size": "16",
-          "requests": [
-            {
-              "q": "avg:mapr.cldb.cluster_memory_capacity{$scope,$clustername}",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "cool",
-                "type": "solid"
-              },
-              "type": "area",
-              "conditional_formats": []
-            },
-            {
-              "q": "avg:mapr.cldb.cluster_memory_used{$scope,$clustername}",
-              "style": {
-                "width": "normal",
-                "palette": "cool",
-                "type": "solid"
-              },
-              "type": "area"
-            }
-          ],
-          "title_align": "left",
-          "autoscale": true
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "time": {},
-        "y": 30,
-        "x": 39,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "error": null,
-        "title_size": 16,
-        "title": true,
-        "type": "timeseries",
-        "title_align": "left",
-        "title_text": "CPUs busy",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "title_size": "16",
-          "requests": [
-            {
-              "q": "avg:mapr.cldb.cluster_cpubusy_percent{$clustername,$scope}",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "orange",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
-            }
-          ],
-          "title_align": "left",
-          "autoscale": true
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "time": {},
-        "y": 9,
-        "x": 80,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "board_id": "2db-kqp-3h5",
-        "title_align": "left",
-        "title_size": 16,
-        "time": {},
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "mapr.db.valuecache_hits, mapr.db.valuecache_lookups",
-        "title_text": "Operations that used value cache (hit/lookup)",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:mapr.db.valuecache_lookups{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "bars",
-              "conditional_formats": []
-            },
-            {
-              "q": "avg:mapr.db.valuecache_hits{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "bars"
-            }
-          ],
-          "autoscale": true
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 81,
-        "x": 39,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "board_id": "2db-kqp-3h5",
-        "title_align": "left",
-        "title_size": 16,
-        "time": {},
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "mapr.streams.listen_msgs, mapr.streams.produce_msgs, mapr.streams.produce_msgs",
-        "title_text": "Messages produced & read",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:mapr.streams.listen_msgs{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "green",
-                "type": "solid"
-              },
-              "type": "bars",
-              "conditional_formats": []
-            },
-            {
-              "q": "avg:mapr.streams.produce_msgs{$clustername,$scope}.as_count()",
-              "style": {
-                "width": "normal",
-                "palette": "purple",
-                "type": "solid"
-              },
-              "type": "bars"
-            }
-          ],
-          "autoscale": true
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 81,
-        "x": 122,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "x": 2,
-        "autoscale": true,
-        "time": {},
-        "title": true,
-        "type": "query_value",
-        "title_align": "left",
-        "title_text": "Available disk space",
-        "height": 10,
-        "tile_def": {
-          "title_size": "16",
-          "title_align": "left",
-          "custom_unit": "%",
-          "precision": "2",
-          "viz": "query_value",
-          "autoscale": true,
-          "requests": [
-            {
-              "q": "(avg:mapr.cldb.disk_space_available{$scope,$clustername}/avg:mapr.cldb.cluster_disk_capacity{$scope,$clustername})*100",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": null,
-              "conditional_formats": [
-                {
-                  "palette": "white_on_green",
-                  "comparator": ">",
-                  "value": "25"
-                }
-              ]
-            }
-          ]
-        },
-        "width": 17,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 47,
-        "title_size": 16,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "board_id": "2db-kqp-3h5",
-        "x": 2,
-        "title_align": "left",
-        "title_size": 16,
-        "time": {},
-        "title": true,
-        "type": "query_value",
-        "generated_title": "Query Value",
-        "title_text": "Container count",
-        "height": 10,
-        "tile_def": {
-          "viz": "query_value",
-          "requests": [
-            {
-              "q": "avg:mapr.cldb.containers{$clustername,$scope}",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": null,
-              "conditional_formats": [
-                {
-                  "palette": "white_on_red",
-                  "comparator": ">",
-                  "value": null
-                },
-                {
-                  "palette": "white_on_yellow",
-                  "comparator": ">=",
-                  "value": null
-                },
-                {
-                  "palette": "white_on_green",
-                  "comparator": "<",
-                  "value": null
-                }
-              ]
-            }
-          ],
-          "autoscale": true
-        },
-        "width": 17,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 34,
-        "autoscale": true,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "height": 6,
-        "viz": "note",
-        "background_color": "gray",
-        "show_tick": true,
-        "title": false,
-        "tick_pos": "50%",
-        "text_align": "center",
-        "content": "Health status",
-        "bgcolor": "pink",
-        "html": "MapR File System",
-        "legend_size": "0",
-        "type": "note",
-        "isShared": false,
-        "refresh_every": 30000,
-        "auto_refresh": false,
-        "tick": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "add_timeframe": true,
-        "font_size": "18",
-        "tick_edge": "bottom",
         "y": 1,
-        "x": 122,
-        "width": 81
-      },
-      {
-        "height": 6,
-        "viz": "note",
-        "background_color": "gray",
-        "show_tick": true,
-        "title": false,
-        "tick_pos": "50%",
-        "text_align": "center",
-        "content": "File System",
-        "bgcolor": "gray",
-        "html": "Resource Utilization",
-        "legend_size": "0",
-        "type": "note",
-        "isShared": false,
-        "refresh_every": 30000,
-        "auto_refresh": false,
-        "tick": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "add_timeframe": true,
-        "font_size": "18",
-        "tick_edge": "bottom",
-        "y": 1,
-        "x": 39,
-        "width": 81
-      },
-      {
-        "height": 6,
-        "viz": "note",
-        "background_color": "gray",
-        "show_tick": true,
-        "title": false,
-        "tick_pos": "50%",
-        "text_align": "center",
-        "content": "Resource utilization",
-        "bgcolor": "pink",
-        "html": "MapR Database",
-        "legend_size": "0",
-        "type": "note",
-        "isShared": false,
-        "refresh_every": 30000,
-        "auto_refresh": false,
-        "tick": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "add_timeframe": true,
-        "font_size": "18",
-        "tick_edge": "bottom",
-        "y": 52,
-        "x": 39,
-        "width": 81
-      },
-      {
-        "error": null,
-        "title_size": 16,
-        "title": true,
-        "type": "timeseries",
-        "title_align": "left",
-        "title_text": "Read & write bytes",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "title_size": "16",
-          "requests": [
-            {
-              "q": "avg:mapr.db.table.read_bytes{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "green",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
-            },
-            {
-              "q": "avg:mapr.db.table.write_bytes{$clustername,$scope}.as_count()",
-              "style": {
-                "width": "normal",
-                "palette": "purple",
-                "type": "solid"
-              },
-              "type": "line"
-            }
-          ],
-          "title_align": "left",
-          "autoscale": true
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "time": {},
-        "y": 60,
-        "x": 80,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "height": 6,
-        "viz": "note",
-        "background_color": "gray",
-        "show_tick": true,
-        "title": false,
-        "tick_pos": "50%",
-        "text_align": "center",
-        "content": "MapR Database (MapR-DB)",
-        "bgcolor": "pink",
-        "html": "MapR Event Store",
-        "legend_size": "0",
-        "type": "note",
-        "isShared": false,
-        "refresh_every": 30000,
-        "auto_refresh": false,
-        "tick": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "add_timeframe": true,
-        "font_size": "18",
-        "tick_edge": "bottom",
-        "y": 73,
-        "x": 122,
-        "width": 81
-      },
-      {
-        "error": null,
-        "title_size": 16,
-        "title": true,
-        "type": "timeseries",
-        "title_align": "left",
-        "title_text": "Producer & consumer RPCs",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "title_size": "16",
-          "requests": [
-            {
-              "q": "avg:mapr.streams.listen_rpcs{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "green",
-                "type": "solid"
-              },
-              "type": "bars",
-              "conditional_formats": []
-            },
-            {
-              "q": "avg:mapr.streams.produce_rpcs{$clustername,$scope}.as_count()",
-              "style": {
-                "width": "normal",
-                "palette": "purple",
-                "type": "solid"
-              },
-              "type": "bars"
-            }
-          ],
-          "title_align": "left",
-          "autoscale": true
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "time": {},
-        "y": 81,
-        "x": 163,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "board_id": "2db-kqp-3h5",
-        "title_align": "left",
-        "title_size": 16,
-        "time": {},
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "mapr.topology.utilization",
-        "title_text": "CPU utilization by process",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:mapr.process.cpu_percent{$clustername,$scope} by {process_name}",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
-            }
-          ],
-          "autoscale": true
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 30,
-        "x": 80,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "board_id": "2db-kqp-3h5",
-        "title_align": "left",
-        "title_size": 16,
-        "time": {},
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "mapr.fs.read_cachehits, mapr.fs.read_cachemisses",
-        "title_text": "Read cache hits & misses",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:mapr.fs.read_cachehits{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "cool",
-                "type": "solid"
-              },
-              "type": "bars",
-              "conditional_formats": []
-            },
-            {
-              "q": "avg:mapr.fs.read_cachemisses{$clustername,$scope}.as_count()",
-              "style": {
-                "width": "normal",
-                "palette": "warm",
-                "type": "solid"
-              },
-              "type": "bars"
-            }
-          ],
-          "autoscale": true
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 9,
-        "x": 163,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "board_id": "2db-kqp-3h5",
-        "title_align": "left",
-        "title_size": 16,
-        "time": {},
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "mapr.db.table.read_rows, mapr.db.table.resp_rows",
-        "title_text": "Rows read & returned",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:mapr.db.table.read_rows{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "green",
-                "type": "solid"
-              },
-              "type": "bars",
-              "conditional_formats": []
-            },
-            {
-              "q": "avg:mapr.db.table.resp_rows{$clustername,$scope}.as_count()",
-              "style": {
-                "width": "normal",
-                "palette": "purple",
-                "type": "solid"
-              },
-              "type": "bars"
-            }
-          ],
-          "autoscale": true
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 81,
-        "x": 80,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "x": 20,
-        "autoscale": true,
-        "time": {},
-        "title": true,
-        "type": "query_value",
-        "title_align": "left",
-        "title_text": "Volume count",
-        "height": 10,
-        "tile_def": {
-          "title_size": "16",
-          "title_align": "left",
-          "precision": "2",
-          "custom_unit": null,
-          "viz": "query_value",
-          "autoscale": true,
-          "requests": [
-            {
-              "q": "avg:mapr.cldb.volumes{$clustername,$scope}",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": null,
-              "conditional_formats": []
-            }
-          ]
-        },
-        "width": 17,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 34,
-        "title_size": 16,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "board_id": "2db-kqp-3h5",
-        "title_align": "left",
-        "title_size": 16,
-        "time": {},
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "Timeseries",
-        "title_text": "RPCs completed (get/put/scan/append/increment)",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:mapr.db.get_rpcs{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "bars",
-              "conditional_formats": []
-            },
-            {
-              "q": "avg:mapr.db.put_rpcs{$clustername,$scope}.as_count()",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "bars"
-            },
-            {
-              "q": "avg:mapr.db.append_rpcs{$clustername,$scope}.as_count()",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "bars"
-            },
-            {
-              "q": "avg:mapr.db.increment_rpcs{$clustername,$scope}.as_count()",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "bars"
-            },
-            {
-              "q": "avg:mapr.db.scan_rpcs{$clustername,$scope}.as_count()",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "bars"
-            }
-          ],
-          "autoscale": true
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "error": null,
-        "y": 60,
-        "x": 39,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "error": null,
-        "title_size": 16,
-        "title": true,
-        "type": "timeseries",
-        "title_align": "left",
-        "title_text": "Local read & write bytes",
-        "height": 18,
-        "tile_def": {
-          "viz": "timeseries",
-          "title_size": "16",
-          "requests": [
-            {
-              "q": "avg:mapr.fs.local_writebytes{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "purple",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
-            },
-            {
-              "q": "avg:mapr.fs.local_readbytes{$clustername,$scope}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "green",
-                "type": "solid"
-              },
-              "type": "line"
-            }
-          ],
-          "title_align": "left",
-          "autoscale": true
-        },
-        "width": 40,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "time": {},
-        "y": 30,
-        "x": 163,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "height": 6,
-        "viz": "note",
-        "background_color": "gray",
-        "title": false,
-        "tick_pos": "50%",
-        "text_align": "center",
-        "content": "Resource utilization",
-        "bgcolor": "gray",
-        "html": "Cluster Health",
-        "legend_size": "0",
-        "type": "note",
-        "isShared": false,
-        "refresh_every": 30000,
-        "auto_refresh": false,
-        "tick": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "add_timeframe": true,
-        "font_size": "18",
-        "tick_edge": "bottom",
-        "y": 13,
-        "x": 2,
-        "width": 35
+        "width": 35,
+        "height": 10
       }
-    ],
-    "disableCog": false,
-    "id": 840637,
-    "isShared": false
-  }
-  
+    },
+    {
+      "id": 5,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "avg:mapr.cldb.cluster_cpu_total{$clustername,$scope}",
+            "aggregator": "avg"
+          }
+        ],
+        "custom_links": [],
+        "title": "CPU count",
+        "title_size": "16",
+        "title_align": "left",
+        "autoscale": true,
+        "custom_unit": "CPUs",
+        "precision": 2
+      },
+      "layout": {
+        "x": 2,
+        "y": 21,
+        "width": 17,
+        "height": 12
+      }
+    },
+    {
+      "id": 6,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "avg:mapr.cldb.nodes_in_cluster{$clustername,$scope}",
+            "aggregator": "avg"
+          }
+        ],
+        "custom_links": [],
+        "title": "Node count",
+        "title_size": "16",
+        "title_align": "left",
+        "autoscale": true,
+        "precision": 2
+      },
+      "layout": {
+        "x": 20,
+        "y": 21,
+        "width": 17,
+        "height": 12
+      }
+    },
+    {
+      "id": 7,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(avg:mapr.cldb.cluster_memory_capacity{$scope,$clustername}-avg:mapr.cldb.cluster_memory_used{$scope,$clustername})/avg:mapr.cldb.cluster_memory_capacity{$scope,$clustername}*100",
+            "aggregator": "avg",
+            "conditional_formats": [
+              {
+                "comparator": "<",
+                "value": 15,
+                "palette": "white_on_red"
+              }
+            ]
+          }
+        ],
+        "custom_links": [],
+        "title": "Available memory",
+        "title_size": "16",
+        "title_align": "left",
+        "autoscale": true,
+        "custom_unit": "%",
+        "precision": 2
+      },
+      "layout": {
+        "x": 20,
+        "y": 47,
+        "width": 17,
+        "height": 12
+      }
+    },
+    {
+      "id": 8,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.cldb.cluster_disk_capacity{$scope,$clustername}",
+            "display_type": "area",
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.cldb.cluster_diskspace_used{$scope,$clustername}",
+            "display_type": "area",
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Disk space utilization",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 39,
+        "y": 9,
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 9,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.cldb.cluster_memory_capacity{$scope,$clustername}",
+            "display_type": "area",
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.cldb.cluster_memory_used{$scope,$clustername}",
+            "display_type": "area",
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Memory utilization",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 39,
+        "y": 30,
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 10,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.cldb.cluster_cpubusy_percent{$clustername,$scope}",
+            "display_type": "line",
+            "style": {
+              "palette": "orange",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "CPUs busy",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 80,
+        "y": 9,
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 11,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.db.valuecache_lookups{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.db.valuecache_hits{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Operations that used value cache (hit/lookup)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 39,
+        "y": 81,
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 12,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.streams.listen_msgs{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "green",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.streams.produce_msgs{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Messages produced & read",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 122,
+        "y": 81,
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 13,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "(avg:mapr.cldb.disk_space_available{$scope,$clustername}/avg:mapr.cldb.cluster_disk_capacity{$scope,$clustername})*100",
+            "aggregator": "avg",
+            "conditional_formats": [
+              {
+                "comparator": ">",
+                "value": 25,
+                "palette": "white_on_green"
+              }
+            ]
+          }
+        ],
+        "custom_links": [],
+        "title": "Available disk space",
+        "title_size": "16",
+        "title_align": "left",
+        "autoscale": true,
+        "custom_unit": "%",
+        "precision": 2
+      },
+      "layout": {
+        "x": 2,
+        "y": 47,
+        "width": 17,
+        "height": 12
+      }
+    },
+    {
+      "id": 14,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "avg:mapr.cldb.containers{$clustername,$scope}",
+            "aggregator": "avg"
+          }
+        ],
+        "custom_links": [],
+        "title": "Container count",
+        "title_size": "16",
+        "title_align": "left",
+        "autoscale": true,
+        "precision": 2
+      },
+      "layout": {
+        "x": 2,
+        "y": 34,
+        "width": 17,
+        "height": 12
+      }
+    },
+    {
+      "id": 15,
+      "definition": {
+        "type": "note",
+        "content": "MapR File System",
+        "background_color": "pink",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 122,
+        "y": 1,
+        "width": 81,
+        "height": 6
+      }
+    },
+    {
+      "id": 16,
+      "definition": {
+        "type": "note",
+        "content": "Resource Utilization",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 39,
+        "y": 1,
+        "width": 81,
+        "height": 6
+      }
+    },
+    {
+      "id": 17,
+      "definition": {
+        "type": "note",
+        "content": "MapR Database",
+        "background_color": "pink",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 39,
+        "y": 52,
+        "width": 81,
+        "height": 6
+      }
+    },
+    {
+      "id": 18,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.db.table.read_bytes{$clustername,$scope}.as_count()",
+            "display_type": "line",
+            "style": {
+              "palette": "green",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.db.table.write_bytes{$clustername,$scope}.as_count()",
+            "display_type": "line",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Read & write bytes",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 80,
+        "y": 60,
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 19,
+      "definition": {
+        "type": "note",
+        "content": "MapR Event Store",
+        "background_color": "pink",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 122,
+        "y": 73,
+        "width": 81,
+        "height": 6
+      }
+    },
+    {
+      "id": 20,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.streams.listen_rpcs{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "green",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.streams.produce_rpcs{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Producer & consumer RPCs",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 163,
+        "y": 81,
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 21,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.process.cpu_percent{$clustername,$scope} by {process_name}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "CPU utilization by process",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 80,
+        "y": 30,
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 22,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.fs.read_cachehits{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.fs.read_cachemisses{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "warm",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Read cache hits & misses",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 163,
+        "y": 9,
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 23,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.db.table.read_rows{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "green",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.db.table.resp_rows{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Rows read & returned",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 80,
+        "y": 81,
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 24,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "avg:mapr.cldb.volumes{$clustername,$scope}",
+            "aggregator": "avg"
+          }
+        ],
+        "custom_links": [],
+        "title": "Volume count",
+        "title_size": "16",
+        "title_align": "left",
+        "autoscale": true,
+        "precision": 2
+      },
+      "layout": {
+        "x": 20,
+        "y": 34,
+        "width": 17,
+        "height": 12
+      }
+    },
+    {
+      "id": 25,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.db.get_rpcs{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.db.put_rpcs{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.db.append_rpcs{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.db.increment_rpcs{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.db.scan_rpcs{$clustername,$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "RPCs completed (get/put/scan/append/increment)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 39,
+        "y": 60,
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 26,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mapr.fs.local_writebytes{$clustername,$scope}.as_count()",
+            "display_type": "line",
+            "style": {
+              "palette": "purple",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mapr.fs.local_readbytes{$clustername,$scope}.as_count()",
+            "display_type": "line",
+            "style": {
+              "palette": "green",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Local read & write bytes",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 163,
+        "y": 30,
+        "width": 40,
+        "height": 20
+      }
+    },
+    {
+      "id": 27,
+      "definition": {
+        "type": "note",
+        "content": "Cluster Health",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 2,
+        "y": 13,
+        "width": 35,
+        "height": 6
+      }
+    }
+  ],
+  "template_variables": [
+    {
+      "name": "clustername",
+      "default": "*",
+      "prefix": "clustername"
+    },
+    {
+      "name": "scope",
+      "default": "*",
+      "prefix": null
+    }
+  ],
+  "layout_type": "free",
+  "is_read_only": true,
+  "notify_list": [],
+  "id": 30290
+}

--- a/nginx/assets/dashboards/plus_overview.json
+++ b/nginx/assets/dashboards/plus_overview.json
@@ -1,1194 +1,750 @@
 {
-  "board_title": "NGINX Plus - Overview",
-  "read_only": false,
-  "author_info": {
-    "author_name": "Datadog"
-  },
-  "description": null,
-  "board_bgtype": "board_graph",
-  "created": "2019-07-03T13:00:32.539566+00:00",
-  "created_by": {
-    "disabled": false,
-    "handle": "support@datadoghq.com",
-    "name": "Datadog",
-    "is_admin": false,
-    "role": null,
-    "access_role": "adm",
-    "verified": true,
-    "email": "support@datadoghq.com"
-  },
-  "new_id": "xit-gm3-zdi",
-  "modified": "2019-07-05T10:26:39.073430+00:00",
-  "originalHeight": 102,
-  "height": 87,
-  "width": "100%",
-  "template_variables": [
-    {
-      "default": "*",
-      "prefix": "host",
-      "name": "scope"
-    }
-  ],
-  "isIntegration": false,
-  "disableEditing": false,
-  "originalWidth": 118,
+  "title": "NGINX Plus - Overview",
+  "description": "",
   "widgets": [
     {
-      "board_id": 26380,
-      "sizing": "fit",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562231340000,
-        "end": 1562234940000
+      "id": 0,
+      "definition": {
+        "type": "image",
+        "url": "https://s3.amazonaws.com/dd-integrations/nginx/configuration/tile/logo.png",
+        "sizing": "fit"
       },
-      "generated_title": "",
-      "title_size": 16,
-      "title": true,
-      "url": "https://s3.amazonaws.com/dd-integrations/nginx/configuration/tile/logo.png",
-      "margin": "",
-      "title_align": "center",
-      "title_text": "center",
-      "height": 10,
-      "width": 54,
-      "type": "image",
-      "y": 0,
-      "x": 0,
-      "isShared": false,
-      "scaleFactor": 1,
-      "add_timeframe": true
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 54,
+        "height": 10
+      }
     },
     {
-      "board_id": 26380,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "title_align": "left",
-      "title_text": "Requests per second",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 1,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "per_second(sum:nginx.requests.total{$scope})",
-            "aggregator": "avg",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "line",
-            "conditional_formats": []
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "autoscale": true
+        "custom_links": [],
+        "title": "Requests per second",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 43,
-      "time": {},
-      "error": null,
-      "y": 18,
-      "x": 0,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 0,
+        "y": 18,
+        "width": 43,
+        "height": 16
+      }
     },
     {
-      "board_id": 26380,
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Request load by host",
-      "height": 23,
-      "tile_def": {
-        "style": {
-          "fillMax": null,
-          "palette": "green_to_orange",
-          "fillMin": null,
-          "paletteFlip": false
+      "id": 2,
+      "definition": {
+        "type": "hostmap",
+        "requests": {
+          "fill": {
+            "q": "avg:nginx.requests.current{$scope} by {host}"
+          }
         },
-        "group": null,
-        "focus": null,
-        "noMetricHosts": false,
-        "viz": "hostmap",
+        "custom_links": [],
+        "title": "Request load by host",
+        "title_size": "16",
+        "title_align": "left",
+        "no_metric_hosts": false,
+        "no_group_hosts": true,
         "scope": [
           "$scope"
         ],
-        "requests": [
-          {
-            "q": "avg:nginx.requests.current{$scope} by {host}",
-            "type": "fill"
-          }
-        ],
-        "groupby": null,
-        "noGroupHosts": true
+        "style": {
+          "palette": "green_to_orange",
+          "palette_flip": false
+        }
       },
-      "width": 28,
-      "query": "avg:system.load.1{*} by {host}",
-      "y": 35,
-      "x": 44,
-      "legend_size": null,
-      "add_timeframe": false,
-      "type": "hostmap",
-      "legend": null,
-      "isShared": false
+      "layout": {
+        "x": 44,
+        "y": 35,
+        "width": 28,
+        "height": 25
+      }
     },
     {
-      "board_id": 26380,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "title_align": "left",
-      "title_text": "Active connections",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 3,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "sum:nginx.connections.active{$scope}",
-            "aggregator": "avg",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "line",
-            "conditional_formats": []
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "autoscale": true
+        "custom_links": [],
+        "title": "Active connections",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 43,
-      "time": {},
-      "error": null,
-      "y": 35,
-      "x": 74,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 74,
+        "y": 35,
+        "width": 43,
+        "height": 16
+      }
     },
     {
-      "height": 5,
-      "tick_pos": "50%",
-      "board_id": 26380,
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "text_align": "center",
-      "bgcolor": "gray",
-      "html": "\n\n\n\n\n\n\nConnections",
-      "type": "note",
-      "isShared": false,
-      "refresh_every": 30000,
-      "auto_refresh": false,
-      "title_text": "",
-      "tick": true,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562231340000,
-        "end": 1562234940000
+      "id": 4,
+      "definition": {
+        "type": "note",
+        "content": "\n\n\n\n\n\n\nConnections",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
       },
-      "font_size": "18",
-      "generated_title": "Notes & Links",
-      "tick_edge": "bottom",
-      "y": 0,
-      "x": 74,
-      "width": 43
+      "layout": {
+        "x": 74,
+        "y": 0,
+        "width": 43,
+        "height": 5
+      }
     },
     {
-      "height": 5,
-      "tick_pos": "50%",
-      "board_id": 26380,
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "text_align": "center",
-      "bgcolor": "gray",
-      "html": "Requests",
-      "type": "note",
-      "isShared": false,
-      "refresh_every": 30000,
-      "auto_refresh": false,
-      "title_text": "",
-      "tick": true,
-      "scaleFactor": 1,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562231340000,
-        "end": 1562234940000
+      "id": 5,
+      "definition": {
+        "type": "note",
+        "content": "Requests",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
       },
-      "font_size": "18",
-      "generated_title": "Notes & Links",
-      "tick_edge": "bottom",
-      "y": 11,
-      "x": 0,
-      "width": 72
+      "layout": {
+        "x": 0,
+        "y": 11,
+        "width": 72,
+        "height": 5
+      }
     },
     {
-      "height": 6,
-      "tick_pos": "50%",
-      "board_id": 26380,
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "text_align": "left",
-      "bgcolor": "yellow",
-      "html": "**Green** : low number of requests\n**Orange**: high number of requests",
-      "type": "note",
-      "isShared": false,
-      "refresh_every": 30000,
-      "auto_refresh": false,
-      "title_text": "",
-      "tick": true,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562231340000,
-        "end": 1562234940000
+      "id": 6,
+      "definition": {
+        "type": "note",
+        "content": "**Green** : low number of requests\n**Orange**: high number of requests",
+        "background_color": "yellow",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "top"
       },
-      "font_size": "14",
-      "generated_title": "Notes & Links",
-      "tick_edge": "top",
-      "y": 62,
-      "x": 44,
-      "width": 28
+      "layout": {
+        "x": 44,
+        "y": 62,
+        "width": 28,
+        "height": 6
+      }
     },
     {
-      "board_id": 211254,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "title_align": "left",
-      "title_text": "Dropped connections (per second)",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 7,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "per_second(sum:nginx.connections.dropped{$scope})",
-            "aggregator": "avg",
+            "display_type": "bars",
             "style": {
-              "width": "normal",
               "palette": "warm",
-              "type": "solid"
-            },
-            "type": "bars",
-            "conditional_formats": []
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "autoscale": true
+        "custom_links": [],
+        "title": "Dropped connections (per second)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 43,
-      "time": {},
-      "error": null,
-      "y": 52,
-      "x": 74,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 74,
+        "y": 52,
+        "width": 43,
+        "height": 16
+      }
     },
     {
-      "board_id": 26380,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "title_align": "left",
-      "title_text": "Current connections (idle + active)",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 8,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "sum:nginx.connections.active{$scope}, sum:nginx.connections.idle{$scope}",
-            "aggregator": "avg",
+            "display_type": "area",
             "style": {
-              "width": "normal",
               "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "area",
-            "conditional_formats": []
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "autoscale": true
+        "custom_links": [],
+        "title": "Current connections (idle + active)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 43,
-      "time": {},
-      "error": null,
-      "y": 18,
-      "x": 74,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 74,
+        "y": 18,
+        "width": 43,
+        "height": 16
+      }
     },
     {
-      "board_id": 211254,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "title_align": "left",
-      "title_text": "4xx + 5xx responses per second",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 9,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "per_second(sum:nginx.server_zone.responses.4xx{$scope}), per_second(sum:nginx.server_zone.responses.5xx{$scope})",
-            "aggregator": "avg",
+            "display_type": "area",
             "style": {
-              "width": "normal",
               "palette": "warm",
-              "type": "solid"
-            },
-            "type": "area",
-            "conditional_formats": []
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "autoscale": true
+        "custom_links": [],
+        "title": "4xx + 5xx responses per second",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 43,
-      "time": {},
-      "error": null,
-      "y": 52,
-      "x": 0,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 0,
+        "y": 52,
+        "width": 43,
+        "height": 16
+      }
     },
     {
-      "board_id": 211254,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "title_align": "left",
-      "title_text": "2xx + 3xx responses per second",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 10,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "per_second(sum:nginx.server_zone.responses.3xx{$scope}), per_second(sum:nginx.server_zone.responses.2xx{$scope})",
-            "aggregator": "avg",
+            "display_type": "area",
             "style": {
-              "width": "normal",
               "palette": "cool",
-              "type": "solid"
-            },
-            "type": "area",
-            "conditional_formats": []
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "autoscale": true
+        "custom_links": [],
+        "title": "2xx + 3xx responses per second",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 43,
-      "time": {},
-      "error": null,
-      "y": 35,
-      "x": 0,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 0,
+        "y": 35,
+        "width": 43,
+        "height": 16
+      }
     },
     {
-      "board_id": 211254,
-      "x": 44,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "autoscale": true,
-      "title": true,
-      "type": "query_value",
-      "title_align": "left",
-      "title_text": "Requests per second",
-      "height": 14,
-      "tile_def": {
-        "viz": "query_value",
+      "id": 11,
+      "definition": {
+        "type": "query_value",
         "requests": [
           {
             "q": "per_second(sum:nginx.requests.total{$scope})",
             "aggregator": "last",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": null,
             "conditional_formats": [
               {
-                "palette": "white_on_red",
                 "comparator": ">",
-                "value": null
-              },
-              {
-                "palette": "white_on_yellow",
-                "comparator": ">=",
-                "value": null
-              },
-              {
-                "palette": "white_on_green",
-                "comparator": ">",
-                "value": "0"
+                "value": 0,
+                "palette": "white_on_green"
               }
             ]
           }
         ],
+        "custom_links": [],
+        "title": "Requests per second",
+        "title_size": "16",
+        "title_align": "left",
         "autoscale": true,
-        "custom_unit": null
+        "precision": 2
       },
-      "width": 28,
-      "time": {},
-      "error": null,
-      "y": 18,
-      "title_size": 16,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 44,
+        "y": 18,
+        "width": 28,
+        "height": 16
+      }
     },
     {
-      "board_id": 211254,
-      "x": 96,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "autoscale": true,
-      "title": true,
-      "type": "query_value",
-      "title_align": "left",
-      "title_text": "Active connections",
-      "height": 8,
-      "tile_def": {
-        "viz": "query_value",
+      "id": 12,
+      "definition": {
+        "type": "query_value",
         "requests": [
           {
             "q": "sum:nginx.connections.active{$scope}",
             "aggregator": "last",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": null,
             "conditional_formats": [
               {
-                "palette": "white_on_red",
                 "comparator": ">",
-                "value": null
-              },
-              {
-                "palette": "white_on_yellow",
-                "comparator": ">=",
-                "value": null
-              },
-              {
-                "palette": "white_on_green",
-                "comparator": ">",
-                "value": "0"
+                "value": 0,
+                "palette": "white_on_green"
               }
             ]
           }
         ],
+        "custom_links": [],
+        "title": "Active connections",
+        "title_size": "16",
+        "title_align": "left",
         "autoscale": true,
-        "custom_unit": null
+        "precision": 2
       },
-      "width": 21,
-      "time": {},
-      "error": null,
-      "y": 7,
-      "title_size": 16,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 96,
+        "y": 7,
+        "width": 21,
+        "height": 10
+      }
     },
     {
-      "board_id": 211254,
-      "x": 74,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "autoscale": true,
-      "title": true,
-      "type": "query_value",
-      "title_align": "left",
-      "title_text": "Current connections",
-      "height": 8,
-      "tile_def": {
-        "viz": "query_value",
+      "id": 13,
+      "definition": {
+        "type": "query_value",
         "requests": [
           {
             "q": "sum:nginx.connections.idle{$scope}+sum:nginx.connections.active{$scope}",
             "aggregator": "last",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": null,
             "conditional_formats": [
               {
-                "palette": "white_on_red",
                 "comparator": ">",
-                "value": null
-              },
-              {
-                "palette": "white_on_yellow",
-                "comparator": ">=",
-                "value": null
-              },
-              {
-                "palette": "white_on_green",
-                "comparator": ">",
-                "value": "0"
+                "value": 0,
+                "palette": "white_on_green"
               }
             ]
           }
         ],
+        "custom_links": [],
+        "title": "Current connections",
+        "title_size": "16",
+        "title_align": "left",
         "autoscale": true,
-        "custom_unit": null
+        "precision": 2
       },
-      "width": 21,
-      "time": {},
-      "error": null,
-      "y": 7,
-      "title_size": 16,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 74,
+        "y": 7,
+        "width": 21,
+        "height": 10
+      }
     },
     {
-      "height": 10,
-      "text_size": "auto",
-      "check": "nginx.can_connect",
-      "board_id": "xit-gm3-zdi",
-      "group": null,
-      "title": true,
-      "title_align": "center",
-      "text_align": "center",
-      "width": 17,
-      "group_by": [],
-      "type": "check_status",
-      "isShared": false,
-      "tags": [
-        "*"
-      ],
-      "time": {},
-      "title_text": "Nginx host up",
-      "title_size": 16,
-      "scaleFactor": 1,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
+      "id": 14,
+      "definition": {
+        "type": "check_status",
+        "title": "Nginx host up",
+        "title_size": "16",
+        "title_align": "center",
+        "check": "nginx.can_connect",
+        "grouping": "cluster",
+        "group_by": [],
+        "tags": [
+          "*"
+        ]
       },
-      "error": null,
-      "y": 0,
-      "x": 55,
-      "grouping": "cluster"
+      "layout": {
+        "x": 55,
+        "y": 0,
+        "width": 17,
+        "height": 10
+      }
     },
     {
-      "board_id": "xit-gm3-zdi",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "nginx.ssl.handshakes_count",
-      "title_text": "Successful ssl handshakes",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 15,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "avg:nginx.ssl.handshakes_count{$scope}.as_count()",
-            "aggregator": "avg",
+            "display_type": "bars",
             "style": {
-              "width": "normal",
               "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "bars",
-            "conditional_formats": []
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "autoscale": true
+        "custom_links": [],
+        "title": "Successful ssl handshakes",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 43,
-      "time": {},
-      "error": null,
-      "y": 70,
-      "x": 30,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 30,
+        "y": 70,
+        "width": 43,
+        "height": 16
+      }
     },
     {
-      "board_id": "xit-gm3-zdi",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
+      "id": 16,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:nginx.ssl.handshakes_failed_count{$scope}.as_count()",
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Failed ssl handshakes",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "nginx.ssl.handshakes_failed_count",
-      "title_text": "Failed ssl handshakes",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
+      "layout": {
+        "x": 74,
+        "y": 70,
+        "width": 43,
+        "height": 16
+      }
+    },
+    {
+      "id": 17,
+      "definition": {
+        "type": "query_value",
         "requests": [
           {
             "q": "avg:nginx.ssl.handshakes_failed_count{$scope}.as_count()",
             "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "bars",
-            "conditional_formats": []
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 43,
-      "time": {},
-      "error": {
-        "status": 500,
-        "responseText": "{\"errors\": [\"Internal Error\"]}"
-      },
-      "y": 70,
-      "x": 74,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "xit-gm3-zdi",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "query_value",
-      "generated_title": "Query Value",
-      "title_text": "Avg of failed ssl handshakes",
-      "height": 5,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:nginx.ssl.handshakes_failed_count{$scope}.as_count()",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": null,
             "conditional_formats": [
               {
-                "palette": "white_on_red",
                 "comparator": ">",
-                "value": ""
+                "value": 0,
+                "palette": "white_on_yellow"
               },
               {
-                "palette": "white_on_yellow",
-                "comparator": ">",
-                "value": "0"
-              },
-              {
-                "palette": "white_on_green",
                 "comparator": "<=",
-                "value": "0"
+                "value": 0,
+                "palette": "white_on_green"
               }
             ]
           }
         ],
-        "autoscale": true
+        "custom_links": [],
+        "title": "Avg of failed ssl handshakes",
+        "title_size": "16",
+        "title_align": "left",
+        "autoscale": true,
+        "precision": 2
       },
-      "width": 15,
-      "time": {},
-      "error": null,
-      "y": 70,
-      "x": 14,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 14,
+        "y": 70,
+        "width": 15,
+        "height": 7
+      }
     },
     {
-      "board_id": "xit-gm3-zdi",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "nginx.cache.size",
-      "title_text": "Cache size",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 18,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "sum:nginx.cache.max_size{$scope}, sum:nginx.cache.size{$scope}",
-            "aggregator": "avg",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "line",
-            "conditional_formats": []
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "autoscale": true
+        "custom_links": [],
+        "title": "Cache size",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 43,
-      "time": {},
-      "error": null,
-      "y": 18,
-      "x": 119,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 119,
+        "y": 18,
+        "width": 43,
+        "height": 16
+      }
     },
     {
-      "board_id": "xit-gm3-zdi",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "query_value",
-      "generated_title": "Query Value",
-      "title_text": "Hosts loading cache",
-      "height": 8,
-      "tile_def": {
-        "viz": "query_value",
+      "id": 19,
+      "definition": {
+        "type": "query_value",
         "requests": [
           {
             "q": "sum:nginx.cache.cold{$scope}",
             "aggregator": "last",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": null,
             "conditional_formats": [
               {
-                "palette": "white_on_red",
                 "comparator": ">",
-                "value": "0"
+                "value": 0,
+                "palette": "white_on_red"
               },
               {
-                "palette": "white_on_yellow",
-                "comparator": ">=",
-                "value": null
-              },
-              {
-                "palette": "white_on_green",
                 "comparator": "<=",
-                "value": "0"
+                "value": 0,
+                "palette": "white_on_green"
               }
             ]
           }
         ],
+        "custom_links": [],
+        "title": "Hosts loading cache",
+        "title_size": "16",
+        "title_align": "left",
         "autoscale": true,
-        "precision": "0"
+        "precision": 0
       },
-      "width": 21,
-      "time": {},
-      "error": null,
-      "y": 7,
-      "x": 119,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 119,
+        "y": 7,
+        "width": 21,
+        "height": 10
+      }
     },
     {
-      "board_id": "xit-gm3-zdi",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "nginx.cache.hit.bytes",
-      "title_text": "Hitten bytes in cache",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 20,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "sum:nginx.cache.hit.bytes{$scope}",
-            "aggregator": "avg",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "line",
-            "conditional_formats": []
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "autoscale": true
+        "custom_links": [],
+        "title": "Hitten bytes in cache",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 43,
-      "time": {},
-      "error": null,
-      "y": 35,
-      "x": 119,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 119,
+        "y": 35,
+        "width": 43,
+        "height": 16
+      }
     },
     {
-      "board_id": "xit-gm3-zdi",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "nginx.cache.miss.bytes",
-      "title_text": "Missed bytes in cache",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 21,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "sum:nginx.cache.miss.bytes{$scope}, sum:nginx.cache.miss.bytes_written{$scope}",
-            "aggregator": "avg",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "line",
-            "conditional_formats": []
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "autoscale": true
+        "custom_links": [],
+        "title": "Missed bytes in cache",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 43,
-      "time": {},
-      "error": {
-        "status": 500,
-        "responseText": "{\"errors\": [\"Internal Error\"]}"
-      },
-      "y": 52,
-      "x": 119,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 119,
+        "y": 52,
+        "width": 43,
+        "height": 16
+      }
     },
     {
-      "board_id": "xit-gm3-zdi",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "nginx.cache.bypass.bytes",
-      "title_text": "Bypassed bytes in cached",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 22,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "sum:nginx.cache.bypass.bytes{$scope}, sum:nginx.cache.bypass.bytes_written{$scope}",
-            "aggregator": "avg",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "line",
-            "conditional_formats": []
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "autoscale": true
+        "custom_links": [],
+        "title": "Bypassed bytes in cached",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 43,
-      "time": {},
-      "error": null,
-      "y": 69,
-      "x": 119,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 119,
+        "y": 69,
+        "width": 43,
+        "height": 16
+      }
     },
     {
-      "height": 5,
-      "tick_pos": "50%",
-      "board_id": 26380,
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "text_align": "center",
-      "bgcolor": "gray",
-      "html": "\n\n\n\n\n\n\nCache",
-      "type": "note",
-      "isShared": false,
-      "refresh_every": 30000,
-      "auto_refresh": false,
-      "title_text": "",
-      "tick": true,
-      "scaleFactor": 1,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562231340000,
-        "end": 1562234940000
+      "id": 23,
+      "definition": {
+        "type": "note",
+        "content": "\n\n\n\n\n\n\nCache",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
       },
-      "font_size": "18",
-      "generated_title": "Notes & Links",
-      "tick_edge": "bottom",
-      "y": 0,
-      "x": 119,
-      "width": 43
+      "layout": {
+        "x": 119,
+        "y": 0,
+        "width": 43,
+        "height": 5
+      }
     },
     {
-      "board_id": "xit-gm3-zdi",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
+      "id": 24,
+      "definition": {
+        "type": "note",
+        "content": "SSL",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "right"
       },
-      "font_size": "18",
-      "title": false,
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "tick_edge": "right",
-      "text_align": "center",
-      "auto_refresh": false,
-      "height": 16,
-      "bgcolor": "gray",
-      "add_timeframe": true,
-      "html": "SSL",
-      "type": "note",
-      "y": 70,
-      "x": 0,
-      "tick": true,
-      "tick_pos": "50%",
-      "width": 12,
-      "isShared": false
+      "layout": {
+        "x": 0,
+        "y": 70,
+        "width": 12,
+        "height": 16
+      }
     },
     {
-      "board_id": "xit-gm3-zdi",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "query_value",
-      "generated_title": "Query Value",
-      "title_text": "Avg hitten bytes",
-      "height": 8,
-      "tile_def": {
-        "viz": "query_value",
+      "id": 25,
+      "definition": {
+        "type": "query_value",
         "requests": [
           {
             "q": "avg:nginx.cache.hit.bytes{$scope}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": null,
-            "conditional_formats": [
-              {
-                "palette": "white_on_red",
-                "comparator": ">",
-                "value": null
-              },
-              {
-                "palette": "white_on_yellow",
-                "comparator": ">=",
-                "value": null
-              },
-              {
-                "palette": "white_on_green",
-                "comparator": "<",
-                "value": null
-              }
-            ]
+            "aggregator": "avg"
           }
         ],
+        "custom_links": [],
+        "title": "Avg hitten bytes",
+        "title_size": "16",
+        "title_align": "left",
         "autoscale": true,
-        "custom_unit": null
+        "precision": 2
       },
-      "width": 21,
-      "time": {},
-      "error": null,
-      "y": 7,
-      "x": 141,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 141,
+        "y": 7,
+        "width": 21,
+        "height": 10
+      }
     },
     {
-      "board_id": "xit-gm3-zdi",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1562306209545,
-        "end": 1562320609545
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "query_value",
-      "generated_title": "Query Value",
-      "title_text": "Avg of successful ssl handshakes",
-      "height": 5,
-      "tile_def": {
-        "viz": "query_value",
+      "id": 26,
+      "definition": {
+        "type": "query_value",
         "requests": [
           {
             "q": "avg:nginx.ssl.handshakes_count{$scope}.as_count()",
             "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": null,
             "conditional_formats": [
               {
-                "palette": "white_on_red",
-                "comparator": ">",
-                "value": ""
-              },
-              {
-                "palette": "white_on_yellow",
                 "comparator": "<=",
-                "value": "0"
+                "value": 0,
+                "palette": "white_on_yellow"
               },
               {
-                "palette": "white_on_green",
                 "comparator": ">",
-                "value": "0"
+                "value": 0,
+                "palette": "white_on_green"
               }
             ]
           }
         ],
-        "autoscale": true
+        "custom_links": [],
+        "title": "Avg of successful ssl handshakes",
+        "title_size": "16",
+        "title_align": "left",
+        "autoscale": true,
+        "precision": 2
       },
-      "width": 15,
-      "time": {},
-      "error": null,
-      "y": 79,
-      "x": 14,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
+      "layout": {
+        "x": 14,
+        "y": 79,
+        "width": 15,
+        "height": 7
+      }
     }
   ],
-  "disableCog": false,
-  "id": 63840,
-  "isShared": false
+  "template_variables": [
+    {
+      "name": "scope",
+      "default": "*",
+      "prefix": "host"
+    }
+  ],
+  "layout_type": "free",
+  "is_read_only": true,
+  "notify_list": [],
+  "id": 30278
 }

--- a/openstack/assets/dashboards/openstack-controller.json
+++ b/openstack/assets/dashboards/openstack-controller.json
@@ -1,693 +1,727 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "OpenStack Controller Overview",
-    "created": "2020-04-22T15:12:53.212166+00:00",
-    "created_by": {
-        "access_role": "st",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": false,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "OpenStack Controller Overview",
     "description": "## OpenStack Controller - Overview\n\nPreset dashboard for the OpenStack Controller integration. Used for OpenStack deployments v13 and higher. \n\n[See integration docs for more details](https://docs.datadoghq.com/integrations/openstack_controller/)",
-    "id": 1065652,
-    "modified": "2020-04-22T15:19:50.067638+00:00",
-    "new_id": "ekn-bqw-h7v",
-    "read_only": false,
-    "template_variables": [
-        {
-            "default": "*",
-            "name": "project",
-            "prefix": "project_name"
-        },
-        {
-            "default": "*",
-            "name": "aggregate",
-            "prefix": "aggregate"
-        }
-    ],
     "widgets": [
-        {
-            "bgcolor": "gray",
-            "font_size": "36",
-            "height": 8,
-            "html": "\n[Hypervisors](https://www.datadoghq.com/blog/openstack-monitoring-nova/#hypervisor-metrics)",
-            "id": 0,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 94,
-            "x": 21,
-            "y": 2
+      {
+        "id": 0,
+        "definition": {
+          "type": "note",
+          "content": "\n[Hypervisors](https://www.datadoghq.com/blog/openstack-monitoring-nova/#hypervisor-metrics)",
+          "background_color": "gray",
+          "font_size": "36",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
         },
-        {
-            "height": 14,
-            "id": 1,
-            "tile_def": {
-                "requests": [
-                    {
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "red",
-                                "value": "200"
-                            }
-                        ],
-                        "q": "top(avg:openstack.nova.server.memory_rss{*} by {project_name}, 10, 'mean', 'desc')"
-                    }
-                ],
-                "viz": "toplist"
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Top memory RSS by project in $aggregate",
-            "type": "toplist",
-            "width": 46,
-            "x": 21,
-            "y": 12
-        },
-        {
-            "check": "openstack.keystone.api.up",
-            "grouping": "cluster",
-            "height": 9,
-            "id": 2,
-            "tags": [
-                "*"
-            ],
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 13,
-            "title_text": "Keystone",
-            "type": "check_status",
-            "width": 19,
-            "x": 0,
-            "y": 22
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "36",
-            "height": 8,
-            "html": "APIs",
-            "id": 3,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 19,
-            "x": 0,
-            "y": 12
-        },
-        {
-            "check": "openstack.nova.hypervisor.up",
-            "grouping": "cluster",
-            "height": 9,
-            "id": 4,
-            "tags": [
-                "$aggregate"
-            ],
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 13,
-            "title_text": "Hypervisors",
-            "type": "check_status",
-            "width": 19,
-            "x": 0,
-            "y": 55
-        },
-        {
-            "check": "openstack.neutron.api.up",
-            "grouping": "cluster",
-            "height": 9,
-            "id": 5,
-            "tags": [
-                "*"
-            ],
-            "time": {
-                "live_span": "10m"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 13,
-            "title_text": "Neutron",
-            "type": "check_status",
-            "width": 19,
-            "x": 0,
-            "y": 44
-        },
-        {
-            "check": "openstack.nova.api.up",
-            "grouping": "cluster",
-            "height": 9,
-            "id": 6,
-            "tags": [
-                "*"
-            ],
-            "time": {
-                "live_span": "10m"
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 13,
-            "title_text": "Nova",
-            "type": "check_status",
-            "width": 19,
-            "x": 0,
-            "y": 33
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "36",
-            "height": 8,
-            "html": "\n[Project](https://www.datadoghq.com/blog/openstack-monitoring-nova/#tenant-metrics)",
-            "id": 7,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 94,
-            "x": 21,
-            "y": 65
-        },
-        {
-            "height": 14,
-            "id": 8,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:openstack.nova.limits.total_cores_used{$project}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    },
-                    {
-                        "q": "avg:openstack.nova.limits.max_total_cores{$project}",
-                        "style": {
-                            "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Cores used vs max by $project",
-            "type": "timeseries",
-            "width": 46,
-            "x": 69,
-            "y": 74
-        },
-        {
-            "height": 14,
-            "id": 9,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:openstack.nova.limits.total_instances_used{$project}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    },
-                    {
-                        "q": "avg:openstack.nova.limits.max_total_instances{$project}",
-                        "style": {
-                            "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Instances used vs max by $project",
-            "type": "timeseries",
-            "width": 46,
-            "x": 69,
-            "y": 92
-        },
-        {
-            "height": 14,
-            "id": 10,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:openstack.nova.limits.total_ram_used{$project}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    },
-                    {
-                        "q": "avg:openstack.nova.limits.max_total_ram_size{$project}",
-                        "style": {
-                            "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "RAM used vs max by $project",
-            "type": "timeseries",
-            "width": 46,
-            "x": 21,
-            "y": 91
-        },
-        {
-            "height": 14,
-            "id": 11,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:openstack.nova.limits.total_floating_ips_used{$project}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    },
-                    {
-                        "q": "avg:openstack.nova.limits.max_total_floating_ips{$project}",
-                        "style": {
-                            "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Floating IPs used vs max by $project",
-            "type": "timeseries",
-            "width": 46,
-            "x": 21,
-            "y": 74
-        },
-        {
-            "height": 16,
-            "id": 12,
-            "tile_def": {
-                "group": [
-                    "aggregate"
-                ],
-                "noGroupHosts": true,
-                "noMetricHosts": false,
-                "requests": [
-                    {
-                        "q": "avg:openstack.nova.hypervisor_load.1{*} by {host}",
-                        "type": "fill"
-                    }
-                ],
-                "style": {
-                    "palette": "hostmap_blues",
-                    "paletteFlip": false
-                },
-                "viz": "hostmap"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Hypervisor load map by $aggregate",
-            "type": "hostmap",
-            "width": 46,
-            "x": 21,
-            "y": 29
-        },
-        {
-            "height": 14,
-            "id": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:openstack.nova.local_gb_used{*} by {host}",
-                        "type": "area"
-                    },
-                    {
-                        "q": "avg:openstack.nova.free_disk_gb{*} by {host}",
-                        "style": {
-                            "palette": "purple"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Used vs free disk by physical host",
-            "type": "timeseries",
-            "width": 46,
-            "x": 21,
-            "y": 48
-        },
-        {
-            "height": 16,
-            "id": 14,
-            "tile_def": {
-                "requests": [
-                    {
-                        "change_type": "absolute",
-                        "compare_to": "hour_before",
-                        "extra_col": "present",
-                        "increase_good": true,
-                        "order_by": "change",
-                        "order_dir": "desc",
-                        "q": "sum:openstack.nova.running_vms{$aggregate} by {hypervisor}"
-                    }
-                ],
-                "viz": "change"
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Change in running VMs by hypervisor in $aggregate",
-            "type": "change",
-            "width": 46,
-            "x": 69,
-            "y": 29
-        },
-        {
-            "height": 14,
-            "id": 15,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:openstack.nova.current_workload{*} by {hypervisor}",
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Nova current workload by hypervisor",
-            "type": "timeseries",
-            "width": 46,
-            "x": 69,
-            "y": 12
-        },
-        {
-            "height": 14,
-            "id": 16,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "sum:openstack.nova.vcpus{$aggregate} by {host}",
-                        "style": {
-                            "palette": "warm"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "sum:openstack.nova.vcpus_used{$aggregate} by {hypervisor}",
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "VCPUs used vs available by hypervisor",
-            "type": "timeseries",
-            "width": 46,
-            "x": 69,
-            "y": 48
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "36",
-            "height": 7,
-            "html": "[Nova Server](https://www.datadoghq.com/blog/openstack-monitoring-nova/#nova-server-metrics)",
-            "id": 17,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 46,
-            "x": 117,
-            "y": 66
-        },
-        {
-            "height": 14,
-            "id": 18,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:openstack.nova.server.vda_read_req{$project} by {host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "HDD read rate by instance for $project",
-            "type": "timeseries",
-            "width": 46,
-            "x": 117,
-            "y": 75
-        },
-        {
-            "height": 10,
-            "id": 19,
-            "sizing": "fit",
-            "type": "image",
-            "url": "https://app.datadoghq.com/static/images/saas_logos/bot/openstack@2x.png",
-            "width": 19,
-            "x": 0,
-            "y": 0
-        },
-        {
-            "height": 14,
-            "id": 20,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "sum:rabbitmq.queue.memory{*} by {rabbitmq_queue}",
-                        "style": {
-                            "palette": "cool"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "RabbitMQ queue memory",
-            "type": "timeseries",
-            "width": 46,
-            "x": 117,
-            "y": 12
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "36",
-            "height": 8,
-            "html": "\n[RabbitMQ](https://www.datadoghq.com/blog/openstack-monitoring-nova/#rabbitmq-metrics)",
-            "id": 21,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 46,
-            "x": 117,
-            "y": 2
-        },
-        {
-            "height": 16,
-            "id": 22,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "top(sum:rabbitmq.queue.consumers{*} by {rabbitmq_queue}, 50, 'mean', 'asc')",
-                        "style": {
-                            "palette": "dog_classic"
-                        }
-                    }
-                ],
-                "viz": "toplist"
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Consumers by queue",
-            "type": "toplist",
-            "width": 46,
-            "x": 117,
-            "y": 29
-        },
-        {
-            "height": 14,
-            "id": 23,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "sum:rabbitmq.queue.consumer_utilisation{*} by {rabbitmq_queue}",
-                        "style": {
-                            "palette": "cool"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "1h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "RabbitMQ consumer utilization",
-            "type": "timeseries",
-            "width": 46,
-            "x": 117,
-            "y": 48
+        "layout": {
+          "x": 21,
+          "y": 2,
+          "width": 94,
+          "height": 8
         }
-    ]
-}
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "q": "top(avg:openstack.nova.server.memory_rss{*} by {project_name}, 10, 'mean', 'desc')",
+              "conditional_formats": [
+                {
+                  "comparator": ">",
+                  "value": 200,
+                  "palette": "red"
+                }
+              ]
+            }
+          ],
+          "custom_links": [],
+          "title": "Top memory RSS by project in $aggregate",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          }
+        },
+        "layout": {
+          "x": 21,
+          "y": 12,
+          "width": 46,
+          "height": 16
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "check_status",
+          "title": "Keystone",
+          "title_size": "13",
+          "title_align": "center",
+          "check": "openstack.keystone.api.up",
+          "grouping": "cluster",
+          "tags": [
+            "*"
+          ],
+          "time": {
+            "live_span": "4h"
+          }
+        },
+        "layout": {
+          "x": 0,
+          "y": 22,
+          "width": 19,
+          "height": 9
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "note",
+          "content": "APIs",
+          "background_color": "gray",
+          "font_size": "36",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 0,
+          "y": 12,
+          "width": 19,
+          "height": 8
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "check_status",
+          "title": "Hypervisors",
+          "title_size": "13",
+          "title_align": "center",
+          "check": "openstack.nova.hypervisor.up",
+          "grouping": "cluster",
+          "tags": [
+            "$aggregate"
+          ],
+          "time": {
+            "live_span": "1h"
+          }
+        },
+        "layout": {
+          "x": 0,
+          "y": 55,
+          "width": 19,
+          "height": 9
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "check_status",
+          "title": "Neutron",
+          "title_size": "13",
+          "title_align": "center",
+          "check": "openstack.neutron.api.up",
+          "grouping": "cluster",
+          "tags": [
+            "*"
+          ],
+          "time": {
+            "live_span": "10m"
+          }
+        },
+        "layout": {
+          "x": 0,
+          "y": 44,
+          "width": 19,
+          "height": 9
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "check_status",
+          "title": "Nova",
+          "title_size": "13",
+          "title_align": "center",
+          "check": "openstack.nova.api.up",
+          "grouping": "cluster",
+          "tags": [
+            "*"
+          ],
+          "time": {
+            "live_span": "10m"
+          }
+        },
+        "layout": {
+          "x": 0,
+          "y": 33,
+          "width": 19,
+          "height": 9
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "note",
+          "content": "\n[Project](https://www.datadoghq.com/blog/openstack-monitoring-nova/#tenant-metrics)",
+          "background_color": "gray",
+          "font_size": "36",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 21,
+          "y": 65,
+          "width": 94,
+          "height": 8
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:openstack.nova.limits.total_cores_used{$project}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:openstack.nova.limits.max_total_cores{$project}",
+              "display_type": "line",
+              "style": {
+                "palette": "warm",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Cores used vs max by $project",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": true,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 69,
+          "y": 74,
+          "width": 46,
+          "height": 16
+        }
+      },
+      {
+        "id": 9,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:openstack.nova.limits.total_instances_used{$project}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:openstack.nova.limits.max_total_instances{$project}",
+              "display_type": "line",
+              "style": {
+                "palette": "warm",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Instances used vs max by $project",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": true,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 69,
+          "y": 92,
+          "width": 46,
+          "height": 16
+        }
+      },
+      {
+        "id": 10,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:openstack.nova.limits.total_ram_used{$project}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:openstack.nova.limits.max_total_ram_size{$project}",
+              "display_type": "line",
+              "style": {
+                "palette": "warm",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "RAM used vs max by $project",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": true,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 21,
+          "y": 91,
+          "width": 46,
+          "height": 16
+        }
+      },
+      {
+        "id": 11,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:openstack.nova.limits.total_floating_ips_used{$project}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:openstack.nova.limits.max_total_floating_ips{$project}",
+              "display_type": "line",
+              "style": {
+                "palette": "warm",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Floating IPs used vs max by $project",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": true,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 21,
+          "y": 74,
+          "width": 46,
+          "height": 16
+        }
+      },
+      {
+        "id": 12,
+        "definition": {
+          "type": "hostmap",
+          "requests": {
+            "fill": {
+              "q": "avg:openstack.nova.hypervisor_load.1{*} by {host}"
+            }
+          },
+          "custom_links": [],
+          "title": "Hypervisor load map by $aggregate",
+          "title_size": "16",
+          "title_align": "left",
+          "no_metric_hosts": false,
+          "no_group_hosts": true,
+          "group": [
+            "aggregate"
+          ],
+          "style": {
+            "palette": "hostmap_blues",
+            "palette_flip": false
+          }
+        },
+        "layout": {
+          "x": 21,
+          "y": 29,
+          "width": 46,
+          "height": 18
+        }
+      },
+      {
+        "id": 13,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:openstack.nova.local_gb_used{*} by {host}",
+              "display_type": "area"
+            },
+            {
+              "q": "avg:openstack.nova.free_disk_gb{*} by {host}",
+              "display_type": "line",
+              "style": {
+                "palette": "purple"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Used vs free disk by physical host",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 21,
+          "y": 48,
+          "width": 46,
+          "height": 16
+        }
+      },
+      {
+        "id": 14,
+        "definition": {
+          "type": "change",
+          "requests": [
+            {
+              "q": "sum:openstack.nova.running_vms{$aggregate} by {hypervisor}",
+              "change_type": "absolute",
+              "compare_to": "hour_before",
+              "increase_good": true,
+              "order_by": "change",
+              "order_dir": "desc",
+              "show_present": true
+            }
+          ],
+          "custom_links": [],
+          "title": "Change in running VMs by hypervisor in $aggregate",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          }
+        },
+        "layout": {
+          "x": 69,
+          "y": 29,
+          "width": 46,
+          "height": 18
+        }
+      },
+      {
+        "id": 15,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:openstack.nova.current_workload{*} by {hypervisor}",
+              "display_type": "bars"
+            }
+          ],
+          "custom_links": [],
+          "title": "Nova current workload by hypervisor",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 69,
+          "y": 12,
+          "width": 46,
+          "height": 16
+        }
+      },
+      {
+        "id": 16,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:openstack.nova.vcpus{$aggregate} by {host}",
+              "display_type": "line",
+              "style": {
+                "palette": "warm"
+              }
+            },
+            {
+              "q": "sum:openstack.nova.vcpus_used{$aggregate} by {hypervisor}",
+              "display_type": "area"
+            }
+          ],
+          "custom_links": [],
+          "title": "VCPUs used vs available by hypervisor",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 69,
+          "y": 48,
+          "width": 46,
+          "height": 16
+        }
+      },
+      {
+        "id": 17,
+        "definition": {
+          "type": "note",
+          "content": "[Nova Server](https://www.datadoghq.com/blog/openstack-monitoring-nova/#nova-server-metrics)",
+          "background_color": "gray",
+          "font_size": "36",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 117,
+          "y": 66,
+          "width": 46,
+          "height": 7
+        }
+      },
+      {
+        "id": 18,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:openstack.nova.server.vda_read_req{$project} by {host}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "HDD read rate by instance for $project",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 117,
+          "y": 75,
+          "width": 46,
+          "height": 16
+        }
+      },
+      {
+        "id": 19,
+        "definition": {
+          "type": "image",
+          "url": "https://app.datadoghq.com/static/images/saas_logos/bot/openstack@2x.png",
+          "sizing": "fit"
+        },
+        "layout": {
+          "x": 0,
+          "y": 0,
+          "width": 19,
+          "height": 10
+        }
+      },
+      {
+        "id": 20,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:rabbitmq.queue.memory{*} by {rabbitmq_queue}",
+              "display_type": "area",
+              "style": {
+                "palette": "cool"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "RabbitMQ queue memory",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 117,
+          "y": 12,
+          "width": 46,
+          "height": 16
+        }
+      },
+      {
+        "id": 21,
+        "definition": {
+          "type": "note",
+          "content": "\n[RabbitMQ](https://www.datadoghq.com/blog/openstack-monitoring-nova/#rabbitmq-metrics)",
+          "background_color": "gray",
+          "font_size": "36",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 117,
+          "y": 2,
+          "width": 46,
+          "height": 8
+        }
+      },
+      {
+        "id": 22,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "q": "top(sum:rabbitmq.queue.consumers{*} by {rabbitmq_queue}, 50, 'mean', 'asc')",
+              "style": {
+                "palette": "dog_classic"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Consumers by queue",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          }
+        },
+        "layout": {
+          "x": 117,
+          "y": 29,
+          "width": 46,
+          "height": 18
+        }
+      },
+      {
+        "id": 23,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:rabbitmq.queue.consumer_utilisation{*} by {rabbitmq_queue}",
+              "display_type": "area",
+              "style": {
+                "palette": "cool"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "RabbitMQ consumer utilization",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 117,
+          "y": 48,
+          "width": 46,
+          "height": 16
+        }
+      }
+    ],
+    "template_variables": [
+      {
+        "name": "project",
+        "default": "*",
+        "prefix": "project_name"
+      },
+      {
+        "name": "aggregate",
+        "default": "*",
+        "prefix": "aggregate"
+      }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30317
+  }

--- a/oracle/assets/dashboards/oracle_overview.json
+++ b/oracle/assets/dashboards/oracle_overview.json
@@ -1,900 +1,786 @@
 {
-    "board_bgtype": "board_graph",
-    "board_title": "Oracle Database - Overview",
+    "title": "Oracle Database - Overview",
     "description": "This dashboard provides an overview of your Oracle databases, so you can track tablespace and disk usage and optimize your caches. Further reading on Oracle Database monitoring:\n\n- [Monitor Oracle Database with Datadog](https://www.datadoghq.com/blog/monitor-oracle-database/)\n\n- [Datadog's Oracle Database integration docs](https://docs.datadoghq.com/integrations/oracle/)\n\nClone this template dashboard to make changes and add your own graph widgets!",
-    "height": 93,
-    "id": "oracle",
-    "template_variables": [
-        {
-            "default": "*",
-            "name": "host",
-            "prefix": "host"
-        },
-        {
-            "default": "*",
-            "name": "scope",
-            "prefix": null
-        }
-    ],
-    "templated": true,
     "widgets": [
-        {
-            "autoscale": true,
-            "board_id": 286414,
-            "height": 8,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": null
-                            },
-                            {
-                                "comparator": ">=",
-                                "palette": "white_on_yellow",
-                                "value": null
-                            },
-                            {
-                                "comparator": "<",
-                                "palette": "white_on_green",
-                                "value": null
-                            }
-                        ],
-                        "q": "avg:oracle.cursor_cachehit_ratio{$host,$scope}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": null
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": { "live_span": "1h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Cursor Cache",
-            "type": "query_value",
-            "width": 17,
-            "x": 1,
-            "y": 49
+      {
+        "id": 0,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:oracle.cursor_cachehit_ratio{$host,$scope}",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Cursor Cache",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "autoscale": true,
+          "precision": 2
         },
-        {
-            "autoscale": true,
-            "board_id": 286414,
-            "height": 8,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": null
-                            },
-                            {
-                                "comparator": ">=",
-                                "palette": "white_on_yellow",
-                                "value": null
-                            },
-                            {
-                                "comparator": "<",
-                                "palette": "white_on_green",
-                                "value": null
-                            }
-                        ],
-                        "q": "avg:oracle.library_cachehit_ratio{$host,$scope}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": null
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": { "live_span": "1h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Library Cache",
-            "type": "query_value",
-            "width": 17,
-            "x": 1,
-            "y": 60
-        },
-        {
-            "autoscale": true,
-            "board_id": 286414,
-            "height": 9,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": null
-                            },
-                            {
-                                "comparator": ">=",
-                                "palette": "white_on_yellow",
-                                "value": null
-                            },
-                            {
-                                "comparator": "<",
-                                "palette": "white_on_green",
-                                "value": null
-                            }
-                        ],
-                        "q": "avg:oracle.buffer_cachehit_ratio{$host,$scope}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": null
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": { "live_span": "1h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Buffer Cache",
-            "type": "query_value",
-            "width": 17,
-            "x": 1,
-            "y": 37
-        },
-        {
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": 286414,
-            "font_size": "18",
-            "height": 5,
-            "html": "Disk Activity",
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "",
-            "type": "note",
-            "width": 45,
-            "x": 67,
-            "y": 1
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q":
-                            "avg:oracle.physical_reads{$host,$scope} by {host}",
-                        "style": {
-                            "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Physical Disk Reads",
-            "type": "timeseries",
-            "width": 45,
-            "x": 67,
-            "y": 7
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q":
-                            "avg:oracle.long_table_scans{$host,$scope} by {host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Full Table Scans",
-            "type": "timeseries",
-            "width": 45,
-            "x": 67,
-            "y": 55
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:oracle.disk_sorts{$host,$scope} by {host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Sorts on Disk",
-            "type": "timeseries",
-            "width": 45,
-            "x": 67,
-            "y": 39
-        },
-        {
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": 286414,
-            "font_size": "18",
-            "height": 5,
-            "html": "Database and Buffer Activity",
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "",
-            "type": "note",
-            "width": 92,
-            "x": 114,
-            "y": 1
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q":
-                            "avg:oracle.active_sessions{$host,$scope} by {host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Active Session Count",
-            "type": "timeseries",
-            "width": 45,
-            "x": 20,
-            "y": 7
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:oracle.user_rollbacks{$host,$scope}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "User Rollbacks",
-            "type": "timeseries",
-            "width": 45,
-            "x": 114,
-            "y": 39
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "markers": [
-                    {
-                        "dim": "y",
-                        "type": "warning dashed",
-                        "val": 85,
-                        "value": "y = 85"
-                    },
-                    {
-                        "dim": "y",
-                        "type": "error dashed",
-                        "val": 97,
-                        "value": "y = 97"
-                    }
-                ],
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q":
-                            "avg:oracle.tablespace.in_use{$host,$scope} by {tablespace,host}",
-                        "style": {
-                            "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Tablespace Usage (%)",
-            "type": "timeseries",
-            "width": 45,
-            "x": 132,
-            "y": 56
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:oracle.enqueue_timeouts{$host,$scope}",
-                        "style": {
-                            "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Enqueue Timeouts",
-            "type": "timeseries",
-            "width": 45,
-            "x": 161,
-            "y": 39
-        },
-        {
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": 286414,
-            "font_size": "18",
-            "height": 31,
-            "html": "Tablespaces",
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "right",
-            "tick_pos": "50%",
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "",
-            "type": "note",
-            "width": 17,
-            "x": 114,
-            "y": 56
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:oracle.memory_sorts_ratio{$host,$scope}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "In-Memory Sorts Ratio (%)",
-            "type": "timeseries",
-            "width": 45,
-            "x": 114,
-            "y": 23
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q":
-                            "avg:oracle.temp_space_used{$host,$scope} by {host}",
-                        "style": {
-                            "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Temp Tablespace Utilization",
-            "type": "timeseries",
-            "width": 45,
-            "x": 132,
-            "y": 72
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q":
-                            "avg:oracle.database_wait_time_ratio{$host,$scope}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Database Wait Time Ratio (%)",
-            "type": "timeseries",
-            "width": 45,
-            "x": 161,
-            "y": 7
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:oracle.service_response_time{$host,$scope}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "SQL Service Response Time (seconds)",
-            "type": "timeseries",
-            "width": 45,
-            "x": 114,
-            "y": 7
-        },
-        {
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": 286414,
-            "font_size": "18",
-            "height": 5,
-            "html": "Session Activity",
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "",
-            "type": "note",
-            "width": 45,
-            "x": 20,
-            "y": 1
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q":
-                            "avg:oracle.session_limit_usage{$host,$scope} by {host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Session Limit Usage (%)",
-            "type": "timeseries",
-            "width": 45,
-            "x": 20,
-            "y": 39
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:oracle.shared_pool_free{$host,$scope}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Shared Pool Free Memory (%)",
-            "type": "timeseries",
-            "width": 45,
-            "x": 161,
-            "y": 23
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:oracle.logons{$host,$scope} by {host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Logons Per Second",
-            "type": "timeseries",
-            "width": 45,
-            "x": 20,
-            "y": 55
-        },
-        {
-            "board_id": 286414,
-            "height": 29,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "conditional_formats": [],
-                        "q":
-                            "top(avg:oracle.tablespace.size{$host,$scope} by {tablespace}, 10, 'mean', 'desc')",
-                        "style": {
-                            "palette": "cool"
-                        }
-                    }
-                ],
-                "viz": "toplist"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Tablespace Size",
-            "type": "toplist",
-            "width": 28,
-            "x": 178,
-            "y": 56
-        },
-        {
-            "board_id": 286414,
-            "check": "oracle.can_connect",
-            "group": null,
-            "group_by": [],
-            "grouping": "cluster",
-            "height": 10,
-            "isShared": false,
-            "tags": ["*"],
-            "text_align": "center",
-            "text_size": "auto",
-            "time": { "live_span": "10m" },
-            "title": true,
-            "title_align": "center",
-            "title_size": 13,
-            "title_text": "Connection Status Check",
-            "type": "check_status",
-            "width": 17,
-            "x": 1,
-            "y": 16
-        },
-        {
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": 286414,
-            "font_size": "18",
-            "height": 8,
-            "html": "Cache Hit Ratios",
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "",
-            "type": "note",
-            "width": 17,
-            "x": 1,
-            "y": 28
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:oracle.session_count{$host,$scope} by {host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Total Session Count",
-            "type": "timeseries",
-            "width": 45,
-            "x": 20,
-            "y": 23
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q":
-                            "avg:oracle.physical_writes{$host,$scope} by {host}",
-                        "style": {
-                            "palette": "purple",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": { "live_span": "4h" },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Physical Disk Writes",
-            "type": "timeseries",
-            "width": 45,
-            "x": 67,
-            "y": 23
-        },
-        {
-            "board_id": 286414,
-            "height": 13,
-            "isShared": false,
-            "margin": "small",
-            "sizing": "fit",
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "",
-            "type": "image",
-            "url":
-                "/static/images/screenboard/integrations/oracle_database.png",
-            "width": 17,
-            "x": 1,
-            "y": 1
+        "layout": {
+          "x": 1,
+          "y": 49,
+          "width": 17,
+          "height": 10
         }
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:oracle.library_cachehit_ratio{$host,$scope}",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Library Cache",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 1,
+          "y": 60,
+          "width": 17,
+          "height": 10
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:oracle.buffer_cachehit_ratio{$host,$scope}",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Buffer Cache",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1h"
+          },
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 1,
+          "y": 37,
+          "width": 17,
+          "height": 11
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "note",
+          "content": "Disk Activity",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 67,
+          "y": 1,
+          "width": 45,
+          "height": 5
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.physical_reads{$host,$scope} by {host}",
+              "display_type": "bars",
+              "style": {
+                "palette": "cool",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Physical Disk Reads",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 67,
+          "y": 7,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.long_table_scans{$host,$scope} by {host}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Full Table Scans",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 67,
+          "y": 55,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.disk_sorts{$host,$scope} by {host}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Sorts on Disk",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 67,
+          "y": 39,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "note",
+          "content": "Database and Buffer Activity",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 114,
+          "y": 1,
+          "width": 92,
+          "height": 5
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.active_sessions{$host,$scope} by {host}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Active Session Count",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 20,
+          "y": 7,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 9,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.user_rollbacks{$host,$scope}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "User Rollbacks",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 114,
+          "y": 39,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 10,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.tablespace.in_use{$host,$scope} by {tablespace,host}",
+              "display_type": "line",
+              "style": {
+                "palette": "cool",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "markers": [
+            {
+              "value": "y = 85",
+              "display_type": "warning dashed"
+            },
+            {
+              "value": "y = 97",
+              "display_type": "error dashed"
+            }
+          ],
+          "title": "Tablespace Usage (%)",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 132,
+          "y": 56,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 11,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.enqueue_timeouts{$host,$scope}",
+              "display_type": "bars",
+              "style": {
+                "palette": "warm",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Enqueue Timeouts",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 161,
+          "y": 39,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 12,
+        "definition": {
+          "type": "note",
+          "content": "Tablespaces",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "right"
+        },
+        "layout": {
+          "x": 114,
+          "y": 56,
+          "width": 17,
+          "height": 31
+        }
+      },
+      {
+        "id": 13,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.memory_sorts_ratio{$host,$scope}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "In-Memory Sorts Ratio (%)",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 114,
+          "y": 23,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 14,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.temp_space_used{$host,$scope} by {host}",
+              "display_type": "line",
+              "style": {
+                "palette": "cool",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Temp Tablespace Utilization",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 132,
+          "y": 72,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 15,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.database_wait_time_ratio{$host,$scope}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Database Wait Time Ratio (%)",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 161,
+          "y": 7,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 16,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.service_response_time{$host,$scope}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "SQL Service Response Time (seconds)",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 114,
+          "y": 7,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 17,
+        "definition": {
+          "type": "note",
+          "content": "Session Activity",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 20,
+          "y": 1,
+          "width": 45,
+          "height": 5
+        }
+      },
+      {
+        "id": 18,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.session_limit_usage{$host,$scope} by {host}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Session Limit Usage (%)",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 20,
+          "y": 39,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 19,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.shared_pool_free{$host,$scope}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Shared Pool Free Memory (%)",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 161,
+          "y": 23,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 20,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.logons{$host,$scope} by {host}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Logons Per Second",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 20,
+          "y": 55,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 21,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "q": "top(avg:oracle.tablespace.size{$host,$scope} by {tablespace}, 10, 'mean', 'desc')",
+              "style": {
+                "palette": "cool"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Tablespace Size",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          }
+        },
+        "layout": {
+          "x": 178,
+          "y": 56,
+          "width": 28,
+          "height": 31
+        }
+      },
+      {
+        "id": 22,
+        "definition": {
+          "type": "check_status",
+          "title": "Connection Status Check",
+          "title_size": "13",
+          "title_align": "center",
+          "check": "oracle.can_connect",
+          "grouping": "cluster",
+          "group_by": [],
+          "tags": [
+            "*"
+          ],
+          "time": {
+            "live_span": "10m"
+          }
+        },
+        "layout": {
+          "x": 1,
+          "y": 16,
+          "width": 17,
+          "height": 10
+        }
+      },
+      {
+        "id": 23,
+        "definition": {
+          "type": "note",
+          "content": "Cache Hit Ratios",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 1,
+          "y": 28,
+          "width": 17,
+          "height": 8
+        }
+      },
+      {
+        "id": 24,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.session_count{$host,$scope} by {host}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Total Session Count",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 20,
+          "y": 23,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 25,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:oracle.physical_writes{$host,$scope} by {host}",
+              "display_type": "bars",
+              "style": {
+                "palette": "purple",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Physical Disk Writes",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 67,
+          "y": 23,
+          "width": 45,
+          "height": 15
+        }
+      },
+      {
+        "id": 26,
+        "definition": {
+          "type": "image",
+          "url": "/static/images/screenboard/integrations/oracle_database.png",
+          "sizing": "fit",
+          "margin": "small"
+        },
+        "layout": {
+          "x": 1,
+          "y": 1,
+          "width": 17,
+          "height": 13
+        }
+      }
     ],
-    "width": "100%"
-}
+    "template_variables": [
+      {
+        "name": "host",
+        "default": "*",
+        "prefix": "host"
+      },
+      {
+        "name": "scope",
+        "default": "*",
+        "prefix": null
+      }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 240
+  }

--- a/presto/assets/dashboards/overview.json
+++ b/presto/assets/dashboards/overview.json
@@ -1,917 +1,623 @@
 {
-    "board_title": "Presto Overview", 
-    "read_only": false, 
-    "description": "This dashboard provides an overview of the health of your Presto infrastructure so you can investigate failed queries and other performance issues as they arise. Further reading on Presto monitoring:\n\n- [How to monitor Presto with Datadog](https://www.datadoghq.com/blog/monitor-presto-with-datadog/)\n\n- [Datadog’s Presto integration docs](https://docs.datadoghq.com/integrations/presto/)\n\nClone this template dashboard to make changes and add your own graphs and widgets.", 
-    "board_bgtype": "board_graph", 
-    "created": "2019-06-10T18:10:17.345955+00:00", 
-    "new_id": "dnt-pvm-9h6", 
-    "height": 80, 
-    "width": 173, 
-    "template_variables": [], 
-    "isIntegration": false, 
-    "originalHeight": 80, 
-    "originalWidth": 173, 
-    "isShared": false, 
+    "title": "Presto Overview",
+    "description": "This dashboard provides an overview of the health of your Presto infrastructure so you can investigate failed queries and other performance issues as they arise. Further reading on Presto monitoring:\n\n- [How to monitor Presto with Datadog](https://www.datadoghq.com/blog/monitor-presto-with-datadog/)\n\n- [Datadog’s Presto integration docs](https://docs.datadoghq.com/integrations/presto/)\n\nClone this template dashboard to make changes and add your own graphs and widgets.",
     "widgets": [
-        {
-            "board_id": "529-gfn-ypv", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "presto.execution.abandoned_queries.one_minute.count", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Abandoned Queries - One Minute Count", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.execution.abandoned_queries.one_minute.count{*}, 10*avg:presto.execution.abandoned_queries.one_minute.count{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "warm", 
-                            "type": "solid"
-                        }, 
-                        "type": "bars", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 8, 
-            "x": 17, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "529-gfn-ypv", 
-            "sizing": "zoom", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1547942400000, 
-                "end": 1555718400000
-            }, 
-            "title_align": "left", 
-            "title_size": 16, 
-            "title": true, 
-            "url": "https://s3.amazonaws.com/dd-integrations/presto/configuration/tile/logo.png", 
-            "type": "image", 
-            "generated_title": "", 
-            "title_text": "", 
-            "height": 14, 
-            "width": 15, 
-            "scaleFactor": 1, 
-            "y": 2, 
-            "x": 1, 
-            "isShared": false, 
-            "margin": "", 
-            "add_timeframe": true
-        }, 
-        {
-            "height": 5, 
-            "tick_pos": "50%", 
-            "board_id": "529-gfn-ypv", 
-            "title_size": 16, 
-            "title": true, 
-            "title_align": "left", 
-            "text_align": "center", 
-            "bgcolor": "gray", 
-            "html": "Query Manager", 
-            "type": "note", 
-            "isShared": false, 
-            "refresh_every": 30000, 
-            "auto_refresh": false, 
-            "title_text": "", 
-            "tick": true, 
-            "scaleFactor": 1, 
-            "add_timeframe": true, 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1547942400000, 
-                "end": 1555718400000
-            }, 
-            "font_size": "18", 
-            "generated_title": "Note", 
-            "tick_edge": "bottom", 
-            "y": 2, 
-            "x": 17, 
-            "width": 34
-        }, 
-        {
-            "height": 15, 
-            "text_size": "auto", 
-            "check": "presto.can_connect", 
-            "board_id": "529-gfn-ypv", 
-            "group": null, 
-            "title": true, 
-            "title_align": "center", 
-            "text_align": "center", 
-            "width": 15, 
-            "group_by": [], 
-            "type": "check_status", 
-            "isShared": false, 
-            "tags": [
-                "*"
-            ], 
-            "time": {}, 
-            "title_text": "Can Connect", 
-            "title_size": 16, 
-            "scaleFactor": 1, 
-            "add_timeframe": true, 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "error": null, 
-            "y": 17, 
-            "x": 1, 
-            "grouping": "cluster"
-        }, 
-        {
-            "height": 5, 
-            "tick_pos": "50%", 
-            "board_id": "529-gfn-ypv", 
-            "title_size": 16, 
-            "title": true, 
-            "title_align": "left", 
-            "text_align": "center", 
-            "bgcolor": "gray", 
-            "html": "Task Executor", 
-            "type": "note", 
-            "isShared": false, 
-            "refresh_every": 30000, 
-            "auto_refresh": false, 
-            "title_text": "", 
-            "tick": true, 
-            "scaleFactor": 1, 
-            "add_timeframe": true, 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1547942400000, 
-                "end": 1555718400000
-            }, 
-            "font_size": "18", 
-            "generated_title": "Note", 
-            "tick_edge": "bottom", 
-            "y": 2, 
-            "x": 52, 
-            "width": 34
-        }, 
-        {
-            "height": 5, 
-            "tick_pos": "50%", 
-            "board_id": "529-gfn-ypv", 
-            "title_size": 16, 
-            "title": true, 
-            "title_align": "left", 
-            "text_align": "center", 
-            "bgcolor": "gray", 
-            "html": "Task Manager", 
-            "type": "note", 
-            "isShared": false, 
-            "refresh_every": 30000, 
-            "auto_refresh": false, 
-            "title_text": "", 
-            "tick": true, 
-            "scaleFactor": 1, 
-            "add_timeframe": true, 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1547942400000, 
-                "end": 1555718400000
-            }, 
-            "font_size": "18", 
-            "generated_title": "Note", 
-            "tick_edge": "bottom", 
-            "y": 2, 
-            "x": 87, 
-            "width": 34
-        }, 
-        {
-            "height": 38, 
-            "tick_pos": "50%", 
-            "board_id": "529-gfn-ypv", 
-            "title_size": 16, 
-            "title": true, 
-            "title_align": "left", 
-            "text_align": "center", 
-            "bgcolor": "gray", 
-            "html": "Memory", 
-            "type": "note", 
-            "isShared": false, 
-            "refresh_every": 30000, 
-            "auto_refresh": false, 
-            "title_text": "", 
-            "tick": true, 
-            "scaleFactor": 1, 
-            "add_timeframe": true, 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1547942400000, 
-                "end": 1555718400000
-            }, 
-            "font_size": "18", 
-            "generated_title": "Note", 
-            "tick_edge": "right", 
-            "y": 33, 
-            "x": 1, 
-            "width": 15
-        }, 
-        {
-            "board_id": "529-gfn-ypv", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "presto.memory.assigned_queries", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Memory Assigned to Queries", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.memory.assigned_queries{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "dog_classic", 
-                            "type": "solid"
-                        }, 
-                        "type": "line", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 40, 
-            "x": 17, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "529-gfn-ypv", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "presto.execution.executor.active_count", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Active Task Count", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.execution.task_notification_executor.active_count{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "dog_classic", 
-                            "type": "solid"
-                        }, 
-                        "type": "bars", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 8, 
-            "x": 52, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "529-gfn-ypv", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "presto.execution.executor.pool_size", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Executor Pool Size", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.execution.executor.pool_size{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "dog_classic", 
-                            "type": "solid"
-                        }, 
-                        "type": "line", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 24, 
-            "x": 52, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "529-gfn-ypv", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "presto.execution.external_failures.one_minute.count", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Insufficient Resource Failures - One Minute Count", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.execution.insufficient_resources_failures.one_minute.count{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "warm", 
-                            "type": "solid"
-                        }, 
-                        "type": "bars", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 24, 
-            "x": 17, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "529-gfn-ypv", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "presto.execution.executor.pool_size", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Executor Pool Size", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.execution.executor.pool_size{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "dog_classic", 
-                            "type": "solid"
-                        }, 
-                        "type": "bars", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 8, 
-            "x": 87, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "529-gfn-ypv", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "presto.execution.executor.processor_executor.queued_task_count", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Queued Task Count", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.execution.executor.queued_task_count{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "dog_classic", 
-                            "type": "solid"
-                        }, 
-                        "type": "bars", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 24, 
-            "x": 87, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "529-gfn-ypv", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "presto.memory.free_bytes, ", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Available Memory", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.memory.free_bytes{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "dog_classic", 
-                            "type": "solid"
-                        }, 
-                        "type": "area", 
-                        "conditional_formats": []
-                    }, 
-                    {
-                        "style": {
-                            "width": "normal", 
-                            "palette": "dog_classic", 
-                            "type": "solid"
-                        }, 
-                        "type": "line", 
-                        "conditional_formats": [], 
-                        "log_query": {
-                            "index": "agent-qa", 
-                            "search": {
-                                "query": ""
-                            }, 
-                            "compute": {
-                                "facet": null, 
-                                "aggregation": "count"
-                            }, 
-                            "groupBy": []
-                        }
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 40, 
-            "x": 52, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "529-gfn-ypv", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "jmx.presto.memory.max_bytes", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Max Memory", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.memory.max_bytes{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "dog_classic", 
-                            "type": "solid"
-                        }, 
-                        "type": "area", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 56, 
-            "x": 52, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "529-gfn-ypv", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "system.processes.mem.pct", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Memory Assigned to Nodes", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.memory.nodes{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "dog_classic", 
-                            "type": "solid"
-                        }, 
-                        "type": "line", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 40, 
-            "x": 87, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "529-gfn-ypv", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "presto.memory.total_distributed_bytes", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Total Distributed Memory", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "diff(avg:presto.memory.total_distributed_bytes{*})", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "dog_classic", 
-                            "type": "solid"
-                        }, 
-                        "type": "line", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 56, 
-            "x": 87, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "height": 5, 
-            "tick_pos": "50%", 
-            "board_id": "dnt-pvm-9h6", 
-            "title_size": 16, 
-            "title": true, 
-            "title_align": "left", 
-            "text_align": "center", 
-            "bgcolor": "gray", 
-            "html": "Latency", 
-            "type": "note", 
-            "isShared": false, 
-            "refresh_every": 30000, 
-            "auto_refresh": false, 
-            "title_text": "", 
-            "tick": true, 
-            "scaleFactor": 1, 
-            "add_timeframe": true, 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560186620369, 
-                "end": 1560190220369
-            }, 
-            "font_size": "18", 
-            "generated_title": "Note", 
-            "tick_edge": "bottom", 
-            "y": 2, 
-            "x": 122, 
-            "width": 34
-        }, 
-        {
-            "board_id": "dnt-pvm-9h6", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "system.cpu.user", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Query Execution Time - All Time Avg", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.execution.execution_time.all_time.avg{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "purple", 
-                            "type": "solid"
-                        }, 
-                        "type": "line", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 8, 
-            "x": 122, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "dnt-pvm-9h6", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "system.cpu.user", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Query Execution Time - All Time Max", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.execution.execution_time.all_time.max{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "purple", 
-                            "type": "solid"
-                        }, 
-                        "type": "line", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 24, 
-            "x": 122, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "dnt-pvm-9h6", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "system.cpu.user", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Query Execution Time - One Minute Avg", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.execution.execution_time.one_minute.avg{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "purple", 
-                            "type": "solid"
-                        }, 
-                        "type": "line", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 40, 
-            "x": 122, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "dnt-pvm-9h6", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "presto.execution.execution_time.all_time.max", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Query Execution Time - One Minute Max", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.execution.execution_time.one_minute.max{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "purple", 
-                            "type": "solid"
-                        }, 
-                        "type": "line", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 56, 
-            "x": 122, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
-        }, 
-        {
-            "board_id": "529-gfn-ypv", 
-            "globalTimeframe": {
-                "isLive": true, 
-                "start": 1560362763973, 
-                "end": 1560366363973
-            }, 
-            "generated_title": "presto.memory.assigned_queries", 
-            "title_size": 16, 
-            "title": true, 
-            "scaleFactor": 1, 
-            "title_align": "left", 
-            "title_text": "Memory Used by Blocked Nodes", 
-            "height": 13, 
-            "tile_def": {
-                "viz": "timeseries", 
-                "requests": [
-                    {
-                        "q": "avg:presto.memory.blocked_nodes{*}", 
-                        "aggregator": "avg", 
-                        "style": {
-                            "width": "normal", 
-                            "palette": "dog_classic", 
-                            "type": "solid"
-                        }, 
-                        "type": "area", 
-                        "conditional_formats": []
-                    }
-                ], 
-                "autoscale": true
-            }, 
-            "width": 34, 
-            "error": null, 
-            "time": {}, 
-            "y": 56, 
-            "x": 17, 
-            "legend_size": "0", 
-            "add_timeframe": true, 
-            "type": "timeseries", 
-            "legend": false, 
-            "isShared": false
+      {
+        "id": 0,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.execution.abandoned_queries.one_minute.count{*}, 10*avg:presto.execution.abandoned_queries.one_minute.count{*}",
+              "display_type": "bars",
+              "style": {
+                "palette": "warm",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Abandoned Queries - One Minute Count",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 17,
+          "y": 8,
+          "width": 34,
+          "height": 15
         }
-    ], 
-    "disableCog": false, 
-    "id": 725794, 
-    "disableEditing": false
-}
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "image",
+          "url": "https://s3.amazonaws.com/dd-integrations/presto/configuration/tile/logo.png",
+          "sizing": "zoom"
+        },
+        "layout": {
+          "x": 1,
+          "y": 2,
+          "width": 15,
+          "height": 14
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "note",
+          "content": "Query Manager",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 17,
+          "y": 2,
+          "width": 34,
+          "height": 5
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "check_status",
+          "title": "Can Connect",
+          "title_size": "16",
+          "title_align": "center",
+          "check": "presto.can_connect",
+          "grouping": "cluster",
+          "group_by": [],
+          "tags": [
+            "*"
+          ]
+        },
+        "layout": {
+          "x": 1,
+          "y": 17,
+          "width": 15,
+          "height": 15
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "note",
+          "content": "Task Executor",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 52,
+          "y": 2,
+          "width": 34,
+          "height": 5
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "note",
+          "content": "Task Manager",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 87,
+          "y": 2,
+          "width": 34,
+          "height": 5
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "note",
+          "content": "Memory",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "right"
+        },
+        "layout": {
+          "x": 1,
+          "y": 33,
+          "width": 15,
+          "height": 38
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.memory.assigned_queries{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Memory Assigned to Queries",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 17,
+          "y": 40,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.execution.task_notification_executor.active_count{*}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Active Task Count",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 52,
+          "y": 8,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 9,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.execution.executor.pool_size{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Executor Pool Size",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 52,
+          "y": 24,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 10,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.execution.insufficient_resources_failures.one_minute.count{*}",
+              "display_type": "bars",
+              "style": {
+                "palette": "warm",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Insufficient Resource Failures - One Minute Count",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 17,
+          "y": 24,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 11,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.execution.executor.pool_size{*}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Executor Pool Size",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 87,
+          "y": 8,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 12,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.execution.executor.queued_task_count{*}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Queued Task Count",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 87,
+          "y": 24,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 13,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.memory.free_bytes{*}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "log_query": {
+                "index": "agent-qa",
+                "compute": {
+                  "aggregation": "count"
+                },
+                "search": {
+                  "query": ""
+                },
+                "group_by": []
+              },
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Available Memory",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 52,
+          "y": 40,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 14,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.memory.max_bytes{*}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Max Memory",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 52,
+          "y": 56,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 15,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.memory.nodes{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Memory Assigned to Nodes",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 87,
+          "y": 40,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 16,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "diff(avg:presto.memory.total_distributed_bytes{*})",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Total Distributed Memory",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 87,
+          "y": 56,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 17,
+        "definition": {
+          "type": "note",
+          "content": "Latency",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 122,
+          "y": 2,
+          "width": 34,
+          "height": 5
+        }
+      },
+      {
+        "id": 18,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.execution.execution_time.all_time.avg{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "purple",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Query Execution Time - All Time Avg",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 122,
+          "y": 8,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 19,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.execution.execution_time.all_time.max{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "purple",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Query Execution Time - All Time Max",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 122,
+          "y": 24,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 20,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.execution.execution_time.one_minute.avg{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "purple",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Query Execution Time - One Minute Avg",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 122,
+          "y": 40,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 21,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.execution.execution_time.one_minute.max{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "purple",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Query Execution Time - One Minute Max",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 122,
+          "y": 56,
+          "width": 34,
+          "height": 15
+        }
+      },
+      {
+        "id": 22,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:presto.memory.blocked_nodes{*}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Memory Used by Blocked Nodes",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 17,
+          "y": 56,
+          "width": 34,
+          "height": 15
+        }
+      }
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30277
+  }

--- a/proxysql/assets/dashboards/overview.json
+++ b/proxysql/assets/dashboards/overview.json
@@ -1,396 +1,414 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "ProxySQL Overview",
-    "created": "2020-04-16T12:34:15.438086+00:00",
-    "created_by": {
-        "access_role": "adm",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": true,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "ProxySQL Overview",
     "description": "This dashboard provides a high-level view of your ProxySQL environment, with in-depth performance indicators regarding the query cache or the latency.\n\n- [How to monitor ProxySQL with Datadog](https://docs.datadoghq.com/integrations/proxysql/) \n\nClone this template dashboard to make changes and add your own graph widgets. ",
-    "id": 1057249,
-    "modified": "2020-04-20T07:58:38.845603+00:00",
-    "new_id": "258-j85-hpt",
-    "read_only": false,
-    "template_variables": [
-        {
-            "default": "*",
-            "name": "proxysql_server",
-            "prefix": "proxysql_server"
-        },
-        {
-            "default": "*",
-            "name": "proxysql_port",
-            "prefix": "proxysql_port"
-        },
-        {
-            "default": "*",
-            "name": "sql_command",
-            "prefix": "sql_command"
-        }
-    ],
     "widgets": [
-        {
-            "height": 8,
-            "id": 0,
-            "sizing": "zoom",
-            "type": "image",
-            "url": "https://static.datadoghq.com/static/images/saas_logos/bot/proxysql@2x.png",
-            "width": 22,
-            "x": 1,
-            "y": 10
+      {
+        "id": 0,
+        "definition": {
+          "type": "image",
+          "url": "https://static.datadoghq.com/static/images/saas_logos/bot/proxysql@2x.png",
+          "sizing": "zoom"
         },
-        {
-            "check": "proxysql.can_connect",
-            "group": "application:test,proxysql_port:6032,proxysql_server:localhost,host:docker-desktop",
-            "group_by": [
-                "proxysql_server",
-                "proxysql_port"
-            ],
-            "grouping": "cluster",
-            "height": 10,
-            "id": 1,
-            "tags": [
-                "$proxysql_port",
-                "$proxysql_server"
-            ],
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Monitored instances status",
-            "type": "check_status",
-            "width": 22,
-            "x": 1,
-            "y": 20
-        },
-        {
-            "check": "proxysql.backend.status",
-            "group_by": [],
-            "grouping": "cluster",
-            "height": 10,
-            "id": 2,
-            "tags": [
-                "$proxysql_server",
-                "$proxysql_port"
-            ],
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Backends status",
-            "type": "check_status",
-            "width": 22,
-            "x": 1,
-            "y": 32
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "14",
-            "height": 6,
-            "html": "# Connection pool",
-            "id": 3,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 47,
-            "x": 25,
-            "y": 2
-        },
-        {
-            "height": 13,
-            "id": 4,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "metadata": {
-                            "avg:proxysql.pool.latency_ms{*} by {hostgroup}": {
-                                "alias": "Latency"
-                            }
-                        },
-                        "q": "avg:proxysql.pool.latency_ms{*} by {hostgroup}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Latency per hostgroup",
-            "type": "timeseries",
-            "width": 47,
-            "x": 25,
-            "y": 10
-        },
-        {
-            "height": 13,
-            "id": 5,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "metadata": {
-                            "sum:proxysql.pool.connections_used{$proxysql_server,$proxysql_port} by {hostgroup}": {
-                                "alias": "Used connections"
-                            }
-                        },
-                        "q": "sum:proxysql.pool.connections_used{$proxysql_server,$proxysql_port} by {hostgroup}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Number of connections currently used per hostgroup",
-            "type": "timeseries",
-            "width": 47,
-            "x": 25,
-            "y": 27
-        },
-        {
-            "height": 13,
-            "id": 6,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "metadata": {
-                            "avg:proxysql.pool.bytes_data_recv{$proxysql_server,$proxysql_port} by {hostgroup}": {
-                                "alias": "Bytes received"
-                            }
-                        },
-                        "q": "avg:proxysql.pool.bytes_data_recv{$proxysql_server,$proxysql_port} by {hostgroup}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "metadata": {
-                            "avg:proxysql.pool.bytes_data_sent{$proxysql_server,$proxysql_port} by {hostgroup}": {
-                                "alias": "Bytes sent"
-                            }
-                        },
-                        "q": "avg:proxysql.pool.bytes_data_sent{$proxysql_server,$proxysql_port} by {hostgroup}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Bytes received and sent per hostgroup",
-            "type": "timeseries",
-            "width": 47,
-            "x": 25,
-            "y": 44
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "14",
-            "height": 6,
-            "html": "# Performance",
-            "id": 7,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 47,
-            "x": 75,
-            "y": 2
-        },
-        {
-            "height": 13,
-            "id": 8,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "sum:proxysql.performance.command.cnt_5s{$proxysql_server,$proxysql_port,$sql_command} by {sql_command}.as_count()+sum:proxysql.performance.command.cnt_10s{$proxysql_server,$proxysql_port,$sql_command} by {sql_command}.as_count()+sum:proxysql.performance.command.cnt_infs{$proxysql_server,$proxysql_port,$sql_command} by {sql_command}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Number of statements that took more than 5 seconds to complete",
-            "type": "timeseries",
-            "width": 47,
-            "x": 75,
-            "y": 10
-        },
-        {
-            "height": 13,
-            "id": 9,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "metadata": {
-                            "avg:proxysql.query_cache.memory_bytes{$proxysql_server,$proxysql_port}": {
-                                "alias": "Memory usage"
-                            }
-                        },
-                        "q": "avg:proxysql.query_cache.memory_bytes{$proxysql_server,$proxysql_port}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Memory usage of the query cache",
-            "type": "timeseries",
-            "width": 47,
-            "x": 75,
-            "y": 27
-        },
-        {
-            "height": 13,
-            "id": 10,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "metadata": {
-                            "avg:proxysql.query_cache.bytes_out{$proxysql_server,$proxysql_port}": {
-                                "alias": "Bytes out"
-                            }
-                        },
-                        "q": "avg:proxysql.query_cache.bytes_out{$proxysql_server,$proxysql_port}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Cache read throughput",
-            "type": "timeseries",
-            "width": 47,
-            "x": 75,
-            "y": 44
-        },
-        {
-            "columns": "[\"host\", \"service\", \"source\"]",
-            "height": 57,
-            "id": 11,
-            "indexes": [],
-            "message_display": "expanded-md",
-            "query": "source:proxysql",
-            "show_date_column": true,
-            "show_message_column": true,
-            "sort": {
-                "column": "time",
-                "order": "desc"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Log stream",
-            "type": "log_stream",
-            "width": 47,
-            "x": 125,
-            "y": 2
+        "layout": {
+          "x": 1,
+          "y": 10,
+          "width": 22,
+          "height": 8
         }
-    ]
-}
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "check_status",
+          "title": "Monitored instances status",
+          "title_size": "16",
+          "title_align": "center",
+          "check": "proxysql.can_connect",
+          "grouping": "cluster",
+          "group": "application:test,proxysql_port:6032,proxysql_server:localhost,host:docker-desktop",
+          "group_by": [
+            "proxysql_server",
+            "proxysql_port"
+          ],
+          "tags": [
+            "$proxysql_port",
+            "$proxysql_server"
+          ]
+        },
+        "layout": {
+          "x": 1,
+          "y": 20,
+          "width": 22,
+          "height": 10
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "check_status",
+          "title": "Backends status",
+          "title_size": "16",
+          "title_align": "center",
+          "check": "proxysql.backend.status",
+          "grouping": "cluster",
+          "group_by": [],
+          "tags": [
+            "$proxysql_server",
+            "$proxysql_port"
+          ]
+        },
+        "layout": {
+          "x": 1,
+          "y": 32,
+          "width": 22,
+          "height": 10
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "note",
+          "content": "# Connection pool",
+          "background_color": "gray",
+          "font_size": "14",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 25,
+          "y": 2,
+          "width": 47,
+          "height": 6
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:proxysql.pool.latency_ms{*} by {hostgroup}",
+              "metadata": [
+                {
+                  "expression": "avg:proxysql.pool.latency_ms{*} by {hostgroup}",
+                  "alias_name": "Latency"
+                }
+              ],
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Latency per hostgroup",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 25,
+          "y": 10,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:proxysql.pool.connections_used{$proxysql_server,$proxysql_port} by {hostgroup}",
+              "metadata": [
+                {
+                  "expression": "sum:proxysql.pool.connections_used{$proxysql_server,$proxysql_port} by {hostgroup}",
+                  "alias_name": "Used connections"
+                }
+              ],
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Number of connections currently used per hostgroup",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 25,
+          "y": 27,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:proxysql.pool.bytes_data_recv{$proxysql_server,$proxysql_port} by {hostgroup}",
+              "metadata": [
+                {
+                  "expression": "avg:proxysql.pool.bytes_data_recv{$proxysql_server,$proxysql_port} by {hostgroup}",
+                  "alias_name": "Bytes received"
+                }
+              ],
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "avg:proxysql.pool.bytes_data_sent{$proxysql_server,$proxysql_port} by {hostgroup}",
+              "metadata": [
+                {
+                  "expression": "avg:proxysql.pool.bytes_data_sent{$proxysql_server,$proxysql_port} by {hostgroup}",
+                  "alias_name": "Bytes sent"
+                }
+              ],
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Bytes received and sent per hostgroup",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 25,
+          "y": 44,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "note",
+          "content": "# Performance",
+          "background_color": "gray",
+          "font_size": "14",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 75,
+          "y": 2,
+          "width": 47,
+          "height": 6
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:proxysql.performance.command.cnt_5s{$proxysql_server,$proxysql_port,$sql_command} by {sql_command}.as_count()+sum:proxysql.performance.command.cnt_10s{$proxysql_server,$proxysql_port,$sql_command} by {sql_command}.as_count()+sum:proxysql.performance.command.cnt_infs{$proxysql_server,$proxysql_port,$sql_command} by {sql_command}.as_count()",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Number of statements that took more than 5 seconds to complete",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 75,
+          "y": 10,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 9,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:proxysql.query_cache.memory_bytes{$proxysql_server,$proxysql_port}",
+              "metadata": [
+                {
+                  "expression": "avg:proxysql.query_cache.memory_bytes{$proxysql_server,$proxysql_port}",
+                  "alias_name": "Memory usage"
+                }
+              ],
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Memory usage of the query cache",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 75,
+          "y": 27,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 10,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:proxysql.query_cache.bytes_out{$proxysql_server,$proxysql_port}",
+              "metadata": [
+                {
+                  "expression": "avg:proxysql.query_cache.bytes_out{$proxysql_server,$proxysql_port}",
+                  "alias_name": "Bytes out"
+                }
+              ],
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Cache read throughput",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 75,
+          "y": 44,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 11,
+        "definition": {
+          "type": "log_stream",
+          "indexes": [],
+          "query": "source:proxysql",
+          "sort": {
+            "column": "time",
+            "order": "desc"
+          },
+          "columns": [
+            "host",
+            "service",
+            "source"
+          ],
+          "show_date_column": true,
+          "show_message_column": true,
+          "message_display": "expanded-md",
+          "title": "Log stream",
+          "title_size": "16",
+          "title_align": "left"
+        },
+        "layout": {
+          "x": 125,
+          "y": 2,
+          "width": 47,
+          "height": 57
+        }
+      }
+    ],
+    "template_variables": [
+      {
+        "name": "proxysql_server",
+        "default": "*",
+        "prefix": "proxysql_server"
+      },
+      {
+        "name": "proxysql_port",
+        "default": "*",
+        "prefix": "proxysql_port"
+      },
+      {
+        "name": "sql_command",
+        "default": "*",
+        "prefix": "sql_command"
+      }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30319
+  }

--- a/rethinkdb/assets/dashboards/overview.json
+++ b/rethinkdb/assets/dashboards/overview.json
@@ -1,534 +1,549 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "RethinkDB Overview",
-    "created": "2020-05-21T15:43:15.489305+00:00",
-    "created_by": {
-        "access_role": "st",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": false,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "RethinkDB Overview",
     "description": "## RethinkDB Overview\n\nThis dashboard provides an overview of RethinkDB availability, client activity, and read/write throughput so you can monitor the health and performance of your deployments. \n\n- [Monitor RethinkDB with Datadog](datadoghq.com/blog/monitor-rethinkdb-with-datadog)\n- [RethinkDB integration documentation](https://docs.datadoghq.com/integrations/rethinkdb/)",
-    "id": 1127697,
-    "modified": "2020-06-03T21:53:28.312481+00:00",
-    "new_id": "bky-fc7-h88",
-    "read_only": false,
-    "template_variables": [
-        {
-            "default": "*",
-            "name": "database",
-            "prefix": "database"
-        },
-        {
-            "default": "*",
-            "name": "table",
-            "prefix": "table"
-        },
-        {
-            "default": "*",
-            "name": "server",
-            "prefix": "server"
-        }
-    ],
     "widgets": [
-        {
-            "height": 13,
-            "id": 0,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "sum:rethinkdb.stats.server.query_engine.clients_active{$database,$table,$server} by {server}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Active clients by server",
-            "type": "timeseries",
-            "width": 47,
-            "x": 0,
-            "y": 23
+      {
+        "id": 0,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:rethinkdb.stats.server.query_engine.clients_active{$database,$table,$server} by {server}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Active clients by server",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
         },
-        {
-            "height": 13,
-            "id": 1,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "sum:rethinkdb.stats.server.query_engine.client_connections{$database,$table,$server} by {server}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Client connections by server",
-            "type": "timeseries",
-            "width": 47,
-            "x": 0,
-            "y": 39
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Client connections",
-            "id": 2,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 47,
-            "x": 0,
-            "y": 17
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Documents read per second",
-            "id": 3,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 47,
-            "x": 49,
-            "y": 17
-        },
-        {
-            "height": 13,
-            "id": 4,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:rethinkdb.stats.table.query_engine.read_docs_per_sec{$database,$table,$server} by {table}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "By table",
-            "type": "timeseries",
-            "width": 47,
-            "x": 49,
-            "y": 23
-        },
-        {
-            "height": 13,
-            "id": 5,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:rethinkdb.stats.server.query_engine.read_docs_per_sec{$database,$table,$server} by {server}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "By server",
-            "type": "timeseries",
-            "width": 47,
-            "x": 49,
-            "y": 39
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Documents written per second",
-            "id": 6,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 47,
-            "x": 98,
-            "y": 17
-        },
-        {
-            "height": 13,
-            "id": 7,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:rethinkdb.stats.table.query_engine.written_docs_per_sec{$database,$table,$server} by {table}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "By table",
-            "type": "timeseries",
-            "width": 47,
-            "x": 98,
-            "y": 23
-        },
-        {
-            "height": 13,
-            "id": 8,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:rethinkdb.stats.server.query_engine.written_docs_per_sec{$database,$table,$server} by {server}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "By server",
-            "type": "timeseries",
-            "width": 47,
-            "x": 98,
-            "y": 39
-        },
-        {
-            "height": 13,
-            "id": 9,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:rethinkdb.stats.server.query_engine.queries_per_sec{$database,$table,$server} by {server}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Queries per second by server",
-            "type": "timeseries",
-            "width": 47,
-            "x": 0,
-            "y": 55
-        },
-        {
-            "height": 13,
-            "id": 11,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:rethinkdb.stats.table_server.query_engine.read_docs_per_sec{$database,$table,$server} by {state}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "By replica state",
-            "type": "timeseries",
-            "width": 47,
-            "x": 49,
-            "y": 55
-        },
-        {
-            "height": 13,
-            "id": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:rethinkdb.stats.table_server.query_engine.written_docs_per_sec{$database,$table,$server} by {state}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "By replica state",
-            "type": "timeseries",
-            "width": 47,
-            "x": 98,
-            "y": 55
-        },
-        {
-            "height": 13,
-            "id": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "sum:rethinkdb.table_status.shards.replicas{$database,$table,$server} by {table}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Replicas per table",
-            "type": "timeseries",
-            "width": 47,
-            "x": 51,
-            "y": 0
-        },
-        {
-            "height": 13,
-            "id": 14,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "sum:rethinkdb.table_status.shards{$database,$table,$server} by {table}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Shards per table",
-            "type": "timeseries",
-            "width": 47,
-            "x": 99,
-            "y": 0
-        },
-        {
-            "height": 13,
-            "id": 15,
-            "tile_def": {
-                "custom_unit": " ",
-                "precision": 0,
-                "requests": [
-                    {
-                        "aggregator": "last",
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_green",
-                                "value": "0"
-                            },
-                            {
-                                "comparator": "<",
-                                "palette": "white_on_red",
-                                "value": "1"
-                            }
-                        ],
-                        "q": "sum:rethinkdb.config.servers{$database,$table,$server}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Servers up",
-            "type": "query_value",
-            "width": 17,
-            "x": 33,
-            "y": 0
-        },
-        {
-            "check": "rethinkdb.table_status.status.all_replicas_ready",
-            "group_by": [],
-            "grouping": "cluster",
-            "height": 15,
-            "id": 16,
-            "tags": [
-                "$table"
-            ],
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Fully replicated tables",
-            "type": "check_status",
-            "width": 17,
-            "x": 15,
-            "y": 0
-        },
-        {
-            "height": 15,
-            "id": 17,
-            "sizing": "center",
-            "type": "image",
-            "url": "https://static.datadoghq.com/static/images/avatars/bot/rethinkdb.png",
-            "width": 13,
-            "x": 0,
-            "y": 0
+        "layout": {
+          "x": 0,
+          "y": 23,
+          "width": 47,
+          "height": 15
         }
-    ]
-}
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:rethinkdb.stats.server.query_engine.client_connections{$database,$table,$server} by {server}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Client connections by server",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 0,
+          "y": 39,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "note",
+          "content": "Client connections",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 0,
+          "y": 17,
+          "width": 47,
+          "height": 5
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "note",
+          "content": "Documents read per second",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 49,
+          "y": 17,
+          "width": 47,
+          "height": 5
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:rethinkdb.stats.table.query_engine.read_docs_per_sec{$database,$table,$server} by {table}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "By table",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 49,
+          "y": 23,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:rethinkdb.stats.server.query_engine.read_docs_per_sec{$database,$table,$server} by {server}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "By server",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 49,
+          "y": 39,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "note",
+          "content": "Documents written per second",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 98,
+          "y": 17,
+          "width": 47,
+          "height": 5
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:rethinkdb.stats.table.query_engine.written_docs_per_sec{$database,$table,$server} by {table}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "By table",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 98,
+          "y": 23,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:rethinkdb.stats.server.query_engine.written_docs_per_sec{$database,$table,$server} by {server}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "By server",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 98,
+          "y": 39,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 9,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:rethinkdb.stats.server.query_engine.queries_per_sec{$database,$table,$server} by {server}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Queries per second by server",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 0,
+          "y": 55,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 10,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:rethinkdb.stats.table_server.query_engine.read_docs_per_sec{$database,$table,$server} by {state}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "By replica state",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 49,
+          "y": 55,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 11,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:rethinkdb.stats.table_server.query_engine.written_docs_per_sec{$database,$table,$server} by {state}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "By replica state",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 98,
+          "y": 55,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 12,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:rethinkdb.table_status.shards.replicas{$database,$table,$server} by {table}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Replicas per table",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 51,
+          "y": 0,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 13,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:rethinkdb.table_status.shards{$database,$table,$server} by {table}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Shards per table",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 99,
+          "y": 0,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 14,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "sum:rethinkdb.config.servers{$database,$table,$server}",
+              "aggregator": "last",
+              "conditional_formats": [
+                {
+                  "comparator": ">",
+                  "value": 0,
+                  "palette": "white_on_green"
+                },
+                {
+                  "comparator": "<",
+                  "value": 1,
+                  "palette": "white_on_red"
+                }
+              ]
+            }
+          ],
+          "custom_links": [],
+          "title": "Servers up",
+          "title_size": "16",
+          "title_align": "left",
+          "custom_unit": " ",
+          "precision": 0
+        },
+        "layout": {
+          "x": 33,
+          "y": 0,
+          "width": 17,
+          "height": 15
+        }
+      },
+      {
+        "id": 15,
+        "definition": {
+          "type": "check_status",
+          "title": "Fully replicated tables",
+          "title_size": "16",
+          "title_align": "center",
+          "check": "rethinkdb.table_status.status.all_replicas_ready",
+          "grouping": "cluster",
+          "group_by": [],
+          "tags": [
+            "$table"
+          ]
+        },
+        "layout": {
+          "x": 15,
+          "y": 0,
+          "width": 17,
+          "height": 15
+        }
+      },
+      {
+        "id": 16,
+        "definition": {
+          "type": "image",
+          "url": "https://static.datadoghq.com/static/images/avatars/bot/rethinkdb.png",
+          "sizing": "center"
+        },
+        "layout": {
+          "x": 0,
+          "y": 0,
+          "width": 13,
+          "height": 15
+        }
+      }
+    ],
+    "template_variables": [
+      {
+        "name": "database",
+        "default": "*",
+        "prefix": "database"
+      },
+      {
+        "name": "table",
+        "default": "*",
+        "prefix": "table"
+      },
+      {
+        "name": "server",
+        "default": "*",
+        "prefix": "server"
+      }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30328
+  }

--- a/sap_hana/assets/dashboards/overview.json
+++ b/sap_hana/assets/dashboards/overview.json
@@ -1,586 +1,435 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "SAP HANA Overview",
-    "created": "2019-10-23T22:03:16.131906+00:00",
-    "created_by": {
-        "access_role": "st",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": false,
-        "name": "Datadog",
-        "role": null,
-        "verified": true
-    },
+    "title": "SAP HANA Overview",
     "description": "## SAP HANA Dashboard\n\nThis is an example SAP HANA dashboard demonstrating the metrics that the integration collects.",
-    "disableCog": false,
-    "disableEditing": false,
-    "id": 872366,
-    "isIntegration": false,
-    "isShared": false,
-    "modified": "2019-12-05T23:33:09.386413+00:00",
-    "new_id": "aiq-tfk-a4n",
-    "originalHeight": 80,
-    "originalWidth": "calc(100% - 32px)",
-    "read_only": false,
-    "template_variables": [],
     "widgets": [
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": "aiq-tfk-a4n",
-            "font_size": "18",
-            "height": 5,
-            "html": "Memory",
-            "isShared": false,
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 47,
-            "x": 20,
-            "y": 1
+      {
+        "id": 0,
+        "definition": {
+          "type": "note",
+          "content": "Memory",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
         },
-        {
-            "add_timeframe": true,
-            "board_id": "aiq-tfk-a4n",
-            "height": 12,
-            "isShared": false,
-            "margin": "",
-            "scaleFactor": 1,
-            "sizing": "fit",
-            "title": false,
-            "type": "image",
-            "url": "/static/images/saas_logos/bot/sap_hana.png",
-            "width": 18,
-            "x": 1,
-            "y": 1
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:sap_hana.memory.service.overall.utilized{service_name:compileserver}, avg:sap_hana.memory.service.overall.utilized{service_name:nameserver}, avg:sap_hana.memory.service.overall.utilized{service_name:indexserver}, avg:sap_hana.memory.service.overall.utilized{service_name:preprocessor}, avg:sap_hana.memory.service.overall.utilized{service_name:webdispatcher}",
-                        "style": {
-                            "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average memory utilization by service (%)",
-            "type": "timeseries",
-            "width": 47,
-            "x": 20,
-            "y": 7
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 15,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:sap_hana.cpu.service.utilized{*} by {hana_host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "CPU utilization",
-            "type": "timeseries",
-            "width": 47,
-            "x": 20,
-            "y": 69
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 15,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:sap_hana.connection.idle{*}, avg:sap_hana.connection.running{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average connections (idle and running)",
-            "type": "timeseries",
-            "width": 47,
-            "x": 69,
-            "y": 69
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:sap_hana.disk.free{*}, avg:sap_hana.disk.used{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average disk free and disk used",
-            "type": "timeseries",
-            "width": 47,
-            "x": 20,
-            "y": 45
-        },
-        {
-            "add_timeframe": true,
-            "autoscale": true,
-            "error": null,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "custom_unit": "%",
-                "precision": "2",
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [
-                            {
-                                "comparator": "<",
-                                "palette": "white_on_green",
-                                "value": "70"
-                            },
-                            {
-                                "comparator": ">=",
-                                "palette": "white_on_yellow",
-                                "value": "70"
-                            },
-                            {
-                                "comparator": ">=",
-                                "palette": "white_on_red",
-                                "value": "80"
-                            }
-                        ],
-                        "q": "avg:sap_hana.disk.utilized{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": null
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": {
-                "live_span": "15m"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Disk utilization",
-            "type": "query_value",
-            "width": 18,
-            "x": 1,
-            "y": 14
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "custom_unit": "%",
-                "precision": "2",
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:sap_hana.memory.row_store.utilized{*}",
-                        "style": {
-                            "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average row store memory utilization (%)",
-            "type": "timeseries",
-            "width": 47,
-            "x": 20,
-            "y": 23
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:sap_hana.thread.service.active{*}, avg:sap_hana.thread.service.inactive{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Count of active and inactive threads",
-            "type": "timeseries",
-            "width": 47,
-            "x": 20,
-            "y": 87
-        },
-        {
-            "add_timeframe": true,
-            "autoscale": true,
-            "error": null,
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "custom_unit": "min",
-                "precision": "0",
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:sap_hana.backup.latest{*}/60",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": null
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": {
-                "live_span": "15m"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Time since last backup",
-            "type": "query_value",
-            "width": 18,
-            "x": 1,
-            "y": 30
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 15,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:sap_hana.volume.io.throughput{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average throughput",
-            "type": "timeseries",
-            "width": 47,
-            "x": 69,
-            "y": 25
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 15,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:sap_hana.volume.io.utilized{*}, avg:sap_hana.volume.io.read.utilized{*}, avg:sap_hana.volume.io.write.utilized{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average read, write, and total I/O time (%)",
-            "type": "timeseries",
-            "width": 47,
-            "x": 69,
-            "y": 7
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "background_color": "gray",
-            "bgcolor": "gray",
-            "content": "Memory",
-            "font_size": "18",
-            "height": 5,
-            "html": "Storage",
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "viz": "note",
-            "width": 47,
-            "x": 20,
-            "y": 39
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "background_color": "gray",
-            "bgcolor": "gray",
-            "content": "Memory",
-            "font_size": "18",
-            "height": 5,
-            "html": "Throughput",
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "viz": "note",
-            "width": 47,
-            "x": 69,
-            "y": 1
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": "aiq-tfk-a4n",
-            "font_size": "18",
-            "height": 6,
-            "html": "Processor and network",
-            "isShared": false,
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 96,
-            "x": 20,
-            "y": 62
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 15,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:sap_hana.volume.io.read.count{*} by {hana_host}.as_count(), avg:sap_hana.volume.io.write.count{*} by {hana_host}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "title_align": "left",
-                "title_size": "16",
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average read and write I/O count",
-            "type": "timeseries",
-            "width": 47,
-            "x": 69,
-            "y": 43
+        "layout": {
+          "x": 20,
+          "y": 1,
+          "width": 47,
+          "height": 5
         }
-    ]
-}
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "image",
+          "url": "/static/images/saas_logos/bot/sap_hana.png",
+          "sizing": "fit"
+        },
+        "layout": {
+          "x": 1,
+          "y": 1,
+          "width": 18,
+          "height": 12
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sap_hana.memory.service.overall.utilized{service_name:compileserver}, avg:sap_hana.memory.service.overall.utilized{service_name:nameserver}, avg:sap_hana.memory.service.overall.utilized{service_name:indexserver}, avg:sap_hana.memory.service.overall.utilized{service_name:preprocessor}, avg:sap_hana.memory.service.overall.utilized{service_name:webdispatcher}",
+              "display_type": "area",
+              "style": {
+                "palette": "cool",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average memory utilization by service (%)",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 20,
+          "y": 7,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sap_hana.cpu.service.utilized{*} by {hana_host}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "CPU utilization",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 20,
+          "y": 69,
+          "width": 47,
+          "height": 17
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sap_hana.connection.idle{*}, avg:sap_hana.connection.running{*}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average connections (idle and running)",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 69,
+          "y": 69,
+          "width": 47,
+          "height": 17
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sap_hana.disk.free{*}, avg:sap_hana.disk.used{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average disk free and disk used",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 20,
+          "y": 45,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:sap_hana.disk.utilized{*}",
+              "aggregator": "avg",
+              "conditional_formats": [
+                {
+                  "comparator": "<",
+                  "value": 70,
+                  "palette": "white_on_green"
+                },
+                {
+                  "comparator": ">=",
+                  "value": 70,
+                  "palette": "white_on_yellow"
+                },
+                {
+                  "comparator": ">=",
+                  "value": 80,
+                  "palette": "white_on_red"
+                }
+              ]
+            }
+          ],
+          "custom_links": [],
+          "title": "Disk utilization",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "15m"
+          },
+          "autoscale": true,
+          "custom_unit": "%",
+          "precision": 2
+        },
+        "layout": {
+          "x": 1,
+          "y": 14,
+          "width": 18,
+          "height": 15
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sap_hana.memory.row_store.utilized{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "cool",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average row store memory utilization (%)",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 20,
+          "y": 23,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sap_hana.thread.service.active{*}, avg:sap_hana.thread.service.inactive{*}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Count of active and inactive threads",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 20,
+          "y": 87,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 9,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:sap_hana.backup.latest{*}/60",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Time since last backup",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "15m"
+          },
+          "autoscale": true,
+          "custom_unit": "min",
+          "precision": 0
+        },
+        "layout": {
+          "x": 1,
+          "y": 30,
+          "width": 18,
+          "height": 15
+        }
+      },
+      {
+        "id": 10,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sap_hana.volume.io.throughput{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average throughput",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 69,
+          "y": 25,
+          "width": 47,
+          "height": 17
+        }
+      },
+      {
+        "id": 11,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sap_hana.volume.io.utilized{*}, avg:sap_hana.volume.io.read.utilized{*}, avg:sap_hana.volume.io.write.utilized{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average read, write, and total I/O time (%)",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 69,
+          "y": 7,
+          "width": 47,
+          "height": 17
+        }
+      },
+      {
+        "id": 12,
+        "definition": {
+          "type": "note",
+          "content": "Storage",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 20,
+          "y": 39,
+          "width": 47,
+          "height": 5
+        }
+      },
+      {
+        "id": 13,
+        "definition": {
+          "type": "note",
+          "content": "Throughput",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 69,
+          "y": 1,
+          "width": 47,
+          "height": 5
+        }
+      },
+      {
+        "id": 14,
+        "definition": {
+          "type": "note",
+          "content": "Processor and network",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 20,
+          "y": 62,
+          "width": 96,
+          "height": 6
+        }
+      },
+      {
+        "id": 15,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sap_hana.volume.io.read.count{*} by {hana_host}.as_count(), avg:sap_hana.volume.io.write.count{*} by {hana_host}.as_count()",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average read and write I/O count",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 69,
+          "y": 43,
+          "width": 47,
+          "height": 17
+        }
+      }
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30294
+  }

--- a/scylla/assets/dashboards/overview.json
+++ b/scylla/assets/dashboards/overview.json
@@ -1,738 +1,538 @@
 {
-  "board_title": "Scylla",
-  "read_only": false,
-  "author_info": {
-    "author_name": "Datadog"
-  },
+  "title": "Scylla",
   "description": "This dashboard provides a high-level overview of your Scylla cluster to help you monitor its performance and resource usage. \n\nClone this template dashboard to make changes and add your own graphs and widgets.\n\n",
-  "created": "2020-02-07T21:22:26.961963+00:00",
-  "created_by": {
-    "access_role": "adm",
-    "disabled": false,
-    "email": "support@datadoghq.com",
-    "handle": "support@datadoghq.com",
-    "is_admin": true,
-    "name": "Datadog",
-    "role": null,
-    "verified": true
-  },
-  "new_id": "xie-6ja-hxz",
-  "modified": "2020-02-18T23:24:50.944728+00:00",
-  "originalHeight": 80,
-  "template_variables": [
-    {
-      "default": "*",
-      "prefix": "host",
-      "name": "host"
-    }
-  ],
-  "isIntegration": false,
-  "disableEditing": false,
-  "originalWidth": "calc(100% - 32px)",
   "widgets": [
     {
-      "title_size": "16",
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_text": "Node status",
-      "height": 37,
-      "tile_def": {
-        "viz": "query_table",
+      "id": 0,
+      "definition": {
+        "type": "query_table",
         "requests": [
           {
+            "q": "avg:scylla.node.operation_mode{*} by {server}",
             "aggregator": "last",
+            "limit": 50,
+            "order": "desc",
+            "alias": "Operation Mode",
             "conditional_formats": [
               {
-                "palette": "white_on_gray",
                 "comparator": "<=",
-                "value": 0
+                "value": 0,
+                "palette": "white_on_gray"
               },
               {
-                "palette": "white_on_green",
                 "comparator": "<=",
-                "value": 3
+                "value": 3,
+                "palette": "white_on_green"
               },
               {
-                "palette": "white_on_red",
                 "comparator": ">",
-                "value": 3
+                "value": 3,
+                "palette": "white_on_red"
               }
-            ],
-            "q": "avg:scylla.node.operation_mode{*} by {server}",
-            "alias": "Operation Mode",
-            "limit": 50,
-            "order": "desc"
+            ]
           }
-        ]
+        ],
+        "custom_links": [],
+        "title": "Node status",
+        "title_size": "16",
+        "title_align": "left"
       },
-      "viz": "query_table",
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "error": null,
-      "y": 14,
-      "x": 1,
-      "isShared": false,
-      "type": "query_table",
-      "width": 30,
-      "add_timeframe": true
+      "layout": {
+        "x": 1,
+        "y": 14,
+        "width": 30,
+        "height": 39
+      }
     },
     {
-      "sizing": "fit",
-      "title": false,
-      "url": "/static/images/saas_logos/bot/scylla@2x.svg",
-      "type": "image",
-      "height": 12,
-      "width": 30,
-      "y": 1,
-      "x": 1,
-      "add_timeframe": true,
-      "margin": "",
-      "isShared": false
+      "id": 1,
+      "definition": {
+        "type": "image",
+        "url": "/static/images/saas_logos/bot/scylla@2x.svg",
+        "sizing": "fit"
+      },
+      "layout": {
+        "x": 1,
+        "y": 1,
+        "width": 30,
+        "height": 12
+      }
     },
     {
-      "isShared": false,
-      "title_align": "left",
-      "title_size": "16",
-      "time": {},
-      "title": true,
-      "yaxis": {
-        "max": "100",
-        "min": "0"
-      },
-      "markers": [],
-      "height": 16,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 2,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "avg:scylla.reactor.utilization{$host} by {server,shard}",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "markers": [],
+        "custom_links": [],
         "yaxis": {
-          "max": "100",
-          "min": "0"
-        }
+          "min": "0",
+          "max": "100"
+        },
+        "title": "CPU utilization (%)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
       },
-      "width": 38,
-      "title_text": "CPU utilization (%)",
-      "error": null,
-      "y": 8,
-      "x": 72,
-      "add_timeframe": true,
-      "type": "timeseries",
-      "legend": false,
-      "viz": "timeseries",
-      "sharedGlobalTime": {
-        "live_span": "1h"
+      "layout": {
+        "x": 72,
+        "y": 8,
+        "width": 38,
+        "height": 18
       }
     },
     {
-      "isShared": false,
-      "title_align": "left",
-      "title_size": "16",
-      "time": {},
-      "title": true,
-      "yaxis": {
-        "min": "auto",
-        "max": "auto",
-        "scale": "linear",
-        "label": "",
-        "includeZero": true
-      },
-      "markers": [],
-      "height": 16,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 3,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "sum:scylla.transport.requests_served{$host} by {server,shard}.as_count()",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "markers": [],
+        "custom_links": [],
         "yaxis": {
+          "label": "",
+          "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "scale": "linear",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "Requests served",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
       },
-      "width": 38,
-      "title_text": "Requests served",
-      "error": null,
-      "y": 8,
-      "x": 33,
-      "add_timeframe": true,
-      "type": "timeseries",
-      "legend": false,
-      "viz": "timeseries",
-      "sharedGlobalTime": {
-        "live_span": "1h"
+      "layout": {
+        "x": 33,
+        "y": 8,
+        "width": 38,
+        "height": 18
       }
     },
     {
-      "isShared": false,
-      "tick_pos": "50%",
-      "show_tick": true,
-      "title": false,
-      "refresh_every": 30000,
-      "type": "note",
-      "tick_edge": "bottom",
-      "text_align": "center",
-      "height": 5,
-      "content": "Read Performance",
-      "bgcolor": "gray",
-      "html": "Read Performance",
-      "y": 28,
-      "x": 33,
-      "font_size": "18",
-      "tick": true,
-      "background_color": "gray",
-      "width": 38,
-      "auto_refresh": false,
-      "add_timeframe": true
+      "id": 4,
+      "definition": {
+        "type": "note",
+        "content": "Read Performance",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 33,
+        "y": 28,
+        "width": 38,
+        "height": 5
+      }
     },
     {
-      "isShared": false,
-      "title_align": "left",
-      "title_size": "16",
-      "time": {},
-      "title": true,
-      "yaxis": {
-        "min": "auto",
-        "max": "auto",
-        "scale": "linear",
-        "label": "",
-        "includeZero": true
-      },
-      "markers": [],
-      "height": 16,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 5,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "sum:scylla.storage.proxy.coordinator_write_latency.sum{$host} by {server}/sum:scylla.storage.proxy.coordinator_write_latency.count{$host,upper_bound:none} by {server}",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "purple",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "markers": [],
+        "custom_links": [],
         "yaxis": {
+          "label": "",
+          "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "scale": "linear",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "Average write latency",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 38,
-      "title_text": "Average write latency",
-      "error": null,
-      "y": 54,
-      "x": 72,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "type": "timeseries",
-      "legend": false,
-      "viz": "timeseries",
-      "sharedGlobalTime": {
-        "live_span": "1h"
+      "layout": {
+        "x": 72,
+        "y": 54,
+        "width": 38,
+        "height": 18
       }
     },
     {
-      "isShared": false,
-      "title_align": "left",
-      "title_size": "16",
-      "time": {},
-      "title": true,
-      "yaxis": {
-        "min": "auto",
-        "max": "auto",
-        "scale": "linear",
-        "label": "",
-        "includeZero": true
-      },
-      "markers": [],
-      "height": 16,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 6,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "sum:scylla.storage.proxy.coordinator_read_latency.sum{$host} by {server}/sum:scylla.storage.proxy.coordinator_read_latency.count{$host,upper_bound:none} by {server}",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "green",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "markers": [],
+        "custom_links": [],
         "yaxis": {
+          "label": "",
+          "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "scale": "linear",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "Average read latency",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 38,
-      "title_text": "Average read latency",
-      "error": null,
-      "y": 54,
-      "x": 33,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "type": "timeseries",
-      "legend": false,
-      "viz": "timeseries",
-      "sharedGlobalTime": {
-        "live_span": "1h"
+      "layout": {
+        "x": 33,
+        "y": 54,
+        "width": 38,
+        "height": 18
       }
     },
     {
-      "isShared": false,
-      "title_align": "left",
-      "title_size": "16",
-      "time": {},
-      "title": true,
-      "yaxis": {
-        "min": "auto",
-        "max": "auto",
-        "scale": "linear",
-        "label": "",
-        "includeZero": true
-      },
-      "markers": [],
-      "height": 16,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 7,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "avg:scylla.cache.row_hits{$host} by {server}.as_count()",
+            "display_type": "bars",
             "style": {
-              "width": "normal",
               "palette": "cool",
-              "type": "solid"
-            },
-            "type": "bars"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "markers": [],
+        "custom_links": [],
         "yaxis": {
+          "label": "",
+          "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "scale": "linear",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "Cache hits",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
       },
-      "width": 38,
-      "title_text": "Cache hits",
-      "error": null,
-      "y": 8,
-      "x": 112,
-      "add_timeframe": true,
-      "type": "timeseries",
-      "legend": false,
-      "viz": "timeseries",
-      "sharedGlobalTime": {
-        "live_span": "1h"
+      "layout": {
+        "x": 112,
+        "y": 8,
+        "width": 38,
+        "height": 18
       }
     },
     {
-      "isShared": false,
-      "title_align": "left",
-      "title_size": "16",
-      "time": {},
-      "title": true,
-      "yaxis": {
-        "min": "auto",
-        "max": "auto",
-        "scale": "linear",
-        "label": "",
-        "includeZero": true
-      },
-      "markers": [],
-      "height": 16,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 8,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "avg:scylla.cache.row_misses{$host} by {server}.as_count()",
+            "display_type": "bars",
             "style": {
-              "width": "normal",
               "palette": "warm",
-              "type": "solid"
-            },
-            "type": "bars"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "markers": [],
+        "custom_links": [],
         "yaxis": {
+          "label": "",
+          "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "scale": "linear",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "Cache misses",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 38,
-      "title_text": "Cache misses",
-      "error": null,
-      "y": 27,
-      "x": 112,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "type": "timeseries",
-      "legend": false,
-      "viz": "timeseries",
-      "sharedGlobalTime": {
-        "live_span": "1h"
+      "layout": {
+        "x": 112,
+        "y": 27,
+        "width": 38,
+        "height": 18
       }
     },
     {
-      "isShared": false,
-      "title_align": "left",
-      "title_size": "16",
-      "time": {},
-      "title": true,
-      "yaxis": {
-        "min": "auto",
-        "max": "auto",
-        "scale": "linear",
-        "label": "",
-        "includeZero": true
-      },
-      "markers": [],
-      "height": 16,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 9,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "avg:scylla.storage.proxy.coordinator_read_timeouts{$host} by {server}.as_count()",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "green",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "markers": [],
+        "custom_links": [],
         "yaxis": {
+          "label": "",
+          "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "scale": "linear",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "Read timeouts",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 38,
-      "title_text": "Read timeouts",
-      "error": null,
-      "y": 73,
-      "x": 33,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "type": "timeseries",
-      "legend": false,
-      "viz": "timeseries",
-      "sharedGlobalTime": {
-        "live_span": "1h"
+      "layout": {
+        "x": 33,
+        "y": 73,
+        "width": 38,
+        "height": 18
       }
     },
     {
-      "isShared": false,
-      "title_align": "left",
-      "title_size": "16",
-      "time": {},
-      "title": true,
-      "yaxis": {
-        "min": "auto",
-        "max": "auto",
-        "scale": "linear",
-        "label": "",
-        "includeZero": true
-      },
-      "markers": [],
-      "height": 16,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 10,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "avg:scylla.storage.proxy.coordinator_write_timeouts{$host} by {server}.as_count()",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "purple",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "markers": [],
+        "custom_links": [],
         "yaxis": {
+          "label": "",
+          "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "scale": "linear",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "Write timeouts",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 38,
-      "title_text": "Write timeouts",
-      "error": null,
-      "y": 73,
-      "x": 72,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "type": "timeseries",
-      "legend": false,
-      "viz": "timeseries",
-      "sharedGlobalTime": {
-        "live_span": "1h"
+      "layout": {
+        "x": 72,
+        "y": 73,
+        "width": 38,
+        "height": 18
       }
     },
     {
-      "isShared": false,
-      "title_align": "left",
-      "title_size": "16",
-      "time": {},
-      "title": true,
-      "yaxis": {
-        "min": "auto",
-        "max": "auto",
-        "scale": "linear",
-        "label": "",
-        "includeZero": true
-      },
-      "markers": [],
-      "height": 16,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 11,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "sum:scylla.storage.proxy.coordinator_total_write_attempts_local_node{$host} by {server,shard}.as_count()",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "purple",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "markers": [],
+        "custom_links": [],
         "yaxis": {
+          "label": "",
+          "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "scale": "linear",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "Write requests",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false
       },
-      "width": 38,
-      "title_text": "Write requests",
-      "error": null,
-      "y": 35,
-      "x": 72,
-      "add_timeframe": true,
-      "type": "timeseries",
-      "legend": false,
-      "viz": "timeseries",
-      "sharedGlobalTime": {
-        "live_span": "1h"
+      "layout": {
+        "x": 72,
+        "y": 35,
+        "width": 38,
+        "height": 18
       }
     },
     {
-      "isShared": false,
-      "title_align": "left",
-      "title_size": "16",
-      "time": {},
-      "title": true,
-      "yaxis": {
-        "min": "auto",
-        "max": "auto",
-        "scale": "linear",
-        "label": "",
-        "includeZero": true
-      },
-      "markers": [],
-      "height": 16,
-      "tile_def": {
-        "viz": "timeseries",
+      "id": 12,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "sum:scylla.storage.proxy.coordinator_reads_local_node{$host} by {server,shard}.as_count()",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "green",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "markers": [],
+        "custom_links": [],
         "yaxis": {
+          "label": "",
+          "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "scale": "linear",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "Read requests",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 38,
-      "title_text": "Read requests",
-      "error": null,
-      "y": 35,
-      "x": 33,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "type": "timeseries",
-      "legend": false,
-      "viz": "timeseries",
-      "sharedGlobalTime": {
-        "live_span": "1h"
+      "layout": {
+        "x": 33,
+        "y": 35,
+        "width": 38,
+        "height": 18
       }
     },
     {
-      "isShared": false,
-      "tick_pos": "50%",
-      "show_tick": true,
-      "title": false,
-      "refresh_every": 30000,
-      "type": "note",
-      "tick_edge": "bottom",
-      "text_align": "center",
-      "height": 5,
-      "content": "Write Performance",
-      "bgcolor": "gray",
-      "html": "Write Performance",
-      "y": 28,
-      "x": 72,
-      "font_size": "18",
-      "tick": true,
-      "background_color": "gray",
-      "width": 38,
-      "auto_refresh": false,
-      "add_timeframe": true
-    },
-    {
-      "isShared": false,
-      "tick_pos": "50%",
-      "show_tick": true,
-      "title": false,
-      "refresh_every": 30000,
-      "type": "note",
-      "tick_edge": "bottom",
-      "text_align": "center",
-      "height": 5,
-      "content": "Resource Utilization",
-      "bgcolor": "gray",
-      "html": "Resource Utilization",
-      "scaleFactor": 1,
-      "y": 1,
-      "x": 33,
-      "font_size": "18",
-      "tick": true,
-      "background_color": "gray",
-      "width": 77,
-      "auto_refresh": false,
-      "add_timeframe": true
-    },
-    {
-      "isShared": false,
-      "tick_pos": "50%",
-      "show_tick": true,
-      "title": false,
-      "refresh_every": 30000,
-      "type": "note",
-      "tick_edge": "bottom",
-      "text_align": "center",
-      "height": 5,
-      "content": "Cache",
-      "bgcolor": "gray",
-      "html": "Cache",
-      "y": 1,
-      "x": 112,
-      "font_size": "18",
-      "tick": true,
-      "background_color": "gray",
-      "width": 38,
-      "auto_refresh": false,
-      "add_timeframe": true
-    },
-    {
-      "isShared": false,
-      "title_align": "left",
-      "title_size": "16",
-      "time": {},
-      "title": true,
-      "yaxis": {
-        "min": "auto",
-        "max": "auto",
-        "scale": "linear",
-        "label": "",
-        "includeZero": true
+      "id": 13,
+      "definition": {
+        "type": "note",
+        "content": "Write Performance",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
       },
-      "markers": [],
-      "height": 16,
-      "tile_def": {
-        "viz": "timeseries",
+      "layout": {
+        "x": 72,
+        "y": 28,
+        "width": 38,
+        "height": 5
+      }
+    },
+    {
+      "id": 14,
+      "definition": {
+        "type": "note",
+        "content": "Resource Utilization",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 33,
+        "y": 1,
+        "width": 77,
+        "height": 5
+      }
+    },
+    {
+      "id": 15,
+      "definition": {
+        "type": "note",
+        "content": "Cache",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 112,
+        "y": 1,
+        "width": 38,
+        "height": 5
+      }
+    },
+    {
+      "id": 16,
+      "definition": {
+        "type": "timeseries",
         "requests": [
           {
             "q": "sum:scylla.cache.bytes_used{$host} by {server}, sum:scylla.cache.bytes_used{$host} by {server}/1000000",
+            "display_type": "line",
             "style": {
-              "width": "normal",
               "palette": "warm",
-              "type": "solid"
-            },
-            "type": "line"
+              "line_type": "solid",
+              "line_width": "normal"
+            }
           }
         ],
-        "markers": [],
+        "custom_links": [],
         "yaxis": {
+          "label": "",
+          "scale": "linear",
           "min": "auto",
           "max": "auto",
-          "scale": "linear",
-          "label": "",
-          "includeZero": true
-        }
+          "include_zero": true
+        },
+        "title": "Cache MB used",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
       },
-      "width": 38,
-      "title_text": "Cache MB used",
-      "error": null,
-      "y": 46,
-      "x": 112,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "type": "timeseries",
-      "legend": false,
-      "viz": "timeseries",
-      "sharedGlobalTime": {
-        "live_span": "1h"
+      "layout": {
+        "x": 112,
+        "y": 46,
+        "width": 38,
+        "height": 18
       }
     }
   ],
-  "disableCog": false,
-  "id": 973385,
-  "isShared": false
+  "template_variables": [
+    {
+      "name": "host",
+      "default": "*",
+      "prefix": "host"
+    }
+  ],
+  "layout_type": "free",
+  "is_read_only": true,
+  "notify_list": [],
+  "id": 30313
 }

--- a/sidekiq/assets/dashboards/overview.json
+++ b/sidekiq/assets/dashboards/overview.json
@@ -1,542 +1,561 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "Sidekiq Overview",
-    "created": "2020-04-01T14:19:50.912045+00:00",
-    "created_by": {
-        "access_role": "st",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": false,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "Sidekiq Overview",
     "description": "This dashboard provides a high-level overview of your Sidekiq deployment so you can monitor metrics related to jobs, queues, and batches.\n\nFor further reading on monitoring Sidekiq, see our [official Sidekiq integration documentation](https://docs.datadoghq.com/integrations/sidekiq/).\n\nClone this template to make changes and add your own graphs and widgets.",
-    "id": 1038262,
-    "modified": "2020-04-02T18:40:12.613606+00:00",
-    "new_id": "u7k-5bn-7ui",
-    "read_only": false,
-    "template_variables": [],
     "widgets": [
-        {
-            "height": 7,
-            "id": 0,
-            "sizing": "zoom",
-            "type": "image",
-            "url": "https://static.datadoghq.com/static/images/saas_logos/bot/sidekiq@2x.png",
-            "width": 25,
-            "x": 1,
-            "y": 1
+      {
+        "id": 0,
+        "definition": {
+          "type": "image",
+          "url": "https://static.datadoghq.com/static/images/saas_logos/bot/sidekiq@2x.png",
+          "sizing": "zoom"
         },
-        {
-            "height": 12,
-            "id": 1,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:sidekiq.busy{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Busy Jobs",
-            "type": "timeseries",
-            "width": 41,
-            "x": 28,
-            "y": 39
-        },
-        {
-            "height": 12,
-            "id": 2,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "diff(avg:sidekiq.dead{*})",
-                        "style": {
-                            "palette": "grey",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Dead Jobs",
-            "type": "timeseries",
-            "width": 41,
-            "x": 28,
-            "y": 54
-        },
-        {
-            "height": 12,
-            "id": 3,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "diff(avg:sidekiq.failed{*})",
-                        "style": {
-                            "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Failed Jobs",
-            "type": "timeseries",
-            "width": 41,
-            "x": 71,
-            "y": 54
-        },
-        {
-            "height": 12,
-            "id": 4,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "diff(avg:sidekiq.retries{*})",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Retries",
-            "type": "timeseries",
-            "width": 41,
-            "x": 71,
-            "y": 39
-        },
-        {
-            "height": 12,
-            "id": 5,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "diff(avg:sidekiq.processed{*})",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Processed Jobs",
-            "type": "timeseries",
-            "width": 41,
-            "x": 71,
-            "y": 9
-        },
-        {
-            "height": 12,
-            "id": 6,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:sidekiq.enqueued{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Enqueued Jobs",
-            "type": "timeseries",
-            "width": 41,
-            "x": 28,
-            "y": 9
-        },
-        {
-            "height": 12,
-            "id": 7,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:sidekiq.scheduled{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Scheduled jobs",
-            "type": "timeseries",
-            "width": 41,
-            "x": 28,
-            "y": 24
-        },
-        {
-            "height": 12,
-            "id": 8,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:sidekiq.jobs.perform.median{*}, avg:sidekiq.jobs.perform.avg{*}, avg:sidekiq.jobs.perform.count{*}, avg:sidekiq.jobs.perform.max{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Job Performance",
-            "type": "timeseries",
-            "width": 25,
-            "x": 1,
-            "y": 46
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 6,
-            "html": "Job Status",
-            "id": 9,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 41,
-            "x": 71,
-            "y": 1
-        },
-        {
-            "height": 7,
-            "id": 10,
-            "tile_def": {
-                "autoscale": true,
-                "precision": 0,
-                "requests": [
-                    {
-                        "aggregator": "last",
-                        "q": "avg:sidekiq.processed{*}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Processed",
-            "type": "query_value",
-            "width": 12,
-            "x": 1,
-            "y": 61
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 6,
-            "html": "Summary",
-            "id": 11,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 25,
-            "x": 1,
-            "y": 9
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 6,
-            "html": "Queue Status",
-            "id": 12,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 41,
-            "x": 28,
-            "y": 1
-        },
-        {
-            "height": 7,
-            "id": 13,
-            "tile_def": {
-                "autoscale": true,
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "last",
-                        "q": "avg:sidekiq.busy{*}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Busy",
-            "type": "query_value",
-            "width": 12,
-            "x": 14,
-            "y": 27
-        },
-        {
-            "height": 7,
-            "id": 14,
-            "tile_def": {
-                "autoscale": true,
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "last",
-                        "q": "avg:sidekiq.dead{*}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Dead",
-            "type": "query_value",
-            "width": 12,
-            "x": 1,
-            "y": 27
-        },
-        {
-            "height": 7,
-            "id": 15,
-            "tile_def": {
-                "autoscale": true,
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "last",
-                        "q": "avg:sidekiq.enqueued{*}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Enqueued",
-            "type": "query_value",
-            "width": 12,
-            "x": 14,
-            "y": 17
-        },
-        {
-            "height": 7,
-            "id": 16,
-            "tile_def": {
-                "autoscale": true,
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "last",
-                        "q": "avg:sidekiq.scheduled{*}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Scheduled",
-            "type": "query_value",
-            "width": 12,
-            "x": 1,
-            "y": 17
-        },
-        {
-            "height": 12,
-            "id": 17,
-            "legend": false,
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:sidekiq.jobs.success{*}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Successful Jobs",
-            "type": "timeseries",
-            "width": 41,
-            "x": 71,
-            "y": 24
-        },
-        {
-            "height": 7,
-            "id": 18,
-            "tile_def": {
-                "autoscale": true,
-                "custom_unit": "%",
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "100*diff(avg:sidekiq.failed{*})/diff(avg:sidekiq.processed{*})"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Failure Rate",
-            "type": "query_value",
-            "width": 12,
-            "x": 14,
-            "y": 61
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 6,
-            "html": "Analytics",
-            "id": 19,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 25,
-            "x": 1,
-            "y": 38
+        "layout": {
+          "x": 1,
+          "y": 1,
+          "width": 25,
+          "height": 7
         }
-    ]
-}
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sidekiq.busy{*}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Busy Jobs",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 28,
+          "y": 39,
+          "width": 41,
+          "height": 14
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "diff(avg:sidekiq.dead{*})",
+              "display_type": "bars",
+              "style": {
+                "palette": "grey",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Dead Jobs",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 28,
+          "y": 54,
+          "width": 41,
+          "height": 14
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "diff(avg:sidekiq.failed{*})",
+              "display_type": "bars",
+              "style": {
+                "palette": "warm",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Failed Jobs",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 71,
+          "y": 54,
+          "width": 41,
+          "height": 14
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "diff(avg:sidekiq.retries{*})",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Retries",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 71,
+          "y": 39,
+          "width": 41,
+          "height": 14
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "diff(avg:sidekiq.processed{*})",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Processed Jobs",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 71,
+          "y": 9,
+          "width": 41,
+          "height": 14
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sidekiq.enqueued{*}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Enqueued Jobs",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 28,
+          "y": 9,
+          "width": 41,
+          "height": 14
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sidekiq.scheduled{*}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Scheduled jobs",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 28,
+          "y": 24,
+          "width": 41,
+          "height": 14
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sidekiq.jobs.perform.median{*}, avg:sidekiq.jobs.perform.avg{*}, avg:sidekiq.jobs.perform.count{*}, avg:sidekiq.jobs.perform.max{*}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Job Performance",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 1,
+          "y": 46,
+          "width": 25,
+          "height": 14
+        }
+      },
+      {
+        "id": 9,
+        "definition": {
+          "type": "note",
+          "content": "Job Status",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 71,
+          "y": 1,
+          "width": 41,
+          "height": 6
+        }
+      },
+      {
+        "id": 10,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:sidekiq.processed{*}",
+              "aggregator": "last"
+            }
+          ],
+          "custom_links": [],
+          "title": "Processed",
+          "title_size": "16",
+          "title_align": "left",
+          "autoscale": true,
+          "precision": 0
+        },
+        "layout": {
+          "x": 1,
+          "y": 61,
+          "width": 12,
+          "height": 9
+        }
+      },
+      {
+        "id": 11,
+        "definition": {
+          "type": "note",
+          "content": "Summary",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 1,
+          "y": 9,
+          "width": 25,
+          "height": 6
+        }
+      },
+      {
+        "id": 12,
+        "definition": {
+          "type": "note",
+          "content": "Queue Status",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 28,
+          "y": 1,
+          "width": 41,
+          "height": 6
+        }
+      },
+      {
+        "id": 13,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:sidekiq.busy{*}",
+              "aggregator": "last"
+            }
+          ],
+          "custom_links": [],
+          "title": "Busy",
+          "title_size": "16",
+          "title_align": "left",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 14,
+          "y": 27,
+          "width": 12,
+          "height": 9
+        }
+      },
+      {
+        "id": 14,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:sidekiq.dead{*}",
+              "aggregator": "last"
+            }
+          ],
+          "custom_links": [],
+          "title": "Dead",
+          "title_size": "16",
+          "title_align": "left",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 1,
+          "y": 27,
+          "width": 12,
+          "height": 9
+        }
+      },
+      {
+        "id": 15,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:sidekiq.enqueued{*}",
+              "aggregator": "last"
+            }
+          ],
+          "custom_links": [],
+          "title": "Enqueued",
+          "title_size": "16",
+          "title_align": "left",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 14,
+          "y": 17,
+          "width": 12,
+          "height": 9
+        }
+      },
+      {
+        "id": 16,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:sidekiq.scheduled{*}",
+              "aggregator": "last"
+            }
+          ],
+          "custom_links": [],
+          "title": "Scheduled",
+          "title_size": "16",
+          "title_align": "left",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 1,
+          "y": 17,
+          "width": 12,
+          "height": 9
+        }
+      },
+      {
+        "id": 17,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:sidekiq.jobs.success{*}.as_count()",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "yaxis": {
+            "label": "",
+            "scale": "linear",
+            "min": "auto",
+            "max": "auto",
+            "include_zero": true
+          },
+          "title": "Successful Jobs",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false
+        },
+        "layout": {
+          "x": 71,
+          "y": 24,
+          "width": 41,
+          "height": 14
+        }
+      },
+      {
+        "id": 18,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "100*diff(avg:sidekiq.failed{*})/diff(avg:sidekiq.processed{*})",
+              "aggregator": "sum"
+            }
+          ],
+          "custom_links": [],
+          "title": "Failure Rate",
+          "title_size": "16",
+          "title_align": "left",
+          "autoscale": true,
+          "custom_unit": "%",
+          "precision": 2
+        },
+        "layout": {
+          "x": 14,
+          "y": 61,
+          "width": 12,
+          "height": 9
+        }
+      },
+      {
+        "id": 19,
+        "definition": {
+          "type": "note",
+          "content": "Analytics",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 1,
+          "y": 38,
+          "width": 25,
+          "height": 6
+        }
+      }
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30314
+  }

--- a/systemd/assets/dashboards/overview.json
+++ b/systemd/assets/dashboards/overview.json
@@ -1,604 +1,455 @@
 {
-  "author_info": {
-    "author_name": "Datadog"
-  },
-  "board_bgtype": "board_graph",
-  "board_title": "Systemd Overview",
-  "created": "2019-07-15T11:02:50.756729+00:00",
-  "created_by": {
-    "access_role": "st",
-    "disabled": false,
-    "email": "support@datadoghq.com",
-    "handle": "support@datadoghq.com",
-    "is_admin": false,
-    "name": "Datadog",
-    "role": null,
-    "verified": true
-  },
+  "title": "Systemd Overview",
   "description": "This dashboard provides an overview of Systemd units and metrics on specific services/sockets to help you monitor and investigate issues. Further reading on Systemd monitoring:\n\n- [Datadog’s Systemd integration docs](https://docs.datadoghq.com/integrations/systemd/)\n\nClone this template dashboard to make changes and add your own graphs and widgets.",
-  "disableCog": false,
-  "disableEditing": false,
-  "height": 111,
-  "id": 783595,
-  "isIntegration": false,
-  "isShared": false,
-  "modified": "2019-07-30T17:02:45.880897+00:00",
-  "new_id": "my7-n2s-zrw",
-  "originalHeight": 80,
-  "originalWidth": "100%",
-  "read_only": false,
+  "widgets": [
+    {
+      "id": 0,
+      "definition": {
+        "type": "image",
+        "url": "https://s3.amazonaws.com/dd-integrations/systemd/configuration/tile/logo.png",
+        "sizing": "zoom"
+      },
+      "layout": {
+        "x": 1,
+        "y": 1,
+        "width": 15,
+        "height": 14
+      }
+    },
+    {
+      "id": 1,
+      "definition": {
+        "type": "note",
+        "content": "All Units",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 17,
+        "y": 1,
+        "width": 57,
+        "height": 6
+      }
+    },
+    {
+      "id": 2,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:systemd.units_by_state{$scope}",
+            "style": {
+              "palette": "dog_classic"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Unit Count",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 17,
+        "y": 8,
+        "width": 57,
+        "height": 15
+      }
+    },
+    {
+      "id": 3,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:systemd.units_loaded_count{$scope}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Unit Loaded",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 17,
+        "y": 24,
+        "width": 57,
+        "height": 15
+      }
+    },
+    {
+      "id": 4,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:systemd.units_by_state{$scope} by {state}",
+            "display_type": "area",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Unit Count by State",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 17,
+        "y": 40,
+        "width": 57,
+        "height": 45
+      }
+    },
+    {
+      "id": 5,
+      "definition": {
+        "type": "note",
+        "content": "Cron Service",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 75,
+        "y": 1,
+        "width": 75,
+        "height": 6
+      }
+    },
+    {
+      "id": 6,
+      "definition": {
+        "type": "check_status",
+        "title": "Can Connect",
+        "title_size": "16",
+        "title_align": "center",
+        "check": "systemd.can_connect",
+        "grouping": "cluster",
+        "group": "host:ubuntu-xenial-alex-test",
+        "group_by": [],
+        "tags": [
+          "*"
+        ]
+      },
+      "layout": {
+        "x": 1,
+        "y": 16,
+        "width": 15,
+        "height": 14
+      }
+    },
+    {
+      "id": 7,
+      "definition": {
+        "type": "check_status",
+        "title": "System State",
+        "title_size": "16",
+        "title_align": "center",
+        "check": "systemd.system.state",
+        "grouping": "cluster",
+        "group": "host:ubuntu-xenial-alex-test",
+        "group_by": [],
+        "tags": [
+          "*"
+        ]
+      },
+      "layout": {
+        "x": 1,
+        "y": 31,
+        "width": 15,
+        "height": 14
+      }
+    },
+    {
+      "id": 8,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:systemd.service.memory_usage{unit:cron.service,$scope}",
+            "style": {
+              "palette": "dog_classic"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Cron Memory Usage",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 113,
+        "y": 24,
+        "width": 37,
+        "height": 15
+      }
+    },
+    {
+      "id": 9,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:systemd.service.cpu_time_consumed{unit:cron.service,$scope}",
+            "style": {
+              "palette": "dog_classic"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Cron CPU Usage",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 113,
+        "y": 8,
+        "width": 37,
+        "height": 15
+      }
+    },
+    {
+      "id": 10,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:systemd.service.restart_count{$scope,unit:ssh.service}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "SSH Restarts",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 113,
+        "y": 47,
+        "width": 37,
+        "height": 15
+      }
+    },
+    {
+      "id": 11,
+      "definition": {
+        "type": "note",
+        "content": "SSH Service",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 75,
+        "y": 40,
+        "width": 75,
+        "height": 6
+      }
+    },
+    {
+      "id": 12,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:systemd.service.task_count{$scope,unit:ssh.service}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "SSH Tasks",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 75,
+        "y": 47,
+        "width": 37,
+        "height": 15
+      }
+    },
+    {
+      "id": 13,
+      "definition": {
+        "type": "note",
+        "content": "Syslog Socket",
+        "background_color": "gray",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 75,
+        "y": 63,
+        "width": 75,
+        "height": 6
+      }
+    },
+    {
+      "id": 14,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:systemd.socket.connection_accepted_count{unit:syslog.socket}",
+            "style": {
+              "palette": "dog_classic"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Syslog Connections Accepted",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 75,
+        "y": 70,
+        "width": 37,
+        "height": 15
+      }
+    },
+    {
+      "id": 15,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:systemd.socket.connection_count{unit:syslog.socket}",
+            "style": {
+              "palette": "dog_classic"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Syslog Current Connections",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 113,
+        "y": 70,
+        "width": 37,
+        "height": 15
+      }
+    },
+    {
+      "id": 16,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:systemd.unit.loaded{$scope,unit:cron.service}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Cron Loaded",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 75,
+        "y": 8,
+        "width": 37,
+        "height": 15
+      }
+    },
+    {
+      "id": 17,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:systemd.unit.active{$scope,unit:cron.service}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "custom_links": [],
+        "title": "Cron Active",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 75,
+        "y": 24,
+        "width": 37,
+        "height": 15
+      }
+    }
+  ],
   "template_variables": [
     {
-      "default": "*",
       "name": "scope",
+      "default": "*",
       "prefix": null
     }
   ],
-  "widgets": [
-    {
-      "add_timeframe": true,
-      "generated_title": "",
-      "height": 14,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "margin": "",
-      "sizing": "zoom",
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "",
-      "type": "image",
-      "url": "https://s3.amazonaws.com/dd-integrations/systemd/configuration/tile/logo.png",
-      "width": 15,
-      "x": 1,
-      "y": 1
-    },
-    {
-      "add_timeframe": true,
-      "auto_refresh": false,
-      "background_color": "gray",
-      "bgcolor": "gray",
-      "content": "All Units",
-      "font_size": "18",
-      "height": 6,
-      "html": "All Units",
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "text_align": "center",
-      "tick": true,
-      "tick_edge": "bottom",
-      "tick_pos": "50%",
-      "title": false,
-      "type": "note",
-      "width": 57,
-      "x": 17,
-      "y": 1
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "tile_def": {
-        "requests": [
-          {
-            "display_type": "line",
-            "q": "sum:systemd.units_by_state{$scope}",
-            "style": {
-              "line_type": "solid",
-              "line_width": "normal",
-              "palette": "dog_classic"
-            }
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Unit Count",
-      "type": "timeseries",
-      "width": 57,
-      "x": 17,
-      "y": 8
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "sum:systemd.units_loaded_count{$scope}",
-            "style": {
-              "line_type": "solid",
-              "line_width": "normal",
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
-            },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Unit Loaded",
-      "type": "timeseries",
-      "width": 57,
-      "x": 17,
-      "y": 24
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 43,
-      "isShared": false,
-      "legend": true,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "sum:systemd.units_by_state{$scope} by {state}",
-            "style": {
-              "line_type": "solid",
-              "line_width": "normal",
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
-            },
-            "type": "area"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Unit Count by State",
-      "type": "timeseries",
-      "width": 57,
-      "x": 17,
-      "y": 40
-    },
-    {
-      "add_timeframe": true,
-      "auto_refresh": false,
-      "background_color": "gray",
-      "bgcolor": "gray",
-      "content": "Service Cron",
-      "font_size": "18",
-      "height": 6,
-      "html": "Cron Service",
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "text_align": "center",
-      "tick": true,
-      "tick_edge": "bottom",
-      "tick_pos": "50%",
-      "title": false,
-      "type": "note",
-      "width": 75,
-      "x": 75,
-      "y": 1
-    },
-    {
-      "add_timeframe": true,
-      "check": "systemd.can_connect",
-      "error": null,
-      "group": "host:ubuntu-xenial-alex-test",
-      "group_by": [],
-      "grouping": "cluster",
-      "height": 14,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "tags": [
-        "*"
-      ],
-      "text_align": "center",
-      "text_size": "auto",
-      "time": {},
-      "title": true,
-      "title_align": "center",
-      "title_size": "16",
-      "title_text": "Can Connect",
-      "type": "check_status",
-      "width": 15,
-      "x": 1,
-      "y": 16
-    },
-    {
-      "add_timeframe": true,
-      "check": "systemd.system.state",
-      "error": null,
-      "group": "host:ubuntu-xenial-alex-test",
-      "group_by": [],
-      "grouping": "cluster",
-      "height": 14,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "tags": [
-        "*"
-      ],
-      "text_align": "center",
-      "text_size": "auto",
-      "time": {},
-      "title": true,
-      "title_align": "center",
-      "title_size": "16",
-      "title_text": "System State",
-      "type": "check_status",
-      "width": 15,
-      "x": 1,
-      "y": 31
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "tile_def": {
-        "requests": [
-          {
-            "display_type": "line",
-            "q": "sum:systemd.service.memory_usage{unit:cron.service,$scope}",
-            "style": {
-              "line_type": "solid",
-              "line_width": "normal",
-              "palette": "dog_classic"
-            }
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Cron Memory Usage",
-      "type": "timeseries",
-      "width": 37,
-      "x": 113,
-      "y": 24
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "tile_def": {
-        "requests": [
-          {
-            "display_type": "line",
-            "q": "avg:systemd.service.cpu_time_consumed{unit:cron.service,$scope}",
-            "style": {
-              "line_type": "solid",
-              "line_width": "normal",
-              "palette": "dog_classic"
-            }
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Cron CPU Usage",
-      "type": "timeseries",
-      "width": 37,
-      "x": 113,
-      "y": 8
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:systemd.service.restart_count{$scope,unit:ssh.service}",
-            "style": {
-              "line_type": "solid",
-              "line_width": "normal",
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
-            },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "SSH Restarts",
-      "type": "timeseries",
-      "width": 37,
-      "x": 113,
-      "y": 47
-    },
-    {
-      "add_timeframe": true,
-      "auto_refresh": false,
-      "background_color": "gray",
-      "bgcolor": "gray",
-      "content": "Service Cron",
-      "font_size": "18",
-      "height": 6,
-      "html": "SSH Service",
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "text_align": "center",
-      "tick": true,
-      "tick_edge": "bottom",
-      "tick_pos": "50%",
-      "title": false,
-      "type": "note",
-      "width": 75,
-      "x": 75,
-      "y": 40
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:systemd.service.task_count{$scope,unit:ssh.service}",
-            "style": {
-              "line_type": "solid",
-              "line_width": "normal",
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
-            },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "SSH Tasks",
-      "type": "timeseries",
-      "width": 37,
-      "x": 75,
-      "y": 47
-    },
-    {
-      "add_timeframe": true,
-      "auto_refresh": false,
-      "background_color": "gray",
-      "bgcolor": "gray",
-      "content": "Service Cron",
-      "font_size": "18",
-      "height": 6,
-      "html": "Syslog Socket",
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "text_align": "center",
-      "tick": true,
-      "tick_edge": "bottom",
-      "tick_pos": "50%",
-      "title": false,
-      "type": "note",
-      "width": 75,
-      "x": 75,
-      "y": 63
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "legend": false,
-      "legend_size": "0",
-      "tile_def": {
-        "requests": [
-          {
-            "display_type": "line",
-            "q": "avg:systemd.socket.connection_accepted_count{unit:syslog.socket}",
-            "style": {
-              "line_type": "solid",
-              "line_width": "normal",
-              "palette": "dog_classic"
-            }
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Syslog Connections Accepted",
-      "type": "timeseries",
-      "width": 37,
-      "x": 75,
-      "y": 70
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "legend": false,
-      "legend_size": "0",
-      "tile_def": {
-        "requests": [
-          {
-            "display_type": "line",
-            "q": "avg:systemd.socket.connection_count{unit:syslog.socket}",
-            "style": {
-              "line_type": "solid",
-              "line_width": "normal",
-              "palette": "dog_classic"
-            }
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Syslog Current Connections",
-      "type": "timeseries",
-      "width": 37,
-      "x": 113,
-      "y": 70
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "sum:systemd.unit.loaded{$scope,unit:cron.service}",
-            "style": {
-              "line_type": "solid",
-              "line_width": "normal",
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
-            },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Cron Loaded",
-      "type": "timeseries",
-      "width": 37,
-      "x": 75,
-      "y": 8
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "sum:systemd.unit.active{$scope,unit:cron.service}",
-            "style": {
-              "line_type": "solid",
-              "line_width": "normal",
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
-            },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Cron Active",
-      "type": "timeseries",
-      "width": 37,
-      "x": 75,
-      "y": 24
-    }
-  ],
-  "width": "100%"
+  "layout_type": "free",
+  "is_read_only": true,
+  "notify_list": [],
+  "id": 30281
 }

--- a/tls/assets/dashboards/overview.json
+++ b/tls/assets/dashboards/overview.json
@@ -1,242 +1,165 @@
 {
-	"board_title": "TLS Overview",
-	"read_only": false,
-  "author_info": {
-      "author_name": "Datadog"
-  },
+	"title": "TLS Overview",
 	"description": "## TLS Integration Dashboard\n\nThis is an example TLS dashboard demonstrating the information that the integration collects.",
-	"board_bgtype": "board_graph",
-	"created": "2019-07-02T18:56:33.814363+00:00",
-	"created_by": {
-		"disabled": false,
-		"handle": "support@datadoghq.com",
-		"name": "Datadog",
-		"is_admin": false,
-		"role": null,
-		"access_role": "st",
-		"verified": true,
-		"email": "support@datadoghq.com",
-		"icon": ""
-	},
-	"new_id": "ngp-qxw-rnw",
-	"modified": "2019-07-09T22:08:28.729138+00:00",
-	"originalHeight": 80,
-	"height": 80,
-	"width": "100%",
-	"template_variables": [{
+	"widgets": [
+	  {
+		"id": 0,
+		"definition": {
+		  "type": "image",
+		  "url": "https://s3.amazonaws.com/dd-integrations/tls/configuration/tile/logo.png",
+		  "sizing": "zoom"
+		},
+		"layout": {
+		  "x": 1,
+		  "y": 0,
+		  "width": 19,
+		  "height": 15
+		}
+	  },
+	  {
+		"id": 1,
+		"definition": {
+		  "type": "query_value",
+		  "requests": [
+			{
+			  "q": "avg:tls.days_left{$scope}",
+			  "aggregator": "avg"
+			}
+		  ],
+		  "custom_links": [],
+		  "title": "Days Till Expiration",
+		  "title_size": "16",
+		  "title_align": "left",
+		  "autoscale": true,
+		  "precision": 2
+		},
+		"layout": {
+		  "x": 21,
+		  "y": 0,
+		  "width": 31,
+		  "height": 15
+		}
+	  },
+	  {
+		"id": 2,
+		"definition": {
+		  "type": "check_status",
+		  "title": "TLS Version",
+		  "title_size": "16",
+		  "title_align": "center",
+		  "check": "tls.version",
+		  "grouping": "cluster",
+		  "group": "$scope",
+		  "group_by": [
+			"$scope"
+		  ],
+		  "tags": [
+			"*"
+		  ]
+		},
+		"layout": {
+		  "x": 1,
+		  "y": 16,
+		  "width": 19,
+		  "height": 11
+		}
+	  },
+	  {
+		"id": 3,
+		"definition": {
+		  "type": "check_status",
+		  "title": "Certificate Expiration",
+		  "title_size": "16",
+		  "title_align": "center",
+		  "check": "tls.cert_expiration",
+		  "grouping": "cluster",
+		  "group": "$scope",
+		  "group_by": [
+			"$scope"
+		  ],
+		  "tags": [
+			"*"
+		  ]
+		},
+		"layout": {
+		  "x": 1,
+		  "y": 28,
+		  "width": 19,
+		  "height": 11
+		}
+	  },
+	  {
+		"id": 4,
+		"definition": {
+		  "type": "check_status",
+		  "title": "Certificate Validity",
+		  "title_size": "16",
+		  "title_align": "center",
+		  "check": "tls.cert_validation",
+		  "grouping": "cluster",
+		  "group": "$scope",
+		  "group_by": [
+			"$scope"
+		  ],
+		  "tags": [
+			"*"
+		  ]
+		},
+		"layout": {
+		  "x": 1,
+		  "y": 40,
+		  "width": 19,
+		  "height": 11
+		}
+	  },
+	  {
+		"id": 5,
+		"definition": {
+		  "type": "note",
+		  "content": "Days until certificate(s) expire",
+		  "background_color": "yellow",
+		  "font_size": "14",
+		  "text_align": "left",
+		  "show_tick": true,
+		  "tick_pos": "50%",
+		  "tick_edge": "top"
+		},
+		"layout": {
+		  "x": 21,
+		  "y": 16,
+		  "width": 31,
+		  "height": 5
+		}
+	  },
+	  {
+		"id": 6,
+		"definition": {
+		  "type": "note",
+		  "content": "Included service checks:\n\n* tls.version: Returns CRITICAL if a connection is made with a protocol version that is not allowed, otherwise returns OK.\n\n* tls.cert_validation - Returns CRITICAL if the certificate is malformed or does not match the server hostname, otherwise returns OK.\n\n* tls.cert_expiration - Returns CRITICAL if the certificate has expired or expires in less than days_critical/seconds_critical, returns WARNING if the certificate expires in less than days_warning/seconds_warning, otherwise returns OK.",
+		  "background_color": "yellow",
+		  "font_size": "14",
+		  "text_align": "left",
+		  "show_tick": true,
+		  "tick_pos": "50%",
+		  "tick_edge": "left"
+		},
+		"layout": {
+		  "x": 21,
+		  "y": 22,
+		  "width": 31,
+		  "height": 29
+		}
+	  }
+	],
+	"template_variables": [
+	  {
+		"name": "scope",
 		"default": "*",
-		"prefix": null,
-		"name": "scope"
-	}],
-	"isIntegration": false,
-	"disableEditing": false,
-	"originalWidth": "100%",
-	"widgets": [{
-		"board_id": "ngp-qxw-rnw",
-		"sizing": "zoom",
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1562704152318,
-			"end": 1562707752318
-		},
-		"title": false,
-		"url": "https://s3.amazonaws.com/dd-integrations/tls/configuration/tile/logo.png",
-		"margin": "",
-		"height": 15,
-		"width": 19,
-		"type": "image",
-		"y": 0,
-		"x": 1,
-		"add_timeframe": true,
-		"scaleFactor": 1,
-		"isShared": false
-	}, {
-		"board_id": "ngp-qxw-rnw",
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1562705313853,
-			"end": 1562708913853
-		},
-		"title_align": "left",
-		"title_size": 16,
-		"title": true,
-		"type": "query_value",
-		"generated_title": "tls.days_left",
-		"title_text": "Days Till Expiration",
-		"height": 13,
-		"tile_def": {
-			"viz": "query_value",
-			"requests": [{
-				"q": "avg:tls.days_left{$scope}",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": null,
-				"conditional_formats": [{
-					"palette": "white_on_red",
-					"comparator": ">",
-					"value": null
-				}, {
-					"palette": "white_on_yellow",
-					"comparator": ">=",
-					"value": null
-				}, {
-					"palette": "white_on_green",
-					"comparator": "<",
-					"value": null
-				}]
-			}],
-			"autoscale": true
-		},
-		"width": 31,
-		"time": {},
-		"error": null,
-		"y": 0,
-		"x": 21,
-		"legend_size": "0",
-		"isShared": false,
-		"scaleFactor": 1,
-		"legend": false,
-		"add_timeframe": true
-	}, {
-		"height": 11,
-		"text_size": "auto",
-		"check": "tls.version",
-		"board_id": "ngp-qxw-rnw",
-		"group": "$scope",
-		"title": true,
-		"title_align": "center",
-		"text_align": "center",
-		"width": 19,
-		"group_by": ["$scope"],
-		"type": "check_status",
-		"isShared": false,
-		"tags": ["*"],
-		"time": {},
-		"title_text": "TLS Version",
-		"title_size": 16,
-		"scaleFactor": 1,
-		"add_timeframe": true,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1562705313853,
-			"end": 1562708913853
-		},
-		"error": null,
-		"y": 16,
-		"x": 1,
-		"grouping": "cluster"
-	}, {
-		"height": 11,
-		"text_size": "auto",
-		"check": "tls.cert_expiration",
-		"board_id": "ngp-qxw-rnw",
-		"group": "$scope",
-		"title": true,
-		"title_align": "center",
-		"text_align": "center",
-		"width": 19,
-		"group_by": ["$scope"],
-		"type": "check_status",
-		"isShared": false,
-		"tags": ["*"],
-		"time": {},
-		"title_text": "Certificate Expiration",
-		"title_size": 16,
-		"scaleFactor": 1,
-		"add_timeframe": true,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1562705313853,
-			"end": 1562708913853
-		},
-		"error": null,
-		"y": 28,
-		"x": 1,
-		"grouping": "cluster"
-	}, {
-		"height": 11,
-		"text_size": "auto",
-		"check": "tls.cert_validation",
-		"board_id": "ngp-qxw-rnw",
-		"group": "$scope",
-		"title": true,
-		"title_align": "center",
-		"text_align": "center",
-		"width": 19,
-		"group_by": ["$scope"],
-		"type": "check_status",
-		"isShared": false,
-		"tags": ["*"],
-		"time": {},
-		"title_text": "Certificate Validity",
-		"title_size": 16,
-		"scaleFactor": 1,
-		"add_timeframe": true,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1562705313853,
-			"end": 1562708913853
-		},
-		"error": null,
-		"y": 40,
-		"x": 1,
-		"grouping": "cluster"
-	}, {
-		"board_id": "ngp-qxw-rnw",
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1562705313853,
-			"end": 1562708913853
-		},
-		"font_size": "14",
-		"title": false,
-		"refresh_every": 30000,
-		"scaleFactor": 1,
-		"tick_edge": "top",
-		"text_align": "left",
-		"auto_refresh": false,
-		"height": 5,
-		"bgcolor": "yellow",
-		"add_timeframe": true,
-		"html": "Days until certificate(s) expire",
-		"type": "note",
-		"y": 16,
-		"x": 21,
-		"tick": true,
-		"tick_pos": "50%",
-		"width": 31,
-		"isShared": false
-	}, {
-		"board_id": "ngp-qxw-rnw",
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1562705313853,
-			"end": 1562708913853
-		},
-		"font_size": "14",
-		"title": false,
-		"refresh_every": 30000,
-		"scaleFactor": 1,
-		"tick_edge": "left",
-		"text_align": "left",
-		"auto_refresh": false,
-		"height": 29,
-		"bgcolor": "yellow",
-		"add_timeframe": true,
-		"html": "Included service checks:\n\n* tls.version: Returns CRITICAL if a connection is made with a protocol version that is not allowed, otherwise returns OK.\n\n* tls.cert_validation - Returns CRITICAL if the certificate is malformed or does not match the server hostname, otherwise returns OK.\n\n* tls.cert_expiration - Returns CRITICAL if the certificate has expired or expires in less than days_critical/seconds_critical, returns WARNING if the certificate expires in less than days_warning/seconds_warning, otherwise returns OK.",
-		"type": "note",
-		"y": 22,
-		"x": 21,
-		"tick": true,
-		"tick_pos": "50%",
-		"width": 31,
-		"isShared": false
-	}],
-	"disableCog": false,
-	"id": 749737,
-	"isShared": false
-}
+		"prefix": null
+	  }
+	],
+	"layout_type": "free",
+	"is_read_only": true,
+	"notify_list": [],
+	"id": 30283
+  }

--- a/vault/assets/dashboards/vault_overview.json
+++ b/vault/assets/dashboards/vault_overview.json
@@ -1,721 +1,594 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "Vault - Overview",
-    "created": "2020-01-07T20:01:49.609474+00:00",
-    "created_by": {
-        "access_role": "adm",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": true,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "Vault - Overview",
     "description": "## Vault\n\nThis dashboard provides a high-level overview of your Vault clusters so you can monitor its performance and cluster health.\n\n- [Official Vault integration docs](https://docs.datadoghq.com/integrations/vault/)\n- [Monitoring HashiCorp Vault with Datadog](https://www.datadoghq.com/blog/monitor-hashicorp-vault-with-datadog/)",
-    "disableCog": false,
-    "disableEditing": false,
-    "id": 939379,
-    "isIntegration": false,
-    "isShared": false,
-    "modified": "2020-01-08T19:42:53.971775+00:00",
-    "new_id": "dn8-p7u-4eb",
-    "originalHeight": 80,
-    "originalWidth": "calc(100% - 32px)",
-    "read_only": false,
-    "template_variables": [],
     "widgets": [
-        {
-            "add_timeframe": true,
-            "height": 7,
-            "id": 0,
-            "isShared": false,
-            "margin": "",
-            "scaleFactor": 1,
-            "sizing": "zoom",
-            "title": false,
-            "type": "image",
-            "url": "https://static.datadoghq.com/static/images/saas_logos/bot/vault@2x.png",
-            "width": 12,
-            "x": 0,
-            "y": 1
+      {
+        "id": 0,
+        "definition": {
+          "type": "image",
+          "url": "https://static.datadoghq.com/static/images/saas_logos/bot/vault@2x.png",
+          "sizing": "zoom"
         },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 17,
-            "id": 1,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:vault.vault.core.handle.request.sum{*}/avg:vault.vault.core.handle.request.count{*}",
-                        "style": {
-                            "palette": "orange",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Average Request Latency",
-            "type": "timeseries",
-            "width": 43,
-            "x": -9,
-            "y": 37
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 17,
-            "id": 2,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "max:vault.vault.runtime.alloc.bytes{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    },
-                    {
-                        "q": "max:vault.vault.runtime.sys.bytes{role:vault} by {vault_cluster}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Allocated Memory",
-            "type": "timeseries",
-            "width": 42,
-            "x": 44,
-            "y": 9
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 17,
-            "id": 3,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "diff(max:vault.vault.runtime.total.gc.pause_ns{*} by {host})",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "GC Time",
-            "type": "timeseries",
-            "width": 43,
-            "x": -9,
-            "y": 9
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 17,
-            "id": 4,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "max:vault.vault.core.handle.login_request.sum{*}, max:vault.vault.core.handle.login_request.count{*}, max:vault.vault.core.handle.login_request.sum{*}/max:vault.vault.core.handle.login_request.count{*}",
-                        "style": {
-                            "palette": "orange",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Average Login Latency",
-            "type": "timeseries",
-            "width": 42,
-            "x": 44,
-            "y": 37
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 17,
-            "id": 5,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "per_second(max:vault.vault.core.handle.login_request.count{*})",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Logins Per Second",
-            "type": "timeseries",
-            "width": 42,
-            "x": 44,
-            "y": 57
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 17,
-            "id": 6,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "per_second(max:vault.vault.core.handle.request.count{*} by {instance})",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Request Handled Per Second",
-            "type": "timeseries",
-            "width": 43,
-            "x": -9,
-            "y": 57
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "font_size": "24",
-            "height": 7,
-            "html": "Runtime",
-            "id": 7,
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 58,
-            "x": 28,
-            "y": 1
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "font_size": "24",
-            "height": 6,
-            "html": "Performance",
-            "id": 8,
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 86,
-            "x": -9,
-            "y": 30
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "font_size": "24",
-            "height": 7,
-            "html": "Tokens",
-            "id": 9,
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 63,
-            "x": 88,
-            "y": 1
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 17,
-            "id": 10,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:vault.vault.core.check.token.sum{*}/avg:vault.vault.core.check.token.count{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Average Time of Token Checks",
-            "type": "timeseries",
-            "width": 63,
-            "x": 88,
-            "y": 29
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 17,
-            "id": 11,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:vault.vault.token.lookup.count{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Token Lookups Count",
-            "type": "timeseries",
-            "width": 47,
-            "x": 104,
-            "y": 9
-        },
-        {
-            "add_timeframe": true,
-            "autoscale": true,
-            "error": null,
-            "height": 7,
-            "id": 12,
-            "isShared": false,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "q": "sum:vault.vault.expire.renew_token.count{*}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Total token renewals",
-            "type": "query_value",
-            "width": 14,
-            "x": 88,
-            "y": 19
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 16,
-            "id": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "sum:vault.vault.expire.num_leases{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Number of leases",
-            "type": "timeseries",
-            "width": 63,
-            "x": 88,
-            "y": 58
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "font_size": "24",
-            "height": 7,
-            "html": "Leases",
-            "id": 14,
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 63,
-            "x": 88,
-            "y": 50
-        },
-        {
-            "add_timeframe": true,
-            "autoscale": true,
-            "error": null,
-            "height": 7,
-            "id": 15,
-            "isShared": false,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "q": "avg:vault.vault.token.create.count{*}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Tokens Created",
-            "type": "query_value",
-            "width": 14,
-            "x": 88,
-            "y": 9
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "font_size": "24",
-            "height": 6,
-            "html": "Storage Backend",
-            "id": 16,
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 86,
-            "x": -8,
-            "y": 78
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "yellow",
-            "font_size": "14",
-            "height": 11,
-            "html": "Default storage backend on this dashboard is Consul. Vault supports the following [storage backend providers](https://www.vaultproject.io/docs/internals/telemetry.html#storage-backend-metrics)",
-            "id": 17,
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "left",
-            "tick": true,
-            "tick_edge": "left",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 18,
-            "x": 88,
-            "y": 79
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 13,
-            "id": 18,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:vault.vault.consul.get.sum{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Consul GET",
-            "type": "timeseries",
-            "width": 43,
-            "x": 0,
-            "y": 85
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 13,
-            "id": 19,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:vault.vault.consul.put.sum{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Consul PUT",
-            "type": "timeseries",
-            "width": 42,
-            "x": 44,
-            "y": 85
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 13,
-            "id": 20,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:vault.vault.consul.list.sum{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Consul LIST",
-            "type": "timeseries",
-            "width": 43,
-            "x": 0,
-            "y": 101
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 13,
-            "id": 21,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:vault.vault.consul.delete.sum{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Consul DELETE",
-            "type": "timeseries",
-            "width": 42,
-            "x": 44,
-            "y": 101
-        },
-        {
-            "add_timeframe": true,
-            "check": "vault.prometheus.health",
-            "error": null,
-            "group": null,
-            "group_by": [],
-            "grouping": "cluster",
-            "height": 7,
-            "id": 22,
-            "isShared": false,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tags": [
-                "*"
-            ],
-            "text_align": "center",
-            "text_size": "auto",
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Check Health",
-            "type": "check_status",
-            "width": 14,
-            "x": 13,
-            "y": 1
+        "layout": {
+          "x": 0,
+          "y": 1,
+          "width": 12,
+          "height": 7
         }
-    ]
-}
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vault.vault.core.handle.request.sum{*}/avg:vault.vault.core.handle.request.count{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "orange",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average Request Latency",
+          "title_size": "16",
+          "title_align": "center",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": -9,
+          "y": 37,
+          "width": 43,
+          "height": 19
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "max:vault.vault.runtime.alloc.bytes{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            },
+            {
+              "q": "max:vault.vault.runtime.sys.bytes{role:vault} by {vault_cluster}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Allocated Memory",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 44,
+          "y": 9,
+          "width": 42,
+          "height": 19
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "diff(max:vault.vault.runtime.total.gc.pause_ns{*} by {host})",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "GC Time",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": -9,
+          "y": 9,
+          "width": 43,
+          "height": 19
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "max:vault.vault.core.handle.login_request.sum{*}, max:vault.vault.core.handle.login_request.count{*}, max:vault.vault.core.handle.login_request.sum{*}/max:vault.vault.core.handle.login_request.count{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "orange",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average Login Latency",
+          "title_size": "16",
+          "title_align": "center",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 44,
+          "y": 37,
+          "width": 42,
+          "height": 19
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "per_second(max:vault.vault.core.handle.login_request.count{*})",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Logins Per Second",
+          "title_size": "16",
+          "title_align": "center",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 44,
+          "y": 57,
+          "width": 42,
+          "height": 19
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "per_second(max:vault.vault.core.handle.request.count{*} by {instance})",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Request Handled Per Second",
+          "title_size": "16",
+          "title_align": "center",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": -9,
+          "y": 57,
+          "width": 43,
+          "height": 19
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "note",
+          "content": "Runtime",
+          "background_color": "gray",
+          "font_size": "24",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 28,
+          "y": 1,
+          "width": 58,
+          "height": 7
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "note",
+          "content": "Performance",
+          "background_color": "gray",
+          "font_size": "24",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": -9,
+          "y": 30,
+          "width": 86,
+          "height": 6
+        }
+      },
+      {
+        "id": 9,
+        "definition": {
+          "type": "note",
+          "content": "Tokens",
+          "background_color": "gray",
+          "font_size": "24",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 88,
+          "y": 1,
+          "width": 63,
+          "height": 7
+        }
+      },
+      {
+        "id": 10,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vault.vault.core.check.token.sum{*}/avg:vault.vault.core.check.token.count{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Average Time of Token Checks",
+          "title_size": "16",
+          "title_align": "center",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 88,
+          "y": 29,
+          "width": 63,
+          "height": 19
+        }
+      },
+      {
+        "id": 11,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vault.vault.token.lookup.count{*}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Token Lookups Count",
+          "title_size": "16",
+          "title_align": "center",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 104,
+          "y": 9,
+          "width": 47,
+          "height": 19
+        }
+      },
+      {
+        "id": 12,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "sum:vault.vault.expire.renew_token.count{*}",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Total token renewals",
+          "title_size": "16",
+          "title_align": "left",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 88,
+          "y": 19,
+          "width": 14,
+          "height": 9
+        }
+      },
+      {
+        "id": 13,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:vault.vault.expire.num_leases{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Number of leases",
+          "title_size": "16",
+          "title_align": "center",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 88,
+          "y": 58,
+          "width": 63,
+          "height": 18
+        }
+      },
+      {
+        "id": 14,
+        "definition": {
+          "type": "note",
+          "content": "Leases",
+          "background_color": "gray",
+          "font_size": "24",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 88,
+          "y": 50,
+          "width": 63,
+          "height": 7
+        }
+      },
+      {
+        "id": 15,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "avg:vault.vault.token.create.count{*}",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "Tokens Created",
+          "title_size": "16",
+          "title_align": "left",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 88,
+          "y": 9,
+          "width": 14,
+          "height": 9
+        }
+      },
+      {
+        "id": 16,
+        "definition": {
+          "type": "note",
+          "content": "Storage Backend",
+          "background_color": "gray",
+          "font_size": "24",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": -8,
+          "y": 78,
+          "width": 86,
+          "height": 6
+        }
+      },
+      {
+        "id": 17,
+        "definition": {
+          "type": "note",
+          "content": "Default storage backend on this dashboard is Consul. Vault supports the following [storage backend providers](https://www.vaultproject.io/docs/internals/telemetry.html#storage-backend-metrics)",
+          "background_color": "yellow",
+          "font_size": "14",
+          "text_align": "left",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "left"
+        },
+        "layout": {
+          "x": 88,
+          "y": 79,
+          "width": 18,
+          "height": 11
+        }
+      },
+      {
+        "id": 18,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vault.vault.consul.get.sum{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Consul GET",
+          "title_size": "16",
+          "title_align": "center",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 0,
+          "y": 85,
+          "width": 43,
+          "height": 15
+        }
+      },
+      {
+        "id": 19,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vault.vault.consul.put.sum{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Consul PUT",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 44,
+          "y": 85,
+          "width": 42,
+          "height": 15
+        }
+      },
+      {
+        "id": 20,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vault.vault.consul.list.sum{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Consul LIST",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 0,
+          "y": 101,
+          "width": 43,
+          "height": 15
+        }
+      },
+      {
+        "id": 21,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vault.vault.consul.delete.sum{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Consul DELETE",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 44,
+          "y": 101,
+          "width": 42,
+          "height": 15
+        }
+      },
+      {
+        "id": 22,
+        "definition": {
+          "type": "check_status",
+          "title": "Check Health",
+          "title_size": "16",
+          "title_align": "center",
+          "check": "vault.prometheus.health",
+          "grouping": "cluster",
+          "group_by": [],
+          "tags": [
+            "*"
+          ]
+        },
+        "layout": {
+          "x": 13,
+          "y": 1,
+          "width": 14,
+          "height": 7
+        }
+      }
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30258
+  }

--- a/vertica/assets/dashboards/overview.json
+++ b/vertica/assets/dashboards/overview.json
@@ -1,521 +1,453 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_bgtype": "board_graph",
-    "board_title": "Vertica Overview",
-    "created": "2019-09-30T16:04:04.432138+00:00",
-    "created_by": {
-        "access_role": "adm",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": true,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "Vertica Overview",
     "description": "## Vertica Dashboard\n\nThis is an example Vertica dashboard demonstrating the metrics that the integration collects.",
-    "disableCog": false,
-    "disableEditing": false,
-    "id": 848156,
-    "isIntegration": false,
-    "isShared": false,
-    "modified": "2019-09-30T16:08:04.049360+00:00",
-    "new_id": "v3z-v66-4vt",
-    "originalHeight": 80,
-    "originalWidth": "calc(100% - 32px)",
-    "read_only": false,
-    "template_variables": [],
     "widgets": [
-        {
-            "add_timeframe": true,
-            "height": 10,
-            "id": 0,
-            "isShared": false,
-            "margin": "",
-            "sizing": "fit",
-            "title": false,
-            "type": "image",
-            "url": "/static/images/saas_logos/bot/vertica@2x.png",
-            "width": 21,
-            "x": 0,
-            "y": 0
+      {
+        "id": 0,
+        "definition": {
+          "type": "image",
+          "url": "/static/images/saas_logos/bot/vertica@2x.png",
+          "sizing": "fit"
         },
-        {
-            "add_timeframe": true,
-            "autoscale": true,
-            "error": null,
-            "height": 10,
-            "id": 1,
-            "isShared": false,
-            "tile_def": {
-                "autoscale": true,
-                "custom_unit": "%",
-                "precision": 0,
-                "requests": [
-                    {
-                        "aggregator": "max",
-                        "conditional_formats": [
-                            {
-                                "comparator": "<=",
-                                "palette": "white_on_yellow",
-                                "value": 80
-                            },
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_green",
-                                "value": 80
-                            },
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": 50
-                            }
-                        ],
-                        "q": "(max:vertica.node.total{*}-max:vertica.node.down{*})/max:vertica.node.total{*}*100"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": {
-                "live_span": "1m"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Nodes available",
-            "type": "query_value",
-            "width": 21,
-            "x": 0,
-            "y": 11
-        },
-        {
-            "add_timeframe": true,
-            "autoscale": true,
-            "error": null,
-            "height": 10,
-            "id": 2,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "tile_def": {
-                "autoscale": false,
-                "custom_unit": null,
-                "precision": "0",
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [
-                            {
-                                "comparator": "<",
-                                "palette": "white_on_red",
-                                "value": 1
-                            },
-                            {
-                                "comparator": "<",
-                                "palette": "white_on_yellow",
-                                "value": 2
-                            },
-                            {
-                                "comparator": ">=",
-                                "palette": "white_on_green",
-                                "value": 3
-                            }
-                        ],
-                        "q": "max:vertica.ksafety.current{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": null
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": {
-                "live_span": "1m"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "K-safety: current value",
-            "type": "query_value",
-            "width": 21,
-            "x": 0,
-            "y": 26
-        },
-        {
-            "add_timeframe": true,
-            "autoscale": true,
-            "error": null,
-            "height": 10,
-            "id": 3,
-            "isShared": false,
-            "tile_def": {
-                "autoscale": false,
-                "custom_unit": " ",
-                "precision": 0,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "q": "max:vertica.ksafety.intended{*}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": {
-                "live_span": "10m"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "K-safety: intended value",
-            "type": "query_value",
-            "width": 21,
-            "x": 0,
-            "y": 41
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 10,
-            "html": "Availability",
-            "id": 4,
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 45,
-            "x": 22,
-            "y": 0
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 10,
-            "id": 5,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "max:vertica.node.total{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Nodes in the cluster",
-            "type": "timeseries",
-            "width": 45,
-            "x": 22,
-            "y": 11
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 10,
-            "id": 6,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "max:vertica.node.down{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Nodes down",
-            "type": "timeseries",
-            "width": 45,
-            "x": 22,
-            "y": 26
-        },
-        {
-            "add_timeframe": true,
-            "height": 16,
-            "id": 7,
-            "isShared": false,
-            "legend": null,
-            "legend_size": null,
-            "query": "avg:system.load.1{*} by {host}",
-            "scaleFactor": 1,
-            "tile_def": {
-                "group": null,
-                "noGroupHosts": true,
-                "noMetricHosts": true,
-                "notes": null,
-                "requests": [
-                    {
-                        "q": "avg:vertica.query.active{role:vertica} by {host}",
-                        "type": "fill"
-                    }
-                ],
-                "scope": [
-                    "role:vertica"
-                ],
-                "style": {
-                    "fillMax": null,
-                    "fillMin": null,
-                    "palette": "green_to_orange",
-                    "paletteFlip": false
-                },
-                "viz": "hostmap"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Cluster map: active and inactive nodes",
-            "type": "hostmap",
-            "width": 45,
-            "x": 22,
-            "y": 41
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 29,
-            "html": "Queries",
-            "id": 8,
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "right",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 12,
-            "x": 69,
-            "y": 0
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 10,
-            "id": 9,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:vertica.query.active{*}, avg:vertica.query.total{*}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Active queries and total queries",
-            "type": "timeseries",
-            "width": 47,
-            "x": 82,
-            "y": 0
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 10,
-            "id": 10,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:vertica.query.total{*}.as_count(), avg:vertica.query.total{*}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Rows in tables and projections",
-            "type": "timeseries",
-            "width": 47,
-            "x": 82,
-            "y": 15
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 44,
-            "html": "Resources",
-            "id": 11,
-            "isShared": false,
-            "refresh_every": 30000,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "right",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 12,
-            "x": 69,
-            "y": 31
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 10,
-            "id": 12,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:vertica.storage.utilized{*}, avg:vertica.memory.utilized{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Storage and memory used",
-            "type": "timeseries",
-            "width": 47,
-            "x": 82,
-            "y": 31
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 10,
-            "id": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:vertica.node.resource_requests{*}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Resource requests",
-            "type": "timeseries",
-            "width": 47,
-            "x": 82,
-            "y": 46
-        },
-        {
-            "add_timeframe": true,
-            "error": null,
-            "height": 10,
-            "id": 14,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "requests": [
-                    {
-                        "q": "avg:vertica.thread.active{*} by {node_name}, avg:vertica.socket.open{*} by {node_name}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Open sockets and active threads",
-            "type": "timeseries",
-            "width": 47,
-            "x": 82,
-            "y": 61
+        "layout": {
+          "x": 0,
+          "y": 0,
+          "width": 21,
+          "height": 10
         }
-    ]
-}
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "(max:vertica.node.total{*}-max:vertica.node.down{*})/max:vertica.node.total{*}*100",
+              "aggregator": "max",
+              "conditional_formats": [
+                {
+                  "comparator": "<=",
+                  "value": 80,
+                  "palette": "white_on_yellow"
+                },
+                {
+                  "comparator": ">",
+                  "value": 80,
+                  "palette": "white_on_green"
+                },
+                {
+                  "comparator": ">",
+                  "value": 50,
+                  "palette": "white_on_red"
+                }
+              ]
+            }
+          ],
+          "custom_links": [],
+          "title": "Nodes available",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1m"
+          },
+          "autoscale": true,
+          "custom_unit": "%",
+          "precision": 0
+        },
+        "layout": {
+          "x": 0,
+          "y": 11,
+          "width": 21,
+          "height": 12
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "max:vertica.ksafety.current{*}",
+              "aggregator": "avg",
+              "conditional_formats": [
+                {
+                  "comparator": "<",
+                  "value": 1,
+                  "palette": "white_on_red"
+                },
+                {
+                  "comparator": "<",
+                  "value": 2,
+                  "palette": "white_on_yellow"
+                },
+                {
+                  "comparator": ">=",
+                  "value": 3,
+                  "palette": "white_on_green"
+                }
+              ]
+            }
+          ],
+          "custom_links": [],
+          "title": "K-safety: current value",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "1m"
+          },
+          "autoscale": false,
+          "precision": 0
+        },
+        "layout": {
+          "x": 0,
+          "y": 26,
+          "width": 21,
+          "height": 12
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "max:vertica.ksafety.intended{*}",
+              "aggregator": "avg"
+            }
+          ],
+          "custom_links": [],
+          "title": "K-safety: intended value",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "10m"
+          },
+          "autoscale": false,
+          "custom_unit": " ",
+          "precision": 0
+        },
+        "layout": {
+          "x": 0,
+          "y": 41,
+          "width": 21,
+          "height": 12
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "note",
+          "content": "Availability",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "bottom"
+        },
+        "layout": {
+          "x": 22,
+          "y": 0,
+          "width": 45,
+          "height": 10
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "max:vertica.node.total{*}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Nodes in the cluster",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 22,
+          "y": 11,
+          "width": 45,
+          "height": 12
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "max:vertica.node.down{*}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Nodes down",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 22,
+          "y": 26,
+          "width": 45,
+          "height": 12
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "hostmap",
+          "requests": {
+            "fill": {
+              "q": "avg:vertica.query.active{role:vertica} by {host}"
+            }
+          },
+          "custom_links": [],
+          "title": "Cluster map: active and inactive nodes",
+          "title_size": "16",
+          "title_align": "left",
+          "no_metric_hosts": true,
+          "no_group_hosts": true,
+          "scope": [
+            "role:vertica"
+          ],
+          "style": {
+            "palette": "green_to_orange",
+            "palette_flip": false
+          }
+        },
+        "layout": {
+          "x": 22,
+          "y": 41,
+          "width": 45,
+          "height": 18
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "note",
+          "content": "Queries",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "right"
+        },
+        "layout": {
+          "x": 69,
+          "y": 0,
+          "width": 12,
+          "height": 29
+        }
+      },
+      {
+        "id": 9,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vertica.query.active{*}, avg:vertica.query.total{*}.as_count()",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Active queries and total queries",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 82,
+          "y": 0,
+          "width": 47,
+          "height": 12
+        }
+      },
+      {
+        "id": 10,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vertica.query.total{*}.as_count(), avg:vertica.query.total{*}.as_count()",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Rows in tables and projections",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 82,
+          "y": 15,
+          "width": 47,
+          "height": 12
+        }
+      },
+      {
+        "id": 11,
+        "definition": {
+          "type": "note",
+          "content": "Resources",
+          "background_color": "gray",
+          "font_size": "18",
+          "text_align": "center",
+          "show_tick": true,
+          "tick_pos": "50%",
+          "tick_edge": "right"
+        },
+        "layout": {
+          "x": 69,
+          "y": 31,
+          "width": 12,
+          "height": 44
+        }
+      },
+      {
+        "id": 12,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vertica.storage.utilized{*}, avg:vertica.memory.utilized{*}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Storage and memory used",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 82,
+          "y": 31,
+          "width": 47,
+          "height": 12
+        }
+      },
+      {
+        "id": 13,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vertica.node.resource_requests{*}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Resource requests",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 82,
+          "y": 46,
+          "width": 47,
+          "height": 12
+        }
+      },
+      {
+        "id": 14,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vertica.thread.active{*} by {node_name}, avg:vertica.socket.open{*} by {node_name}",
+              "display_type": "bars",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Open sockets and active threads",
+          "title_size": "16",
+          "title_align": "left",
+          "time": {
+            "live_span": "4h"
+          },
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 82,
+          "y": 61,
+          "width": 47,
+          "height": 12
+        }
+      }
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30299
+  }

--- a/vsphere/assets/dashboards/vsphere_overview.json
+++ b/vsphere/assets/dashboards/vsphere_overview.json
@@ -1,880 +1,578 @@
 {
-    "board_title": "VMware vSphere - Overview",
-    "read_only": false,
-    "guid": 583,
-    "isIntegration": false,
-    "description": "This dashboard provides a high-level view of your VMware vSphere environment, with in-depth resource utilization metrics from your hosts and VMs, along with the status of your vCenter Server. For further reading on monitoring vSphere: \n\n- [How to monitor vSphere and application metrics with Datadog](https://www.datadoghq.com/blog/unified-vsphere-app-monitoring-datadog/) \n\n- [Datadog's vSphere integration docs](https://docs.datadoghq.com/integrations/vsphere/#pagetitle). \n\nClone this template dashboard to make changes and add your own graph widgets. ",
-    "board_bgtype": "board_graph",
-    "created": "2020-02-05T16:39:17.081662+00:00",
-    "new_id": "m7e-3hv-p6n",
-    "created_by": {
-        "access_role": "adm", 
-        "disabled": false, 
-        "email": "support@datadoghq.com", 
-        "handle": "support@datadoghq.com", 
-        "is_admin": true, 
-        "name": "Datadog", 
-        "role": null, 
-        "title": null, 
-        "verified": true
-    }, 
-    "original_title": "VMware vSphere - Overview",
-    "modified": "2020-02-10T15:43:28.499024+00:00",
-    "originalHeight": 80,
-    "template_variables": [
-        {
-            "default": "*",
-            "prefix": "vcenter_server",
-            "name": "vcenter_server"
-        },
-        {
-            "default": "*",
-            "prefix": "vsphere_datacenter",
-            "name": "vcenter_datacenter"
-        },
-        {
-            "default": "*",
-            "prefix": "host",
-            "name": "host"
-        }
-    ],
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "disableEditing": false,
-    "originalWidth": "calc(100% - 32px)",
+    "title": "VMware vSphere - Overview",
+    "description": "An overview of your vSphere cluster",
     "widgets": [
-        {
-            "board_id": 506294,
-            "sizing": "fit",
-            "generated_title": "",
-            "title_size": 16,
-            "title": true,
-            "url": "/static/images/saas_logos/bot/vsphere@2x.png",
-            "type": "image",
-            "title_align": "left",
-            "title_text": "",
-            "height": 10,
-            "width": 47,
-            "y": 1,
-            "x": 0,
-            "add_timeframe": true,
-            "margin": "",
-            "isShared": false
+      {
+        "id": 0,
+        "definition": {
+          "type": "image",
+          "url": "https://static.datadoghq.com/static/images/saas_logos/bot/vsphere.png",
+          "sizing": "fit"
         },
-        {
-            "board_id": 506294,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "type": "event_stream",
-            "generated_title": "Events that match \"sources:vsphere $vcenter_server.value $vcenter_datacenter.value\"",
-            "tags_execution": "and",
-            "height": 60,
-            "width": 47,
-            "add_timeframe": true,
-            "query": "sources:vsphere $vcenter_server.value $vcenter_datacenter.value",
-            "title_text": "vSphere events",
-            "error": null,
-            "y": 32,
-            "x": 0,
-            "isShared": false,
-            "scaleFactor": 1,
-            "event_size": "l",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            }
-        },
-        {
-            "board_id": 506294,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Top List",
-            "title_text": "Most % memory loaded VMs (Top 25)",
-            "height": 24,
-            "tile_def": {
-                "viz": "toplist",
-                "requests": [
-                    {
-                        "q": "top(avg:vsphere.mem.usage.avg{vsphere_type:vm,$vcenter_server,$vcenter_datacenter} by {host}, 25, 'mean', 'desc')",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_green",
-                                "comparator": "<=",
-                                "value": "70"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "comparator": "<=",
-                                "value": "90"
-                            },
-                            {
-                                "palette": "white_on_red",
-                                "comparator": ">",
-                                "value": "90"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "width": 47,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 9,
-            "x": 98,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "toplist",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "board_id": 506294,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Top List",
-            "title_text": "Most % CPU loaded VMs (Top 25)",
-            "height": 24,
-            "tile_def": {
-                "viz": "toplist",
-                "requests": [
-                    {
-                        "q": "top(avg:vsphere.cpu.usage.avg{$vcenter_datacenter,$vcenter_server,vsphere_type:vm} by {host}, 25, 'mean', 'desc')",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_green",
-                                "comparator": "<=",
-                                "value": "70"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "comparator": "<=",
-                                "value": "90"
-                            },
-                            {
-                                "palette": "white_on_red",
-                                "comparator": ">",
-                                "value": "90"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "width": 47,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 36,
-            "x": 98,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "toplist",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "board_id": 506294,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Top List",
-            "title_text": "Most % memory loaded hosts (Top 10)",
-            "height": 24,
-            "tile_def": {
-                "viz": "toplist",
-                "requests": [
-                    {
-                        "q": "top(avg:vsphere.mem.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:host} by {host}, 10, 'mean', 'desc')",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_green",
-                                "comparator": "<=",
-                                "value": "70"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "comparator": "<=",
-                                "value": "90"
-                            },
-                            {
-                                "palette": "white_on_red",
-                                "comparator": ">",
-                                "value": "90"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "width": 47,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 36,
-            "x": 49,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "toplist",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "board_id": 506294,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Avg of vsphere.cpu.usage.avg over $vcenter_server,$vcenter_datacenter,vsphere...",
-            "title_text": "Most % CPU loaded hosts (Top 10)",
-            "height": 24,
-            "tile_def": {
-                "viz": "toplist",
-                "requests": [
-                    {
-                        "q": "top(avg:vsphere.cpu.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:host} by {host}, 10, 'mean', 'desc')",
-                        "conditional_formats": [
-                            {
-                                "requestIndex": 0,
-                                "palette": "white_on_green",
-                                "comparator": "<=",
-                                "value": "70"
-                            },
-                            {
-                                "requestIndex": 0,
-                                "palette": "white_on_yellow",
-                                "comparator": "<=",
-                                "value": "90"
-                            },
-                            {
-                                "requestIndex": 0,
-                                "palette": "white_on_red",
-                                "comparator": ">",
-                                "value": "90"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "width": 47,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 9,
-            "x": 49,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "toplist",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "board_id": 506294,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Timeseries",
-            "title_text": "Disk I/O rates per VM (Top 25)",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
-                "requests": [
-                    {
-                        "q": "top(avg:vsphere.disk.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:vm} by {host}, 25, 'mean', 'desc')",
-                        "aggregator": "avg",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
-                    }
-                ],
-                "autoscale": true
-            },
-            "width": 47,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 63,
-            "x": 98,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "board_id": 506294,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Avg of vsphere.mem.vmmemctl.avg over $vcenter_server,$vcenter_datacenter,vsph...",
-            "title_text": "Memory ballooning by host (Top 25)",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
-                "requests": [
-                    {
-                        "q": "top(avg:vsphere.mem.vmmemctl.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:host} by {host}, 25, 'mean', 'desc')",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "markers": [],
-                "yaxis": {
-                    "min": "auto",
-                    "max": "auto",
-                    "scale": "linear",
-                    "label": "",
-                    "includeZero": true
-                }
-            },
-            "width": 47,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 79,
-            "x": 49,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "board_id": 506294,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Avg of vsphere.net.usage.avg over $vcenter_server,$vcenter_datacenter,vsphere...",
-            "title_text": "Total network utilization of VMs (Top 25)",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
-                "requests": [
-                    {
-                        "q": "top(avg:vsphere.net.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:vm}, 25, 'mean', 'desc')",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "markers": [],
-                "yaxis": {
-                    "min": "auto",
-                    "max": "auto",
-                    "scale": "linear",
-                    "label": "",
-                    "includeZero": true
-                }
-            },
-            "width": 47,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 79,
-            "x": 98,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "board_id": 506294,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Sum of vsphere.net.usage.avg over $vcenter_server,$vcenter_datacenter,vsphere...",
-            "title_text": "Total network utilization of hosts",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
-                "requests": [
-                    {
-                        "q": "top(sum:vsphere.net.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:host} by {host}, 25, 'mean', 'desc')",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "markers": [],
-                "yaxis": {
-                    "min": "auto",
-                    "max": "auto",
-                    "scale": "linear",
-                    "label": "",
-                    "includeZero": true
-                }
-            },
-            "width": 47,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 63,
-            "x": 49,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "board_id": "m7e-3hv-p6n",
-            "tick": true,
-            "font_size": "14",
-            "title": false,
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "tick_edge": "bottom",
-            "text_align": "center",
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "add_timeframe": true,
-            "html": "# ESXi hosts",
-            "type": "note",
-            "y": 1,
-            "x": 49,
-            "height": 6,
-            "tick_pos": "50%",
-            "width": 47,
-            "isShared": false
-        },
-        {
-            "x": 32,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Sum of vsphere.host.count over $vcenter_server,$vcenter_datacenter,$host",
-            "title_text": "Host Count",
-            "height": 7,
-            "tile_def": {
-                "viz": "query_value",
-                "requests": [
-                    {
-                        "q": "sum:vsphere.host.count{$vcenter_server,$vcenter_datacenter,$host}",
-                        "aggregator": "last",
-                        "conditional_formats": []
-                    }
-                ],
-                "autoscale": true,
-                "precision": "0"
-            },
-            "width": 15,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 12,
-            "autoscale": true,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "x": 16,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Sum of vsphere.vm.count over $vcenter_server,$vcenter_datacenter,$host",
-            "title_text": "VM Count",
-            "height": 7,
-            "tile_def": {
-                "viz": "query_value",
-                "requests": [
-                    {
-                        "q": "sum:vsphere.vm.count{$vcenter_server,$vcenter_datacenter,$host}",
-                        "aggregator": "last",
-                        "conditional_formats": []
-                    }
-                ],
-                "autoscale": true,
-                "precision": "0"
-            },
-            "width": 15,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 12,
-            "autoscale": true,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "height": 9,
-            "text_size": "auto",
-            "check": "vsphere.can_connect",
-            "board_id": "m7e-3hv-p6n",
-            "group": null,
-            "title": true,
-            "title_align": "center",
-            "text_align": "center",
-            "width": 15,
-            "group_by": [
-                "$vcenter_server"
-            ],
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "type": "check_status",
-            "isShared": false,
-            "tags": [
-                "*"
-            ],
-            "time": {},
-            "title_text": "vSphere status",
-            "title_size": 16,
-            "scaleFactor": 1,
-            "add_timeframe": true,
-            "error": null,
-            "y": 12,
-            "x": 0,
-            "grouping": "cluster"
-        },
-        {
-            "x": 0,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Sum of vsphere.datastore.count over $vcenter_server,$vcenter_datacenter,$host",
-            "title_text": "Datastore Count",
-            "height": 7,
-            "tile_def": {
-                "viz": "query_value",
-                "requests": [
-                    {
-                        "q": "sum:vsphere.datastore.count{$vcenter_server,$vcenter_datacenter,$host}",
-                        "aggregator": "last",
-                        "conditional_formats": []
-                    }
-                ],
-                "precision": "0"
-            },
-            "width": 15,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 22,
-            "autoscale": true,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "x": 16,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Sum of vsphere.cluster.count over $vcenter_server,$vcenter_datacenter,$host",
-            "title_text": "Cluster Count",
-            "height": 7,
-            "tile_def": {
-                "viz": "query_value",
-                "requests": [
-                    {
-                        "q": "sum:vsphere.cluster.count{$vcenter_server,$vcenter_datacenter,$host}",
-                        "aggregator": "last",
-                        "conditional_formats": []
-                    }
-                ],
-                "autoscale": true,
-                "precision": "0"
-            },
-            "width": 15,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 22,
-            "autoscale": true,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "x": 32,
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Sum of vsphere.datacenter.count over $vcenter_server,$vcenter_datacenter,$host",
-            "title_text": "Datacenter Count",
-            "height": 7,
-            "tile_def": {
-                "viz": "query_value",
-                "requests": [
-                    {
-                        "q": "sum:vsphere.datacenter.count{$vcenter_server,$vcenter_datacenter,$host}",
-                        "aggregator": "last",
-                        "conditional_formats": []
-                    }
-                ],
-                "autoscale": true,
-                "precision": 2
-            },
-            "width": 15,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 22,
-            "autoscale": true,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "height": 6,
-            "viz": "note",
-            "tick_pos": "50%",
-            "title": false,
-            "background_color": "gray",
-            "text_align": "center",
-            "content": "# ESXi hosts",
-            "bgcolor": "gray",
-            "html": "# Virtual Machines",
-            "legend_size": "0",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "tick": true,
-            "scaleFactor": 1,
-            "legend": false,
-            "add_timeframe": true,
-            "font_size": "14",
-            "tick_edge": "bottom",
-            "y": 1,
-            "x": 98,
-            "width": 47
-        },
-        {
-            "height": 6,
-            "viz": "note",
-            "tick_pos": "50%",
-            "title": false,
-            "background_color": "gray",
-            "text_align": "center",
-            "content": "# Virtual Machines",
-            "bgcolor": "gray",
-            "html": "# Datastores",
-            "legend_size": "0",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "tick": true,
-            "scaleFactor": 1,
-            "legend": false,
-            "add_timeframe": true,
-            "font_size": "14",
-            "tick_edge": "bottom",
-            "y": 1,
-            "x": 147,
-            "width": 47
-        },
-        {
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Avg of vsphere.disk.used.latest over $vcenter_server,$vcenter_datacenter,vsph...",
-            "title_text": "Datastore used space in % (Top 10)",
-            "height": 34,
-            "tile_def": {
-                "viz": "toplist",
-                "requests": [
-                    {
-                        "q": "top(avg:vsphere.disk.used.latest{$vcenter_server,$vcenter_datacenter,vsphere_type:datastore} by {vsphere_datastore}/avg:vsphere.disk.capacity.latest{$vcenter_server,$vcenter_datacenter,vsphere_type:datastore} by {vsphere_datastore}*100,10,'mean','desc')",
-                        "conditional_formats": [
-                            {
-                                "requestIndex": 0,
-                                "palette": "white_on_green",
-                                "comparator": "<=",
-                                "value": "270"
-                            },
-                            {
-                                "requestIndex": 0,
-                                "palette": "white_on_yellow",
-                                "comparator": "<=",
-                                "value": 90
-                            },
-                            {
-                                "requestIndex": 0,
-                                "palette": "white_on_red",
-                                "comparator": ">",
-                                "value": 90
-                            }
-                        ]
-                    }
-                ]
-            },
-            "width": 47,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 9,
-            "x": 147,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "toplist",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "board_id": "m7e-3hv-p6n",
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Avg of vsphere.datastore.numberReadAveraged.avg over vsphere_type:datastore,$...",
-            "title_text": "Number of reads per datastore (Top 25)",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
-                "requests": [
-                    {
-                        "q": "top(avg:vsphere.datastore.numberReadAveraged.avg{vsphere_type:datastore,$vcenter_server,$vcenter_datacenter} by {vsphere_datastore}, 25, 'mean', 'desc')",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "markers": [],
-                "yaxis": {
-                    "min": "auto",
-                    "max": "auto",
-                    "scale": "linear",
-                    "label": "",
-                    "includeZero": true
-                }
-            },
-            "width": 47,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 46,
-            "x": 147,
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
-        },
-        {
-            "title_align": "left",
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "generated_title": "Avg of vsphere.disk.numberWriteAveraged.avg over vsphere_type:datastore,$vcen...",
-            "title_text": "Number of write per datastore (Top 25)",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
-                "requests": [
-                    {
-                        "q": "top(avg:vsphere.disk.numberWriteAveraged.avg{vsphere_type:datastore,$vcenter_server,$vcenter_datacenter} by {vsphere_datastore}, 25, 'mean', 'desc')",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "markers": [],
-                "yaxis": {
-                    "max": "auto",
-                    "label": "",
-                    "scale": "linear",
-                    "min": "auto",
-                    "includeZero": true
-                }
-            },
-            "width": 47,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 63,
-            "x": 147,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+        "layout": {
+          "x": 0,
+          "y": 3,
+          "width": 47,
+          "height": 10
         }
+      },
+      {
+        "id": 1,
+        "definition": {
+          "type": "query_value",
+          "requests": [
+            {
+              "q": "sum:vsphere.vm.count{$vcenter_server}",
+              "aggregator": "last"
+            }
+          ],
+          "custom_links": [],
+          "title": "VM Count",
+          "title_size": "16",
+          "title_align": "center",
+          "autoscale": true,
+          "precision": 2
+        },
+        "layout": {
+          "x": 22,
+          "y": 14,
+          "width": 25,
+          "height": 11
+        }
+      },
+      {
+        "id": 2,
+        "definition": {
+          "type": "event_stream",
+          "query": "sources:vsphere ",
+          "tags_execution": "and",
+          "event_size": "l",
+          "title": "vSphere Events",
+          "title_size": "16",
+          "title_align": "left"
+        },
+        "layout": {
+          "x": 0,
+          "y": 26,
+          "width": 47,
+          "height": 31
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "q": "top(avg:vsphere.mem.usage.avg{vsphere_type:vm,$vcenter_server,$vcenter_datacenter} by {host}, 25, 'mean', 'desc')",
+              "conditional_formats": [
+                {
+                  "comparator": "<=",
+                  "value": 70,
+                  "palette": "white_on_green"
+                },
+                {
+                  "comparator": "<=",
+                  "value": 90,
+                  "palette": "white_on_yellow"
+                },
+                {
+                  "comparator": ">",
+                  "value": 90,
+                  "palette": "white_on_red"
+                }
+              ],
+              "style": {
+                "palette": "dog_classic"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Most % memory loaded VMs (Top 25)",
+          "title_size": "16",
+          "title_align": "left"
+        },
+        "layout": {
+          "x": 146,
+          "y": 3,
+          "width": 47,
+          "height": 26
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "type": "check_status",
+          "title": "vCenter Server status",
+          "title_size": "16",
+          "title_align": "center",
+          "check": "vcenter.can_connect",
+          "grouping": "cluster",
+          "group": "$vcenter_server",
+          "group_by": [],
+          "tags": [
+            "$vcenter_server"
+          ]
+        },
+        "layout": {
+          "x": 0,
+          "y": 14,
+          "width": 21,
+          "height": 11
+        }
+      },
+      {
+        "id": 5,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "q": "top(avg:vsphere.cpu.usage.avg{$vcenter_datacenter,$vcenter_server,vsphere_type:vm} by {host}, 25, 'mean', 'desc')",
+              "conditional_formats": [
+                {
+                  "comparator": "<=",
+                  "value": 70,
+                  "palette": "white_on_green"
+                },
+                {
+                  "comparator": "<=",
+                  "value": 90,
+                  "palette": "white_on_yellow"
+                },
+                {
+                  "comparator": ">",
+                  "value": 90,
+                  "palette": "white_on_red"
+                }
+              ],
+              "style": {
+                "palette": "dog_classic"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Most % CPU loaded VMs (Top 25)",
+          "title_size": "16",
+          "title_align": "left"
+        },
+        "layout": {
+          "x": 146,
+          "y": 30,
+          "width": 47,
+          "height": 27
+        }
+      },
+      {
+        "id": 6,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "q": "top(avg:vsphere.mem.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:host} by {host}, 10, 'mean', 'desc')",
+              "conditional_formats": [
+                {
+                  "comparator": "<=",
+                  "value": 70,
+                  "palette": "white_on_green"
+                },
+                {
+                  "comparator": "<=",
+                  "value": 90,
+                  "palette": "white_on_yellow"
+                },
+                {
+                  "comparator": ">",
+                  "value": 90,
+                  "palette": "white_on_red"
+                }
+              ],
+              "style": {
+                "palette": "dog_classic"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Most % memory loaded hosts (Top 10)",
+          "title_size": "16",
+          "title_align": "left"
+        },
+        "layout": {
+          "x": 49,
+          "y": 42,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 7,
+        "definition": {
+          "type": "toplist",
+          "requests": [
+            {
+              "q": "top(avg:vsphere.cpu.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:host} by {host}, 10, 'mean', 'desc')",
+              "conditional_formats": [
+                {
+                  "comparator": "<=",
+                  "value": 70,
+                  "palette": "white_on_green"
+                },
+                {
+                  "comparator": "<=",
+                  "value": 90,
+                  "palette": "white_on_yellow"
+                },
+                {
+                  "comparator": ">",
+                  "value": 90,
+                  "palette": "white_on_red"
+                }
+              ],
+              "style": {
+                "palette": "dog_classic"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Most % CPU loaded hosts (Top 10)",
+          "title_size": "16",
+          "title_align": "left"
+        },
+        "layout": {
+          "x": 49,
+          "y": 26,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 8,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vsphere.disk.deviceLatency.avg{$vcenter_server,$vcenter_datacenter} by {host}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Disk device latency per host",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 49,
+          "y": 58,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 9,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "top(avg:vsphere.disk.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:vm} by {host}, 25, 'mean', 'desc')",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Disk I/O rates per VM (Top 25)",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 146,
+          "y": 58,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 10,
+        "definition": {
+          "type": "hostmap",
+          "requests": {
+            "fill": {
+              "q": "avg:vsphere.cpu.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:vm} by {host}"
+            },
+            "size": {
+              "q": "avg:vsphere.mem.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:vm} by {host}"
+            }
+          },
+          "custom_links": [],
+          "title": "VMs CPU usage sized by memory usage",
+          "title_size": "16",
+          "title_align": "left",
+          "no_metric_hosts": true,
+          "no_group_hosts": true,
+          "group": [
+            "vsphere_datacenter",
+            "vsphere_host"
+          ],
+          "scope": [
+            "$vcenter_server",
+            "$vcenter_datacenter",
+            "vsphere_type:vm"
+          ],
+          "style": {
+            "palette": "YlOrRd",
+            "palette_flip": false,
+            "fill_min": "0",
+            "fill_max": "100"
+          }
+        },
+        "layout": {
+          "x": 98,
+          "y": 3,
+          "width": 47,
+          "height": 54
+        }
+      },
+      {
+        "id": 11,
+        "definition": {
+          "type": "hostmap",
+          "requests": {
+            "fill": {
+              "q": "avg:vsphere.cpu.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:host} by {host}"
+            },
+            "size": {
+              "q": "avg:vsphere.mem.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:host} by {host}"
+            }
+          },
+          "custom_links": [],
+          "title": "Hosts CPU usage sized by memory usage",
+          "title_size": "16",
+          "title_align": "left",
+          "no_metric_hosts": true,
+          "no_group_hosts": true,
+          "group": [
+            "vsphere_datacenter",
+            "vsphere_cluster"
+          ],
+          "scope": [
+            "$vcenter_server",
+            "$vcenter_datacenter",
+            "vsphere_type:host"
+          ],
+          "style": {
+            "palette": "YlOrRd",
+            "palette_flip": false,
+            "fill_min": "0",
+            "fill_max": "100"
+          }
+        },
+        "layout": {
+          "x": 49,
+          "y": 3,
+          "width": 47,
+          "height": 22
+        }
+      },
+      {
+        "id": 12,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vsphere.disk.maxTotalLatency.latest{$vcenter_server,$vcenter_datacenter,vsphere_type:host} by {host}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Disk max total latency per host",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 49,
+          "y": 74,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 13,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "avg:vsphere.mem.vmmemctl.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:host} by {host}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Memory ballooning by host",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 0,
+          "y": 58,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 14,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "top(avg:vsphere.mem.swapinRate.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:vm} by {host}, 25, 'mean', 'desc')",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Memory swap in rate per VM (Top 25)",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 98,
+          "y": 74,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 15,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "top(avg:vsphere.mem.swapoutRate.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:vm} by {host}, 25, 'mean', 'desc')",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Memory swap out rate per VM (Top 25)",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 98,
+          "y": 58,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 16,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:vsphere.net.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:vm,!instance:none}",
+              "display_type": "line",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Total network utilization of VMs",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 146,
+          "y": 74,
+          "width": 47,
+          "height": 15
+        }
+      },
+      {
+        "id": 17,
+        "definition": {
+          "type": "timeseries",
+          "requests": [
+            {
+              "q": "sum:vsphere.net.usage.avg{$vcenter_server,$vcenter_datacenter,vsphere_type:host,!instance:none} by {host}",
+              "display_type": "area",
+              "style": {
+                "palette": "dog_classic",
+                "line_type": "solid",
+                "line_width": "normal"
+              }
+            }
+          ],
+          "custom_links": [],
+          "title": "Total network utilization of hosts",
+          "title_size": "16",
+          "title_align": "left",
+          "show_legend": false,
+          "legend_size": "0"
+        },
+        "layout": {
+          "x": 0,
+          "y": 74,
+          "width": 47,
+          "height": 15
+        }
+      }
     ],
-    "disableCog": false,
-    "id": 969848,
-    "title_edited": false,
-    "isShared": false
-}
+    "template_variables": [
+      {
+        "name": "vcenter_server",
+        "default": "*",
+        "prefix": "vcenter_server"
+      },
+      {
+        "name": "vcenter_datacenter",
+        "default": "*",
+        "prefix": "vsphere_datacenter"
+      }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 249
+  }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Migrates a handful of integration dashboards to use the new `dashboard` payload structure

### Motivation
<!-- What inspired you to submit this pull request? -->
Trying to migrate away from the older screenboard/timeboard payload usage

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Can be confirmed by checking each dashboard loads properly on staging. 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
