### PR TITLE
Use `black` profile for isort

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -37,6 +37,7 @@ from ..utils.secrets import SecretsSanitizer
 
 try:
     import datadog_agent
+
     from ..log import CheckLoggingAdapter, init_logging
 
     init_logging()

--- a/datadog_checks_base/datadog_checks/base/checks/win/winpdh_base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/winpdh_base.py
@@ -11,9 +11,9 @@ from ... import AgentCheck, is_affirmative
 from ...utils.containers import hash_mutable
 
 try:
-    from .winpdh import WinPDHCounter, DATA_TYPE_INT, DATA_TYPE_DOUBLE
+    from .winpdh import DATA_TYPE_DOUBLE, DATA_TYPE_INT, WinPDHCounter
 except ImportError:
-    from .winpdh_stub import WinPDHCounter, DATA_TYPE_INT, DATA_TYPE_DOUBLE
+    from .winpdh_stub import DATA_TYPE_DOUBLE, DATA_TYPE_INT, WinPDHCounter
 
 
 RESOURCETYPE_ANY = 0

--- a/datadog_checks_base/datadog_checks/base/ddyaml.py
+++ b/datadog_checks_base/datadog_checks/base/ddyaml.py
@@ -8,12 +8,12 @@ import yaml
 from six import string_types
 
 try:
-    from yaml import CSafeLoader as yLoader
     from yaml import CSafeDumper as yDumper
+    from yaml import CSafeLoader as yLoader
 except ImportError:
     # On source install C Extensions might have not been built
-    from yaml import SafeLoader as yLoader  # noqa, imported from here elsewhere
     from yaml import SafeDumper as yDumper  # noqa, imported from here elsewhere
+    from yaml import SafeLoader as yLoader  # noqa, imported from here elsewhere
 
 log = logging.getLogger(__name__)
 

--- a/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
@@ -8,12 +8,12 @@ from six import string_types
 from .. import ensure_unicode
 
 try:
-    from _util import get_subprocess_output as subprocess_output
     from _util import SubprocessOutputEmptyError  # noqa
+    from _util import get_subprocess_output as subprocess_output
 except ImportError:
     # No agent
-    from ..stubs._util import subprocess_output
     from ..stubs._util import SubprocessOutputEmptyError  # noqa
+    from ..stubs._util import subprocess_output
 
 
 log = logging.getLogger(__name__)

--- a/datadog_checks_base/tests/test_kube_leader.py
+++ b/datadog_checks_base/tests/test_kube_leader.py
@@ -7,11 +7,11 @@ from datetime import datetime, timedelta
 
 import mock
 import pytest
-from kubernetes.config.dateutil import format_rfc3339
 from six import iteritems, string_types
 
 from datadog_checks.base import AgentCheck, KubeLeaderElectionBaseCheck
 from datadog_checks.base.checks.kube_leader import ElectionRecord
+from kubernetes.config.dateutil import format_rfc3339
 
 # Trigger lazy imports
 try:

--- a/datadog_checks_base/tests/test_pdhbasecheck.py
+++ b/datadog_checks_base/tests/test_pdhbasecheck.py
@@ -9,8 +9,9 @@ import pytest
 from .utils import requires_windows
 
 try:
-    from datadog_checks.checks.win.winpdh_base import PDHBaseCheck
     from datadog_test_libs.win.pdh_mocks import initialize_pdh_tests, pdh_mocks_fixture  # noqa: F401
+
+    from datadog_checks.checks.win.winpdh_base import PDHBaseCheck
 except ImportError:
     pass
 

--- a/datadog_checks_base/tests/test_winpdh.py
+++ b/datadog_checks_base/tests/test_winpdh.py
@@ -10,12 +10,13 @@ import pytest
 from .utils import requires_windows
 
 try:
-    from datadog_checks.checks.win.winpdh import WinPDHCounter, SINGLE_INSTANCE_KEY
     from datadog_test_libs.win.pdh_mocks import (  # noqa: F401
         initialize_pdh_tests,
-        pdh_mocks_fixture_bad_perf_strings,
         pdh_mocks_fixture,
+        pdh_mocks_fixture_bad_perf_strings,
     )
+
+    from datadog_checks.checks.win.winpdh import SINGLE_INSTANCE_KEY, WinPDHCounter
 except ImportError:
     import platform
 

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -15,7 +15,7 @@ TYPES_FLAG = 'dd_check_types'
 MYPY_ARGS_OPTION = 'dd_mypy_args'
 E2E_READY_CONDITION = 'e2e ready if'
 FIX_DEFAULT_ENVDIR_FLAG = 'ensure_default_envdir'
-ISORT_DEP = 'isort[pyproject]==4.3.21'  # cap isort due to https://github.com/timothycrosley/isort/issues/1278
+ISORT_DEP = 'isort[pyproject]==5.*'
 
 
 @tox.hookimpl

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/jmx.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/jmx.py
@@ -19,8 +19,7 @@ def jmx():
 @click.pass_context
 def query_endpoint(ctx, host, port, domain):
     import jpype
-    from jpype import java
-    from jpype import javax
+    from jpype import java, javax
 
     url = "service:jmx:rmi:///jndi/rmi://{}:{}/jmxrmi".format(host, port)
     jpype.startJVM(convertStrings=False)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
@@ -43,7 +43,7 @@ def make(ctx, checks, version, initial_release, skip_sign, sign_only, exclude, a
       - Ensure you did `gpg --import <YOUR_KEY_ID>.gpg.pub`
     """
     # Import lazily since in-toto runs a subprocess to check for gpg2 on load
-    from ...signing import update_link_metadata, YubikeyException
+    from ...signing import YubikeyException, update_link_metadata
 
     releasing_all = 'all' in checks
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -8,16 +8,16 @@ import shutil
 
 # How long ddev will wait for GPG to finish, especially when asking dev for signature.
 import securesystemslib.settings
+
 securesystemslib.settings.SUBPROCESS_TIMEOUT = 60
 
+from in_toto import runlib, util
 from securesystemslib.gpg.constants import GPG_COMMAND
 
-from in_toto import runlib, util
-
-from .constants import get_root
-from .git import ignored_by_git, tracked_by_git
 from ..subprocess import run_command
 from ..utils import chdir, ensure_dir_exists, path_join, stream_file_lines
+from .constants import get_root
+from .git import ignored_by_git, tracked_by_git
 
 LINK_DIR = '.in-toto'
 STEP_NAME = 'tag'

--- a/datadog_checks_tests_helper/datadog_test_libs/win/pdh_mocks.py
+++ b/datadog_checks_tests_helper/datadog_test_libs/win/pdh_mocks.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 
 import mock
 import pytest
-
 from six import PY3
 from six.moves import winreg
 

--- a/datadog_checks_tests_helper/setup.py
+++ b/datadog_checks_tests_helper/setup.py
@@ -1,10 +1,10 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from setuptools import setup, find_packages
 from codecs import open  # To use a consistent encoding
 from os import path
 
+from setuptools import find_packages, setup
 
 HERE = path.abspath(path.dirname(__file__))
 

--- a/docs/developer/.scripts/33_render_status.py
+++ b/docs/developer/.scripts/33_render_status.py
@@ -7,7 +7,12 @@ from datadog_checks.dev.tooling.utils import (
     get_readme_file,
     get_valid_checks,
     get_valid_integrations,
-    is_tile_only, has_e2e, has_dashboard, has_process_signature)
+    has_dashboard,
+    has_e2e,
+    has_process_signature,
+    is_tile_only,
+)
+
 MARKER = '<docs-insert-status>'
 
 

--- a/go-metro/setup.py
+++ b/go-metro/setup.py
@@ -1,9 +1,10 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from setuptools import setup
 from codecs import open  # To use a consistent encoding
 from os import path
+
+from setuptools import setup
 
 HERE = path.dirname(path.abspath(__file__))
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -4,13 +4,13 @@
 from collections import defaultdict
 from time import time
 
+from six import string_types
+
+from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 from kafka import KafkaAdminClient, KafkaClient
 from kafka import errors as kafka_errors
 from kafka.protocol.offset import OffsetRequest, OffsetResetStrategy, OffsetResponse
 from kafka.structs import TopicPartition
-from six import string_types
-
-from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
 
 from .constants import BROKER_REQUESTS_BATCH_SIZE, CONTEXT_UPPER_BOUND, DEFAULT_KAFKA_TIMEOUT, KAFKA_INTERNAL_TOPICS
 from .legacy_0_10_2 import LegacyKafkaCheck_0_10_2

--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -6,15 +6,15 @@ from __future__ import division
 from collections import defaultdict
 from time import time
 
-from kafka import KafkaClient
-from kafka import errors as kafka_errors
-from kafka.protocol.commit import GroupCoordinatorRequest, OffsetFetchRequest
-from kafka.protocol.offset import OffsetRequest, OffsetResetStrategy, OffsetResponse
 from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeError
 from six import string_types
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
+from kafka import KafkaClient
+from kafka import errors as kafka_errors
+from kafka.protocol.commit import GroupCoordinatorRequest, OffsetFetchRequest
+from kafka.protocol.offset import OffsetRequest, OffsetResetStrategy, OffsetResponse
 
 from .constants import CONTEXT_UPPER_BOUND, DEFAULT_KAFKA_TIMEOUT, KAFKA_INTERNAL_TOPICS
 

--- a/kafka_consumer/tests/conftest.py
+++ b/kafka_consumer/tests/conftest.py
@@ -6,9 +6,9 @@ import time
 
 import pytest
 from datadog_test_libs.utils.mock_dns import mock_local
-from kafka import KafkaConsumer
 
 from datadog_checks.dev import WaitFor, docker_run
+from kafka import KafkaConsumer
 
 from .common import DOCKER_IMAGE_PATH, HOST_IP, KAFKA_CONNECT_STR, PARTITIONS, TOPICS, ZK_CONNECT_STR
 from .runners import KConsumer, Producer, ZKConsumer

--- a/kafka_consumer/tests/runners.py
+++ b/kafka_consumer/tests/runners.py
@@ -5,9 +5,10 @@ import os
 import threading
 import time
 
-from kafka import KafkaConsumer, KafkaProducer
 from kazoo.client import KazooClient
 from six import binary_type, iteritems
+
+from kafka import KafkaConsumer, KafkaProducer
 
 from .common import KAFKA_CONNECT_STR, PARTITIONS, ZK_CONNECT_STR
 

--- a/openstack_controller/datadog_checks/openstack_controller/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api.py
@@ -5,8 +5,9 @@ from os import environ
 
 import requests
 import simplejson as json
-from openstack import connection
 from six.moves.urllib.parse import urljoin
+
+from openstack import connection
 
 from .exceptions import (
     AuthenticationNeeded,

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -7,12 +7,12 @@ from collections import defaultdict
 from datetime import datetime
 
 import requests
-from openstack.config.loader import OpenStackConfig
 from six import iteritems, itervalues
 
 from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.common import pattern_filter
 from datadog_checks.base.utils.tracing import traced
+from openstack.config.loader import OpenStackConfig
 
 from .api import ApiFactory
 from .exceptions import (

--- a/openstack_controller/tests/test_openstack_sdk_api.py
+++ b/openstack_controller/tests/test_openstack_sdk_api.py
@@ -1,6 +1,5 @@
 import mock
 import pytest
-from openstack.exceptions import SDKException
 
 from datadog_checks.openstack_controller.api import OpenstackSDKApi
 from datadog_checks.openstack_controller.exceptions import (
@@ -9,6 +8,7 @@ from datadog_checks.openstack_controller.exceptions import (
     MissingNeutronEndpoint,
     MissingNovaEndpoint,
 )
+from openstack.exceptions import SDKException
 
 from . import common
 

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -309,8 +309,8 @@ def test_check_real_process_regex(aggregator):
 
 
 def test_relocated_procfs(aggregator):
-    import tempfile
     import shutil
+    import tempfile
     import uuid
 
     unique_process_name = str(uuid.uuid4())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,8 @@ py36 = false
 skip-string-normalization = true
 
 [tool.isort]
+profile = 'black'
 default_section = 'THIRDPARTY'
-force_grid_wrap = 0
-include_trailing_comma = true
 known_first_party = 'datadog_checks'
 line_length = 120
-multi_line_output = 3
 skip_glob = 'datadog_checks/dev/tooling/signing.py,datadog_checks/dev/tooling/templates/*,datadog_checks/*/vendor/*'
-use_parentheses = true

--- a/rethinkdb/datadog_checks/rethinkdb/check.py
+++ b/rethinkdb/datadog_checks/rethinkdb/check.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from typing import Any, Callable, Iterator, Sequence, cast
 
 import rethinkdb
-
 from datadog_checks.base import AgentCheck
 
 from . import operations, queries

--- a/rethinkdb/tests/cluster.py
+++ b/rethinkdb/tests/cluster.py
@@ -6,10 +6,9 @@ from contextlib import contextmanager
 from typing import Iterator, List
 
 import rethinkdb
-from rethinkdb import r
-
 from datadog_checks.dev.conditions import WaitFor
 from datadog_checks.dev.docker import temporarily_stop_service
+from rethinkdb import r
 
 from .common import (
     AGENT_PASSWORD,

--- a/rethinkdb/tests/test_integration.py
+++ b/rethinkdb/tests/test_integration.py
@@ -6,8 +6,8 @@ from typing import ContextManager, Set
 
 import mock
 import pytest
-import rethinkdb
 
+import rethinkdb
 from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.base.stubs.datadog_agent import DatadogAgentStub
 from datadog_checks.base.types import ServiceCheckStatus

--- a/tokumx/datadog_checks/tokumx/vendor/bson/__init__.py
+++ b/tokumx/datadog_checks/tokumx/vendor/bson/__init__.py
@@ -23,36 +23,24 @@ import re
 import struct
 import sys
 import uuid
+from codecs import utf_8_decode as _utf_8_decode
+from codecs import utf_8_encode as _utf_8_encode
 
-from codecs import (utf_8_decode as _utf_8_decode,
-                    utf_8_encode as _utf_8_encode)
-
-from datadog_checks.tokumx.vendor.bson.binary import (Binary, OLD_UUID_SUBTYPE,
-                         JAVA_LEGACY, CSHARP_LEGACY,
-                         UUIDLegacy)
+from datadog_checks.tokumx.vendor.bson.binary import CSHARP_LEGACY, JAVA_LEGACY, OLD_UUID_SUBTYPE, Binary, UUIDLegacy
 from datadog_checks.tokumx.vendor.bson.code import Code
-from datadog_checks.tokumx.vendor.bson.codec_options import (
-    CodecOptions, DEFAULT_CODEC_OPTIONS, _raw_document_class)
+from datadog_checks.tokumx.vendor.bson.codec_options import DEFAULT_CODEC_OPTIONS, CodecOptions, _raw_document_class
 from datadog_checks.tokumx.vendor.bson.dbref import DBRef
 from datadog_checks.tokumx.vendor.bson.decimal128 import Decimal128
-from datadog_checks.tokumx.vendor.bson.errors import (InvalidBSON,
-                         InvalidDocument,
-                         InvalidStringData)
+from datadog_checks.tokumx.vendor.bson.errors import InvalidBSON, InvalidDocument, InvalidStringData
 from datadog_checks.tokumx.vendor.bson.int64 import Int64
 from datadog_checks.tokumx.vendor.bson.max_key import MaxKey
 from datadog_checks.tokumx.vendor.bson.min_key import MinKey
 from datadog_checks.tokumx.vendor.bson.objectid import ObjectId
-from datadog_checks.tokumx.vendor.bson.py3compat import (b,
-                            PY3,
-                            iteritems,
-                            text_type,
-                            string_type,
-                            reraise)
+from datadog_checks.tokumx.vendor.bson.py3compat import PY3, b, iteritems, reraise, string_type, text_type
 from datadog_checks.tokumx.vendor.bson.regex import Regex
-from datadog_checks.tokumx.vendor.bson.son import SON, RE_TYPE
+from datadog_checks.tokumx.vendor.bson.son import RE_TYPE, SON
 from datadog_checks.tokumx.vendor.bson.timestamp import Timestamp
 from datadog_checks.tokumx.vendor.bson.tz_util import utc
-
 
 try:
     from datadog_checks.tokumx.vendor.bson import _cbson

--- a/tokumx/datadog_checks/tokumx/vendor/bson/code.py
+++ b/tokumx/datadog_checks/tokumx/vendor/bson/code.py
@@ -16,7 +16,7 @@
 """
 import collections
 
-from datadog_checks.tokumx.vendor.bson.py3compat import string_type, PY3, text_type
+from datadog_checks.tokumx.vendor.bson.py3compat import PY3, string_type, text_type
 
 
 class Code(str):

--- a/tokumx/datadog_checks/tokumx/vendor/bson/codec_options.py
+++ b/tokumx/datadog_checks/tokumx/vendor/bson/codec_options.py
@@ -15,13 +15,10 @@
 """Tools for specifying BSON codec options."""
 
 import datetime
-
 from collections import MutableMapping, namedtuple
 
+from datadog_checks.tokumx.vendor.bson.binary import ALL_UUID_REPRESENTATIONS, PYTHON_LEGACY, UUID_REPRESENTATION_NAMES
 from datadog_checks.tokumx.vendor.bson.py3compat import string_type
-from datadog_checks.tokumx.vendor.bson.binary import (ALL_UUID_REPRESENTATIONS,
-                         PYTHON_LEGACY,
-                         UUID_REPRESENTATION_NAMES)
 
 _RAW_BSON_DOCUMENT_MARKER = 101
 

--- a/tokumx/datadog_checks/tokumx/vendor/bson/decimal128.py
+++ b/tokumx/datadog_checks/tokumx/vendor/bson/decimal128.py
@@ -23,9 +23,8 @@ import decimal
 import struct
 import sys
 
-from datadog_checks.tokumx.vendor.bson.py3compat import (PY3 as _PY3,
-                            string_type as _string_type)
-
+from datadog_checks.tokumx.vendor.bson.py3compat import PY3 as _PY3
+from datadog_checks.tokumx.vendor.bson.py3compat import string_type as _string_type
 
 if _PY3:
     _from_bytes = int.from_bytes  # pylint: disable=no-member, invalid-name

--- a/tokumx/datadog_checks/tokumx/vendor/bson/json_util.py
+++ b/tokumx/datadog_checks/tokumx/vendor/bson/json_util.py
@@ -124,12 +124,9 @@ if sys.version_info[:2] == (2, 6):
 else:
     import json
 
-from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError
-
 from datadog_checks.tokumx.vendor import bson
 from datadog_checks.tokumx.vendor.bson import EPOCH_AWARE, EPOCH_NAIVE, RE_TYPE, SON
-from datadog_checks.tokumx.vendor.bson.binary import (Binary, JAVA_LEGACY, CSHARP_LEGACY, OLD_UUID_SUBTYPE,
-                         UUID_SUBTYPE)
+from datadog_checks.tokumx.vendor.bson.binary import CSHARP_LEGACY, JAVA_LEGACY, OLD_UUID_SUBTYPE, UUID_SUBTYPE, Binary
 from datadog_checks.tokumx.vendor.bson.code import Code
 from datadog_checks.tokumx.vendor.bson.codec_options import CodecOptions
 from datadog_checks.tokumx.vendor.bson.dbref import DBRef
@@ -138,12 +135,11 @@ from datadog_checks.tokumx.vendor.bson.int64 import Int64
 from datadog_checks.tokumx.vendor.bson.max_key import MaxKey
 from datadog_checks.tokumx.vendor.bson.min_key import MinKey
 from datadog_checks.tokumx.vendor.bson.objectid import ObjectId
-from datadog_checks.tokumx.vendor.bson.py3compat import (PY3, iteritems, integer_types, string_type,
-                            text_type)
+from datadog_checks.tokumx.vendor.bson.py3compat import PY3, integer_types, iteritems, string_type, text_type
 from datadog_checks.tokumx.vendor.bson.regex import Regex
 from datadog_checks.tokumx.vendor.bson.timestamp import Timestamp
 from datadog_checks.tokumx.vendor.bson.tz_util import utc
-
+from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError
 
 _RE_OPT_TABLE = {
     "i": re.I,

--- a/tokumx/datadog_checks/tokumx/vendor/bson/py3compat.py
+++ b/tokumx/datadog_checks/tokumx/vendor/bson/py3compat.py
@@ -19,8 +19,8 @@ import sys
 PY3 = sys.version_info[0] == 3
 
 if PY3:
-    import codecs
     import _thread as thread
+    import codecs
     from io import BytesIO as StringIO
     MAXSIZE = sys.maxsize
 
@@ -53,9 +53,9 @@ if PY3:
     string_type = str
     integer_types = int
 else:
-    import thread
-
     from itertools import imap
+
+    import thread
     try:
         from cStringIO import StringIO
     except ImportError:

--- a/tokumx/datadog_checks/tokumx/vendor/bson/raw_bson.py
+++ b/tokumx/datadog_checks/tokumx/vendor/bson/raw_bson.py
@@ -18,10 +18,11 @@
 import collections
 
 from datadog_checks.tokumx.vendor.bson import _UNPACK_INT, _iterate_elements
-from datadog_checks.tokumx.vendor.bson.py3compat import iteritems
-from datadog_checks.tokumx.vendor.bson.codec_options import (
-    CodecOptions, DEFAULT_CODEC_OPTIONS as DEFAULT, _RAW_BSON_DOCUMENT_MARKER)
+from datadog_checks.tokumx.vendor.bson.codec_options import _RAW_BSON_DOCUMENT_MARKER
+from datadog_checks.tokumx.vendor.bson.codec_options import DEFAULT_CODEC_OPTIONS as DEFAULT
+from datadog_checks.tokumx.vendor.bson.codec_options import CodecOptions
 from datadog_checks.tokumx.vendor.bson.errors import InvalidBSON
+from datadog_checks.tokumx.vendor.bson.py3compat import iteritems
 
 
 class RawBSONDocument(collections.Mapping):

--- a/tokumx/datadog_checks/tokumx/vendor/bson/regex.py
+++ b/tokumx/datadog_checks/tokumx/vendor/bson/regex.py
@@ -17,8 +17,8 @@
 
 import re
 
-from datadog_checks.tokumx.vendor.bson.son import RE_TYPE
 from datadog_checks.tokumx.vendor.bson.py3compat import string_type, text_type
+from datadog_checks.tokumx.vendor.bson.son import RE_TYPE
 
 
 def str_flags_to_int(str_flags):

--- a/tokumx/datadog_checks/tokumx/vendor/bson/son.py
+++ b/tokumx/datadog_checks/tokumx/vendor/bson/son.py
@@ -24,7 +24,6 @@ import re
 
 from datadog_checks.tokumx.vendor.bson.py3compat import iteritems
 
-
 # This sort of sucks, but seems to be as good as it gets...
 # This is essentially the same as re._pattern_type
 RE_TYPE = type(re.compile(""))

--- a/tokumx/datadog_checks/tokumx/vendor/bson/tz_util.py
+++ b/tokumx/datadog_checks/tokumx/vendor/bson/tz_util.py
@@ -14,8 +14,7 @@
 
 """Timezone related utilities for BSON."""
 
-from datetime import (timedelta,
-                      tzinfo)
+from datetime import timedelta, tzinfo
 
 ZERO = timedelta(0)
 

--- a/tokumx/datadog_checks/tokumx/vendor/gridfs/__init__.py
+++ b/tokumx/datadog_checks/tokumx/vendor/gridfs/__init__.py
@@ -23,12 +23,8 @@ The :mod:`gridfs` package is an implementation of GridFS on top of
 from collections import Mapping
 
 from datadog_checks.tokumx.vendor.gridfs.errors import NoFile
-from datadog_checks.tokumx.vendor.gridfs.grid_file import (GridIn,
-                              GridOut,
-                              GridOutCursor,
-                              DEFAULT_CHUNK_SIZE)
-from datadog_checks.tokumx.vendor.pymongo import (ASCENDING,
-                     DESCENDING)
+from datadog_checks.tokumx.vendor.gridfs.grid_file import DEFAULT_CHUNK_SIZE, GridIn, GridOut, GridOutCursor
+from datadog_checks.tokumx.vendor.pymongo import ASCENDING, DESCENDING
 from datadog_checks.tokumx.vendor.pymongo.common import UNAUTHORIZED_CODES, validate_string
 from datadog_checks.tokumx.vendor.pymongo.database import Database
 from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError, OperationFailure

--- a/tokumx/datadog_checks/tokumx/vendor/gridfs/grid_file.py
+++ b/tokumx/datadog_checks/tokumx/vendor/gridfs/grid_file.py
@@ -16,20 +16,17 @@
 import datetime
 import math
 import os
-
 from hashlib import md5
 
-from datadog_checks.tokumx.vendor.bson.son import SON
 from datadog_checks.tokumx.vendor.bson.binary import Binary
 from datadog_checks.tokumx.vendor.bson.objectid import ObjectId
-from datadog_checks.tokumx.vendor.bson.py3compat import text_type, StringIO
+from datadog_checks.tokumx.vendor.bson.py3compat import StringIO, text_type
+from datadog_checks.tokumx.vendor.bson.son import SON
 from datadog_checks.tokumx.vendor.gridfs.errors import CorruptGridFile, FileExists, NoFile
 from datadog_checks.tokumx.vendor.pymongo import ASCENDING
 from datadog_checks.tokumx.vendor.pymongo.collection import Collection
 from datadog_checks.tokumx.vendor.pymongo.cursor import Cursor
-from datadog_checks.tokumx.vendor.pymongo.errors import (ConfigurationError,
-                            DuplicateKeyError,
-                            OperationFailure)
+from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError, DuplicateKeyError, OperationFailure
 from datadog_checks.tokumx.vendor.pymongo.read_preferences import ReadPreference
 
 try:

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/__init__.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/__init__.py
@@ -81,20 +81,22 @@ __version__ = version = get_version_string()
 """Current version of PyMongo."""
 
 from datadog_checks.tokumx.vendor.pymongo.collection import ReturnDocument
-from datadog_checks.tokumx.vendor.pymongo.common import (MIN_SUPPORTED_WIRE_VERSION,
-                            MAX_SUPPORTED_WIRE_VERSION)
+from datadog_checks.tokumx.vendor.pymongo.common import MAX_SUPPORTED_WIRE_VERSION, MIN_SUPPORTED_WIRE_VERSION
 from datadog_checks.tokumx.vendor.pymongo.cursor import CursorType
 from datadog_checks.tokumx.vendor.pymongo.mongo_client import MongoClient
 from datadog_checks.tokumx.vendor.pymongo.mongo_replica_set_client import MongoReplicaSetClient
-from datadog_checks.tokumx.vendor.pymongo.operations import (IndexModel,
-                                InsertOne,
-                                DeleteOne,
-                                DeleteMany,
-                                UpdateOne,
-                                UpdateMany,
-                                ReplaceOne)
+from datadog_checks.tokumx.vendor.pymongo.operations import (
+    DeleteMany,
+    DeleteOne,
+    IndexModel,
+    InsertOne,
+    ReplaceOne,
+    UpdateMany,
+    UpdateOne,
+)
 from datadog_checks.tokumx.vendor.pymongo.read_preferences import ReadPreference
 from datadog_checks.tokumx.vendor.pymongo.write_concern import WriteConcern
+
 
 def has_c():
     """Is the C extension installed?"""

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/auth.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/auth.py
@@ -40,10 +40,9 @@ from hashlib import md5, sha1
 from random import SystemRandom
 
 from datadog_checks.tokumx.vendor.bson.binary import Binary
-from datadog_checks.tokumx.vendor.bson.py3compat import b, string_type, _unicode, PY3
+from datadog_checks.tokumx.vendor.bson.py3compat import PY3, _unicode, b, string_type
 from datadog_checks.tokumx.vendor.bson.son import SON
 from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError, OperationFailure
-
 
 MECHANISMS = frozenset(
     ['GSSAPI', 'MONGODB-CR', 'MONGODB-X509', 'PLAIN', 'SCRAM-SHA-1', 'DEFAULT'])
@@ -96,8 +95,8 @@ if PY3:
     _from_bytes = int.from_bytes
     _to_bytes = int.to_bytes
 else:
-    from binascii import (hexlify as _hexlify,
-                          unhexlify as _unhexlify)
+    from binascii import hexlify as _hexlify
+    from binascii import unhexlify as _unhexlify
 
 
     def _xor(fir, sec):

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/bulk.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/bulk.py
@@ -20,22 +20,29 @@
 from datadog_checks.tokumx.vendor.bson.objectid import ObjectId
 from datadog_checks.tokumx.vendor.bson.raw_bson import RawBSONDocument
 from datadog_checks.tokumx.vendor.bson.son import SON
-from datadog_checks.tokumx.vendor.pymongo.common import (validate_is_mapping,
-                            validate_is_document_type,
-                            validate_ok_for_replace,
-                            validate_ok_for_update)
 from datadog_checks.tokumx.vendor.pymongo.collation import validate_collation_or_none
-from datadog_checks.tokumx.vendor.pymongo.errors import (BulkWriteError,
-                            ConfigurationError,
-                            DocumentTooLarge,
-                            InvalidOperation,
-                            OperationFailure)
-from datadog_checks.tokumx.vendor.pymongo.message import (_INSERT, _UPDATE, _DELETE,
-                             _do_batched_write_command,
-                             _randint,
-                             _BulkWriteContext)
+from datadog_checks.tokumx.vendor.pymongo.common import (
+    validate_is_document_type,
+    validate_is_mapping,
+    validate_ok_for_replace,
+    validate_ok_for_update,
+)
+from datadog_checks.tokumx.vendor.pymongo.errors import (
+    BulkWriteError,
+    ConfigurationError,
+    DocumentTooLarge,
+    InvalidOperation,
+    OperationFailure,
+)
+from datadog_checks.tokumx.vendor.pymongo.message import (
+    _DELETE,
+    _INSERT,
+    _UPDATE,
+    _BulkWriteContext,
+    _do_batched_write_command,
+    _randint,
+)
 from datadog_checks.tokumx.vendor.pymongo.write_concern import WriteConcern
-
 
 _DELETE_ALL = 0
 _DELETE_ONE = 1

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/client_options.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/client_options.py
@@ -15,15 +15,14 @@
 """Tools to parse mongo client options."""
 
 from datadog_checks.tokumx.vendor.bson.codec_options import _parse_codec_options
+from datadog_checks.tokumx.vendor.pymongo import common
 from datadog_checks.tokumx.vendor.pymongo.auth import _build_credentials_tuple
 from datadog_checks.tokumx.vendor.pymongo.common import validate_boolean
-from datadog_checks.tokumx.vendor.pymongo import common
 from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError
 from datadog_checks.tokumx.vendor.pymongo.monitoring import _EventListeners
 from datadog_checks.tokumx.vendor.pymongo.pool import PoolOptions
 from datadog_checks.tokumx.vendor.pymongo.read_concern import ReadConcern
-from datadog_checks.tokumx.vendor.pymongo.read_preferences import (make_read_preference,
-                                      read_pref_mode_from_name)
+from datadog_checks.tokumx.vendor.pymongo.read_preferences import make_read_preference, read_pref_mode_from_name
 from datadog_checks.tokumx.vendor.pymongo.ssl_support import get_ssl_context
 from datadog_checks.tokumx.vendor.pymongo.write_concern import WriteConcern
 

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/collection.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/collection.py
@@ -19,31 +19,28 @@ import datetime
 import warnings
 
 from datadog_checks.tokumx.vendor.bson.code import Code
-from datadog_checks.tokumx.vendor.bson.objectid import ObjectId
-from datadog_checks.tokumx.vendor.bson.py3compat import (_unicode,
-                            integer_types,
-                            string_type)
-from datadog_checks.tokumx.vendor.bson.raw_bson import RawBSONDocument
 from datadog_checks.tokumx.vendor.bson.codec_options import CodecOptions
+from datadog_checks.tokumx.vendor.bson.objectid import ObjectId
+from datadog_checks.tokumx.vendor.bson.py3compat import _unicode, integer_types, string_type
+from datadog_checks.tokumx.vendor.bson.raw_bson import RawBSONDocument
 from datadog_checks.tokumx.vendor.bson.son import SON
-from datadog_checks.tokumx.vendor.pymongo import (common,
-                     helpers,
-                     message)
+from datadog_checks.tokumx.vendor.pymongo import common, helpers, message
 from datadog_checks.tokumx.vendor.pymongo.bulk import BulkOperationBuilder, _Bulk
-from datadog_checks.tokumx.vendor.pymongo.command_cursor import CommandCursor
 from datadog_checks.tokumx.vendor.pymongo.collation import validate_collation_or_none
+from datadog_checks.tokumx.vendor.pymongo.command_cursor import CommandCursor
 from datadog_checks.tokumx.vendor.pymongo.cursor import Cursor
 from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError, InvalidName, OperationFailure
-from datadog_checks.tokumx.vendor.pymongo.helpers import _check_write_command_response
-from datadog_checks.tokumx.vendor.pymongo.helpers import _UNICODE_REPLACE_CODEC_OPTIONS
+from datadog_checks.tokumx.vendor.pymongo.helpers import _UNICODE_REPLACE_CODEC_OPTIONS, _check_write_command_response
 from datadog_checks.tokumx.vendor.pymongo.operations import IndexModel
 from datadog_checks.tokumx.vendor.pymongo.read_concern import DEFAULT_READ_CONCERN
 from datadog_checks.tokumx.vendor.pymongo.read_preferences import ReadPreference
-from datadog_checks.tokumx.vendor.pymongo.results import (BulkWriteResult,
-                             DeleteResult,
-                             InsertOneResult,
-                             InsertManyResult,
-                             UpdateResult)
+from datadog_checks.tokumx.vendor.pymongo.results import (
+    BulkWriteResult,
+    DeleteResult,
+    InsertManyResult,
+    InsertOneResult,
+    UpdateResult,
+)
 from datadog_checks.tokumx.vendor.pymongo.write_concern import WriteConcern
 
 try:

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/command_cursor.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/command_cursor.py
@@ -15,13 +15,12 @@
 """CommandCursor class to iterate over command results."""
 
 import datetime
-
 from collections import deque
 
 from datadog_checks.tokumx.vendor.bson.py3compat import integer_types
 from datadog_checks.tokumx.vendor.pymongo import helpers
 from datadog_checks.tokumx.vendor.pymongo.errors import AutoReconnect, NotMasterError, OperationFailure
-from datadog_checks.tokumx.vendor.pymongo.message import _CursorAddress, _GetMore, _convert_exception
+from datadog_checks.tokumx.vendor.pymongo.message import _convert_exception, _CursorAddress, _GetMore
 
 
 class CommandCursor(object):

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/common.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/common.py
@@ -19,10 +19,9 @@ import collections
 import datetime
 import warnings
 
-from datadog_checks.tokumx.vendor.bson.binary import (STANDARD, PYTHON_LEGACY,
-                         JAVA_LEGACY, CSHARP_LEGACY)
+from datadog_checks.tokumx.vendor.bson.binary import CSHARP_LEGACY, JAVA_LEGACY, PYTHON_LEGACY, STANDARD
 from datadog_checks.tokumx.vendor.bson.codec_options import CodecOptions
-from datadog_checks.tokumx.vendor.bson.py3compat import string_type, integer_types, iteritems
+from datadog_checks.tokumx.vendor.bson.py3compat import integer_types, iteritems, string_type
 from datadog_checks.tokumx.vendor.bson.raw_bson import RawBSONDocument
 from datadog_checks.tokumx.vendor.pymongo.auth import MECHANISMS
 from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/cursor.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/cursor.py
@@ -17,24 +17,23 @@
 import copy
 import datetime
 import warnings
-
 from collections import deque
 
 from datadog_checks.tokumx.vendor.bson import RE_TYPE
 from datadog_checks.tokumx.vendor.bson.code import Code
-from datadog_checks.tokumx.vendor.bson.py3compat import (iteritems,
-                            integer_types,
-                            string_type)
+from datadog_checks.tokumx.vendor.bson.py3compat import integer_types, iteritems, string_type
 from datadog_checks.tokumx.vendor.bson.son import SON
 from datadog_checks.tokumx.vendor.pymongo import helpers
-from datadog_checks.tokumx.vendor.pymongo.common import validate_boolean, validate_is_mapping
 from datadog_checks.tokumx.vendor.pymongo.collation import validate_collation_or_none
-from datadog_checks.tokumx.vendor.pymongo.errors import (AutoReconnect,
-                            ConnectionFailure,
-                            InvalidOperation,
-                            NotMasterError,
-                            OperationFailure)
-from datadog_checks.tokumx.vendor.pymongo.message import _CursorAddress, _GetMore, _Query, _convert_exception
+from datadog_checks.tokumx.vendor.pymongo.common import validate_boolean, validate_is_mapping
+from datadog_checks.tokumx.vendor.pymongo.errors import (
+    AutoReconnect,
+    ConnectionFailure,
+    InvalidOperation,
+    NotMasterError,
+    OperationFailure,
+)
+from datadog_checks.tokumx.vendor.pymongo.message import _convert_exception, _CursorAddress, _GetMore, _Query
 from datadog_checks.tokumx.vendor.pymongo.read_preferences import ReadPreference
 
 _QUERY_OPTIONS = {

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/cursor_manager.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/cursor_manager.py
@@ -29,6 +29,7 @@ installed on a client by calling
 
 import warnings
 import weakref
+
 from datadog_checks.tokumx.vendor.bson.py3compat import integer_types
 
 

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/database.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/database.py
@@ -17,18 +17,20 @@
 import warnings
 
 from datadog_checks.tokumx.vendor.bson.code import Code
-from datadog_checks.tokumx.vendor.bson.codec_options import CodecOptions, DEFAULT_CODEC_OPTIONS
+from datadog_checks.tokumx.vendor.bson.codec_options import DEFAULT_CODEC_OPTIONS, CodecOptions
 from datadog_checks.tokumx.vendor.bson.dbref import DBRef
 from datadog_checks.tokumx.vendor.bson.objectid import ObjectId
-from datadog_checks.tokumx.vendor.bson.py3compat import iteritems, string_type, _unicode
+from datadog_checks.tokumx.vendor.bson.py3compat import _unicode, iteritems, string_type
 from datadog_checks.tokumx.vendor.bson.son import SON
 from datadog_checks.tokumx.vendor.pymongo import auth, common, helpers
 from datadog_checks.tokumx.vendor.pymongo.collection import Collection
 from datadog_checks.tokumx.vendor.pymongo.command_cursor import CommandCursor
-from datadog_checks.tokumx.vendor.pymongo.errors import (CollectionInvalid,
-                            ConfigurationError,
-                            InvalidName,
-                            OperationFailure)
+from datadog_checks.tokumx.vendor.pymongo.errors import (
+    CollectionInvalid,
+    ConfigurationError,
+    InvalidName,
+    OperationFailure,
+)
 from datadog_checks.tokumx.vendor.pymongo.helpers import _first_batch
 from datadog_checks.tokumx.vendor.pymongo.read_preferences import ReadPreference
 from datadog_checks.tokumx.vendor.pymongo.son_manipulator import SONManipulator

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/helpers.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/helpers.py
@@ -22,21 +22,22 @@ import traceback
 
 from datadog_checks.tokumx.vendor import bson
 from datadog_checks.tokumx.vendor.bson.codec_options import CodecOptions
-from datadog_checks.tokumx.vendor.bson.py3compat import itervalues, string_type, iteritems
+from datadog_checks.tokumx.vendor.bson.py3compat import iteritems, itervalues, string_type
 from datadog_checks.tokumx.vendor.bson.son import SON
 from datadog_checks.tokumx.vendor.pymongo import ASCENDING
-from datadog_checks.tokumx.vendor.pymongo.errors import (CursorNotFound,
-                            DuplicateKeyError,
-                            ExecutionTimeout,
-                            NotMasterError,
-                            OperationFailure,
-                            ProtocolError,
-                            WriteError,
-                            WriteConcernError,
-                            WTimeoutError)
-from datadog_checks.tokumx.vendor.pymongo.message import _Query, _convert_exception
+from datadog_checks.tokumx.vendor.pymongo.errors import (
+    CursorNotFound,
+    DuplicateKeyError,
+    ExecutionTimeout,
+    NotMasterError,
+    OperationFailure,
+    ProtocolError,
+    WriteConcernError,
+    WriteError,
+    WTimeoutError,
+)
+from datadog_checks.tokumx.vendor.pymongo.message import _convert_exception, _Query
 from datadog_checks.tokumx.vendor.pymongo.read_concern import DEFAULT_READ_CONCERN
-
 
 _UUNDER = u"_"
 

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/max_staleness_selectors.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/max_staleness_selectors.py
@@ -30,7 +30,6 @@ where "SMax" is the secondary with the greatest lastWriteDate.
 from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError
 from datadog_checks.tokumx.vendor.pymongo.server_type import SERVER_TYPE
 
-
 # Constant defined in Max Staleness Spec: An idle primary writes a no-op every
 # 10 seconds to refresh secondaries' lastWriteDate values.
 IDLE_WRITE_PERIOD = 10

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/message.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/message.py
@@ -26,8 +26,9 @@ import struct
 
 from datadog_checks.tokumx.vendor import bson
 from datadog_checks.tokumx.vendor.bson.codec_options import DEFAULT_CODEC_OPTIONS
-from datadog_checks.tokumx.vendor.bson.py3compat import b, StringIO
+from datadog_checks.tokumx.vendor.bson.py3compat import StringIO, b
 from datadog_checks.tokumx.vendor.bson.son import SON
+
 try:
     from datadog_checks.tokumx.vendor.pymongo import _cmessage
     _use_c = True
@@ -36,7 +37,6 @@ except ImportError:
 from datadog_checks.tokumx.vendor.pymongo.errors import DocumentTooLarge, InvalidOperation, OperationFailure
 from datadog_checks.tokumx.vendor.pymongo.read_concern import DEFAULT_READ_CONCERN
 from datadog_checks.tokumx.vendor.pymongo.read_preferences import ReadPreference
-
 
 MAX_INT32 = 2147483647
 MIN_INT32 = -2147483648

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/mongo_client.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/mongo_client.py
@@ -36,36 +36,33 @@ import datetime
 import threading
 import warnings
 import weakref
-
 from collections import defaultdict
 
 from datadog_checks.tokumx.vendor.bson.codec_options import DEFAULT_CODEC_OPTIONS
-from datadog_checks.tokumx.vendor.bson.py3compat import (integer_types,
-                            string_type)
+from datadog_checks.tokumx.vendor.bson.py3compat import integer_types, string_type
 from datadog_checks.tokumx.vendor.bson.son import SON
-from datadog_checks.tokumx.vendor.pymongo import (common,
-                     database,
-                     helpers,
-                     message,
-                     periodic_executor,
-                     uri_parser)
+from datadog_checks.tokumx.vendor.pymongo import common, database, helpers, message, periodic_executor, uri_parser
 from datadog_checks.tokumx.vendor.pymongo.client_options import ClientOptions
 from datadog_checks.tokumx.vendor.pymongo.cursor_manager import CursorManager
-from datadog_checks.tokumx.vendor.pymongo.errors import (AutoReconnect,
-                            ConfigurationError,
-                            ConnectionFailure,
-                            InvalidOperation,
-                            InvalidURI,
-                            NetworkTimeout,
-                            NotMasterError,
-                            OperationFailure)
+from datadog_checks.tokumx.vendor.pymongo.errors import (
+    AutoReconnect,
+    ConfigurationError,
+    ConnectionFailure,
+    InvalidOperation,
+    InvalidURI,
+    NetworkTimeout,
+    NotMasterError,
+    OperationFailure,
+)
 from datadog_checks.tokumx.vendor.pymongo.read_preferences import ReadPreference
-from datadog_checks.tokumx.vendor.pymongo.server_selectors import (writable_preferred_server_selector,
-                                      writable_server_selector)
+from datadog_checks.tokumx.vendor.pymongo.server_selectors import (
+    writable_preferred_server_selector,
+    writable_server_selector,
+)
 from datadog_checks.tokumx.vendor.pymongo.server_type import SERVER_TYPE
+from datadog_checks.tokumx.vendor.pymongo.settings import TopologySettings
 from datadog_checks.tokumx.vendor.pymongo.topology import Topology
 from datadog_checks.tokumx.vendor.pymongo.topology_description import TOPOLOGY_TYPE
-from datadog_checks.tokumx.vendor.pymongo.settings import TopologySettings
 from datadog_checks.tokumx.vendor.pymongo.write_concern import WriteConcern
 
 

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/monitor.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/monitor.py
@@ -19,11 +19,11 @@ import weakref
 from datadog_checks.tokumx.vendor.bson.codec_options import DEFAULT_CODEC_OPTIONS
 from datadog_checks.tokumx.vendor.bson.son import SON
 from datadog_checks.tokumx.vendor.pymongo import common, helpers, message, periodic_executor
-from datadog_checks.tokumx.vendor.pymongo.server_type import SERVER_TYPE
 from datadog_checks.tokumx.vendor.pymongo.ismaster import IsMaster
 from datadog_checks.tokumx.vendor.pymongo.monotonic import time as _time
 from datadog_checks.tokumx.vendor.pymongo.read_preferences import MovingAverage
 from datadog_checks.tokumx.vendor.pymongo.server_description import ServerDescription
+from datadog_checks.tokumx.vendor.pymongo.server_type import SERVER_TYPE
 
 
 class Monitor(object):

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/monitoring.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/monitoring.py
@@ -136,8 +136,8 @@ will not add that listener to existing client instances.
 
 import sys
 import traceback
+from collections import Sequence, namedtuple
 
-from collections import namedtuple, Sequence
 from datadog_checks.tokumx.vendor.pymongo.helpers import _handle_exception
 
 _Listeners = namedtuple('Listeners',

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/network.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/network.py
@@ -36,10 +36,7 @@ except ImportError:
 
 from datadog_checks.tokumx.vendor.pymongo import helpers, message
 from datadog_checks.tokumx.vendor.pymongo.common import MAX_MESSAGE_SIZE
-from datadog_checks.tokumx.vendor.pymongo.errors import (AutoReconnect,
-                            NotMasterError,
-                            OperationFailure,
-                            ProtocolError)
+from datadog_checks.tokumx.vendor.pymongo.errors import AutoReconnect, NotMasterError, OperationFailure, ProtocolError
 from datadog_checks.tokumx.vendor.pymongo.read_concern import DEFAULT_READ_CONCERN
 
 _UNPACK_INT = struct.Struct("<i").unpack

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/operations.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/operations.py
@@ -14,8 +14,8 @@
 
 """Operation class definitions."""
 
-from datadog_checks.tokumx.vendor.pymongo.common import validate_boolean, validate_is_mapping
 from datadog_checks.tokumx.vendor.pymongo.collation import validate_collation_or_none
+from datadog_checks.tokumx.vendor.pymongo.common import validate_boolean, validate_is_mapping
 from datadog_checks.tokumx.vendor.pymongo.helpers import _gen_index_name, _index_document, _index_list
 
 

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/pool.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/pool.py
@@ -30,27 +30,28 @@ except ImportError:
 
 
 from datadog_checks.tokumx.vendor.bson import DEFAULT_CODEC_OPTIONS
-from datadog_checks.tokumx.vendor.bson.py3compat import imap, itervalues, _unicode, integer_types
+from datadog_checks.tokumx.vendor.bson.py3compat import _unicode, imap, integer_types, itervalues
 from datadog_checks.tokumx.vendor.bson.son import SON
-from datadog_checks.tokumx.vendor.pymongo import auth, helpers, thread_util, __version__
+from datadog_checks.tokumx.vendor.pymongo import __version__, auth, helpers, thread_util
 from datadog_checks.tokumx.vendor.pymongo.common import MAX_MESSAGE_SIZE
-from datadog_checks.tokumx.vendor.pymongo.errors import (AutoReconnect,
-                            ConnectionFailure,
-                            ConfigurationError,
-                            DocumentTooLarge,
-                            NetworkTimeout,
-                            NotMasterError,
-                            OperationFailure)
+from datadog_checks.tokumx.vendor.pymongo.errors import (
+    AutoReconnect,
+    ConfigurationError,
+    ConnectionFailure,
+    DocumentTooLarge,
+    NetworkTimeout,
+    NotMasterError,
+    OperationFailure,
+)
 from datadog_checks.tokumx.vendor.pymongo.ismaster import IsMaster
 from datadog_checks.tokumx.vendor.pymongo.monotonic import time as _time
-from datadog_checks.tokumx.vendor.pymongo.network import (command,
-                             receive_message,
-                             SocketChecker)
+from datadog_checks.tokumx.vendor.pymongo.network import SocketChecker, command, receive_message
 from datadog_checks.tokumx.vendor.pymongo.read_concern import DEFAULT_READ_CONCERN
 from datadog_checks.tokumx.vendor.pymongo.read_preferences import ReadPreference
 from datadog_checks.tokumx.vendor.pymongo.server_type import SERVER_TYPE
+
 # Always use our backport so we always have support for IP address matching
-from datadog_checks.tokumx.vendor.pymongo.ssl_match_hostname import match_hostname, CertificateError
+from datadog_checks.tokumx.vendor.pymongo.ssl_match_hostname import CertificateError, match_hostname
 
 # For SNI support. According to RFC6066, section 3, IPv4 and IPv6 literals are
 # not permitted for SNI hostname.
@@ -98,7 +99,7 @@ except ImportError:
                 return False
 
 try:
-    from fcntl import fcntl, F_GETFD, F_SETFD, FD_CLOEXEC
+    from fcntl import F_GETFD, F_SETFD, FD_CLOEXEC, fcntl
     def _set_non_inheritable_non_atomic(fd):
         """Set the close-on-exec flag on the given file descriptor."""
         flags = fcntl(fd, F_GETFD)

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/read_preferences.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/read_preferences.py
@@ -19,9 +19,10 @@ from collections import Mapping
 from datadog_checks.tokumx.vendor.bson.py3compat import integer_types
 from datadog_checks.tokumx.vendor.pymongo import max_staleness_selectors
 from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError
-from datadog_checks.tokumx.vendor.pymongo.server_selectors import (member_with_tags_server_selector,
-                                      secondary_with_tags_server_selector)
-
+from datadog_checks.tokumx.vendor.pymongo.server_selectors import (
+    member_with_tags_server_selector,
+    secondary_with_tags_server_selector,
+)
 
 _PRIMARY = 0
 _PRIMARY_PREFERRED = 1

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/server.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/server.py
@@ -15,12 +15,11 @@
 """Communicate with one MongoDB server in a topology."""
 
 import contextlib
-
 from datetime import datetime
 
 from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError
-from datadog_checks.tokumx.vendor.pymongo.message import _Query, _convert_exception
-from datadog_checks.tokumx.vendor.pymongo.response import Response, ExhaustResponse
+from datadog_checks.tokumx.vendor.pymongo.message import _convert_exception, _Query
+from datadog_checks.tokumx.vendor.pymongo.response import ExhaustResponse, Response
 from datadog_checks.tokumx.vendor.pymongo.server_type import SERVER_TYPE
 
 

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/server_description.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/server_description.py
@@ -15,9 +15,9 @@
 """Represent one server the driver is connected to."""
 
 from datadog_checks.tokumx.vendor.bson import EPOCH_NAIVE
-from datadog_checks.tokumx.vendor.pymongo.server_type import SERVER_TYPE
 from datadog_checks.tokumx.vendor.pymongo.ismaster import IsMaster
 from datadog_checks.tokumx.vendor.pymongo.monotonic import time as _time
+from datadog_checks.tokumx.vendor.pymongo.server_type import SERVER_TYPE
 
 
 def _total_seconds(delta):

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/server_type.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/server_type.py
@@ -16,7 +16,6 @@
 
 from collections import namedtuple
 
-
 SERVER_TYPE = namedtuple('ServerType',
                          ['Unknown', 'Mongos', 'RSPrimary', 'RSSecondary',
                           'RSArbiter', 'RSOther', 'RSGhost',

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/settings.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/settings.py
@@ -20,9 +20,9 @@ from datadog_checks.tokumx.vendor.bson.objectid import ObjectId
 from datadog_checks.tokumx.vendor.pymongo import common, monitor, pool
 from datadog_checks.tokumx.vendor.pymongo.common import LOCAL_THRESHOLD_MS, SERVER_SELECTION_TIMEOUT
 from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError
-from datadog_checks.tokumx.vendor.pymongo.topology_description import TOPOLOGY_TYPE
 from datadog_checks.tokumx.vendor.pymongo.pool import PoolOptions
 from datadog_checks.tokumx.vendor.pymongo.server_description import ServerDescription
+from datadog_checks.tokumx.vendor.pymongo.topology_description import TOPOLOGY_TYPE
 
 
 class TopologySettings(object):

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/thread_util.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/thread_util.py
@@ -15,13 +15,14 @@
 """Utilities for multi-threading support."""
 
 import threading
+
 try:
     from time import monotonic as _time
 except ImportError:
     from time import time as _time
 
-from datadog_checks.tokumx.vendor.pymongo.monotonic import time as _time
 from datadog_checks.tokumx.vendor.pymongo.errors import ExceededMaxWaiters
+from datadog_checks.tokumx.vendor.pymongo.monotonic import time as _time
 
 
 ### Begin backport from CPython 3.2 for timeout support for Semaphore.acquire

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/topology.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/topology.py
@@ -20,26 +20,30 @@ import threading
 import warnings
 import weakref
 
-from datadog_checks.tokumx.vendor.bson.py3compat import itervalues, PY3
+from datadog_checks.tokumx.vendor.bson.py3compat import PY3, itervalues
+
 if PY3:
     import queue as Queue
 else:
     import Queue
 
-from datadog_checks.tokumx.vendor.pymongo import common
-from datadog_checks.tokumx.vendor.pymongo import periodic_executor
-from datadog_checks.tokumx.vendor.pymongo.pool import PoolOptions
-from datadog_checks.tokumx.vendor.pymongo.topology_description import (updated_topology_description,
-                                          TOPOLOGY_TYPE,
-                                          TopologyDescription)
+from datadog_checks.tokumx.vendor.pymongo import common, periodic_executor
 from datadog_checks.tokumx.vendor.pymongo.errors import ServerSelectionTimeoutError
 from datadog_checks.tokumx.vendor.pymongo.monotonic import time as _time
+from datadog_checks.tokumx.vendor.pymongo.pool import PoolOptions
 from datadog_checks.tokumx.vendor.pymongo.server import Server
-from datadog_checks.tokumx.vendor.pymongo.server_selectors import (any_server_selector,
-                                      arbiter_server_selector,
-                                      secondary_server_selector,
-                                      writable_server_selector,
-                                      Selection)
+from datadog_checks.tokumx.vendor.pymongo.server_selectors import (
+    Selection,
+    any_server_selector,
+    arbiter_server_selector,
+    secondary_server_selector,
+    writable_server_selector,
+)
+from datadog_checks.tokumx.vendor.pymongo.topology_description import (
+    TOPOLOGY_TYPE,
+    TopologyDescription,
+    updated_topology_description,
+)
 
 
 def process_events_queue(queue_ref):

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/topology_description.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/topology_description.py
@@ -23,7 +23,6 @@ from datadog_checks.tokumx.vendor.pymongo.server_description import ServerDescri
 from datadog_checks.tokumx.vendor.pymongo.server_selectors import Selection
 from datadog_checks.tokumx.vendor.pymongo.server_type import SERVER_TYPE
 
-
 TOPOLOGY_TYPE = namedtuple('TopologyType', ['Single', 'ReplicaSetNoPrimary',
                                             'ReplicaSetWithPrimary', 'Sharded',
                                             'Unknown'])(*range(5))

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/uri_parser.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/uri_parser.py
@@ -27,7 +27,6 @@ else:
 from datadog_checks.tokumx.vendor.pymongo.common import get_validated_options
 from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError, InvalidURI
 
-
 SCHEME = 'mongodb://'
 SCHEME_LEN = len(SCHEME)
 DEFAULT_PORT = 27017

--- a/tokumx/datadog_checks/tokumx/vendor/pymongo/write_concern.py
+++ b/tokumx/datadog_checks/tokumx/vendor/pymongo/write_concern.py
@@ -17,6 +17,7 @@
 from datadog_checks.tokumx.vendor.bson.py3compat import integer_types, string_type
 from datadog_checks.tokumx.vendor.pymongo.errors import ConfigurationError
 
+
 class WriteConcern(object):
     """WriteConcern
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Revisit of https://github.com/DataDog/integrations-core/pull/7062

Use https://pycqa.github.io/isort/docs/configuration/profiles/#black
Then run isort <check> on all checks.

Refs #7060

Used `changelog/Fixed` because of code changes in integrations.

### Motivation
<!-- What inspired you to submit this pull request? -->
Ensure we use `isort` behavior that work well with Black, with less configuration.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
`ddev test -fs all` would have been too long, so I ran:

```python
from pathlib import Path
from subprocess import call

from tqdm import tqdm

checks = [
    path for path in Path('.').iterdir()
    if path.is_dir() and not path.name.startswith(('.', '_')) and path.name != 'venv'
]

for check in tqdm(checks):
    command = ['isort', check]
    call(command)
```
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
