### PR TITLE
Fix tailer on missing file

### DIFF
--- a/nagios/tests/test_nagios.py
+++ b/nagios/tests/test_nagios.py
@@ -42,7 +42,7 @@ class TestEventLogTailer:
         counters = {}
 
         for line in open(NAGIOS_TEST_LOG).readlines():
-            parsed = nagios_tailer._parse_line(line)
+            parsed = nagios_tailer.parse_line(line)
             if parsed:
                 event = aggregator.events[-1]
                 t = event["event_type"]

--- a/nagios/tests/test_nagios.py
+++ b/nagios/tests/test_nagios.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
+import os
 import tempfile
 import time
 
@@ -97,7 +98,7 @@ class TestEventLogTailer:
         Make sure the tailer continues to parse nagios as the file grows
         """
         test_data = ensure_bytes(open(NAGIOS_TEST_LOG).read())
-        ITERATIONS = 1
+        ITERATIONS = 10
         log_file = tempfile.NamedTemporaryFile(mode="a+b")
 
         # Get the config
@@ -113,6 +114,43 @@ class TestEventLogTailer:
 
         log_file.close()
         assert len(aggregator.events) == ITERATIONS * 503
+
+    def test_recovers_from_deleted_file(self, aggregator):
+        """
+        Make sure the tailer continues to parse nagios as the file grows
+        """
+        test_data = ensure_bytes(open(NAGIOS_TEST_LOG).read())
+        log_file = tempfile.NamedTemporaryFile(mode="a+b")
+
+        # Get the config
+        config, nagios_cfg = get_config("log_file={}\n".format(log_file.name), events=True)
+
+        # Set up the check
+        nagios = NagiosCheck(CHECK_NAME, {}, config['instances'])
+
+        def write_and_check():
+            log_file.write(test_data)
+            log_file.flush()
+            nagios.check(config['instances'][0])
+
+        # First call, will create events
+        write_and_check()
+        assert len(aggregator.events) == 503
+        os.rename(log_file.name, log_file.name + "_renamed")
+        # File has been renamed, the check will fail but should recover later.
+        write_and_check()
+        assert len(aggregator.events) == 503
+        os.rename(log_file.name + "_renamed", log_file.name)
+
+        # Check recovers but start from the EOF
+        write_and_check()
+        assert len(aggregator.events) == 503
+
+        # Check has fully recovered and submit events again
+        write_and_check()
+        assert len(aggregator.events) == 2 * 503
+
+        log_file.close()
 
 
 class TestPerfDataTailer:

--- a/nagios/tests/test_unit.py
+++ b/nagios/tests/test_unit.py
@@ -17,7 +17,7 @@ def test_centreon_event_logs():
     events = []
     mock_log = MagicMock()
     tailer = NagiosEventLogTailer(NAGIOS_TEST_LOG, mock_log, "host", events.append, None, False)
-    tailer._parse_line(log)
+    tailer.parse_line(log)
     assert len(events) == 1
     assert events[0]['event_type'] == 'SERVICE ALERT'
     assert events[0]['host'] == 'SOMEHOST'


### PR DESCRIPTION
If a nagios log file suddenly end up missing the check enters an unhealthy state where even if the file re-appears in the future, the agent will not be able to recover from the error.

The PR allows the check to recover.