### PR TITLE
Remove unused ORIG_CI_BUILD_REF_NAME param in release

### DIFF
--- a/.gitlab/tagger/build-packages.sh
+++ b/.gitlab/tagger/build-packages.sh
@@ -5,7 +5,6 @@ IFS=$'\n\t'
 
 curl --request POST --form "token=$CI_JOB_TOKEN" --form ref=master \
   --form variables[ORIG_CI_BUILD_REF]=$CI_BUILD_REF \
-  --form variables[ORIG_CI_BUILD_REF_NAME]=$CI_BUILD_REF_NAME \
   --form variables[ROOT_LAYOUT_TYPE]=core \
   --form variables[REPO_NAME]=integrations-core \
   https://gitlab.ddbuild.io/api/v4/projects/138/trigger/pipeline


### PR DESCRIPTION
Field isn't used