### PR TITLE
Add the new env parameter to get_subprocess_output

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/_util.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/_util.py
@@ -10,7 +10,7 @@ class SubprocessOutputEmptyError(Exception):
     pass
 
 
-def subprocess_output(command, raise_on_empty_output):
+def subprocess_output(command, raise_on_empty_output, env=None):
     """
     This is a stub to allow a check requiring `Popen` to run without an Agent (e.g. during tests or development),
     it's not supposed to be used anywhere outside the `datadog_checks.utils` package.
@@ -20,7 +20,7 @@ def subprocess_output(command, raise_on_empty_output):
     # docs warn that the data read is buffered in memory. They suggest not to
     # use subprocess.PIPE if the data size is large or unlimited.
     with tempfile.TemporaryFile() as stdout_f, tempfile.TemporaryFile() as stderr_f:
-        proc = subprocess.Popen(command, stdout=stdout_f, stderr=stderr_f)
+        proc = subprocess.Popen(command, stdout=stdout_f, stderr=stderr_f, env=env)
         proc.wait()
         stderr_f.seek(0)
         err = stderr_f.read()

--- a/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
@@ -19,7 +19,7 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
-def get_subprocess_output(command, log, raise_on_empty_output=True, log_debug=True):
+def get_subprocess_output(command, log, raise_on_empty_output=True, log_debug=True, env=None):
     """
     Run the given subprocess command and return its output. Raise an Exception
     if an error occurs.
@@ -33,6 +33,9 @@ def get_subprocess_output(command, log, raise_on_empty_output=True, log_debug=Tr
     :param bool raise_on_empty_output: Whether to raise a SubprocessOutputEmptyError exception when
                                        the subprocess doesn't output anything to its stdout.
     :param bool log_debug: Whether to enable debug logging of full command.
+    :param env: The environment variables to run the command with. If this parameter is set to None
+                then, the environment variables of the agent are used. The default value is None.
+    :type env: dict(str, str) or None
     :returns: The stdout contents, stderr contents and status code of the command
     :rtype: tuple(str, str, int)
     """
@@ -50,7 +53,7 @@ def get_subprocess_output(command, log, raise_on_empty_output=True, log_debug=Tr
     if log_debug:
         log.debug('Running get_subprocess_output with cmd: %s', cmd_args)
 
-    out, err, returncode = subprocess_output(cmd_args, raise_on_empty_output)
+    out, err, returncode = subprocess_output(cmd_args, raise_on_empty_output, env=env)
 
     log.debug(
         'get_subprocess_output returned (len(out): %s ; len(err): %s ; returncode: %s)', len(out), len(err), returncode


### PR DESCRIPTION
### What does this PR do?

Add a new `env` parameter to `get_subprocess_output` to be able to specify custom environment variables when spawning subprocesses.

### Motivation

Thanks to DataDog/datadog-agent#5987, it is now possible to use the `env` parameter of `get_subprocess_output` to explicitly set custom environment variables when spawning subprocesses.
This change needs to be reflected in the python code.
This will be used by #7095.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
