### PR TITLE
Support service checks in recommended monitors

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -13,7 +13,7 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
 
 REQUIRED_ATTRIBUTES = {'name', 'type', 'query', 'message', 'tags', 'options', 'recommended_monitor_metadata'}
 EXTRA_NOT_ALLOWED_FIELDS = ['id']
-ALLOWED_MONITOR_TYPES = ['metric alert', 'query alert', 'event alert']
+ALLOWED_MONITOR_TYPES = ['metric alert', 'query alert', 'event alert', 'service check']
 
 
 @click.command(


### PR DESCRIPTION
### What does this PR do?
Adds service checks to `ALLOWED_MONITOR_TYPES` for recommended monitors.  Support added https://github.com/DataDog/web-ui/pull/18806 and https://github.com/DataDog/k8s-resources/pull/9827

### Motivation
Recommended monitors work

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
