### PR TITLE
Fix broken docs build, deleted tab start

### DIFF
--- a/iis/README.md
+++ b/iis/README.md
@@ -12,6 +12,9 @@ Collect IIS metrics aggregated across all of your sites, or on a per-site basis.
 
 The IIS check is packaged with the Agent. To start gathering your IIS metrics and logs, [install the Agent][2] on your IIS servers.
 
+<!-- xxx tabs xxx -->	
+<!-- xxx tab "Host" xxx -->	
+
 #### Host
 
 To configure this check for an Agent running on a host:


### PR DESCRIPTION
### What does this PR do?
adds back start-tab tags

### Motivation
broken docs build

