### PR TITLE
Add Cloud Foundry event metadata to DataDog event text as serialized JSON

### DIFF
--- a/cloud_foundry_api/tests/fixtures/event_v2.json
+++ b/cloud_foundry_api/tests/fixtures/event_v2.json
@@ -15,7 +15,9 @@
     "actee_type": "target_type",
     "actee_name": "target_name",
     "timestamp": "2020-06-08T00:00:02Z",
-    "metadata": {},
+    "metadata": {
+        "some": "metadata"
+    },
     "space_guid": "space_guid",
     "organization_guid": "org_guid"
   }

--- a/cloud_foundry_api/tests/fixtures/event_v3.json
+++ b/cloud_foundry_api/tests/fixtures/event_v3.json
@@ -13,7 +13,9 @@
     "type": "target_type",
     "name": "target_name"
   },
-  "data": {},
+  "data": {
+      "some": "metadata"
+  },
   "space": {
     "guid": "space_guid"
   },

--- a/cloud_foundry_api/tests/test_cloud_foundry_api.py
+++ b/cloud_foundry_api/tests/test_cloud_foundry_api.py
@@ -392,6 +392,7 @@ def test_parse_event(build_dd_event_mock, _, __, ___, ____, event_v2, event_v3, 
         "target_guid",
         "space_guid",
         "org_guid",
+        {"some": "metadata"},
     )
 
     # v3
@@ -412,6 +413,7 @@ def test_parse_event(build_dd_event_mock, _, __, ___, ____, event_v2, event_v3, 
         "target_guid",
         "space_guid",
         "org_guid",
+        {"some": "metadata"},
     )
 
 
@@ -432,6 +434,7 @@ def test_build_dd_event(_, __, ___, instance):
         "target_guid",
         "space_guid",
         "org_guid",
+        {"some": "metadata"},
     )
     tags = [
         "event_type:event_type",
@@ -452,14 +455,15 @@ def test_build_dd_event(_, __, ___, instance):
         "event_type": "event_type",
         "timestamp": 1234,
         "msg_title": "Event event_type happened for target_type target_name",
-        "msg_text": "Triggered by actor_type actor_name",
+        "msg_text": "%%% \n Triggered by actor_type actor_name\n\n"
+        + "Metadata:\n```\n{\n  \"some\": \"metadata\"\n}\n``` \n %%%",
         "priority": "normal",
         "tags": tags,
         "aggregation_key": "event_guid",
     }
     assert event == expected_event
 
-    # With no space and org
+    # With no space and org and metadata
     event = check.build_dd_event(
         "event_type",
         "event_guid",
@@ -472,6 +476,7 @@ def test_build_dd_event(_, __, ___, instance):
         "target_guid",
         "",
         "",
+        {},
     )
     tags = [
         "event_type:event_type",
@@ -492,7 +497,7 @@ def test_build_dd_event(_, __, ___, instance):
         "event_type": "event_type",
         "timestamp": 1234,
         "msg_title": "Event event_type happened for target_type target_name",
-        "msg_text": "Triggered by actor_type actor_name",
+        "msg_text": "%%% \n Triggered by actor_type actor_name\n\nMetadata:\n```\n{}\n``` \n %%%",
         "priority": "normal",
         "tags": tags,
         "aggregation_key": "event_guid",


### PR DESCRIPTION
### What does this PR do?

Adds the CF API event metadata to DataDog events as serialized JSON (also makes the event text markdown in order to be able to use preformatted text).

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
