### PR TITLE
[doc] addition to host conf.yaml example

### DIFF
--- a/solr/README.md
+++ b/solr/README.md
@@ -26,6 +26,18 @@ To configure this check for an Agent running on a host:
 1. Edit the `solr.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][5]. See the [sample solr.d/conf.yaml][6] for all available configuration options.
 
    ```yaml
+   init_config:
+
+     ## @param is_jmx - boolean - required
+     ## Whether or not this file is a configuration for a JMX integration.
+     #
+     is_jmx: true
+
+     ## @param collect_default_metrics - boolean - required
+     ## Whether or not the check should collect all default metrics.
+     #
+     collect_default_metrics: true
+    
    instances:
      ## @param host - string - required
      ## Solr host to connect to.


### PR DESCRIPTION
### What does this PR do?
Addition of all required param to the example host `solr.d/conf.yaml` given within the documentation.

### Motivation
The current example is deceptive. If it is directly copied and used for`solr.d/conf.yaml,` the integration will not work.

### Additional Notes
Lines added to the documentation are directly taken from:
https://github.com/DataDog/integrations-core/blob/bb5d227c5e32ce489c501b81b27615783a03892c/solr/datadog_checks/solr/data/conf.yaml.example#L3-L13

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
