### PR TITLE
[dashboards] Convert rest of integrations-core dashboard payloads

### DIFF
--- a/airflow/assets/dashboards/overview.json
+++ b/airflow/assets/dashboards/overview.json
@@ -1,851 +1,610 @@
 {
-  "author_info": {
-    "author_name": "Datadog"
-  },
-  "board_title": "Airflow Overview",
-  "created": "2019-12-19T11:02:09.240104+00:00",
-  "created_by": {
-    "access_role": "st",
-    "disabled": false,
-    "email": "support@datadoghq.com",
-    "handle": "support@datadoghq.com",
-    "is_admin": false,
-    "name": "Datadog",
-    "role": null,
-    "verified": true
-  },
-  "description": "## Airflow\n\nThis dashboard provides a high-level overview of your Airflow instances so you can monitor metrics related to DAGs, tasks, pools and executors.\n\nFor further reading on monitoring Airflow, see:\n\n- [Official Airflow integration docs](https://docs.datadoghq.com/integrations/airflow/#data-collected)\n\nClone this template to make changes and add your own graphs and widgets.",
-  "disableCog": false,
-  "disableEditing": false,
-  "id": 929073,
-  "isIntegration": false,
-  "isShared": false,
-  "modified": "2019-12-19T14:05:34.007621+00:00",
-  "new_id": "b6s-n9f-vzu",
-  "originalHeight": 80,
-  "originalWidth": "calc(100% - 32px)",
-  "read_only": false,
-  "template_variables": [
-    {
-      "default": "*",
-      "name": "scope",
-      "prefix": null
-    },
-    {
-      "default": "*",
-      "name": "host",
-      "prefix": "host"
-    }
-  ],
-  "widgets": [
-    {
-      "add_timeframe": true,
-      "generated_title": "",
-      "height": 9,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "margin": "",
-      "sizing": "fit",
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "",
-      "type": "image",
-      "url": "/static/images/saas_logos/bot/airflow@2x.png",
-      "viz": "image",
-      "width": 16,
-      "x": 1,
-      "y": 1
-    },
-    {
-      "add_timeframe": true,
-      "check": "airflow.can_connect",
-      "error": null,
-      "group": null,
-      "group_by": [],
-      "grouping": "cluster",
-      "height": 8,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tags": [
-        "$scope",
-        "$host"
-      ],
-      "text_align": "center",
-      "text_size": "auto",
-      "time": {},
-      "title": true,
-      "title_align": "center",
-      "title_size": "16",
-      "title_text": "Can Connect",
-      "type": "check_status",
-      "viz": "check_status",
-      "width": 16,
-      "x": 1,
-      "y": 11
-    },
-    {
-      "add_timeframe": true,
-      "check": "airflow.healthy",
-      "error": null,
-      "group": null,
-      "group_by": [],
-      "grouping": "cluster",
-      "height": 8,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tags": [
-        "$scope",
-        "$host"
-      ],
-      "text_align": "center",
-      "text_size": "auto",
-      "time": {},
-      "title": true,
-      "title_align": "center",
-      "title_size": "16",
-      "title_text": "Healthy",
-      "type": "check_status",
-      "viz": "check_status",
-      "width": 16,
-      "x": 1,
-      "y": 20
-    },
-    {
-      "add_timeframe": true,
-      "auto_refresh": false,
-      "background_color": "gray",
-      "bgcolor": "gray",
-      "content": "JVM & System",
-      "font_size": "24",
-      "height": 7,
-      "html": "DAGs",
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "text_align": "center",
-      "tick": true,
-      "tick_edge": "bottom",
-      "tick_pos": "50%",
-      "title": false,
-      "type": "note",
-      "viz": "note",
-      "width": 95,
-      "x": 66,
-      "y": 1
-    },
-    {
-      "add_timeframe": true,
-      "board_id": "b6s-n9f-vzu",
-      "error": null,
-      "generated_title": "airflow.dagbag_size",
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.dagbag_size{$host,$scope}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+    "title": "Airflow Overview",
+    "description": "## Airflow\n\nThis dashboard provides a high-level overview of your Airflow instances so you can monitor metrics related to DAGs, tasks, pools and executors.\n\nFor further reading on monitoring Airflow, see:\n\n- [Official Airflow integration docs](https://docs.datadoghq.com/integrations/airflow/#data-collected)\n\nClone this template to make changes and add your own graphs and widgets.",
+    "widgets": [
+        {
+            "id": 0,
+            "definition": {
+                "type": "image",
+                "url": "/static/images/saas_logos/bot/airflow@2x.png",
+                "sizing": "fit"
             },
-            "type": "line"
-          }
-        ],
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "DAG Bag Size",
-      "type": "timeseries",
-      "width": 47,
-      "x": 114,
-      "y": 25
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.dagbag_import_errors{$host,$scope}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 16,
+                "height": 9
+            }
+        },
+        {
+            "id": 1,
+            "definition": {
+                "type": "check_status",
+                "title": "Can Connect",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "airflow.can_connect",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "$scope",
+                    "$host"
+                ]
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "DAG Import Errors",
-      "type": "timeseries",
-      "width": 47,
-      "x": 114,
-      "y": 41
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.dag_processing.processes{$host,$scope}.as_count()",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 1,
+                "y": 11,
+                "width": 16,
+                "height": 8
+            }
+        },
+        {
+            "id": 2,
+            "definition": {
+                "type": "check_status",
+                "title": "Healthy",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "airflow.healthy",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "$scope",
+                    "$host"
+                ]
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "DAG Processes",
-      "type": "timeseries",
-      "width": 47,
-      "x": 114,
-      "y": 57
-    },
-    {
-      "add_timeframe": true,
-      "auto_refresh": false,
-      "background_color": "gray",
-      "bgcolor": "gray",
-      "content": "DAG",
-      "font_size": "24",
-      "height": 7,
-      "html": "Executors",
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "text_align": "center",
-      "tick": true,
-      "tick_edge": "bottom",
-      "tick_pos": "50%",
-      "title": false,
-      "type": "note",
-      "viz": "note",
-      "width": 47,
-      "x": 162,
-      "y": 1
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.executor.open_slots{$host,$scope}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 1,
+                "y": 20,
+                "width": 16,
+                "height": 8
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "note",
+                "content": "DAGs",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Executor Slots",
-      "type": "timeseries",
-      "width": 47,
-      "x": 162,
-      "y": 9
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.executor.queued_tasks{$host,$scope}, avg:airflow.executor.running_tasks{$host,$scope}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 66,
+                "y": 1,
+                "width": 95,
+                "height": 7
+            }
+        },
+        {
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.dagbag_size{$host,$scope}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "DAG Bag Size",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Executor Tasks",
-      "type": "timeseries",
-      "width": 47,
-      "x": 162,
-      "y": 25
-    },
-    {
-      "add_timeframe": true,
-      "auto_refresh": false,
-      "background_color": "gray",
-      "bgcolor": "gray",
-      "content": "Executor",
-      "font_size": "24",
-      "height": 7,
-      "html": "Scheduler",
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "text_align": "center",
-      "tick": true,
-      "tick_edge": "bottom",
-      "tick_pos": "50%",
-      "title": false,
-      "type": "note",
-      "viz": "note",
-      "width": 47,
-      "x": 162,
-      "y": 41
-    },
-    {
-      "add_timeframe": true,
-      "auto_refresh": false,
-      "background_color": "gray",
-      "bgcolor": "gray",
-      "content": "Executor",
-      "font_size": "24",
-      "height": 7,
-      "html": "Jobs",
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "text_align": "center",
-      "tick": true,
-      "tick_edge": "bottom",
-      "tick_pos": "50%",
-      "title": false,
-      "type": "note",
-      "viz": "note",
-      "width": 47,
-      "x": 18,
-      "y": 25
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.job.start{$host,$scope} by {job_name}.as_count()",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 114,
+                "y": 25,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.dagbag_import_errors{$host,$scope}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "DAG Import Errors",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Job Started",
-      "type": "timeseries",
-      "width": 47,
-      "x": 18,
-      "y": 33
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.job.end{$host,$scope} by {job_name}.as_count()",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 114,
+                "y": 41,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.dag_processing.processes{$host,$scope}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "DAG Processes",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Job Ended",
-      "type": "timeseries",
-      "width": 47,
-      "x": 18,
-      "y": 49
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.scheduler_heartbeat{$host,$scope}.as_count()",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 114,
+                "y": 57,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 7,
+            "definition": {
+                "type": "note",
+                "content": "Executors",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Job Scheduler Heatbeat",
-      "type": "timeseries",
-      "width": 47,
-      "x": 162,
-      "y": 49
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.dag.task.duration.avg{$host,$scope} by {dag_id}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 162,
+                "y": 1,
+                "width": 47,
+                "height": 7
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.executor.open_slots{$host,$scope}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Executor Slots",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "DAG Run Task Duration",
-      "type": "timeseries",
-      "width": 47,
-      "x": 66,
-      "y": 9
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.dagrun.duration.success.avg{$host,$scope} by {dag_id}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 162,
+                "y": 9,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.executor.queued_tasks{$host,$scope}, avg:airflow.executor.running_tasks{$host,$scope}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Executor Tasks",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "DAG Run Success Duration",
-      "type": "timeseries",
-      "width": 47,
-      "x": 66,
-      "y": 41
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.dagrun.duration.failed.avg{$host,$scope} by {dag_id}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 162,
+                "y": 25,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "note",
+                "content": "Scheduler",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "DAG Run Failed Duration",
-      "type": "timeseries",
-      "width": 47,
-      "x": 66,
-      "y": 57
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.dagrun.schedule_delay.avg{$host,$scope} by {dag_id}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 162,
+                "y": 41,
+                "width": 47,
+                "height": 7
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "note",
+                "content": "Jobs",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "DAG Run Failed Duration",
-      "type": "timeseries",
-      "width": 47,
-      "x": 66,
-      "y": 25
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.dag.loading_duration.avg{$host,$scope} by {dag_file}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 18,
+                "y": 25,
+                "width": 47,
+                "height": 7
+            }
+        },
+        {
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.job.start{$host,$scope} by {job_name}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Job Started",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "area"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "DAG Loading Duration",
-      "type": "timeseries",
-      "width": 47,
-      "x": 114,
-      "y": 9
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.ti_failures{$host,$scope}.as_count(), avg:airflow.ti_successes{$host,$scope}.as_count()",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 18,
+                "y": 33,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.job.end{$host,$scope} by {job_name}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Job Ended",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "bars"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Task Instances Successes & Failures",
-      "type": "timeseries",
-      "width": 47,
-      "x": 18,
-      "y": 9
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "sharedGlobalTime": {
-        "live_span": "1h"
-      },
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:airflow.pool.open_slots{$host,$scope}, avg:airflow.pool.used_slots{$host,$scope}, avg:airflow.pool.starving_tasks{$host,$scope}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 18,
+                "y": 49,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 14,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.scheduler_heartbeat{$host,$scope}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Job Scheduler Heatbeat",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Pools Open/Used/Starving",
-      "type": "timeseries",
-      "width": 47,
-      "x": 162,
-      "y": 65
-    },
-    {
-      "add_timeframe": true,
-      "auto_refresh": false,
-      "background_color": "gray",
-      "bgcolor": "gray",
-      "content": "Jobs",
-      "font_size": "24",
-      "height": 7,
-      "html": "Tasks",
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "text_align": "center",
-      "tick": true,
-      "tick_edge": "bottom",
-      "tick_pos": "50%",
-      "title": false,
-      "type": "note",
-      "viz": "note",
-      "width": 47,
-      "x": 18,
-      "y": 1
-    }
-  ]
+            "layout": {
+                "x": 162,
+                "y": 49,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.dag.task.duration.avg{$host,$scope} by {dag_id}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "DAG Run Task Duration",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 66,
+                "y": 9,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.dagrun.duration.success.avg{$host,$scope} by {dag_id}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "DAG Run Success Duration",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 66,
+                "y": 41,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 17,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.dagrun.duration.failed.avg{$host,$scope} by {dag_id}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "DAG Run Failed Duration",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 66,
+                "y": 57,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 18,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.dagrun.schedule_delay.avg{$host,$scope} by {dag_id}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "DAG Run Failed Duration",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 66,
+                "y": 25,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 19,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.dag.loading_duration.avg{$host,$scope} by {dag_file}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "DAG Loading Duration",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 114,
+                "y": 9,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 20,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.ti_failures{$host,$scope}.as_count(), avg:airflow.ti_successes{$host,$scope}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Task Instances Successes & Failures",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 18,
+                "y": 9,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 21,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:airflow.pool.open_slots{$host,$scope}, avg:airflow.pool.used_slots{$host,$scope}, avg:airflow.pool.starving_tasks{$host,$scope}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pools Open/Used/Starving",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 162,
+                "y": 65,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 22,
+            "definition": {
+                "type": "note",
+                "content": "Tasks",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 18,
+                "y": 1,
+                "width": 47,
+                "height": 7
+            }
+        }
+    ],
+    "template_variables": [
+        {
+            "name": "scope",
+            "default": "*",
+            "prefix": null
+        },
+        {
+            "name": "host",
+            "default": "*",
+            "prefix": "host"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30298
 }

--- a/amazon_msk/assets/dashboards/overview.json
+++ b/amazon_msk/assets/dashboards/overview.json
@@ -1,561 +1,428 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "Amazon MSK Overview",
-    "created": "2020-01-14T16:12:01.379535+00:00",
-    "created_by": {
-        "access_role": "st",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": false,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "Amazon MSK Overview",
     "description": "## Amazon MSK Overview\n\nThis is an example Amazon MSK dashboard demonstrating the metrics that the integration collects.",
-    "disableCog": false,
-    "disableEditing": false,
-    "id": 945872,
-    "isIntegration": false,
-    "isShared": false,
-    "modified": "2020-01-15T17:30:24.079208+00:00",
-    "new_id": "sq7-gcx-8fg",
-    "originalHeight": 80,
-    "originalWidth": "calc(100% - 32px)",
-    "read_only": false,
-    "template_variables": [],
     "widgets": [
         {
-            "add_timeframe": true,
-            "board_id": "sq7-gcx-8fg",
-            "error": null,
-            "generated_title": "Sum of aws.kafka.memory_free over * by broker_id",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "markers": [],
+            "id": 0,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:aws.kafka.memory_free{*} by {broker_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Free memory by broker",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Free memory by broker",
-            "type": "timeseries",
-            "width": 47,
-            "x": 115,
-            "y": 8
+            "layout": {
+                "x": 115,
+                "y": 8,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "add_timeframe": true,
-            "autoscale": true,
-            "board_id": "sq7-gcx-8fg",
-            "error": null,
-            "generated_title": "Avg of aws.kafka.offline_partitions_count over *",
-            "height": 8,
-            "isShared": false,
-            "legend": false,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "precision": "0",
+            "id": 1,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "avg:aws.kafka.offline_partitions_count{*}",
                         "aggregator": "avg",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": "1"
-                            },
-                            {
-                                "comparator": ">=",
-                                "palette": "white_on_yellow"
-                            },
-                            {
-                                "comparator": "<=",
-                                "palette": "white_on_green",
-                                "value": "0"
-                            }
-                        ],
-                        "q": "avg:aws.kafka.offline_partitions_count{*}"
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "# Offline",
-            "type": "query_value",
-            "width": 17,
-            "x": 1,
-            "y": 20
-        },
-        {
-            "add_timeframe": true,
-            "autoscale": true,
-            "board_id": "sq7-gcx-8fg",
-            "error": null,
-            "generated_title": "Avg of aws.kafka.under_replicated_partitions over *",
-            "height": 9,
-            "isShared": false,
-            "legend": false,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "precision": "0",
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
+                                "value": 1,
                                 "palette": "white_on_red"
                             },
                             {
-                                "comparator": ">=",
-                                "palette": "white_on_yellow"
-                            },
-                            {
-                                "comparator": "<",
+                                "comparator": "<=",
+                                "value": 0,
                                 "palette": "white_on_green"
                             }
-                        ],
-                        "q": "avg:aws.kafka.under_replicated_partitions{*}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "# Offline",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "# Under replicated",
-            "type": "query_value",
-            "width": 17,
-            "x": 1,
-            "y": 31
+            "layout": {
+                "x": 1,
+                "y": 20,
+                "width": 17,
+                "height": 10
+            }
         },
         {
-            "add_timeframe": true,
-            "error": null,
-            "generated_title": "Sum of aws.kafka.kafka_data_logs_disk_used over * by broker_id",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
+            "id": 2,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:aws.kafka.under_replicated_partitions{*}",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "# Under replicated",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "tile_def": {
-                "markers": [],
+            "layout": {
+                "x": 1,
+                "y": 31,
+                "width": 17,
+                "height": 11
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:aws.kafka.kafka_data_logs_disk_used{*} by {broker_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Disk usage (data logs)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Disk usage (data logs)",
-            "type": "timeseries",
-            "width": 47,
-            "x": 67,
-            "y": 8
+            "layout": {
+                "x": 67,
+                "y": 8,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "add_timeframe": true,
-            "board_id": "sq7-gcx-8fg",
-            "error": null,
-            "generated_title": "Avg of aws.kafka.cpu_user over *",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "markers": [],
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:aws.kafka.cpu_user{*}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "User CPU",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "User CPU",
-            "type": "timeseries",
-            "width": 47,
-            "x": 19,
-            "y": 8
+            "layout": {
+                "x": 19,
+                "y": 8,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "add_timeframe": true,
-            "board_id": "sq7-gcx-8fg",
-            "error": null,
-            "generated_title": "Avg of aws.kafka.cpu_system over *",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "markers": [],
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:aws.kafka.cpu_system{*}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "System CPU",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "System CPU",
-            "type": "timeseries",
-            "width": 47,
-            "x": 19,
-            "y": 24
+            "layout": {
+                "x": 19,
+                "y": 24,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": "sq7-gcx-8fg",
-            "font_size": "14",
-            "height": 6,
-            "html": "CPU",
-            "isShared": false,
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 47,
-            "x": 19,
-            "y": 1
+            "id": 6,
+            "definition": {
+                "type": "note",
+                "content": "CPU",
+                "background_color": "gray",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 19,
+                "y": 1,
+                "width": 47,
+                "height": 6
+            }
         },
         {
-            "add_timeframe": true,
-            "error": null,
-            "generated_title": "Sum of aws.kafka.kafka_app_logs_disk_used over * by broker_id",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "markers": [],
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:aws.kafka.kafka_app_logs_disk_used{*} by {broker_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Disk usage (application logs)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Disk usage (application logs)",
-            "type": "timeseries",
-            "width": 47,
-            "x": 67,
-            "y": 24
+            "layout": {
+                "x": 67,
+                "y": 24,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "background_color": "gray",
-            "bgcolor": "gray",
-            "content": "CPU",
-            "font_size": "18",
-            "height": 6,
-            "html": "Disk",
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "viz": "note",
-            "width": 47,
-            "x": 67,
-            "y": 1
+            "id": 8,
+            "definition": {
+                "type": "note",
+                "content": "Disk",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 67,
+                "y": 1,
+                "width": 47,
+                "height": 6
+            }
         },
         {
-            "add_timeframe": true,
-            "error": null,
-            "generated_title": "Sum of aws.kafka.memory_used over * by broker_id",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "markers": [],
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:aws.kafka.memory_used{*} by {broker_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Used memory by broker",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Used memory by broker",
-            "type": "timeseries",
-            "width": 47,
-            "x": 115,
-            "y": 24
+            "layout": {
+                "x": 115,
+                "y": 24,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "background_color": "gray",
-            "bgcolor": "gray",
-            "content": "Disk",
-            "font_size": "18",
-            "height": 6,
-            "html": "Memory",
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "viz": "note",
-            "width": 47,
-            "x": 115,
-            "y": 1
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": "sq7-gcx-8fg",
-            "font_size": "18",
-            "height": 12,
-            "html": "ZooKeeper latency",
-            "isShared": false,
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "right",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 17,
-            "x": 1,
-            "y": 43
-        },
-        {
-            "add_timeframe": true,
-            "board_id": "sq7-gcx-8fg",
-            "error": null,
-            "generated_title": "Avg of aws.kafka.zoo_keeper_request_latency_ms_mean over *",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
+            "id": 10,
+            "definition": {
+                "type": "note",
+                "content": "Memory",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "tile_def": {
-                "autoscale": true,
+            "layout": {
+                "x": 115,
+                "y": 1,
+                "width": 47,
+                "height": 6
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "note",
+                "content": "ZooKeeper latency",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 1,
+                "y": 43,
+                "width": 17,
+                "height": 12
+            }
+        },
+        {
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
                         "q": "avg:aws.kafka.zoo_keeper_request_latency_ms_mean{*}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average ZooKeeper request latency (ms)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average ZooKeeper request latency (ms)",
-            "type": "timeseries",
-            "width": 47,
-            "x": 19,
-            "y": 40
+            "layout": {
+                "x": 19,
+                "y": 40,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": "sq7-gcx-8fg",
-            "font_size": "18",
-            "height": 5,
-            "html": "partitions",
-            "isShared": false,
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 17,
-            "x": 1,
-            "y": 14
+            "id": 13,
+            "definition": {
+                "type": "note",
+                "content": "partitions",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 14,
+                "width": 17,
+                "height": 5
+            }
         },
         {
-            "add_timeframe": true,
-            "board_id": "sq7-gcx-8fg",
-            "height": 12,
-            "isShared": false,
-            "margin": "",
-            "scaleFactor": 1,
-            "sizing": "zoom",
-            "title": false,
-            "type": "image",
-            "url": "/static/images/saas_logos/bot/amazon_msk@2x.png",
-            "width": 17,
-            "x": 1,
-            "y": 1
+            "id": 14,
+            "definition": {
+                "type": "image",
+                "url": "/static/images/saas_logos/bot/amazon_msk@2x.png",
+                "sizing": "zoom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 17,
+                "height": 12
+            }
         }
-    ]
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30260
 }

--- a/ambari/assets/dashboards/base_dashboard.json
+++ b/ambari/assets/dashboards/base_dashboard.json
@@ -1,593 +1,420 @@
 {
-  "board_title": "Ambari base dashboard",
-  "read_only": false,
-  "author_info": {
-    "author_name": "Datadog"
-  },
-  "description": "## Ambari Dashboard\n\nThis is an example Ambari dashboard demonstrating the metrics that the integration collects.",
-  "board_bgtype": "board_graph",
-  "created": "2019-06-13T14:39:10.350422+00:00",
-  "created_by": {
-    "disabled": false,
-    "handle": "support@datadoghq.com",
-    "name": "Datadog",
-    "is_admin": false,
-    "role": null,
-    "access_role": "st",
-    "verified": true,
-    "email": "support@datadoghq.com"
-  },
-  "new_id": "i74-xsf-mfs",
-  "modified": "2019-06-27T13:59:13.583154+00:00",
-  "originalHeight": 80,
-  "height": 91,
-  "width": 151,
-  "template_variables": [
-    {
-      "default": "*",
-      "prefix": "ambari_cluster",
-      "name": "ambari_cluster"
-    }
-  ],
-  "isIntegration": false,
-  "disableEditing": false,
-  "originalWidth": "100%",
-  "widgets": [
-    {
-      "board_id": "i74-xsf-mfs",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1561638246082,
-        "end": 1561641846082
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "Memory by host",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ambari.memory.mem_free{*} by {host,ambari_cluster}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+    "title": "Ambari base dashboard",
+    "description": "## Ambari Dashboard\n\nThis is an example Ambari dashboard demonstrating the metrics that the integration collects.",
+    "widgets": [
+        {
+            "id": 0,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ambari.memory.mem_free{*} by {host,ambari_cluster}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:ambari.memory.mem_total{*} by {host,ambari_cluster}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:ambari.memory.mem_cached{*} by {host,ambari_cluster}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:ambari.memory.mem_shared{*} by {host,ambari_cluster}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:ambari.memory.swap_total{*} by {host,ambari_cluster}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:ambari.memory.swap_free{*} by {host,ambari_cluster}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Memory by host",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "area",
-            "conditional_formats": []
-          },
-          {
-            "q": "avg:ambari.memory.mem_total{*} by {host,ambari_cluster}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "line"
-          },
-          {
-            "q": "avg:ambari.memory.mem_cached{*} by {host,ambari_cluster}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "area"
-          },
-          {
-            "q": "avg:ambari.memory.mem_shared{*} by {host,ambari_cluster}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "area"
-          },
-          {
-            "q": "avg:ambari.memory.swap_total{*} by {host,ambari_cluster}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "line"
-          },
-          {
-            "q": "avg:ambari.memory.swap_free{*} by {host,ambari_cluster}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "area"
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 24,
-      "x": 50,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "i74-xsf-mfs",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1561638246082,
-        "end": 1561641846082
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "Disk by host",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ambari.disk.disk_free{*} by {host,ambari_cluster}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "area",
-            "conditional_formats": []
-          },
-          {
-            "q": "avg:ambari.disk.disk_total{*} by {host,ambari_cluster}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "area"
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 24,
-      "x": 0,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "i74-xsf-mfs",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1561638246082,
-        "end": 1561641846082
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "Cluster process by cluster",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ambari.process.proc_total{*} by {ambari_cluster}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "area",
-            "conditional_formats": []
-          },
-          {
-            "q": "avg:ambari.process.proc_run{*} by {ambari_cluster}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "line"
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 41,
-      "x": 0,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "i74-xsf-mfs",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1561638246082,
-        "end": 1561641846082
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "Load 15 by host",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ambari.load.load_fifteen{*} by {host,ambari_cluster}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "line",
-            "conditional_formats": []
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 24,
-      "x": 99,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "i74-xsf-mfs",
-      "sizing": "zoom",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560854985850,
-        "end": 1560858585850
-      },
-      "generated_title": "",
-      "title_size": 16,
-      "title": true,
-      "url": "https://s3.amazonaws.com/dd-integrations/ambari/configuration/tile/logo.png",
-      "scaleFactor": 1,
-      "title_align": "left",
-      "title_text": "",
-      "height": 11,
-      "width": 47,
-      "type": "image",
-      "y": 2,
-      "x": 0,
-      "add_timeframe": true,
-      "margin": "",
-      "isShared": false
-    },
-    {
-      "height": 8,
-      "text_size": "auto",
-      "check": "ambari.can_connect",
-      "board_id": "i74-xsf-mfs",
-      "group": null,
-      "title": true,
-      "title_align": "center",
-      "text_align": "center",
-      "width": 15,
-      "group_by": [],
-      "type": "check_status",
-      "isShared": false,
-      "tags": [
-        "*"
-      ],
-      "time": {},
-      "title_text": "Agent Up",
-      "title_size": 16,
-      "scaleFactor": 1,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1561638246082,
-        "end": 1561641846082
-      },
-      "error": null,
-      "y": 14,
-      "x": 15,
-      "grouping": "cluster"
-    },
-    {
-      "board_id": "i74-xsf-mfs",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1561638246082,
-        "end": 1561641846082
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "CPU by host",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ambari.cpu.cpu_system{*} by {ambari_cluster,host}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "area",
-            "conditional_formats": []
-          },
-          {
-            "q": "avg:ambari.cpu.cpu_user{*} by {ambari_cluster,host}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "area"
-          },
-          {
-            "q": "avg:ambari.cpu.cpu_idle{*} by {ambari_cluster,host}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
-            },
-            "type": "area"
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 41,
-      "x": 99,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "i74-xsf-mfs",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1561638246082,
-        "end": 1561641846082
-      },
-      "title": false,
-      "type": "hostmap",
-      "generated_title": "Host Map",
-      "height": 20,
-      "tile_def": {
-        "style": {
-          "fillMax": null,
-          "palette": "green_to_orange",
-          "fillMin": null,
-          "paletteFlip": false
+            "layout": {
+                "x": 50,
+                "y": 24,
+                "width": 47,
+                "height": 15
+            }
         },
-        "group": [],
-        "notes": null,
-        "noMetricHosts": false,
-        "viz": "hostmap",
-        "scope": [
-          "$ambari_cluster"
-        ],
-        "requests": [
-          {
-            "q": "avg:ambari.load.load_one{$ambari_cluster} by {host}",
-            "type": "fill"
-          }
-        ],
-        "groupby": null,
-        "noGroupHosts": true
-      },
-      "width": 47,
-      "query": "avg:system.load.1{*} by {host}",
-      "y": 2,
-      "x": 50,
-      "legend_size": null,
-      "add_timeframe": true,
-      "scaleFactor": 1,
-      "legend": null,
-      "isShared": false
-    },
-    {
-      "board_id": "i74-xsf-mfs",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1561638246082,
-        "end": 1561641846082
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "Disk read/write bytes by host",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ambari.disk.read_bytes{*} by {ambari_cluster,host}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+        {
+            "id": 1,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ambari.disk.disk_free{*} by {host,ambari_cluster}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:ambari.disk.disk_total{*} by {host,ambari_cluster}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Disk by host",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "area",
-            "conditional_formats": []
-          },
-          {
-            "q": "avg:ambari.disk.write_bytes{*} by {ambari_cluster,host}",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 0,
+                "y": 24,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 2,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ambari.process.proc_total{*} by {ambari_cluster}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:ambari.process.proc_run{*} by {ambari_cluster}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Cluster process by cluster",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 58,
-      "x": 0,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "i74-xsf-mfs",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1561638246082,
-        "end": 1561641846082
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "system.cpu.user",
-      "title_text": "Disk read/Write time by host",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ambari.disk.read_time{*} by {ambari_cluster,host}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 0,
+                "y": 41,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ambari.load.load_fifteen{*} by {host,ambari_cluster}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Load 15 by host",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line",
-            "conditional_formats": []
-          },
-          {
-            "q": "avg:ambari.disk.write_time{*} by {ambari_cluster,host}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 99,
+                "y": 24,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 4,
+            "definition": {
+                "type": "image",
+                "url": "https://s3.amazonaws.com/dd-integrations/ambari/configuration/tile/logo.png",
+                "sizing": "zoom"
             },
-            "type": "line"
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 58,
-      "x": 50,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "i74-xsf-mfs",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1561638246082,
-        "end": 1561641846082
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "Network bytes in/out by host",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ambari.network.bytes_in{*} by {ambari_cluster,host}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 0,
+                "y": 2,
+                "width": 47,
+                "height": 11
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "check_status",
+                "title": "Agent Up",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "ambari.can_connect",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "*"
+                ]
             },
-            "type": "line",
-            "conditional_formats": []
-          },
-          {
-            "q": "avg:ambari.network.bytes_out{*} by {ambari_cluster,host}",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 15,
+                "y": 14,
+                "width": 15,
+                "height": 8
+            }
+        },
+        {
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ambari.cpu.cpu_system{*} by {ambari_cluster,host}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:ambari.cpu.cpu_user{*} by {ambari_cluster,host}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:ambari.cpu.cpu_idle{*} by {ambari_cluster,host}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "CPU by host",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 41,
-      "x": 50,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    }
-  ],
-  "disableCog": false,
-  "id": 729436,
-  "isShared": false
+            "layout": {
+                "x": 99,
+                "y": 41,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 7,
+            "definition": {
+                "type": "hostmap",
+                "requests": {
+                    "fill": {
+                        "q": "avg:ambari.load.load_one{$ambari_cluster} by {host}"
+                    }
+                },
+                "custom_links": [],
+                "no_metric_hosts": false,
+                "no_group_hosts": true,
+                "group": [],
+                "scope": [
+                    "$ambari_cluster"
+                ],
+                "style": {
+                    "palette": "green_to_orange",
+                    "palette_flip": false
+                }
+            },
+            "layout": {
+                "x": 50,
+                "y": 2,
+                "width": 47,
+                "height": 22
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ambari.disk.read_bytes{*} by {ambari_cluster,host}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:ambari.disk.write_bytes{*} by {ambari_cluster,host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Disk read/write bytes by host",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 0,
+                "y": 58,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ambari.disk.read_time{*} by {ambari_cluster,host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:ambari.disk.write_time{*} by {ambari_cluster,host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Disk read/Write time by host",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 50,
+                "y": 58,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ambari.network.bytes_in{*} by {ambari_cluster,host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:ambari.network.bytes_out{*} by {ambari_cluster,host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Network bytes in/out by host",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 50,
+                "y": 41,
+                "width": 47,
+                "height": 15
+            }
+        }
+    ],
+    "template_variables": [
+        {
+            "name": "ambari_cluster",
+            "default": "*",
+            "prefix": "ambari_cluster"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30198
 }

--- a/cilium/assets/dashboards/overview.json
+++ b/cilium/assets/dashboards/overview.json
@@ -1,1041 +1,748 @@
 {
-    "author_info": {
-      "author_name": "Datadog"
-    },
-    "board_title": "Cilium Overview",
-    "created": "2019-11-11T22:04:50.947513+00:00",
-    "created_by": {
-      "access_role": "st",
-      "disabled": false,
-      "email": "support@datadoghq.com",
-      "handle": "support@datadoghq.com",
-      "is_admin": false,
-      "name": "Datadog",
-      "role": null,
-      "verified": true
-    },
+    "title": "Cilium Overview",
     "description": "",
-    "disableCog": false,
-    "disableEditing": false,
-    "id": 890677,
-    "isIntegration": false,
-    "isShared": false,
-    "modified": "2019-11-11T22:53:22.136334+00:00",
-    "new_id": "fqp-saw-qbw",
-    "originalHeight": 80,
-    "originalWidth": "calc(100% - 32px)",
-    "read_only": false,
-    "template_variables": [],
     "widgets": [
-      {
-        "add_timeframe": true,
-        "auto_refresh": false,
-        "bgcolor": "gray",
-        "font_size": "18",
-        "height": 5,
-        "html": "Endpoints",
-        "id": 0,
-        "isShared": false,
-        "refresh_every": 30000,
-        "text_align": "center",
-        "tick": true,
-        "tick_edge": "bottom",
-        "tick_pos": "50%",
-        "title": false,
-        "type": "note",
-        "width": 23,
-        "x": 25,
-        "y": 1
-      },
-      {
-        "add_timeframe": true,
-        "autoscale": true,
-        "error": null,
-        "height": 12,
-        "id": 1,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": false,
-          "precision": 0,
-          "requests": [
-            {
-              "aggregator": "last",
-              "conditional_formats": [],
-              "q": "sum:cilium.endpoint.count{*}",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": null
+        {
+            "id": 0,
+            "definition": {
+                "type": "note",
+                "content": "Endpoints",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 25,
+                "y": 1,
+                "width": 23,
+                "height": 5
             }
-          ],
-          "viz": "query_value"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Ready Endpoint Count",
-        "type": "query_value",
-        "width": 23,
-        "x": 1,
-        "y": 8
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 2,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "sum:cilium.endpoint.state{*} by {endpoint_state}",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": "area"
+        {
+            "id": 1,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:cilium.endpoint.count{*}",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Ready Endpoint Count",
+                "title_size": "13",
+                "title_align": "left",
+                "autoscale": false,
+                "precision": 0
+            },
+            "layout": {
+                "x": 1,
+                "y": 8,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "timeseries"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Endpoints by State",
-        "type": "timeseries",
-        "width": 23,
-        "x": 25,
-        "y": 8
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 3,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "sum:cilium.endpoint.regenerations.count{*} by {outcome}.as_count()",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": "area"
+        {
+            "id": 2,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cilium.endpoint.state{*} by {endpoint_state}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Endpoints by State",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 25,
+                "y": 8,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "timeseries"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Endpoint Regenerations by Outcome",
-        "type": "timeseries",
-        "width": 23,
-        "x": 25,
-        "y": 23
-      },
-      {
-        "add_timeframe": true,
-        "autoscale": true,
-        "error": null,
-        "height": 12,
-        "id": 4,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "custom_unit": "sec",
-          "precision": 0,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "avg:cilium.endpoint.regeneration_time_stats.seconds.sum{*}",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": null
+        {
+            "id": 3,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cilium.endpoint.regenerations.count{*} by {outcome}.as_count()",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Endpoint Regenerations by Outcome",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 25,
+                "y": 23,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "query_value"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Avg Endpoint Regeneration Time",
-        "type": "query_value",
-        "width": 23,
-        "x": 1,
-        "y": 23
-      },
-      {
-        "add_timeframe": true,
-        "auto_refresh": false,
-        "bgcolor": "gray",
-        "font_size": "18",
-        "height": 5,
-        "html": "Packet Drops and Forwards",
-        "id": 5,
-        "isShared": false,
-        "refresh_every": 30000,
-        "text_align": "center",
-        "tick": true,
-        "tick_edge": "bottom",
-        "tick_pos": "50%",
-        "title": false,
-        "type": "note",
-        "width": 47,
-        "x": 49,
-        "y": 1
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 6,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "sum:cilium.drop_count.total{direction:egress} by {reason}.as_count()",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": "bars"
+        {
+            "id": 4,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:cilium.endpoint.regeneration_time_stats.seconds.sum{*}",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Avg Endpoint Regeneration Time",
+                "title_size": "13",
+                "title_align": "left",
+                "autoscale": true,
+                "custom_unit": "sec",
+                "precision": 0
+            },
+            "layout": {
+                "x": 1,
+                "y": 23,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "timeseries"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Egress Packets Dropped by Reason",
-        "type": "timeseries",
-        "width": 23,
-        "x": 73,
-        "y": 8
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 7,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "sum:cilium.drop_count.total{direction:ingress} by {reason}.as_count()",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": "bars"
+        {
+            "id": 5,
+            "definition": {
+                "type": "note",
+                "content": "Packet Drops and Forwards",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 49,
+                "y": 1,
+                "width": 47,
+                "height": 5
             }
-          ],
-          "viz": "timeseries"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Ingress Packets Dropped by Reason",
-        "type": "timeseries",
-        "width": 23,
-        "x": 49,
-        "y": 8
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 8,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "sum:cilium.forward_count.total{direction:ingress}.as_count()",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": "line"
+        {
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cilium.drop_count.total{direction:egress} by {reason}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Egress Packets Dropped by Reason",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 73,
+                "y": 8,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "timeseries"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Ingress Packets Forwarded",
-        "type": "timeseries",
-        "width": 23,
-        "x": 49,
-        "y": 23
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 9,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "avg:cilium.forward_count.total{*}.as_count()",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": "line"
+        {
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cilium.drop_count.total{direction:ingress} by {reason}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Ingress Packets Dropped by Reason",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 49,
+                "y": 8,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "timeseries"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Egress Packets Forwarded",
-        "type": "timeseries",
-        "width": 23,
-        "x": 73,
-        "y": 23
-      },
-      {
-        "add_timeframe": true,
-        "height": 5,
-        "id": 10,
-        "isShared": false,
-        "margin": "",
-        "sizing": "fit",
-        "title": false,
-        "type": "image",
-        "url": "/static/images/saas_logos/bot/cilium.png",
-        "width": 23,
-        "x": 1,
-        "y": 1
-      },
-      {
-        "add_timeframe": true,
-        "auto_refresh": false,
-        "bgcolor": "gray",
-        "font_size": "18",
-        "height": 5,
-        "html": "Policies",
-        "id": 11,
-        "isShared": false,
-        "refresh_every": 30000,
-        "text_align": "center",
-        "tick": true,
-        "tick_edge": "bottom",
-        "tick_pos": "50%",
-        "title": false,
-        "type": "note",
-        "width": 47,
-        "x": 49,
-        "y": 38
-      },
-      {
-        "add_timeframe": true,
-        "autoscale": true,
-        "error": null,
-        "height": 12,
-        "id": 12,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "precision": 0,
-          "requests": [
-            {
-              "aggregator": "last",
-              "conditional_formats": [],
-              "q": "max:cilium.policy.count{*}",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": null
+        {
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cilium.forward_count.total{direction:ingress}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Ingress Packets Forwarded",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 49,
+                "y": 23,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "query_value"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Policy Count",
-        "type": "query_value",
-        "width": 23,
-        "x": 49,
-        "y": 45
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 13,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "sum:cilium.policy.import_errors.count{*}.as_count()",
-              "style": {
-                "palette": "warm",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": "bars"
+        {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:cilium.forward_count.total{*}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Egress Packets Forwarded",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 73,
+                "y": 23,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "timeseries"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Policy Import Errors",
-        "type": "timeseries",
-        "width": 23,
-        "x": 73,
-        "y": 60
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 14,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "sum:cilium.policy.endpoint_enforcement_status{*}",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": "line"
+        {
+            "id": 10,
+            "definition": {
+                "type": "image",
+                "url": "/static/images/saas_logos/bot/cilium.png",
+                "sizing": "fit"
+            },
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 23,
+                "height": 5
             }
-          ],
-          "viz": "timeseries"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Endpoint Enforcement Status",
-        "type": "timeseries",
-        "width": 23,
-        "x": 73,
-        "y": 45
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 15,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "sum:cilium.policy.regeneration_time_stats.seconds.sum{*}/sum:cilium.policy.regeneration_time_stats.seconds.count{upper_bound:none}",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": "line"
+        {
+            "id": 11,
+            "definition": {
+                "type": "note",
+                "content": "Policies",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 49,
+                "y": 38,
+                "width": 47,
+                "height": 5
             }
-          ],
-          "viz": "timeseries"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Policy Regeneration Time",
-        "type": "timeseries",
-        "width": 23,
-        "x": 49,
-        "y": 60
-      },
-      {
-        "add_timeframe": true,
-        "auto_refresh": false,
-        "bgcolor": "gray",
-        "font_size": "18",
-        "height": 5,
-        "html": "K8S API and KVStore Requests",
-        "id": 16,
-        "isShared": false,
-        "refresh_every": 30000,
-        "text_align": "center",
-        "tick": true,
-        "tick_edge": "bottom",
-        "tick_pos": "50%",
-        "title": false,
-        "type": "note",
-        "width": 47,
-        "x": 97,
-        "y": 38
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 17,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "sum:cilium.ipam.events.total{*} by {action}.as_count()",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": "line"
+        {
+            "id": 12,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "max:cilium.policy.count{*}",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Policy Count",
+                "title_size": "13",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 0
+            },
+            "layout": {
+                "x": 49,
+                "y": 45,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "timeseries"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "IP Allocation by Action",
-        "type": "timeseries",
-        "width": 23,
-        "x": 25,
-        "y": 38
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 18,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "requests": [
-            {
-              "q": "sum:cilium.kvstore.operations_duration.seconds.sum{*} by {action}",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": "line"
+        {
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cilium.policy.import_errors.count{*}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Policy Import Errors",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 73,
+                "y": 60,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "timeseries"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": "13",
-        "title_text": "KVStore Ops Duration by Action",
-        "type": "timeseries",
-        "width": 23,
-        "x": 97,
-        "y": 45
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 19,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "requests": [
-            {
-              "q": "avg:cilium.kvstore.events_queue.seconds.sum{*} by {action}",
-              "style": {
-                "palette": "warm",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": "line"
+        {
+            "id": 14,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cilium.policy.endpoint_enforcement_status{*}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Endpoint Enforcement Status",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 73,
+                "y": 45,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "timeseries"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": "13",
-        "title_text": "KVStore Event Queue by Action",
-        "type": "timeseries",
-        "width": 23,
-        "x": 121,
-        "y": 45
-      },
-      {
-        "add_timeframe": true,
-        "autoscale": true,
-        "error": null,
-        "height": 12,
-        "id": 20,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": false,
-          "precision": 0,
-          "requests": [
-            {
-              "aggregator": "last",
-              "conditional_formats": [],
-              "q": "max:cilium.identity.count{*}",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": null
+        {
+            "id": 15,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cilium.policy.regeneration_time_stats.seconds.sum{*}/sum:cilium.policy.regeneration_time_stats.seconds.count{upper_bound:none}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Policy Regeneration Time",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 49,
+                "y": 60,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "query_value"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Identities Allocated",
-        "type": "query_value",
-        "width": 23,
-        "x": 1,
-        "y": 38
-      },
-      {
-        "add_timeframe": true,
-        "auto_refresh": false,
-        "bgcolor": "gray",
-        "font_size": "18",
-        "height": 5,
-        "html": "Agent and Operator Stats",
-        "id": 21,
-        "isShared": false,
-        "refresh_every": 30000,
-        "text_align": "center",
-        "tick": true,
-        "tick_edge": "bottom",
-        "tick_pos": "50%",
-        "title": false,
-        "type": "note",
-        "width": 47,
-        "x": 97,
-        "y": 1
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 22,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "avg:cilium.process.cpu.seconds.total{*} by {host}.as_count()",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": null
+        {
+            "id": 16,
+            "definition": {
+                "type": "note",
+                "content": "K8S API and KVStore Requests",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 97,
+                "y": 38,
+                "width": 47,
+                "height": 5
             }
-          ],
-          "viz": "heatmap"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Agent CPU Usage by Host",
-        "type": "heatmap",
-        "width": 23,
-        "x": 97,
-        "y": 8
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 23,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "avg:cilium.operator.process.cpu.seconds{*}.as_count()",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": null
+        {
+            "id": 17,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cilium.ipam.events.total{*} by {action}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "IP Allocation by Action",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 25,
+                "y": 38,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "heatmap"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Operator CPU Usage by Host",
-        "type": "heatmap",
-        "width": 23,
-        "x": 121,
-        "y": 8
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 24,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "avg:cilium.process.resident_memory.bytes{*} by {host}",
-              "style": {
-                "palette": "cool",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": null
+        {
+            "id": 18,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cilium.kvstore.operations_duration.seconds.sum{*} by {action}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "KVStore Ops Duration by Action",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 97,
+                "y": 45,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "heatmap"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Agent Process Memory",
-        "type": "heatmap",
-        "width": 23,
-        "x": 97,
-        "y": 23
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 25,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "avg:cilium.operator.process.resident_memory.bytes{*}",
-              "style": {
-                "palette": "cool",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": null
+        {
+            "id": 19,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:cilium.kvstore.events_queue.seconds.sum{*} by {action}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "KVStore Event Queue by Action",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 121,
+                "y": 45,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "heatmap"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Operator Process Memory",
-        "type": "heatmap",
-        "width": 23,
-        "x": 121,
-        "y": 23
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 26,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "avg:cilium.k8s_client.api_calls.count{*} by {host}.as_rate()",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": "line"
+        {
+            "id": 20,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "max:cilium.identity.count{*}",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Identities Allocated",
+                "title_size": "13",
+                "title_align": "left",
+                "autoscale": false,
+                "precision": 0
+            },
+            "layout": {
+                "x": 1,
+                "y": 38,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "timeseries"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "K8S API Calls by Host",
-        "type": "timeseries",
-        "width": 23,
-        "x": 97,
-        "y": 60
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 12,
-        "id": 27,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "autoscale": true,
-          "requests": [
-            {
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "avg:cilium.k8s_client.api_latency_time.seconds.sum{*}/avg:cilium.k8s_client.api_latency_time.seconds.count{upper_bound:none}",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": null
+        {
+            "id": 21,
+            "definition": {
+                "type": "note",
+                "content": "Agent and Operator Stats",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 97,
+                "y": 1,
+                "width": 47,
+                "height": 5
             }
-          ],
-          "viz": "heatmap"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "K8S API Call Latency by Host",
-        "type": "heatmap",
-        "width": 23,
-        "x": 121,
-        "y": 60
-      },
-      {
-        "add_timeframe": true,
-        "error": null,
-        "height": 19,
-        "id": 28,
-        "isShared": false,
-        "legend": false,
-        "legend_size": "0",
-        "scaleFactor": 1,
-        "sharedGlobalTime": {
-          "live_span": "1h"
-        },
-        "tile_def": {
-          "requests": [
-            {
-              "conditional_formats": [],
-              "q": "top(sum:cilium.unreachable.nodes{*} by {host}, 10, 'max', 'desc')",
-              "style": {
-                "palette": "dog_classic",
-                "type": "solid",
-                "width": "normal"
-              },
-              "type": null
+        {
+            "id": 22,
+            "definition": {
+                "type": "heatmap",
+                "requests": [
+                    {
+                        "q": "avg:cilium.process.cpu.seconds.total{*} by {host}.as_count()",
+                        "style": {
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Agent CPU Usage by Host",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 97,
+                "y": 8,
+                "width": 23,
+                "height": 14
             }
-          ],
-          "viz": "toplist"
         },
-        "time": {},
-        "title": true,
-        "title_align": "left",
-        "title_size": 13,
-        "title_text": "Unreachable Node Count by Host",
-        "type": "toplist",
-        "width": 28,
-        "x": 1,
-        "y": 53
-      }
-    ]
-  }
+        {
+            "id": 23,
+            "definition": {
+                "type": "heatmap",
+                "requests": [
+                    {
+                        "q": "avg:cilium.operator.process.cpu.seconds{*}.as_count()",
+                        "style": {
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Operator CPU Usage by Host",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 121,
+                "y": 8,
+                "width": 23,
+                "height": 14
+            }
+        },
+        {
+            "id": 24,
+            "definition": {
+                "type": "heatmap",
+                "requests": [
+                    {
+                        "q": "avg:cilium.process.resident_memory.bytes{*} by {host}",
+                        "style": {
+                            "palette": "cool"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Agent Process Memory",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 97,
+                "y": 23,
+                "width": 23,
+                "height": 14
+            }
+        },
+        {
+            "id": 25,
+            "definition": {
+                "type": "heatmap",
+                "requests": [
+                    {
+                        "q": "avg:cilium.operator.process.resident_memory.bytes{*}",
+                        "style": {
+                            "palette": "cool"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Operator Process Memory",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 121,
+                "y": 23,
+                "width": 23,
+                "height": 14
+            }
+        },
+        {
+            "id": 26,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:cilium.k8s_client.api_calls.count{*} by {host}.as_rate()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "K8S API Calls by Host",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 97,
+                "y": 60,
+                "width": 23,
+                "height": 14
+            }
+        },
+        {
+            "id": 27,
+            "definition": {
+                "type": "heatmap",
+                "requests": [
+                    {
+                        "q": "avg:cilium.k8s_client.api_latency_time.seconds.sum{*}/avg:cilium.k8s_client.api_latency_time.seconds.count{upper_bound:none}",
+                        "style": {
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "K8S API Call Latency by Host",
+                "title_size": "13",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 121,
+                "y": 60,
+                "width": 23,
+                "height": 14
+            }
+        },
+        {
+            "id": 28,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:cilium.unreachable.nodes{*} by {host}, 10, 'max', 'desc')",
+                        "style": {
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Unreachable Node Count by Host",
+                "title_size": "13",
+                "title_align": "left"
+            },
+            "layout": {
+                "x": 1,
+                "y": 53,
+                "width": 28,
+                "height": 21
+            }
+        }
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30295
+}

--- a/clickhouse/assets/dashboards/overview.json
+++ b/clickhouse/assets/dashboards/overview.json
@@ -1,719 +1,464 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "ClickHouse Overview",
-    "created": "2020-01-03T02:09:27.019808+00:00",
-    "created_by": {
-        "access_role": "adm",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": true,
-        "name": "Datadog",
-        "role": null,
-        "verified": true
-    },
+    "title": "ClickHouse Overview",
     "description": "## ClickHouse Dashboard\n\nThis is an example ClickHouse dashboard demonstrating the metrics that the integration collects.",
-    "disableCog": false,
-    "disableEditing": false,
-    "id": 936069,
-    "isIntegration": false,
-    "isShared": false,
-    "modified": "2020-01-03T15:39:31.313707+00:00",
-    "new_id": "5n5-sg7-jjv",
-    "originalHeight": 80,
-    "originalWidth": "calc(100% - 32px)",
-    "read_only": false,
+    "widgets": [
+        {
+            "id": 0,
+            "definition": {
+                "type": "image",
+                "url": "/static/images/saas_logos/bot/clickhouse@2x.png",
+                "sizing": "zoom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 26,
+                "height": 12
+            }
+        },
+        {
+            "id": 1,
+            "definition": {
+                "type": "note",
+                "content": "Insertion",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 28,
+                "y": 0,
+                "width": 70,
+                "height": 8
+            }
+        },
+        {
+            "id": 2,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:clickhouse.table.insert.size.count{$host}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Bytes per second",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 28,
+                "y": 10,
+                "width": 34,
+                "height": 15
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:clickhouse.table.mergetree.insert.delayed.count{$host}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Delayed inserts per second",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 64,
+                "y": 26,
+                "width": 34,
+                "height": 15
+            }
+        },
+        {
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:clickhouse.table.insert.row.count{$host}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Rows per second",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 64,
+                "y": 10,
+                "width": 34,
+                "height": 15
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:clickhouse.query.insert.count{$host}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Inserts per second",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 28,
+                "y": 26,
+                "width": 34,
+                "height": 15
+            }
+        },
+        {
+            "id": 6,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:clickhouse.uptime{$host}",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Uptime",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 0,
+                "y": 14,
+                "width": 26,
+                "height": 17
+            }
+        },
+        {
+            "id": 7,
+            "definition": {
+                "type": "note",
+                "content": "Active connections",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 33,
+                "width": 26,
+                "height": 8
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:clickhouse.connection.http{$host}",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "HTTP",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 0,
+                "y": 43,
+                "width": 26,
+                "height": 6
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:clickhouse.connection.tcp{$host}",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "TCP",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 0,
+                "y": 50,
+                "width": 26,
+                "height": 6
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:clickhouse.connection.interserver{$host}",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Interserver",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 0,
+                "y": 57,
+                "width": 26,
+                "height": 6
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "note",
+                "content": "Replication",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 100,
+                "y": 0,
+                "width": 71,
+                "height": 8
+            }
+        },
+        {
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:clickhouse.table.replicated.part.check{$host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Checks",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 104,
+                "y": 10,
+                "width": 63,
+                "height": 15
+            }
+        },
+        {
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:clickhouse.table.replicated.part.fetch{$host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Fetch",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 104,
+                "y": 26,
+                "width": 63,
+                "height": 15
+            }
+        },
+        {
+            "id": 14,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:clickhouse.table.replicated.part.send{$host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Send",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 104,
+                "y": 42,
+                "width": 63,
+                "height": 15
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "note",
+                "content": "Query",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 28,
+                "y": 43,
+                "width": 70,
+                "height": 8
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:clickhouse.query.active{$host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Active",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 28,
+                "y": 53,
+                "width": 34,
+                "height": 15
+            }
+        },
+        {
+            "id": 17,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:clickhouse.query.memory{$host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Memory in use",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 64,
+                "y": 53,
+                "width": 34,
+                "height": 15
+            }
+        }
+    ],
     "template_variables": [
         {
-            "default": "*",
             "name": "host",
+            "default": "*",
             "prefix": "host"
         }
     ],
-    "widgets": [
-        {
-            "add_timeframe": true,
-            "board_id": "5n5-sg7-jjv",
-            "height": 12,
-            "isShared": false,
-            "margin": "",
-            "scaleFactor": 1,
-            "sizing": "zoom",
-            "title": false,
-            "type": "image",
-            "url": "/static/images/saas_logos/bot/clickhouse@2x.png",
-            "width": 26,
-            "x": 0,
-            "y": 0
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": "5n5-sg7-jjv",
-            "font_size": "18",
-            "height": 8,
-            "html": "Insertion",
-            "isShared": false,
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 70,
-            "x": 28,
-            "y": 0
-        },
-        {
-            "add_timeframe": true,
-            "board_id": "5n5-sg7-jjv",
-            "error": null,
-            "generated_title": "Timeseries",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:clickhouse.table.insert.size.count{$host}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Bytes per second",
-            "type": "timeseries",
-            "width": 34,
-            "x": 28,
-            "y": 10
-        },
-        {
-            "add_timeframe": true,
-            "board_id": "5n5-sg7-jjv",
-            "error": null,
-            "generated_title": "clickhouse.table.mergetree.insert.delayed.count",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:clickhouse.table.mergetree.insert.delayed.count{$host}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Delayed inserts per second",
-            "type": "timeseries",
-            "width": 34,
-            "x": 64,
-            "y": 26
-        },
-        {
-            "add_timeframe": true,
-            "board_id": "5n5-sg7-jjv",
-            "error": null,
-            "generated_title": "Timeseries",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:clickhouse.table.insert.row.count{$host}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Rows per second",
-            "type": "timeseries",
-            "width": 34,
-            "x": 64,
-            "y": 10
-        },
-        {
-            "add_timeframe": true,
-            "board_id": "5n5-sg7-jjv",
-            "error": null,
-            "generated_title": "Timeseries",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:clickhouse.query.insert.count{$host}.as_count()",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Inserts per second",
-            "type": "timeseries",
-            "width": 34,
-            "x": 28,
-            "y": 26
-        },
-        {
-            "add_timeframe": true,
-            "autoscale": true,
-            "board_id": "5n5-sg7-jjv",
-            "error": null,
-            "generated_title": "Query Value",
-            "height": 15,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "custom_unit": null,
-                "requests": [
-                    {
-                        "aggregator": "last",
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": null
-                            },
-                            {
-                                "comparator": ">=",
-                                "palette": "white_on_yellow",
-                                "value": null
-                            },
-                            {
-                                "comparator": "<",
-                                "palette": "white_on_green",
-                                "value": null
-                            }
-                        ],
-                        "q": "avg:clickhouse.uptime{$host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": null
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Uptime",
-            "type": "query_value",
-            "width": 26,
-            "x": 0,
-            "y": 14
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": "5n5-sg7-jjv",
-            "font_size": "18",
-            "height": 8,
-            "html": "Active connections",
-            "isShared": false,
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 26,
-            "x": 0,
-            "y": 33
-        },
-        {
-            "add_timeframe": true,
-            "autoscale": true,
-            "board_id": "5n5-sg7-jjv",
-            "error": null,
-            "generated_title": "Query Value",
-            "height": 4,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "last",
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": null
-                            },
-                            {
-                                "comparator": ">=",
-                                "palette": "white_on_yellow",
-                                "value": null
-                            },
-                            {
-                                "comparator": "<",
-                                "palette": "white_on_green",
-                                "value": null
-                            }
-                        ],
-                        "q": "avg:clickhouse.connection.http{$host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": null
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "HTTP",
-            "type": "query_value",
-            "width": 26,
-            "x": 0,
-            "y": 43
-        },
-        {
-            "add_timeframe": true,
-            "autoscale": true,
-            "board_id": "5n5-sg7-jjv",
-            "error": null,
-            "generated_title": "Query Value",
-            "height": 4,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "last",
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": null
-                            },
-                            {
-                                "comparator": ">=",
-                                "palette": "white_on_yellow",
-                                "value": null
-                            },
-                            {
-                                "comparator": "<",
-                                "palette": "white_on_green",
-                                "value": null
-                            }
-                        ],
-                        "q": "avg:clickhouse.connection.tcp{$host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": null
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "TCP",
-            "type": "query_value",
-            "width": 26,
-            "x": 0,
-            "y": 50
-        },
-        {
-            "add_timeframe": true,
-            "autoscale": true,
-            "board_id": "5n5-sg7-jjv",
-            "error": null,
-            "generated_title": "Query Value",
-            "height": 4,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "last",
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": null
-                            },
-                            {
-                                "comparator": ">=",
-                                "palette": "white_on_yellow",
-                                "value": null
-                            },
-                            {
-                                "comparator": "<",
-                                "palette": "white_on_green",
-                                "value": null
-                            }
-                        ],
-                        "q": "avg:clickhouse.connection.interserver{$host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": null
-                    }
-                ],
-                "viz": "query_value"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Interserver",
-            "type": "query_value",
-            "width": 26,
-            "x": 0,
-            "y": 57
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": "5n5-sg7-jjv",
-            "font_size": "18",
-            "height": 8,
-            "html": "Replication",
-            "isShared": false,
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 71,
-            "x": 100,
-            "y": 0
-        },
-        {
-            "add_timeframe": true,
-            "board_id": "5n5-sg7-jjv",
-            "error": null,
-            "generated_title": "Timeseries",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:clickhouse.table.replicated.part.check{$host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Checks",
-            "type": "timeseries",
-            "width": 63,
-            "x": 104,
-            "y": 10
-        },
-        {
-            "add_timeframe": true,
-            "board_id": "5n5-sg7-jjv",
-            "error": null,
-            "generated_title": "Timeseries",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:clickhouse.table.replicated.part.fetch{$host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Fetch",
-            "type": "timeseries",
-            "width": 63,
-            "x": 104,
-            "y": 26
-        },
-        {
-            "add_timeframe": true,
-            "board_id": "5n5-sg7-jjv",
-            "error": null,
-            "generated_title": "Timeseries",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:clickhouse.table.replicated.part.send{$host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Send",
-            "type": "timeseries",
-            "width": 63,
-            "x": 104,
-            "y": 42
-        },
-        {
-            "add_timeframe": true,
-            "auto_refresh": false,
-            "bgcolor": "gray",
-            "board_id": "5n5-sg7-jjv",
-            "font_size": "18",
-            "height": 8,
-            "html": "Query",
-            "isShared": false,
-            "refresh_every": 30000,
-            "scaleFactor": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "title": false,
-            "type": "note",
-            "width": 70,
-            "x": 28,
-            "y": 43
-        },
-        {
-            "add_timeframe": true,
-            "board_id": "5n5-sg7-jjv",
-            "error": null,
-            "generated_title": "Timeseries",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:clickhouse.query.active{$host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Active",
-            "type": "timeseries",
-            "width": 34,
-            "x": 28,
-            "y": 53
-        },
-        {
-            "add_timeframe": true,
-            "board_id": "5n5-sg7-jjv",
-            "error": null,
-            "generated_title": "Timeseries",
-            "height": 13,
-            "isShared": false,
-            "legend": false,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "tile_def": {
-                "autoscale": true,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [],
-                        "q": "avg:clickhouse.query.memory{$host}",
-                        "style": {
-                            "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "viz": "timeseries"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Memory in use",
-            "type": "timeseries",
-            "width": 34,
-            "x": 64,
-            "y": 53
-        }
-    ]
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30256
 }

--- a/cockroachdb/assets/dashboards/overview.json
+++ b/cockroachdb/assets/dashboards/overview.json
@@ -1,967 +1,565 @@
 {
-    "board_title": "CockroachDB Overview",
+    "title": "CockroachDB Overview",
     "description": "This dashboard provides a high-level overview of key CockroachDB metrics so you can ensure that your cluster is available, serving queries, and has sufficient resources to maintain high levels of performance. Further reading on CockroachDB monitoring:\n\n- [Monitor CockroachDB with Datadog](https://www.datadoghq.com/blog/monitor-cockroachdb-performance-metrics-with-datadog/)\n\n- [Datadog's CockroachDB docs](https://docs.datadoghq.com/integrations/cockroachdb/).\n\nClone this template dashboard to make changes and add your own graphs and widgets.",
-    "board_bgtype": "board_graph",
-    "created": "2019-05-10T19:41:52.064458+00:00",
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "created_by": {
-        "handle": "support@datadoghq.com",
-        "name": "Datadog",
-        "access_role": "st",
-        "verified": true,
-        "disabled": false,
-        "is_admin": false,
-        "role": null,
-        "email": "support@datadoghq.com",
-        "icon": ""
-    },
-    "new_id": "rdz-jzs-edp",
-    "height": 80,
-    "width": 168,
-    "template_variables": [
-        {
-            "default": "*",
-            "prefix": null,
-            "name": "scope"
-        }
-    ],
-    "isIntegration": false,
-    "originalHeight": 80,
-    "originalWidth": 168,
-    "isShared": false,
     "widgets": [
         {
-            "board_id": "rdz-jzs-edp",
-            "sizing": "zoom",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1557513720000,
-                "end": 1557517320000
+            "id": 0,
+            "definition": {
+                "type": "image",
+                "url": "https://s3.amazonaws.com/dd-integrations/cockroachdb/configuration/tile/logo.png",
+                "sizing": "zoom"
             },
-            "title_align": "left",
-            "title_size": 16,
-            "title": true,
-            "url": "https://s3.amazonaws.com/dd-integrations/cockroachdb/configuration/tile/logo.png",
-            "type": "image",
-            "generated_title": "",
-            "title_text": "",
-            "height": 9,
-            "width": 29,
-            "scaleFactor": 1,
-            "y": 2,
-            "x": 1,
-            "isShared": false,
-            "margin": "",
-            "add_timeframe": true
+            "layout": {
+                "x": 1,
+                "y": 2,
+                "width": 29,
+                "height": 9
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "cockroachdb.syscount",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "KV Pairs",
-            "height": 10,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 1,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:cockroachdb.syscount{*}",
-                        "aggregator": "avg",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_red",
-                                "value": null,
-                                "comparator": ">"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "value": null,
-                                "comparator": ">="
-                            },
-                            {
-                                "palette": "white_on_green",
-                                "value": null,
-                                "comparator": "<"
-                            }
-                        ]
+                        "aggregator": "avg"
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "KV Pairs",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
             },
-            "width": 14,
-            "add_timeframe": true,
-            "error": null,
-            "time": {},
-            "y": 26,
-            "x": 1,
-            "legend_size": "0",
-            "autoscale": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 1,
+                "y": 26,
+                "width": 14,
+                "height": 12
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "cockroachdb.liveness.livenodes",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Live Nodes",
-            "height": 11,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 2,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:cockroachdb.liveness.livenodes{*}",
-                        "aggregator": "avg",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_red",
-                                "value": null,
-                                "comparator": ">"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "value": null,
-                                "comparator": ">="
-                            },
-                            {
-                                "palette": "white_on_green",
-                                "value": null,
-                                "comparator": "<"
-                            }
-                        ]
+                        "aggregator": "avg"
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Live Nodes",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
             },
-            "width": 14,
-            "add_timeframe": true,
-            "error": null,
-            "time": {},
-            "y": 39,
-            "x": 1,
-            "legend_size": "0",
-            "autoscale": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 1,
+                "y": 39,
+                "width": 14,
+                "height": 13
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "cockroachdb.sys.cpu.sys.percent",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "System CPU (%)",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 3,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:cockroachdb.sys.cpu.sys.percent{*}",
-                        "aggregator": "avg",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "System CPU (%)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 41,
-            "error": null,
-            "time": {},
-            "y": 27,
-            "x": 31,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 31,
+                "y": 27,
+                "width": 41,
+                "height": 18
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "cockroachdb.sys.cpu.user.percent",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Current User CPU (%)",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:cockroachdb.sys.cpu.user.percent{*}",
-                        "aggregator": "avg",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Current User CPU (%)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 41,
-            "error": null,
-            "time": {},
-            "y": 8,
-            "x": 31,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 31,
+                "y": 8,
+                "width": 41,
+                "height": 18
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "cockroachdb.capacity.used",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Capacity Available (%)",
-            "height": 11,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 5,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "100-avg:cockroachdb.capacity.used{*}/avg:cockroachdb.capacity.total{*}*100",
                         "aggregator": "avg",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
                         "conditional_formats": [
                             {
-                                "palette": "green_on_white",
-                                "value": "90",
-                                "comparator": ">"
+                                "comparator": ">",
+                                "value": 90,
+                                "palette": "green_on_white"
                             },
                             {
-                                "palette": "yellow_on_white",
-                                "value": "80",
-                                "comparator": ">="
+                                "comparator": ">=",
+                                "value": 80,
+                                "palette": "yellow_on_white"
                             },
                             {
-                                "palette": "red_on_white",
-                                "value": "80",
-                                "comparator": "<"
+                                "comparator": "<",
+                                "value": 80,
+                                "palette": "red_on_white"
                             }
                         ]
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Capacity Available (%)",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
             },
-            "width": 14,
-            "add_timeframe": true,
-            "error": null,
-            "time": {},
-            "y": 12,
-            "x": 1,
-            "legend_size": "0",
-            "autoscale": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 1,
+                "y": 12,
+                "width": 14,
+                "height": 13
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "cockroachdb.sql.service.latency.sum",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "SQL Service Latency (milliseconds)",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "(diff(avg:cockroachdb.sql.service.latency.sum{*})/diff(avg:cockroachdb.sql.service.latency.count{*}))/1000000",
-                        "aggregator": "avg",
+                        "display_type": "area",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "area",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true,
+                "custom_links": [],
                 "yaxis": {
                     "max": "2"
-                }
+                },
+                "title": "SQL Service Latency (milliseconds)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 41,
-            "error": null,
-            "time": {},
-            "y": 8,
-            "x": 73,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 73,
+                "y": 8,
+                "width": 41,
+                "height": 18
+            }
         },
         {
-            "height": 5,
-            "tick_pos": "50%",
-            "board_id": "rdz-jzs-edp",
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "text_align": "center",
-            "bgcolor": "gray",
-            "html": "CPU",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "title_text": "",
-            "tick": true,
-            "scaleFactor": 1,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1557754970720,
-                "end": 1557758570720
+            "id": 7,
+            "definition": {
+                "type": "note",
+                "content": "CPU",
+                "background_color": "gray",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "font_size": "14",
-            "generated_title": "Note",
-            "tick_edge": "bottom",
-            "y": 2,
-            "x": 31,
-            "width": 41
+            "layout": {
+                "x": 31,
+                "y": 2,
+                "width": 41,
+                "height": 5
+            }
         },
         {
-            "height": 5,
-            "tick_pos": "50%",
-            "board_id": "rdz-jzs-edp",
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "text_align": "center",
-            "bgcolor": "gray",
-            "html": "Latency",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "title_text": "",
-            "tick": true,
-            "scaleFactor": 1,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1557754970720,
-                "end": 1557758570720
+            "id": 8,
+            "definition": {
+                "type": "note",
+                "content": "Latency",
+                "background_color": "gray",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "font_size": "14",
-            "generated_title": "Note",
-            "tick_edge": "bottom",
-            "y": 2,
-            "x": 73,
-            "width": 41
+            "layout": {
+                "x": 73,
+                "y": 2,
+                "width": 41,
+                "height": 5
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "Query Value",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "SQL Connections",
-            "height": 11,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 9,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:cockroachdb.sql.conns{*}",
-                        "aggregator": "avg",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_red",
-                                "value": null,
-                                "comparator": ">"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "value": null,
-                                "comparator": ">="
-                            },
-                            {
-                                "palette": "white_on_green",
-                                "value": null,
-                                "comparator": "<"
-                            }
-                        ]
+                        "aggregator": "avg"
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "SQL Connections",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
             },
-            "width": 14,
-            "add_timeframe": true,
-            "error": null,
-            "time": {},
-            "y": 39,
-            "x": 16,
-            "legend_size": "0",
-            "autoscale": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 16,
+                "y": 39,
+                "width": 14,
+                "height": 13
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "cockroachdb.exec.latency.sum",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Batch Request Latency (milliseconds)",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 10,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "(diff(avg:cockroachdb.exec.latency.sum{*})/diff(avg:cockroachdb.exec.latency.count{*}))/1000000",
-                        "aggregator": "avg",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true,
+                "custom_links": [],
                 "yaxis": {
                     "max": "10"
-                }
+                },
+                "title": "Batch Request Latency (milliseconds)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 41,
-            "error": null,
-            "time": {},
-            "y": 27,
-            "x": 73,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 73,
+                "y": 27,
+                "width": 41,
+                "height": 18
+            }
         },
         {
-            "height": 30,
-            "tick_pos": "50%",
-            "board_id": "rdz-jzs-edp",
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "text_align": "center",
-            "bgcolor": "gray",
-            "html": "Operations\n",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "title_text": "",
-            "tick": true,
-            "scaleFactor": 1,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558373908057,
-                "end": 1558377508057
+            "id": 11,
+            "definition": {
+                "type": "note",
+                "content": "Operations\n",
+                "background_color": "gray",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
             },
-            "font_size": "14",
-            "generated_title": "Note",
-            "tick_edge": "right",
-            "y": 46,
-            "x": 31,
-            "width": 12
+            "layout": {
+                "x": 31,
+                "y": 46,
+                "width": 12,
+                "height": 30
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "cockroachdb.sql.select.count",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "SQL SELECT Count",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:cockroachdb.sql.select.count{*}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "bars",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "bars",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "SQL SELECT Count",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 46,
-            "x": 44,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 44,
+                "y": 46,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "cockroachdb.sql.delete.count",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "SQL DELETE Count",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:cockroachdb.sql.delete.count{*}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "bars",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "bars",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "SQL DELETE Count",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 49,
-            "error": null,
-            "time": {},
-            "y": 46,
-            "x": 92,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 92,
+                "y": 46,
+                "width": 49,
+                "height": 15
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "cockroachdb.sql.insert.count",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "SQL INSERT Count",
-            "height": 12,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 14,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:cockroachdb.sql.insert.count{*}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "bars",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "bars",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "SQL INSERT Count",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 62,
-            "x": 44,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 44,
+                "y": 62,
+                "width": 47,
+                "height": 14
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "cockroachdb.sql.update.count",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "SQL UPDATE Count",
-            "height": 12,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 15,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:cockroachdb.sql.update.count{*}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "bars",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "bars",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "SQL UPDATE Count",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 49,
-            "error": null,
-            "time": {},
-            "y": 62,
-            "x": 92,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 92,
+                "y": 62,
+                "width": 49,
+                "height": 14
+            }
         },
         {
-            "height": 5,
-            "tick_pos": "50%",
-            "board_id": "rdz-jzs-edp",
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "text_align": "center",
-            "bgcolor": "gray",
-            "html": "Admin Memory",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "title_text": "",
-            "tick": true,
-            "scaleFactor": 1,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1559742250222,
-                "end": 1559745850222
+            "id": 16,
+            "definition": {
+                "type": "note",
+                "content": "Admin Memory",
+                "background_color": "gray",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "font_size": "14",
-            "generated_title": "Note",
-            "tick_edge": "bottom",
-            "y": 2,
-            "x": 115,
-            "width": 41
+            "layout": {
+                "x": 115,
+                "y": 2,
+                "width": 41,
+                "height": 5
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "Timeseries",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Admin Memory Usage Per SQL Statement",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 17,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:cockroachdb.sql.mem.admin.max.sum{*}",
-                        "aggregator": "avg",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Admin Memory Usage Per SQL Statement",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 41,
-            "error": null,
-            "time": {},
-            "y": 8,
-            "x": 115,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 115,
+                "y": 8,
+                "width": 41,
+                "height": 18
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "cockroachdb.sql.mem.admin.session.max.sum",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Admin Memory Usage Per SQL Session",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 18,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:cockroachdb.sql.mem.admin.session.max.sum{*}",
-                        "aggregator": "avg",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Admin Memory Usage Per SQL Session",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 41,
-            "error": null,
-            "time": {},
-            "y": 27,
-            "x": 115,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 115,
+                "y": 27,
+                "width": 41,
+                "height": 18
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "cockroachdb.capacity.total",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Total Capacity",
-            "height": 11,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 19,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:cockroachdb.capacity.total{*}/1000000000",
-                        "aggregator": "avg",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_red",
-                                "value": null,
-                                "comparator": ">"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "value": null,
-                                "comparator": ">="
-                            },
-                            {
-                                "palette": "white_on_green",
-                                "value": null,
-                                "comparator": "<"
-                            }
-                        ]
+                        "aggregator": "avg"
                     }
                 ],
+                "custom_links": [],
+                "title": "Total Capacity",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": false,
-                "custom_unit": "GB",
-                "precision": "undefined"
+                "custom_unit": "GB"
             },
-            "width": 14,
-            "add_timeframe": true,
-            "error": null,
-            "time": {},
-            "y": 12,
-            "x": 16,
-            "legend_size": "0",
-            "autoscale": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 16,
+                "y": 12,
+                "width": 14,
+                "height": 13
+            }
         },
         {
-            "board_id": "rdz-jzs-edp",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560515719011,
-                "end": 1560519319011
-            },
-            "generated_title": "Query Value",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Capacity Used",
-            "height": 10,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 20,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:cockroachdb.capacity.used{*}/1000000000",
-                        "aggregator": "avg",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_red",
-                                "value": null,
-                                "comparator": ">"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "value": null,
-                                "comparator": ">="
-                            },
-                            {
-                                "palette": "white_on_green",
-                                "value": null,
-                                "comparator": "<"
-                            }
-                        ]
+                        "aggregator": "avg"
                     }
                 ],
+                "custom_links": [],
+                "title": "Capacity Used",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": false,
                 "custom_unit": "",
-                "precision": "2"
+                "precision": 2
             },
-            "width": 14,
-            "add_timeframe": true,
-            "error": null,
-            "time": {},
-            "y": 26,
-            "x": 16,
-            "legend_size": "0",
-            "autoscale": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 16,
+                "y": 26,
+                "width": 14,
+                "height": 12
+            }
         }
     ],
-    "disableCog": false,
-    "id": 696973,
-    "disableEditing": false
+    "template_variables": [
+        {
+            "name": "scope",
+            "default": "*",
+            "prefix": null
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30282
 }

--- a/confluent_platform/assets/dashboards/overview.json
+++ b/confluent_platform/assets/dashboards/overview.json
@@ -1,888 +1,930 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "Confluent Platform Overview",
-    "created": "2020-04-14T14:05:36.816349+00:00",
-    "created_by": {
-        "access_role": "st",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": false,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "Confluent Platform Overview",
     "description": "The default Dashboard for monitoring Confluent Platform including:\n\n* Brokers,\n* Producers, and Consumers (Java-based)\n* Kafka Connect\n* Schema Registry\n* REST Proxy\n* KSQLDB",
-    "id": 1053943,
-    "modified": "2020-04-14T14:47:32.837099+00:00",
-    "new_id": "gi5-jub-nfu",
-    "read_only": false,
-    "template_variables": [],
     "widgets": [
         {
-            "height": 6,
             "id": 0,
-            "sizing": "zoom",
-            "type": "image",
-            "url": "/static/images/saas_logos/bot/confluent_platform@2x.png",
-            "width": 25,
-            "x": 1,
-            "y": 1
+            "definition": {
+                "type": "image",
+                "url": "/static/images/saas_logos/bot/confluent_platform@2x.png",
+                "sizing": "zoom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 25,
+                "height": 6
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "16",
-            "height": 5,
-            "html": "Brokers",
             "id": 1,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 67,
-            "x": 27,
-            "y": 1
+            "definition": {
+                "type": "note",
+                "content": "Brokers",
+                "background_color": "gray",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 27,
+                "y": 1,
+                "width": 67,
+                "height": 5
+            }
         },
         {
-            "height": 14,
             "id": 2,
-            "legend": false,
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:confluent.kafka.server.topic.bytes_in_per_sec.rate{*} by {instance}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Bytes In per Second by Broker",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Bytes In per Second by Broker",
-            "type": "timeseries",
-            "width": 33,
-            "x": 27,
-            "y": 8
+            "layout": {
+                "x": 27,
+                "y": 8,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 3,
-            "legend": false,
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:confluent.kafka.server.topic.bytes_out_per_sec.rate{*} by {instance}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Bytes Out per Second by Broker",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Bytes Out per Second by Broker",
-            "type": "timeseries",
-            "width": 33,
-            "x": 61,
-            "y": 8
+            "layout": {
+                "x": 61,
+                "y": 8,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 4,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:confluent.kafka.network.request.total_time_ms.75percentile{request:fetchconsumer} by {instance}, avg:confluent.kafka.network.request.total_time_ms.95percentile{request:fetchconsumer} by {instance}, avg:confluent.kafka.network.request.total_time_ms.99percentile{request:fetchconsumer} by {instance}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Avg Consumer Fetch Latency by Broker",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Avg Consumer Fetch Latency by Broker",
-            "type": "timeseries",
-            "width": 33,
-            "x": 61,
-            "y": 25
+            "layout": {
+                "x": 61,
+                "y": 25,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 5,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:confluent.kafka.network.request.total_time_ms.75percentile{request:produce} by {instance}, avg:confluent.kafka.network.request.total_time_ms.95percentile{request:produce} by {instance}, avg:confluent.kafka.network.request.total_time_ms.99percentile{request:produce} by {instance}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Producer Request Latency by Broker",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Producer Request Latency by Broker",
-            "type": "timeseries",
-            "width": 33,
-            "x": 27,
-            "y": 25
+            "layout": {
+                "x": 27,
+                "y": 25,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 6,
-            "tile_def": {
-                "precision": 0,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
-                        "aggregator": "last",
-                        "q": "sum:confluent.kafka.controller.offline_partitions_count{*} by {host}"
+                        "q": "sum:confluent.kafka.controller.offline_partitions_count{*} by {host}",
+                        "aggregator": "last"
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Offline Partitions",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Offline Partitions",
-            "type": "query_value",
-            "width": 25,
-            "x": 1,
-            "y": 25
+            "layout": {
+                "x": 1,
+                "y": 25,
+                "width": 25,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 7,
-            "tile_def": {
-                "precision": 0,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
-                        "aggregator": "last",
-                        "q": "sum:confluent.kafka.server.replica_manager.under_replicated_partitions{*} by {host}"
+                        "q": "sum:confluent.kafka.server.replica_manager.under_replicated_partitions{*} by {host}",
+                        "aggregator": "last"
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Under Replicated Partitions",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Under Replicated Partitions",
-            "type": "query_value",
-            "width": 25,
-            "x": 1,
-            "y": 59
+            "layout": {
+                "x": 1,
+                "y": 59,
+                "width": 25,
+                "height": 16
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "16",
-            "height": 5,
-            "html": "Producers",
             "id": 8,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 33,
-            "x": 27,
-            "y": 42
+            "definition": {
+                "type": "note",
+                "content": "Producers",
+                "background_color": "gray",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 27,
+                "y": 42,
+                "width": 33,
+                "height": 5
+            }
         },
         {
-            "height": 14,
             "id": 9,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:confluent.kafka.producer.topic.byte_rate{*} by {instance}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Byte Rate by Producer",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Byte Rate by Producer",
-            "type": "timeseries",
-            "width": 33,
-            "x": 27,
-            "y": 49
+            "layout": {
+                "x": 27,
+                "y": 49,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 10,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:confluent.kafka.producer.batch_size_avg{*} by {instance}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Avg Batch Size per Producer",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Avg Batch Size per Producer",
-            "type": "timeseries",
-            "width": 33,
-            "x": 27,
-            "y": 66
+            "layout": {
+                "x": 27,
+                "y": 66,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "16",
-            "height": 5,
-            "html": "Consumers",
             "id": 11,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 33,
-            "x": 61,
-            "y": 42
+            "definition": {
+                "type": "note",
+                "content": "Consumers",
+                "background_color": "gray",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 61,
+                "y": 42,
+                "width": 33,
+                "height": 5
+            }
         },
         {
-            "height": 14,
             "id": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:confluent.kafka.consumer.fetch.bytes_consumed_rate{*} by {instance}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Bytes Consumed by Consumer",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Bytes Consumed by Consumer",
-            "type": "timeseries",
-            "width": 33,
-            "x": 61,
-            "y": 49
+            "layout": {
+                "x": 61,
+                "y": 49,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "max:confluent.kafka.consumer.fetch.records_lag_max{*} by {instance}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Max Lag by Consumer",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Max Lag by Consumer",
-            "type": "timeseries",
-            "width": 33,
-            "x": 61,
-            "y": 66
+            "layout": {
+                "x": 61,
+                "y": 66,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "16",
-            "height": 5,
-            "html": "Connect",
             "id": 14,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 67,
-            "x": 95,
-            "y": 1
+            "definition": {
+                "type": "note",
+                "content": "Connect",
+                "background_color": "gray",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 95,
+                "y": 1,
+                "width": 67,
+                "height": 5
+            }
         },
         {
-            "height": 14,
             "id": 15,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:confluent.kafka.connect.worker.connector_count{*} by {instance}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Connector Count by Worker",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Connector Count by Worker",
-            "type": "timeseries",
-            "width": 33,
-            "x": 95,
-            "y": 8
+            "layout": {
+                "x": 95,
+                "y": 8,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 16,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:confluent.kafka.connect.worker_rebalance.rebalance_avg_time_ms{*} by {instance}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Avg Rebalance Time by Worker",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Avg Rebalance Time by Worker",
-            "type": "timeseries",
-            "width": 33,
-            "x": 95,
-            "y": 25
+            "layout": {
+                "x": 95,
+                "y": 25,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 17,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:confluent.kafka.connect.worker.connector_failed_task_count{*} by {instance}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Failed Task Count by Worker",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Failed Task Count by Worker",
-            "type": "timeseries",
-            "width": 33,
-            "x": 129,
-            "y": 25
+            "layout": {
+                "x": 129,
+                "y": 25,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 18,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:confluent.kafka.connect.worker.connector_running_task_count{*} by {instance}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Running Task Count by Worker",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Running Task Count by Worker",
-            "type": "timeseries",
-            "width": 33,
-            "x": 129,
-            "y": 8
+            "layout": {
+                "x": 129,
+                "y": 8,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "16",
-            "height": 5,
-            "html": "Schema Registry",
             "id": 19,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 33,
-            "x": 95,
-            "y": 42
+            "definition": {
+                "type": "note",
+                "content": "Schema Registry",
+                "background_color": "gray",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 95,
+                "y": 42,
+                "width": 33,
+                "height": 5
+            }
         },
         {
-            "height": 14,
             "id": 20,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:confluent.kafka.schema.registry.jetty.connections_opened_rate{*} by {instance}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "HTTP Request Rate by Instance",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "HTTP Request Rate by Instance",
-            "type": "timeseries",
-            "width": 33,
-            "x": 95,
-            "y": 66
+            "layout": {
+                "x": 95,
+                "y": 66,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 21,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:confluent.kafka.schema.registry.jersey.request_error_rate{*} by {instance}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Request Error Rate by Instance",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Request Error Rate by Instance",
-            "type": "timeseries",
-            "width": 33,
-            "x": 95,
-            "y": 49
+            "layout": {
+                "x": 95,
+                "y": 49,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "16",
-            "height": 5,
-            "html": "REST Proxy",
             "id": 22,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 33,
-            "x": 129,
-            "y": 42
+            "definition": {
+                "type": "note",
+                "content": "REST Proxy",
+                "background_color": "gray",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 129,
+                "y": 42,
+                "width": 33,
+                "height": 5
+            }
         },
         {
-            "height": 14,
             "id": 23,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:confluent.kafka.rest.jersey.request_error_rate{*} by {instance}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Request Error Rate by Instance",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Request Error Rate by Instance",
-            "type": "timeseries",
-            "width": 33,
-            "x": 129,
-            "y": 49
+            "layout": {
+                "x": 129,
+                "y": 49,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 24,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:confluent.kafka.rest.jetty.connections_opened_rate{*} by {instance}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "HTTP Request Rate by Instance",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "HTTP Request Rate by Instance",
-            "type": "timeseries",
-            "width": 33,
-            "x": 129,
-            "y": 66
+            "layout": {
+                "x": 129,
+                "y": 66,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "check": "confluentplatform.can_connect",
-            "group_by": [],
-            "grouping": "cluster",
-            "height": 16,
             "id": 25,
-            "tags": [
-                "*"
-            ],
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Connected Hosts",
-            "type": "check_status",
-            "width": 25,
-            "x": 1,
-            "y": 8
+            "definition": {
+                "type": "check_status",
+                "title": "Connected Hosts",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "confluentplatform.can_connect",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "*"
+                ]
+            },
+            "layout": {
+                "x": 1,
+                "y": 8,
+                "width": 25,
+                "height": 16
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "16",
-            "height": 5,
-            "html": "KSQLDB",
             "id": 26,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 33,
-            "x": 163,
-            "y": 1
+            "definition": {
+                "type": "note",
+                "content": "KSQLDB",
+                "background_color": "gray",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 163,
+                "y": 1,
+                "width": 33,
+                "height": 5
+            }
         },
         {
-            "height": 14,
             "id": 27,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:confluent.ksql.query_stats.num_active_queries{*} by {instance}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Active Queries by Instance",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Active Queries by Instance",
-            "type": "timeseries",
-            "width": 33,
-            "x": 163,
-            "y": 25
+            "layout": {
+                "x": 163,
+                "y": 25,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 28,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:confluent.ksql.query_stats.error_rate{*} by {instance}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Query Error Rate by Instance",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Query Error Rate by Instance",
-            "type": "timeseries",
-            "width": 33,
-            "x": 163,
-            "y": 42
+            "layout": {
+                "x": 163,
+                "y": 42,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 29,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:confluent.ksql.query_stats.bytes_consumed_total{*} by {instance}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Bytes Consumed by Instance",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Bytes Consumed by Instance",
-            "type": "timeseries",
-            "width": 33,
-            "x": 163,
-            "y": 8
+            "layout": {
+                "x": 163,
+                "y": 8,
+                "width": 33,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 30,
-            "tile_def": {
-                "precision": 0,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
-                        "aggregator": "last",
-                        "q": "sum:confluent.kafka.server.replica_manager.under_min_isr_partition_count{*} by {host}"
+                        "q": "sum:confluent.kafka.server.replica_manager.under_min_isr_partition_count{*} by {host}",
+                        "aggregator": "last"
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Partitions under Min ISR",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Partitions under Min ISR",
-            "type": "query_value",
-            "width": 25,
-            "x": 1,
-            "y": 42
+            "layout": {
+                "x": 1,
+                "y": 42,
+                "width": 25,
+                "height": 16
+            }
         }
-    ]
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30275
 }

--- a/druid/assets/dashboards/overview.json
+++ b/druid/assets/dashboards/overview.json
@@ -1,694 +1,536 @@
 {
-  "author_info": {
-    "author_name": "Datadog"
-  },
-  "board_bgtype": "board_graph",
-  "board_title": "Druid Overview",
-  "created": "2019-07-15T11:02:50.756729+00:00",
-  "created_by": {
-    "access_role": "st",
-    "disabled": false,
-    "email": "support@datadoghq.com",
-    "handle": "support@datadoghq.com",
-    "is_admin": false,
-    "name": "Datadog",
-    "role": null,
-    "verified": true
-  },
-  "description": "This dashboard provides an overview of Druid queries, segments, ingestion, jvm, and system metrics for monitoring and investigating issues. Further reading on Druid monitoring:\n\n- [Datadog’s Druid integration docs](https://docs.datadoghq.com/integrations/druid/)\n\nClone this template dashboard to make changes and add your own graphs and widgets.",
-  "disableCog": false,
-  "disableEditing": false,
-  "id": 835346,
-  "isIntegration": false,
-  "isShared": false,
-  "modified": "2019-09-18T15:17:24.899641+00:00",
-  "new_id": "guh-z4u-ezc",
-  "originalHeight": 80,
-  "originalWidth": "calc(100% - 32px)",
-  "read_only": false,
-  "template_variables": [
-    {
-      "default": "*",
-      "name": "scope",
-      "prefix": null
-    },
-    {
-      "default": "*",
-      "name": "host",
-      "prefix": "host"
-    },
-    {
-      "default": "*",
-      "name": "druid_service",
-      "prefix": "druid_service"
-    }
-  ],
-  "widgets": [
-    {
-      "add_timeframe": true,
-      "board_id": "guh-z4u-ezc",
-      "height": 9,
-      "isShared": false,
-      "margin": "",
-      "scaleFactor": 1,
-      "sizing": "fit",
-      "title": false,
-      "type": "image",
-      "url": "https://s3.amazonaws.com/dd-integrations/druid/configuration/tile/logo.png",
-      "width": 47,
-      "x": 1,
-      "y": 1
-    },
-    {
-      "add_timeframe": true,
-      "board_id": "guh-z4u-ezc",
-      "error": null,
-      "generated_title": "druid.jvm.mem.used",
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:druid.jvm.mem.used{$scope,$host,$druid_service}, avg:druid.jvm.mem.init{$scope,$host,$druid_service}, avg:druid.jvm.mem.max{$scope,$host,$druid_service}, avg:druid.jvm.mem.committed{$scope,$host,$druid_service}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+    "title": "Druid Overview",
+    "description": "This dashboard provides an overview of Druid queries, segments, ingestion, jvm, and system metrics for monitoring and investigating issues. Further reading on Druid monitoring:\n\n- [Datadog’s Druid integration docs](https://docs.datadoghq.com/integrations/druid/)\n\nClone this template dashboard to make changes and add your own graphs and widgets.",
+    "widgets": [
+        {
+            "id": 0,
+            "definition": {
+                "type": "image",
+                "url": "https://s3.amazonaws.com/dd-integrations/druid/configuration/tile/logo.png",
+                "sizing": "fit"
             },
-            "type": "line"
-          }
-        ],
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "JVM Memory",
-      "type": "timeseries",
-      "width": 47,
-      "x": 1,
-      "y": 28
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:druid.jvm.pool.used{$scope,$host,$druid_service}, avg:druid.jvm.pool.init{$scope,$host,$druid_service}, avg:druid.jvm.pool.max{$scope,$host,$druid_service}, avg:druid.jvm.pool.committed{$scope,$host,$druid_service}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 47,
+                "height": 9
+            }
+        },
+        {
+            "id": 1,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:druid.jvm.mem.used{$scope,$host,$druid_service}, avg:druid.jvm.mem.init{$scope,$host,$druid_service}, avg:druid.jvm.mem.max{$scope,$host,$druid_service}, avg:druid.jvm.mem.committed{$scope,$host,$druid_service}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "JVM Memory",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "JVM Pool",
-      "type": "timeseries",
-      "width": 47,
-      "x": 1,
-      "y": 44
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:druid.segment.size{$scope,$host,$druid_service} by {datasource}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 1,
+                "y": 28,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 2,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:druid.jvm.pool.used{$scope,$host,$druid_service}, avg:druid.jvm.pool.init{$scope,$host,$druid_service}, avg:druid.jvm.pool.max{$scope,$host,$druid_service}, avg:druid.jvm.pool.committed{$scope,$host,$druid_service}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "JVM Pool",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Segments Size",
-      "type": "timeseries",
-      "width": 47,
-      "x": 49,
-      "y": 9
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "tile_def": {
-        "requests": [
-          {
-            "preTemplateQuery": "avg:druid.query.count{*}.as_count(), avg:druid.query.failed.count{*}.as_count(), avg:druid.query.success.count{*}.as_count()",
-            "q": "avg:druid.query.count{$scope,$host,$druid_service}.as_count(), avg:druid.query.failed.count{$scope,$host,$druid_service}.as_count(), avg:druid.query.success.count{$scope,$host,$druid_service}.as_count()",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 1,
+                "y": 44,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:druid.segment.size{$scope,$host,$druid_service} by {datasource}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Segments Size",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Query Count / Failed / Success",
-      "type": "timeseries",
-      "width": 47,
-      "x": 97,
-      "y": 41
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "tile_def": {
-        "requests": [
-          {
-            "preTemplateQuery": "avg:druid.query.bytes{*}.as_count()",
-            "q": "avg:druid.query.bytes{$scope,$host,$druid_service}.as_count()",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 49,
+                "y": 9,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:druid.query.count{$scope,$host,$druid_service}.as_count(), avg:druid.query.failed.count{$scope,$host,$druid_service}.as_count(), avg:druid.query.success.count{$scope,$host,$druid_service}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Query Count / Failed / Success",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Query Bytes",
-      "type": "timeseries",
-      "width": 47,
-      "x": 97,
-      "y": 9
-    },
-    {
-      "add_timeframe": true,
-      "auto_refresh": false,
-      "bgcolor": "gray",
-      "board_id": "guh-z4u-ezc",
-      "font_size": "24",
-      "height": 7,
-      "html": "Segments",
-      "isShared": false,
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "text_align": "center",
-      "tick": true,
-      "tick_edge": "bottom",
-      "tick_pos": "50%",
-      "title": false,
-      "type": "note",
-      "width": 47,
-      "x": 49,
-      "y": 1
-    },
-    {
-      "add_timeframe": true,
-      "auto_refresh": false,
-      "background_color": "white",
-      "bgcolor": "gray",
-      "content": "Segments",
-      "font_size": "24",
-      "height": 7,
-      "html": "Queries",
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "show_tick": true,
-      "text_align": "center",
-      "tick": true,
-      "tick_edge": "bottom",
-      "tick_pos": "50%",
-      "title": false,
-      "type": "note",
-      "viz": "note",
-      "width": 47,
-      "x": 97,
-      "y": 1
-    },
-    {
-      "add_timeframe": true,
-      "auto_refresh": false,
-      "background_color": "white",
-      "bgcolor": "gray",
-      "content": "Segments",
-      "font_size": "24",
-      "height": 7,
-      "html": "JVM & System",
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "show_tick": true,
-      "text_align": "center",
-      "tick": true,
-      "tick_edge": "bottom",
-      "tick_pos": "50%",
-      "title": false,
-      "type": "note",
-      "viz": "note",
-      "width": 47,
-      "x": 1,
-      "y": 20
-    },
-    {
-      "add_timeframe": true,
-      "board_id": "guh-z4u-ezc",
-      "check": "druid.service.can_connect",
-      "error": null,
-      "group": null,
-      "group_by": [],
-      "grouping": "cluster",
-      "height": 8,
-      "isShared": false,
-      "scaleFactor": 1,
-      "tags": [
-        "*"
-      ],
-      "text_align": "center",
-      "text_size": "auto",
-      "time": {},
-      "title": true,
-      "title_align": "center",
-      "title_size": 16,
-      "title_text": "Can Connect",
-      "type": "check_status",
-      "width": 23,
-      "x": 25,
-      "y": 11
-    },
-    {
-      "add_timeframe": true,
-      "check": "druid.service.health",
-      "error": null,
-      "group": null,
-      "group_by": [],
-      "grouping": "cluster",
-      "height": 8,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tags": [
-        "*"
-      ],
-      "text_align": "center",
-      "text_size": "auto",
-      "time": {},
-      "title": true,
-      "title_align": "center",
-      "title_size": "16",
-      "title_text": "Healthy",
-      "type": "check_status",
-      "viz": "check_status",
-      "width": 23,
-      "x": 1,
-      "y": 11
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:druid.sys.cpu{$scope,$host,$druid_service}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 97,
+                "y": 41,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:druid.query.bytes{$scope,$host,$druid_service}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Query Bytes",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "System CPU",
-      "type": "timeseries",
-      "width": 47,
-      "x": 1,
-      "y": 60
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:druid.sys.mem.max{$scope,$host,$druid_service}, avg:druid.sys.mem.used{$scope,$host,$druid_service}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 97,
+                "y": 9,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 6,
+            "definition": {
+                "type": "note",
+                "content": "Segments",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "System CPU",
-      "type": "timeseries",
-      "width": 47,
-      "x": 1,
-      "y": 76
-    },
-    {
-      "add_timeframe": true,
-      "error": {
-        "status": 0
-      },
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:druid.segment.used{$scope,$host,$druid_service}, avg:druid.segment.max{$scope,$host,$druid_service}, avg:druid.segment.size{$scope,$host,$druid_service}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 49,
+                "y": 1,
+                "width": 47,
+                "height": 7
+            }
+        },
+        {
+            "id": 7,
+            "definition": {
+                "type": "note",
+                "content": "Queries",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Segments Usage",
-      "type": "timeseries",
-      "width": 47,
-      "x": 49,
-      "y": 25
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:druid.query.wait.time.avg{$scope,$host,$druid_service}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 97,
+                "y": 1,
+                "width": 47,
+                "height": 7
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "note",
+                "content": "JVM & System",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Query Wait Time",
-      "type": "timeseries",
-      "width": 47,
-      "x": 97,
-      "y": 57
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 17,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:druid.ingest.events.processed{$scope,$host,$druid_service}.as_count(), avg:druid.ingest.events.duplicate{$scope,$host,$druid_service}.as_count(), avg:druid.ingest.events.messageGap{$scope,$host,$druid_service}, avg:druid.ingest.events.thrownAway{$scope,$host,$druid_service}.as_count(), avg:druid.ingest.events.unparseable{$scope,$host,$druid_service}.as_count()",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 1,
+                "y": 20,
+                "width": 47,
+                "height": 7
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "check_status",
+                "title": "Can Connect",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "druid.service.can_connect",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "*"
+                ]
             },
-            "type": "area"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Ingest Events",
-      "type": "timeseries",
-      "width": 47,
-      "x": 49,
-      "y": 49
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 20,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:druid.ingest.persists.count{$scope,$host,$druid_service}.as_count()",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 25,
+                "y": 11,
+                "width": 23,
+                "height": 8
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "check_status",
+                "title": "Healthy",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "druid.service.health",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "*"
+                ]
             },
-            "type": "area"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Ingest Persists Count",
-      "type": "timeseries",
-      "width": 47,
-      "x": 49,
-      "y": 69
-    },
-    {
-      "add_timeframe": true,
-      "auto_refresh": false,
-      "background_color": "white",
-      "bgcolor": "gray",
-      "content": "Tasks",
-      "font_size": "24",
-      "height": 7,
-      "html": "Ingest",
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "show_tick": false,
-      "text_align": "center",
-      "tick": true,
-      "tick_edge": "bottom",
-      "tick_pos": "50%",
-      "title": false,
-      "type": "note",
-      "viz": "note",
-      "width": 47,
-      "x": 49,
-      "y": 41
-    },
-    {
-      "add_timeframe": true,
-      "error": null,
-      "height": 13,
-      "isShared": false,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:druid.query.count{$scope,$host,$druid_service}.as_count()",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 1,
+                "y": 11,
+                "width": 23,
+                "height": 8
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:druid.sys.cpu{$scope,$host,$druid_service}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "System CPU",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Query Count",
-      "type": "timeseries",
-      "width": 47,
-      "x": 97,
-      "y": 25
-    },
-    {
-      "add_timeframe": true,
-      "error": {
-        "status": 0
-      },
-      "height": 16,
-      "legend": false,
-      "legend_size": "0",
-      "scaleFactor": 1,
-      "tile_def": {
-        "autoscale": true,
-        "requests": [
-          {
-            "aggregator": "avg",
-            "conditional_formats": [],
-            "q": "avg:druid.query.cpu.time.avg{$scope,$host,$druid_service}",
-            "style": {
-              "palette": "dog_classic",
-              "type": "solid",
-              "width": "normal"
+            "layout": {
+                "x": 1,
+                "y": 60,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:druid.sys.mem.max{$scope,$host,$druid_service}, avg:druid.sys.mem.used{$scope,$host,$druid_service}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "System CPU",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "title_align": "left",
-        "title_size": "16",
-        "viz": "timeseries"
-      },
-      "time": {},
-      "title": true,
-      "title_align": "left",
-      "title_size": 16,
-      "title_text": "Query CPU Time",
-      "type": "timeseries",
-      "width": 47,
-      "x": 97,
-      "y": 73
-    }
-  ]
+            "layout": {
+                "x": 1,
+                "y": 76,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:druid.segment.used{$scope,$host,$druid_service}, avg:druid.segment.max{$scope,$host,$druid_service}, avg:druid.segment.size{$scope,$host,$druid_service}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Segments Usage",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 49,
+                "y": 25,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 14,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:druid.query.wait.time.avg{$scope,$host,$druid_service}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Query Wait Time",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 97,
+                "y": 57,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:druid.ingest.events.processed{$scope,$host,$druid_service}.as_count(), avg:druid.ingest.events.duplicate{$scope,$host,$druid_service}.as_count(), avg:druid.ingest.events.messageGap{$scope,$host,$druid_service}, avg:druid.ingest.events.thrownAway{$scope,$host,$druid_service}.as_count(), avg:druid.ingest.events.unparseable{$scope,$host,$druid_service}.as_count()",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Ingest Events",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 49,
+                "y": 49,
+                "width": 47,
+                "height": 19
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:druid.ingest.persists.count{$scope,$host,$druid_service}.as_count()",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Ingest Persists Count",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 49,
+                "y": 69,
+                "width": 47,
+                "height": 22
+            }
+        },
+        {
+            "id": 17,
+            "definition": {
+                "type": "note",
+                "content": "Ingest",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 49,
+                "y": 41,
+                "width": 47,
+                "height": 7
+            }
+        },
+        {
+            "id": 18,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:druid.query.count{$scope,$host,$druid_service}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Query Count",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 97,
+                "y": 25,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 19,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:druid.query.cpu.time.avg{$scope,$host,$druid_service}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Query CPU Time",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 97,
+                "y": 73,
+                "width": 47,
+                "height": 18
+            }
+        }
+    ],
+    "template_variables": [
+        {
+            "name": "scope",
+            "default": "*",
+            "prefix": null
+        },
+        {
+            "name": "host",
+            "default": "*",
+            "prefix": "host"
+        },
+        {
+            "name": "druid_service",
+            "default": "*",
+            "prefix": "druid_service"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30244
 }

--- a/ecs_fargate/assets/dashboards/amazon_fargate_overview.json
+++ b/ecs_fargate/assets/dashboards/amazon_fargate_overview.json
@@ -1,650 +1,673 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "Amazon Fargate Overview",
-    "created": "2020-04-21T21:08:15.396904+00:00",
-    "created_by": {
-        "access_role": "st",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": false,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "Amazon Fargate Overview",
     "description": "## Amazon Fargate\n\nThis dashboard displays key metrics from your Amazon ECS cluster on AWS Fargate, such as cpu, memory, IO usage, and network.\n\nFurther reading on ECS-Fargate:\n\n- [Datadog ECS-Fargate integration docs](https://docs.datadoghq.com/integrations/ecs_fargate/)\n- [Integration setup docs](https://docs.datadoghq.com/integrations/faq/integration-setup-ecs-fargate/?tab=rediswebui)\n",
-    "modified": "2020-04-21T21:16:19.604409+00:00",
-    "read_only": false,
-    "template_variables": [],
     "widgets": [
         {
-            "height": 7,
             "id": 0,
-            "sizing": "zoom",
-            "type": "image",
-            "url": "/static/images/saas_logos/bot/amazon_fargate@2x.png",
-            "width": 11,
-            "x": 1,
-            "y": 1
+            "definition": {
+                "type": "image",
+                "url": "/static/images/saas_logos/bot/amazon_fargate@2x.png",
+                "sizing": "zoom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 11,
+                "height": 7
+            }
         },
         {
-            "height": 13,
             "id": 1,
-            "legend": false,
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.cpu.user{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Total CPU time consumed per container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Total CPU time consumed per container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 98,
-            "y": 9
+            "layout": {
+                "x": 98,
+                "y": 9,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "24",
-            "height": 5,
-            "html": "CPU",
             "id": 2,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 95,
-            "x": 98,
-            "y": 2
+            "definition": {
+                "type": "note",
+                "content": "CPU",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 98,
+                "y": 2,
+                "width": 95,
+                "height": 5
+            }
         },
         {
-            "height": 13,
             "id": 3,
-            "legend": false,
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.cpu.percent{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "CPU percent usage per container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "CPU percent usage per container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 146,
-            "y": 9
+            "layout": {
+                "x": 146,
+                "y": 9,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "24",
-            "height": 5,
-            "html": "Memory",
             "id": 4,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 83,
-            "x": 13,
-            "y": 2
+            "definition": {
+                "type": "note",
+                "content": "Memory",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 13,
+                "y": 2,
+                "width": 83,
+                "height": 5
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "24",
-            "height": 5,
-            "html": "IO Read/Write",
             "id": 5,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 95,
-            "x": 1,
-            "y": 42
+            "definition": {
+                "type": "note",
+                "content": "IO Read/Write",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 42,
+                "width": 95,
+                "height": 5
+            }
         },
         {
-            "height": 13,
             "id": 6,
-            "legend": false,
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.mem.usage{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average memory usage per container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average memory usage per container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 1,
-            "y": 9
+            "layout": {
+                "x": 1,
+                "y": 9,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "height": 13,
             "id": 7,
-            "legend": false,
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.io.ops.read{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average number of read operations per container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average number of read operations per container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 1,
-            "y": 49
+            "layout": {
+                "x": 1,
+                "y": 49,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "height": 13,
             "id": 8,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.io.ops.write{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average number of write operations per container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average number of write operations per container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 49,
-            "y": 49
+            "layout": {
+                "x": 49,
+                "y": 49,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "height": 13,
             "id": 9,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.io.bytes.read{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average number of bytes read per container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average number of bytes read per container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 1,
-            "y": 65
+            "layout": {
+                "x": 1,
+                "y": 65,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "height": 13,
             "id": 10,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.io.bytes.write{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average number of bytes write per container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average number of bytes write per container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 49,
-            "y": 65
+            "layout": {
+                "x": 49,
+                "y": 65,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "height": 13,
             "id": 11,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.mem.cache{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average memory cache per container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average memory cache per container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 49,
-            "y": 9
+            "layout": {
+                "x": 49,
+                "y": 9,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "height": 13,
             "id": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.mem.pgpgin{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average # of charging events to the mem cgroup",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average # of charging events to the mem cgroup",
-            "type": "timeseries",
-            "width": 47,
-            "x": 1,
-            "y": 25
+            "layout": {
+                "x": 1,
+                "y": 25,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "height": 13,
             "id": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.mem.rss{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average # of bytes of anonymous and swap cache memory",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average # of bytes of anonymous and swap cache memory",
-            "type": "timeseries",
-            "width": 47,
-            "x": 49,
-            "y": 25
+            "layout": {
+                "x": 49,
+                "y": 25,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "24",
-            "height": 5,
-            "html": "Network",
             "id": 14,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 96,
-            "x": 98,
-            "y": 26
+            "definition": {
+                "type": "note",
+                "content": "Network",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 98,
+                "y": 26,
+                "width": 96,
+                "height": 5
+            }
         },
         {
-            "height": 13,
             "id": 15,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.net.bytes_sent{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average bytes sent per container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average bytes sent per container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 98,
-            "y": 33
+            "layout": {
+                "x": 98,
+                "y": 33,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "height": 13,
             "id": 16,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.net.bytes_rcvd{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average bytes received per container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average bytes received per container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 147,
-            "y": 33
+            "layout": {
+                "x": 147,
+                "y": 33,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "height": 13,
             "id": 17,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.net.packet.in_dropped{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average ingoing packets dropped by container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average ingoing packets dropped by container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 98,
-            "y": 49
+            "layout": {
+                "x": 98,
+                "y": 49,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "height": 13,
             "id": 18,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.net.packet.out_dropped{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average outgoing packets dropped by container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average outgoing packets dropped by container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 147,
-            "y": 49
+            "layout": {
+                "x": 147,
+                "y": 49,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "height": 13,
             "id": 19,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.net.sent_errors{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average sent errors by container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average sent errors by container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 98,
-            "y": 65
+            "layout": {
+                "x": 98,
+                "y": 65,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "height": 13,
             "id": 20,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ecs.fargate.net.rcvd_errors{*} by {container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average received errors by container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average received errors by container",
-            "type": "timeseries",
-            "width": 47,
-            "x": 147,
-            "y": 65
+            "layout": {
+                "x": 147,
+                "y": 65,
+                "width": 47,
+                "height": 15
+            }
         }
-    ]
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30264
 }

--- a/envoy/assets/dashboards/envoy_overview.json
+++ b/envoy/assets/dashboards/envoy_overview.json
@@ -1,583 +1,410 @@
 {
-    "board_title": "Envoy - Overview",
-    "read_only": false,
-    "author_info": {
-        "author_name": "Datadog"
-    },
+    "title": "Envoy - Overview",
     "description": "## Envoy\n\nThis dashboard provides a high-level overview of your Envoy cluster so you can monitor its performance and resource usage.\n\nFor further reading on monitoring Envoy, see:\n\n- [Official Envoy integration docs](https://docs.datadoghq.com/integrations/envoy/#data-collected)\n- [Monitoring AWS App Mesh and Envoy with Datadog](https://www.datadoghq.com/blog/envoy-app-mesh-monitoring/)\n\nClone this template to make changes and add your own graphs and widgets.",
-    "board_bgtype": "board_graph",
-    "created": "2019-11-26T10:01:27.045918+00:00",
-    "created_by": {
-        "disabled": false,
-        "handle": "support@datadoghq.com",
-        "name": "Datadog",
-        "is_admin": false,
-        "role": null,
-        "access_role": "st",
-        "verified": true,
-        "email": "support@datadoghq.com"
-    },
-    "new_id": "ccb-44a-8gh",
-    "modified": "2019-11-26T14:00:43.907183+00:00",
-    "originalHeight": 80,
-    "template_variables": [
-        {
-            "default": "*",
-            "prefix": null,
-            "name": "scope"
-        }
-    ],
-    "isIntegration": false,
-    "disableEditing": false,
-    "originalWidth": "calc(100% - 32px)",
     "widgets": [
         {
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "type": "timeseries",
-            "title_align": "left",
-            "title_text": "Requests (req/s)",
-            "height": 15,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 0,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:envoy.http.downstream_rq_total{$scope}.as_rate()",
-                        "aggregator": "avg",
+                        "display_type": "area",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "area",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Requests (req/s)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 43,
-            "legend": false,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 17,
-            "x": 1,
-            "legend_size": "0",
-            "isShared": false,
-            "scaleFactor": 1,
-            "id": 0,
-            "add_timeframe": true
+            "layout": {
+                "x": 1,
+                "y": 17,
+                "width": 43,
+                "height": 17
+            }
         },
         {
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "type": "timeseries",
-            "title_align": "left",
-            "title_text": "Total cluster membership update successes",
-            "height": 15,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 1,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:envoy.cluster.update_success{*} by {cluster_name}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "bars",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "bars",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Total cluster membership update successes",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 43,
-            "legend": false,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 53,
-            "x": 48,
-            "legend_size": "0",
-            "isShared": false,
-            "scaleFactor": 1,
-            "id": 2,
-            "add_timeframe": true
+            "layout": {
+                "x": 48,
+                "y": 53,
+                "width": 43,
+                "height": 17
+            }
         },
         {
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "type": "timeseries",
-            "title_align": "left",
-            "title_text": "Bytes received and sent (B/s)",
-            "height": 15,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 2,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:envoy.http.downstream_cx_rx_bytes_total{$scope}.as_rate()",
-                        "aggregator": "avg",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     },
                     {
                         "q": "avg:envoy.http.downstream_cx_tx_bytes_total{$scope}.as_rate()",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Bytes received and sent (B/s)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 43,
-            "legend": false,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 35,
-            "x": 1,
-            "legend_size": "0",
-            "isShared": false,
-            "scaleFactor": 1,
-            "id": 3,
-            "add_timeframe": true
+            "layout": {
+                "x": 1,
+                "y": 35,
+                "width": 43,
+                "height": 17
+            }
         },
         {
-            "x": 48,
-            "autoscale": true,
-            "time": {},
-            "title": true,
-            "type": "query_value",
-            "id": 4,
-            "title_align": "left",
-            "title_text": "Total active clusters",
-            "height": 5,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 3,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:envoy.cluster_manager.active_clusters{*}",
-                        "aggregator": "last",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": []
+                        "aggregator": "last"
                     }
                 ],
+                "custom_links": [],
+                "title": "Total active clusters",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": true,
-                "precision": "2"
+                "precision": 2
             },
-            "width": 21,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 45,
-            "title_size": 16,
-            "legend_size": "0",
-            "isShared": false,
-            "scaleFactor": 1,
-            "legend": false,
-            "add_timeframe": true
+            "layout": {
+                "x": 48,
+                "y": 45,
+                "width": 21,
+                "height": 7
+            }
         },
         {
-            "x": 70,
-            "autoscale": true,
-            "time": {},
-            "title": true,
-            "type": "query_value",
-            "id": 5,
-            "title_align": "left",
-            "title_text": "Total warming clusters",
-            "height": 5,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 4,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:envoy.cluster_manager.warming_clusters{*}",
-                        "aggregator": "last",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": []
+                        "aggregator": "last"
                     }
                 ],
+                "custom_links": [],
+                "title": "Total warming clusters",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": true,
-                "precision": "2"
+                "precision": 2
             },
-            "width": 21,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 45,
-            "title_size": 16,
-            "legend_size": "0",
-            "isShared": false,
-            "scaleFactor": 1,
-            "legend": false,
-            "add_timeframe": true
+            "layout": {
+                "x": 70,
+                "y": 45,
+                "width": 21,
+                "height": 7
+            }
         },
         {
-            "title_size": "16",
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_text": "Total pending requests per cluster",
-            "height": 15,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:envoy.cluster.upstream_rq_pending_total{*} by {cluster_name}.as_count()",
+                        "display_type": "bars",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
-                ]
+                ],
+                "custom_links": [],
+                "title": "Total pending requests per cluster",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 43,
-            "legend": false,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 53,
-            "x": 1,
-            "legend_size": "0",
-            "isShared": false,
-            "type": "timeseries",
+            "layout": {
+                "x": 1,
+                "y": 53,
+                "width": 43,
+                "height": 17
+            }
+        },
+        {
             "id": 6,
-            "add_timeframe": true
+            "definition": {
+                "type": "image",
+                "url": "/static/images/saas_logos/bot/envoy.png",
+                "sizing": "zoom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 19,
+                "height": 7
+            }
         },
         {
-            "sizing": "zoom",
-            "title": false,
-            "url": "/static/images/saas_logos/bot/envoy.png",
-            "type": "image",
-            "height": 7,
-            "width": 19,
-            "y": 1,
-            "x": 1,
-            "isShared": false,
-            "margin": "",
-            "id": 9,
-            "add_timeframe": true
-        },
-        {
-            "x": 74,
-            "autoscale": true,
-            "time": {},
-            "title": true,
-            "type": "query_value",
-            "id": 10,
-            "title_align": "left",
-            "title_text": "Allocated memory",
-            "height": 5,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 7,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:envoy.server.memory_allocated{*}",
-                        "aggregator": "avg",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": []
+                        "aggregator": "avg"
                     }
                 ],
-                "autoscale": true,
-                "custom_unit": "B",
-                "precision": "2"
-            },
-            "width": 17,
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            },
-            "error": null,
-            "y": 1,
-            "title_size": 16,
-            "legend_size": "0",
-            "isShared": false,
-            "scaleFactor": 1,
-            "legend": false,
-            "add_timeframe": true
-        },
-        {
-            "height": 5,
-            "viz": "note",
-            "background_color": "yellow",
-            "title": false,
-            "tick_pos": "50%",
-            "text_align": "center",
-            "content": "\n\n\n\n\n\n\nConnections",
-            "bgcolor": "yellow",
-            "html": "Requests",
-            "legend_size": "0",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "tick": true,
-            "scaleFactor": 1,
-            "legend": false,
-            "add_timeframe": true,
-            "font_size": "14",
-            "tick_edge": "bottom",
-            "y": 10,
-            "x": 1,
-            "width": 43
-        },
-        {
-            "title_size": 16,
-            "time": {},
-            "title": true,
-            "type": "timeseries",
-            "title_align": "left",
-            "title_text": "Total connections per cluster",
-            "height": 15,
-            "tile_def": {
+                "custom_links": [],
+                "title": "Allocated memory",
                 "title_size": "16",
                 "title_align": "left",
-                "custom_unit": "B",
-                "precision": "2",
-                "viz": "timeseries",
                 "autoscale": true,
+                "custom_unit": "B",
+                "precision": 2
+            },
+            "layout": {
+                "x": 74,
+                "y": 1,
+                "width": 17,
+                "height": 7
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "note",
+                "content": "Requests",
+                "background_color": "yellow",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 10,
+                "width": 43,
+                "height": 5
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:envoy.http.downstream_cx_total{$scope} by {cluster_name}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "bars",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "bars",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
-                ]
+                ],
+                "custom_links": [],
+                "title": "Total connections per cluster",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 43,
-            "sharedGlobalTime": {
-                "live_span": "1h"
+            "layout": {
+                "x": 48,
+                "y": 17,
+                "width": 43,
+                "height": 17
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "note",
+                "content": "Connections",
+                "background_color": "yellow",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "error": null,
-            "y": 17,
-            "x": 48,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "scaleFactor": 1,
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 48,
+                "y": 10,
+                "width": 43,
+                "height": 5
+            }
         },
         {
-            "height": 5,
-            "viz": "note",
-            "background_color": "yellow",
-            "title": false,
-            "tick_pos": "50%",
-            "text_align": "center",
-            "content": "\n\n\n\n\n\n\nRequests",
-            "bgcolor": "yellow",
-            "html": "Connections",
-            "legend_size": "0",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "tick": true,
-            "scaleFactor": 1,
-            "legend": false,
-            "add_timeframe": true,
-            "font_size": "14",
-            "tick_edge": "bottom",
-            "y": 10,
-            "x": 48,
-            "width": 43
+            "id": 11,
+            "definition": {
+                "type": "note",
+                "content": "Clusters",
+                "background_color": "yellow",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 48,
+                "y": 38,
+                "width": 43,
+                "height": 5
+            }
         },
         {
-            "height": 5,
-            "viz": "note",
-            "tick_pos": "50%",
-            "title": false,
-            "background_color": "yellow",
-            "text_align": "center",
-            "content": "\n\n\n\n\n\n\nConnections",
-            "bgcolor": "yellow",
-            "html": "Clusters",
-            "legend_size": "0",
-            "type": "note",
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "tick": true,
-            "scaleFactor": 1,
-            "legend": false,
-            "add_timeframe": true,
-            "font_size": "14",
-            "tick_edge": "bottom",
-            "y": 38,
-            "x": 48,
-            "width": 43
-        },
-        {
-            "title_size": 16,
-            "title": true,
-            "type": "query_value",
-            "title_align": "left",
-            "title_text": "Uptime",
-            "height": 5,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 12,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:envoy.server.uptime{*}/3600/24",
-                        "aggregator": "last",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": []
+                        "aggregator": "last"
                     }
                 ],
-                "autoscale": true,
-                "custom_unit": "days",
-                "precision": "1"
-            },
-            "width": 17,
-            "time": {},
-            "error": null,
-            "y": 1,
-            "x": 56,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "legend": false,
-            "add_timeframe": true
-        },
-        {
-            "title_size": 16,
-            "title": true,
-            "type": "query_value",
-            "title_align": "left",
-            "title_text": "Live",
-            "height": 5,
-            "tile_def": {
+                "custom_links": [],
+                "title": "Uptime",
                 "title_size": "16",
                 "title_align": "left",
-                "custom_unit": null,
-                "precision": "2",
-                "viz": "query_value",
                 "autoscale": true,
+                "custom_unit": "days",
+                "precision": 1
+            },
+            "layout": {
+                "x": 56,
+                "y": 1,
+                "width": 17,
+                "height": 7
+            }
+        },
+        {
+            "id": 13,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:envoy.server.live{*}",
                         "aggregator": "last",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
                         "conditional_formats": [
                             {
-                                "palette": "white_on_green",
                                 "comparator": ">",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "white_on_green"
                             },
                             {
-                                "palette": "white_on_yellow",
                                 "comparator": "<",
-                                "value": "1"
+                                "value": 1,
+                                "palette": "white_on_yellow"
                             }
                         ]
                     }
-                ]
+                ],
+                "custom_links": [],
+                "title": "Live",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
             },
-            "width": 17,
-            "time": {},
-            "error": null,
-            "y": 1,
-            "x": 38,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "legend": false,
-            "add_timeframe": true
+            "layout": {
+                "x": 38,
+                "y": 1,
+                "width": 17,
+                "height": 7
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "type": "query_value",
-            "title_align": "left",
-            "title_text": "Cluster membership update failures",
-            "height": 5,
-            "tile_def": {
-                "title_size": "13",
-                "title_align": "left",
-                "precision": "2",
-                "viz": "query_value",
-                "autoscale": true,
+            "id": 14,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:envoy.cluster.update_failure{*}.as_count()",
                         "aggregator": "last",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
                         "conditional_formats": [
                             {
-                                "palette": "red_on_white",
                                 "comparator": ">",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "red_on_white"
                             }
                         ]
                     }
-                ]
+                ],
+                "custom_links": [],
+                "title": "Cluster membership update failures",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "30m"
+                },
+                "autoscale": true,
+                "precision": 2
             },
-            "width": 43,
-            "time": {
-                "live_span": "30m"
-            },
-            "error": null,
-            "y": 71,
-            "x": 48,
-            "legend_size": "0",
-            "scaleFactor": 1,
-            "legend": false,
-            "add_timeframe": true
+            "layout": {
+                "x": 48,
+                "y": 71,
+                "width": 43,
+                "height": 7
+            }
         }
     ],
-    "disableCog": false,
-    "id": 907169,
-    "isShared": false
+    "template_variables": [
+        {
+            "name": "scope",
+            "default": "*",
+            "prefix": null
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30293
 }

--- a/etcd/assets/dashboards/etcd_overview.json
+++ b/etcd/assets/dashboards/etcd_overview.json
@@ -1,472 +1,375 @@
 {
-  "board_title": "Etcd Overview",
-  "read_only": false,
-  "author_info": {
-    "author_name": "Datadog"
-  },
-  "description": "",
-  "board_bgtype": "board_graph",
-  "created": "2019-09-30T12:31:31.471879+00:00",
-  "created_by": {
-    "disabled": false,
-    "handle": "support@datadoghq.com",
-    "name": "Datadog",
-    "is_admin": false,
-    "role": null,
-    "access_role": "st",
-    "verified": true,
-    "email": "support@datadoghq.com"
-  },
-  "new_id": "ur6-853-452",
-  "modified": "2019-09-30T13:25:21.920780+00:00",
-  "originalHeight": 80,
-  "template_variable_presets": [],
-  "template_variables": [
-    {
-      "default": "*",
-      "prefix": null,
-      "name": "scope"
-    }
-  ],
-  "isIntegration": false,
-  "disableEditing": false,
-  "originalWidth": "calc(100% - 32px)",
-  "widgets": [
-    {
-      "board_id": "ur6-853-452",
-      "sizing": "zoom",
-      "title": false,
-      "url": "/static/images/screenboard/integrations/etcd.png",
-      "margin": "",
-      "height": 15,
-      "width": 47,
-      "scaleFactor": 1,
-      "y": 0,
-      "x": 0,
-      "add_timeframe": true,
-      "type": "image",
-      "isShared": false
-    },
-    {
-      "board_id": "ur6-853-452",
-      "tick": true,
-      "font_size": "14",
-      "title": false,
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "tick_edge": "bottom",
-      "text_align": "left",
-      "auto_refresh": false,
-      "bgcolor": "blue",
-      "add_timeframe": true,
-      "html": "Network",
-      "type": "note",
-      "y": 0,
-      "x": 49,
-      "height": 5,
-      "tick_pos": "50%",
-      "width": 96,
-      "isShared": false
-    },
-    {
-      "board_id": "ur6-853-452",
-      "tick": true,
-      "font_size": "14",
-      "title": false,
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "tick_edge": "bottom",
-      "text_align": "left",
-      "auto_refresh": false,
-      "bgcolor": "blue",
-      "add_timeframe": true,
-      "html": "GRPC cache",
-      "type": "note",
-      "y": 17,
-      "x": 0,
-      "height": 5,
-      "tick_pos": "50%",
-      "width": 47,
-      "isShared": false
-    },
-    {
-      "board_id": "ur6-853-452",
-      "tick": true,
-      "font_size": "14",
-      "title": false,
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "tick_edge": "bottom",
-      "text_align": "left",
-      "auto_refresh": false,
-      "bgcolor": "blue",
-      "add_timeframe": true,
-      "html": "Disk",
-      "type": "note",
-      "y": 42,
-      "x": 0,
-      "height": 5,
-      "tick_pos": "50%",
-      "width": 47,
-      "isShared": false
-    },
-    {
-      "board_id": "ur6-853-452",
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "system.cpu.user",
-      "title_text": "Commit / Fsync duration",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:etcd.disk.backend.commit.duration.seconds{$scope}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+    "title": "Etcd Overview",
+    "description": "",
+    "widgets": [
+        {
+            "id": 0,
+            "definition": {
+                "type": "image",
+                "url": "/static/images/screenboard/integrations/etcd.png",
+                "sizing": "zoom"
             },
-            "type": "line",
-            "conditional_formats": []
-          },
-          {
-            "q": "avg:etcd.disk.wal.fsync.duration.seconds{$scope}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 1,
+            "definition": {
+                "type": "note",
+                "content": "Network",
+                "background_color": "blue",
+                "font_size": "14",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": "line"
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 49,
-      "x": 0,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "scaleFactor": 1,
-      "legend": false,
-      "isShared": false
-    },
-    {
-      "board_id": "ur6-853-452",
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "system.cpu.user",
-      "title_text": "GRPC cache hits / misses",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:etcd.grpc.proxy.cache.hits.total{$scope}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 49,
+                "y": 0,
+                "width": 96,
+                "height": 5
+            }
+        },
+        {
+            "id": 2,
+            "definition": {
+                "type": "note",
+                "content": "GRPC cache",
+                "background_color": "blue",
+                "font_size": "14",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": "line",
-            "conditional_formats": []
-          },
-          {
-            "q": "avg:etcd.grpc.proxy.cache.misses.total{$scope}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 0,
+                "y": 17,
+                "width": 47,
+                "height": 5
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "note",
+                "content": "Disk",
+                "background_color": "blue",
+                "font_size": "14",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": "line"
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 25,
-      "x": 0,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "scaleFactor": 1,
-      "legend": false,
-      "isShared": false
-    },
-    {
-      "board_id": "ur6-853-452",
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "Client received and sent bytes",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:etcd.network.client.grpc.received.bytes.total{*}.as_count()",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 0,
+                "y": 42,
+                "width": 47,
+                "height": 5
+            }
+        },
+        {
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:etcd.disk.backend.commit.duration.seconds{$scope}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:etcd.disk.wal.fsync.duration.seconds{$scope}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Commit / Fsync duration",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line",
-            "conditional_formats": []
-          },
-          {
-            "q": "avg:etcd.network.client.grpc.sent.bytes.total{*}.as_count()",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 0,
+                "y": 49,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:etcd.grpc.proxy.cache.hits.total{$scope}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:etcd.grpc.proxy.cache.misses.total{$scope}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "GRPC cache hits / misses",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 7,
-      "x": 49,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "scaleFactor": 1,
-      "legend": false,
-      "isShared": false
-    },
-    {
-      "board_id": "ur6-853-452",
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "Peer received and sent bytes",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:etcd.network.peer.received.bytes.total{$scope}.as_count()",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 0,
+                "y": 25,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:etcd.network.client.grpc.received.bytes.total{*}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:etcd.network.client.grpc.sent.bytes.total{*}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Client received and sent bytes",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line",
-            "conditional_formats": []
-          },
-          {
-            "q": "avg:etcd.network.peer.sent.bytes.total{$scope}.as_count()",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 49,
+                "y": 7,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:etcd.network.peer.received.bytes.total{$scope}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "avg:etcd.network.peer.sent.bytes.total{$scope}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Peer received and sent bytes",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line"
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 7,
-      "x": 98,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "scaleFactor": 1,
-      "legend": false,
-      "isShared": false
-    },
-    {
-      "board_id": "ur6-853-452",
-      "font_size": "14",
-      "title": false,
-      "refresh_every": 30000,
-      "scaleFactor": 1,
-      "tick_edge": "bottom",
-      "text_align": "left",
-      "auto_refresh": false,
-      "height": 6,
-      "bgcolor": "blue",
-      "add_timeframe": true,
-      "html": "Memstats",
-      "type": "note",
-      "y": 25,
-      "x": 49,
-      "tick": true,
-      "tick_pos": "50%",
-      "width": 96,
-      "isShared": false
-    },
-    {
-      "board_id": "ur6-853-452",
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "GC time",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:etcd.go.memstats.last.gc.time.seconds{$scope}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 98,
+                "y": 7,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "note",
+                "content": "Memstats",
+                "background_color": "blue",
+                "font_size": "14",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": "bars",
-            "conditional_formats": []
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 49,
-      "x": 49,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "scaleFactor": 1,
-      "legend": false,
-      "isShared": false
-    },
-    {
-      "board_id": "ur6-853-452",
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "Allocated heap",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:etcd.go.memstats.heap.alloc.bytes{$scope}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 49,
+                "y": 25,
+                "width": 96,
+                "height": 6
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:etcd.go.memstats.last.gc.time.seconds{$scope}",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "GC time",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line",
-            "conditional_formats": []
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 33,
-      "x": 98,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "scaleFactor": 1,
-      "legend": false,
-      "isShared": false
-    },
-    {
-      "board_id": "ur6-853-452",
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "Allocated bytes",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:etcd.go.memstats.alloc.bytes{$scope}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 49,
+                "y": 49,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:etcd.go.memstats.heap.alloc.bytes{$scope}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Allocated heap",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line",
-            "conditional_formats": []
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 33,
-      "x": 49,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "scaleFactor": 1,
-      "legend": false,
-      "isShared": false
-    },
-    {
-      "board_id": "ur6-853-452",
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "Profiling bucket hash table size",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:etcd.go.memstats.buck.hash.sys.bytes{$scope}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 98,
+                "y": 33,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:etcd.go.memstats.alloc.bytes{$scope}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Allocated bytes",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line",
-            "conditional_formats": []
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 49,
-      "x": 98,
-      "legend_size": "0",
-      "add_timeframe": true,
-      "scaleFactor": 1,
-      "legend": false,
-      "isShared": false
-    }
-  ],
-  "disableCog": false,
-  "id": 64746,
-  "isShared": false
+            "layout": {
+                "x": 49,
+                "y": 33,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:etcd.go.memstats.buck.hash.sys.bytes{$scope}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Profiling bucket hash table size",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 98,
+                "y": 49,
+                "width": 47,
+                "height": 15
+            }
+        }
+    ],
+    "template_variables": [
+        {
+            "name": "scope",
+            "default": "*",
+            "prefix": null
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30289
 }

--- a/exchange_server/assets/dashboards/overview.json
+++ b/exchange_server/assets/dashboards/overview.json
@@ -1,805 +1,845 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "Exchange Server Overview",
-    "read_only": false,
+    "title": "Exchange Server Overview",
     "description": "## Exchange Server\n\nThis dashboard provides a high-level overview of your Exchange Server instances so you can monitor metrics related to network, storage, and workers.\n\n[Official integration docs](https://docs.datadoghq.com/integrations/exchange_server/)\n\nClone this template to make changes and add your own graphs and widgets.\n",
-    "created": "2020-05-29T11:07:43.815841+00:00",
-    "id": 1143460,
-    "new_id": "yxx-ehn-dh5",
-    "modified": "2020-05-29T12:54:58.039110+00:00",
-    "created_by": {
-        "disabled": false,
-        "handle": "support@datadoghq.com",
-        "name": "Datadog",
-        "title": null,
-        "is_admin": true,
-        "role": null,
-        "access_role": "adm",
-        "verified": true,
-        "email": "support@datadoghq.com"
-    },
-    "template_variables": [
-        {
-            "default": "*",
-            "prefix": "host",
-            "name": "host"
-        },
-        {
-            "default": "*",
-            "prefix": "instance",
-            "name": "instance"
-        }
-    ],
     "widgets": [
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "I/O Latency",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 0,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:exchange.database.io_writes_avg_latency{$host,$instance}",
-                        "style": {
-                            "width": "normal",
-                            "palette": "purple",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "metadata": {
-                            "avg:exchange.database.io_writes_avg_latency{$host,$instance}": {
-                                "alias": "Writing latency"
+                        "metadata": [
+                            {
+                                "expression": "avg:exchange.database.io_writes_avg_latency{$host,$instance}",
+                                "alias_name": "Writing latency"
                             }
+                        ],
+                        "display_type": "line",
+                        "style": {
+                            "palette": "purple",
+                            "line_type": "solid",
+                            "line_width": "normal"
                         }
                     },
                     {
                         "q": "avg:exchange.database.io_reads_avg_latency{$host,$instance}",
-                        "style": {
-                            "width": "normal",
-                            "palette": "cool",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "metadata": {
-                            "avg:exchange.database.io_reads_avg_latency{$host,$instance}": {
-                                "alias": "Reading latency"
+                        "metadata": [
+                            {
+                                "expression": "avg:exchange.database.io_reads_avg_latency{$host,$instance}",
+                                "alias_name": "Reading latency"
                             }
+                        ],
+                        "display_type": "line",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
                         }
                     }
                 ],
+                "custom_links": [],
                 "yaxis": {
-                    "max": "auto",
-                    "scale": "linear",
-                    "includeZero": true,
                     "label": "",
-                    "min": "auto"
-                }
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "I/O Latency",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "width": 37,
-            "legend": false,
-            "time": {},
-            "y": 10,
-            "x": 112,
-            "type": "timeseries",
-            "id": 0
+            "layout": {
+                "x": 112,
+                "y": 10,
+                "width": 37,
+                "height": 15
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Memory available",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 1,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:exchange.memory.available{$host,$instance}",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
+                "custom_links": [],
                 "yaxis": {
-                    "max": "auto",
-                    "scale": "linear",
-                    "includeZero": true,
                     "label": "",
-                    "min": "auto"
-                }
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Memory available",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "width": 37,
-            "legend": false,
-            "time": {},
-            "y": 77,
-            "x": 1,
-            "type": "timeseries",
-            "id": 1
+            "layout": {
+                "x": 1,
+                "y": 77,
+                "width": 37,
+                "height": 15
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Latency",
-            "height": 13,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 2,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:exchange.is.store.rpc_latency{*}",
                         "aggregator": "last"
                     }
                 ],
+                "custom_links": [],
+                "title": "Latency",
+                "title_size": "16",
+                "title_align": "left",
                 "custom_unit": "ms",
                 "precision": 1
             },
-            "width": 18,
-            "y": 10,
-            "x": 54,
-            "type": "query_value",
-            "id": 2
+            "layout": {
+                "x": 54,
+                "y": 10,
+                "width": 18,
+                "height": 15
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Operations rate",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 3,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:exchange.is.clienttype.rpc_ops_persec{$host,$instance}",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line"
-                    }
-                ],
-                "yaxis": {
-                    "max": "auto",
-                    "scale": "linear",
-                    "includeZero": true,
-                    "label": "",
-                    "min": "auto"
-                }
-            },
-            "width": 37,
-            "legend": false,
-            "time": {},
-            "y": 26,
-            "x": 73,
-            "type": "timeseries",
-            "id": 3
-        },
-        {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Operations rate",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
-                "requests": [
-                    {
-                        "q": "avg:exchange.is.store.rpc_ops_persec{$host,$instance}",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "metadata": {
-                            "avg:exchange.is.store.rpc_ops_persec{$host,$instance}": {
-                                "alias": "Operations"
-                            }
+                            "line_type": "solid",
+                            "line_width": "normal"
                         }
                     }
                 ],
+                "custom_links": [],
                 "yaxis": {
-                    "max": "auto",
-                    "scale": "linear",
-                    "includeZero": true,
                     "label": "",
-                    "min": "auto"
-                }
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Operations rate",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "width": 37,
-            "legend": false,
-            "time": {},
-            "y": 10,
-            "x": 73,
-            "type": "timeseries",
-            "id": 4
+            "layout": {
+                "x": 73,
+                "y": 26,
+                "width": 37,
+                "height": 15
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Latency",
-            "height": 13,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:exchange.is.store.rpc_ops_persec{$host,$instance}",
+                        "metadata": [
+                            {
+                                "expression": "avg:exchange.is.store.rpc_ops_persec{$host,$instance}",
+                                "alias_name": "Operations"
+                            }
+                        ],
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Operations rate",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 73,
+                "y": 10,
+                "width": 37,
+                "height": 15
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:exchange.is.clienttype.rpc_latency{*}",
                         "aggregator": "last"
                     }
                 ],
+                "custom_links": [],
+                "title": "Latency",
+                "title_size": "16",
+                "title_align": "left",
                 "custom_unit": "ms",
                 "precision": 1
             },
-            "width": 18,
-            "y": 26,
-            "x": 54,
-            "type": "query_value",
-            "id": 5
+            "layout": {
+                "x": 54,
+                "y": 26,
+                "width": 18,
+                "height": 15
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Unique users",
-            "height": 13,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 6,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "sum:exchange.owa.unique_users{*}",
                         "aggregator": "last"
                     }
                 ],
+                "custom_links": [],
+                "title": "Unique users",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": true,
                 "precision": 0
             },
-            "width": 18,
-            "y": 52,
-            "x": 54,
-            "type": "query_value",
-            "id": 6
+            "layout": {
+                "x": 54,
+                "y": 52,
+                "width": 18,
+                "height": 15
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Requests rate",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:exchange.owa.requests_persec{$host,$instance}",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
+                "custom_links": [],
                 "yaxis": {
-                    "max": "auto",
-                    "scale": "linear",
-                    "includeZero": true,
                     "label": "",
-                    "min": "auto"
-                }
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Requests rate",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "width": 37,
-            "legend": false,
-            "time": {},
-            "y": 52,
-            "x": 73,
-            "type": "timeseries",
-            "id": 7
+            "layout": {
+                "x": 73,
+                "y": 52,
+                "width": 37,
+                "height": 15
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Requests rate",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:exchange.ws.requests_persec{$host,$instance}",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
+                "custom_links": [],
                 "yaxis": {
-                    "max": "auto",
-                    "scale": "linear",
-                    "includeZero": true,
                     "label": "",
-                    "min": "auto"
-                }
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Requests rate",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "width": 37,
-            "legend": false,
-            "time": {},
-            "y": 68,
-            "x": 73,
-            "type": "timeseries",
-            "id": 8
+            "layout": {
+                "x": 73,
+                "y": 68,
+                "width": 37,
+                "height": 15
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Current connections",
-            "height": 13,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 9,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "sum:exchange.ws.current_connections_total{*}",
                         "aggregator": "last"
                     }
                 ],
+                "custom_links": [],
+                "title": "Current connections",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": true,
                 "precision": 0
             },
-            "width": 18,
-            "y": 68,
-            "x": 54,
-            "type": "query_value",
-            "id": 9
+            "layout": {
+                "x": 54,
+                "y": 68,
+                "width": 18,
+                "height": 15
+            }
         },
         {
-            "sizing": "zoom",
-            "url": "https://static.datadoghq.com/static/images/saas_logos/bot/exchange_server@2x.png",
-            "height": 7,
-            "width": 37,
-            "y": 1,
-            "x": 1,
-            "type": "image",
-            "id": 10
+            "id": 10,
+            "definition": {
+                "type": "image",
+                "url": "https://static.datadoghq.com/static/images/saas_logos/bot/exchange_server@2x.png",
+                "sizing": "zoom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 37,
+                "height": 7
+            }
         },
         {
-            "font_size": "18",
-            "bgcolor": "gray",
-            "type": "note",
-            "tick_edge": "bottom",
-            "text_align": "center",
-            "height": 7,
-            "width": 37,
-            "html": "General",
-            "y": 10,
-            "x": 1,
-            "tick": true,
-            "tick_pos": "50%",
-            "id": 11
+            "id": 11,
+            "definition": {
+                "type": "note",
+                "content": "General",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 10,
+                "width": 37,
+                "height": 7
+            }
         },
         {
-            "font_size": "16",
-            "bgcolor": "blue",
-            "type": "note",
-            "tick_edge": "right",
-            "text_align": "center",
-            "height": 15,
-            "width": 12,
-            "html": "Store",
-            "y": 10,
-            "x": 40,
-            "tick": true,
-            "tick_pos": "50%",
-            "id": 12
+            "id": 12,
+            "definition": {
+                "type": "note",
+                "content": "Store",
+                "background_color": "blue",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 40,
+                "y": 10,
+                "width": 12,
+                "height": 15
+            }
         },
         {
-            "font_size": "16",
-            "bgcolor": "blue",
-            "type": "note",
-            "tick_edge": "right",
-            "text_align": "center",
-            "height": 15,
-            "width": 12,
-            "html": "Client",
-            "y": 26,
-            "x": 40,
-            "tick": true,
-            "tick_pos": "50%",
-            "id": 13
+            "id": 13,
+            "definition": {
+                "type": "note",
+                "content": "Client",
+                "background_color": "blue",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 40,
+                "y": 26,
+                "width": 12,
+                "height": 15
+            }
         },
         {
-            "font_size": "18",
-            "bgcolor": "gray",
-            "type": "note",
-            "tick_edge": "bottom",
-            "text_align": "center",
-            "height": 7,
-            "width": 37,
-            "html": "Database",
-            "y": 1,
-            "x": 112,
-            "tick": true,
-            "tick_pos": "50%",
-            "id": 14
+            "id": 14,
+            "definition": {
+                "type": "note",
+                "content": "Database",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 112,
+                "y": 1,
+                "width": 37,
+                "height": 7
+            }
         },
         {
-            "font_size": "16",
-            "bgcolor": "blue",
-            "type": "note",
-            "tick_edge": "right",
-            "text_align": "center",
-            "height": 15,
-            "width": 12,
-            "html": "Outlook Web Application",
-            "y": 52,
-            "x": 40,
-            "tick": true,
-            "tick_pos": "50%",
-            "id": 15
+            "id": 15,
+            "definition": {
+                "type": "note",
+                "content": "Outlook Web Application",
+                "background_color": "blue",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 40,
+                "y": 52,
+                "width": 12,
+                "height": 15
+            }
         },
         {
-            "font_size": "16",
-            "bgcolor": "blue",
-            "type": "note",
-            "tick_edge": "right",
-            "text_align": "center",
-            "height": 15,
-            "width": 12,
-            "html": "Web Service",
-            "y": 68,
-            "x": 40,
-            "tick": true,
-            "tick_pos": "50%",
-            "id": 16
+            "id": 16,
+            "definition": {
+                "type": "note",
+                "content": "Web Service",
+                "background_color": "blue",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 40,
+                "y": 68,
+                "width": 12,
+                "height": 15
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Unique users",
-            "height": 7,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 17,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "sum:exchange.owa.unique_users{*}",
                         "aggregator": "last"
                     }
                 ],
+                "custom_links": [],
+                "title": "Unique users",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": true,
                 "precision": 0
             },
-            "width": 18,
-            "y": 19,
-            "x": 1,
-            "type": "query_value",
-            "id": 17
+            "layout": {
+                "x": 1,
+                "y": 19,
+                "width": 18,
+                "height": 9
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Total outbound packet errors",
-            "height": 7,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 18,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "sum:exchange.network.outbound_errors{*}",
                         "aggregator": "last"
                     }
                 ],
+                "custom_links": [],
+                "title": "Total outbound packet errors",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": true,
                 "precision": 0
             },
-            "width": 18,
-            "y": 19,
-            "x": 20,
-            "type": "query_value",
-            "id": 18
+            "layout": {
+                "x": 20,
+                "y": 19,
+                "width": 18,
+                "height": 9
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "I/O operations rate",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 19,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:exchange.database.io_db_reads_attached_persec{$host,$instance}",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "metadata": {
-                            "avg:exchange.database.io_db_reads_attached_persec{$host,$instance}": {
-                                "alias": "Reading rate"
+                        "metadata": [
+                            {
+                                "expression": "avg:exchange.database.io_db_reads_attached_persec{$host,$instance}",
+                                "alias_name": "Reading rate"
                             }
+                        ],
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
                         }
                     },
                     {
                         "q": "avg:exchange.database.io_db_writes_attached_persec{$host,$instance}",
-                        "style": {
-                            "width": "normal",
-                            "palette": "purple",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "metadata": {
-                            "avg:exchange.database.io_db_writes_attached_persec{$host,$instance}": {
-                                "alias": "Writing rate"
+                        "metadata": [
+                            {
+                                "expression": "avg:exchange.database.io_db_writes_attached_persec{$host,$instance}",
+                                "alias_name": "Writing rate"
                             }
+                        ],
+                        "display_type": "line",
+                        "style": {
+                            "palette": "purple",
+                            "line_type": "solid",
+                            "line_width": "normal"
                         }
                     }
                 ],
+                "custom_links": [],
                 "yaxis": {
-                    "max": "auto",
-                    "scale": "linear",
-                    "includeZero": true,
                     "label": "",
-                    "min": "auto"
-                }
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "I/O operations rate",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "width": 37,
-            "legend": false,
-            "time": {},
-            "y": 26,
-            "x": 112,
-            "type": "timeseries",
-            "id": 19
+            "layout": {
+                "x": 112,
+                "y": 26,
+                "width": 37,
+                "height": 15
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "CPU usage",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 20,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:exchange.processor.cpu_time{$host,$instance}",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
+                "custom_links": [],
                 "yaxis": {
-                    "max": "auto",
-                    "scale": "linear",
-                    "includeZero": true,
                     "label": "",
-                    "min": "auto"
-                }
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "CPU usage",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "width": 37,
-            "legend": false,
-            "time": {},
-            "y": 61,
-            "x": 1,
-            "type": "timeseries",
-            "id": 20
+            "layout": {
+                "x": 1,
+                "y": 61,
+                "width": 37,
+                "height": 15
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Number of connections",
-            "height": 13,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 21,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "sum:exchange.rpc.conn_count{*}",
                         "aggregator": "last"
                     }
                 ],
+                "custom_links": [],
+                "title": "Number of connections",
+                "title_size": "16",
+                "title_align": "left",
                 "precision": 0
             },
-            "width": 18,
-            "y": 52,
-            "x": 112,
-            "type": "query_value",
-            "id": 21
+            "layout": {
+                "x": 112,
+                "y": 52,
+                "width": 18,
+                "height": 15
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Operations rate",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 22,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:exchange.rpc.ops_persec{$host,$instance}",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
+                "custom_links": [],
                 "yaxis": {
-                    "max": "auto",
-                    "scale": "linear",
-                    "includeZero": true,
                     "label": "",
-                    "min": "auto"
-                }
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Operations rate",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "width": 37,
-            "legend": false,
-            "time": {},
-            "y": 68,
-            "x": 112,
-            "type": "timeseries",
-            "id": 22
+            "layout": {
+                "x": 112,
+                "y": 68,
+                "width": 37,
+                "height": 15
+            }
         },
         {
-            "font_size": "18",
-            "bgcolor": "gray",
-            "type": "note",
-            "tick_edge": "bottom",
-            "text_align": "center",
-            "height": 7,
-            "width": 70,
-            "html": "ExchangeIS",
-            "y": 1,
-            "x": 40,
-            "tick": true,
-            "tick_pos": "50%",
-            "id": 23
+            "id": 23,
+            "definition": {
+                "type": "note",
+                "content": "ExchangeIS",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 40,
+                "y": 1,
+                "width": 70,
+                "height": 7
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Latency",
-            "height": 13,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 24,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:exchange.rpc.averaged_latency{*}",
                         "aggregator": "last"
                     }
                 ],
+                "custom_links": [],
+                "title": "Latency",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": false,
                 "custom_unit": "ms",
                 "precision": 1
             },
-            "width": 18,
-            "y": 52,
-            "x": 131,
-            "type": "query_value",
-            "id": 24
+            "layout": {
+                "x": 131,
+                "y": 52,
+                "width": 18,
+                "height": 15
+            }
         },
         {
-            "font_size": "18",
-            "bgcolor": "gray",
-            "type": "note",
-            "tick_edge": "bottom",
-            "text_align": "center",
-            "height": 7,
-            "width": 70,
-            "html": "Web",
-            "y": 43,
-            "x": 40,
-            "tick": true,
-            "tick_pos": "50%",
-            "id": 25
+            "id": 25,
+            "definition": {
+                "type": "note",
+                "content": "Web",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 40,
+                "y": 43,
+                "width": 70,
+                "height": 7
+            }
         },
         {
-            "font_size": "18",
-            "bgcolor": "gray",
-            "type": "note",
-            "tick_edge": "bottom",
-            "text_align": "center",
-            "height": 7,
-            "width": 37,
-            "html": "RPC",
-            "y": 43,
-            "x": 112,
-            "tick": true,
-            "tick_pos": "50%",
-            "id": 26
+            "id": 26,
+            "definition": {
+                "type": "note",
+                "content": "RPC",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 112,
+                "y": 43,
+                "width": 37,
+                "height": 7
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Queued tasks",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 27,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:exchange.workload_management.queued_tasks{$host,$instance}",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "metadata": {
-                            "avg:exchange.workload_management.queued_tasks{$host,$instance}": {
-                                "alias": "Queued tasks"
+                        "metadata": [
+                            {
+                                "expression": "avg:exchange.workload_management.queued_tasks{$host,$instance}",
+                                "alias_name": "Queued tasks"
                             }
+                        ],
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
                         }
                     }
                 ],
+                "custom_links": [],
                 "yaxis": {
-                    "max": "auto",
-                    "scale": "linear",
-                    "includeZero": true,
                     "label": "",
-                    "min": "auto"
-                }
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Queued tasks",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "width": 37,
-            "legend": false,
-            "time": {},
-            "y": 45,
-            "x": 1,
-            "type": "timeseries",
-            "id": 27
+            "layout": {
+                "x": 1,
+                "y": 45,
+                "width": 37,
+                "height": 15
+            }
         },
         {
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Active tasks",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 28,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:exchange.workload_management.active_tasks{$host,$instance}",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "metadata": {
-                            "avg:exchange.workload_management.active_tasks{$host,$instance}": {
-                                "alias": "Active tasks"
+                        "metadata": [
+                            {
+                                "expression": "avg:exchange.workload_management.active_tasks{$host,$instance}",
+                                "alias_name": "Active tasks"
                             }
+                        ],
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
                         }
                     }
                 ],
+                "custom_links": [],
                 "yaxis": {
-                    "max": "auto",
-                    "scale": "linear",
-                    "includeZero": true,
                     "label": "",
-                    "min": "auto"
-                }
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Active tasks",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 37,
-            "legend": false,
-            "time": {},
-            "y": 29,
-            "x": 1,
-            "legend_size": "0",
-            "type": "timeseries",
-            "id": 28
+            "layout": {
+                "x": 1,
+                "y": 29,
+                "width": 37,
+                "height": 15
+            }
         }
-    ]
+    ],
+    "template_variables": [
+        {
+            "name": "host",
+            "default": "*",
+            "prefix": "host"
+        },
+        {
+            "name": "instance",
+            "default": "*",
+            "prefix": "instance"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30282
 }

--- a/flink/assets/dashboards/overview.json
+++ b/flink/assets/dashboards/overview.json
@@ -1,581 +1,599 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "Flink Overview",
-    "created": "2020-03-23T15:15:53.717640+00:00",
-    "created_by": {
-        "access_role": "st",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": false,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "Flink Overview",
     "description": "## Flink Overview\n\nThis dashboard provides a high-level overview of your Flink JobManagers and TaskManagers so you can monitor metrics related to jobs, memory, and checkpoints. For further reading on monitoring Flink, see the [Datadog Flink integration docs](https://docs.datadoghq.com/integrations/flink/).\n\nClone this template dashboard to make changes and add your own graphs and widgets.",
-    "id": 1025423,
-    "modified": "2020-03-24T20:56:24.868775+00:00",
-    "new_id": "z22-5a6-hh8",
-    "read_only": false,
-    "template_variables": [
-        {
-            "default": "*",
-            "name": "var",
-            "prefix": null
-        }
-    ],
     "widgets": [
         {
-            "height": 13,
             "id": 0,
-            "sizing": "fit",
-            "type": "image",
-            "url": "https://static.datadoghq.com/static/images/saas_logos/bot/flink@2x.png",
-            "width": 35,
-            "x": 1,
-            "y": 1
+            "definition": {
+                "type": "image",
+                "url": "https://static.datadoghq.com/static/images/saas_logos/bot/flink@2x.png",
+                "sizing": "fit"
+            },
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 35,
+                "height": 13
+            }
         },
         {
-            "height": 10,
             "id": 1,
-            "tile_def": {
-                "precision": 0,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
-                        "aggregator": "avg",
-                        "q": "avg:flink.jobmanager.numRunningJobs{*}"
+                        "q": "avg:flink.jobmanager.numRunningJobs{*}",
+                        "aggregator": "avg"
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Running jobs",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Running jobs",
-            "type": "query_value",
-            "width": 17,
-            "x": 1,
-            "y": 23
+            "layout": {
+                "x": 1,
+                "y": 23,
+                "width": 17,
+                "height": 12
+            }
         },
         {
-            "height": 14,
             "id": 2,
-            "legend": false,
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:flink.task.Shuffle.Netty.Input.Buffers.inPoolUsage{*} by {task_id,subtask_index}*100",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Input buffer usage (%)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Input buffer usage (%)",
-            "type": "timeseries",
-            "width": 53,
-            "x": 38,
-            "y": 48
+            "layout": {
+                "x": 38,
+                "y": 48,
+                "width": 53,
+                "height": 16
+            }
         },
         {
-            "height": 10,
             "id": 3,
-            "tile_def": {
-                "precision": 0,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
-                        "aggregator": "sum",
-                        "q": "avg:flink.jobmanager.job.numRestarts{*}"
+                        "q": "avg:flink.jobmanager.job.numRestarts{*}",
+                        "aggregator": "sum"
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Full restarts",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Full restarts",
-            "type": "query_value",
-            "width": 17,
-            "x": 19,
-            "y": 23
+            "layout": {
+                "x": 19,
+                "y": 23,
+                "width": 17,
+                "height": 12
+            }
         },
         {
-            "height": 10,
             "id": 4,
-            "tile_def": {
-                "autoscale": false,
-                "custom_unit": "ms",
-                "precision": 1,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
-                        "aggregator": "avg",
-                        "q": "avg:flink.jobmanager.job.downtime{*}"
+                        "q": "avg:flink.jobmanager.job.downtime{*}",
+                        "aggregator": "avg"
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Avg job downtime",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": false,
+                "custom_unit": "ms",
+                "precision": 1
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Avg job downtime",
-            "type": "query_value",
-            "width": 17,
-            "x": 19,
-            "y": 36
+            "layout": {
+                "x": 19,
+                "y": 36,
+                "width": 17,
+                "height": 12
+            }
         },
         {
-            "height": 10,
             "id": 5,
-            "tile_def": {
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:flink.jobmanager.job.uptime{*}",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Avg job uptime ",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": false,
                 "custom_unit": "ms",
-                "precision": 1,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "q": "avg:flink.jobmanager.job.uptime{*}"
-                    }
-                ],
-                "viz": "query_value"
+                "precision": 1
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Avg job uptime ",
-            "type": "query_value",
-            "width": 17,
-            "x": 1,
-            "y": 36
+            "layout": {
+                "x": 1,
+                "y": 36,
+                "width": 17,
+                "height": 12
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 6,
-            "html": "Health",
             "id": 6,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 35,
-            "x": 1,
-            "y": 15
+            "definition": {
+                "type": "note",
+                "content": "Health",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 15,
+                "width": 35,
+                "height": 6
+            }
         },
         {
-            "height": 10,
             "id": 7,
-            "tile_def": {
-                "precision": 0,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
-                        "aggregator": "sum",
-                        "q": "avg:flink.jobmanager.numRegisteredTaskManagers{*}"
+                        "q": "avg:flink.jobmanager.numRegisteredTaskManagers{*}",
+                        "aggregator": "sum"
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "TaskManager count",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "TaskManager count",
-            "type": "query_value",
-            "width": 17,
-            "x": 1,
-            "y": 49
+            "layout": {
+                "x": 1,
+                "y": 49,
+                "width": 17,
+                "height": 12
+            }
         },
         {
-            "height": 10,
             "id": 8,
-            "tile_def": {
-                "precision": 0,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "avg:flink.jobmanager.job.numberOfFailedCheckpoints{*}",
                         "aggregator": "sum",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": 0
+                                "value": 0,
+                                "palette": "white_on_red"
                             },
                             {
                                 "comparator": "<=",
-                                "palette": "white_on_green",
-                                "value": 0
+                                "value": 0,
+                                "palette": "white_on_green"
                             }
-                        ],
-                        "q": "avg:flink.jobmanager.job.numberOfFailedCheckpoints{*}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Failed checkpoints",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Failed checkpoints",
-            "type": "query_value",
-            "width": 17,
-            "x": 74,
-            "y": 9
+            "layout": {
+                "x": 74,
+                "y": 9,
+                "width": 17,
+                "height": 12
+            }
         },
         {
-            "height": 14,
             "id": 9,
-            "legend": false,
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:flink.task.Shuffle.Netty.Output.Buffers.outPoolUsage{*} by {task_id,subtask_index}*100",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Output buffer usage (%)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Output buffer usage (%)",
-            "type": "timeseries",
-            "width": 53,
-            "x": 38,
-            "y": 65
+            "layout": {
+                "x": 38,
+                "y": 65,
+                "width": 53,
+                "height": 16
+            }
         },
         {
-            "height": 10,
             "id": 10,
-            "tile_def": {
-                "precision": 0,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "avg:flink.jobmanager.job.numberOfCompletedCheckpoints{*}",
                         "aggregator": "sum",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "white_on_green",
-                                "value": 0
+                                "value": 0,
+                                "palette": "white_on_green"
                             }
-                        ],
-                        "q": "avg:flink.jobmanager.job.numberOfCompletedCheckpoints{*}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Completed checkpoints",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Completed checkpoints",
-            "type": "query_value",
-            "width": 17,
-            "x": 38,
-            "y": 9
+            "layout": {
+                "x": 38,
+                "y": 9,
+                "width": 17,
+                "height": 12
+            }
         },
         {
-            "height": 14,
             "id": 11,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:flink.task.numRecordsOut{*} by {task_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Outgoing records per second ",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Outgoing records per second ",
-            "type": "timeseries",
-            "width": 53,
-            "x": 93,
-            "y": 69
+            "layout": {
+                "x": 93,
+                "y": 69,
+                "width": 53,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:flink.taskmanager.Status.JVM.Memory.Heap.Used{*} by {tm_id}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "TaskManager heap memory usage (bytes)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "TaskManager heap memory usage (bytes)",
-            "type": "timeseries",
-            "width": 53,
-            "x": 93,
-            "y": 9
+            "layout": {
+                "x": 93,
+                "y": 9,
+                "width": 53,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:flink.taskmanager.Status.JVM.CPU.Load{*} by {tm_id}*100",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "TaskManager CPU load (%)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "TaskManager CPU load (%)",
-            "type": "timeseries",
-            "width": 53,
-            "x": 93,
-            "y": 26
+            "layout": {
+                "x": 93,
+                "y": 26,
+                "width": 53,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 14,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:flink.taskmanager.Status.JVM.GarbageCollector.G1_Young_Generation.Time{*} by {tm_id}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     },
                     {
                         "q": "avg:flink.taskmanager.Status.JVM.GarbageCollector.G1_Old_Generation.Time{*} by {tm_id}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "TaskManager garbage collection time (ms)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "TaskManager garbage collection time (ms)",
-            "type": "timeseries",
-            "width": 53,
-            "x": 93,
-            "y": 43
+            "layout": {
+                "x": 93,
+                "y": 43,
+                "width": 53,
+                "height": 16
+            }
         },
         {
-            "height": 15,
             "id": 15,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:flink.jobmanager.job.lastCheckpointDuration{*} by {job_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Last checkpoint completion time (ms)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Last checkpoint completion time (ms)",
-            "type": "timeseries",
-            "width": 53,
-            "x": 38,
-            "y": 22
+            "layout": {
+                "x": 38,
+                "y": 22,
+                "width": 53,
+                "height": 17
+            }
         },
         {
-            "height": 10,
             "id": 16,
-            "tile_def": {
-                "precision": 0,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "avg:flink.jobmanager.job.numberOfInProgressCheckpoints{*}",
                         "aggregator": "sum",
                         "conditional_formats": [
                             {
                                 "comparator": ">=",
-                                "palette": "white_on_yellow",
-                                "value": 0
+                                "value": 0,
+                                "palette": "white_on_yellow"
                             }
-                        ],
-                        "q": "avg:flink.jobmanager.job.numberOfInProgressCheckpoints{*}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "In progress checkpoints",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "In progress checkpoints",
-            "type": "query_value",
-            "width": 17,
-            "x": 56,
-            "y": 9
+            "layout": {
+                "x": 56,
+                "y": 9,
+                "width": 17,
+                "height": 12
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 6,
-            "html": "Checkpoints",
             "id": 17,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 53,
-            "x": 38,
-            "y": 1
+            "definition": {
+                "type": "note",
+                "content": "Checkpoints",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 38,
+                "y": 1,
+                "width": 53,
+                "height": 6
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 6,
-            "html": "Buffers",
             "id": 18,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 53,
-            "x": 38,
-            "y": 40
+            "definition": {
+                "type": "note",
+                "content": "Buffers",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 38,
+                "y": 40,
+                "width": 53,
+                "height": 6
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 6,
-            "html": "JVM Resource Utilization",
             "id": 19,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 53,
-            "x": 93,
-            "y": 1
+            "definition": {
+                "type": "note",
+                "content": "JVM Resource Utilization",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 93,
+                "y": 1,
+                "width": 53,
+                "height": 6
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 6,
-            "html": "Throughput",
             "id": 20,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 53,
-            "x": 93,
-            "y": 61
+            "definition": {
+                "type": "note",
+                "content": "Throughput",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 93,
+                "y": 61,
+                "width": 53,
+                "height": 6
+            }
         }
-    ]
+    ],
+    "template_variables": [
+        {
+            "name": "var",
+            "default": "*",
+            "prefix": null
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30312
 }

--- a/gitlab/assets/dashboards/overview.json
+++ b/gitlab/assets/dashboards/overview.json
@@ -1,428 +1,445 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "Gitlab Overview",
-    "created": "2020-03-13T15:43:50.298533+00:00",
-    "created_by": {
-        "access_role": "st",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": false,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "Gitlab Overview",
     "description": "This dashboard provides a high-level overview of your Gitlab instance so you can monitor metrics related to pipelines, repositories, requests, and more.\n\nFor further reading on monitoring Gitlab, see: [Official Gitlab integration docs](https://docs.datadoghq.com/integrations/gitlab/)\n\nClone this template to make changes and add your own graphs and widgets.",
-    "id": 1014699,
-    "modified": "2020-03-31T13:41:21.413244+00:00",
-    "new_id": "c9w-dnm-m3a",
-    "read_only": false,
-    "template_variables": [
-        {
-            "default": "*",
-            "name": "gitlab_host",
-            "prefix": "gitlab_host"
-        },
-        {
-            "default": "*",
-            "name": "gitlab_port",
-            "prefix": "gitlab_port"
-        }
-    ],
     "widgets": [
         {
-            "height": 9,
             "id": 0,
-            "sizing": "zoom",
-            "type": "image",
-            "url": "https://static.datadoghq.com/static/images/saas_logos/bot/gitlab@2x.png",
-            "width": 15,
-            "x": 1,
-            "y": 1
+            "definition": {
+                "type": "image",
+                "url": "https://static.datadoghq.com/static/images/saas_logos/bot/gitlab@2x.png",
+                "sizing": "zoom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 15,
+                "height": 9
+            }
         },
         {
-            "check": "gitlab.readiness",
-            "group_by": [],
-            "grouping": "cluster",
-            "height": 8,
+            "id": 1,
+            "definition": {
+                "type": "check_status",
+                "title": "Readiness",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "gitlab.readiness",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "$gitlab_port",
+                    "$gitlab_host"
+                ]
+            },
+            "layout": {
+                "x": 18,
+                "y": 11,
+                "width": 14,
+                "height": 8
+            }
+        },
+        {
             "id": 2,
-            "tags": [
-                "$gitlab_port",
-                "$gitlab_host"
-            ],
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Readiness",
-            "type": "check_status",
-            "width": 14,
-            "x": 18,
-            "y": 11
+            "definition": {
+                "type": "check_status",
+                "title": "Health",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "gitlab.health",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "$gitlab_port",
+                    "$gitlab_host"
+                ]
+            },
+            "layout": {
+                "x": 18,
+                "y": 20,
+                "width": 14,
+                "height": 8
+            }
         },
         {
-            "check": "gitlab.health",
-            "group_by": [],
-            "grouping": "cluster",
-            "height": 8,
             "id": 3,
-            "tags": [
-                "$gitlab_port",
-                "$gitlab_host"
-            ],
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Health",
-            "type": "check_status",
-            "width": 14,
-            "x": 18,
-            "y": 20
+            "definition": {
+                "type": "check_status",
+                "title": "Endpoint Up",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "gitlab.prometheus_endpoint_up",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "$gitlab_port",
+                    "$gitlab_host"
+                ]
+            },
+            "layout": {
+                "x": 18,
+                "y": 29,
+                "width": 14,
+                "height": 8
+            }
         },
         {
-            "check": "gitlab.prometheus_endpoint_up",
-            "group_by": [],
-            "grouping": "cluster",
-            "height": 8,
             "id": 4,
-            "tags": [
-                "$gitlab_port",
-                "$gitlab_host"
-            ],
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Endpoint Up",
-            "type": "check_status",
-            "width": 14,
-            "x": 18,
-            "y": 29
+            "definition": {
+                "type": "note",
+                "content": "Service Checks",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 1,
+                "y": 12,
+                "width": 15,
+                "height": 25
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 25,
-            "html": "Service Checks",
             "id": 5,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "right",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 15,
-            "x": 1,
-            "y": 12
-        },
-        {
-            "height": 13,
-            "id": 6,
-            "legend": false,
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:gitlab.rack.http_requests_total{$gitlab_host,$gitlab_port} by {method}.as_count()",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "HTTP requests",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "HTTP requests",
-            "type": "timeseries",
-            "width": 43,
-            "x": 34,
-            "y": 13
+            "layout": {
+                "x": 34,
+                "y": 13,
+                "width": 43,
+                "height": 15
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 10,
-            "html": "Load Information",
+            "id": 6,
+            "definition": {
+                "type": "note",
+                "content": "Load Information",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 34,
+                "y": 1,
+                "width": 43,
+                "height": 10
+            }
+        },
+        {
             "id": 7,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 43,
-            "x": 34,
-            "y": 1
-        },
-        {
-            "height": 13,
-            "id": 8,
-            "legend": false,
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:gitlab.pipelines_created_total{$gitlab_host,$gitlab_port}.as_count()",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Pipelines Created",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Pipelines Created",
-            "type": "timeseries",
-            "width": 43,
-            "x": 79,
-            "y": 29
+            "layout": {
+                "x": 79,
+                "y": 29,
+                "width": 43,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "id": 9,
-            "legend": false,
-            "tile_def": {
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:gitlab.transaction.event_create_repository_total{$gitlab_host,$gitlab_port}.as_count()",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "New Repositories Created ",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "New Repositories Created ",
-            "type": "timeseries",
-            "width": 43,
-            "x": 79,
-            "y": 45
+            "layout": {
+                "x": 79,
+                "y": 45,
+                "width": 43,
+                "height": 15
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 10,
-            "html": "Project Information",
+            "id": 9,
+            "definition": {
+                "type": "note",
+                "content": "Project Information",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 79,
+                "y": 1,
+                "width": 43,
+                "height": 10
+            }
+        },
+        {
             "id": 10,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 43,
-            "x": 79,
-            "y": 1
+            "definition": {
+                "type": "note",
+                "content": "Users",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 39,
+                "width": 31,
+                "height": 8
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 8,
-            "html": "Users",
             "id": 11,
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 31,
-            "x": 1,
-            "y": 39
-        },
-        {
-            "height": 13,
-            "id": 12,
-            "legend": false,
-            "tile_def": {
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:gitlab.user_session_logins_total{$gitlab_host,$gitlab_port}.as_count()",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "User Logins ",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "User Logins ",
-            "type": "timeseries",
-            "width": 31,
-            "x": 1,
-            "y": 49
+            "layout": {
+                "x": 1,
+                "y": 49,
+                "width": 31,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "id": 13,
-            "legend": false,
-            "tile_def": {
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:gitlab.unicorn.workers{$gitlab_host,$gitlab_port}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Unicorn Workers",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Unicorn Workers",
-            "type": "timeseries",
-            "width": 43,
-            "x": 34,
-            "y": 45
+            "layout": {
+                "x": 34,
+                "y": 45,
+                "width": 43,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "id": 14,
-            "legend": false,
-            "tile_def": {
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:gitlab.transaction.event_push_branch_total{$gitlab_host,$gitlab_port}.as_count()",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Branches Pushed",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "Branches Pushed",
-            "type": "timeseries",
-            "width": 43,
-            "x": 79,
-            "y": 13
+            "layout": {
+                "x": 79,
+                "y": 13,
+                "width": 43,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "id": 15,
-            "legend": false,
-            "tile_def": {
+            "id": 14,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "p90:gitlab.sql_duration_seconds{$gitlab_host,$gitlab_port}.as_count(), p75:gitlab.sql_duration_seconds{$gitlab_host,$gitlab_port}.as_count(), p50:gitlab.sql_duration_seconds{$gitlab_host,$gitlab_port}.as_count(), min:gitlab.sql_duration_seconds{$gitlab_host,$gitlab_port}.as_count(), max:gitlab.sql_duration_seconds{$gitlab_host,$gitlab_port}.as_count()",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "SQL Execution Time",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": "16",
-            "title_text": "SQL Execution Time",
-            "type": "timeseries",
-            "width": 43,
-            "x": 34,
-            "y": 29
+            "layout": {
+                "x": 34,
+                "y": 29,
+                "width": 43,
+                "height": 15
+            }
         },
         {
-            "check": "gitlab.liveness",
-            "group_by": [],
-            "grouping": "cluster",
-            "height": 9,
-            "id": 16,
-            "tags": [
-                "$gitlab_host",
-                "$gitlab_port"
-            ],
-            "title": true,
-            "title_align": "center",
-            "title_size": "16",
-            "title_text": "Liveness",
-            "type": "check_status",
-            "width": 14,
-            "x": 18,
-            "y": 1
+            "id": 15,
+            "definition": {
+                "type": "check_status",
+                "title": "Liveness",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "gitlab.liveness",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "$gitlab_host",
+                    "$gitlab_port"
+                ]
+            },
+            "layout": {
+                "x": 18,
+                "y": 1,
+                "width": 14,
+                "height": 9
+            }
         }
-    ]
+    ],
+    "template_variables": [
+        {
+            "name": "gitlab_host",
+            "default": "*",
+            "prefix": "gitlab_host"
+        },
+        {
+            "name": "gitlab_port",
+            "default": "*",
+            "prefix": "gitlab_port"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30315
 }

--- a/harbor/assets/dashboards/overview.json
+++ b/harbor/assets/dashboards/overview.json
@@ -1,225 +1,143 @@
 {
-    "board_title": "Harbor Integration Dashboard",
-    "read_only": false,
-    "author_info": {
-        "author_name": "Datadog"
-    },
+    "title": "Harbor Integration Dashboard",
     "description": "",
-    "board_bgtype": "board_graph",
-    "created": "2019-06-14T16:43:14.048654+00:00",
-    "new_id": "4ww-yha-rpg",
-    "modified": "2019-06-14T17:16:05.146592+00:00",
-    "created_by": {
-        "handle": "support@datadoghq.com",
-        "name": "Datadog",
-        "access_role": "st",
-        "verified": true,
-        "disabled": false,
-        "is_admin": false,
-        "role": null,
-        "email": "support@datadoghq.com",
-        "icon": ""
-    },
-    "height": 80,
-    "width": "100%",
-    "template_variables": [
-        {
-            "default": "*",
-            "prefix": "host",
-            "name": "host"
-        }
-    ],
-    "isIntegration": false,
-    "originalHeight": 80,
-    "originalWidth": "100%",
-    "isShared": false,
     "widgets": [
         {
-            "sizing": "zoom",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560527115294,
-                "end": 1560530715294
+            "id": 0,
+            "definition": {
+                "type": "image",
+                "url": "https://s3.amazonaws.com/dd-integrations/harbor/configuration/tile/logo.png",
+                "sizing": "zoom"
             },
-            "title_align": "left",
-            "title_size": 16,
-            "title": true,
-            "url": "https://s3.amazonaws.com/dd-integrations/harbor/configuration/tile/logo.png",
-            "margin": "",
-            "generated_title": "",
-            "title_text": "",
-            "height": 8,
-            "width": 25,
-            "y": 4,
-            "x": 2,
-            "legend_size": "0",
-            "isShared": false,
-            "type": "image",
-            "legend": false,
-            "add_timeframe": true
+            "layout": {
+                "x": 2,
+                "y": 4,
+                "width": 25,
+                "height": 8
+            }
         },
         {
-            "height": 9,
-            "text_size": "auto",
-            "check": "harbor.status",
-            "group": "$host",
-            "title": true,
-            "title_align": "center",
-            "text_align": "center",
-            "width": 25,
-            "group_by": [
-                "component"
-            ],
-            "legend_size": "0",
-            "type": "check_status",
-            "isShared": false,
-            "tags": [
-                "$host"
-            ],
-            "time": {
-                "live_span": "10m"
+            "id": 1,
+            "definition": {
+                "type": "check_status",
+                "title": "Components health",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "harbor.status",
+                "grouping": "cluster",
+                "group": "$host",
+                "group_by": [
+                    "component"
+                ],
+                "tags": [
+                    "$host"
+                ],
+                "time": {
+                    "live_span": "10m"
+                }
             },
-            "title_text": "Components health",
-            "title_size": "16",
-            "scaleFactor": 1,
-            "legend": false,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560527115294,
-                "end": 1560530715294
-            },
-            "error": null,
-            "y": 26,
-            "x": 2,
-            "grouping": "cluster"
+            "layout": {
+                "x": 2,
+                "y": 26,
+                "width": 25,
+                "height": 9
+            }
         },
         {
-            "height": 9,
-            "text_size": "auto",
-            "check": "harbor.can_connect",
-            "group": "$host",
-            "title": true,
-            "title_align": "center",
-            "text_align": "center",
-            "width": 25,
-            "group_by": [],
-            "legend_size": "0",
-            "type": "check_status",
-            "isShared": false,
-            "tags": [
-                "$host"
-            ],
-            "time": {},
-            "title_text": "Can connect",
-            "title_size": "16",
-            "scaleFactor": 1,
-            "legend": false,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560527541250,
-                "end": 1560531141250
+            "id": 2,
+            "definition": {
+                "type": "check_status",
+                "title": "Can connect",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "harbor.can_connect",
+                "grouping": "cluster",
+                "group": "$host",
+                "group_by": [],
+                "tags": [
+                    "$host"
+                ]
             },
-            "error": null,
-            "y": 14,
-            "x": 2,
-            "grouping": "cluster"
+            "layout": {
+                "x": 2,
+                "y": 14,
+                "width": 25,
+                "height": 9
+            }
         },
         {
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560527541250,
-                "end": 1560531141250
-            },
-            "error": null,
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Harbor volume metrics",
-            "height": 13,
-            "tile_def": {
-                "viz": "timeseries",
-                "autoscale": true,
+            "id": 3,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:harbor.disk.total{$host}",
-                        "aggregator": "avg",
+                        "display_type": "area",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid",
                             "line_type": "solid",
                             "line_width": "normal"
-                        },
-                        "type": "area",
-                        "conditional_formats": []
+                        }
                     },
                     {
                         "q": "avg:harbor.disk.free{$host}",
+                        "display_type": "area",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid",
                             "line_type": "solid",
                             "line_width": "normal"
-                        },
-                        "type": "area"
+                        }
                     }
                 ],
+                "custom_links": [],
+                "title": "Harbor volume metrics",
+                "title_size": "16",
                 "title_align": "left",
-                "title_size": "16"
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "time": {},
-            "y": 4,
-            "x": 32,
-            "legend_size": "0",
-            "isShared": false,
-            "type": "timeseries",
-            "legend": false,
-            "add_timeframe": true
+            "layout": {
+                "x": 32,
+                "y": 4,
+                "width": 47,
+                "height": 15
+            }
         },
         {
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1560527541250,
-                "end": 1560531141250
-            },
-            "error": null,
-            "autoscale": true,
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "title_text": "Number of projects",
-            "height": 13,
-            "tile_def": {
-                "autoscale": true,
-                "title_align": "left",
-                "custom_unit": "proj",
-                "precision": 0,
-                "viz": "query_value",
-                "title_size": "16",
+            "id": 4,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:harbor.projects.count{$host}",
                         "aggregator": "last"
                     }
-                ]
+                ],
+                "custom_links": [],
+                "title": "Number of projects",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "custom_unit": "proj",
+                "precision": 0
             },
-            "width": 47,
-            "time": {},
-            "y": 20,
-            "x": 32,
-            "legend_size": "0",
-            "isShared": false,
-            "type": "query_value",
-            "legend": false,
-            "add_timeframe": true
+            "layout": {
+                "x": 32,
+                "y": 20,
+                "width": 47,
+                "height": 15
+            }
         }
     ],
-    "disableCog": false,
-    "id": 731451,
-    "disableEditing": false
+    "template_variables": [
+        {
+            "name": "host",
+            "default": "*",
+            "prefix": "host"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30276
 }

--- a/hazelcast/assets/dashboards/overview.json
+++ b/hazelcast/assets/dashboards/overview.json
@@ -1,571 +1,604 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "Hazelcast Overview",
+    "title": "Hazelcast Overview",
     "description": "This dashboard provides a high-level overview of the health and performance of your Hazelcast IMDG deployment.\n\nFor further reading on monitoring Hazelcast, see our official [Hazelcast integration documentation](https://docs.datadoghq.com/integrations/hazelcast/).\n\nClone this template to make changes and add your own graphs and widgets.",
-    "template_variables": [],
     "widgets": [
         {
-            "height": 11,
-            "sizing": "zoom",
-            "type": "image",
-            "url": "/static/images/saas_logos/bot/hazelcast@2x.png",
-            "width": 24,
-            "x": 1,
-            "y": 1
+            "id": 0,
+            "definition": {
+                "type": "image",
+                "url": "/static/images/saas_logos/bot/hazelcast@2x.png",
+                "sizing": "zoom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 24,
+                "height": 11
+            }
         },
         {
-            "height": 9,
-            "tile_def": {
-                "precision": 0,
+            "id": 1,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
-                        "aggregator": "avg",
-                        "q": "avg:hazelcast.instance.member_count{*}"
+                        "q": "avg:hazelcast.instance.member_count{*}",
+                        "aggregator": "avg"
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Member count",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Member count",
-            "type": "query_value",
-            "width": 18,
-            "x": 27,
-            "y": 1
+            "layout": {
+                "x": 27,
+                "y": 1,
+                "width": 18,
+                "height": 11
+            }
         },
         {
-            "height": 9,
-            "tile_def": {
+            "id": 2,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:hazelcast.instance.partition_service.active_partition_count{*}",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Active partitions",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": true,
-                "precision": 0,
-                "requests": [
-                    {
-                        "aggregator": "last",
-                        "q": "avg:hazelcast.instance.partition_service.active_partition_count{*}"
-                    }
-                ],
-                "viz": "query_value"
+                "precision": 0
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Active partitions",
-            "type": "query_value",
-            "width": 18,
-            "x": 46,
-            "y": 1
+            "layout": {
+                "x": 46,
+                "y": 1,
+                "width": 18,
+                "height": 11
+            }
         },
         {
-            "height": 9,
-            "tile_def": {
-                "precision": 0,
+            "id": 3,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
-                        "aggregator": "sum",
-                        "q": "avg:hazelcast.member.backup_timeouts{*}"
+                        "q": "avg:hazelcast.member.backup_timeouts{*}",
+                        "aggregator": "sum"
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Backups timed out",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Backups timed out",
-            "type": "query_value",
-            "width": 18,
-            "x": 65,
-            "y": 1
+            "layout": {
+                "x": 65,
+                "y": 1,
+                "width": 18,
+                "height": 11
+            }
         },
         {
-            "height": 9,
-            "tile_def": {
+            "id": 4,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:hazelcast.member.failed_backups{*}",
+                        "aggregator": "sum"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Backups failed",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": true,
-                "precision": 2,
-                "requests": [
-                    {
-                        "aggregator": "sum",
-                        "q": "avg:hazelcast.member.failed_backups{*}"
-                    }
-                ],
-                "viz": "query_value"
+                "precision": 2
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Backups failed",
-            "type": "query_value",
-            "width": 18,
-            "x": 84,
-            "y": 1
+            "layout": {
+                "x": 84,
+                "y": 1,
+                "width": 18,
+                "height": 11
+            }
         },
         {
-            "height": 13,
-            "legend": false,
-            "tile_def": {
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:hazelcast.member.free_memory{*}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Available memory",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Available memory",
-            "type": "timeseries",
-            "width": 39,
-            "x": 1,
-            "y": 21
+            "layout": {
+                "x": 1,
+                "y": 21,
+                "width": 39,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:hazelcast.member.system_cpu_load{*}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "CPU load",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "CPU load",
-            "type": "timeseries",
-            "width": 39,
-            "x": 1,
-            "y": 37
+            "layout": {
+                "x": 1,
+                "y": 37,
+                "width": 39,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "legend": false,
-            "tile_def": {
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:hazelcast.instance.managed_executor_service.remaining_queue_capacity{*}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Remaining work queue capacity",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Remaining work queue capacity",
-            "type": "timeseries",
-            "width": 39,
-            "x": 1,
-            "y": 69
+            "layout": {
+                "x": 1,
+                "y": 69,
+                "width": 39,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:hazelcast.member.thread_count{*}",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Thread Count",
-            "type": "timeseries",
-            "width": 39,
-            "x": 1,
-            "y": 53
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Map performance",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 79,
-            "x": 42,
-            "y": 14
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "tile_def": {
                 "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Thread Count",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 1,
+                "y": 53,
+                "width": 39,
+                "height": 15
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "note",
+                "content": "Map performance",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 42,
+                "y": 14,
+                "width": 79,
+                "height": 5
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:hazelcast.imap.local_put_operation_count{*}",
+                        "display_type": "bars",
                         "style": {
                             "palette": "green",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Map put operations",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Map put operations",
-            "type": "timeseries",
-            "width": 39,
-            "x": 42,
-            "y": 21
+            "layout": {
+                "x": 42,
+                "y": 21,
+                "width": 39,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
+            "id": 11,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:hazelcast.imap.local_remove_operation_count{*}",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Map remove operations",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Map remove operations",
-            "type": "timeseries",
-            "width": 39,
-            "x": 42,
-            "y": 53
+            "layout": {
+                "x": 42,
+                "y": 53,
+                "width": 39,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:hazelcast.imap.local_total_get_latency{*}",
+                        "display_type": "line",
                         "style": {
                             "palette": "purple",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Map total get latency",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Map total get latency",
-            "type": "timeseries",
-            "width": 39,
-            "x": 82,
-            "y": 37
+            "layout": {
+                "x": 82,
+                "y": 37,
+                "width": 39,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:hazelcast.imap.local_total_put_latency{*}",
+                        "display_type": "line",
                         "style": {
                             "palette": "green",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Map put latency",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Map put latency",
-            "type": "timeseries",
-            "width": 39,
-            "x": 82,
-            "y": 21
+            "layout": {
+                "x": 82,
+                "y": 21,
+                "width": 39,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 14,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:hazelcast.imap.local_total_remove_latency{*}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Map remove latency",
-            "type": "timeseries",
-            "width": 39,
-            "x": 82,
-            "y": 53
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Cluster health",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 39,
-            "x": 1,
-            "y": 14
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
                 "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Map remove latency",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 82,
+                "y": 53,
+                "width": 39,
+                "height": 15
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "note",
+                "content": "Cluster health",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 14,
+                "width": 39,
+                "height": 5
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:hazelcast.imap.local_get_operation_count{*}",
+                        "display_type": "bars",
                         "style": {
                             "palette": "purple",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Map get operations",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Map get operations",
-            "type": "timeseries",
-            "width": 39,
-            "x": 42,
-            "y": 37
+            "layout": {
+                "x": 42,
+                "y": 37,
+                "width": 39,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 17,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:hazelcast.imap.local_backup_count{*}",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Map backup count",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Map backup count",
-            "type": "timeseries",
-            "width": 39,
-            "x": 82,
-            "y": 69
+            "layout": {
+                "x": 82,
+                "y": 69,
+                "width": 39,
+                "height": 15
+            }
         },
         {
-            "height": 9,
-            "tile_def": {
-                "precision": 0,
+            "id": 18,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
-                        "aggregator": "last",
-                        "q": "avg:hazelcast.member.migration_active{*}"
+                        "q": "avg:hazelcast.member.migration_active{*}",
+                        "aggregator": "last"
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Active migrations",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Active migrations",
-            "type": "query_value",
-            "width": 18,
-            "x": 103,
-            "y": 1
+            "layout": {
+                "x": 103,
+                "y": 1,
+                "width": 18,
+                "height": 11
+            }
         },
         {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 19,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:hazelcast.imap.local_hits{*}",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Map hits",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Map hits",
-            "type": "timeseries",
-            "width": 39,
-            "x": 42,
-            "y": 69
+            "layout": {
+                "x": 42,
+                "y": 69,
+                "width": 39,
+                "height": 15
+            }
         }
-    ]
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30338
 }

--- a/hive/assets/dashboards/overview.json
+++ b/hive/assets/dashboards/overview.json
@@ -1,1071 +1,604 @@
 {
-  "board_title": "Hive Integration Dashboard",
-  "read_only": false,
-  "author_info": {
-    "author_name": "Datadog"
-  },
-  "description": "",
-  "board_bgtype": "board_graph",
-  "created": "2019-06-05T15:42:48.726209+00:00",
-  "created_by": {
-    "disabled": false,
-    "handle": "support@datadoghq.com",
-    "name": "Datadog",
-    "is_admin": false,
-    "role": null,
-    "access_role": "st",
-    "verified": true,
-    "email": "support@datadoghq.com"
-  },
-  "new_id": "fv6-fz8-isy",
-  "modified": "2019-06-17T14:21:59.895027+00:00",
-  "originalHeight": 80,
-  "height": 80,
-  "width": "100%",
-  "template_variables": [],
-  "isIntegration": false,
-  "disableEditing": false,
-  "originalWidth": "100%",
-  "widgets": [
-    {
-      "board_id": "fv6-fz8-isy",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "hive.server.memory.total.max",
-      "title_text": "HiveServer2 memory",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:hive.server.memory.total.max{*}, avg:hive.server.memory.total.used{*}, avg:hive.server.memory.total.init{*}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+    "title": "Hive Integration Dashboard",
+    "description": "",
+    "widgets": [
+        {
+            "id": 0,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:hive.server.memory.total.max{*}, avg:hive.server.memory.total.used{*}, avg:hive.server.memory.total.init{*}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "HiveServer2 memory",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line",
-            "conditional_formats": []
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 6,
-      "x": 46,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "hive.server.api.sql_operation.running.count",
-      "title_text": "SQL Operation (running/pending)",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hive.server.api.sql_operation.running.count{*}.as_count(), sum:hive.server.api.sql_operation.pending.count{*}.as_count()",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 46,
+                "y": 6,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 1,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hive.server.api.sql_operation.running.count{*}.as_count(), sum:hive.server.api.sql_operation.pending.count{*}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "SQL Operation (running/pending)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line",
-            "conditional_formats": []
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 38,
-      "x": 46,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "sizing": "fit",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1559810361824,
-        "end": 1559813961824
-      },
-      "generated_title": "",
-      "title_size": 16,
-      "title": true,
-      "url": "https://s3.amazonaws.com/dd-integrations/hive/configuration/tile/logo.png",
-      "margin": "",
-      "title_align": "left",
-      "title_text": "",
-      "height": 12,
-      "width": 31,
-      "type": "image",
-      "y": 0,
-      "x": 0,
-      "add_timeframe": true,
-      "scaleFactor": 1,
-      "isShared": false
-    },
-    {
-      "height": 8,
-      "text_size": "auto",
-      "check": "hive.can_connect",
-      "board_id": "fv6-fz8-isy",
-      "group": "instance:hive-localhost-8808,jmx_server:localhost,host:vagrant",
-      "title": true,
-      "title_align": "center",
-      "text_align": "center",
-      "width": 15,
-      "group_by": [],
-      "type": "check_status",
-      "isShared": false,
-      "tags": [
-        "*"
-      ],
-      "time": {},
-      "title_text": "Hive host up",
-      "title_size": 16,
-      "scaleFactor": 1,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "error": null,
-      "y": 19,
-      "x": 0,
-      "grouping": "cluster"
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "x": 16,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "query_value",
-      "generated_title": "hive.server.session.open",
-      "title_text": "Opened session",
-      "height": 6,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:hive.server.session.open{*}",
-            "aggregator": "last",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 46,
+                "y": 38,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 2,
+            "definition": {
+                "type": "image",
+                "url": "https://s3.amazonaws.com/dd-integrations/hive/configuration/tile/logo.png",
+                "sizing": "fit"
             },
-            "type": null,
-            "conditional_formats": [
-              {
-                "palette": "white_on_red",
-                "comparator": ">",
-                "value": null
-              },
-              {
-                "palette": "white_on_yellow",
-                "comparator": ">=",
-                "value": null
-              },
-              {
-                "palette": "white_on_green",
-                "comparator": "<",
-                "value": null
-              }
-            ]
-          }
-        ],
-        "autoscale": true,
-        "precision": "0"
-      },
-      "width": 15,
-      "time": {},
-      "error": null,
-      "y": 19,
-      "autoscale": true,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "hive.metastore.table.created",
-      "title_text": "Created table",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:hive.metastore.table.created{*}.as_count()",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 31,
+                "height": 12
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "check_status",
+                "title": "Hive host up",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "hive.can_connect",
+                "grouping": "cluster",
+                "group": "instance:hive-localhost-8808,jmx_server:localhost,host:vagrant",
+                "group_by": [],
+                "tags": [
+                    "*"
+                ]
             },
-            "type": "bars",
-            "conditional_formats": [
-              {
-                "palette": "white_on_red",
-                "comparator": ">",
-                "value": null
-              },
-              {
-                "palette": "white_on_yellow",
-                "comparator": ">=",
-                "value": null
-              },
-              {
-                "palette": "white_on_green",
-                "comparator": "<",
-                "value": null
-              }
-            ]
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 54,
-      "x": 95,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "hive.metastore.memory.total.max",
-      "title_text": "HiveMetaStore memory",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:hive.metastore.memory.total.max{*}, avg:hive.metastore.memory.total.used{*}, avg:hive.metastore.memory.total.init{*}",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 0,
+                "y": 19,
+                "width": 15,
+                "height": 8
+            }
+        },
+        {
+            "id": 4,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:hive.server.session.open{*}",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Opened session",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 0
             },
-            "type": "line",
-            "conditional_formats": []
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 6,
-      "x": 95,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "height": 5,
-      "tick_pos": "50%",
-      "board_id": "fv6-fz8-isy",
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "text_align": "center",
-      "bgcolor": "pink",
-      "html": "HiveServer2",
-      "type": "note",
-      "isShared": false,
-      "refresh_every": 30000,
-      "auto_refresh": false,
-      "title_text": "",
-      "tick": true,
-      "scaleFactor": 1,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1559831495851,
-        "end": 1559835095851
-      },
-      "font_size": "18",
-      "generated_title": "Note",
-      "tick_edge": "bottom",
-      "y": 0,
-      "x": 46,
-      "width": 47
-    },
-    {
-      "height": 5,
-      "tick_pos": "50%",
-      "board_id": "fv6-fz8-isy",
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "text_align": "center",
-      "bgcolor": "pink",
-      "html": "HiveMetaStore",
-      "type": "note",
-      "isShared": false,
-      "refresh_every": 30000,
-      "auto_refresh": false,
-      "title_text": "",
-      "tick": true,
-      "scaleFactor": 1,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1559831495851,
-        "end": 1559835095851
-      },
-      "font_size": "18",
-      "generated_title": "Note",
-      "tick_edge": "bottom",
-      "y": 0,
-      "x": 95,
-      "width": 47
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "hive.metastore.api.get_table",
-      "title_text": "API calls table (get/drop/alter)",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:hive.metastore.api.get_table{*}.as_count(), avg:hive.metastore.api.drop_table{*}.as_count(), avg:hive.metastore.api.alter_table{*}.as_count()",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 16,
+                "y": 19,
+                "width": 15,
+                "height": 8
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:hive.metastore.table.created{*}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Created table",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line",
-            "conditional_formats": []
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 22,
-      "x": 95,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "hive.server.queries.compiling.count",
-      "title_text": "Queries (compiling/executing/submitting/succeeded)",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hive.server.queries.compiling.count{*}.as_count(), sum:hive.server.queries.executing.count{*}.as_count(), sum:hive.server.queries.submitted.count{*}.as_count(), sum:hive.server.queries.succeeded.count{*}.as_count()",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 95,
+                "y": 54,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:hive.metastore.memory.total.max{*}, avg:hive.metastore.memory.total.used{*}, avg:hive.metastore.memory.total.init{*}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "HiveMetaStore memory",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line",
-            "conditional_formats": []
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 22,
-      "x": 46,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "x": 16,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "query_value",
-      "generated_title": "hive.server.api.sql_operation.pending.count",
-      "title_text": "Pending SQL Operation",
-      "height": 6,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "sum:hive.server.api.sql_operation.pending.count{*}.as_count()",
-            "aggregator": "last",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 95,
+                "y": 6,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 7,
+            "definition": {
+                "type": "note",
+                "content": "HiveServer2",
+                "background_color": "pink",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": null,
-            "conditional_formats": [
-              {
-                "palette": "white_on_red",
-                "comparator": ">",
-                "value": null
-              },
-              {
-                "palette": "white_on_yellow",
-                "comparator": ">",
-                "value": "0"
-              },
-              {
-                "palette": "white_on_green",
-                "comparator": "<=",
-                "value": "0"
-              }
-            ]
-          }
-        ],
-        "autoscale": true,
-        "precision": "0"
-      },
-      "width": 15,
-      "time": {},
-      "error": null,
-      "y": 34,
-      "autoscale": true,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "x": 16,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "query_value",
-      "generated_title": "hive.server.queries.succeeded.meanrate",
-      "title_text": "Rate of succeeded queries",
-      "height": 6,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "sum:hive.server.queries.succeeded.count{*}.as_rate()",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 46,
+                "y": 0,
+                "width": 47,
+                "height": 5
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "note",
+                "content": "HiveMetaStore",
+                "background_color": "pink",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": null,
-            "conditional_formats": [
-              {
-                "palette": "white_on_red",
-                "comparator": ">",
-                "value": null
-              },
-              {
-                "palette": "white_on_yellow",
-                "comparator": ">=",
-                "value": null
-              },
-              {
-                "palette": "white_on_green",
-                "comparator": "<",
-                "value": null
-              }
-            ]
-          }
-        ],
-        "autoscale": true,
-        "precision": "3",
-        "custom_unit": null
-      },
-      "width": 15,
-      "time": {},
-      "error": null,
-      "y": 43,
-      "autoscale": true,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "height": 5,
-      "tick_pos": "50%",
-      "board_id": "fv6-fz8-isy",
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "text_align": "left",
-      "bgcolor": "gray",
-      "html": "General",
-      "type": "note",
-      "isShared": false,
-      "refresh_every": 30000,
-      "auto_refresh": false,
-      "title_text": "",
-      "tick": true,
-      "scaleFactor": 1,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1559897121408,
-        "end": 1559900721408
-      },
-      "font_size": "14",
-      "generated_title": "Note",
-      "tick_edge": "bottom",
-      "y": 13,
-      "x": 0,
-      "width": 31
-    },
-    {
-      "height": 5,
-      "tick_pos": "50%",
-      "board_id": "fv6-fz8-isy",
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "text_align": "left",
-      "bgcolor": "gray",
-      "html": "HS2 Operations",
-      "type": "note",
-      "isShared": false,
-      "refresh_every": 30000,
-      "auto_refresh": false,
-      "title_text": "",
-      "tick": true,
-      "scaleFactor": 1,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1559897121408,
-        "end": 1559900721408
-      },
-      "font_size": "14",
-      "generated_title": "Note",
-      "tick_edge": "bottom",
-      "y": 28,
-      "x": 0,
-      "width": 31
-    },
-    {
-      "height": 15,
-      "tick_pos": "50%",
-      "board_id": "fv6-fz8-isy",
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "text_align": "center",
-      "bgcolor": "gray",
-      "html": "Memory",
-      "type": "note",
-      "isShared": false,
-      "refresh_every": 30000,
-      "auto_refresh": false,
-      "title_text": "",
-      "tick": true,
-      "scaleFactor": 1,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560323461272,
-        "end": 1560327061272
-      },
-      "font_size": "14",
-      "generated_title": "Note",
-      "tick_edge": "right",
-      "y": 6,
-      "x": 33,
-      "width": 12
-    },
-    {
-      "height": 47,
-      "tick_pos": "50%",
-      "board_id": "fv6-fz8-isy",
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "text_align": "center",
-      "bgcolor": "gray",
-      "html": "Activity",
-      "type": "note",
-      "isShared": false,
-      "refresh_every": 30000,
-      "auto_refresh": false,
-      "title_text": "",
-      "tick": true,
-      "scaleFactor": 1,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560323461272,
-        "end": 1560327061272
-      },
-      "font_size": "14",
-      "generated_title": "Note",
-      "tick_edge": "right",
-      "y": 23,
-      "x": 33,
-      "width": 12
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "API Calls get_all (table/db/function)",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hive.metastore.api.get_all_tables{*}.as_count(), sum:hive.metastore.api.get_all_databases{*}.as_count(), sum:hive.metastore.api.get_all_functions{*}.as_count()",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 95,
+                "y": 0,
+                "width": 47,
+                "height": 5
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:hive.metastore.api.get_table{*}.as_count(), avg:hive.metastore.api.drop_table{*}.as_count(), avg:hive.metastore.api.alter_table{*}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "API calls table (get/drop/alter)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line",
-            "conditional_formats": []
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 38,
-      "x": 95,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "timeseries",
-      "generated_title": "Timeseries",
-      "title_text": "API Operations (running/pending/initialized)",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hive.server.api.operation.running.count{*}.as_count(), sum:hive.server.api.operation.pending.count{*}.as_count(), sum:hive.server.api.operation.initialized.count{*}.as_count()",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 95,
+                "y": 22,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hive.server.queries.compiling.count{*}.as_count(), sum:hive.server.queries.executing.count{*}.as_count(), sum:hive.server.queries.submitted.count{*}.as_count(), sum:hive.server.queries.succeeded.count{*}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Queries (compiling/executing/submitting/succeeded)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "type": "line",
-            "conditional_formats": []
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 47,
-      "time": {},
-      "error": null,
-      "y": 54,
-      "x": 46,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "x": 0,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "query_value",
-      "generated_title": "hive.server.api.sql_operation.pending.count",
-      "title_text": "Pending Operation",
-      "height": 6,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "sum:hive.server.api.operation.pending.count{*}.as_count()",
-            "aggregator": "last",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 46,
+                "y": 22,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:hive.server.api.sql_operation.pending.count{*}.as_count()",
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "white_on_yellow"
+                            },
+                            {
+                                "comparator": "<=",
+                                "value": 0,
+                                "palette": "white_on_green"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pending SQL Operation",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 0
             },
-            "type": null,
-            "conditional_formats": [
-              {
-                "palette": "white_on_red",
-                "comparator": ">",
-                "value": null
-              },
-              {
-                "palette": "white_on_yellow",
-                "comparator": ">",
-                "value": "0"
-              },
-              {
-                "palette": "white_on_green",
-                "comparator": "<=",
-                "value": "0"
-              }
-            ]
-          }
-        ],
-        "autoscale": true,
-        "precision": "0"
-      },
-      "width": 15,
-      "time": {},
-      "error": null,
-      "y": 34,
-      "autoscale": true,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "height": 5,
-      "tick_pos": "50%",
-      "board_id": "fv6-fz8-isy",
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "text_align": "left",
-      "bgcolor": "gray",
-      "html": "HMS Calls",
-      "type": "note",
-      "isShared": false,
-      "refresh_every": 30000,
-      "auto_refresh": false,
-      "title_text": "",
-      "tick": true,
-      "scaleFactor": 1,
-      "add_timeframe": true,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1559897121408,
-        "end": 1559900721408
-      },
-      "font_size": "14",
-      "generated_title": "Note",
-      "tick_edge": "bottom",
-      "y": 52,
-      "x": 0,
-      "width": 31
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "x": 16,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "query_value",
-      "generated_title": "Query Value",
-      "title_text": "Avg of get_db API call",
-      "height": 6,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:hive.metastore.api.get_database{*}.as_count()",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 16,
+                "y": 34,
+                "width": 15,
+                "height": 8
+            }
+        },
+        {
+            "id": 12,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:hive.server.queries.succeeded.count{*}.as_rate()",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Rate of succeeded queries",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 3
             },
-            "type": null,
-            "conditional_formats": [
-              {
-                "palette": "white_on_red",
-                "comparator": ">",
-                "value": null
-              },
-              {
-                "palette": "white_on_yellow",
-                "comparator": ">=",
-                "value": null
-              },
-              {
-                "palette": "white_on_green",
-                "comparator": "<",
-                "value": null
-              }
-            ]
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 15,
-      "time": {},
-      "error": null,
-      "y": 58,
-      "autoscale": true,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "x": 0,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "query_value",
-      "generated_title": "hive.server.queries.succeeded.meanrate",
-      "title_text": "Rate of executing queries",
-      "height": 6,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "sum:hive.server.queries.executing.count{*}.as_rate()",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 16,
+                "y": 43,
+                "width": 15,
+                "height": 8
+            }
+        },
+        {
+            "id": 13,
+            "definition": {
+                "type": "note",
+                "content": "General",
+                "background_color": "gray",
+                "font_size": "14",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": null,
-            "conditional_formats": [
-              {
-                "palette": "white_on_red",
-                "comparator": ">",
-                "value": null
-              },
-              {
-                "palette": "white_on_yellow",
-                "comparator": ">=",
-                "value": null
-              },
-              {
-                "palette": "white_on_green",
-                "comparator": "<",
-                "value": null
-              }
-            ]
-          }
-        ],
-        "autoscale": true,
-        "precision": "3",
-        "custom_unit": null
-      },
-      "width": 15,
-      "time": {},
-      "error": null,
-      "y": 43,
-      "autoscale": true,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    },
-    {
-      "board_id": "fv6-fz8-isy",
-      "x": 0,
-      "globalTimeframe": {
-        "isLive": true,
-        "start": 1560780367586,
-        "end": 1560781267586
-      },
-      "title_align": "left",
-      "title_size": 16,
-      "title": true,
-      "type": "query_value",
-      "generated_title": "Query Value",
-      "title_text": "Avg of get_table API call",
-      "height": 6,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:hive.metastore.api.get_table{*}.as_count()",
-            "aggregator": "avg",
-            "style": {
-              "width": "normal",
-              "palette": "dog_classic",
-              "type": "solid"
+            "layout": {
+                "x": 0,
+                "y": 13,
+                "width": 31,
+                "height": 5
+            }
+        },
+        {
+            "id": 14,
+            "definition": {
+                "type": "note",
+                "content": "HS2 Operations",
+                "background_color": "gray",
+                "font_size": "14",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": null,
-            "conditional_formats": [
-              {
-                "palette": "white_on_red",
-                "comparator": ">",
-                "value": null
-              },
-              {
-                "palette": "white_on_yellow",
-                "comparator": ">=",
-                "value": null
-              },
-              {
-                "palette": "white_on_green",
-                "comparator": "<",
-                "value": null
-              }
-            ]
-          }
-        ],
-        "autoscale": true
-      },
-      "width": 15,
-      "time": {},
-      "error": null,
-      "y": 58,
-      "autoscale": true,
-      "legend_size": "0",
-      "isShared": false,
-      "scaleFactor": 1,
-      "legend": false,
-      "add_timeframe": true
-    }
-  ],
-  "disableCog": false,
-  "id": 63647,
-  "isShared": false
+            "layout": {
+                "x": 0,
+                "y": 28,
+                "width": 31,
+                "height": 5
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "note",
+                "content": "Memory",
+                "background_color": "gray",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 33,
+                "y": 6,
+                "width": 12,
+                "height": 15
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "note",
+                "content": "Activity",
+                "background_color": "gray",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 33,
+                "y": 23,
+                "width": 12,
+                "height": 47
+            }
+        },
+        {
+            "id": 17,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hive.metastore.api.get_all_tables{*}.as_count(), sum:hive.metastore.api.get_all_databases{*}.as_count(), sum:hive.metastore.api.get_all_functions{*}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "API Calls get_all (table/db/function)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 95,
+                "y": 38,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 18,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hive.server.api.operation.running.count{*}.as_count(), sum:hive.server.api.operation.pending.count{*}.as_count(), sum:hive.server.api.operation.initialized.count{*}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "API Operations (running/pending/initialized)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 46,
+                "y": 54,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 19,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:hive.server.api.operation.pending.count{*}.as_count()",
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "white_on_yellow"
+                            },
+                            {
+                                "comparator": "<=",
+                                "value": 0,
+                                "palette": "white_on_green"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pending Operation",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 0
+            },
+            "layout": {
+                "x": 0,
+                "y": 34,
+                "width": 15,
+                "height": 8
+            }
+        },
+        {
+            "id": 20,
+            "definition": {
+                "type": "note",
+                "content": "HMS Calls",
+                "background_color": "gray",
+                "font_size": "14",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 52,
+                "width": 31,
+                "height": 5
+            }
+        },
+        {
+            "id": 21,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:hive.metastore.api.get_database{*}.as_count()",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Avg of get_db API call",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 16,
+                "y": 58,
+                "width": 15,
+                "height": 8
+            }
+        },
+        {
+            "id": 22,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:hive.server.queries.executing.count{*}.as_rate()",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Rate of executing queries",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 3
+            },
+            "layout": {
+                "x": 0,
+                "y": 43,
+                "width": 15,
+                "height": 8
+            }
+        },
+        {
+            "id": 23,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:hive.metastore.api.get_table{*}.as_count()",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Avg of get_table API call",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 0,
+                "y": 58,
+                "width": 15,
+                "height": 8
+            }
+        }
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30239
 }

--- a/hivemq/assets/dashboards/hivemq.json
+++ b/hivemq/assets/dashboards/hivemq.json
@@ -1,837 +1,881 @@
 {
-  "board_title": "HiveMQ Overview",
-  "read_only": false,
-  "description": "The default dashboard for monitoring HiveMQ brokers including connections, subscriptions, and messages.",
-  "created": "2020-07-07T18:59:17.091896+00:00",
-  "new_id": "6wx-fj2-7rr",
-  "modified": "2020-07-07T19:00:39.807147+00:00",
-  "created_by": {
-    "disabled": false,
-    "handle": "jimmy.caputo@datadoghq.com",
-    "name": "Jimmy Caputo",
-    "title": null,
-    "is_admin": false,
-    "role": null,
-    "access_role": "st",
-    "verified": true,
-    "email": "jimmy.caputo@datadoghq.com",
-    "icon": "https://secure.gravatar.com/avatar/82006bfcbc5cabfd12c9717b0a1c63fc?s=48&d=retro"
-  },
-  "template_variables": [
-    {
-      "default": "*",
-      "prefix": "host",
-      "name": "host"
-    }
-  ],
-  "widgets": [
-    {
-      "sizing": "zoom",
-      "y": -13,
-      "width": 17,
-      "url": "/static/images/saas_logos/bot/hivemq@2x.png",
-      "x": 0,
-      "type": "image",
-      "height": 6
-    },
-    {
-      "title_align": "center",
-      "title_size": 16,
-      "title": true,
-      "tags": [
-        "*"
-      ],
-      "title_text": "Connected Nodes",
-      "height": 11,
-      "width": 17,
-      "group_by": [],
-      "y": 7,
-      "x": 0,
-      "type": "check_status",
-      "check": "hivemq.can_connect",
-      "grouping": "cluster"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Current Connections",
-      "height": 6,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "sum:hivemq.networking.connections.current{$host}",
-            "aggregator": "last"
-          }
-        ],
-        "custom_links": [],
-        "autoscale": true,
-        "precision": 0
-      },
-      "width": 17,
-      "y": 7,
-      "x": 26,
-      "type": "query_value"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Incoming Messages",
-      "height": 6,
-      "tile_def": {
-        "custom_links": [],
-        "autoscale": true,
-        "custom_unit": "/s",
-        "precision": 0,
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "sum:hivemq.messages.incoming.total.count{$host}.as_rate()",
-            "aggregator": "avg"
-          }
-        ]
-      },
-      "width": 18,
-      "y": 7,
-      "x": 110,
-      "type": "query_value"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Outgoing Messages",
-      "height": 6,
-      "tile_def": {
-        "custom_links": [],
-        "autoscale": true,
-        "custom_unit": "/s",
-        "precision": 0,
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "sum:hivemq.messages.outgoing.total.count{$host}.as_rate()",
-            "aggregator": "avg"
-          }
-        ]
-      },
-      "width": 17,
-      "y": 7,
-      "x": 144,
-      "type": "query_value"
-    },
-    {
-      "font_size": "18",
-      "width": 33,
-      "tick_pos": "50%",
-      "tick_edge": "bottom",
-      "text_align": "center",
-      "height": 5,
-      "bgcolor": "vivid_yellow",
-      "html": "**Connections**",
-      "y": 0,
-      "x": 18,
-      "tick": true,
-      "type": "note"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Ungraceful Disconnects",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.networking.connections_closed.ungraceful.count{$host} by {host}.as_count()",
-            "style": {
-              "palette": "warm",
-              "width": "normal",
-              "type": "solid"
+    "title": "HiveMQ Overview",
+    "description": "The default dashboard for monitoring HiveMQ brokers including connections, subscriptions, and messages.",
+    "widgets": [
+        {
+            "id": 0,
+            "definition": {
+                "type": "image",
+                "url": "/static/images/saas_logos/bot/hivemq@2x.png",
+                "sizing": "zoom"
             },
-            "type": "bars"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 33,
-      "y": 32,
-      "x": 18,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Connections",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.networking.connections.current{$host} by {host}",
-            "style": {
-              "palette": "cool",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "area"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 33,
-      "y": 49,
-      "x": 18,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Current Subscriptions",
-      "height": 6,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "sum:hivemq.subscriptions.overall.current{$host}.as_count()",
-            "aggregator": "last"
-          }
-        ],
-        "custom_links": [],
-        "autoscale": true,
-        "precision": 0
-      },
-      "width": 17,
-      "y": 7,
-      "x": 60,
-      "type": "query_value"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Graceful Disconnects",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.networking.connections_closed.graceful.count{$host} by {host}.as_count()",
-            "style": {
-              "palette": "grey",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "bars"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 33,
-      "y": 82,
-      "x": 18,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "font_size": "18",
-      "width": 33,
-      "tick_pos": "50%",
-      "tick_edge": "bottom",
-      "text_align": "center",
-      "height": 5,
-      "bgcolor": "vivid_yellow",
-      "html": "**Subscriptions**",
-      "y": 0,
-      "x": 52,
-      "tick": true,
-      "type": "note"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Incoming Message per Second",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.messages.incoming.total.count{$host} by {host}.as_rate()",
-            "style": {
-              "palette": "cool",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 33,
-      "y": 49,
-      "x": 86,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Outgoing Message per Second",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.messages.outgoing.total.count{$host} by {host}.as_rate()",
-            "style": {
-              "palette": "cool",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 33,
-      "y": 65,
-      "x": 86,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Incoming Connect Messages",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.messages.incoming.connect.count{$host} by {host}.as_count()",
-            "style": {
-              "palette": "cool",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "bars"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 33,
-      "y": 65,
-      "x": 18,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Messages Dropped",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.messages.dropped.count{$host} by {host}.as_count()",
-            "style": {
-              "palette": "warm",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "bars"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 33,
-      "y": 32,
-      "x": 86,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "% Messages Dropped by Reason",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count()), (sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count()), (sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count()), (sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count()), (sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count())",
-            "style": {
-              "palette": "warm",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "area",
-            "metadata": {
-              "(sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count())": {
-                "alias": "Internal Error"
-              },
-              "(sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count())": {
-                "alias": "MQTT Packet Too Large"
-              },
-              "(sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count())": {
-                "alias": "QoS 0 Memory Exceeded"
-              },
-              "(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count())": {
-                "alias": "Client Message Queue Full"
-              },
-              "(sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count())": {
-                "alias": "QoS 0 Channel Not Writable"
-              }
+            "layout": {
+                "x": 0,
+                "y": -13,
+                "width": 17,
+                "height": 6
             }
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "max": "100"
-        }
-      },
-      "width": 33,
-      "y": 16,
-      "x": 154,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "font_size": "18",
-      "width": 100,
-      "tick_pos": "50%",
-      "tick_edge": "bottom",
-      "text_align": "center",
-      "height": 5,
-      "bgcolor": "vivid_yellow",
-      "html": "**Messages**",
-      "y": 0,
-      "x": 87,
-      "tick": true,
-      "type": "note"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Retained Messages",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.messages.retained.current{$host} by {host}",
-            "style": {
-              "palette": "cool",
-              "width": "normal",
-              "type": "solid"
+        },
+        {
+            "id": 1,
+            "definition": {
+                "type": "check_status",
+                "title": "Connected Nodes",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "hivemq.can_connect",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "*"
+                ]
             },
-            "type": "bars"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 33,
-      "y": 65,
-      "x": 120,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Subscriptions",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.subscriptions.overall.current{$host} by {host}.as_count()",
-            "style": {
-              "palette": "cool",
-              "width": "normal",
-              "type": "solid"
+            "layout": {
+                "x": 0,
+                "y": 7,
+                "width": 17,
+                "height": 11
+            }
+        },
+        {
+            "id": 2,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.networking.connections.current{$host}",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Current Connections",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 0
             },
-            "type": "area"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 33,
-      "y": 49,
-      "x": 52,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Subscribe Request per Second",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.messages.incoming.subscribe.count{$host} by {host}.as_rate()",
-            "style": {
-              "palette": "cool",
-              "width": "normal",
-              "type": "solid"
+            "layout": {
+                "x": 26,
+                "y": 7,
+                "width": 17,
+                "height": 8
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.messages.incoming.total.count{$host}.as_rate()",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Incoming Messages",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "custom_unit": "/s",
+                "precision": 0
             },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 33,
-      "y": 65,
-      "x": 52,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Unsubscribe Request per Second",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.messages.incoming.unsubscribe.count{$host} by {host}.as_rate()",
-            "style": {
-              "palette": "grey",
-              "width": "normal",
-              "type": "solid"
+            "layout": {
+                "x": 110,
+                "y": 7,
+                "width": 18,
+                "height": 8
+            }
+        },
+        {
+            "id": 4,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.messages.outgoing.total.count{$host}.as_rate()",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Outgoing Messages",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "custom_unit": "/s",
+                "precision": 0
             },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 33,
-      "y": 82,
-      "x": 52,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Messages w/out Subscribers ",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.publish.without_matching_subscribers{$host} by {host}.as_count()",
-            "style": {
-              "palette": "warm",
-              "width": "normal",
-              "type": "solid"
+            "layout": {
+                "x": 144,
+                "y": 7,
+                "width": 17,
+                "height": 8
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "note",
+                "content": "**Connections**",
+                "background_color": "vivid_yellow",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "type": "bars"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 33,
-      "y": 32,
-      "x": 52,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Queued Messages",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.messages.queued.count{$host} by {host}",
-            "style": {
-              "palette": "cool",
-              "width": "normal",
-              "type": "solid"
+            "layout": {
+                "x": 18,
+                "y": 0,
+                "width": 33,
+                "height": 5
+            }
+        },
+        {
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.networking.connections_closed.ungraceful.count{$host} by {host}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Ungraceful Disconnects",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "type": "bars"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 33,
-      "y": 49,
-      "x": 120,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Expired Messages",
-      "height": 14,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:hivemq.messages.expired_messages{$host} by {host}.as_count()",
-            "style": {
-              "palette": "warm",
-              "width": "normal",
-              "type": "solid"
+            "layout": {
+                "x": 18,
+                "y": 32,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.networking.connections.current{$host} by {host}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Connections",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "type": "bars"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
+            "layout": {
+                "x": 18,
+                "y": 49,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.subscriptions.overall.current{$host}.as_count()",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Current Subscriptions",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 0
+            },
+            "layout": {
+                "x": 60,
+                "y": 7,
+                "width": 17,
+                "height": 8
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.networking.connections_closed.graceful.count{$host} by {host}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "grey",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Graceful Disconnects",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 18,
+                "y": 82,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "note",
+                "content": "**Subscriptions**",
+                "background_color": "vivid_yellow",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 52,
+                "y": 0,
+                "width": 33,
+                "height": 5
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.messages.incoming.total.count{$host} by {host}.as_rate()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Incoming Message per Second",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 86,
+                "y": 49,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.messages.outgoing.total.count{$host} by {host}.as_rate()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Outgoing Message per Second",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 86,
+                "y": 65,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.messages.incoming.connect.count{$host} by {host}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Incoming Connect Messages",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 18,
+                "y": 65,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 14,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.messages.dropped.count{$host} by {host}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Messages Dropped",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 86,
+                "y": 32,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count()), (sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count()), (sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count()), (sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count()), (sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count())",
+                        "metadata": [
+                            {
+                                "expression": "(sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count())",
+                                "alias_name": "Internal Error"
+                            },
+                            {
+                                "expression": "(sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count())",
+                                "alias_name": "MQTT Packet Too Large"
+                            },
+                            {
+                                "expression": "(sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count())",
+                                "alias_name": "QoS 0 Memory Exceeded"
+                            },
+                            {
+                                "expression": "(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count())",
+                                "alias_name": "Client Message Queue Full"
+                            },
+                            {
+                                "expression": "(sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()*100)/(sum:hivemq.messages.dropped.queue_full.count{$host}.as_count()+sum:hivemq.messages.dropped.not_writable.count{$host}.as_count()+sum:hivemq.messages.dropped.internal_error.count{$host}.as_count()+sum:hivemq.messages.dropped.mqtt_packet_too_large.count{$host}.as_count()+sum:hivemq.messages.dropped.qos_0_memory_exceeded.count{$host}.as_count())",
+                                "alias_name": "QoS 0 Channel Not Writable"
+                            }
+                        ],
+                        "display_type": "area",
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "max": "100"
+                },
+                "title": "% Messages Dropped by Reason",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 154,
+                "y": 16,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "note",
+                "content": "**Messages**",
+                "background_color": "vivid_yellow",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 87,
+                "y": 0,
+                "width": 100,
+                "height": 5
+            }
+        },
+        {
+            "id": 17,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.messages.retained.current{$host} by {host}",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Retained Messages",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 120,
+                "y": 65,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 18,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.subscriptions.overall.current{$host} by {host}.as_count()",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Subscriptions",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 52,
+                "y": 49,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 19,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.messages.incoming.subscribe.count{$host} by {host}.as_rate()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Subscribe Request per Second",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 52,
+                "y": 65,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 20,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.messages.incoming.unsubscribe.count{$host} by {host}.as_rate()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "grey",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Unsubscribe Request per Second",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 52,
+                "y": 82,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 21,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.publish.without_matching_subscribers{$host} by {host}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Messages w/out Subscribers ",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 52,
+                "y": 32,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 22,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.messages.queued.count{$host} by {host}",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Queued Messages",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 120,
+                "y": 49,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 23,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:hivemq.messages.expired_messages{$host} by {host}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Expired Messages",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 120,
+                "y": 32,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 24,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:hivemq.networking.connections_closed.ungraceful.count{$host} by {host}.as_count().rollup(sum), 10, 'sum', 'desc')",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "white_on_yellow"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Ungraceful Disconnects - Top Host",
+                "title_size": "16",
+                "title_align": "left"
+            },
+            "layout": {
+                "x": 18,
+                "y": 16,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 25,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:hivemq.publish.without_matching_subscribers{$host} by {host}.as_count().rollup(sum), 10, 'sum', 'desc')",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 1,
+                                "palette": "white_on_yellow"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Messages w/out Subscribers - Top Host",
+                "title_size": "16",
+                "title_align": "left"
+            },
+            "layout": {
+                "x": 52,
+                "y": 16,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 26,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:hivemq.messages.dropped.count{$host} by {host}.as_count(), 10, 'mean', 'desc')",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 1,
+                                "palette": "white_on_yellow"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Messages Dropped - Top Host",
+                "title_size": "16",
+                "title_align": "left"
+            },
+            "layout": {
+                "x": 86,
+                "y": 16,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 27,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:hivemq.messages.expired_messages{$host} by {host}.as_count(), 10, 'mean', 'desc')",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 1,
+                                "palette": "white_on_yellow"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Expired Messages - Top Host",
+                "title_size": "16",
+                "title_align": "left"
+            },
+            "layout": {
+                "x": 120,
+                "y": 16,
+                "width": 33,
+                "height": 16
+            }
+        },
+        {
+            "id": 28,
+            "definition": {
+                "type": "note",
+                "content": "**Dropped Message Reason Explanations:**\n\n**Client Message Queue Full**   \nClient's message queue was full when another message for that client arrived. Clients may be consuming too slow or have unstable connections.\n\n**QoS 0 Memory Exceeded**  \nBroker-wide memory for queueing Quality of Service 0 messages has been exceeded. Clients may be consuming too slow or have unstable connections.\n\n**QoS Channel Not Writable**\nSocket of the receiving client could not be written to. Caused by a client not reading fast enough.\n\n**Maximum Packet Size Exceeded**\nMessage is larger than maximum size set by receiving client. Coordination between sending and receiving clients needs tuning.\n\n**Internal Error**\nUnexpected problem. Check the HiveMQ logs for details.\n",
+                "background_color": "orange",
+                "font_size": "14",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "top"
+            },
+            "layout": {
+                "x": 154,
+                "y": 34,
+                "width": 33,
+                "height": 40
+            }
         }
-      },
-      "width": 33,
-      "y": 32,
-      "x": 120,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Ungraceful Disconnects - Top Host",
-      "height": 14,
-      "tile_def": {
-        "viz": "toplist",
-        "requests": [
-          {
-            "q": "top(sum:hivemq.networking.connections_closed.ungraceful.count{$host} by {host}.as_count().rollup(sum), 10, 'sum', 'desc')",
-            "conditional_formats": [
-              {
-                "palette": "white_on_yellow",
-                "value": "0",
-                "comparator": ">"
-              }
-            ]
-          }
-        ],
-        "custom_links": []
-      },
-      "width": 33,
-      "y": 16,
-      "x": 18,
-      "type": "toplist"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Messages w/out Subscribers - Top Host",
-      "height": 14,
-      "tile_def": {
-        "viz": "toplist",
-        "requests": [
-          {
-            "q": "top(sum:hivemq.publish.without_matching_subscribers{$host} by {host}.as_count().rollup(sum), 10, 'sum', 'desc')",
-            "conditional_formats": [
-              {
-                "palette": "white_on_yellow",
-                "value": "1",
-                "comparator": ">"
-              }
-            ]
-          }
-        ],
-        "custom_links": []
-      },
-      "width": 33,
-      "y": 16,
-      "x": 52,
-      "type": "toplist"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Messages Dropped - Top Host",
-      "height": 14,
-      "tile_def": {
-        "viz": "toplist",
-        "requests": [
-          {
-            "q": "top(sum:hivemq.messages.dropped.count{$host} by {host}.as_count(), 10, 'mean', 'desc')",
-            "conditional_formats": [
-              {
-                "palette": "white_on_yellow",
-                "value": "1",
-                "comparator": ">"
-              }
-            ]
-          }
-        ],
-        "custom_links": []
-      },
-      "width": 33,
-      "y": 16,
-      "x": 86,
-      "type": "toplist"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Expired Messages - Top Host",
-      "height": 14,
-      "tile_def": {
-        "viz": "toplist",
-        "requests": [
-          {
-            "q": "top(sum:hivemq.messages.expired_messages{$host} by {host}.as_count(), 10, 'mean', 'desc')",
-            "conditional_formats": [
-              {
-                "palette": "white_on_yellow",
-                "value": "1",
-                "comparator": ">"
-              }
-            ]
-          }
-        ],
-        "custom_links": []
-      },
-      "width": 33,
-      "y": 16,
-      "x": 120,
-      "type": "toplist"
-    },
-    {
-      "font_size": "14",
-      "width": 33,
-      "tick_pos": "50%",
-      "tick_edge": "top",
-      "text_align": "left",
-      "height": 40,
-      "bgcolor": "orange",
-      "html": "**Dropped Message Reason Explanations:**\n\n**Client Message Queue Full**   \nClient's message queue was full when another message for that client arrived. Clients may be consuming too slow or have unstable connections.\n\n**QoS 0 Memory Exceeded**  \nBroker-wide memory for queueing Quality of Service 0 messages has been exceeded. Clients may be consuming too slow or have unstable connections.\n\n**QoS Channel Not Writable**\nSocket of the receiving client could not be written to. Caused by a client not reading fast enough.\n\n**Maximum Packet Size Exceeded**\nMessage is larger than maximum size set by receiving client. Coordination between sending and receiving clients needs tuning.\n\n**Internal Error**\nUnexpected problem. Check the HiveMQ logs for details.\n",
-      "y": 34,
-      "x": 154,
-      "tick": true,
-      "type": "note"
-    }
-  ],
-  "id": 66017
+    ],
+    "template_variables": [
+        {
+            "name": "host",
+            "default": "*",
+            "prefix": "host"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30331
 }

--- a/ibm_db2/assets/dashboards/overview.json
+++ b/ibm_db2/assets/dashboards/overview.json
@@ -1,1254 +1,738 @@
 {
-    "board_title": "IBM Db2 Overview",
-    "read_only": false,
-    "author_info": {
-        "author_name": "Datadog"
-    },
+    "title": "IBM Db2 Overview",
     "description": "## IBM Db2 Dashboard\n\nThis is an example IBM Db2 dashboard demonstrating the metrics that the integration collects.",
-    "board_bgtype": "board_graph",
-    "created": "2019-05-03T14:26:08.120761+00:00",
-    "new_id": "xa5-hrs-4jx",
-    "modified": "2019-05-20T23:17:12.317801+00:00",
-    "created_by": {
-        "handle": "support@datadoghq.com",
-        "name": "Datadog",
-        "access_role": "st",
-        "verified": true,
-        "disabled": false,
-        "is_admin": false,
-        "role": null,
-        "email": "support@datadoghq.com",
-        "icon": ""
-    },
-    "height": 101,
-    "width": 200,
-    "template_variables": [
-        {
-            "default": "*",
-            "prefix": "host",
-            "name": "host"
-        },
-        {
-            "default": "*",
-            "prefix": "db",
-            "name": "db"
-        }
-    ],
-    "isIntegration": false,
-    "originalHeight": 101,
-    "originalWidth": 200,
-    "isShared": false,
     "widgets": [
         {
-            "board_id": "jzh-m57-fyf",
-            "sizing": "fit",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1554925560000,
-                "end": 1554929160000
+            "id": 0,
+            "definition": {
+                "type": "image",
+                "url": "https://s3.amazonaws.com/dd-integrations/ibm-db2/configuration/tile/logo.png",
+                "sizing": "fit"
             },
-            "title_align": "left",
-            "title_size": 16,
-            "title": true,
-            "url": "https://s3.amazonaws.com/dd-integrations/ibm-db2/configuration/tile/logo.png",
-            "type": "image",
-            "generated_title": "",
-            "title_text": "",
-            "height": 14,
-            "width": 19,
-            "scaleFactor": 1,
-            "y": 0,
-            "x": 0,
-            "isShared": false,
-            "margin": "",
-            "add_timeframe": true
+            "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 19,
+                "height": 14
+            }
         },
         {
-            "height": 14,
-            "text_size": "auto",
-            "check": "ibm_db2.status",
-            "board_id": "jzh-m57-fyf",
-            "group": null,
-            "title": true,
-            "title_align": "center",
-            "text_align": "center",
-            "width": 19,
-            "group_by": [
-                "$host",
-                "$db"
-            ],
-            "type": "check_status",
-            "isShared": false,
-            "tags": [
-                "$host"
-            ],
-            "time": {},
-            "title_text": "Database status",
-            "title_size": 16,
-            "scaleFactor": 1,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
+            "id": 1,
+            "definition": {
+                "type": "check_status",
+                "title": "Database status",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "ibm_db2.status",
+                "grouping": "cluster",
+                "group_by": [
+                    "$host",
+                    "$db"
+                ],
+                "tags": [
+                    "$host"
+                ]
             },
-            "error": null,
-            "y": 0,
-            "x": 20,
-            "grouping": "cluster"
+            "layout": {
+                "x": 20,
+                "y": 0,
+                "width": 19,
+                "height": 14
+            }
         },
         {
-            "board_id": "jzh-m57-fyf",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "Query Value",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Time since last backup",
-            "height": 12,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 2,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.backup.latest{$host,$db}",
-                        "aggregator": "last",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_red",
-                                "value": null,
-                                "comparator": ">"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "value": null,
-                                "comparator": ">="
-                            },
-                            {
-                                "palette": "white_on_green",
-                                "value": null,
-                                "comparator": "<"
-                            }
-                        ]
+                        "aggregator": "last"
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Time since last backup",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
             },
-            "width": 19,
-            "add_timeframe": true,
-            "error": null,
-            "time": {},
-            "y": 15,
-            "x": 0,
-            "legend_size": "0",
-            "autoscale": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 0,
+                "y": 15,
+                "width": 19,
+                "height": 14
+            }
         },
         {
-            "board_id": "jzh-m57-fyf",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "Top List",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Table space utilization",
-            "height": 16,
-            "tile_def": {
-                "viz": "toplist",
+            "id": 3,
+            "definition": {
+                "type": "toplist",
                 "requests": [
                     {
                         "q": "top(avg:ibm_db2.tablespace.utilized{$host,$db} by {tablespace}, 10, 'mean', 'desc')",
                         "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": []
+                            "palette": "dog_classic"
+                        }
                     }
-                ]
+                ],
+                "custom_links": [],
+                "title": "Table space utilization",
+                "title_size": "16",
+                "title_align": "left"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 61,
-            "x": 88,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "toplist",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 88,
+                "y": 61,
+                "width": 47,
+                "height": 18
+            }
         },
         {
-            "board_id": "jzh-m57-fyf",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "Query Value",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Buffer pool cache hit ratio",
-            "height": 12,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 4,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.bufferpool.hit_percent{$host,$db}",
-                        "aggregator": "last",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_red",
-                                "value": null,
-                                "comparator": ">"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "value": null,
-                                "comparator": ">="
-                            },
-                            {
-                                "palette": "white_on_green",
-                                "value": null,
-                                "comparator": "<"
-                            }
-                        ]
+                        "aggregator": "last"
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Buffer pool cache hit ratio",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
             },
-            "width": 19,
-            "add_timeframe": true,
-            "error": null,
-            "time": {},
-            "y": 69,
-            "x": 0,
-            "legend_size": "0",
-            "autoscale": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 0,
+                "y": 69,
+                "width": 19,
+                "height": 14
+            }
         },
         {
-            "board_id": "jzh-m57-fyf",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "Query Value",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Max simultaneous connections",
-            "height": 8,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 5,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.connection.max{$host,$db}",
-                        "aggregator": "last",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_red",
-                                "value": null,
-                                "comparator": ">"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "value": null,
-                                "comparator": ">="
-                            },
-                            {
-                                "palette": "white_on_green",
-                                "value": null,
-                                "comparator": "<"
-                            }
-                        ]
+                        "aggregator": "last"
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Max simultaneous connections",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
             },
-            "width": 23,
-            "add_timeframe": true,
-            "error": null,
-            "time": {},
-            "y": 44,
-            "x": 64,
-            "legend_size": "0",
-            "autoscale": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 64,
+                "y": 44,
+                "width": 23,
+                "height": 10
+            }
         },
         {
-            "board_id": "jzh-m57-fyf",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "Query Value",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Log utilization",
-            "height": 8,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 6,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.log.utilized{$host,$db}",
-                        "aggregator": "last",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_red",
-                                "value": null,
-                                "comparator": ">"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "value": null,
-                                "comparator": ">="
-                            },
-                            {
-                                "palette": "white_on_green",
-                                "value": null,
-                                "comparator": "<"
-                            }
-                        ]
+                        "aggregator": "last"
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Log utilization",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
             },
-            "width": 47,
-            "add_timeframe": true,
-            "error": null,
-            "time": {},
-            "y": 44,
-            "x": 88,
-            "legend_size": "0",
-            "autoscale": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 88,
+                "y": 44,
+                "width": 47,
+                "height": 10
+            }
         },
         {
-            "board_id": "jzh-m57-fyf",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "Query Value",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Active connections",
-            "height": 8,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 7,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.connection.active{$host,$db}",
-                        "aggregator": "last",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_red",
-                                "value": null,
-                                "comparator": ">"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "value": null,
-                                "comparator": ">="
-                            },
-                            {
-                                "palette": "white_on_green",
-                                "value": null,
-                                "comparator": "<"
-                            }
-                        ]
+                        "aggregator": "last"
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Active connections",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
             },
-            "width": 23,
-            "add_timeframe": true,
-            "error": null,
-            "time": {},
-            "y": 44,
-            "x": 40,
-            "legend_size": "0",
-            "autoscale": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 40,
+                "y": 44,
+                "width": 23,
+                "height": 10
+            }
         },
         {
-            "board_id": "jzh-m57-fyf",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "Timeseries",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Established connections",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.connection.total{$host,$db}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "bars",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "bars",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Established connections",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 25,
-            "x": 40,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 40,
+                "y": 25,
+                "width": 47,
+                "height": 18
+            }
         },
         {
-            "board_id": "jzh-m57-fyf",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "Timeseries",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Deadlocks",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.lock.dead{$host,$db}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "bars",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "bars",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Deadlocks",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 61,
-            "x": 40,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 40,
+                "y": 61,
+                "width": 47,
+                "height": 18
+            }
         },
         {
-            "board_id": "jzh-m57-fyf",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "Query Value",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Average lock wait",
-            "height": 12,
-            "tile_def": {
-                "viz": "query_value",
+            "id": 10,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.lock.wait{$host,$db}",
-                        "aggregator": "last",
-                        "style": {
-                            "width": "normal",
-                            "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": null,
-                        "conditional_formats": [
-                            {
-                                "palette": "white_on_red",
-                                "value": null,
-                                "comparator": ">"
-                            },
-                            {
-                                "palette": "white_on_yellow",
-                                "value": null,
-                                "comparator": ">="
-                            },
-                            {
-                                "palette": "white_on_green",
-                                "value": null,
-                                "comparator": "<"
-                            }
-                        ]
+                        "aggregator": "last"
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Average lock wait",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 2
             },
-            "width": 19,
-            "add_timeframe": true,
-            "error": null,
-            "time": {},
-            "y": 15,
-            "x": 20,
-            "legend_size": "0",
-            "autoscale": true,
-            "type": "query_value",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 20,
+                "y": 15,
+                "width": 19,
+                "height": 14
+            }
         },
         {
-            "board_id": "jzh-m57-fyf",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "Timeseries",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Lock timeouts",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 11,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.lock.timeouts{$host,$db}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "bars",
                         "style": {
-                            "width": "normal",
                             "palette": "dog_classic",
-                            "type": "solid"
-                        },
-                        "type": "bars",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Lock timeouts",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 80,
-            "x": 40,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 40,
+                "y": 80,
+                "width": 47,
+                "height": 18
+            }
         },
         {
-            "height": 12,
-            "tick_pos": "50%",
-            "board_id": "xa5-hrs-4jx",
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "text_align": "left",
-            "bgcolor": "yellow",
-            "html": "This dashboard provides an example of metrics to monitor for IBM Db2. \n\nClone this dashboard in order to make modifications.",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "title_text": "",
-            "tick": false,
-            "scaleFactor": 1,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1556893005000,
-                "end": 1556893905000
+            "id": 12,
+            "definition": {
+                "type": "note",
+                "content": "This dashboard provides an example of metrics to monitor for IBM Db2. \n\nClone this dashboard in order to make modifications.",
+                "background_color": "yellow",
+                "font_size": "14",
+                "text_align": "left",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "top"
             },
-            "font_size": "14",
-            "generated_title": "Note",
-            "tick_edge": "top",
-            "y": 30,
-            "x": 0,
-            "width": 39
+            "layout": {
+                "x": 0,
+                "y": 30,
+                "width": 39,
+                "height": 12
+            }
         },
         {
-            "board_id": "xa5-hrs-4jx",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "ibm_db2.row.reads.total",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Active Connections",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.connection.max{$host,$db}, avg:ibm_db2.connection.active{$host,$db}",
-                        "aggregator": "avg",
+                        "display_type": "area",
                         "style": {
-                            "width": "normal",
                             "palette": "cool",
-                            "type": "solid"
-                        },
-                        "type": "area",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Active Connections",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 6,
-            "x": 40,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 40,
+                "y": 6,
+                "width": 47,
+                "height": 18
+            }
         },
         {
-            "board_id": "xa5-hrs-4jx",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "ibm_db2.row.reads.total",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Average Tablespace Usage",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 14,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.tablespace.usable{$host,$db}, avg:ibm_db2.tablespace.used{$host,$db}",
-                        "aggregator": "avg",
+                        "display_type": "area",
                         "style": {
-                            "width": "normal",
                             "palette": "cool",
-                            "type": "solid"
-                        },
-                        "type": "area",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Average Tablespace Usage",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 80,
-            "x": 88,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 88,
+                "y": 80,
+                "width": 47,
+                "height": 18
+            }
         },
         {
-            "board_id": "xa5-hrs-4jx",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "ibm_db2.row.reads.total",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Total Row Reads and Updates",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 15,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.row.modified.total{$host,$db}.as_count(), avg:ibm_db2.row.reads.total{$host,$db}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "cool",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Total Row Reads and Updates",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 44,
-            "x": 136,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 136,
+                "y": 44,
+                "width": 47,
+                "height": 18
+            }
         },
         {
-            "board_id": "xa5-hrs-4jx",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "ibm_db2.row.reads.total",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Log Utilization",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 16,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.log.available{$host,$db}, avg:ibm_db2.log.used{$host,$db}",
-                        "aggregator": "avg",
+                        "display_type": "area",
                         "style": {
-                            "width": "normal",
                             "palette": "cool",
-                            "type": "solid"
-                        },
-                        "type": "area",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Log Utilization",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 6,
-            "x": 88,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 88,
+                "y": 6,
+                "width": 47,
+                "height": 18
+            }
         },
         {
-            "board_id": "xa5-hrs-4jx",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "ibm_db2.row.reads.total",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Total Column Reads",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 17,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.bufferpool.column.reads.total{$host,$db}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "cool",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Total Column Reads",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 25,
-            "x": 136,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 136,
+                "y": 25,
+                "width": 47,
+                "height": 18
+            }
         },
         {
-            "board_id": "xa5-hrs-4jx",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "ibm_db2.row.reads.total",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Total Data Reads",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 18,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.bufferpool.data.reads.total{$host,$db}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "cool",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Total Data Reads",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 82,
-            "x": 136,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 136,
+                "y": 82,
+                "width": 47,
+                "height": 18
+            }
         },
         {
-            "board_id": "xa5-hrs-4jx",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "ibm_db2.row.reads.total",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Total Index Reads",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 19,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.bufferpool.index.reads.total{$host,$db}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "cool",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Total Index Reads",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 6,
-            "x": 136,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 136,
+                "y": 6,
+                "width": 47,
+                "height": 18
+            }
         },
         {
-            "board_id": "xa5-hrs-4jx",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "ibm_db2.row.reads.total",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Total XDA Reads",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 20,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.bufferpool.xda.reads.total{$host,$db}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "cool",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Total XDA Reads",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 63,
-            "x": 136,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 136,
+                "y": 63,
+                "width": 47,
+                "height": 18
+            }
         },
         {
-            "board_id": "xa5-hrs-4jx",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "ibm_db2.row.reads.total",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Log Reads and Writes",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 21,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.log.reads{$host,$db}.as_count(), avg:ibm_db2.log.writes{$host,$db}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "cool",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Log Reads and Writes",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 47,
-            "error": null,
-            "time": {},
-            "y": 25,
-            "x": 88,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 88,
+                "y": 25,
+                "width": 47,
+                "height": 18
+            }
         },
         {
-            "board_id": "xa5-hrs-4jx",
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1558390082705,
-                "end": 1558393682705
-            },
-            "generated_title": "ibm_db2.row.reads.total",
-            "title_size": 16,
-            "title": true,
-            "scaleFactor": 1,
-            "title_align": "left",
-            "title_text": "Total Bufferpool Reads",
-            "height": 16,
-            "tile_def": {
-                "viz": "timeseries",
+            "id": 22,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:ibm_db2.bufferpool.reads.total{$host,$db}.as_count()",
-                        "aggregator": "avg",
+                        "display_type": "line",
                         "style": {
-                            "width": "normal",
                             "palette": "cool",
-                            "type": "solid"
-                        },
-                        "type": "line",
-                        "conditional_formats": []
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "autoscale": true
+                "custom_links": [],
+                "title": "Total Bufferpool Reads",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "width": 39,
-            "error": null,
-            "time": {},
-            "y": 50,
-            "x": 0,
-            "legend_size": "0",
-            "add_timeframe": true,
-            "type": "timeseries",
-            "legend": false,
-            "isShared": false
+            "layout": {
+                "x": 0,
+                "y": 50,
+                "width": 39,
+                "height": 18
+            }
         },
         {
-            "height": 5,
-            "tick_pos": "50%",
-            "board_id": "xa5-hrs-4jx",
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "text_align": "center",
-            "bgcolor": "gray",
-            "html": "Connections",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "title_text": "",
-            "tick": true,
-            "scaleFactor": 1,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1554902282088,
-                "end": 1557494282088
+            "id": 23,
+            "definition": {
+                "type": "note",
+                "content": "Connections",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "font_size": "18",
-            "generated_title": "Note",
-            "tick_edge": "bottom",
-            "y": 0,
-            "x": 40,
-            "width": 47
+            "layout": {
+                "x": 40,
+                "y": 0,
+                "width": 47,
+                "height": 5
+            }
         },
         {
-            "height": 5,
-            "tick_pos": "50%",
-            "board_id": "xa5-hrs-4jx",
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "text_align": "center",
-            "bgcolor": "gray",
-            "html": "Lock Statistics",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "title_text": "",
-            "tick": true,
-            "scaleFactor": 1,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1554902282088,
-                "end": 1557494282088
+            "id": 24,
+            "definition": {
+                "type": "note",
+                "content": "Lock Statistics",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "font_size": "18",
-            "generated_title": "Note",
-            "tick_edge": "bottom",
-            "y": 55,
-            "x": 40,
-            "width": 47
+            "layout": {
+                "x": 40,
+                "y": 55,
+                "width": 47,
+                "height": 5
+            }
         },
         {
-            "height": 5,
-            "tick_pos": "50%",
-            "board_id": "xa5-hrs-4jx",
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "text_align": "center",
-            "bgcolor": "gray",
-            "html": "Log Statistics",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "title_text": "",
-            "tick": true,
-            "scaleFactor": 1,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1554902282088,
-                "end": 1557494282088
+            "id": 25,
+            "definition": {
+                "type": "note",
+                "content": "Log Statistics",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "font_size": "18",
-            "generated_title": "Note",
-            "tick_edge": "bottom",
-            "y": 0,
-            "x": 88,
-            "width": 47
+            "layout": {
+                "x": 88,
+                "y": 0,
+                "width": 47,
+                "height": 5
+            }
         },
         {
-            "height": 5,
-            "tick_pos": "50%",
-            "board_id": "xa5-hrs-4jx",
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "text_align": "center",
-            "bgcolor": "gray",
-            "html": "Tablespace",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "title_text": "",
-            "tick": true,
-            "scaleFactor": 1,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1554902282088,
-                "end": 1557494282088
+            "id": 26,
+            "definition": {
+                "type": "note",
+                "content": "Tablespace",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "font_size": "18",
-            "generated_title": "Note",
-            "tick_edge": "bottom",
-            "y": 55,
-            "x": 88,
-            "width": 47
+            "layout": {
+                "x": 88,
+                "y": 55,
+                "width": 47,
+                "height": 5
+            }
         },
         {
-            "height": 5,
-            "tick_pos": "50%",
-            "board_id": "xa5-hrs-4jx",
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "text_align": "center",
-            "bgcolor": "gray",
-            "html": "Reads/Writes",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "title_text": "",
-            "tick": true,
-            "scaleFactor": 1,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1554902282088,
-                "end": 1557494282088
+            "id": 27,
+            "definition": {
+                "type": "note",
+                "content": "Reads/Writes",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "font_size": "18",
-            "generated_title": "Note",
-            "tick_edge": "bottom",
-            "y": 0,
-            "x": 136,
-            "width": 47
+            "layout": {
+                "x": 136,
+                "y": 0,
+                "width": 47,
+                "height": 5
+            }
         },
         {
-            "height": 5,
-            "tick_pos": "50%",
-            "board_id": "xa5-hrs-4jx",
-            "title_size": 16,
-            "title": true,
-            "title_align": "left",
-            "text_align": "center",
-            "bgcolor": "gray",
-            "html": "Bufferpool",
-            "type": "note",
-            "isShared": false,
-            "refresh_every": 30000,
-            "auto_refresh": false,
-            "title_text": "",
-            "tick": true,
-            "scaleFactor": 1,
-            "add_timeframe": true,
-            "globalTimeframe": {
-                "isLive": true,
-                "start": 1554902282088,
-                "end": 1557494282088
+            "id": 28,
+            "definition": {
+                "type": "note",
+                "content": "Bufferpool",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "font_size": "18",
-            "generated_title": "Note",
-            "tick_edge": "bottom",
-            "y": 44,
-            "x": 0,
-            "width": 39
+            "layout": {
+                "x": 0,
+                "y": 44,
+                "width": 39,
+                "height": 5
+            }
         }
     ],
-    "disableCog": false,
-    "id": 689417,
-    "disableEditing": false
+    "template_variables": [
+        {
+            "name": "host",
+            "default": "*",
+            "prefix": "host"
+        },
+        {
+            "name": "db",
+            "default": "*",
+            "prefix": "db"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30274
 }

--- a/ignite/assets/dashboards/ignite_overview.json
+++ b/ignite/assets/dashboards/ignite_overview.json
@@ -1,851 +1,918 @@
 {
-  "board_title": "Ignite Overview",
-  "read_only": false,
-  "description": "## Ignite\n\nThis dashboard provides a high-level overview of your Ignite instances so you can monitor metrics related to memory statistics and workers, storage, and network.\n\n- [Official integration docs](https://docs.datadoghq.com/integrations/ignite/)\n- See [Ignite documentation](https://ignite.apache.org/) for more information\n\nClone this template to make changes and add your own graphs and widgets. (cloned)",
-  "created": "2020-06-26T20:00:04.068440+00:00",
-  "new_id": "968-mhs-ck5",
-  "modified": "2020-07-07T14:24:56.744124+00:00",
-  "created_by": {
-    "disabled": false,
-    "handle": "mallory.mooney@datadoghq.com",
-    "name": "Mallory Mooney",
-    "title": null,
-    "is_admin": false,
-    "role": null,
-    "access_role": "st",
-    "verified": true,
-    "email": "mallory.mooney@datadoghq.com",
-    "icon": "https://secure.gravatar.com/avatar/d3371ccb820d39ee0dc8b112488d6553?s=48&d=retro"
-  },
-  "template_variables": [
-    {
-      "default": "*",
-      "prefix": "host",
-      "name": "host"
-    },
-    {
-      "default": "*",
-      "prefix": "instance",
-      "name": "instance"
-    }
-  ],
-  "widgets": [
-    {
-      "sizing": "zoom",
-      "y": 1,
-      "width": 36,
-      "url": "https://static.datadoghq.com/static/images/saas_logos/bot/ignite@2x.png",
-      "x": 1,
-      "type": "image",
-      "height": 13
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Total GETs",
-      "height": 13,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:ignite.cache.gets{$host,$instance}.as_count()",
-            "aggregator": "avg"
-          }
-        ],
-        "custom_links": [],
-        "precision": 0
-      },
-      "width": 17,
-      "y": 38,
-      "x": 146,
-      "type": "query_value"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Current heap size used",
-      "height": 15,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ignite.heap_memory_used{$host,$instance}",
-            "style": {
-              "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
+    "title": "Ignite Overview",
+    "description": "## Ignite\n\nThis dashboard provides a high-level overview of your Ignite instances so you can monitor metrics related to memory statistics and workers, storage, and network.\n\n- [Official integration docs](https://docs.datadoghq.com/integrations/ignite/)\n- See [Ignite documentation](https://ignite.apache.org/) for more information\n\nClone this template to make changes and add your own graphs and widgets. (cloned)",
+    "widgets": [
+        {
+            "id": 0,
+            "definition": {
+                "type": "image",
+                "url": "https://static.datadoghq.com/static/images/saas_logos/bot/ignite@2x.png",
+                "sizing": "zoom"
             },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 71,
-      "y": 92,
-      "x": 38,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Current non-heap memory size used",
-      "height": 15,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ignite.non_heap_memory_used{$host,$instance}",
-            "style": {
-              "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 71,
-      "y": 74,
-      "x": 38,
-      "legend_size": "0",
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Number of pages in physical RAM",
-      "height": 15,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ignite.physical_memory_pages{$host,$instance}",
-            "style": {
-              "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 71,
-      "y": 38,
-      "x": 38,
-      "legend_size": "0",
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Maximum memory size by region",
-      "height": 15,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ignite.max_memory_size{$host,$instance} by {region}",
-            "style": {
-              "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 71,
-      "y": 56,
-      "x": 38,
-      "legend_size": "0",
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Total number of threads in the pool",
-      "height": 15,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:ignite.threads.pool_size{$host,$instance}",
-            "style": {
-              "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 71,
-      "y": 139,
-      "x": 38,
-      "legend_size": "0",
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Number of completed vs incomplete tasks",
-      "height": 15,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:ignite.threads.completed_tasks{$host,$instance}.as_count(), sum:ignite.threads.tasks{$host,$instance}.as_count()-sum:ignite.threads.completed_tasks{$host,$instance}.as_count()",
-            "style": {
-              "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "area"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 71,
-      "y": 157,
-      "x": 38,
-      "legend_size": "0",
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Total number of active threads",
-      "height": 15,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "sum:ignite.threads.active{$host,$instance}",
-            "style": {
-              "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 71,
-      "y": 121,
-      "x": 38,
-      "legend_size": "0",
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Total PUTs",
-      "height": 13,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:ignite.cache.puts{$host,$instance}.as_count()",
-            "aggregator": "avg"
-          }
-        ],
-        "custom_links": [],
-        "precision": 0
-      },
-      "width": 17,
-      "y": 38,
-      "x": 164,
-      "type": "query_value"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Average GET time",
-      "height": 15,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ignite.cache.average_get_time{$host,$instance}",
-            "style": {
-              "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 71,
-      "y": 90,
-      "x": 110,
-      "legend_size": "0",
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Average PUT time",
-      "height": 15,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ignite.cache.average_put_time{$host,$instance}",
-            "style": {
-              "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 71,
-      "y": 108,
-      "x": 110,
-      "legend_size": "0",
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Transaction committed queue size",
-      "height": 15,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ignite.cache.commit_queue_size{$host,$instance}",
-            "style": {
-              "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 71,
-      "y": 54,
-      "x": 110,
-      "legend_size": "0",
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Total partitions",
-      "height": 13,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:ignite.cache.total_partitions{$host,$instance}",
-            "aggregator": "avg"
-          }
-        ],
-        "custom_links": [],
-        "precision": 0
-      },
-      "width": 17,
-      "y": 38,
-      "x": 128,
-      "type": "query_value"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Total backups",
-      "height": 13,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:ignite.cache.backups{$host,$instance}",
-            "aggregator": "avg"
-          }
-        ],
-        "custom_links": [],
-        "precision": 0
-      },
-      "width": 17,
-      "y": 38,
-      "x": 110,
-      "type": "query_value"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Number of partitions in state MOVING",
-      "height": 15,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ignite.cache.cluster_moving_partitions{$instance,$host} by {host}",
-            "style": {
-              "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
-            },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "right_yaxis": {
-          "max": "auto",
-          "include_zero": true,
-          "scale": "linear",
-          "min": "auto",
-          "label": ""
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 36,
+                "height": 13
+            }
         },
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
-        }
-      },
-      "width": 71,
-      "y": 72,
-      "x": 110,
-      "legend_size": "0",
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Total pages read",
-      "height": 13,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:ignite.pages_read{$host,$instance}.as_count()",
-            "aggregator": "avg"
-          }
-        ],
-        "custom_links": [],
-        "precision": 0
-      },
-      "width": 17,
-      "y": 11,
-      "x": 146,
-      "type": "query_value"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Number of pages in memory not synchronized",
-      "height": 13,
-      "tile_def": {
-        "viz": "timeseries",
-        "requests": [
-          {
-            "q": "avg:ignite.dirty_pages{$host,$instance}",
-            "style": {
-              "palette": "dog_classic",
-              "width": "normal",
-              "type": "solid"
+        {
+            "id": 1,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:ignite.cache.gets{$host,$instance}.as_count()",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Total GETs",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "type": "line"
-          }
-        ],
-        "custom_links": [],
-        "right_yaxis": {
-          "max": "auto",
-          "include_zero": true,
-          "scale": "linear",
-          "min": "auto",
-          "label": ""
+            "layout": {
+                "x": 146,
+                "y": 38,
+                "width": 17,
+                "height": 15
+            }
         },
-        "yaxis": {
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "label": "",
-          "includeZero": true
+        {
+            "id": 2,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ignite.heap_memory_used{$host,$instance}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Current heap size used",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 38,
+                "y": 92,
+                "width": 71,
+                "height": 17
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ignite.non_heap_memory_used{$host,$instance}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Current non-heap memory size used",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 38,
+                "y": 74,
+                "width": 71,
+                "height": 17
+            }
+        },
+        {
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ignite.physical_memory_pages{$host,$instance}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Number of pages in physical RAM",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 38,
+                "y": 38,
+                "width": 71,
+                "height": 17
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ignite.max_memory_size{$host,$instance} by {region}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Maximum memory size by region",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 38,
+                "y": 56,
+                "width": 71,
+                "height": 17
+            }
+        },
+        {
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:ignite.threads.pool_size{$host,$instance}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Total number of threads in the pool",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 38,
+                "y": 139,
+                "width": 71,
+                "height": 17
+            }
+        },
+        {
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:ignite.threads.completed_tasks{$host,$instance}.as_count(), sum:ignite.threads.tasks{$host,$instance}.as_count()-sum:ignite.threads.completed_tasks{$host,$instance}.as_count()",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Number of completed vs incomplete tasks",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 38,
+                "y": 157,
+                "width": 71,
+                "height": 17
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:ignite.threads.active{$host,$instance}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Total number of active threads",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 38,
+                "y": 121,
+                "width": 71,
+                "height": 17
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:ignite.cache.puts{$host,$instance}.as_count()",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Total PUTs",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 164,
+                "y": 38,
+                "width": 17,
+                "height": 15
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ignite.cache.average_get_time{$host,$instance}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average GET time",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 110,
+                "y": 90,
+                "width": 71,
+                "height": 17
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ignite.cache.average_put_time{$host,$instance}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average PUT time",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 110,
+                "y": 108,
+                "width": 71,
+                "height": 17
+            }
+        },
+        {
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ignite.cache.commit_queue_size{$host,$instance}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Transaction committed queue size",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 110,
+                "y": 54,
+                "width": 71,
+                "height": 17
+            }
+        },
+        {
+            "id": 13,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:ignite.cache.total_partitions{$host,$instance}",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Total partitions",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 128,
+                "y": 38,
+                "width": 17,
+                "height": 15
+            }
+        },
+        {
+            "id": 14,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:ignite.cache.backups{$host,$instance}",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Total backups",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 110,
+                "y": 38,
+                "width": 17,
+                "height": 15
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ignite.cache.cluster_moving_partitions{$instance,$host} by {host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "Number of partitions in state MOVING",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 110,
+                "y": 72,
+                "width": 71,
+                "height": 17
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:ignite.pages_read{$host,$instance}.as_count()",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Total pages read",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 146,
+                "y": 11,
+                "width": 17,
+                "height": 15
+            }
+        },
+        {
+            "id": 17,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:ignite.dirty_pages{$host,$instance}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "Number of pages in memory not synchronized",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 110,
+                "y": 11,
+                "width": 35,
+                "height": 15
+            }
+        },
+        {
+            "id": 18,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:ignite.jobs.active.current{$host,$instance}",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Current active",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 38,
+                "y": 11,
+                "width": 17,
+                "height": 15
+            }
+        },
+        {
+            "id": 19,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:ignite.jobs.executed.total{$host,$instance}.as_count()",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Total executed",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 56,
+                "y": 11,
+                "width": 17,
+                "height": 15
+            }
+        },
+        {
+            "id": 20,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:ignite.jobs.wait_time.average{$host,$instance}",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Average wait time",
+                "title_size": "16",
+                "title_align": "left",
+                "custom_unit": "sec",
+                "precision": 0
+            },
+            "layout": {
+                "x": 74,
+                "y": 11,
+                "width": 17,
+                "height": 15
+            }
+        },
+        {
+            "id": 21,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:ignite.pages_written{$host,$instance}.as_count()",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Total pages written",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 164,
+                "y": 11,
+                "width": 17,
+                "height": 15
+            }
+        },
+        {
+            "id": 22,
+            "definition": {
+                "type": "note",
+                "content": "With this dashboard, you can get a high-level view of your Apache Ignite deployments and troubleshoot performance issues, including:\n\n- when a node goes offline or is kicked out of a cluster\n- unresponsive applications due to insufficient heap space on a node\n- drops in cache size, resulting in data loss\n- page write throttling\n\nTo learn more about our Ignite integration, see:\n\n- Our [official integration documentation](https://docs.datadoghq.com/integrations/ignite)\n- Our [blog post](https://www.datadoghq.com/blog/monitor-apache-ignite-with-datadog)\n\nYou can clone this dashboard, copy and paste widgets from other out-of-the-box dashboards, and create your own visualizations for your custom applications.",
+                "background_color": "white",
+                "font_size": "18",
+                "text_align": "left",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "left"
+            },
+            "layout": {
+                "x": 1,
+                "y": 15,
+                "width": 36,
+                "height": 45
+            }
+        },
+        {
+            "id": 23,
+            "definition": {
+                "type": "note",
+                "content": "# Memory\nThese metrics show memory usage across Ignite clusters",
+                "background_color": "blue",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 38,
+                "y": 27,
+                "width": 71,
+                "height": 10
+            }
+        },
+        {
+            "id": 24,
+            "definition": {
+                "type": "note",
+                "content": "# Threads\nThese metrics show data for node thread pools ",
+                "background_color": "blue",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 38,
+                "y": 110,
+                "width": 71,
+                "height": 10
+            }
+        },
+        {
+            "id": 25,
+            "definition": {
+                "type": "note",
+                "content": "# Cache\nThese metrics represent the distributed cache for Ignite nodes",
+                "background_color": "blue",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 110,
+                "y": 27,
+                "width": 71,
+                "height": 10
+            }
+        },
+        {
+            "id": 26,
+            "definition": {
+                "type": "note",
+                "content": "A node’s health can be affected by increases in heap space usage such as inefficient SQL queries that return large result sets. You can optimize the queries that are consuming the most memory by splitting them up into smaller ones or using lazy queries.",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 1,
+                "y": 84,
+                "width": 35,
+                "height": 19
+            }
+        },
+        {
+            "id": 27,
+            "definition": {
+                "type": "note",
+                "content": "A sudden drop in cache size could be an indicator that memory was lost when a node was restarted. This can happen if there are no available backups. ",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "left"
+            },
+            "layout": {
+                "x": 184,
+                "y": 48,
+                "width": 31,
+                "height": 14
+            }
+        },
+        {
+            "id": 28,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:ignite.jobs.rejected.current{$host,$instance}",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Current rejected jobs",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 92,
+                "y": 11,
+                "width": 17,
+                "height": 15
+            }
+        },
+        {
+            "id": 29,
+            "definition": {
+                "type": "note",
+                "content": "# Job Summary\n",
+                "background_color": "vivid_blue",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 38,
+                "y": 1,
+                "width": 71,
+                "height": 9
+            }
+        },
+        {
+            "id": 30,
+            "definition": {
+                "type": "note",
+                "content": "# Page Summary\n",
+                "background_color": "vivid_blue",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 110,
+                "y": 1,
+                "width": 71,
+                "height": 9
+            }
+        },
+        {
+            "id": 31,
+            "definition": {
+                "type": "note",
+                "content": "Periodically, Ignite starts a checkpointing process to sync dirty pages between RAM and specific partition files on disk to ensure pages are up to date and free up disk space.\n\nIf there is an issue, you may see a spike in pages that are not synchronized, and the number of page writes may drop to zero. This could halt any update operations until Ignite can successfully complete the checkpointing process.\n",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "left"
+            },
+            "layout": {
+                "x": 184,
+                "y": 1,
+                "width": 31,
+                "height": 30
+            }
+        },
+        {
+            "id": 32,
+            "definition": {
+                "type": "note",
+                "content": "Ignite uses a variety of thread pools to efficiently manage cache, compute grid, query, and other critical processes. By default, Ignite will automatically manage the number of threads in each of these pools.\n\nMonitoring thread activity ensures there are enough threads in a pool to process incoming jobs and not block I/O operations.",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 1,
+                "y": 128,
+                "width": 35,
+                "height": 25
+            }
+        },
+        {
+            "id": 33,
+            "definition": {
+                "type": "note",
+                "content": "Ignite uses cache partitions by default, which divides data into partitions that are equally distributed across nodes. Partitions are rebalanced automatically as nodes are added or removed from a cluster, known as affinity colocation.\n\nYou can monitor the state of your rebalanced partitions to ensure they are evenly distributed across participating nodes. If not, tuning the affinity function may be needed.\n\n",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "left"
+            },
+            "layout": {
+                "x": 184,
+                "y": 69,
+                "width": 31,
+                "height": 30
+            }
         }
-      },
-      "width": 35,
-      "y": 11,
-      "x": 110,
-      "type": "timeseries",
-      "legend": false
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Current active",
-      "height": 13,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:ignite.jobs.active.current{$host,$instance}",
-            "aggregator": "avg"
-          }
-        ],
-        "custom_links": [],
-        "precision": 0
-      },
-      "width": 17,
-      "y": 11,
-      "x": 38,
-      "type": "query_value"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Total executed",
-      "height": 13,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:ignite.jobs.executed.total{$host,$instance}.as_count()",
-            "aggregator": "avg"
-          }
-        ],
-        "custom_links": [],
-        "precision": 0
-      },
-      "width": 17,
-      "y": 11,
-      "x": 56,
-      "type": "query_value"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Average wait time",
-      "height": 13,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:ignite.jobs.wait_time.average{$host,$instance}",
-            "aggregator": "avg"
-          }
-        ],
-        "custom_links": [],
-        "precision": 0,
-        "custom_unit": "sec"
-      },
-      "width": 17,
-      "y": 11,
-      "x": 74,
-      "type": "query_value"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Total pages written",
-      "height": 13,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:ignite.pages_written{$host,$instance}.as_count()",
-            "aggregator": "avg"
-          }
-        ],
-        "custom_links": [],
-        "precision": 0
-      },
-      "width": 17,
-      "y": 11,
-      "x": 164,
-      "type": "query_value"
-    },
-    {
-      "font_size": "18",
-      "width": 36,
-      "tick_pos": "50%",
-      "tick_edge": "left",
-      "text_align": "left",
-      "height": 45,
-      "bgcolor": "white",
-      "html": "With this dashboard, you can get a high-level view of your Apache Ignite deployments and troubleshoot performance issues, including:\n\n- when a node goes offline or is kicked out of a cluster\n- unresponsive applications due to insufficient heap space on a node\n- drops in cache size, resulting in data loss\n- page write throttling\n\nTo learn more about our Ignite integration, see:\n\n- Our [official integration documentation](https://docs.datadoghq.com/integrations/ignite)\n- Our [blog post](https://www.datadoghq.com/blog/monitor-apache-ignite-with-datadog)\n\nYou can clone this dashboard, copy and paste widgets from other out-of-the-box dashboards, and create your own visualizations for your custom applications.",
-      "y": 15,
-      "x": 1,
-      "tick": false,
-      "type": "note"
-    },
-    {
-      "font_size": "18",
-      "width": 71,
-      "tick_pos": "50%",
-      "tick_edge": "bottom",
-      "text_align": "center",
-      "height": 10,
-      "bgcolor": "blue",
-      "html": "# Memory\nThese metrics show memory usage across Ignite clusters",
-      "y": 27,
-      "x": 38,
-      "tick": false,
-      "type": "note"
-    },
-    {
-      "font_size": "18",
-      "width": 71,
-      "tick_pos": "50%",
-      "tick_edge": "bottom",
-      "text_align": "center",
-      "height": 10,
-      "bgcolor": "blue",
-      "html": "# Threads\nThese metrics show data for node thread pools ",
-      "y": 110,
-      "x": 38,
-      "tick": false,
-      "type": "note"
-    },
-    {
-      "font_size": "18",
-      "width": 71,
-      "tick_pos": "50%",
-      "tick_edge": "bottom",
-      "text_align": "center",
-      "height": 10,
-      "bgcolor": "blue",
-      "html": "# Cache\nThese metrics represent the distributed cache for Ignite nodes",
-      "y": 27,
-      "x": 110,
-      "tick": false,
-      "type": "note"
-    },
-    {
-      "font_size": "18",
-      "width": 35,
-      "tick_pos": "50%",
-      "tick_edge": "right",
-      "text_align": "left",
-      "height": 19,
-      "bgcolor": "gray",
-      "html": "A node\u2019s health can be affected by increases in heap space usage such as inefficient SQL queries that return large result sets. You can optimize the queries that are consuming the most memory by splitting them up into smaller ones or using lazy queries.",
-      "y": 84,
-      "x": 1,
-      "tick": true,
-      "type": "note"
-    },
-    {
-      "font_size": "18",
-      "width": 31,
-      "tick_pos": "50%",
-      "tick_edge": "left",
-      "text_align": "left",
-      "height": 14,
-      "bgcolor": "gray",
-      "html": "A sudden drop in cache size could be an indicator that memory was lost when a node was restarted. This can happen if there are no available backups. ",
-      "y": 48,
-      "x": 184,
-      "tick": true,
-      "type": "note"
-    },
-    {
-      "title_size": 16,
-      "title": true,
-      "title_align": "left",
-      "title_text": "Current rejected jobs",
-      "height": 13,
-      "tile_def": {
-        "viz": "query_value",
-        "requests": [
-          {
-            "q": "avg:ignite.jobs.rejected.current{$host,$instance}",
-            "aggregator": "avg"
-          }
-        ],
-        "custom_links": [],
-        "precision": 0
-      },
-      "width": 17,
-      "y": 11,
-      "x": 92,
-      "type": "query_value"
-    },
-    {
-      "font_size": "16",
-      "width": 71,
-      "tick_pos": "50%",
-      "tick_edge": "bottom",
-      "text_align": "center",
-      "height": 9,
-      "bgcolor": "vivid_blue",
-      "html": "# Job Summary\n",
-      "y": 1,
-      "x": 38,
-      "tick": false,
-      "type": "note"
-    },
-    {
-      "font_size": "16",
-      "width": 71,
-      "tick_pos": "50%",
-      "tick_edge": "bottom",
-      "text_align": "center",
-      "height": 9,
-      "bgcolor": "vivid_blue",
-      "html": "# Page Summary\n",
-      "y": 1,
-      "x": 110,
-      "tick": false,
-      "type": "note"
-    },
-    {
-      "font_size": "18",
-      "width": 31,
-      "tick_pos": "50%",
-      "tick_edge": "left",
-      "text_align": "left",
-      "height": 30,
-      "bgcolor": "gray",
-      "html": "Periodically, Ignite starts a checkpointing process to sync dirty pages between RAM and specific partition files on disk to ensure pages are up to date and free up disk space.\n\nIf there is an issue, you may see a spike in pages that are not synchronized, and the number of page writes may drop to zero. This could halt any update operations until Ignite can successfully complete the checkpointing process.\n",
-      "y": 1,
-      "x": 184,
-      "tick": true,
-      "type": "note"
-    },
-    {
-      "font_size": "18",
-      "width": 35,
-      "tick_pos": "50%",
-      "tick_edge": "right",
-      "text_align": "left",
-      "height": 25,
-      "bgcolor": "gray",
-      "html": "Ignite uses a variety of thread pools to efficiently manage cache, compute grid, query, and other critical processes. By default, Ignite will automatically manage the number of threads in each of these pools.\n\nMonitoring thread activity ensures there are enough threads in a pool to process incoming jobs and not block I/O operations.",
-      "y": 128,
-      "x": 1,
-      "tick": true,
-      "type": "note"
-    },
-    {
-      "font_size": "18",
-      "width": 31,
-      "tick_pos": "50%",
-      "tick_edge": "left",
-      "text_align": "left",
-      "height": 30,
-      "bgcolor": "gray",
-      "html": "Ignite uses cache partitions by default, which divides data into partitions that are equally distributed across nodes. Partitions are rebalanced automatically as nodes are added or removed from a cluster, known as affinity colocation.\n\nYou can monitor the state of your rebalanced partitions to ensure they are evenly distributed across participating nodes. If not, tuning the affinity function may be needed.\n\n",
-      "y": 69,
-      "x": 184,
-      "tick": true,
-      "type": "note"
-    }
-  ],
-  "id": 65996
+    ],
+    "template_variables": [
+        {
+            "name": "host",
+            "default": "*",
+            "prefix": "host"
+        },
+        {
+            "name": "instance",
+            "default": "*",
+            "prefix": "instance"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30334
 }

--- a/istio/assets/dashboards/istio_1_5_overview.json
+++ b/istio/assets/dashboards/istio_1_5_overview.json
@@ -1,943 +1,983 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "Istio overview (v1.5+)",
-    "created": "2020-08-17T14:59:00.345556+00:00",
-    "created_by": {
-        "access_role": "adm",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": true,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "Istio overview (v1.5+)",
     "description": "### Istio\n\nNote: This dashboard outlines new metrics from Istio `v1.5+.\n\n- [What is Istio](https://istio.io/docs/concepts/what-is-istio/)?\n- [Istiod](https://istio.io/docs/ops/deployment/architecture/)\n- [Envoy](https://istio.io/docs/concepts/what-is-istio/#envoy), a high performance proxy.\n    - XDS = Envoy management APIs that can be implemented by backend servers. \n        - These APIs support:\n            - Cluster discovery service (CDS)\n            - Route discovery service (RDS)\n            - Endpoint discovery service (EDS)\n            - Listener discovery service (LDS)",
-    "id": 1285907,
-    "modified": "2020-08-17T15:50:21.941036+00:00",
-    "new_id": "p8q-mi5-mks",
-    "read_only": false,
-    "template_variables": [
-        {
-            "default": "*",
-            "name": "cluster",
-            "prefix": "cluster_name"
-        }
-    ],
     "widgets": [
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "istiod resource usage",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 80,
-            "x": 109,
-            "y": 0
+            "id": 0,
+            "definition": {
+                "type": "note",
+                "content": "istiod resource usage",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 109,
+                "y": 0,
+                "width": 80,
+                "height": 5
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Mesh metrics",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 40,
-            "x": 14,
-            "y": 0
+            "id": 1,
+            "definition": {
+                "type": "note",
+                "content": "Mesh metrics",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 14,
+                "y": 0,
+                "width": 40,
+                "height": 5
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 2,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "top(avg:istio.mesh.request.count{$cluster} by {host}, 10, 'mean', 'desc')",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Request count",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Request count",
-            "type": "timeseries",
-            "width": 26,
-            "x": 1,
-            "y": 21
+            "layout": {
+                "x": 1,
+                "y": 21,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "tile_def": {
-                "custom_links": [],
+            "id": 3,
+            "definition": {
+                "type": "toplist",
                 "requests": [
                     {
                         "q": "top(top(avg:istio.mesh.request.duration.milliseconds.sum{$cluster} by {host}, 10, 'mean', 'desc')/top(avg:istio.mesh.request.duration.milliseconds.count{$cluster} by {host}, 10, 'mean', 'desc'),10,'mean','desc')"
                     }
                 ],
-                "viz": "toplist"
+                "custom_links": [],
+                "title": "Average request latency by host",
+                "title_size": "16",
+                "title_align": "center"
             },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Average request latency by host",
-            "type": "toplist",
-            "width": 53,
-            "x": 1,
-            "y": 6
+            "layout": {
+                "x": 1,
+                "y": 6,
+                "width": 53,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "top(avg:istio.mesh.response.size.sum{$cluster}, 10, 'mean', 'desc')/top(avg:istio.mesh.response.size.count{$cluster}, 10, 'mean', 'desc')",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries"
+                "custom_links": [],
+                "title": "Average response size",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Average response size",
-            "type": "timeseries",
-            "width": 26,
-            "x": 28,
-            "y": 36
+            "layout": {
+                "x": 28,
+                "y": 36,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "top(avg:istio.go.threads{$cluster}, 10, 'mean', 'desc')",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "thin"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "thin"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Number of OS threads created",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Number of OS threads created",
-            "type": "timeseries",
-            "width": 26,
-            "x": 163,
-            "y": 51
+            "layout": {
+                "x": 163,
+                "y": 51,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "top(avg:istio.go.memstats.alloc_bytes{$cluster}, 10, 'mean', 'desc')",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Memory allocated",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Memory allocated",
-            "type": "timeseries",
-            "width": 53,
-            "x": 109,
-            "y": 6
+            "layout": {
+                "x": 109,
+                "y": 6,
+                "width": 53,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "(top(avg:istio.go.memstats.heap_inuse_bytes{$cluster}, 10, 'mean', 'desc')/top(avg:istio.go.memstats.heap_alloc_bytes{$cluster}, 10, 'mean', 'desc'))*100",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "thin"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "thin"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Heap in use (percent)",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Heap in use (percent)",
-            "type": "timeseries",
-            "width": 26,
-            "x": 163,
-            "y": 6
+            "layout": {
+                "x": 163,
+                "y": 6,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "top(avg:istio.go.memstats.gc_cpu_fraction{$cluster}, 10, 'mean', 'desc')",
+                        "display_type": "area",
                         "style": {
                             "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "CPU required for GC",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "CPU required for GC",
-            "type": "timeseries",
-            "width": 26,
-            "x": 136,
-            "y": 36
+            "layout": {
+                "x": 136,
+                "y": 36,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "top(avg:istio.go.gc_duration_seconds.sum{$cluster}, 10, 'mean', 'desc')/top(avg:istio.go.gc_duration_seconds.count{$cluster}, 10, 'mean', 'desc')",
+                        "display_type": "area",
                         "style": {
                             "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Average GC duration",
-            "type": "timeseries",
-            "width": 26,
-            "x": 109,
-            "y": 36
-        },
-        {
-            "height": 5,
-            "sizing": "fit",
-            "type": "image",
-            "url": "https://s3.amazonaws.com/dd-integrations/istio/configuration/tile/logo.png",
-            "width": 12,
-            "x": 1,
-            "y": 0
-        },
-        {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
                 "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average GC duration",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 109,
+                "y": 36,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "image",
+                "url": "https://s3.amazonaws.com/dd-integrations/istio/configuration/tile/logo.png",
+                "sizing": "fit"
+            },
+            "layout": {
+                "x": 1,
+                "y": 0,
+                "width": 12,
+                "height": 5
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "top(avg:istio.grpc.server.msg_sent_total{$cluster}.as_count(), 10, 'mean', 'desc'), top(avg:istio.grpc.server.msg_received_total{$cluster}.as_count(), 10, 'mean', 'desc')",
+                        "display_type": "area",
                         "style": {
                             "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "GRPC messages sent/received by host",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "GRPC messages sent/received by host",
-            "type": "timeseries",
-            "width": 26,
-            "x": 136,
-            "y": 21
+            "layout": {
+                "x": 136,
+                "y": 21,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "tile_def": {
+            "id": 12,
+            "definition": {
+                "type": "toplist",
                 "requests": [
                     {
                         "q": "top(avg:istio.go.gc_duration_seconds.sum{$cluster} by {host}, 10, 'mean', 'desc')"
                     }
                 ],
-                "viz": "toplist"
+                "custom_links": [],
+                "title": "Hosts with the highest GC time",
+                "title_size": "16",
+                "title_align": "center"
             },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Hosts with the highest GC time",
-            "type": "toplist",
-            "width": 53,
-            "x": 109,
-            "y": 51
+            "layout": {
+                "x": 109,
+                "y": 51,
+                "width": 53,
+                "height": 14
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "xDS metrics",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 53,
-            "x": 55,
-            "y": 0
+            "id": 13,
+            "definition": {
+                "type": "note",
+                "content": "xDS metrics",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 55,
+                "y": 0,
+                "width": 53,
+                "height": 5
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 14,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:istio.pilot.xds{$cluster}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "xDS connected endpoints",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "xDS connected endpoints",
-            "type": "timeseries",
-            "width": 26,
-            "x": 55,
-            "y": 6
+            "layout": {
+                "x": 55,
+                "y": 6,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 15,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
-                        "on_right_yaxis": false,
                         "q": "sum:istio.pilot.xds.pushes{$cluster} by {type}",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
+                            "line_type": "solid",
+                            "line_width": "normal"
                         },
-                        "type": "bars"
+                        "on_right_yaxis": false
                     }
                 ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "xDS pushes per API (including errors)",
-            "type": "timeseries",
-            "width": 26,
-            "x": 82,
-            "y": 6
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Configuration validation metrics",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 53,
-            "x": 55,
-            "y": 51
-        },
-        {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
                 "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "xDS pushes per API (including errors)",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 82,
+                "y": 6,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "note",
+                "content": "Configuration validation metrics",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 55,
+                "y": 51,
+                "width": 53,
+                "height": 5
+            }
+        },
+        {
+            "id": 17,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:istio.galley.endpoint_no_pod{$cluster}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries"
+                "custom_links": [],
+                "title": "Endpoints without a pod",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Endpoints without a pod",
-            "type": "timeseries",
-            "width": 26,
-            "x": 55,
-            "y": 57
+            "layout": {
+                "x": 55,
+                "y": 57,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 18,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:istio.process.max_fds{$cluster}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Max # of file descriptors",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Max # of file descriptors",
-            "type": "timeseries",
-            "width": 26,
-            "x": 163,
-            "y": 36
+            "layout": {
+                "x": 163,
+                "y": 36,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 19,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:istio.process.virtual_memory_bytes{$cluster}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Virtual memory size",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Virtual memory size",
-            "type": "timeseries",
-            "width": 26,
-            "x": 163,
-            "y": 21
+            "layout": {
+                "x": 163,
+                "y": 21,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "tile_def": {
+            "id": 20,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:istio.pilot.proxy_convergence_time.sum{$cluster}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "xDS proxy convergence time",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "xDS proxy convergence time",
-            "type": "timeseries",
-            "width": 26,
-            "x": 55,
-            "y": 21
+            "layout": {
+                "x": 55,
+                "y": 21,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 21,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
-                        "on_right_yaxis": false,
                         "q": "avg:istio.sidecar_injection.requests_total{$cluster}.as_count()",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
+                            "line_type": "solid",
+                            "line_width": "normal"
                         },
-                        "type": "bars"
+                        "on_right_yaxis": false
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Total sidecar injection requests",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Total sidecar injection requests",
-            "type": "timeseries",
-            "width": 26,
-            "x": 1,
-            "y": 57
+            "layout": {
+                "x": 1,
+                "y": 57,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 22,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:istio.galley.validation.failed{$cluster}.as_count()",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Total failed configuration validations",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Total failed configuration validations",
-            "type": "timeseries",
-            "width": 26,
-            "x": 82,
-            "y": 57
+            "layout": {
+                "x": 82,
+                "y": 57,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 23,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
-                        "on_right_yaxis": false,
                         "q": "avg:istio.sidecar_injection.requests_total{$cluster}.as_count()-avg:istio.sidecar_injection.success_total{$cluster}.as_count()",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
+                            "line_type": "solid",
+                            "line_width": "normal"
                         },
-                        "type": "bars"
+                        "on_right_yaxis": false
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Failed or skipped sidecar injection requests",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Failed or skipped sidecar injection requests",
-            "type": "timeseries",
-            "width": 26,
-            "x": 28,
-            "y": 57
+            "layout": {
+                "x": 28,
+                "y": 57,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 24,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "top(avg:istio.mesh.request.size.sum{$cluster}, 10, 'mean', 'desc')/top(avg:istio.mesh.request.size.count{$cluster}, 10, 'mean', 'desc')",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average request size",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average request size",
-            "type": "timeseries",
-            "width": 26,
-            "x": 1,
-            "y": 36
+            "layout": {
+                "x": 1,
+                "y": 36,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 25,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:istio.grpc.server.handling_seconds.sum{$cluster}/avg:istio.grpc.server.handling_seconds.count{$cluster}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "thin"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "thin"
+                        }
                     }
                 ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average response latency of gRPC",
-            "type": "timeseries",
-            "width": 26,
-            "x": 109,
-            "y": 21
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Sidecar injection",
-            "text_align": "center",
-            "tick": true,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 53,
-            "x": 1,
-            "y": 51
-        },
-        {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
                 "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average response latency of gRPC",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 109,
+                "y": 21,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 26,
+            "definition": {
+                "type": "note",
+                "content": "Sidecar injection",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 51,
+                "width": 53,
+                "height": 5
+            }
+        },
+        {
+            "id": 27,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:istio.pilot.proxy_queue_time.sum{$cluster}, avg:istio.pilot.proxy_queue_time.count{$cluster}, avg:istio.pilot.proxy_queue_time.sum{$cluster}/avg:istio.pilot.proxy_queue_time.count{$cluster}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average proxy queue duration",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average proxy queue duration",
-            "type": "timeseries",
-            "width": 26,
-            "x": 82,
-            "y": 21
+            "layout": {
+                "x": 82,
+                "y": 21,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 28,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "top(avg:istio.mesh.request.duration.milliseconds.sum{$cluster} by {host}, 10, 'mean', 'desc')/top(avg:istio.mesh.request.duration.milliseconds.count{$cluster} by {host}, 10, 'mean', 'desc')",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "thin"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "thin"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Average request latency by host",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Average request latency by host",
-            "type": "timeseries",
-            "width": 26,
-            "x": 28,
-            "y": 21
+            "layout": {
+                "x": 28,
+                "y": 21,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 29,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:istio.pilot.services{$cluster}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Services known to istiod",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Services known to istiod",
-            "type": "timeseries",
-            "width": 26,
-            "x": 55,
-            "y": 36
+            "layout": {
+                "x": 55,
+                "y": 36,
+                "width": 26,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 30,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:istio.pilot.rds_expired_nonce{$cluster}.as_count()",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Total expired RDS messages",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Total expired RDS messages",
-            "type": "timeseries",
-            "width": 26,
-            "x": 82,
-            "y": 36
+            "layout": {
+                "x": 82,
+                "y": 36,
+                "width": 26,
+                "height": 14
+            }
         }
-    ]
+    ],
+    "template_variables": [
+        {
+            "name": "cluster",
+            "default": "*",
+            "prefix": "cluster_name"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30320
 }

--- a/istio/assets/dashboards/istio_overview.json
+++ b/istio/assets/dashboards/istio_overview.json
@@ -1,835 +1,579 @@
 {
-	"board_title": "Istio Dashboard",
-	"read_only": false,
-	"author_info": {
-		"author_name": "Datadog"
-	},
-	"description": "### Istio\n\n- [What is Istio](https://istio.io/docs/concepts/what-is-istio/)?\n- [Envoy](https://istio.io/docs/concepts/what-is-istio/#envoy), a high performance proxy.\n    - XDS = Envoy management APIs that can be implemented by backend servers. \n        - These APIs support:\n            - Cluster discovery service (CDS)\n            - Route discovery service (RDS)\n            - Endpoint discovery service (EDS)\n            - Listener discovery service (LDS)\n- [Mixer](https://istio.io/docs/concepts/what-is-istio/#mixer), enforces access control and usage policies across the service mesh, and collects telemetry data from the Envoy proxy and other services.\n- [Pilot](https://istio.io/docs/concepts/what-is-istio/#pilot), provides service discovery for the Envoy sidecars, traffic management capabilities for intelligent routing (e.g., A/B tests, canary rollouts, etc.), and resiliency (timeouts, retries, circuit breakers, etc.).\n- [Citadel](https://istio.io/docs/concepts/what-is-istio/#citadel), enables strong service-to-service and end-user authentication with built-in identity and credential management.\n- [Galley](https://istio.io/docs/concepts/what-is-istio/#galley), configuration validation, ingestion, processing and distribution component.)",
-	"board_bgtype": "board_graph",
-	"created": "2019-06-14T14:42:13.236275+00:00",
-	"created_by": {
-		"disabled": false,
-		"handle": "support@datadoghq.com",
-        	"name": "Datadog",
-		"is_admin": false,
-		"role": null,
-		"access_role": "st",
-		"verified": true,
-		"email": "support@datadoghq.com"
-	},
-	"new_id": "vkv-tf3-74m",
-	"modified": "2019-06-19T19:53:35.501287+00:00",
-	"originalHeight": 105,
-	"height": 105,
-	"width": 111,
-	"template_variables": [],
-	"isIntegration": false,
-	"disableEditing": false,
-	"originalWidth": 111,
-	"widgets": [{
-		"height": 5,
-		"tick_pos": "50%",
-		"board_id": 592110,
-		"title_size": 16,
-		"title": true,
-		"title_align": "left",
-		"text_align": "center",
-		"bgcolor": "gray",
-		"html": "Resource usage",
-		"type": "note",
-		"isShared": false,
-		"refresh_every": 30000,
-		"auto_refresh": false,
-		"title_text": "",
-		"tick": true,
-		"scaleFactor": 1,
-		"add_timeframe": true,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1552068210000,
-			"end": 1552069110000
-		},
-		"font_size": "18",
-		"generated_title": "Notes & Links",
-		"tick_edge": "bottom",
-		"y": 0,
-		"x": 55,
-		"width": 53
-	}, {
-		"height": 5,
-		"tick_pos": "50%",
-		"board_id": 592110,
-		"title_size": 16,
-		"title": true,
-		"title_align": "left",
-		"text_align": "center",
-		"bgcolor": "gray",
-		"html": "Mesh throughput",
-		"type": "note",
-		"isShared": false,
-		"refresh_every": 30000,
-		"auto_refresh": false,
-		"title_text": "",
-		"tick": true,
-		"scaleFactor": 1,
-		"add_timeframe": true,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1552068210000,
-			"end": 1552069110000
-		},
-		"font_size": "18",
-		"generated_title": "Notes & Links",
-		"tick_edge": "bottom",
-		"y": 0,
-		"x": 14,
-		"width": 40
-	}, {
-		"board_id": 592110,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"title_align": "center",
-		"title_text": "Request count",
-		"height": 12,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "top(avg:istio.mesh.request.count{*} by {host}, 10, 'mean', 'desc')",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": "area",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 21,
-		"x": 1,
-		"legend_size": "0",
-		"add_timeframe": true,
-		"scaleFactor": 1,
-		"legend": false,
-		"isShared": false
-	}, {
-		"board_id": 592110,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_size": 16,
-		"title": true,
-		"type": "toplist",
-		"title_align": "center",
-		"title_text": "Average request latency",
-		"height": 12,
-		"tile_def": {
-			"viz": "toplist",
-			"requests": [{
-				"q": "top(top(avg:istio.mesh.request.duration.sum{*} by {host}, 10, 'mean', 'desc')/top(avg:istio.mesh.request.duration.count{*} by {host}, 10, 'mean', 'desc'),10,'mean','desc')",
-				"style": {
-					"width": "normal",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": null,
-				"conditional_formats": []
-			}]
-		},
-		"width": 53,
-		"time": {},
-		"error": null,
-		"y": 6,
-		"x": 1,
-		"legend_size": "0",
-		"add_timeframe": true,
-		"scaleFactor": 1,
-		"legend": false,
-		"isShared": false
-	}, {
-		"board_id": 592110,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"title_align": "center",
-		"title_text": "Average response size",
-		"height": 12,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "top(avg:istio.mesh.response.size.sum{*}, 10, 'mean', 'desc')/top(avg:istio.mesh.response.size.count{*}, 10, 'mean', 'desc')",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": "area",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 36,
-		"x": 28,
-		"legend_size": "0",
-		"add_timeframe": true,
-		"scaleFactor": 1,
-		"legend": false,
-		"isShared": false
-	}, {
-		"board_id": 592110,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"title_align": "center",
-		"title_text": "Number of OS threads created",
-		"height": 18,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "top(avg:istio.mixer.go.threads{*} by {host}, 10, 'mean', 'desc')",
-				"aggregator": "avg",
-				"style": {
-					"width": "thin",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": "line",
-				"conditional_formats": [{
-					"palette": "white_on_red",
-					"comparator": ">",
-					"value": null
-				}, {
-					"palette": "white_on_yellow",
-					"comparator": ">=",
-					"value": null
-				}, {
-					"palette": "white_on_green",
-					"comparator": "<",
-					"value": null
-				}]
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 51,
-		"x": 82,
-		"legend_size": "0",
-		"add_timeframe": true,
-		"scaleFactor": 1,
-		"legend": false,
-		"isShared": false
-	}, {
-		"board_id": 592110,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_align": "center",
-		"title_size": 16,
-		"title": true,
-		"type": "toplist",
-		"generated_title": "istio.mixer.go.memstats.alloc_bytes",
-		"title_text": "Percentage of available memory allocated",
-		"height": 12,
-		"tile_def": {
-			"viz": "toplist",
-			"requests": [{
-				"q": "top((top(avg:istio.mixer.go.memstats.alloc_bytes{*} by {host}, 10, 'mean', 'desc')/top(avg:istio.mixer.go.memstats.alloc_bytes_total{*} by {host}, 10, 'mean', 'desc'))*100,10,'mean','desc')",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": "area",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 53,
-		"time": {},
-		"error": null,
-		"y": 6,
-		"x": 55,
-		"legend_size": "0",
-		"add_timeframe": true,
-		"scaleFactor": 1,
-		"legend": false,
-		"isShared": false
-	}, {
-		"board_id": 592110,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"title_align": "center",
-		"title_text": "Heap in use (percent)",
-		"height": 18,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "(top(avg:istio.mixer.go.memstats.heap_inuse_bytes{*} by {host}, 10, 'mean', 'desc')/top(avg:istio.mixer.go.memstats.heap_alloc_bytes{*} by {host}, 10, 'mean', 'desc'))*100",
-				"aggregator": "avg",
-				"style": {
-					"width": "thin",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": "line",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 51,
-		"x": 55,
-		"legend_size": "0",
-		"add_timeframe": true,
-		"scaleFactor": 1,
-		"legend": false,
-		"isShared": false
-	}, {
-		"board_id": 592110,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"title_align": "center",
-		"title_text": "CPU required for GC",
-		"height": 12,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "top(avg:istio.mixer.go.memstats.gc_cpu_fraction{*}, 10, 'mean', 'desc')",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "cool",
-					"type": "solid"
-				},
-				"type": "area",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 21,
-		"x": 82,
-		"legend_size": "0",
-		"add_timeframe": true,
-		"scaleFactor": 1,
-		"legend": false,
-		"isShared": false
-	}, {
-		"board_id": 592110,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"title_align": "center",
-		"title_text": "Average GC duration",
-		"height": 12,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "top(avg:istio.mixer.go.gc_duration_seconds.sum{*}, 10, 'mean', 'desc')/top(avg:istio.mixer.go.gc_duration_seconds.count{*}, 10, 'mean', 'desc')",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "cool",
-					"type": "solid"
-				},
-				"type": "area",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 21,
-		"x": 55,
-		"legend_size": "0",
-		"add_timeframe": true,
-		"scaleFactor": 1,
-		"legend": false,
-		"isShared": false
-	}, {
-		"board_id": 592110,
-		"sizing": "fit",
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1552068210000,
-			"end": 1552069110000
-		},
-		"generated_title": "",
-		"title_size": 16,
-		"title": true,
-		"url": "https://s3.amazonaws.com/dd-integrations/istio/configuration/tile/logo.png",
-		"margin": "",
-		"title_align": "left",
-		"title_text": "",
-		"height": 5,
-		"width": 12,
-		"type": "image",
-		"y": 0,
-		"x": 1,
-		"add_timeframe": true,
-		"scaleFactor": 1,
-		"isShared": false
-	}, {
-		"board_id": 592110,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"title_align": "center",
-		"title_text": "GRPC messages sent/received by host",
-		"height": 12,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "top(avg:istio.mixer.grpc.server.msg_sent_total{*} by {host}, 10, 'mean', 'desc'), top(avg:istio.mixer.grpc.server.msg_received_total{*} by {host}, 10, 'mean', 'desc')",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "cool",
-					"type": "solid"
-				},
-				"type": "area",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 36,
-		"x": 1,
-		"legend_size": "0",
-		"add_timeframe": true,
-		"scaleFactor": 1,
-		"legend": false,
-		"isShared": false
-	}, {
-		"board_id": 592110,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_size": 16,
-		"title": true,
-		"type": "toplist",
-		"title_align": "center",
-		"title_text": "Hosts with the highest GC time",
-		"height": 12,
-		"tile_def": {
-			"viz": "toplist",
-			"requests": [{
-				"q": "top(avg:istio.mixer.go.gc_duration_seconds.sum{*} by {host}, 10, 'mean', 'desc')",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": "line",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 53,
-		"time": {},
-		"error": null,
-		"y": 36,
-		"x": 55,
-		"legend_size": "0",
-		"add_timeframe": true,
-		"scaleFactor": 1,
-		"legend": false,
-		"isShared": false
-	}, {
-		"board_id": 592110,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"title_align": "center",
-		"title_text": "Average request latency by host",
-		"height": 12,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "top(avg:istio.mesh.request.duration.sum{*} by {host}, 10, 'mean', 'desc')/top(avg:istio.mesh.request.duration.count{*} by {host}, 10, 'mean', 'desc')",
-				"aggregator": "avg",
-				"style": {
-					"width": "thin",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": "line",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 21,
-		"x": 28,
-		"legend_size": "0",
-		"add_timeframe": true,
-		"scaleFactor": 1,
-		"legend": false,
-		"isShared": false
-	}, {
-		"height": 5,
-		"tick_pos": "50%",
-		"board_id": "vkv-tf3-74m",
-		"title_size": 16,
-		"title": true,
-		"title_align": "left",
-		"text_align": "center",
-		"bgcolor": "gray",
-		"html": "Pilot Traffic Management",
-		"type": "note",
-		"isShared": false,
-		"refresh_every": 30000,
-		"auto_refresh": false,
-		"title_text": "",
-		"tick": true,
-		"scaleFactor": 1,
-		"add_timeframe": true,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560965499389,
-			"end": 1560969099389
-		},
-		"font_size": "18",
-		"generated_title": "Notes & Links",
-		"tick_edge": "bottom",
-		"y": 51,
-		"x": 1,
-		"width": 53
-	}, {
-		"board_id": "vkv-tf3-74m",
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_align": "center",
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"generated_title": "Timeseries",
-		"title_text": "XDS connected endpoints",
-		"height": 12,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "sum:istio.pilot.xds{*}",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": "area",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 57,
-		"x": 1,
-		"legend_size": "0",
-		"isShared": false,
-		"scaleFactor": 1,
-		"legend": false,
-		"add_timeframe": true
-	}, {
-		"board_id": "vkv-tf3-74m",
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_align": "center",
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"generated_title": "Timeseries",
-		"title_text": "LDS/EDS/RDS/CDS Build,Send Errors",
-		"height": 12,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "sum:istio.pilot.xds.pushes{*}",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": "line",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 57,
-		"x": 28,
-		"legend_size": "0",
-		"isShared": false,
-		"scaleFactor": 1,
-		"legend": false,
-		"add_timeframe": true
-	}, {
-		"height": 5,
-		"tick_pos": "50%",
-		"board_id": "vkv-tf3-74m",
-		"title_size": 16,
-		"title": true,
-		"title_align": "left",
-		"text_align": "center",
-		"bgcolor": "gray",
-		"html": "Galley Configuration Validation",
-		"type": "note",
-		"isShared": false,
-		"refresh_every": 30000,
-		"auto_refresh": false,
-		"title_text": "",
-		"tick": true,
-		"scaleFactor": 1,
-		"add_timeframe": true,
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560965499389,
-			"end": 1560969099389
-		},
-		"font_size": "18",
-		"generated_title": "Notes & Links",
-		"tick_edge": "bottom",
-		"y": 72,
-		"x": 1,
-		"width": 107
-	}, {
-		"board_id": "vkv-tf3-74m",
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_align": "center",
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"generated_title": "Timeseries",
-		"title_text": "Endpoints without a pod",
-		"height": 12,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "sum:istio.galley.endpoint_no_pod{*}",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": "area",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 78,
-		"x": 1,
-		"legend_size": "0",
-		"isShared": false,
-		"scaleFactor": 1,
-		"legend": false,
-		"add_timeframe": true
-	}, {
-		"board_id": "vkv-tf3-74m",
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_align": "center",
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"generated_title": "Timeseries",
-		"title_text": "Max # of File Descriptors",
-		"height": 12,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "sum:istio.galley.process.max_fds{*}",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": "area",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 78,
-		"x": 28,
-		"legend_size": "0",
-		"isShared": false,
-		"scaleFactor": 1,
-		"legend": false,
-		"add_timeframe": true
-	}, {
-		"board_id": "vkv-tf3-74m",
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_align": "center",
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"generated_title": "Timeseries",
-		"title_text": "Virtual Memory Size",
-		"height": 12,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "sum:istio.galley.process.virtual_memory_bytes{*}",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": "area",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 78,
-		"x": 55,
-		"legend_size": "0",
-		"isShared": false,
-		"scaleFactor": 1,
-		"legend": false,
-		"add_timeframe": true
-	}, {
-		"board_id": "vkv-tf3-74m",
-		"globalTimeframe": {
-			"isLive": true,
-			"start": 1560970403016,
-			"end": 1560974003016
-		},
-		"title_align": "center",
-		"title_size": 16,
-		"title": true,
-		"type": "timeseries",
-		"generated_title": "Timeseries",
-		"title_text": "# Instances per URL",
-		"height": 12,
-		"tile_def": {
-			"viz": "timeseries",
-			"requests": [{
-				"q": "sum:istio.galley.runtime_state_type_instances_total{*} by {collection}",
-				"aggregator": "avg",
-				"style": {
-					"width": "normal",
-					"palette": "dog_classic",
-					"type": "solid"
-				},
-				"type": "area",
-				"conditional_formats": []
-			}],
-			"autoscale": true
-		},
-		"width": 26,
-		"time": {},
-		"error": null,
-		"y": 78,
-		"x": 82,
-		"legend_size": "0",
-		"isShared": false,
-		"scaleFactor": 1,
-		"legend": false,
-		"add_timeframe": true
-	}],
-	"disableCog": false,
-	"id": 730802,
-	"isShared": false
+    "title": "Istio Dashboard",
+    "description": "### Istio\n\n- [What is Istio](https://istio.io/docs/concepts/what-is-istio/)?\n- [Envoy](https://istio.io/docs/concepts/what-is-istio/#envoy), a high performance proxy.\n    - XDS = Envoy management APIs that can be implemented by backend servers. \n        - These APIs support:\n            - Cluster discovery service (CDS)\n            - Route discovery service (RDS)\n            - Endpoint discovery service (EDS)\n            - Listener discovery service (LDS)\n- [Mixer](https://istio.io/docs/concepts/what-is-istio/#mixer), enforces access control and usage policies across the service mesh, and collects telemetry data from the Envoy proxy and other services.\n- [Pilot](https://istio.io/docs/concepts/what-is-istio/#pilot), provides service discovery for the Envoy sidecars, traffic management capabilities for intelligent routing (e.g., A/B tests, canary rollouts, etc.), and resiliency (timeouts, retries, circuit breakers, etc.).\n- [Citadel](https://istio.io/docs/concepts/what-is-istio/#citadel), enables strong service-to-service and end-user authentication with built-in identity and credential management.\n- [Galley](https://istio.io/docs/concepts/what-is-istio/#galley), configuration validation, ingestion, processing and distribution component.)",
+    "widgets": [
+        {
+            "id": 0,
+            "definition": {
+                "type": "note",
+                "content": "Resource usage",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 55,
+                "y": 0,
+                "width": 53,
+                "height": 5
+            }
+        },
+        {
+            "id": 1,
+            "definition": {
+                "type": "note",
+                "content": "Mesh throughput",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 14,
+                "y": 0,
+                "width": 40,
+                "height": 5
+            }
+        },
+        {
+            "id": 2,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "top(avg:istio.mesh.request.count{*} by {host}, 10, 'mean', 'desc')",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Request count",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 1,
+                "y": 21,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(top(avg:istio.mesh.request.duration.sum{*} by {host}, 10, 'mean', 'desc')/top(avg:istio.mesh.request.duration.count{*} by {host}, 10, 'mean', 'desc'),10,'mean','desc')",
+                        "style": {
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Average request latency",
+                "title_size": "16",
+                "title_align": "center"
+            },
+            "layout": {
+                "x": 1,
+                "y": 6,
+                "width": 53,
+                "height": 14
+            }
+        },
+        {
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "top(avg:istio.mesh.response.size.sum{*}, 10, 'mean', 'desc')/top(avg:istio.mesh.response.size.count{*}, 10, 'mean', 'desc')",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Average response size",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 28,
+                "y": 36,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "top(avg:istio.mixer.go.threads{*} by {host}, 10, 'mean', 'desc')",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "thin"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Number of OS threads created",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 82,
+                "y": 51,
+                "width": 26,
+                "height": 20
+            }
+        },
+        {
+            "id": 6,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top((top(avg:istio.mixer.go.memstats.alloc_bytes{*} by {host}, 10, 'mean', 'desc')/top(avg:istio.mixer.go.memstats.alloc_bytes_total{*} by {host}, 10, 'mean', 'desc'))*100,10,'mean','desc')",
+                        "style": {
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Percentage of available memory allocated",
+                "title_size": "16",
+                "title_align": "center"
+            },
+            "layout": {
+                "x": 55,
+                "y": 6,
+                "width": 53,
+                "height": 14
+            }
+        },
+        {
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "(top(avg:istio.mixer.go.memstats.heap_inuse_bytes{*} by {host}, 10, 'mean', 'desc')/top(avg:istio.mixer.go.memstats.heap_alloc_bytes{*} by {host}, 10, 'mean', 'desc'))*100",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "thin"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Heap in use (percent)",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 55,
+                "y": 51,
+                "width": 26,
+                "height": 20
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "top(avg:istio.mixer.go.memstats.gc_cpu_fraction{*}, 10, 'mean', 'desc')",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "CPU required for GC",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 82,
+                "y": 21,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "top(avg:istio.mixer.go.gc_duration_seconds.sum{*}, 10, 'mean', 'desc')/top(avg:istio.mixer.go.gc_duration_seconds.count{*}, 10, 'mean', 'desc')",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Average GC duration",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 55,
+                "y": 21,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "image",
+                "url": "https://s3.amazonaws.com/dd-integrations/istio/configuration/tile/logo.png",
+                "sizing": "fit"
+            },
+            "layout": {
+                "x": 1,
+                "y": 0,
+                "width": 12,
+                "height": 5
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "top(avg:istio.mixer.grpc.server.msg_sent_total{*} by {host}, 10, 'mean', 'desc'), top(avg:istio.mixer.grpc.server.msg_received_total{*} by {host}, 10, 'mean', 'desc')",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "GRPC messages sent/received by host",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 1,
+                "y": 36,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 12,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(avg:istio.mixer.go.gc_duration_seconds.sum{*} by {host}, 10, 'mean', 'desc')",
+                        "style": {
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Hosts with the highest GC time",
+                "title_size": "16",
+                "title_align": "center"
+            },
+            "layout": {
+                "x": 55,
+                "y": 36,
+                "width": 53,
+                "height": 14
+            }
+        },
+        {
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "top(avg:istio.mesh.request.duration.sum{*} by {host}, 10, 'mean', 'desc')/top(avg:istio.mesh.request.duration.count{*} by {host}, 10, 'mean', 'desc')",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "thin"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Average request latency by host",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 28,
+                "y": 21,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 14,
+            "definition": {
+                "type": "note",
+                "content": "Pilot Traffic Management",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 51,
+                "width": 53,
+                "height": 5
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:istio.pilot.xds{*}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "XDS connected endpoints",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 1,
+                "y": 57,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:istio.pilot.xds.pushes{*}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "LDS/EDS/RDS/CDS Build,Send Errors",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 28,
+                "y": 57,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 17,
+            "definition": {
+                "type": "note",
+                "content": "Galley Configuration Validation",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 72,
+                "width": 107,
+                "height": 5
+            }
+        },
+        {
+            "id": 18,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:istio.galley.endpoint_no_pod{*}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Endpoints without a pod",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 1,
+                "y": 78,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 19,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:istio.galley.process.max_fds{*}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Max # of File Descriptors",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 28,
+                "y": 78,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 20,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:istio.galley.process.virtual_memory_bytes{*}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Virtual Memory Size",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 55,
+                "y": 78,
+                "width": 26,
+                "height": 14
+            }
+        },
+        {
+            "id": 21,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:istio.galley.runtime_state_type_instances_total{*} by {collection}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "# Instances per URL",
+                "title_size": "16",
+                "title_align": "center",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 82,
+                "y": 78,
+                "width": 26,
+                "height": 14
+            }
+        }
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30287
 }

--- a/kong/assets/dashboards/kong_overview.json
+++ b/kong/assets/dashboards/kong_overview.json
@@ -1,354 +1,267 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    }, 
-    "board_title": "Kong Overview", 
-    "created": "2020-01-27T21:24:10.697435+00:00", 
-    "created_by": {
-        "access_role": "adm", 
-        "disabled": false, 
-        "email": "support@datadoghq.com", 
-        "handle": "support@datadoghq.com", 
-        "is_admin": true, 
-        "name": "Datadog", 
-        "role": null, 
-        "title": null, 
-        "verified": true
-    }, 
-    "description": "## Kong\n\nThis dashboard provides a high-level overview of your Kong instances so you can monitor metrics related to connections, table counts, and total requests.\n\nFor further reading on monitoring Kong, see:\n[Official Kong integration docs](https://docs.datadoghq.com/integrations/kong/)\n\nClone this template to make changes and add your own graphs and widgets.", 
-    "disableCog": false, 
-    "disableEditing": false, 
-    "id": 959028, 
-    "isIntegration": false, 
-    "isShared": false, 
-    "modified": "2020-01-27T21:46:56.309272+00:00", 
-    "new_id": "e8q-ckb-rkb", 
-    "originalHeight": 80, 
-    "originalWidth": "calc(100% - 32px)", 
-    "read_only": false, 
-    "template_variables": [], 
+    "title": "Kong Overview",
+    "description": "## Kong\n\nThis dashboard provides a high-level overview of your Kong instances so you can monitor metrics related to connections, table counts, and total requests.\n\nFor further reading on monitoring Kong, see:\n[Official Kong integration docs](https://docs.datadoghq.com/integrations/kong/)\n\nClone this template to make changes and add your own graphs and widgets.",
     "widgets": [
         {
-            "add_timeframe": true, 
-            "board_id": "e8q-ckb-rkb", 
-            "height": 8, 
-            "isShared": false, 
-            "margin": "", 
-            "scaleFactor": 1, 
-            "sizing": "fit", 
-            "title": false, 
-            "type": "image", 
-            "url": "https://static.datadoghq.com/static/images/saas_logos/bot/kong@2x.png", 
-            "width": 13, 
-            "x": 1, 
-            "y": 1
-        }, 
+            "id": 0,
+            "definition": {
+                "type": "image",
+                "url": "https://static.datadoghq.com/static/images/saas_logos/bot/kong@2x.png",
+                "sizing": "fit"
+            },
+            "layout": {
+                "x": 1,
+                "y": 1,
+                "width": 13,
+                "height": 8
+            }
+        },
         {
-            "add_timeframe": true, 
-            "board_id": "e8q-ckb-rkb", 
-            "error": null, 
-            "generated_title": "Avg of kong.total_requests over * by host", 
-            "height": 13, 
-            "isShared": false, 
-            "legend": false, 
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            }, 
-            "tile_def": {
-                "markers": [], 
+            "id": 1,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
-                        "q": "per_minute(avg:kong.total_requests{*} by {host})", 
+                        "q": "per_minute(avg:kong.total_requests{*} by {host})",
+                        "display_type": "bars",
                         "style": {
-                            "palette": "dog_classic", 
-                            "type": "solid", 
-                            "width": "normal"
-                        }, 
-                        "type": "bars"
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
-                ], 
-                "viz": "timeseries", 
+                ],
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true, 
-                    "label": "", 
-                    "max": "auto", 
-                    "min": "auto", 
-                    "scale": "linear"
-                }
-            }, 
-            "time": {}, 
-            "title": true, 
-            "title_align": "left", 
-            "title_size": 16, 
-            "title_text": "Total requests rate (per minute)", 
-            "type": "timeseries", 
-            "width": 39, 
-            "x": 1, 
-            "y": 26
-        }, 
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Total requests rate (per minute)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 1,
+                "y": 26,
+                "width": 39,
+                "height": 15
+            }
+        },
         {
-            "add_timeframe": true, 
-            "board_id": "e8q-ckb-rkb", 
-            "check": "kong.can_connect", 
-            "error": null, 
-            "group": null, 
-            "group_by": [], 
-            "grouping": "cluster", 
-            "height": 8, 
-            "isShared": false, 
-            "scaleFactor": 1, 
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            }, 
-            "tags": [
-                "*"
-            ], 
-            "text_align": "center", 
-            "text_size": "auto", 
-            "time": {}, 
-            "title": true, 
-            "title_align": "center", 
-            "title_size": 16, 
-            "title_text": "Status", 
-            "type": "check_status", 
-            "width": 12, 
-            "x": 15, 
-            "y": 1
-        }, 
+            "id": 2,
+            "definition": {
+                "type": "check_status",
+                "title": "Status",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "kong.can_connect",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "*"
+                ]
+            },
+            "layout": {
+                "x": 15,
+                "y": 1,
+                "width": 12,
+                "height": 8
+            }
+        },
         {
-            "add_timeframe": true, 
-            "auto_refresh": false, 
-            "bgcolor": "gray", 
-            "board_id": "e8q-ckb-rkb", 
-            "font_size": "24", 
-            "height": 6, 
-            "html": "Connections", 
-            "isShared": false, 
-            "refresh_every": 30000, 
-            "scaleFactor": 1, 
-            "text_align": "center", 
-            "tick": true, 
-            "tick_edge": "bottom", 
-            "tick_pos": "50%", 
-            "title": false, 
-            "type": "note", 
-            "width": 71, 
-            "x": 41, 
-            "y": 2
-        }, 
+            "id": 3,
+            "definition": {
+                "type": "note",
+                "content": "Connections",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 41,
+                "y": 2,
+                "width": 71,
+                "height": 6
+            }
+        },
         {
-            "add_timeframe": true, 
-            "error": null, 
-            "generated_title": "Avg of kong.table.items over * by table", 
-            "height": 13, 
-            "isShared": false, 
-            "legend": false, 
-            "legend_size": "0", 
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            }, 
-            "tile_def": {
-                "markers": [], 
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
-                        "q": "avg:kong.table.items{*} by {table}", 
+                        "q": "avg:kong.table.items{*} by {table}",
+                        "display_type": "bars",
                         "style": {
-                            "palette": "dog_classic", 
-                            "type": "solid", 
-                            "width": "normal"
-                        }, 
-                        "type": "bars"
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
-                ], 
-                "viz": "timeseries", 
+                ],
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true, 
-                    "label": "", 
-                    "max": "auto", 
-                    "min": "auto", 
-                    "scale": "linear"
-                }
-            }, 
-            "time": {}, 
-            "title": true, 
-            "title_align": "left", 
-            "title_size": 16, 
-            "title_text": "Items per table", 
-            "type": "timeseries", 
-            "width": 39, 
-            "x": 1, 
-            "y": 10
-        }, 
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Items per table",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 1,
+                "y": 10,
+                "width": 39,
+                "height": 15
+            }
+        },
         {
-            "add_timeframe": true, 
-            "error": null, 
-            "generated_title": "Avg of kong.connections_active over * by host", 
-            "height": 13, 
-            "isShared": false, 
-            "legend": false, 
-            "legend_size": "0", 
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            }, 
-            "tile_def": {
-                "markers": [], 
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
-                        "q": "avg:kong.connections_active{*} by {host}", 
+                        "q": "avg:kong.connections_active{*} by {host}",
+                        "display_type": "bars",
                         "style": {
-                            "palette": "dog_classic", 
-                            "type": "solid", 
-                            "width": "normal"
-                        }, 
-                        "type": "bars"
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
-                ], 
-                "viz": "timeseries", 
+                ],
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true, 
-                    "label": "", 
-                    "max": "auto", 
-                    "min": "auto", 
-                    "scale": "linear"
-                }
-            }, 
-            "time": {}, 
-            "title": true, 
-            "title_align": "left", 
-            "title_size": 16, 
-            "title_text": "Active connections", 
-            "type": "timeseries", 
-            "width": 35, 
-            "x": 41, 
-            "y": 10
-        }, 
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Active connections",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 41,
+                "y": 10,
+                "width": 35,
+                "height": 15
+            }
+        },
         {
-            "add_timeframe": true, 
-            "error": null, 
-            "generated_title": "Avg of kong.connections_waiting over * by host", 
-            "height": 13, 
-            "isShared": false, 
-            "legend": false, 
-            "legend_size": "0", 
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            }, 
-            "tile_def": {
-                "markers": [], 
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
-                        "q": "avg:kong.connections_waiting{*} by {host}", 
+                        "q": "avg:kong.connections_waiting{*} by {host}",
+                        "display_type": "bars",
                         "style": {
-                            "palette": "dog_classic", 
-                            "type": "solid", 
-                            "width": "normal"
-                        }, 
-                        "type": "bars"
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
-                ], 
-                "viz": "timeseries", 
+                ],
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true, 
-                    "label": "", 
-                    "max": "auto", 
-                    "min": "auto", 
-                    "scale": "linear"
-                }
-            }, 
-            "time": {}, 
-            "title": true, 
-            "title_align": "left", 
-            "title_size": 16, 
-            "title_text": "Idle connections", 
-            "type": "timeseries", 
-            "width": 35, 
-            "x": 77, 
-            "y": 10
-        }, 
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Idle connections",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 77,
+                "y": 10,
+                "width": 35,
+                "height": 15
+            }
+        },
         {
-            "add_timeframe": true, 
-            "error": null, 
-            "generated_title": "Avg of kong.connections_handled over * by host", 
-            "height": 13, 
-            "isShared": false, 
-            "legend": false, 
-            "legend_size": "0", 
-            "sharedGlobalTime": {
-                "live_span": "1h"
-            }, 
-            "tile_def": {
-                "markers": [], 
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
-                        "q": "per_minute(avg:kong.connections_handled{*} by {host}), per_minute(avg:kong.connections_accepted{*} by {host})", 
+                        "q": "per_minute(avg:kong.connections_handled{*} by {host}), per_minute(avg:kong.connections_accepted{*} by {host})",
+                        "display_type": "bars",
                         "style": {
-                            "palette": "cool", 
-                            "type": "solid", 
-                            "width": "normal"
-                        }, 
-                        "type": "bars"
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
-                ], 
-                "viz": "timeseries", 
+                ],
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true, 
-                    "label": "", 
-                    "max": "auto", 
-                    "min": "auto", 
-                    "scale": "linear"
-                }
-            }, 
-            "time": {}, 
-            "title": true, 
-            "title_align": "left", 
-            "title_size": 16, 
-            "title_text": "Rate of accepted and handled connections", 
-            "type": "timeseries", 
-            "width": 71, 
-            "x": 41, 
-            "y": 26
-        }, 
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Rate of accepted and handled connections",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 41,
+                "y": 26,
+                "width": 71,
+                "height": 15
+            }
+        },
         {
-            "add_timeframe": true, 
-            "board_id": "e8q-ckb-rkb", 
-            "error": null, 
-            "generated_title": "Avg of kong.table.count over *", 
-            "height": 6, 
-            "isShared": false, 
-            "legend": false, 
-            "tile_def": {
-                "precision": "0", 
+            "id": 8,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
-                        "aggregator": "avg", 
-                        "conditional_formats": [
-                            {
-                                "comparator": ">", 
-                                "palette": "white_on_red"
-                            }, 
-                            {
-                                "comparator": ">=", 
-                                "palette": "white_on_yellow"
-                            }, 
-                            {
-                                "comparator": "<", 
-                                "palette": "white_on_green"
-                            }
-                        ], 
-                        "q": "avg:kong.table.count{*}"
+                        "q": "avg:kong.table.count{*}",
+                        "aggregator": "avg"
                     }
-                ], 
-                "viz": "query_value"
-            }, 
-            "time": {}, 
-            "title": true, 
-            "title_align": "left", 
-            "title_size": 16, 
-            "title_text": "Number of Tables", 
-            "type": "query_value", 
-            "width": 12, 
-            "x": 28, 
-            "y": 1
+                ],
+                "custom_links": [],
+                "title": "Number of Tables",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 28,
+                "y": 1,
+                "width": 12,
+                "height": 8
+            }
         }
-    ]
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30262
 }

--- a/kube_metrics_server/assets/dashboards/overview.json
+++ b/kube_metrics_server/assets/dashboards/overview.json
@@ -1,582 +1,391 @@
 {
-    "board_title": "Kubernetes Metrics Server",
-    "description": null,
-    "board_bgtype": "board_graph",
-    "originalHeight": 76,
-    "height": 76,
-    "width": 225,
-    "template_variables": [
-      {
-        "default": "*",
-        "prefix": null,
-        "name": "scope"
-      }
-    ],
-    "isIntegration": false,
-    "disableEditing": false,
-    "originalWidth": 225,
+    "title": "Kubernetes Metrics Server",
+    "description": "",
     "widgets": [
-      {
-        "board_id": "mmk-zds-miy",
-        "sizing": "zoom",
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1558079520000,
-          "end": 1558083120000
-        },
-        "generated_title": "",
-        "title_size": 16,
-        "title": true,
-        "url": "/static/images/screenboard/integrations/kubernetes.jpg",
-        "scaleFactor": 1,
-        "title_align": "left",
-        "title_text": "",
-        "height": 13,
-        "width": 24,
-        "type": "image",
-        "y": 3,
-        "x": 2,
-        "add_timeframe": true,
-        "margin": "",
-        "isShared": false
-      },
-      {
-        "board_id": "mmk-zds-miy",
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1558079520000,
-          "end": 1558083120000
-        },
-        "generated_title": "",
-        "font_size": "auto",
-        "title": true,
-        "color": "#000",
-        "text": "Metrics Server",
-        "title_align": "left",
-        "text_align": "left",
-        "title_text": "",
-        "height": 5,
-        "width": 24,
-        "type": "free_text",
-        "x": 2,
-        "y": 16,
-        "title_size": 16,
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "isShared": false
-      },
-      {
-        "height": 12,
-        "text_size": "auto",
-        "check": "kube_metrics_server.prometheus.health",
-        "board_id": "mmk-zds-miy",
-        "group": null,
-        "title": true,
-        "title_align": "center",
-        "text_align": "center",
-        "width": 15,
-        "group_by": [],
-        "type": "check_status",
-        "isShared": false,
-        "tags": [
-          "*"
-        ],
-        "time": {},
-        "title_text": "Replicas Up",
-        "title_size": 16,
-        "scaleFactor": 1,
-        "add_timeframe": true,
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1560870108937,
-          "end": 1560873708937
-        },
-        "error": null,
-        "y": 23,
-        "x": 6,
-        "grouping": "cluster"
-      },
-      {
-        "board_id": "mmk-zds-miy",
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1560870108937,
-          "end": 1560873708937
-        },
-        "title_align": "left",
-        "title_size": 16,
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "Timeseries",
-        "title_text": "Average scraping duration in seconds",
-        "height": 15,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "derivative(avg:kube_metrics_server.scraper_duration.sum{*})/derivative(avg:kube_metrics_server.scraper_duration.count{*})",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
+        {
+            "id": 0,
+            "definition": {
+                "type": "image",
+                "url": "/static/images/screenboard/integrations/kubernetes.jpg",
+                "sizing": "zoom"
+            },
+            "layout": {
+                "x": 2,
+                "y": 3,
+                "width": 24,
+                "height": 13
             }
-          ],
-          "autoscale": true
         },
-        "width": 42,
-        "time": {},
-        "error": null,
-        "y": 2,
-        "x": 44,
-        "legend_size": "0",
-        "isShared": false,
-        "scaleFactor": 1,
-        "legend": false,
-        "add_timeframe": true
-      },
-      {
-        "board_id": "mmk-zds-miy",
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1560870108937,
-          "end": 1560873708937
-        },
-        "title_align": "left",
-        "title_size": 16,
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "Timeseries",
-        "title_text": "Authenticated user requests by username",
-        "height": 15,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:kube_metrics_server.authenticated_user.requests{*} by {username}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "bars",
-              "conditional_formats": []
+        {
+            "id": 1,
+            "definition": {
+                "type": "free_text",
+                "text": "Metrics Server",
+                "color": "#000",
+                "font_size": "auto",
+                "text_align": "left"
+            },
+            "layout": {
+                "x": 2,
+                "y": 16,
+                "width": 24,
+                "height": 5
             }
-          ],
-          "autoscale": true
         },
-        "width": 42,
-        "time": {},
-        "error": null,
-        "y": 38,
-        "x": 44,
-        "legend_size": "0",
-        "isShared": false,
-        "scaleFactor": 1,
-        "legend": false,
-        "add_timeframe": true
-      },
-      {
-        "board_id": "mmk-zds-miy",
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1560870108937,
-          "end": 1560873708937
-        },
-        "title_align": "left",
-        "title_size": 16,
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "Timeseries",
-        "title_text": "Average of Processing duration in seconds",
-        "height": 15,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "derivative(avg:kube_metrics_server.manager_tick_duration.sum{*})/derivative(avg:kube_metrics_server.manager_tick_duration.count{*})",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
+        {
+            "id": 2,
+            "definition": {
+                "type": "check_status",
+                "title": "Replicas Up",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "kube_metrics_server.prometheus.health",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "*"
+                ]
+            },
+            "layout": {
+                "x": 6,
+                "y": 23,
+                "width": 15,
+                "height": 12
             }
-          ],
-          "autoscale": true
         },
-        "width": 42,
-        "time": {},
-        "error": null,
-        "y": 2,
-        "x": 132,
-        "legend_size": "0",
-        "isShared": false,
-        "scaleFactor": 1,
-        "legend": false,
-        "add_timeframe": true
-      },
-      {
-        "board_id": "mmk-zds-miy",
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1560870108937,
-          "end": 1560873708937
-        },
-        "title_align": "left",
-        "title_size": 16,
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "Timeseries",
-        "title_text": "Average kubelet summary request duration in seconds",
-        "height": 15,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "derivative(avg:kube_metrics_server.kubelet_summary_request_duration.sum{*})/derivative(avg:kube_metrics_server.kubelet_summary_request_duration.count{*})",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
+        {
+            "id": 3,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "derivative(avg:kube_metrics_server.scraper_duration.sum{*})/derivative(avg:kube_metrics_server.scraper_duration.count{*})",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Average scraping duration in seconds",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 44,
+                "y": 2,
+                "width": 42,
+                "height": 17
             }
-          ],
-          "autoscale": true
         },
-        "width": 42,
-        "time": {},
-        "error": null,
-        "y": 2,
-        "x": 88,
-        "legend_size": "0",
-        "isShared": false,
-        "scaleFactor": 1,
-        "legend": false,
-        "add_timeframe": true
-      },
-      {
-        "board_id": "mmk-zds-miy",
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1560870108937,
-          "end": 1560873708937
-        },
-        "title_align": "left",
-        "title_size": 16,
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "Timeseries",
-        "title_text": "Kubelet summary scrapes",
-        "height": 15,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:kube_metrics_server.kubelet_summary_scrapes_total{*}.as_count()",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
+        {
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:kube_metrics_server.authenticated_user.requests{*} by {username}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Authenticated user requests by username",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 44,
+                "y": 38,
+                "width": 42,
+                "height": 17
             }
-          ],
-          "autoscale": true
         },
-        "width": 42,
-        "time": {},
-        "error": null,
-        "y": 2,
-        "x": 176,
-        "legend_size": "0",
-        "isShared": false,
-        "scaleFactor": 1,
-        "legend": false,
-        "add_timeframe": true
-      },
-      {
-        "board_id": "mmk-zds-miy",
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1560870108937,
-          "end": 1560873708937
-        },
-        "title_align": "left",
-        "title_size": 16,
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "Timeseries",
-        "title_text": "Number of Goroutines",
-        "height": 15,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "avg:kube_metrics_server.go.goroutines{*}",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
+        {
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "derivative(avg:kube_metrics_server.manager_tick_duration.sum{*})/derivative(avg:kube_metrics_server.manager_tick_duration.count{*})",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Average of Processing duration in seconds",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 132,
+                "y": 2,
+                "width": 42,
+                "height": 17
             }
-          ],
-          "autoscale": true
         },
-        "width": 42,
-        "time": {},
-        "error": null,
-        "y": 20,
-        "x": 88,
-        "legend_size": "0",
-        "isShared": false,
-        "scaleFactor": 1,
-        "legend": false,
-        "add_timeframe": true
-      },
-      {
-        "board_id": "458-fey-7vs",
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1560870108937,
-          "end": 1560873708937
-        },
-        "title_align": "left",
-        "title_size": 16,
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "Timeseries",
-        "title_text": "Average go garbage collection duration in milliseconds",
-        "height": 15,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "q": "derivative(avg:kube_metrics_server.go.gc_duration_seconds.sum{*})",
-              "aggregator": "avg",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "area",
-              "conditional_formats": []
+        {
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "derivative(avg:kube_metrics_server.kubelet_summary_request_duration.sum{*})/derivative(avg:kube_metrics_server.kubelet_summary_request_duration.count{*})",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Average kubelet summary request duration in seconds",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 88,
+                "y": 2,
+                "width": 42,
+                "height": 17
             }
-          ],
-          "autoscale": true
         },
-        "width": 42,
-        "time": {},
-        "error": null,
-        "y": 20,
-        "x": 44,
-        "legend_size": "0",
-        "add_timeframe": true,
-        "scaleFactor": 1,
-        "legend": false,
-        "isShared": false
-      },
-      {
-        "board_id": "mmk-zds-miy",
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1560870108937,
-          "end": 1560873708937
-        },
-        "title_align": "left",
-        "title_size": 16,
-        "title": true,
-        "type": "timeseries",
-        "generated_title": "Timeseries",
-        "title_text": "File descriptors",
-        "height": 15,
-        "tile_def": {
-          "viz": "timeseries",
-          "requests": [
-            {
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "aggregator": "avg",
-              "conditional_formats": [],
-              "q": "avg:kube_metrics_server.process.max_fds{*}, avg:kube_metrics_server.process.open_fds{*}",
-              "type": "area",
-              "metadata": {
-                "avg:kube_metrics_server.process.max_fds{*}": {
-                  "alias": "max"
-                },
-                "avg:kube_metrics_server.process.open_fds{*}": {
-                  "alias": "open"
-                }
-              }
+        {
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:kube_metrics_server.kubelet_summary_scrapes_total{*}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Kubelet summary scrapes",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 176,
+                "y": 2,
+                "width": 42,
+                "height": 17
             }
-          ],
-          "autoscale": true
         },
-        "width": 42,
-        "time": {},
-        "error": null,
-        "y": 20,
-        "x": 132,
-        "legend_size": "0",
-        "isShared": false,
-        "scaleFactor": 1,
-        "legend": true,
-        "add_timeframe": true
-      },
-      {
-        "board_id": "mmk-zds-miy",
-        "x": 6,
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1560870108937,
-          "end": 1560873708937
-        },
-        "title_align": "left",
-        "title_size": 16,
-        "title": true,
-        "type": "query_value",
-        "generated_title": "Timeseries",
-        "title_text": "Last update EPOCH",
-        "height": 10,
-        "tile_def": {
-          "viz": "query_value",
-          "requests": [
-            {
-              "q": "avg:kube_metrics_server.scraper_last_time{*}",
-              "aggregator": "last",
-              "style": {
-                "width": "normal",
-                "palette": "dog_classic",
-                "type": "solid"
-              },
-              "type": "line",
-              "conditional_formats": []
+        {
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:kube_metrics_server.go.goroutines{*}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Number of Goroutines",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 88,
+                "y": 20,
+                "width": 42,
+                "height": 17
             }
-          ],
-          "autoscale": false,
-          "color_by_groups": [],
-          "precision": "0"
         },
-        "width": 15,
-        "time": {},
-        "error": null,
-        "y": 37,
-        "autoscale": true,
-        "legend_size": "0",
-        "isShared": false,
-        "scaleFactor": 1,
-        "legend": false,
-        "add_timeframe": true
-      },
-      {
-        "height": 7,
-        "tick_pos": "50%",
-        "board_id": "68j-v2s-ewc",
-        "title_size": 16,
-        "title": true,
-        "title_align": "left",
-        "text_align": "left",
-        "bgcolor": "blue",
-        "html": "Performance",
-        "type": "note",
-        "isShared": false,
-        "refresh_every": 30000,
-        "auto_refresh": false,
-        "title_text": "",
-        "tick": true,
-        "scaleFactor": 1,
-        "add_timeframe": true,
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1558098394900,
-          "end": 1558101994900
+        {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "derivative(avg:kube_metrics_server.go.gc_duration_seconds.sum{*})",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Average go garbage collection duration in milliseconds",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 44,
+                "y": 20,
+                "width": 42,
+                "height": 17
+            }
         },
-        "font_size": "18",
-        "generated_title": "Note",
-        "tick_edge": "right",
-        "y": 7,
-        "x": 28,
-        "width": 14
-      },
-      {
-        "height": 7,
-        "tick_pos": "50%",
-        "board_id": "68j-v2s-ewc",
-        "title_size": 16,
-        "title": true,
-        "title_align": "left",
-        "text_align": "left",
-        "bgcolor": "blue",
-        "html": "Telemetry",
-        "type": "note",
-        "isShared": false,
-        "refresh_every": 30000,
-        "auto_refresh": false,
-        "title_text": "",
-        "tick": true,
-        "scaleFactor": 1,
-        "add_timeframe": true,
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1558098394900,
-          "end": 1558101994900
+        {
+            "id": 10,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:kube_metrics_server.process.max_fds{*}, avg:kube_metrics_server.process.open_fds{*}",
+                        "metadata": [
+                            {
+                                "expression": "avg:kube_metrics_server.process.max_fds{*}",
+                                "alias_name": "max"
+                            },
+                            {
+                                "expression": "avg:kube_metrics_server.process.open_fds{*}",
+                                "alias_name": "open"
+                            }
+                        ],
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "File descriptors",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 132,
+                "y": 20,
+                "width": 42,
+                "height": 17
+            }
         },
-        "font_size": "18",
-        "generated_title": "Note",
-        "tick_edge": "right",
-        "y": 25,
-        "x": 28,
-        "width": 14
-      },
-      {
-        "height": 7,
-        "tick_pos": "50%",
-        "board_id": "68j-v2s-ewc",
-        "title_size": 16,
-        "title": true,
-        "title_align": "left",
-        "text_align": "left",
-        "bgcolor": "blue",
-        "html": "Audit",
-        "type": "note",
-        "isShared": false,
-        "refresh_every": 30000,
-        "auto_refresh": false,
-        "title_text": "",
-        "tick": true,
-        "scaleFactor": 1,
-        "add_timeframe": true,
-        "globalTimeframe": {
-          "isLive": true,
-          "start": 1558098394900,
-          "end": 1558101994900
+        {
+            "id": 11,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:kube_metrics_server.scraper_last_time{*}",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Last update EPOCH",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": false,
+                "precision": 0
+            },
+            "layout": {
+                "x": 6,
+                "y": 37,
+                "width": 15,
+                "height": 12
+            }
         },
-        "font_size": "18",
-        "generated_title": "Note",
-        "tick_edge": "right",
-        "y": 43,
-        "x": 28,
-        "width": 14
-      }
+        {
+            "id": 12,
+            "definition": {
+                "type": "note",
+                "content": "Performance",
+                "background_color": "blue",
+                "font_size": "18",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 28,
+                "y": 7,
+                "width": 14,
+                "height": 7
+            }
+        },
+        {
+            "id": 13,
+            "definition": {
+                "type": "note",
+                "content": "Telemetry",
+                "background_color": "blue",
+                "font_size": "18",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 28,
+                "y": 25,
+                "width": 14,
+                "height": 7
+            }
+        },
+        {
+            "id": 14,
+            "definition": {
+                "type": "note",
+                "content": "Audit",
+                "background_color": "blue",
+                "font_size": "18",
+                "text_align": "left",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 28,
+                "y": 43,
+                "width": 14,
+                "height": 7
+            }
+        }
     ],
-    "disableCog": false,
-    "id": 703392,
-    "isShared": false
-  }
+    "template_variables": [
+        {
+            "name": "scope",
+            "default": "*",
+            "prefix": null
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30280
+}

--- a/kubernetes/assets/dashboards/kubernetes_deployments.json
+++ b/kubernetes/assets/dashboards/kubernetes_deployments.json
@@ -1,1311 +1,1356 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "Kubernetes Deployments Overview",
-    "created": "2020-07-14T17:23:45.442889+00:00",
-    "created_by": {
-        "access_role": "st",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": false,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "Kubernetes Deployments Overview",
     "description": "Our Kubernetes dashboard gives you broad visibility into the scale, status, and resource usage of your cluster and its containers. Further reading for Kubernetes monitoring:\n\n- [Autoscale Kubernetes workloads with any Datadog metric](https://www.datadoghq.com/blog/autoscale-kubernetes-datadog/)\n\n- [How to monitor Kubernetes + Docker with Datadog](https://www.datadoghq.com/blog/monitor-kubernetes-docker/)\n\n- [Monitoring in the Kubernetes era](https://www.datadoghq.com/blog/monitoring-kubernetes-era/)\n\n- [Monitoring Kubernetes performance metrics](https://www.datadoghq.com/blog/monitoring-kubernetes-performance-metrics/)\n\n- [Collecting metrics with built-in Kubernetes monitoring tools](https://www.datadoghq.com/blog/how-to-collect-and-graph-kubernetes-metrics/)\n\n- [Monitoring Kubernetes with Datadog](https://www.datadoghq.com/blog/monitoring-kubernetes-with-datadog/)\n\n- [Datadog's Kubernetes integration docs](https://docs.datadoghq.com/integrations/kubernetes/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
-    "id": 1227732,
-    "modified": "2020-07-19T17:46:45.196308+00:00",
-    "new_id": "yn5-ms6-w87",
-    "read_only": false,
-    "template_variables": [
-        {
-            "default": "*",
-            "name": "scope",
-            "prefix": null
-        },
-        {
-            "default": "*",
-            "name": "kube_cluster_name",
-            "prefix": "kube_cluster_name"
-        },
-        {
-            "default": "*",
-            "name": "kube_namespace",
-            "prefix": "kube_namespace"
-        },
-        {
-            "default": "*",
-            "name": "kube_deployment",
-            "prefix": "kube_deployment"
-        }
-    ],
     "widgets": [
         {
-            "height": 12,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 0,
+            "id": 0,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "sum:kubernetes_state.deployment.replicas_available{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}",
                         "aggregator": "last",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "green_on_white",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "green_on_white"
                             }
-                        ],
-                        "q": "sum:kubernetes_state.deployment.replicas_available{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Available",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Available",
-            "type": "query_value",
-            "width": 14,
-            "x": 45,
-            "y": 6
+            "layout": {
+                "x": 45,
+                "y": 6,
+                "width": 14,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 1,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.deployment.replicas_available{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "display_type": "area",
                         "style": {
                             "palette": "green",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Replicas Available",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Replicas Available",
-            "type": "timeseries",
-            "width": 59,
-            "x": 0,
-            "y": 57
+            "layout": {
+                "x": 0,
+                "y": 57,
+                "width": 59,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "tile_def": {
-                "autoscale": true,
-                "precision": 0,
+            "id": 2,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}",
                         "aggregator": "last",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "custom_fg_color": "#6a53a1",
+                                "value": 0,
                                 "palette": "green_on_white",
-                                "value": "0"
+                                "custom_fg_color": "#6a53a1"
                             }
-                        ],
-                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Replicas",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 0
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Replicas",
-            "type": "query_value",
-            "width": 14,
-            "x": 15,
-            "y": 6
+            "layout": {
+                "x": 15,
+                "y": 6,
+                "width": 14,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 3,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace} by {deployment}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Replicas",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Replicas",
-            "type": "timeseries",
-            "width": 59,
-            "x": 0,
-            "y": 42
+            "layout": {
+                "x": 0,
+                "y": 42,
+                "width": 59,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 0,
+            "id": 4,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "sum:kubernetes_state.deployment.replicas_unavailable{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}",
                         "aggregator": "last",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "red_on_white",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "red_on_white"
                             },
                             {
                                 "comparator": "<=",
-                                "palette": "green_on_white",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "green_on_white"
                             }
-                        ],
-                        "q": "sum:kubernetes_state.deployment.replicas_unavailable{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Unavailable",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Unavailable",
-            "type": "query_value",
-            "width": 14,
-            "x": 75,
-            "y": 6
+            "layout": {
+                "x": 75,
+                "y": 6,
+                "width": 14,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.deployment.replicas_unavailable{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {kube_cluster_name,kube_namespace,kube_deployment}",
+                        "display_type": "area",
                         "style": {
                             "palette": "orange",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "Replicas Unavailable",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Replicas Unavailable",
-            "type": "timeseries",
-            "width": 59,
-            "x": 0,
-            "y": 72
+            "layout": {
+                "x": 0,
+                "y": 72,
+                "width": 59,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "tile_def": {
-                "autoscale": true,
-                "precision": 0,
+            "id": 6,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}",
                         "aggregator": "last",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "green_on_white",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "green_on_white"
                             }
-                        ],
-                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Desired",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 0
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Desired",
-            "type": "query_value",
-            "width": 14,
-            "x": 30,
-            "y": 6
+            "layout": {
+                "x": 30,
+                "y": 6,
+                "width": 14,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "display_type": "area",
                         "style": {
                             "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Replicas Desired",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Replicas Desired",
-            "type": "timeseries",
-            "width": 59,
-            "x": 60,
-            "y": 42
+            "layout": {
+                "x": 60,
+                "y": 42,
+                "width": 59,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 0,
+            "id": 8,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}",
                         "aggregator": "last",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "green_on_white",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "green_on_white"
                             }
-                        ],
-                        "q": "sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Updated",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Updated",
-            "type": "query_value",
-            "width": 14,
-            "x": 60,
-            "y": 6
+            "layout": {
+                "x": 60,
+                "y": 6,
+                "width": 14,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "Replicas Updated",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Replicas Updated",
-            "type": "timeseries",
-            "width": 59,
-            "x": 60,
-            "y": 57
+            "layout": {
+                "x": 60,
+                "y": 57,
+                "width": 59,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 10,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.deployment.rollingupdate.max_unavailable{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "display_type": "area",
                         "style": {
                             "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Max Unavailable Replicas in Rolling Update (spec strategy)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Max Unavailable Replicas in Rolling Update (spec strategy)",
-            "type": "timeseries",
-            "width": 59,
-            "x": 60,
-            "y": 87
+            "layout": {
+                "x": 60,
+                "y": 87,
+                "width": 59,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 11,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment,kube_cluster_name,kube_namespace}-sum:kubernetes_state.deployment.replicas_available{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment,kube_cluster_name,kube_namespace}",
+                        "display_type": "area",
                         "style": {
                             "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "Replicas Desired but Not Available",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Replicas Desired but Not Available",
-            "type": "timeseries",
-            "width": 59,
-            "x": 0,
-            "y": 87
+            "layout": {
+                "x": 0,
+                "y": 87,
+                "width": 59,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "markers": [
-                    {
-                        "label": "y = 0",
-                        "type": "ok dashed",
-                        "value": "y = 0"
-                    }
-                ],
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}-sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "display_type": "area",
                         "style": {
                             "palette": "orange",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "markers": [
+                    {
+                        "value": "y = 0",
+                        "display_type": "ok dashed",
+                        "label": "y = 0"
+                    }
+                ],
+                "title": "Replicas Outdated",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Replicas Outdated",
-            "type": "timeseries",
-            "width": 59,
-            "x": 60,
-            "y": 72
+            "layout": {
+                "x": 60,
+                "y": 72,
+                "width": 59,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 0,
+            "id": 13,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}-sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}",
                         "aggregator": "last",
                         "conditional_formats": [
                             {
                                 "comparator": ">=",
-                                "palette": "yellow_on_white",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "yellow_on_white"
                             }
-                        ],
-                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}-sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Outdated",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Outdated",
-            "type": "query_value",
-            "width": 14,
-            "x": 105,
-            "y": 6
+            "layout": {
+                "x": 105,
+                "y": 6,
+                "width": 14,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "tile_def": {
-                "autoscale": true,
-                "custom_links": [],
-                "precision": 0,
+            "id": 14,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}-sum:kubernetes_state.deployment.replicas_available{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}",
                         "aggregator": "last",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "red_on_white",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "red_on_white"
                             },
                             {
                                 "comparator": "<=",
-                                "palette": "green_on_white",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "green_on_white"
                             }
-                        ],
-                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}-sum:kubernetes_state.deployment.replicas_available{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Desired Not Available",
-            "type": "query_value",
-            "width": 14,
-            "x": 90,
-            "y": 6
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Overview",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 119,
-            "x": 0,
-            "y": 0
-        },
-        {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
                 "custom_links": [],
+                "title": "Desired Not Available",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": true,
+                "precision": 0
+            },
+            "layout": {
+                "x": 90,
+                "y": 6,
+                "width": 14,
+                "height": 14
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "note",
+                "content": "Overview",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 119,
+                "height": 5
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "count_nonzero(avg:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_namespace,$kube_cluster_name} by {kube_cluster_name,kube_namespace,kube_deployment})",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "Deployments",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Deployments",
-            "type": "timeseries",
-            "width": 29,
-            "x": 0,
-            "y": 21
+            "layout": {
+                "x": 0,
+                "y": 21,
+                "width": 29,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 17,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_namespace,$kube_cluster_name} by {kube_cluster_name,kube_namespace,kube_deployment}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "Replicas per Deployments",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Replicas per Deployments",
-            "type": "timeseries",
-            "width": 29,
-            "x": 30,
-            "y": 21
+            "layout": {
+                "x": 30,
+                "y": 21,
+                "width": 29,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "tile_def": {
-                "custom_links": [],
+            "id": 18,
+            "definition": {
+                "type": "change",
                 "requests": [
                     {
+                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_namespace,$kube_cluster_name} by {kube_cluster_name,kube_namespace,kube_deployment}",
                         "change_type": "absolute",
                         "compare_to": "week_before",
                         "increase_good": true,
                         "order_by": "change",
-                        "order_dir": "desc",
-                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_namespace,$kube_cluster_name} by {kube_cluster_name,kube_namespace,kube_deployment}"
+                        "order_dir": "desc"
                     }
                 ],
-                "viz": "change"
+                "custom_links": [],
+                "title": "Replicas per Deployments",
+                "title_size": "16",
+                "title_align": "left"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Replicas per Deployments",
-            "type": "change",
-            "width": 29,
-            "x": 60,
-            "y": 21
+            "layout": {
+                "x": 60,
+                "y": 21,
+                "width": 29,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 19,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}-sum:kubernetes_state.deployment.replicas_available{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Replicas Desired but Not Available",
-            "type": "timeseries",
-            "width": 29,
-            "x": 90,
-            "y": 21
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Replicas by Deployment",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 119,
-            "x": 0,
-            "y": 36
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Resources",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 119,
-            "x": 0,
-            "y": 102
-        },
-        {
-            "height": 22,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
                 "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "Replicas Desired but Not Available",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 90,
+                "y": 21,
+                "width": 29,
+                "height": 14
+            }
+        },
+        {
+            "id": 20,
+            "definition": {
+                "type": "note",
+                "content": "Replicas by Deployment",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 36,
+                "width": 119,
+                "height": 5
+            }
+        },
+        {
+            "id": 21,
+            "definition": {
+                "type": "note",
+                "content": "Resources",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 102,
+                "width": 119,
+                "height": 5
+            }
+        },
+        {
+            "id": 22,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.cpu.usage.total{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_cluster_name,kube_namespace,kube_deployment}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "CPU Usage by Deployment",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "CPU Usage by Deployment",
-            "type": "timeseries",
-            "width": 59,
-            "x": 0,
-            "y": 114
+            "layout": {
+                "x": 0,
+                "y": 114,
+                "width": 59,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 23,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:kubernetes.memory.usage{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "Memory Usage by Deployment",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Memory Usage by Deployment",
-            "type": "timeseries",
-            "width": 59,
-            "x": 60,
-            "y": 114
+            "layout": {
+                "x": 60,
+                "y": 114,
+                "width": 59,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "tile_def": {
-                "custom_links": [],
+            "id": 24,
+            "definition": {
+                "type": "toplist",
                 "requests": [
                     {
                         "q": "top(sum:kubernetes.memory.usage{$scope,$kube_namespace,$kube_deployment,!pod_name:no_pod,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}, 10, 'mean', 'desc')"
                     }
                 ],
-                "viz": "toplist"
+                "custom_links": [],
+                "title": "Most memory-intensive Deployments",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                }
             },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Most memory-intensive Deployments",
-            "type": "toplist",
-            "width": 59,
-            "x": 60,
-            "y": 139
+            "layout": {
+                "x": 60,
+                "y": 139,
+                "width": 59,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "tile_def": {
-                "custom_links": [],
+            "id": 25,
+            "definition": {
+                "type": "toplist",
                 "requests": [
                     {
                         "q": "top(sum:kubernetes.cpu.usage.total{$scope,$kube_namespace,$kube_deployment,!pod_name:no_pod,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}, 10, 'mean', 'desc')"
                     }
                 ],
-                "viz": "toplist"
+                "custom_links": [],
+                "title": "Most CPU-intensive Deployments",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                }
             },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Most CPU-intensive Deployments",
-            "type": "toplist",
-            "width": 59,
-            "x": 0,
-            "y": 139
+            "layout": {
+                "x": 0,
+                "y": 139,
+                "width": 59,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 26,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
-                        "metadata": {
-                            "sum:kubernetes.cpu.limits{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}": {
-                                "alias": "Limits"
-                            },
-                            "sum:kubernetes.cpu.requests{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}": {
-                                "alias": "Requests"
-                            },
-                            "sum:kubernetes.cpu.usage.total{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}": {
-                                "alias": "Usage"
-                            }
-                        },
                         "q": "sum:kubernetes.cpu.requests{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}, sum:kubernetes.cpu.usage.total{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}, sum:kubernetes.cpu.limits{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}",
+                        "metadata": [
+                            {
+                                "expression": "sum:kubernetes.cpu.requests{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}",
+                                "alias_name": "Requests"
+                            },
+                            {
+                                "expression": "sum:kubernetes.cpu.limits{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}",
+                                "alias_name": "Limits"
+                            },
+                            {
+                                "expression": "sum:kubernetes.cpu.usage.total{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}",
+                                "alias_name": "Usage"
+                            }
+                        ],
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "CPU requests, limits and usage",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "CPU requests, limits and usage",
-            "type": "timeseries",
-            "width": 59,
-            "x": 0,
-            "y": 164
+            "layout": {
+                "x": 0,
+                "y": 164,
+                "width": 59,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 27,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
-                        "metadata": {
-                            "sum:kubernetes.memory.limits{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}": {
-                                "alias": "Limits"
-                            },
-                            "sum:kubernetes.memory.requests{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}": {
-                                "alias": "Requests"
-                            },
-                            "sum:kubernetes.memory.rss{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}": {
-                                "alias": "Usage"
-                            }
-                        },
                         "q": "sum:kubernetes.memory.requests{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}, sum:kubernetes.memory.rss{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}, sum:kubernetes.memory.limits{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}",
+                        "metadata": [
+                            {
+                                "expression": "sum:kubernetes.memory.limits{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}",
+                                "alias_name": "Limits"
+                            },
+                            {
+                                "expression": "sum:kubernetes.memory.requests{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}",
+                                "alias_name": "Requests"
+                            },
+                            {
+                                "expression": "sum:kubernetes.memory.rss{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name}",
+                                "alias_name": "Usage"
+                            }
+                        ],
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "Memory requests, limits and usage",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Memory requests, limits and usage",
-            "type": "timeseries",
-            "width": 59,
-            "x": 60,
-            "y": 164
+            "layout": {
+                "x": 60,
+                "y": 164,
+                "width": 59,
+                "height": 24
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "CPU",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 59,
-            "x": 0,
-            "y": 108
+            "id": 28,
+            "definition": {
+                "type": "note",
+                "content": "CPU",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 108,
+                "width": 59,
+                "height": 5
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Memory",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 59,
-            "x": 60,
-            "y": 108
+            "id": 29,
+            "definition": {
+                "type": "note",
+                "content": "Memory",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 60,
+                "y": 108,
+                "width": 59,
+                "height": 5
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Disk",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 59,
-            "x": 0,
-            "y": 189
+            "id": 30,
+            "definition": {
+                "type": "note",
+                "content": "Disk",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 189,
+                "width": 59,
+                "height": 5
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Network",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 59,
-            "x": 60,
-            "y": 189
+            "id": 31,
+            "definition": {
+                "type": "note",
+                "content": "Network",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 60,
+                "y": 189,
+                "width": 59,
+                "height": 5
+            }
         },
         {
-            "height": 22,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 32,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.network.rx_bytes{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}, sum:kubernetes.network.tx_bytes{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Network Usage (Rx / Tx rate)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Network Usage (Rx / Tx rate)",
-            "type": "timeseries",
-            "width": 59,
-            "x": 60,
-            "y": 195
+            "layout": {
+                "x": 60,
+                "y": 195,
+                "width": 59,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
-                "markers": [
-                    {
-                        "label": "y = 0",
-                        "type": "ok dashed",
-                        "value": "y = 0"
-                    }
-                ],
+            "id": 33,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.network.rx_errors{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}, sum:kubernetes.network.tx_errors{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": [
+                    {
+                        "value": "y = 0",
+                        "display_type": "ok dashed",
+                        "label": "y = 0"
+                    }
+                ],
+                "title": "Network Errors",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Network Errors",
-            "type": "timeseries",
-            "width": 59,
-            "x": 60,
-            "y": 220
+            "layout": {
+                "x": 60,
+                "y": 220,
+                "width": 59,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 34,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.filesystem.usage{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "Disk Usage",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Disk Usage",
-            "type": "timeseries",
-            "width": 59,
-            "x": 0,
-            "y": 195
+            "layout": {
+                "x": 0,
+                "y": 195,
+                "width": 59,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
-                "markers": [
-                    {
-                        "label": "\u00a0100%\u00a0",
-                        "type": "error dashed",
-                        "value": "y = 100"
-                    }
-                ],
+            "id": 35,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.filesystem.usage_pct{$kube_namespace,$kube_deployment,$scope,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}*100",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": [
+                    {
+                        "value": "y = 100",
+                        "display_type": "error dashed",
+                        "label": " 100% "
+                    }
+                ],
+                "title": "Disk Usage %",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Disk Usage %",
-            "type": "timeseries",
-            "width": 59,
-            "x": 0,
-            "y": 220
+            "layout": {
+                "x": 0,
+                "y": 220,
+                "width": 59,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "tile_def": {
-                "custom_links": [],
+            "id": 36,
+            "definition": {
+                "type": "toplist",
                 "requests": [
                     {
                         "q": "top(sum:kubernetes.filesystem.usage{$scope,$kube_namespace,$kube_deployment,!pod_name:no_pod,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}, 10, 'mean', 'desc')"
                     }
                 ],
-                "viz": "toplist"
+                "custom_links": [],
+                "title": "Most Disk-intensive Deployments",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                }
             },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Most Disk-intensive Deployments",
-            "type": "toplist",
-            "width": 59,
-            "x": -1,
-            "y": 245
+            "layout": {
+                "x": -1,
+                "y": 245,
+                "width": 59,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "tile_def": {
-                "custom_links": [],
+            "id": 37,
+            "definition": {
+                "type": "toplist",
                 "requests": [
                     {
                         "q": "top(sum:kubernetes.network.tx_bytes{$scope,$kube_namespace,$kube_deployment,!pod_name:no_pod,$kube_cluster_name} by {kube_deployment,kube_namespace,kube_cluster_name}, 10, 'mean', 'desc')"
                     }
                 ],
-                "viz": "toplist"
+                "custom_links": [],
+                "title": "Most Network-intensive Deployments",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                }
             },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Most Network-intensive Deployments",
-            "type": "toplist",
-            "width": 59,
-            "x": 60,
-            "y": 245
+            "layout": {
+                "x": 60,
+                "y": 245,
+                "width": 59,
+                "height": 24
+            }
         },
         {
-            "height": 12,
-            "tile_def": {
-                "precision": 0,
+            "id": 38,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "count_nonzero(sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace} by {kube_deployment})",
                         "aggregator": "avg",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "white_on_green",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "white_on_green"
                             }
-                        ],
-                        "q": "count_nonzero(sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace} by {kube_deployment})"
+                        ]
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Deployments",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Deployments",
-            "type": "query_value",
-            "width": 14,
-            "x": 0,
-            "y": 6
+            "layout": {
+                "x": 0,
+                "y": 6,
+                "width": 14,
+                "height": 14
+            }
         }
-    ]
+    ],
+    "template_variables": [
+        {
+            "name": "scope",
+            "default": "*",
+            "prefix": null
+        },
+        {
+            "name": "kube_cluster_name",
+            "default": "*",
+            "prefix": "kube_cluster_name"
+        },
+        {
+            "name": "kube_namespace",
+            "default": "*",
+            "prefix": "kube_namespace"
+        },
+        {
+            "name": "kube_deployment",
+            "default": "*",
+            "prefix": "kube_deployment"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30341
 }

--- a/kubernetes/assets/dashboards/kubernetes_nodes.json
+++ b/kubernetes/assets/dashboards/kubernetes_nodes.json
@@ -1,1404 +1,1492 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "Kubernetes Nodes Overview",
+    "title": "Kubernetes Nodes Overview",
     "description": "Our Kubernetes dashboard gives you broad visibility into the scale, status, and resource usage of your cluster and its containers. Further reading for Kubernetes monitoring:\n\n- [Autoscale Kubernetes workloads with any Datadog metric](https://www.datadoghq.com/blog/autoscale-kubernetes-datadog/)\n\n- [How to monitor Kubernetes + Docker with Datadog](https://www.datadoghq.com/blog/monitor-kubernetes-docker/)\n\n- [Monitoring in the Kubernetes era](https://www.datadoghq.com/blog/monitoring-kubernetes-era/)\n\n- [Monitoring Kubernetes performance metrics](https://www.datadoghq.com/blog/monitoring-kubernetes-performance-metrics/)\n\n- [Collecting metrics with built-in Kubernetes monitoring tools](https://www.datadoghq.com/blog/how-to-collect-and-graph-kubernetes-metrics/)\n\n- [Monitoring Kubernetes with Datadog](https://www.datadoghq.com/blog/monitoring-kubernetes-with-datadog/)\n\n- [Datadog's Kubernetes integration docs](https://docs.datadoghq.com/integrations/kubernetes/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
-    "template_variables": [
-        {
-            "default": "*",
-            "name": "cluster",
-            "prefix": "cluster_name"
-        },
-        {
-            "default": "*",
-            "name": "host",
-            "prefix": "host"
-        }
-    ],
     "widgets": [
         {
-            "height": 14,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
-                "markers": [
-                    {
-                        "label": "y = 0",
-                        "type": "error dashed",
-                        "value": "y = 0"
-                    }
-                ],
+            "id": 0,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "top(sum:kubernetes_state.nodes.by_condition{$cluster,status:true,$host,!condition:ready} by {status,condition,cluster_name}, 10, 'last', 'desc')",
+                        "display_type": "line",
                         "style": {
                             "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "markers": [
+                    {
+                        "value": "y = 0",
+                        "display_type": "error dashed",
+                        "label": "y = 0"
+                    }
+                ],
+                "title": "Nodes not in Ready condition",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 40,
+                "y": 36,
+                "width": 39,
+                "height": 16
+            }
+        },
+        {
+            "id": 1,
+            "definition": {
+                "type": "check_status",
+                "title": "Kubelets up",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "kubernetes.kubelet.check",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "$cluster",
+                    "$host"
+                ],
+                "time": {
+                    "live_span": "10m"
                 }
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Nodes not in Ready condition",
-            "type": "timeseries",
-            "width": 39,
-            "x": 40,
-            "y": 36
+            "layout": {
+                "x": 0,
+                "y": 22,
+                "width": 19,
+                "height": 7
+            }
         },
         {
-            "check": "kubernetes.kubelet.check",
-            "group_by": [],
-            "grouping": "cluster",
-            "height": 7,
-            "tags": [
-                "$cluster",
-                "$host"
-            ],
-            "time": {
-                "live_span": "10m"
+            "id": 2,
+            "definition": {
+                "type": "check_status",
+                "title": "Kubelet Ping",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "kubernetes.kubelet.check.ping",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": [
+                    "$cluster",
+                    "$host"
+                ],
+                "time": {
+                    "live_span": "10m"
+                }
             },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Kubelets up",
-            "type": "check_status",
-            "width": 19,
-            "x": 0,
-            "y": 22
+            "layout": {
+                "x": 20,
+                "y": 22,
+                "width": 19,
+                "height": 7
+            }
         },
         {
-            "check": "kubernetes.kubelet.check.ping",
-            "group_by": [],
-            "grouping": "cluster",
-            "height": 7,
-            "tags": [
-                "$cluster",
-                "$host"
-            ],
-            "time": {
-                "live_span": "10m"
+            "id": 3,
+            "definition": {
+                "type": "note",
+                "content": "Nodes Utilization",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
             },
-            "title": true,
-            "title_align": "center",
-            "title_size": 16,
-            "title_text": "Kubelet Ping",
-            "type": "check_status",
-            "width": 19,
-            "x": 20,
-            "y": 22
+            "layout": {
+                "x": 0,
+                "y": 53,
+                "width": 115,
+                "height": 5
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Nodes Utilization",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 115,
-            "x": 0,
-            "y": 53
-        },
-        {
-            "height": 14,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.memory.usage{$cluster,$host} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Memory usage per node",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Memory usage per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 76
+            "layout": {
+                "x": 58,
+                "y": 76,
+                "width": 57,
+                "height": 16
+            }
         },
         {
-            "height": 14,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.cpu.requests{$cluster,$host} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Total Kubernetes CPU requests per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Total Kubernetes CPU requests per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 93
+            "layout": {
+                "x": 0,
+                "y": 93,
+                "width": 57,
+                "height": 16
+            }
         },
         {
-            "height": 14,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.memory.requests{$cluster,$host} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Total Kubernetes memory requests per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Total Kubernetes memory requests per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 93
+            "layout": {
+                "x": 58,
+                "y": 93,
+                "width": 57,
+                "height": 16
+            }
         },
         {
-            "height": 14,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.cpu.usage.total{$cluster,$host} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "CPU usage per node",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "CPU usage per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 76
+            "layout": {
+                "x": 0,
+                "y": 76,
+                "width": 57,
+                "height": 16
+            }
         },
         {
-            "height": 14,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "top(sum:kubernetes.pods.running{$cluster,$host} by {host}, 50, 'mean', 'desc')",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Number of Pods per Node ",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 173
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Disk I/O & Network",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 115,
-            "x": 0,
-            "y": 302
-        },
-        {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
                 "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Number of Pods per Node ",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 58,
+                "y": 173,
+                "width": 57,
+                "height": 16
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "note",
+                "content": "Disk I/O & Network",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 302,
+                "width": 115,
+                "height": 5
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.network.rx_bytes{$cluster,$host} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "purple",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Network in per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Network in per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 308
+            "layout": {
+                "x": 0,
+                "y": 308,
+                "width": 57,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 11,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.network.tx_bytes{$cluster,$host} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "green",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Network out per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Network out per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 324
+            "layout": {
+                "x": 0,
+                "y": 324,
+                "width": 57,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.io.read_bytes{$cluster,$host} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "grey",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Disk reads per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Disk reads per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 324
+            "layout": {
+                "x": 58,
+                "y": 324,
+                "width": 57,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.io.write_bytes{$cluster,$host} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "grey",
-                            "type": "solid",
-                            "width": "thick"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "thick"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Disk writes per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Disk writes per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 308
+            "layout": {
+                "x": 58,
+                "y": 308,
+                "width": 57,
+                "height": 15
+            }
         },
         {
-            "height": 14,
-            "tile_def": {
-                "custom_links": [],
+            "id": 14,
+            "definition": {
+                "type": "toplist",
                 "requests": [
                     {
                         "q": "top(sum:kubernetes_state.nodes.by_condition{$cluster,status:true,$host} by {condition,status}, 10, 'mean', 'desc')"
                     }
                 ],
-                "viz": "toplist"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Node by condition",
-            "type": "toplist",
-            "width": 35,
-            "x": 80,
-            "y": 36
-        },
-        {
-            "height": 9,
-            "query": "sources:kubernetes $host $cluster",
-            "tags_execution": "and",
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "",
-            "type": "event_timeline",
-            "width": 57,
-            "x": 0,
-            "y": 213
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "[Events](https://www.datadoghq.com/blog/monitoring-kubernetes-performance-metrics/#toc-correlate-with-events10)\nand certificates",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 115,
-            "x": 0,
-            "y": 207
-        },
-        {
-            "event_size": "s",
-            "height": 32,
-            "query": "sources:kubernetes $host $cluster",
-            "tags_execution": "and",
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "",
-            "type": "event_stream",
-            "width": 57,
-            "x": 58,
-            "y": 213
-        },
-        {
-            "height": 14,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
                 "custom_links": [],
-                "markers": [
-                    {
-                        "type": "error dashed",
-                        "value": "y = 100"
-                    }
-                ],
+                "title": "Node by condition",
+                "title_size": "16",
+                "title_align": "left"
+            },
+            "layout": {
+                "x": 80,
+                "y": 36,
+                "width": 35,
+                "height": 16
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "event_timeline",
+                "query": "sources:kubernetes $host $cluster",
+                "tags_execution": "and",
+                "title": "",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                }
+            },
+            "layout": {
+                "x": 0,
+                "y": 213,
+                "width": 57,
+                "height": 9
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "note",
+                "content": "[Events](https://www.datadoghq.com/blog/monitoring-kubernetes-performance-metrics/#toc-correlate-with-events10)\nand certificates",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 207,
+                "width": 115,
+                "height": 5
+            }
+        },
+        {
+            "id": 17,
+            "definition": {
+                "type": "event_stream",
+                "query": "sources:kubernetes $host $cluster",
+                "tags_execution": "and",
+                "event_size": "s",
+                "title": "",
+                "title_size": "16",
+                "title_align": "left"
+            },
+            "layout": {
+                "x": 58,
+                "y": 213,
+                "width": 57,
+                "height": 34
+            }
+        },
+        {
+            "id": 18,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}, avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}*100",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": false
-                }
+                    "include_zero": false
+                },
+                "markers": [
+                    {
+                        "value": "y = 100",
+                        "display_type": "error dashed"
+                    }
+                ],
+                "title": "Memory utilization per node",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Memory utilization per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 59
+            "layout": {
+                "x": 58,
+                "y": 59,
+                "width": 57,
+                "height": 16
+            }
         },
         {
-            "height": 13,
-            "legend": true,
-            "tile_def": {
-                "custom_links": [],
+            "id": 19,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:kubernetes_state.node.cpu_allocatable{$cluster,$host} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Allocatable cpu cores per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 254
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "16",
-            "height": 5,
-            "html": "Allocatable resources per Node",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "left",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 115,
-            "x": 0,
-            "y": 248
-        },
-        {
-            "height": 13,
-            "legend": true,
-            "tile_def": {
                 "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Allocatable cpu cores per node",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true
+            },
+            "layout": {
+                "x": 58,
+                "y": 254,
+                "width": 57,
+                "height": 15
+            }
+        },
+        {
+            "id": 20,
+            "definition": {
+                "type": "note",
+                "content": "Allocatable resources per Node",
+                "background_color": "gray",
+                "font_size": "16",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "left"
+            },
+            "layout": {
+                "x": 0,
+                "y": 248,
+                "width": 115,
+                "height": 5
+            }
+        },
+        {
+            "id": 21,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:kubernetes_state.node.pods_allocatable{$cluster,$host} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Allocatable pods per node",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Allocatable pods per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 254
+            "layout": {
+                "x": 0,
+                "y": 254,
+                "width": 57,
+                "height": 15
+            }
         },
         {
-            "height": 14,
-            "legend": true,
-            "tile_def": {
-                "custom_links": [],
+            "id": 22,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:kubernetes_state.node.memory_allocatable{$cluster,$host} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Allocatable memory per node",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Allocatable memory per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 173
+            "layout": {
+                "x": 0,
+                "y": 173,
+                "width": 57,
+                "height": 16
+            }
         },
         {
-            "height": 14,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
+            "id": 23,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.containers.running{$cluster,$host} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Number of containers per node",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Number of containers per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 190
+            "layout": {
+                "x": 58,
+                "y": 190,
+                "width": 57,
+                "height": 16
+            }
         },
         {
-            "height": 13,
-            "tile_def": {
-                "custom_links": [],
+            "id": 24,
+            "definition": {
+                "type": "query_table",
                 "requests": [
                     {
+                        "q": "avg:kubernetes_state.node.cpu_allocatable{$host, $cluster} by {host}",
                         "aggregator": "avg",
                         "limit": 25,
                         "order": "asc",
-                        "q": "avg:kubernetes_state.node.cpu_allocatable{$host, $cluster} by {host}",
                         "alias": "CPU Available"
                     }
                 ],
-                "viz": "query_table"
+                "custom_links": [],
+                "title": "Allocatable CPU sort ASC",
+                "title_size": "16",
+                "title_align": "left"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Allocatable CPU sort ASC",
-            "type": "query_table",
-            "width": 57,
-            "x": 0,
-            "y": 270
+            "layout": {
+                "x": 0,
+                "y": 270,
+                "width": 57,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "tile_def": {
-                "custom_links": [],
+            "id": 25,
+            "definition": {
+                "type": "query_table",
                 "requests": [
                     {
+                        "q": "avg:kubernetes_state.node.pods_allocatable{$cluster,$host} by {host}",
                         "aggregator": "avg",
                         "limit": 25,
                         "order": "asc",
-                        "q": "avg:kubernetes_state.node.pods_allocatable{$cluster,$host} by {host}",
                         "alias": "Pods Available"
                     }
                 ],
-                "viz": "query_table"
+                "custom_links": [],
+                "title": "Allocatable Pods sort ASC",
+                "title_size": "16",
+                "title_align": "left"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Allocatable Pods sort ASC",
-            "type": "query_table",
-            "width": 57,
-            "x": 58,
-            "y": 270
+            "layout": {
+                "x": 58,
+                "y": 270,
+                "width": 57,
+                "height": 15
+            }
         },
         {
-            "height": 13,
-            "tile_def": {
-                "custom_links": [],
+            "id": 26,
+            "definition": {
+                "type": "query_table",
                 "requests": [
                     {
+                        "q": "avg:kubernetes_state.node.memory_allocatable{$cluster,$host} by {host}",
                         "aggregator": "avg",
                         "limit": 25,
                         "order": "asc",
-                        "q": "avg:kubernetes_state.node.memory_allocatable{$cluster,$host} by {host}",
                         "alias": "Memory Available"
                     }
                 ],
-                "viz": "query_table"
+                "custom_links": [],
+                "title": "Allocatable Memory sort ASC",
+                "title_size": "16",
+                "title_align": "left"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Allocatable Memory sort ASC",
-            "type": "query_table",
-            "width": 57,
-            "x": 0,
-            "y": 286
+            "layout": {
+                "x": 0,
+                "y": 286,
+                "width": 57,
+                "height": 15
+            }
         },
         {
-            "height": 14,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
+            "id": 27,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.nodes.by_condition{$cluster,$host,condition:ready,status:true} by {condition,status,cluster_name}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Nodes in Ready condition",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Nodes in Ready condition",
-            "type": "timeseries",
-            "width": 39,
-            "x": 0,
-            "y": 36
+            "layout": {
+                "x": 0,
+                "y": 36,
+                "width": 39,
+                "height": 16
+            }
         },
         {
-            "height": 20,
-            "tile_def": {
-                "custom_links": [],
+            "id": 28,
+            "definition": {
+                "type": "toplist",
                 "requests": [
                     {
+                        "q": "top(max:tls.seconds_left{kubelet:server,$cluster,$host} by {host}, 25, 'last', 'asc')",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "white_on_green",
-                                "value": "3600"
+                                "value": 3600,
+                                "palette": "white_on_green"
                             },
                             {
                                 "comparator": ">",
-                                "palette": "white_on_yellow",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "white_on_yellow"
                             },
                             {
                                 "comparator": "<",
-                                "palette": "white_on_red",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "white_on_red"
                             }
-                        ],
-                        "q": "top(max:tls.seconds_left{kubelet:server,$cluster,$host} by {host}, 25, 'last', 'asc')"
+                        ]
                     }
                 ],
-                "viz": "toplist"
+                "custom_links": [],
+                "title": "Kubelet certificates expirations (<1 hour left)",
+                "title_size": "16",
+                "title_align": "left"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Kubelet certificates expirations (<1 hour left)",
-            "type": "toplist",
-            "width": 57,
-            "x": 0,
-            "y": 225
+            "layout": {
+                "x": 0,
+                "y": 225,
+                "width": 57,
+                "height": 22
+            }
         },
         {
-            "height": 5,
-            "tile_def": {
-                "autoscale": false,
-                "custom_links": [],
-                "precision": 0,
+            "id": 29,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "sum:kubernetes_state.node.count{$cluster,$host}",
                         "aggregator": "avg",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "green_on_white",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "green_on_white"
                             }
-                        ],
-                        "q": "sum:kubernetes_state.node.count{$cluster,$host}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Number of nodes",
+                "title_size": "16",
+                "title_align": "left",
+                "autoscale": false,
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Number of nodes",
-            "type": "query_value",
-            "width": 19,
-            "x": 0,
-            "y": 6
+            "layout": {
+                "x": 0,
+                "y": 6,
+                "width": 19,
+                "height": 7
+            }
         },
         {
-            "height": 14,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
-                "markers": [
-                    {
-                        "type": "error dashed",
-                        "value": "y = 100"
-                    }
-                ],
+            "id": 30,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:kubernetes.memory.usage_pct{$cluster,$host} by {cluster_name}, avg:kubernetes.memory.usage_pct{$cluster,$host} by {cluster_name}*100",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": [
+                    {
+                        "value": "y = 100",
+                        "display_type": "error dashed"
+                    }
+                ],
+                "title": "Memory utilization per cluster",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Memory utilization per cluster",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 150
+            "layout": {
+                "x": 0,
+                "y": 150,
+                "width": 57,
+                "height": 16
+            }
         },
         {
-            "height": 14,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
+            "id": 31,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.filesystem.usage_pct{$cluster,$host} by {cluster_name}, sum:kubernetes.filesystem.usage_pct{$cluster,$host} by {cluster_name}*100",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "title": "Filesystem utilization per cluster",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Filesystem utilization per cluster",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 133
+            "layout": {
+                "x": 58,
+                "y": 133,
+                "width": 57,
+                "height": 16
+            }
         },
         {
-            "height": 14,
-            "legend": false,
-            "tile_def": {
-                "custom_links": [],
-                "markers": [
-                    {
-                        "type": "error dashed",
-                        "value": "y = 100"
-                    }
-                ],
+            "id": 32,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.cpu.requests{$cluster,$host} by {cluster_name}/sum:kubernetes.cpu.capacity{$cluster,$host} by {cluster_name}*100",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "CPU Allocation (requests / capacity) per cluster",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 133
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Cluster Utilization",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 115,
-            "x": 0,
-            "y": 127
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Pods and Containers",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 115,
-            "x": 0,
-            "y": 167
-        },
-        {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Nodes Conditions",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 115,
-            "x": 0,
-            "y": 30
-        },
-        {
-            "height": 14,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
                 "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
                 "markers": [
                     {
-                        "type": "error dashed",
-                        "value": "y = 100"
+                        "value": "y = 100",
+                        "display_type": "error dashed"
                     }
                 ],
+                "title": "CPU Allocation (requests / capacity) per cluster",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 0,
+                "y": 133,
+                "width": 57,
+                "height": 16
+            }
+        },
+        {
+            "id": 33,
+            "definition": {
+                "type": "note",
+                "content": "Cluster Utilization",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 127,
+                "width": 115,
+                "height": 5
+            }
+        },
+        {
+            "id": 34,
+            "definition": {
+                "type": "note",
+                "content": "Pods and Containers",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 167,
+                "width": 115,
+                "height": 5
+            }
+        },
+        {
+            "id": 35,
+            "definition": {
+                "type": "note",
+                "content": "Nodes Conditions",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 30,
+                "width": 115,
+                "height": 5
+            }
+        },
+        {
+            "id": 36,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "100-avg:system.cpu.idle{$host,$cluster} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "CPU utilization per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 59
-        },
-        {
-            "height": 14,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
                 "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
                 "markers": [
                     {
-                        "type": "error dashed",
-                        "value": "y = 100"
+                        "value": "y = 100",
+                        "display_type": "error dashed"
                     }
                 ],
+                "title": "CPU utilization per node",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 0,
+                "y": 59,
+                "width": 57,
+                "height": 16
+            }
+        },
+        {
+            "id": 37,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "100-avg:system.cpu.idle{$host,$cluster} by {cluster_name}",
+                        "display_type": "line",
                         "style": {
                             "palette": "warm",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "right_yaxis": {
-                    "include_zero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                },
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "CPU utilization per cluster",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 150
-        },
-        {
-            "height": 14,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
                 "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "right_yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
                 "markers": [
                     {
-                        "type": "error dashed",
-                        "value": "y = 100"
+                        "value": "y = 100",
+                        "display_type": "error dashed"
                     }
                 ],
+                "title": "CPU utilization per cluster",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 58,
+                "y": 150,
+                "width": 57,
+                "height": 16
+            }
+        },
+        {
+            "id": 38,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.cpu.requests{$cluster,$host} by {host}/sum:kubernetes.cpu.capacity{$cluster,$host} by {host}*100",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "markers": [
+                    {
+                        "value": "y = 100",
+                        "display_type": "error dashed"
+                    }
+                ],
+                "title": "Kubernetes (requests / capacity) per node",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Kubernetes (requests / capacity) per node",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 110
+            "layout": {
+                "x": 0,
+                "y": 110,
+                "width": 57,
+                "height": 16
+            }
         },
         {
-            "height": 5,
-            "tile_def": {
+            "id": 39,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.node.cpu_capacity{$cluster,$host}",
+                        "aggregator": "avg",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "green_on_white"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Total CPU",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": false,
-                "custom_links": [],
-                "precision": 0,
+                "precision": 0
+            },
+            "layout": {
+                "x": 20,
+                "y": 6,
+                "width": 19,
+                "height": 7
+            }
+        },
+        {
+            "id": 40,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "sum:kubernetes_state.node.memory_capacity{$cluster,$host}",
                         "aggregator": "avg",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "green_on_white",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "green_on_white"
                             }
-                        ],
-                        "q": "sum:kubernetes_state.node.cpu_capacity{$cluster,$host}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Total CPU",
-            "type": "query_value",
-            "width": 19,
-            "x": 20,
-            "y": 6
-        },
-        {
-            "height": 5,
-            "tile_def": {
+                "custom_links": [],
+                "title": "Total memory",
+                "title_size": "16",
+                "title_align": "left",
                 "autoscale": true,
-                "custom_links": [],
-                "precision": 0,
-                "requests": [
-                    {
-                        "aggregator": "avg",
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "green_on_white",
-                                "value": "0"
-                            }
-                        ],
-                        "q": "sum:kubernetes_state.node.memory_capacity{$cluster,$host}"
-                    }
-                ],
-                "viz": "query_value"
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Total memory",
-            "type": "query_value",
-            "width": 19,
-            "x": 20,
-            "y": 14
+            "layout": {
+                "x": 20,
+                "y": 14,
+                "width": 19,
+                "height": 7
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Overview",
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 115,
-            "x": -3,
-            "y": 0
+            "id": 41,
+            "definition": {
+                "type": "note",
+                "content": "Overview",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": -3,
+                "y": 0,
+                "width": 115,
+                "height": 5
+            }
         },
         {
-            "height": 14,
-            "tile_def": {
-                "custom_links": [],
+            "id": 42,
+            "definition": {
+                "type": "toplist",
                 "requests": [
                     {
                         "q": "top(sum:kubernetes_state.pod.ready{$cluster,condition:true,$host} by {host,pod_name}, 10, 'last', 'desc')"
                     }
                 ],
-                "viz": "toplist"
+                "custom_links": [],
+                "title": "Pods in Ready State per Node",
+                "title_size": "16",
+                "title_align": "left"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Pods in Ready State per Node",
-            "type": "toplist",
-            "width": 57,
-            "x": 0,
-            "y": 190
+            "layout": {
+                "x": 0,
+                "y": 190,
+                "width": 57,
+                "height": 16
+            }
         },
         {
-            "height": 21,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
-                "custom_links": [],
-                "markers": [
-                    {
-                        "label": "y = 100",
-                        "type": "error dashed",
-                        "value": "y = 100"
-                    },
-                    {
-                        "label": "y = 80",
-                        "type": "warning dashed",
-                        "value": "y = 80"
-                    }
-                ],
+            "id": 43,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "100-avg:system.cpu.idle{$host,$cluster} by {host}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
-                }
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "CPU % utilization per node",
-            "type": "timeseries",
-            "width": 35,
-            "x": 80,
-            "y": 6
-        },
-        {
-            "height": 21,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
                 "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
                 "markers": [
                     {
-                        "label": "y = 100",
-                        "type": "error dashed",
-                        "value": "y = 100"
+                        "value": "y = 100",
+                        "display_type": "error dashed",
+                        "label": "y = 100"
                     },
                     {
-                        "label": "y = 80",
-                        "type": "warning dashed",
-                        "value": "y = 80"
+                        "value": "y = 80",
+                        "display_type": "warning dashed",
+                        "label": "y = 80"
                     }
                 ],
+                "title": "CPU % utilization per node",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 80,
+                "y": 6,
+                "width": 35,
+                "height": 23
+            }
+        },
+        {
+            "id": 44,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}, avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}*100",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": false
-                }
+                    "include_zero": false
+                },
+                "markers": [
+                    {
+                        "value": "y = 100",
+                        "display_type": "error dashed",
+                        "label": "y = 100"
+                    },
+                    {
+                        "value": "y = 80",
+                        "display_type": "warning dashed",
+                        "label": "y = 80"
+                    }
+                ],
+                "title": "Memory utilization % per node",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Memory utilization % per node",
-            "type": "timeseries",
-            "width": 39,
-            "x": 40,
-            "y": 6
+            "layout": {
+                "x": 40,
+                "y": 6,
+                "width": 39,
+                "height": 23
+            }
         },
         {
-            "height": 5,
-            "tile_def": {
-                "custom_links": [],
-                "precision": 0,
+            "id": 45,
+            "definition": {
+                "type": "query_value",
                 "requests": [
                     {
+                        "q": "sum:kubernetes_state.nodes.by_condition{$cluster,status:true,$host,!condition:ready}",
                         "aggregator": "avg",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "white_on_red"
                             },
                             {
                                 "comparator": "<=",
-                                "palette": "green_on_white",
-                                "value": "0"
+                                "value": 0,
+                                "palette": "green_on_white"
                             }
-                        ],
-                        "q": "sum:kubernetes_state.nodes.by_condition{$cluster,status:true,$host,!condition:ready}"
+                        ]
                     }
                 ],
-                "viz": "query_value"
+                "custom_links": [],
+                "title": "Nodes not ready",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Nodes not ready",
-            "type": "query_value",
-            "width": 19,
-            "x": 0,
-            "y": 14
+            "layout": {
+                "x": 0,
+                "y": 14,
+                "width": 19,
+                "height": 7
+            }
         }
-    ]
+    ],
+    "template_variables": [
+        {
+            "name": "cluster",
+            "default": "*",
+            "prefix": "cluster_name"
+        },
+        {
+            "name": "host",
+            "default": "*",
+            "prefix": "host"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30340
 }

--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -1,788 +1,805 @@
 {
-    "author_info": {
-        "author_name": "Datadog"
-    },
-    "board_title": "Kubernetes Pods Overview",
-    "created": "2020-05-01T18:00:49.049142+00:00",
-    "created_by": {
-        "access_role": "st",
-        "disabled": false,
-        "email": "support@datadoghq.com",
-        "handle": "support@datadoghq.com",
-        "is_admin": false,
-        "name": "Datadog",
-        "role": null,
-        "title": null,
-        "verified": true
-    },
+    "title": "Kubernetes Pods Overview",
     "description": "Our Kubernetes dashboard gives you broad visibility into the scale, status, and resource usage of your cluster and its containers. Further reading for Kubernetes monitoring:\n\n- [Autoscale Kubernetes workloads with any Datadog metric](https://www.datadoghq.com/blog/autoscale-kubernetes-datadog/)\n\n- [How to monitor Kubernetes + Docker with Datadog](https://www.datadoghq.com/blog/monitor-kubernetes-docker/)\n\n- [Monitoring in the Kubernetes era](https://www.datadoghq.com/blog/monitoring-kubernetes-era/)\n\n- [Monitoring Kubernetes performance metrics](https://www.datadoghq.com/blog/monitoring-kubernetes-performance-metrics/)\n\n- [Collecting metrics with built-in Kubernetes monitoring tools](https://www.datadoghq.com/blog/how-to-collect-and-graph-kubernetes-metrics/)\n\n- [Monitoring Kubernetes with Datadog](https://www.datadoghq.com/blog/monitoring-kubernetes-with-datadog/)\n\n- [Datadog's Kubernetes integration docs](https://docs.datadoghq.com/integrations/kubernetes/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
-    "id": 1081578,
-    "modified": "2020-05-13T15:17:48.421139+00:00",
-    "new_id": "ztq-ghw-wpg",
-    "read_only": false,
-    "template_variables": [
-        {
-            "default": "*",
-            "name": "scope",
-            "prefix": null
-        },
-        {
-            "default": "*",
-            "name": "cluster",
-            "prefix": "cluster_name"
-        },
-        {
-            "default": "*",
-            "name": "namespace",
-            "prefix": "kube_namespace"
-        },
-        {
-            "default": "*",
-            "name": "deployment",
-            "prefix": "kube_deployment"
-        },
-        {
-            "default": "*",
-            "name": "statefulset",
-            "prefix": "kube_stateful_set"
-        },
-        {
-            "default": "*",
-            "name": "daemonset",
-            "prefix": "kube_daemon_set"
-        },
-        {
-            "default": "*",
-            "name": "job",
-            "prefix": "kube_job"
-        }
-    ],
     "widgets": [
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Overview",
-            "id": 1,
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 115,
-            "x": 0,
-            "y": -8
+            "id": 0,
+            "definition": {
+                "type": "note",
+                "content": "Overview",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": -8,
+                "width": 115,
+                "height": 5
+            }
         },
         {
-            "height": 22,
-            "id": 4,
-            "tile_def": {
+            "id": 1,
+            "definition": {
+                "type": "toplist",
                 "requests": [
                     {
                         "q": "top(sum:kubernetes.memory.usage{$scope,$namespace,$deployment,!pod_name:no_pod,$cluster,$statefulset,$daemonset,$job} by {pod_name}, 10, 'mean', 'desc')"
                     }
                 ],
-                "viz": "toplist"
+                "custom_links": [],
+                "title": "Most memory-intensive pods",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                }
             },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Most memory-intensive pods",
-            "type": "toplist",
-            "width": 28,
-            "x": 29,
-            "y": 52
+            "layout": {
+                "x": 29,
+                "y": 52,
+                "width": 28,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "id": 5,
-            "tile_def": {
+            "id": 2,
+            "definition": {
+                "type": "toplist",
                 "requests": [
                     {
                         "q": "top(sum:kubernetes.cpu.usage.total{$scope,$namespace,$deployment,!pod_name:no_pod,$cluster,$statefulset,$daemonset,$job} by {pod_name}, 10, 'mean', 'desc')"
                     }
                 ],
-                "viz": "toplist"
-            },
-            "time": {
-                "live_span": "4h"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Most CPU-intensive pods",
-            "type": "toplist",
-            "width": 28,
-            "x": 0,
-            "y": 52
-        },
-        {
-            "height": 22,
-            "id": 6,
-            "legend": true,
-            "tile_def": {
-                "requests": [
-                    {
-                        "metadata": {
-                            "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:failed,$scope}": {
-                                "alias": "Failed pods"
-                            },
-                            "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:pending,$scope}": {
-                                "alias": "Pending pods"
-                            },
-                            "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:running,$scope}": {
-                                "alias": "Running pods"
-                            },
-                            "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:succeeded,$scope}": {
-                                "alias": "Succeeded pods"
-                            }
-                        },
-                        "q": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:failed,$scope,$statefulset,$daemonset,$job}, sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:pending,$scope,$statefulset,$daemonset,$job}, sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:running,$scope,$statefulset,$daemonset,$job}, sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:succeeded,$scope,$statefulset,$daemonset,$job}",
-                        "style": {
-                            "palette": "cool",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
-                    }
-                ],
-                "viz": "timeseries",
-                "yaxis": {
-                    "includeZero": true,
-                    "label": "",
-                    "max": "auto",
-                    "min": "auto",
-                    "scale": "linear"
+                "custom_links": [],
+                "title": "Most CPU-intensive pods",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
                 }
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Pods Status Phase",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 52
+            "layout": {
+                "x": 0,
+                "y": 52,
+                "width": 28,
+                "height": 24
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Containers",
-            "id": 7,
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 115,
-            "x": 0,
-            "y": 94
+            "id": 3,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:failed,$scope,$statefulset,$daemonset,$job}, sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:pending,$scope,$statefulset,$daemonset,$job}, sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:running,$scope,$statefulset,$daemonset,$job}, sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:succeeded,$scope,$statefulset,$daemonset,$job}",
+                        "metadata": [
+                            {
+                                "expression": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:failed,$scope}",
+                                "alias_name": "Failed pods"
+                            },
+                            {
+                                "expression": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:pending,$scope}",
+                                "alias_name": "Pending pods"
+                            },
+                            {
+                                "expression": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:running,$scope}",
+                                "alias_name": "Running pods"
+                            },
+                            {
+                                "expression": "sum:kubernetes_state.pod.status_phase{$cluster,$namespace,$deployment,pod_phase:succeeded,$scope}",
+                                "alias_name": "Succeeded pods"
+                            }
+                        ],
+                        "display_type": "area",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Pods Status Phase",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true
+            },
+            "layout": {
+                "x": 58,
+                "y": 52,
+                "width": 57,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "id": 8,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 4,
+            "definition": {
+                "type": "note",
+                "content": "Containers",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 94,
+                "width": 115,
+                "height": 5
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.container.ready{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job}, sum:kubernetes_state.container.running{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job}, sum:kubernetes_state.container.terminated{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job}, sum:kubernetes_state.container.waiting{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Containers States",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Containers States",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 100
+            "layout": {
+                "x": 0,
+                "y": 100,
+                "width": 57,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "id": 9,
-            "legend": false,
-            "legend_size": "4",
-            "tile_def": {
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.container.restarts{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job} by {pod_name}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Container Restarts by Pod",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "4"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Container Restarts by Pod",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 100
+            "layout": {
+                "x": 58,
+                "y": 100,
+                "width": 57,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "id": 10,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.containers.state.waiting{$cluster,$namespace,$deployment,reason:crashloopbackoff,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Containers in CrashloopBackOff (by Pod)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Containers in CrashloopBackOff (by Pod)",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 125
+            "layout": {
+                "x": 0,
+                "y": 125,
+                "width": 57,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "id": 11,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.containers.state.terminated{$cluster,$namespace,$deployment,reason:oomkilled,$statefulset,$daemonset,$job} by {pod_name}",
+                        "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "bars"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Containers OOM Killed (by Pod)",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Containers OOM Killed (by Pod)",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 125
+            "layout": {
+                "x": 58,
+                "y": 125,
+                "width": 57,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "id": 12,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.cpu.usage.total{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {kube_container_name,container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "CPU Usage by Container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "CPU Usage by Container",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 150
+            "layout": {
+                "x": 0,
+                "y": 150,
+                "width": 57,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "id": 13,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 10,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.memory.usage{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {kube_container_name,container_id}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Memory Usage by Container",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Memory Usage by Container",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 150
+            "layout": {
+                "x": 58,
+                "y": 150,
+                "width": 57,
+                "height": 24
+            }
         },
         {
-            "bgcolor": "gray",
-            "font_size": "18",
-            "height": 5,
-            "html": "Pods",
-            "id": 14,
-            "text_align": "center",
-            "tick": false,
-            "tick_edge": "bottom",
-            "tick_pos": "50%",
-            "type": "note",
-            "width": 115,
-            "x": -1,
-            "y": 21
+            "id": 11,
+            "definition": {
+                "type": "note",
+                "content": "Pods",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": -1,
+                "y": 21,
+                "width": 115,
+                "height": 5
+            }
         },
         {
-            "height": 22,
-            "id": 15,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.network.rx_bytes{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}, sum:kubernetes.network.tx_bytes{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Network Rate by Pod",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Network Rate by Pod",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 175
+            "layout": {
+                "x": 0,
+                "y": 175,
+                "width": 57,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "id": 16,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.network.rx_errors{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}, sum:kubernetes.network.tx_errors{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Network Errors by Pod",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Network Errors by Pod",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 175
+            "layout": {
+                "x": 58,
+                "y": 175,
+                "width": 57,
+                "height": 24
+            }
         },
         {
-            "height": 14,
+            "id": 14,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:kubernetes.pods.running{$scope,$namespace,$deployment,$cluster,$statefulset,$daemonset,$job} by {kubernetes_cluster,kube_namespace}, 100, 'max', 'desc')",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 2000,
+                                "palette": "white_on_red"
+                            },
+                            {
+                                "comparator": ">",
+                                "value": 1500,
+                                "palette": "white_on_yellow"
+                            },
+                            {
+                                "comparator": "<=",
+                                "value": 3000,
+                                "palette": "white_on_green"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods Running By Namespace",
+                "title_size": "16",
+                "title_align": "left"
+            },
+            "layout": {
+                "x": 0,
+                "y": 77,
+                "width": 28,
+                "height": 16
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:kubernetes_state.pod.ready{$scope,$cluster,$namespace,$deployment,condition:true,$statefulset,$daemonset,$job} by {kubernetes_cluster,host,nodepool}, 10, 'last', 'desc')",
+                        "conditional_formats": [
+                            {
+                                "comparator": "<=",
+                                "value": 24,
+                                "palette": "white_on_green"
+                            },
+                            {
+                                "comparator": ">",
+                                "value": 32,
+                                "palette": "white_on_red"
+                            },
+                            {
+                                "comparator": ">",
+                                "value": 24,
+                                "palette": "white_on_yellow"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods in Ready State By Node",
+                "title_size": "16",
+                "title_align": "left"
+            },
+            "layout": {
+                "x": 29,
+                "y": 77,
+                "width": 28,
+                "height": 16
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:kubernetes_state.pod.status_phase{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,!phase:running,!phase:succeeded} by {phase,kube_namespace}, 100, 'last', 'desc')",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "white_on_red"
+                            },
+                            {
+                                "comparator": "<=",
+                                "value": 0,
+                                "palette": "white_on_green"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods in Bad Phase by Namespaces",
+                "title_size": "16",
+                "title_align": "left"
+            },
+            "layout": {
+                "x": 87,
+                "y": 6,
+                "width": 28,
+                "height": 14
+            }
+        },
+        {
             "id": 17,
-            "tile_def": {
+            "definition": {
+                "type": "toplist",
                 "requests": [
                     {
+                        "q": "top(exclude_null(sum:kubernetes_state.pod.ready{condition:false,$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job} by {kube_namespace}), 25, 'last', 'desc')",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": "2000"
-                            },
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_yellow",
-                                "value": "1500"
+                                "value": 0,
+                                "palette": "white_on_red"
                             },
                             {
                                 "comparator": "<=",
-                                "palette": "white_on_green",
-                                "value": "3000"
+                                "value": 0,
+                                "palette": "white_on_green"
                             }
-                        ],
-                        "q": "top(sum:kubernetes.pods.running{$scope,$namespace,$deployment,$cluster,$statefulset,$daemonset,$job} by {kubernetes_cluster,kube_namespace}, 100, 'max', 'desc')"
+                        ]
                     }
                 ],
-                "viz": "toplist"
+                "custom_links": [],
+                "title": "Pods in Bad State (Not Ready) by Namespace",
+                "title_size": "16",
+                "title_align": "left"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Pods Running By Namespace",
-            "type": "toplist",
-            "width": 28,
-            "x": 0,
-            "y": 77
+            "layout": {
+                "x": 58,
+                "y": 77,
+                "width": 57,
+                "height": 16
+            }
         },
         {
-            "height": 14,
             "id": 18,
-            "tile_def": {
+            "definition": {
+                "type": "change",
                 "requests": [
                     {
-                        "conditional_formats": [
-                            {
-                                "comparator": "<=",
-                                "palette": "white_on_green",
-                                "value": "24"
-                            },
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": "32"
-                            },
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_yellow",
-                                "value": "24"
-                            }
-                        ],
-                        "q": "top(sum:kubernetes_state.pod.ready{$scope,$cluster,$namespace,$deployment,condition:true,$statefulset,$daemonset,$job} by {kubernetes_cluster,host,nodepool}, 10, 'last', 'desc')"
-                    }
-                ],
-                "viz": "toplist"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Pods in Ready State By Node",
-            "type": "toplist",
-            "width": 28,
-            "x": 29,
-            "y": 77
-        },
-        {
-            "height": 12,
-            "id": 19,
-            "tile_def": {
-                "requests": [
-                    {
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": "0"
-                            },
-                            {
-                                "comparator": "<=",
-                                "palette": "white_on_green",
-                                "value": "0"
-                            }
-                        ],
-                        "q": "top(sum:kubernetes_state.pod.status_phase{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,!phase:running,!phase:succeeded} by {phase,kube_namespace}, 100, 'last', 'desc')"
-                    }
-                ],
-                "viz": "toplist"
-            },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Pods in Bad Phase by Namespaces",
-            "type": "toplist",
-            "width": 28,
-            "x": 87,
-            "y": 6
-        },
-        {
-            "height": 14,
-            "id": 20,
-            "tile_def": {
-                "requests": [
-                    {
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "white_on_red",
-                                "value": "0"
-                            },
-                            {
-                                "comparator": "<=",
-                                "palette": "white_on_green",
-                                "value": "0"
-                            }
-                        ],
-                        "q": "top(exclude_null(sum:kubernetes_state.pod.ready{condition:false,$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job} by {kube_namespace}), 25, 'last', 'desc')"
-                    }
-                ],
-                "viz": "toplist"
-            },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Pods in Bad State (Not Ready) by Namespace",
-            "type": "toplist",
-            "width": 57,
-            "x": 58,
-            "y": 77
-        },
-        {
-            "height": 12,
-            "id": 22,
-            "tile_def": {
-                "requests": [
-                    {
+                        "q": "sum:kubernetes.pods.running{$scope,$namespace,$cluster,$deployment,$statefulset,$daemonset,$job} by {kube_namespace,kube_deployment}",
                         "change_type": "absolute",
                         "compare_to": "week_before",
                         "increase_good": true,
                         "order_by": "change",
-                        "order_dir": "desc",
-                        "q": "sum:kubernetes.pods.running{$scope,$namespace,$cluster,$deployment,$statefulset,$daemonset,$job} by {kube_namespace,kube_deployment}"
+                        "order_dir": "desc"
                     }
                 ],
-                "viz": "change"
+                "custom_links": [],
+                "title": "Pods Running (changed weekly)",
+                "title_size": "16",
+                "title_align": "left"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Pods Running (changed weekly)",
-            "type": "change",
-            "width": 28,
-            "x": 58,
-            "y": 6
+            "layout": {
+                "x": 58,
+                "y": 6,
+                "width": 28,
+                "height": 14
+            }
         },
         {
-            "height": 12,
-            "id": 23,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 19,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.pods.running{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Pods Running",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Pods Running",
-            "type": "timeseries",
-            "width": 28,
-            "x": 0,
-            "y": 6
+            "layout": {
+                "x": 0,
+                "y": 6,
+                "width": 28,
+                "height": 14
+            }
         },
         {
-            "height": 22,
-            "id": 26,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 20,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:kubernetes.cpu.usage.total{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "CPU Usage by Pod",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "CPU Usage by Pod",
-            "type": "timeseries",
-            "width": 57,
-            "x": 0,
-            "y": 27
+            "layout": {
+                "x": 0,
+                "y": 27,
+                "width": 57,
+                "height": 24
+            }
         },
         {
-            "height": 22,
-            "id": 27,
-            "legend": true,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 21,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "avg:kubernetes.memory.usage{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "line"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Memory Usage by Pod",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_size": "0"
             },
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Memory Usage by Pod",
-            "type": "timeseries",
-            "width": 57,
-            "x": 58,
-            "y": 27
+            "layout": {
+                "x": 58,
+                "y": 27,
+                "width": 57,
+                "height": 24
+            }
         },
         {
-            "height": 12,
-            "id": 29,
-            "legend": false,
-            "legend_size": "0",
-            "tile_def": {
+            "id": 22,
+            "definition": {
+                "type": "timeseries",
                 "requests": [
                     {
                         "q": "sum:kubernetes.pods.running{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job} by {cluster_name,kube_namespace}",
+                        "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
-                            "type": "solid",
-                            "width": "normal"
-                        },
-                        "type": "area"
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
                     }
                 ],
-                "viz": "timeseries",
+                "custom_links": [],
                 "yaxis": {
-                    "includeZero": true,
                     "label": "",
-                    "max": "auto",
+                    "scale": "linear",
                     "min": "auto",
-                    "scale": "linear"
-                }
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Pods running by Namespace",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
             },
-            "time": {},
-            "title": true,
-            "title_align": "left",
-            "title_size": 16,
-            "title_text": "Pods running by Namespace",
-            "type": "timeseries",
-            "width": 28,
-            "x": 29,
-            "y": 6
+            "layout": {
+                "x": 29,
+                "y": 6,
+                "width": 28,
+                "height": 14
+            }
         }
-    ]
+    ],
+    "template_variables": [
+        {
+            "name": "scope",
+            "default": "*",
+            "prefix": null
+        },
+        {
+            "name": "cluster",
+            "default": "*",
+            "prefix": "cluster_name"
+        },
+        {
+            "name": "namespace",
+            "default": "*",
+            "prefix": "kube_namespace"
+        },
+        {
+            "name": "deployment",
+            "default": "*",
+            "prefix": "kube_deployment"
+        },
+        {
+            "name": "statefulset",
+            "default": "*",
+            "prefix": "kube_stateful_set"
+        },
+        {
+            "name": "daemonset",
+            "default": "*",
+            "prefix": "kube_daemon_set"
+        },
+        {
+            "name": "job",
+            "default": "*",
+            "prefix": "kube_job"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 30322
 }


### PR DESCRIPTION
### What does this PR do?

This pull request converts the rest of the dashboard payloads in `integrations-core`.

### Motivation

@DataDog/dashboards is seeking to deprecate all legacy payloads as they are cumbersome and difficult to get. We use the new format payloads everywhere now.

### Additional Notes

Ensure that these boards still work on staging:

* https://dd.datad0g.com/screen/integration/30253/airflow-overview?from_ts=1597861698253&live=true&to_ts=1597865298253
* https://dd.datad0g.com/screen/integration/30260/amazon-msk-overview
* https://dd.datad0g.com/screen/integration/30198/ambari-base-dashboard
* https://dd.datad0g.com/screen/integration/30247/cilium-overview?from_ts=1597861751948&to_ts=1597865351948&live=true
* https://dd.datad0g.com/screen/integration/30256/clickhouse-overview?from_ts=1597861767907&to_ts=1597865367907&live=true
* https://dd.datad0g.com/screen/integration/30201/cockroachdb-overview
* https://dd.datad0g.com/screen/integration/30264/amazon-fargate-overview?from_ts=1597861840284&live=true&to_ts=1597865440284
* https://dd.datad0g.com/screen/integration/30250/envoy---overview?from_ts=1597861861895&live=true&to_ts=1597865461895
* https://dd.datad0g.com/screen/integration/30245/etcd-overview?from_ts=1597861876105&live=true&to_ts=1597865476105
* https://dd.datad0g.com/screen/integration/30282/exchange-server-overview?from_ts=1597861888725&live=true&to_ts=1597865488725
* https://dd.datad0g.com/screen/integration/30270/flink-overview
* https://dd.datad0g.com/screen/integration/30274/gitlab-overview?from_ts=1597861913253&live=true&to_ts=1597865513253
* https://dd.datad0g.com/screen/integration/30200/harbor-integration-dashboard?from_ts=1597861926876&live=true&to_ts=1597865526876
* https://dd.datad0g.com/screen/integration/30336/hazelcast-overview
* https://dd.datad0g.com/screen/integration/30239/hive-integration-dashboard
* https://dd.datad0g.com/screen/integration/30318/hivemq-overview?from_ts=1597861958539&live=true&to_ts=1597865558539
* https://dd.datad0g.com/screen/integration/30275/confluent-platform-overview
* https://dd.datad0g.com/screen/integration/30244/druid-overview
* https://dd.datad0g.com/screen/integration/30196/ibm-db2-overview
* https://dd.datad0g.com/screen/integration/30283/ignite-overview?from_ts=1597862001337&live=true&to_ts=1597865601337
* https://dd.datad0g.com/screen/integration/30279/istio-overview-v15?from_ts=1597862016516&live=true&to_ts=1597865616516
* https://dd.datad0g.com/screen/integration/30243/istio-dashboard?from_ts=1597862033929&live=true&to_ts=1597865633929
* https://dd.datad0g.com/screen/integration/30262/kong-overview?from_ts=1597862074919&live=true&to_ts=1597865674919
* https://dd.datad0g.com/screen/integration/30199/kubernetes-metrics-server?from_ts=1597862090124&to_ts=1597865690124&live=true
* https://dd.datad0g.com/screen/integration/30340/kubernetes-deployments-overview?from_ts=1597862110159&live=true&to_ts=1597865710159
* https://dd.datad0g.com/screen/integration/30338/kubernetes-nodes-overview
* https://dd.datad0g.com/screen/integration/30280/kubernetes-pods-overview

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
