### PR TITLE
Use author_name instead of author_info object

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
@@ -75,8 +75,7 @@ def export(ctx, url, integration, author):
 
     payload = response.json()
     new_payload = {field: payload[field] for field in REQUIRED_FIELDS}
-    new_payload.setdefault('author_info', {})
-    new_payload['author_info']['author_name'] = author
+    new_payload['author_name'] = author
 
     output = json.dumps(new_payload, indent=4, sort_keys=True)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The author_info field was used in the old screen/time payload format. The `author_name` field is whats used in the newer payloads. This updates the `ddev meta dash export` command to place the author cli value in this newer field. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
