### PR TITLE
Improve the kubelet check error reporting in the output of `agent status`

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -294,7 +294,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         kubelet_conn_info = get_connection_info()
         endpoint = kubelet_conn_info.get('url')
         if endpoint is None:
-            raise CheckException("Unable to detect the kubelet URL automatically.")
+            raise CheckException("Unable to detect the kubelet URL automatically: " + kubelet_conn_info.get('err', ''))
 
         self.kube_health_url = urljoin(endpoint, KUBELET_HEALTH_PATH)
         self.node_spec_url = urljoin(endpoint, NODE_SPEC_PATH)


### PR DESCRIPTION
### What does this PR do?

In combination with DataDog/datadog-agent#6315 , this change improves the `kubelet` check error reported in the output of `agent status` when the agent cannot properly connect to the kubelet.

### Motivation

In case the agent cannot properly connect to the kubelet, the useful details were in the logs but the output of the `agent status` command gave no clue about the reasons.

Here is an example of the `agent status` output in such a case:
```
$ agent status
[…]

=========
Collector
=========

  Running Checks
  ==============

    kubelet (4.1.1)
    ---------------
      Instance ID: kubelet:d884b5186b651429 [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default
      Total Runs: 1
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 2ms
      Last Execution Date : 2020-09-03 11:40:31.000000 UTC
      Last Successful Execution Date : Never
      Error: Unable to detect the kubelet URL automatically.
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 827, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/kubelet/kubelet.py", line 297, in check
          raise CheckException("Unable to detect the kubelet URL automatically.")
      datadog_checks.base.errors.CheckException: Unable to detect the kubelet URL automatically.
```

Here is what the output becomes with this PR:

```
$ agent status
[…]

=========
Collector
=========

  Running Checks
  ==============

    kubelet (4.1.1)
    ---------------
      Instance ID: kubelet:d884b5186b651429 [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default
      Total Runs: 1
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 3ms
      Last Execution Date : 2020-09-03 11:14:20.000000 UTC
      Last Successful Execution Date : Never
      Error: Unable to detect the kubelet URL automatically: cannot set a valid kubelet host: cannot connect to kubelet using any of the given hosts: [1.2.3.4] [], Errors: [Get https://1.2.3.4:10250/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers) cannot connect: http: "Get http://1.2.3.4:10255/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"]
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 827, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/kubelet/kubelet.py", line 297, in check
          raise CheckException("Unable to detect the kubelet URL automatically: " + kubelet_conn_info.get('err'))
      datadog_checks.base.errors.CheckException: Unable to detect the kubelet URL automatically: cannot set a valid kubelet host: cannot connect to kubelet using any of the given hosts: [1.2.3.4] [], Errors: [Get https://1.2.3.4:10250/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers) cannot connect: http: "Get http://1.2.3.4:10255/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"]
```

### Additional Notes

This would help the investigation of issues like DataDog/integrations-core#2582.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
