### PR TITLE
update kubernetes_state auto_conf.yaml with valid example configuration

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
@@ -30,7 +30,7 @@ instances:
     # label_joins:
     #  kube_deployment_labels:
     #    labels_to_match:
-    #    - deployment
+    #      - deployment
     #    labels_to_get:
     #      - label_addonmanager_kubernetes_io_mode
 

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
@@ -29,7 +29,8 @@ instances:
     #
     # label_joins:
     #  kube_deployment_labels:
-    #    labels_to_match: deployment
+    #    labels_to_match:
+    #    - deployment
     #    labels_to_get:
     #      - label_addonmanager_kubernetes_io_mode
 

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -23,7 +23,8 @@ instances:
     #
     # label_joins:
     #   kube_deployment_labels:
-    #     label_to_match: deployment
+    #     labels_to_match:
+    #       - deployment
     #     labels_to_get:
     #       - label_addonmanager_kubernetes_io_mode
 


### PR DESCRIPTION
### What does this PR do?

Tiny change to the example configuration in the `auto_conf.yaml` for `kubernetes_state`.

### Motivation

I tried copying the example configuration and it didn't work. Had to read the code to figure out the correct value.

### Additional Notes

No.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
