### PR TITLE
Remove intg-tools-libs from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,8 @@
 conf.yaml.example     @DataDog/documentation @DataDog/agent-integrations
 conf.yaml.default     @DataDog/documentation @DataDog/agent-integrations @DataDog/agent-core
 auto_conf.yaml        @DataDog/documentation @DataDog/agent-integrations @DataDog/container-integrations
-manifest.json         @DataDog/documentation @DataDog/agent-integrations @DataDog/integrations-tools-and-libraries
-assets/               @DataDog/agent-integrations @DataDog/integrations-tools-and-libraries
+manifest.json         @DataDog/documentation @DataDog/agent-integrations
+assets/               @DataDog/agent-integrations
 
 
 # Container monitoring


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removes intg-tools-libs from the codeowners file for this repo

### Motivation
<!-- What inspired you to submit this pull request? -->
We'll get notified when an integration gets synced after this point, so this removes getting notified on all manifest/asset changes.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
