### PR TITLE
Handle redis role missing

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -196,7 +196,9 @@ class Redis(AgentCheck):
 
             tags = self.tags
             if info.get("role"):
-                tags += ["redis_role:{}".format(info["role"])]
+                tags.append("redis_role:{}".format(info["role"]))
+            else:
+                self.log.debug("Redis role was not found")
             tags = sorted(tags)
 
             self.gauge('redis.info.latency_ms', latency_ms, tags=tags)

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -194,7 +194,7 @@ class Redis(AgentCheck):
             info = conn.info()
             latency_ms = round_value((time.time() - start) * 1000, 2)
 
-            tags = self.tags
+            tags = list(self.tags)
             if info.get("role"):
                 tags.append("redis_role:{}".format(info["role"]))
             else:

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -199,7 +199,6 @@ class Redis(AgentCheck):
                 tags.append("redis_role:{}".format(info["role"]))
             else:
                 self.log.debug("Redis role was not found")
-            tags = sorted(tags)
 
             self.gauge('redis.info.latency_ms', latency_ms, tags=tags)
             try:

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -193,7 +193,12 @@ class Redis(AgentCheck):
         try:
             info = conn.info()
             latency_ms = round_value((time.time() - start) * 1000, 2)
-            tags = sorted(self.tags + ["redis_role:%s" % info["role"]])
+
+            tags = self.tags
+            if info.get("role"):
+                tags += ["redis_role:{}".format(info["role"])]
+            tags = sorted(tags)
+
             self.gauge('redis.info.latency_ms', latency_ms, tags=tags)
             try:
                 config = conn.config_get("maxclients")

--- a/redisdb/tests/test_slowlog.py
+++ b/redisdb/tests/test_slowlog.py
@@ -14,7 +14,7 @@ from .common import HOST, PASSWORD, PORT
 
 TEST_KEY = "testkey"
 
-pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("dd_environment")]
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("redis_auth")]
 
 
 def test_slowlog(aggregator, redis_instance):
@@ -34,7 +34,7 @@ def test_slowlog(aggregator, redis_instance):
     redis_check = Redis('redisdb', {}, [redis_instance])
     redis_check.check(redis_instance)
 
-    expected_tags = ['foo:bar', 'redis_host:{}'.format(HOST), 'redis_port:6379', 'command:LPUSH', 'redis_role:master']
+    expected_tags = ['foo:bar', 'redis_host:{}'.format(HOST), 'redis_port:6379', 'command:LPUSH']
     aggregator.assert_metric('redis.slowlog.micros', tags=expected_tags)
 
 

--- a/redisdb/tests/test_slowlog.py
+++ b/redisdb/tests/test_slowlog.py
@@ -34,7 +34,7 @@ def test_slowlog(aggregator, redis_instance):
     redis_check = Redis('redisdb', {}, [redis_instance])
     redis_check.check(redis_instance)
 
-    expected_tags = ['foo:bar', 'redis_host:{}'.format(HOST), 'redis_port:6379', 'command:LPUSH']
+    expected_tags = ['foo:bar', 'redis_host:{}'.format(HOST), 'redis_port:6379', 'command:LPUSH', 'redis_role:master']
     aggregator.assert_metric('redis.slowlog.micros', tags=expected_tags)
 
 


### PR DESCRIPTION
### What does this PR do?
Check the `redis_role` exist before adding it as a tag.
Gracefully handle cases where the role is not here.

### Motivation
<!-- What inspired you to submit this pull request? -->
It seems the role is not in Alibaba ApsaraDB for example https://github.com/DataDog/integrations-core/issues/5915.
Note that it may not be enough to support ApsaraDB and other Redis-like.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
