### PR TITLE
Gunicorn README metrics

### DIFF
--- a/gunicorn/README.md
+++ b/gunicorn/README.md
@@ -28,7 +28,11 @@ See the [sample gunicorn.yaml][6] for all available configuration options.
 
 #### Metric collection
 
-1. Add this configuration block to your `gunicorn.d/conf.yaml` file to start gathering your [Gunicorn metrics](#metrics):
+##### Connect Gunicorn to DogStatsD
+
+1. As of version 19.1, Gunicorn [provides an option][7] to send its metrics to a daemon that implements the StatsD protocol, such as [DogStatsD][8]. As with many Gunicorn options, you can either pass it to `gunicorn` on the CLI (`--statsd-host`) or set it in your app's configuration file (`statsd_host`). To ensure that you collect **all Gunicorn metrics**, configure your app to send metrics to [DogStatsD][8] at `"localhost:8125"`, and restart the app.
+
+2. Add this configuration block to your `gunicorn.d/conf.yaml` file to start gathering [Gunicorn metrics](#metrics):
 
 ```yaml
 init_config:
@@ -41,10 +45,6 @@ instances:
 ```
 
 2. [Restart the Agent][3] to begin sending Gunicorn metrics to Datadog.
-
-#### Connect Gunicorn to DogStatsD
-
-Since version 19.1, Gunicorn [provides an option][7] to send its metrics to a daemon that implements the StatsD protocol, such as [DogStatsD][8]. As with many Gunicorn options, you can either pass it to `gunicorn` on the CLI (`--statsd-host`) or set it in your app's configuration file (`statsd_host`). Configure your app to send metrics to DogStatsD at `"localhost:8125"`, and restart the app.
 
 #### Log collection
 


### PR DESCRIPTION
### What does this PR do?
Edits the Gunicorn README metrics section to inform users that they will need to use DogStatsD in order to collect all integration metrics.
 
### Motivation
Jira request

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
