### PR TITLE
Avoid depleting collection_metric_names

### DIFF
--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -88,7 +88,7 @@ class MongoDb(AgentCheck):
         # Members' last replica set states
         self._last_state_by_server = {}
 
-        self.collection_metrics_names = (key.split('.')[1] for key in metrics.COLLECTION_METRICS)
+        self.collection_metrics_names = tuple([key.split('.')[1] for key in metrics.COLLECTION_METRICS])
 
         # x.509 authentication
         ssl_params = {

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -88,7 +88,7 @@ class MongoDb(AgentCheck):
         # Members' last replica set states
         self._last_state_by_server = {}
 
-        self.collection_metrics_names = tuple([key.split('.')[1] for key in metrics.COLLECTION_METRICS])
+        self.collection_metrics_names = tuple(key.split('.')[1] for key in metrics.COLLECTION_METRICS)
 
         # x.509 authentication
         ssl_params = {


### PR DESCRIPTION
Solves bug introduced in https://github.com/DataDog/integrations-core/pull/6085/files#diff-0efa0f9b704463fe48690c966595316cR90 that made collection metrics be collected only once.