### PR TITLE
Minimize aurora postgres warnings

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -69,7 +69,6 @@ class PostgreSql(AgentCheck):
             raw_version = get_raw_version(self.db)
             self._version = parse_version(raw_version)
             self.set_metadata('version', raw_version)
-            self.is_aurora = is_aurora(self.db)
         return self._version
 
     def _build_relations_config(self, yamlconfig):
@@ -415,6 +414,10 @@ class PostgreSql(AgentCheck):
             if self.config.tag_replication_role:
                 tags.extend(["replication_role:{}".format(self._get_replication_role())])
             self.log.debug("Running check against version %s", str(self.version))
+
+            if self.is_aurora is None:
+                self.is_aurora = is_aurora(self.db)
+
             self._collect_stats(tags)
             self._collect_custom_queries(tags)
         except Exception as e:


### PR DESCRIPTION
### What does this PR do?

This PR only allows `is_aurora()` to be called once.

### Motivation

Resolves https://github.com/DataDog/integrations-core/issues/7450

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
