### PR TITLE
Use more specific metric_to_check

### DIFF
--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -15,7 +15,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "couch.",
-  "metric_to_check": "couchdb.couchdb.request_time",
+  "metric_to_check": "couchdb.couchdb.request_time.n",
   "name": "couch",
   "process_signatures": [
     "couchjs"

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -15,7 +15,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "couch.",
-  "metric_to_check": "couchdb.couchdb.request_time.n",
+  "metric_to_check": ["couchdb.couchdb.request_time.n", "couchdb.couchdb.request_time"],
   "name": "couch",
   "process_signatures": [
     "couchjs"


### PR DESCRIPTION
### What does this PR do?
`couchdb.couchdb.request_time` is not available for V2.
Adds `couchdb.couchdb.request_time.n` for tile installation for couchdb v2 users.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
