### PR TITLE
Add initial validations for EULA files

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
@@ -11,6 +11,7 @@ from .codeowners import codeowners
 from .config import config
 from .dashboards import dashboards
 from .dep import dep
+from .eula import eula
 from .imports import imports
 from .manifest import manifest
 from .metadata import metadata
@@ -27,6 +28,7 @@ ALL_COMMANDS = (
     config,
     dashboards,
     dep,
+    eula,
     legacy_signature,
     imports,
     manifest,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/eula.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/eula.py
@@ -1,0 +1,50 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import click
+
+from ...utils import get_valid_integrations, get_eula_from_manifest
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
+
+
+@click.command('eula', context_settings=CONTEXT_SETTINGS, short_help='Validate EULA files')
+def eula():
+    """Validate all EULA definition files."""
+    echo_info("Validating all EULA files...")
+    failed_checks = 0
+    ok_checks = 0
+
+    for check_name in sorted(get_valid_integrations()):
+        eula_relative_location, eula_exists = get_eula_from_manifest(check_name)
+
+        if not eula_exists:
+            echo_info(f'{check_name}... ', nl=False)
+            echo_info(' FAILED')
+            echo_failure(f'  {eula_relative_location} does not exist')
+            failed_checks += 1
+            continue
+
+        # Check file extension of eula is .pdf
+        if not eula_relative_location.endswith(".pdf"):
+            echo_info(f'{check_name}... ', nl=False)
+            echo_info(' FAILED')
+            echo_failure(f'  {eula_relative_location} is missing the pdf extension')
+            continue
+
+        # Check PDF starts with PDF magic_number: "%PDF"
+        with open(eula_relative_location, 'rb') as f:
+            magic_number = f.readline()
+            if b'%PDF' not in magic_number:
+                echo_info(f'{check_name}... ', nl=False)
+                echo_info(' FAILED')
+                echo_failure(f'  {eula_relative_location} is not a PDF file')
+                failed_checks += 1
+                continue
+
+        ok_checks += 1
+
+    if ok_checks:
+        echo_success(f"{ok_checks} valid files")
+    if failed_checks:
+        echo_failure(f"{failed_checks} invalid files")
+        abort()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/eula.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/eula.py
@@ -1,9 +1,9 @@
-# (C) Datadog, Inc. 2018-present
+# (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import click
 
-from ...utils import get_valid_integrations, get_eula_from_manifest
+from ...utils import get_eula_from_manifest, get_valid_integrations
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -93,7 +93,7 @@ def recommended_monitors():
                 result = [i for i in decoded.get('tags') if i.startswith('integration:')]
                 if len(result) < 1:
                     file_failed = True
-                    display_queue.append((echo_failure, f"    {monitor_filename} must have an `integration` tag"),)
+                    display_queue.append((echo_failure, f"    {monitor_filename} must have an `integration` tag"))
 
                 display_name = manifest.get("display_name").lower()
                 monitor_name = decoded.get('name').lower()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -93,9 +93,7 @@ def recommended_monitors():
                 result = [i for i in decoded.get('tags') if i.startswith('integration:')]
                 if len(result) < 1:
                     file_failed = True
-                    display_queue.append(
-                        (echo_failure, f"    {monitor_filename} must have an `integration` tag"),
-                    )
+                    display_queue.append((echo_failure, f"    {monitor_filename} must have an `integration` tag"),)
 
                 display_name = manifest.get("display_name").lower()
                 monitor_name = decoded.get('name').lower()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -251,6 +251,12 @@ def get_metadata_file(check_name):
     return os.path.join(get_root(), check_name, 'metadata.csv')
 
 
+def get_eula_from_manifest(check_name):
+    path = load_manifest(check_name).get('terms', {}).get('eula')
+    path = os.path.join(get_root(), check_name, *path.split('/'))
+    return path, file_exists(path)
+
+
 def get_assets_from_manifest(check_name, asset_type):
     paths = load_manifest(check_name).get('assets', {}).get(asset_type, {})
     assets = []


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add a new ddev validate subcommand for `eula`. This will quickly validate that EULA files attached to an integration:
* exist
* contain the .pdf extension
* Are of the type "pdf" when opened (detected by the file's magic number)

### Motivation
<!-- What inspired you to submit this pull request? -->
More validations cross all pieces of an integration. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
While EULAs aren't attached to integrations in this repo, they are used in marketplace integrations. I'd like to add this to the CI in the Azure Pipeline templates if the repo choice is set to marketplace in a followup PR, if/when this is merged and released. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
