### PR TITLE
Handle unfound processes in no matching PIDs logs

### DIFF
--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -189,13 +189,13 @@ class ProcessCheck(AgentCheck):
                 # Allow debug logging while preserving warning check state.
                 # Uncaught psutil exceptions trigger an Error state
                 try:
-                    self.log.debug(
-                        "Unable to find process named %s among processes: %s",
-                        search_string,
-                        ', '.join(sorted(proc.name() for proc in self.process_list_cache.elements)),
-                    )
+                    processes = sorted(proc.name() for proc in self.process_list_cache.elements)
                 except (psutil.NoSuchProcess, psutil.AccessDenied):
                     pass
+                else:
+                    self.log.debug(
+                        "Unable to find process named %s among processes: %s", search_string, ', '.join(processes)
+                    )
 
         self.pid_cache[name] = matching_pids
         self.last_pid_cache_ts[name] = time.time()

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -186,11 +186,16 @@ class ProcessCheck(AgentCheck):
                             break
 
             if not matching_pids:
-                self.log.debug(
-                    "Unable to find process named %s among processes: %s",
-                    search_string,
-                    ', '.join(sorted(proc.name() for proc in self.process_list_cache.elements)),
-                )
+                # Allow debug logging while preserving warning check state.
+                # Uncaught psutil exceptions trigger an Error state
+                try:
+                    self.log.debug(
+                        "Unable to find process named %s among processes: %s",
+                        search_string,
+                        ', '.join(sorted(proc.name() for proc in self.process_list_cache.elements)),
+                    )
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
 
         self.pid_cache[name] = matching_pids
         self.last_pid_cache_ts[name] = time.time()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR prevents uncaught psutil exceptions from changing unfound processes from creating an Error state in the check as opposed to the warning state.

### Motivation
<!-- What inspired you to submit this pull request? -->
This is blocking upgrade to the newer version of the agent rpm and utilizing some universal tagging functionality, since some of our existing process checks will now generate Error states instead of Warning states.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Live usage example from our agent
With the fix above:
```
      Instance ID: process:dummy-target-process:d33e96bb37c78a9d [WARNING]
      Configuration Source: file:/etc/datadog-agent/conf.d/process.yaml
      Total Runs: 8
      Metric Samples: Last Run: 1, Total: 8
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 8
      Average Execution Time : 13ms
      Last Execution Date : 2020-09-01 14:20:06.000000 EDT
      Last Successful Execution Date : 2020-09-01 14:20:06.000000 EDT
      
      Warning: No matching process 'dummy-target-process' was found
```
Without the fix
```
      Instance ID: process:dummy-target-process:d33e96bb37c78a9d [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/process.yaml
      Total Runs: 1
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 59ms
      Last Execution Date : 2020-09-01 14:30:53.000000 EDT
      Last Successful Execution Date : Never
      Error: psutil.NoSuchProcess process no longer exists (pid=5132, name='transient-process')
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_common.py", line 340, in wrapper
          ret = self._cache[fun]
      AttributeError: _cache
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_pslinux.py", line 1517, in wrapper
          return fun(self, *args, **kwargs)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_common.py", line 343, in wrapper
          return fun(self)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_pslinux.py", line 1559, in _parse_stat_file
          with open_binary("%s/%s/stat" % (self._procfs_path, self.pid)) as f:
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_common.py", line 604, in open_binary
          return open(fname, "rb", **kwargs)
      FileNotFoundError: [Errno 2] No such file or directory: '/proc/5132/stat'
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 841, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/process/process.py", line 417, in check
          pids = self.find_pids(name, search_string, exact_match, ignore_ad=ignore_ad)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/process/process.py", line 192, in find_pids
          ', '.join(sorted(proc.name() for proc in self.process_list_cache.elements)),
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/process/process.py", line 192, in <genexpr>
          ', '.join(sorted(proc.name() for proc in self.process_list_cache.elements)),
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/__init__.py", line 731, in name
          name = self._proc.name()
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_pslinux.py", line 1517, in wrapper
          return fun(self, *args, **kwargs)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_pslinux.py", line 1612, in name
          name = self._parse_stat_file()['name']
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/psutil/_pslinux.py", line 1524, in wrapper
          raise NoSuchProcess(self.pid, self._name)
      psutil.NoSuchProcess: psutil.NoSuchProcess process no longer exists (pid=5132, name='transient-process')
```
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
