### PR TITLE
Fix changelog check trigger

### DIFF
--- a/.github/workflows/changelog-label-check.yml
+++ b/.github/workflows/changelog-label-check.yml
@@ -1,9 +1,7 @@
 name: Changelog label check
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
-  repository_dispatch:
-    types: [labeled]
+    types: [labeled, unlabeled]
 
 jobs:
   check:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,9 +13,3 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/workflows/config/labeler.yml
-
-    - name: Check labels
-      uses: peter-evans/repository-dispatch@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        event-type: labeled


### PR DESCRIPTION
The labeler should add at least one label when the pull request is open, triggering the changelog label checker