### PR TITLE
Add `index_transform` to support tagging using another table with different indexes

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/chatsworth_pdu.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/chatsworth_pdu.yaml
@@ -570,6 +570,13 @@ metrics:
         column:
           OID: 1.3.6.1.4.1.30932.1.10.1.3.110.1.2
           name: cpiPduBranchId
+      - column:
+          OID: 1.3.6.1.4.1.30932.1.10.1.2.10.1.3
+          name: cpiPduName
+        table: cpiPduTable
+        index_transform: "1:8"
+        MIB: CPI-UNITY-MIB
+        tag: pdu_name
 
   - # Redefine the table to force the type on cpiPduBranchEnergy
     MIB: CPI-UNITY-MIB
@@ -586,6 +593,13 @@ metrics:
         column:
           OID: 1.3.6.1.4.1.30932.1.10.1.3.110.1.2
           name: cpiPduBranchId
+      - column:
+          OID: 1.3.6.1.4.1.30932.1.10.1.2.10.1.3
+          name: cpiPduName
+        table: cpiPduTable
+        index_transform: "1:8"
+        MIB: CPI-UNITY-MIB
+        tag: pdu_name
 
   ### Outlet
 

--- a/snmp/datadog_checks/snmp/data/profiles/chatsworth_pdu.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/chatsworth_pdu.yaml
@@ -575,7 +575,6 @@ metrics:
           name: cpiPduName
         table: cpiPduTable
         index_transform: "1:8"
-        MIB: CPI-UNITY-MIB
         tag: pdu_name
 
   - # Redefine the table to force the type on cpiPduBranchEnergy
@@ -598,7 +597,6 @@ metrics:
           name: cpiPduName
         table: cpiPduTable
         index_transform: "1:8"
-        MIB: CPI-UNITY-MIB
         tag: pdu_name
 
   ### Outlet

--- a/snmp/datadog_checks/snmp/data/profiles/chatsworth_pdu.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/chatsworth_pdu.yaml
@@ -576,7 +576,7 @@ metrics:
         table: cpiPduTable
         index_transform:
           - start: 1
-            end: 8
+            end: 7
         tag: pdu_name
 
   - # Redefine the table to force the type on cpiPduBranchEnergy
@@ -600,7 +600,7 @@ metrics:
         table: cpiPduTable
         index_transform:
           - start: 1
-            end: 8
+            end: 7
         tag: pdu_name
 
   ### Outlet

--- a/snmp/datadog_checks/snmp/data/profiles/chatsworth_pdu.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/chatsworth_pdu.yaml
@@ -574,7 +574,9 @@ metrics:
           OID: 1.3.6.1.4.1.30932.1.10.1.2.10.1.3
           name: cpiPduName
         table: cpiPduTable
-        index_transform: "1:8"
+        index_transform:
+          - start: 1
+            end: 8
         tag: pdu_name
 
   - # Redefine the table to force the type on cpiPduBranchEnergy
@@ -596,7 +598,9 @@ metrics:
           OID: 1.3.6.1.4.1.30932.1.10.1.2.10.1.3
           name: cpiPduName
         table: cpiPduTable
-        index_transform: "1:8"
+        index_transform:
+          - start: 1
+            end: 8
         tag: pdu_name
 
   ### Outlet

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -451,7 +451,7 @@ def _parse_column_metric_tag(mib, parsed_table, metric_tag):
     raw_index_transform = metric_tag.get('index_transform')
     if raw_index_transform:
         for rule in raw_index_transform:
-            if not isinstance(rule, dict) or sorted(rule.keys()) != ['end', 'start']:
+            if not isinstance(rule, dict) or set(rule) != {'start', 'end'}:
                 raise ConfigurationError('Transform rule must contain start and end. Invalid rule: {}'.format(rule))
             start, end = rule['start'], rule['end']
             if not isinstance(start, six.integer_types) or not isinstance(end, six.integer_types):

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -484,8 +484,10 @@ def _parse_index_metric_tag(metric_tag):
 
 
 def _parse_index_slices(metric_tag):
-    index_slices = []  # type: List[slice]
+    # type: (ColumnTableMetricTag) -> List[slice]
     raw_index_slices = metric_tag.get('index_transform')
+    index_slices = []  # type: List[slice]
+
     if raw_index_slices:
         for rule in raw_index_slices:
             if not isinstance(rule, dict) or set(rule) != {'start', 'end'}:
@@ -499,7 +501,8 @@ def _parse_index_slices(metric_tag):
                 )
             if start < 0:
                 raise ConfigurationError('Transform rule start must be greater than 0. Invalid rule: {}'.format(rule))
-
+            # For a better user experience, the `end` in metrics definition is inclusive.
+            # We +1 to `end` since the `end` in python slices is exclusive.
             index_slices.append(slice(start, end + 1))
-    return index_slices
 
+    return index_slices

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -449,9 +449,9 @@ def _parse_column_metric_tag(mib, parsed_table, metric_tag):
     if raw_index_transform:
         transform_rules = raw_index_transform.split(',')
         for rule in transform_rules:
-            start, end = rule.split(':')
             try:
-                start, end = int(start), int(end)
+                # ValueError handle issue cast to int and too many values to unpack
+                start, end = [int(i) for i in rule.split(':')]
             except ValueError as e:
                 raise ConfigurationError('Invalid transform rule `{}`: {}'.format(raw_index_transform, e))
             index_transform.append((start, end))

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -5,7 +5,7 @@
 Helpers for parsing the `metrics` section of a config file.
 """
 from logging import Logger
-from typing import Dict, List, NamedTuple, Optional, Sequence, TypedDict, Union, cast, Tuple
+from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple, TypedDict, Union, cast
 
 from datadog_checks.base import ConfigurationError
 
@@ -344,7 +344,9 @@ def merge_table_batches(target, source):
 
 
 IndexTag = NamedTuple('IndexTag', [('parsed_metric_tag', ParsedMetricTag), ('index', int)])
-ColumnTag = NamedTuple('ColumnTag', [('parsed_metric_tag', ParsedMetricTag), ('column', str), ('index_transform', List[Tuple[int, int]])])
+ColumnTag = NamedTuple(
+    'ColumnTag', [('parsed_metric_tag', ParsedMetricTag), ('column', str), ('index_transform', List[Tuple[int, int]])]
+)
 
 ParsedColumnMetricTag = NamedTuple(
     'ParsedColumnMetricTag',
@@ -451,8 +453,11 @@ def _parse_column_metric_tag(mib, parsed_table, metric_tag):
     return ParsedColumnMetricTag(
         oids_to_resolve=parsed_column.oids_to_resolve,
         column_tags=[
-            ColumnTag(parsed_metric_tag=parse_metric_tag(cast(MetricTag, metric_tag)), column=parsed_column.name,
-                      index_transform=index_transform)
+            ColumnTag(
+                parsed_metric_tag=parse_metric_tag(cast(MetricTag, metric_tag)),
+                column=parsed_column.name,
+                index_transform=index_transform,
+            )
         ],
         table_batches=batches,
     )

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -345,7 +345,8 @@ def merge_table_batches(target, source):
 
 IndexTag = NamedTuple('IndexTag', [('parsed_metric_tag', ParsedMetricTag), ('index', int)])
 ColumnTag = NamedTuple(
-    'ColumnTag', [('parsed_metric_tag', ParsedMetricTag), ('column', str), ('index_transform', List[Tuple[int, int]])]
+    'ColumnTag',
+    [('parsed_metric_tag', ParsedMetricTag), ('column', str), ('index_transform_rules', List[Tuple[int, int]])],
 )
 
 ParsedColumnMetricTag = NamedTuple(
@@ -444,7 +445,7 @@ def _parse_column_metric_tag(mib, parsed_table, metric_tag):
 
     batches = {TableBatchKey(mib, table=parsed_table.name): TableBatch(parsed_table.oid, oids=[parsed_column.oid])}
 
-    index_transform = []
+    index_transform_rules = []
     raw_index_transform = metric_tag.get('index_transform')
     if raw_index_transform:
         transform_rules = raw_index_transform.split(',')
@@ -454,7 +455,7 @@ def _parse_column_metric_tag(mib, parsed_table, metric_tag):
                 start, end = [int(i) for i in rule.split(':')]
             except ValueError as e:
                 raise ConfigurationError('Invalid transform rule `{}`: {}'.format(raw_index_transform, e))
-            index_transform.append((start, end))
+            index_transform_rules.append((start, end))
 
     return ParsedColumnMetricTag(
         oids_to_resolve=parsed_column.oids_to_resolve,
@@ -462,7 +463,7 @@ def _parse_column_metric_tag(mib, parsed_table, metric_tag):
             ColumnTag(
                 parsed_metric_tag=parse_metric_tag(cast(MetricTag, metric_tag)),
                 column=parsed_column.name,
-                index_transform=index_transform,
+                index_transform_rules=index_transform_rules,
             )
         ],
         table_batches=batches,

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -447,8 +447,14 @@ def _parse_column_metric_tag(mib, parsed_table, metric_tag):
     index_transform = []
     raw_index_transform = metric_tag.get('index_transform')
     if raw_index_transform:
-        start, end = raw_index_transform.split(':')
-        index_transform.append((int(start), int(end)))
+        transform_rules = raw_index_transform.split(',')
+        for rule in transform_rules:
+            start, end = rule.split(':')
+            try:
+                start, end = int(start), int(end)
+            except ValueError as e:
+                raise ConfigurationError('Invalid transform rule `{}`: {}'.format(raw_index_transform, e))
+            index_transform.append((start, end))
 
     return ParsedColumnMetricTag(
         oids_to_resolve=parsed_column.oids_to_resolve,

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -485,6 +485,29 @@ def _parse_index_metric_tag(metric_tag):
 
 def _parse_index_slices(metric_tag):
     # type: (ColumnTableMetricTag) -> List[slice]
+    """
+    Transform index_transform into list of index slices.
+
+    `index_transform` is needed to support tagging using another table with different indexes.
+
+    Example: TableB have two indexes indexX (1 digit) and indexY (3 digits).
+        We want to tag by an external TableA that have indexY (3 digits).
+
+        For example TableB has a row with full index `1.2.3.4`, indexX is `1` and indexY is `2.3.4`.
+        TableA has a row with full index `2.3.4`, indexY is `2.3.4` (matches indexY of TableB).
+
+        SNMP integration doesn't know how to compare the full indexes from TableB and TableA.
+        We need to extract a subset of the full index of TableB to match with TableA full index.
+
+        Using the below `index_transform` we provide enough info to extract a subset of index that
+        will be used to match TableA's full index.
+
+        ```yaml
+        index_transform:
+          - start: 1
+          - end: 3
+        ```
+    """
     raw_index_slices = metric_tag.get('index_transform')
     index_slices = []  # type: List[slice]
 

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -450,7 +450,7 @@ def _parse_column_metric_tag(mib, parsed_table, metric_tag):
         transform_rules = raw_index_transform.split(',')
         for rule in transform_rules:
             try:
-                # ValueError handle issue cast to int and too many values to unpack
+                # Might raise ValueError for casting to int and too many values to unpack
                 start, end = [int(i) for i in rule.split(':')]
             except ValueError as e:
                 raise ConfigurationError('Invalid transform rule `{}`: {}'.format(raw_index_transform, e))

--- a/snmp/datadog_checks/snmp/parsing/metrics_types.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics_types.py
@@ -20,7 +20,9 @@ IndexTableMetricTag = TypedDict(
 )
 
 ColumnTableMetricTag = TypedDict(
-    'ColumnTableMetricTag', {'MIB': str, 'column': Symbol, 'table': str, 'tag': str}, total=False
+    'ColumnTableMetricTag',
+    {'MIB': str, 'column': Symbol, 'table': str, 'tag': str, 'index_transform': str},
+    total=False,
 )
 
 TableMetricTag = Union[IndexTableMetricTag, ColumnTableMetricTag]

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -501,8 +501,8 @@ class SnmpCheck(AgentCheck):
         for column_tag in column_tags:
             raw_column_value = column_tag.column
 
-            if column_tag.index_transform:
-                new_index = transform_index(index, column_tag.index_transform)
+            if column_tag.index_transform_rules:
+                new_index = transform_index(index, column_tag.index_transform_rules)
             else:
                 new_index = index
             try:

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -35,6 +35,7 @@ from .utils import (
     get_profile_definition,
     oid_pattern_specificity,
     recursively_expand_base_profiles,
+    transform_index,
 )
 
 DEFAULT_OID_BATCH_SIZE = 10
@@ -501,11 +502,8 @@ class SnmpCheck(AgentCheck):
             raw_column_value = column_tag.column
 
             try:
-                new_index = ()
                 if column_tag.index_transform:
-                    for transform in column_tag.index_transform:
-                        start, end = transform
-                        new_index += index[start: end]
+                    new_index = transform_index(index, column_tag.index_transform)
                 else:
                     new_index = index
                 column_value = results[raw_column_value][new_index]

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -499,8 +499,16 @@ class SnmpCheck(AgentCheck):
 
         for column_tag in column_tags:
             raw_column_value = column_tag.column
+
             try:
-                column_value = results[raw_column_value][index]
+                new_index = ()
+                if column_tag.index_transform:
+                    for transform in column_tag.index_transform:
+                        start, end = transform
+                        new_index += index[start: end]
+                else:
+                    new_index = index
+                column_value = results[raw_column_value][new_index]
             except KeyError:
                 self.log.warning('Column %s not present in the table, skipping this tag', raw_column_value)
                 continue

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -508,7 +508,7 @@ class SnmpCheck(AgentCheck):
             try:
                 column_value = results[raw_column_value][new_index]
             except KeyError:
-                self.log.warning('Column %s not present in the table, skipping this tag', raw_column_value)
+                self.log.warning('Column `%s not present in the table, skipping this tag. index=%s', raw_column_value, new_index)
                 continue
             if reply_invalid(column_value):
                 self.log.warning("Can't deduct tag from column %s", column_tag.column)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -501,8 +501,8 @@ class SnmpCheck(AgentCheck):
         for column_tag in column_tags:
             raw_column_value = column_tag.column
 
-            if column_tag.index_transform_rules:
-                new_index = transform_index(index, column_tag.index_transform_rules)
+            if column_tag.index_slices:
+                new_index = transform_index(index, column_tag.index_slices)
             else:
                 new_index = index
             try:

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -508,7 +508,9 @@ class SnmpCheck(AgentCheck):
             try:
                 column_value = results[raw_column_value][new_index]
             except KeyError:
-                self.log.warning('Column `%s not present in the table, skipping this tag. index=%s', raw_column_value, new_index)
+                self.log.warning(
+                    'Column `%s not present in the table, skipping this tag. index=%s', raw_column_value, new_index
+                )
                 continue
             if reply_invalid(column_value):
                 self.log.warning("Can't deduct tag from column %s", column_tag.column)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -502,13 +502,7 @@ class SnmpCheck(AgentCheck):
             raw_column_value = column_tag.column
 
             if column_tag.index_transform:
-                try:
-                    new_index = transform_index(index, column_tag.index_transform)
-                except KeyError:
-                    self.log.warning(
-                        'Cannot transform %s with following index_transform rules', index, column_tag.index_transform
-                    )
-                    continue
+                new_index = transform_index(index, column_tag.index_transform)
             else:
                 new_index = index
             try:

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -501,11 +501,17 @@ class SnmpCheck(AgentCheck):
         for column_tag in column_tags:
             raw_column_value = column_tag.column
 
-            try:
-                if column_tag.index_transform:
+            if column_tag.index_transform:
+                try:
                     new_index = transform_index(index, column_tag.index_transform)
-                else:
-                    new_index = index
+                except KeyError:
+                    self.log.warning(
+                        'Cannot transform %s with following index_transform rules', index, column_tag.index_transform
+                    )
+                    continue
+            else:
+                new_index = index
+            try:
                 column_value = results[raw_column_value][new_index]
             except KeyError:
                 self.log.warning('Column %s not present in the table, skipping this tag', raw_column_value)

--- a/snmp/datadog_checks/snmp/utils.py
+++ b/snmp/datadog_checks/snmp/utils.py
@@ -373,7 +373,7 @@ def transform_index(src_index, index_slices):
     A transform rule is slice and is used to extract a subset of the source index.
 
     ```python
-    >>> transform_index(('10', '11', '12', '13'), [(2, 2), (0, 1)])
+    >>> transform_index(('10', '11', '12', '13'), [slice(2, 3), slice(0, 2)])
     ('12', '10', '11')
     ```
     """

--- a/snmp/datadog_checks/snmp/utils.py
+++ b/snmp/datadog_checks/snmp/utils.py
@@ -365,13 +365,12 @@ def batches(lst, size):
         yield lst[index : index + size]
 
 
-def transform_index(src_index, index_transform_rules):
-    # type: (Tuple[str, ...], List[Tuple[int, int]]) -> Tuple[str, ...]
+def transform_index(src_index, index_slices):
+    # type: (Tuple[str, ...], List[slice]) -> Tuple[str, ...]
     """
     Transform a source index into a new index using a list of transform rules.
 
-    A transform rule is a tuple of (start, end) and is used to extract a subset of the source index.
-    Indexing is zero based and both start and end are inclusive.
+    A transform rule is slice and is used to extract a subset of the source index.
 
     ```python
     >>> transform_index(('10', '11', '12', '13'), [(2, 2), (0, 1)])
@@ -379,7 +378,6 @@ def transform_index(src_index, index_transform_rules):
     ```
     """
     dst_index = []  # type: List[str]
-    for transform in index_transform_rules:
-        start, end = transform
-        dst_index.extend(src_index[start:end+1])
+    for index_slice in index_slices:
+        dst_index.extend(src_index[index_slice])
     return tuple(dst_index)

--- a/snmp/datadog_checks/snmp/utils.py
+++ b/snmp/datadog_checks/snmp/utils.py
@@ -371,14 +371,15 @@ def transform_index(src_index, index_transform_rules):
     Transform a source index into a new index using a list of transform rules.
 
     A transform rule is a tuple of (start, end) and is used to extract a subset of the source index.
+    Indexing is zero based and both start and end are inclusive.
 
     ```python
-    >>> transform_index(('10', '11', '12', '13'), [(2, 3), (0, 2)])
+    >>> transform_index(('10', '11', '12', '13'), [(2, 2), (0, 1)])
     ('12', '10', '11')
     ```
     """
     dst_index = []  # type: List[str]
     for transform in index_transform_rules:
         start, end = transform
-        dst_index.extend(src_index[start:end])
+        dst_index.extend(src_index[start:end+1])
     return tuple(dst_index)

--- a/snmp/datadog_checks/snmp/utils.py
+++ b/snmp/datadog_checks/snmp/utils.py
@@ -373,8 +373,8 @@ def transform_index(src_index, index_transform_rules):
     A transform rule is a tuple of (start, end) and is used to extract a subset of the source index.
 
     ```python
-    >>> transform_index(('a', 'b', 'c', 'd'), [(2, 3), (0, 2)])
-    ('c', 'a', 'b')
+    >>> transform_index(('10', '11', '12', '13'), [(2, 3), (0, 2)])
+    ('12', '10', '11')
     ```
     """
     dst_index = []  # type: List[str]

--- a/snmp/datadog_checks/snmp/utils.py
+++ b/snmp/datadog_checks/snmp/utils.py
@@ -363,3 +363,22 @@ def batches(lst, size):
 
     for index in range(0, len(lst), size):
         yield lst[index : index + size]
+
+
+def transform_index(src_index, index_transform_rules):
+    # type: (Tuple[str, ...], List[Tuple[int, int]]) -> Tuple[str, ...]
+    """
+    Transform a source index into a new index using a list of transform rules.
+
+    A transform rule is a tuple of (start, end) and is used to extract a subset of the source index.
+
+    ```python
+    >>> transform_index(('a', 'b', 'c', 'd'), [(2, 3), (0, 2)])
+    ('c', 'a', 'b')
+    ```
+    """
+    dst_index = []  # type: List[str]
+    for transform in index_transform_rules:
+        start, end = transform
+        dst_index.extend(src_index[start:end])
+    return tuple(dst_index)

--- a/snmp/tests/test_parsing.py
+++ b/snmp/tests/test_parsing.py
@@ -43,7 +43,7 @@ def test_parse_index_transform_ok_cases(index_transform, expected_rules):
     )
 
     results = parse_metrics(yaml.load(metrics), resolver=mock.MagicMock(), logger=logger, bulk_threshold=10)
-    actual_transform_rules = results['parsed_metrics'][0].column_tags[0].index_transform
+    actual_transform_rules = results['parsed_metrics'][0].column_tags[0].index_transform_rules
     assert actual_transform_rules == expected_rules
 
 

--- a/snmp/tests/test_parsing.py
+++ b/snmp/tests/test_parsing.py
@@ -1,0 +1,84 @@
+import logging
+
+import mock
+import pytest
+import yaml
+
+from datadog_checks.base import ConfigurationError
+from datadog_checks.snmp.parsing import parse_metrics
+
+from . import common
+
+pytestmark = common.python_autodiscovery_only
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'index_transform, expected_rules',
+    [
+        (pytest.param("1:8", [(1, 8)], id="one_rule")),
+        (pytest.param("1:8,10:20", [(1, 8), (10, 20)], id="multi_rules")),
+    ],
+)
+def test_parse_index_transform_ok_cases(index_transform, expected_rules):
+    metrics = """
+- MIB: CPI-UNITY-MIB
+  table:
+    OID: 1.3.6.1.4.1.30932.1.10.1.3.110
+    name: cpiPduBranchTable
+  symbols:
+    - OID: 1.3.6.1.4.1.30932.1.10.1.3.110.1.9
+      name: cpiPduBranchEnergy
+  metric_tags:
+    - column:
+        OID: 1.3.6.1.4.1.30932.1.10.1.2.10.1.3
+        name: cpiPduName
+      table: cpiPduTable
+      index_transform: "{}"
+      tag: pdu_name
+""".format(
+        index_transform
+    )
+
+    results = parse_metrics(yaml.load(metrics), resolver=mock.MagicMock(), logger=logger, bulk_threshold=10)
+    actual_transform_rules = results['parsed_metrics'][0].column_tags[0].index_transform
+    assert actual_transform_rules == expected_rules
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'index_transform, error_msg',
+    [
+        (pytest.param("1:", "Invalid transform rule", id="one_rule")),
+        (pytest.param("1:8:20", "Invalid transform rule", id="too_many_values")),
+        (pytest.param("1", "Invalid transform rule", id="not_enough_values")),
+        (pytest.param("1:2,3:8:20", "Invalid transform rule", id="multi_too_many_values")),
+        (pytest.param("1:2,", "Invalid transform rule", id="empty_element")),
+        (pytest.param("a:2", "Invalid transform rule", id="not_integer")),
+    ],
+)
+def test_parse_index_transform_config_error(index_transform, error_msg):
+    metrics = """
+- MIB: CPI-UNITY-MIB
+  table:
+    OID: 1.3.6.1.4.1.30932.1.10.1.3.110
+    name: cpiPduBranchTable
+  symbols:
+    - OID: 1.3.6.1.4.1.30932.1.10.1.3.110.1.9
+      name: cpiPduBranchEnergy
+  metric_tags:
+    - column:
+        OID: 1.3.6.1.4.1.30932.1.10.1.2.10.1.3
+        name: cpiPduName
+      table: cpiPduTable
+      index_transform: "{}"
+      tag: pdu_name
+""".format(
+        index_transform
+    )
+
+    with pytest.raises(ConfigurationError) as e:
+        parse_metrics(yaml.load(metrics), resolver=mock.MagicMock(), logger=logger, bulk_threshold=10)
+    assert error_msg in str(e.value)

--- a/snmp/tests/test_parsing.py
+++ b/snmp/tests/test_parsing.py
@@ -18,9 +18,13 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize(
     'index_transform, expected_rules',
     [
-        (pytest.param("[{'start': 1, 'end': 8}]", [(1, 8)], id="one_rule")),
-        (pytest.param("[{'start': 1, 'end': 8}, {'start': 10, 'end': 20}, ]", [(1, 8), (10, 20)], id="multi_rules")),
-        (pytest.param("[{'start': 1, 'end': 1}]", [(1, 1)], id="one_value_index")),
+        (pytest.param("[{'start': 1, 'end': 7}]", [slice(1, 8)], id="one_rule")),
+        (
+            pytest.param(
+                "[{'start': 1, 'end': 7}, {'start': 10, 'end': 19}, ]", [slice(1, 8), slice(10, 20)], id="multi_rules"
+            )
+        ),
+        (pytest.param("[{'start': 1, 'end': 1}]", [slice(1, 2)], id="one_value_index")),
     ],
 )
 def test_parse_index_transform_ok_cases(index_transform, expected_rules):
@@ -44,7 +48,7 @@ def test_parse_index_transform_ok_cases(index_transform, expected_rules):
     )
 
     results = parse_metrics(yaml.load(metrics), resolver=mock.MagicMock(), logger=logger, bulk_threshold=10)
-    actual_transform_rules = results['parsed_metrics'][0].column_tags[0].index_transform_rules
+    actual_transform_rules = results['parsed_metrics'][0].column_tags[0].index_slices
     assert actual_transform_rules == expected_rules
 
 

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -1639,7 +1639,7 @@ def test_chatsworth(aggregator):
         aggregator.assert_metric('snmp.cpiPduLineCurrent', metric_type=aggregator.GAUGE, tags=line_tags, count=1)
 
     for branch in [1, 17]:
-        branch_tags = common_tags + ['branch_id:{}'.format(branch)]
+        branch_tags = common_tags + ['branch_id:{}'.format(branch), 'pdu_name:name1']
         aggregator.assert_metric('snmp.cpiPduBranchCurrent', metric_type=aggregator.GAUGE, tags=branch_tags, count=1)
         aggregator.assert_metric('snmp.cpiPduBranchMaxCurrent', metric_type=aggregator.GAUGE, tags=branch_tags, count=1)
         aggregator.assert_metric('snmp.cpiPduBranchVoltage', metric_type=aggregator.GAUGE, tags=branch_tags, count=1)

--- a/snmp/tests/test_utils.py
+++ b/snmp/tests/test_utils.py
@@ -154,8 +154,8 @@ def test_as_metric_with_forced_type(input_string, forced_type, expected):
     'src_index, transform_rules, expected_dst_index',
     [
         pytest.param(('10', '11', '12', '13'), [], tuple(), id='no_transform_rules'),
-        pytest.param(('10', '11', '12', '13'), [(2, 3)], ('12', '13'), id='one'),
-        pytest.param(('10', '11', '12', '13'), [(2, 2), (0, 1)], ('12', '10', '11'), id='multi'),
+        pytest.param(('10', '11', '12', '13'), [(2, 4)], ('12', '13'), id='one'),
+        pytest.param(('10', '11', '12', '13'), [(2, 3), (0, 2)], ('12', '10', '11'), id='multi'),
         pytest.param(('10', '11', '12', '13'), [(2, 1000)], ('12', '13'), id='out_of_index_end'),
         pytest.param(('10', '11', '12', '13'), [(1000, 2000)], tuple(), id='out_of_index_start_end'),
     ],

--- a/snmp/tests/test_utils.py
+++ b/snmp/tests/test_utils.py
@@ -154,8 +154,8 @@ def test_as_metric_with_forced_type(input_string, forced_type, expected):
     'src_index, transform_rules, expected_dst_index',
     [
         pytest.param(('10', '11', '12', '13'), [], tuple(), id='no_transform_rules'),
-        pytest.param(('10', '11', '12', '13'), [(2, 4)], ('12', '13'), id='one'),
-        pytest.param(('10', '11', '12', '13'), [(2, 3), (0, 2)], ('12', '10', '11'), id='multi'),
+        pytest.param(('10', '11', '12', '13'), [(2, 3)], ('12', '13'), id='one'),
+        pytest.param(('10', '11', '12', '13'), [(2, 2), (0, 1)], ('12', '10', '11'), id='multi'),
         pytest.param(('10', '11', '12', '13'), [(2, 1000)], ('12', '13'), id='out_of_index_end'),
         pytest.param(('10', '11', '12', '13'), [(1000, 2000)], tuple(), id='out_of_index_start_end'),
     ],

--- a/snmp/tests/test_utils.py
+++ b/snmp/tests/test_utils.py
@@ -154,10 +154,10 @@ def test_as_metric_with_forced_type(input_string, forced_type, expected):
     'src_index, transform_rules, expected_dst_index',
     [
         pytest.param(('10', '11', '12', '13'), [], tuple(), id='no_transform_rules'),
-        pytest.param(('10', '11', '12', '13'), [(2, 4)], ('12', '13'), id='one'),
-        pytest.param(('10', '11', '12', '13'), [(2, 3), (0, 2)], ('12', '10', '11'), id='multi'),
-        pytest.param(('10', '11', '12', '13'), [(2, 1000)], ('12', '13'), id='out_of_index_end'),
-        pytest.param(('10', '11', '12', '13'), [(1000, 2000)], tuple(), id='out_of_index_start_end'),
+        pytest.param(('10', '11', '12', '13'), [slice(2, 4)], ('12', '13'), id='one'),
+        pytest.param(('10', '11', '12', '13'), [slice(2, 3), slice(0, 2)], ('12', '10', '11'), id='multi'),
+        pytest.param(('10', '11', '12', '13'), [slice(2, 1000)], ('12', '13'), id='out_of_index_end'),
+        pytest.param(('10', '11', '12', '13'), [slice(1000, 2000)], tuple(), id='out_of_index_start_end'),
     ],
 )
 def test_transform_index(src_index, transform_rules, expected_dst_index):

--- a/snmp/tests/test_utils.py
+++ b/snmp/tests/test_utils.py
@@ -13,6 +13,7 @@ from datadog_checks.snmp.pysnmp_types import (
     OctetString,
     SnmpEngine,
 )
+from datadog_checks.snmp.utils import transform_index
 
 from . import common
 
@@ -147,3 +148,17 @@ def test_oid_mib_symbol(identity, mib, symbol, prefix):
 )
 def test_as_metric_with_forced_type(input_string, forced_type, expected):
     assert expected == as_metric_with_forced_type(input_string, forced_type, options={})
+
+
+@pytest.mark.parametrize(
+    'src_index, transform_rules, expected_dst_index',
+    [
+        pytest.param(('10', '11', '12', '13'), [], tuple(), id='no_transform_rules'),
+        pytest.param(('10', '11', '12', '13'), [(2, 4)], ('12', '13'), id='one'),
+        pytest.param(('10', '11', '12', '13'), [(2, 3), (0, 2)], ('12', '10', '11'), id='multi'),
+        pytest.param(('10', '11', '12', '13'), [(2, 1000)], ('12', '13'), id='out_of_index_end'),
+        pytest.param(('10', '11', '12', '13'), [(1000, 2000)], tuple(), id='out_of_index_start_end'),
+    ],
+)
+def test_transform_index(src_index, transform_rules, expected_dst_index):
+    assert expected_dst_index == transform_index(src_index, transform_rules)


### PR DESCRIPTION
### What does this PR do?

TL;DR: Currently we can’t tag with an external table that have different indexes. There is a possible solution, but we need to provide more info to tell how to match the indexes.

Note: feel free to comment if you think of another way to handle this feature or another syntax/way for indicating `index_transform: "1:8"`

TODO:
- [X] Add implementation
- [ ] If review OK. Update profile format documentation https://datadoghq.dev/integrations-core/tutorials/snmp/profile-format/

### Motivation

The current table have multiple indexes and we want to tag metrics using another table which has a subset of the current table.

> im looking to add the pdu_name tag to metrics from the cpiPduBranchTable — pdu_name comes from cpiPduTable  and both tables contain an index from MAC address. branchtable is indexed by both branch id and PDU MAC

Currently, when fetching metrics from Table1, we don’t handle tagging by an external Table2 with different indexes.

OK cases:

- Table1 have one index1 and Table2 have both index1
- Table1 have one index1+index2 and Table2 have both index1+index2

NOK cases:

- Table1 have one index1 and Table2 have index1+index2
- Table1 have one index1+index2 and Table2 have index1
- Table1 have one index1+index2 and Table2 have index2+index1 (index order matter)

The issue is that we try to match the full index (index1+index2 if there are 2 indexes) and when the full index does not match the tag won’t be applied.

Without MIB or providing additional info (see possible solution), we don’t know how to decompose the full index. 

For example the cpiPduBranchTable have a full index like (branchId+branchMac indexes) 1.6.0.36.155.53.3.246 but we don’t know how to decompose it.

by looking at the MIB we can tell

- the first integer 1 is the branchId
- the rest 6.0.36.155.53.3.246 is the BranchMac address (not sure what the extra prefix 6 means, but seems part of the second index)

Constraint:
- the solution should work even if MIB are not present