### PR TITLE
Apply overrides recursively to config specs

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/template.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/template.py
@@ -21,9 +21,7 @@ class ConfigTemplates(object):
 
         self.paths.append(TEMPLATES_DIR)
 
-        self.fields = {'overrides': (self.override, lambda: {})}
-
-    def load(self, template, parameters=None):
+    def load(self, template):
         path_parts = template.split('/')
         branches = path_parts.pop().split('.')
         path_parts.append(branches.pop(0))
@@ -73,36 +71,48 @@ class ConfigTemplates(object):
                     )
                 )
 
-        if parameters is None:
-            parameters = {}
-
-        for parameter, (method, default) in self.fields.items():
-            method(data, parameters.get(parameter, default()))
-
         return data
 
-    @classmethod
-    def override(cls, template, overrides):
+    @staticmethod
+    def apply_overrides(template, overrides):
+        errors = []
+
         for override, value in sorted(overrides.items()):
             root = template
             override_keys = override.split('.')
             final_key = override_keys.pop()
 
+            intermediate_error = ''
+
             # Iterate through all but the last key, attempting to find a dictionary at every step
             for i, key in enumerate(override_keys):
                 if isinstance(root, dict):
-                    root = root.setdefault(key, {})
+                    if key in root:
+                        root = root[key]
+                    else:
+                        intermediate_error = (
+                            f"Template override `{'.'.join(override_keys[:i])}` has no named mapping `{key}`"
+                        )
+                        break
                 elif isinstance(root, list):
                     for item in root:
                         if isinstance(item, dict) and item.get('name') == key:
                             root = item
                             break
                     else:
-                        raise ValueError(
+                        intermediate_error = (
                             f"Template override `{'.'.join(override_keys[:i])}` has no named mapping `{key}`"
                         )
+                        break
                 else:
-                    raise ValueError(f"Template override `{'.'.join(override_keys[:i])}` does not refer to a mapping")
+                    intermediate_error = (
+                        f"Template override `{'.'.join(override_keys[:i])}` does not refer to a mapping"
+                    )
+                    break
+
+            if intermediate_error:
+                errors.append(intermediate_error)
+                continue
 
             # Force assign the desired value to the final key
             if isinstance(root, dict):
@@ -113,14 +123,18 @@ class ConfigTemplates(object):
                         root[i] = value
                         break
                 else:
-                    raise ValueError(
-                        'Template override has no named mapping `{}`'.format(
-                            '.'.join(override_keys) if override_keys else override
-                        )
-                    )
-            else:
-                raise ValueError(
-                    'Template override `{}` does not refer to a mapping'.format(
+                    intermediate_error = 'Template override has no named mapping `{}`'.format(
                         '.'.join(override_keys) if override_keys else override
                     )
+            else:
+                intermediate_error = 'Template override `{}` does not refer to a mapping'.format(
+                    '.'.join(override_keys) if override_keys else override
                 )
+
+            if intermediate_error:
+                errors.append(intermediate_error)
+                continue
+
+            overrides.pop(override)
+
+        return errors

--- a/datadog_checks_dev/tests/tooling/configuration/test_template.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_template.py
@@ -111,11 +111,15 @@ class TestLoadBranches:
             templates.load('instances/http.skip_proxy.value.example.foo')
 
 
-class TestLoadOverride:
+class TestApplyOverrides:
     def test_mapping(self):
         templates = ConfigTemplates()
 
-        assert templates.load('init_config/tags', parameters={'overrides': {'value.example': ['foo', 'bar']}}) == {
+        template = templates.load('init_config/tags')
+        errors = templates.apply_overrides(template, {'value.example': ['foo', 'bar']})
+        assert not errors
+
+        assert template == {
             'name': 'tags',
             'value': {'example': ['foo', 'bar'], 'type': 'array', 'items': {'type': 'string'}},
             'description': (
@@ -125,55 +129,21 @@ class TestLoadOverride:
             ),
         }
 
-    def test_mapping_create(self):
-        templates = ConfigTemplates()
-
-        assert templates.load('init_config/tags', parameters={'overrides': {'foo': 'foo'}}) == {
-            'name': 'tags',
-            'value': {
-                'example': ['<KEY_1>:<VALUE_1>', '<KEY_2>:<VALUE_2>'],
-                'type': 'array',
-                'items': {'type': 'string'},
-            },
-            'description': (
-                'A list of tags to attach to every metric and service check emitted by this integration.\n'
-                '\n'
-                'Learn more about tagging at https://docs.datadoghq.com/tagging\n'
-            ),
-            'foo': 'foo',
-        }
-
-    def test_mapping_create_nested(self):
-        templates = ConfigTemplates()
-
-        assert templates.load('init_config/tags', parameters={'overrides': {'foo.bar': 'foobar'}}) == {
-            'name': 'tags',
-            'value': {
-                'example': ['<KEY_1>:<VALUE_1>', '<KEY_2>:<VALUE_2>'],
-                'type': 'array',
-                'items': {'type': 'string'},
-            },
-            'description': (
-                'A list of tags to attach to every metric and service check emitted by this integration.\n'
-                '\n'
-                'Learn more about tagging at https://docs.datadoghq.com/tagging\n'
-            ),
-            'foo': {'bar': 'foobar'},
-        }
-
     def test_mapping_with_branches(self):
         templates = ConfigTemplates()
 
-        assert templates.load('init_config/tags.value', parameters={'overrides': {'example': ['foo', 'bar']}}) == {
-            'example': ['foo', 'bar'],
-            'type': 'array',
-            'items': {'type': 'string'},
-        }
+        template = templates.load('init_config/tags.value')
+        errors = templates.apply_overrides(template, {'example': ['foo', 'bar']})
+        assert not errors
+
+        assert template == {'example': ['foo', 'bar'], 'type': 'array', 'items': {'type': 'string'}}
 
     def test_list(self):
         templates = ConfigTemplates()
 
-        template = templates.load('instances/http', parameters={'overrides': {'skip_proxy.description': 'foobar'}})
+        template = templates.load('instances/http')
+        errors = templates.apply_overrides(template, {'skip_proxy.description': 'foobar'})
+        assert not errors
 
         assert {
             'name': 'skip_proxy',
@@ -184,7 +154,9 @@ class TestLoadOverride:
     def test_list_with_branches(self):
         templates = ConfigTemplates()
 
-        template = templates.load('instances/http.skip_proxy', parameters={'overrides': {'description': 'foobar'}})
+        template = templates.load('instances/http.skip_proxy')
+        errors = templates.apply_overrides(template, {'description': 'foobar'})
+        assert not errors
 
         assert template == {
             'name': 'skip_proxy',
@@ -198,7 +170,9 @@ class TestLoadOverride:
         original_template = templates.load('instances/http')
         index = next(i for i, item in enumerate(original_template) if item.get('name') == 'skip_proxy')  # no cov
 
-        template = templates.load('instances/http', parameters={'overrides': {'skip_proxy': 'foobar'}})
+        template = templates.load('instances/http')
+        errors = templates.apply_overrides(template, {'skip_proxy': 'foobar'})
+        assert not errors
 
         assert 'foobar' in template
         assert template.index('foobar') == index
@@ -210,23 +184,35 @@ class TestLoadOverride:
     def test_list_not_found(self):
         templates = ConfigTemplates()
 
-        with pytest.raises(ValueError, match='^Template override `proxy.value.properties` has no named mapping `foo`$'):
-            templates.load('instances/http', parameters={'overrides': {'proxy.value.properties.foo.foo': 'bar'}})
+        template = templates.load('instances/http')
+        errors = templates.apply_overrides(template, {'proxy.value.properties.foo.foo': 'bar'})
+
+        assert len(errors) == 1
+        assert errors[0] == 'Template override `proxy.value.properties` has no named mapping `foo`'
 
     def test_list_not_found_root(self):
         templates = ConfigTemplates()
 
-        with pytest.raises(ValueError, match='^Template override has no named mapping `foo`$'):
-            templates.load('instances/http', parameters={'overrides': {'foo': 'bar'}})
+        template = templates.load('instances/http')
+        errors = templates.apply_overrides(template, {'foo': 'bar'})
+
+        assert len(errors) == 1
+        assert errors[0] == 'Template override has no named mapping `foo`'
 
     def test_primitive(self):
         templates = ConfigTemplates()
 
-        with pytest.raises(ValueError, match='^Template override `proxy.description` does not refer to a mapping$'):
-            templates.load('instances/http', parameters={'overrides': {'proxy.description.foo': 'bar'}})
+        template = templates.load('instances/http')
+        errors = templates.apply_overrides(template, {'proxy.description.foo': 'bar'})
+
+        assert len(errors) == 1
+        assert errors[0] == 'Template override `proxy.description` does not refer to a mapping'
 
     def test_primitive_recurse(self):
         templates = ConfigTemplates()
 
-        with pytest.raises(ValueError, match='^Template override `proxy.description` does not refer to a mapping$'):
-            templates.load('instances/http', parameters={'overrides': {'proxy.description.foo.foo': 'bar'}})
+        template = templates.load('instances/http')
+        errors = templates.apply_overrides(template, {'proxy.description.foo.foo': 'bar'})
+
+        assert len(errors) == 1
+        assert errors[0] == 'Template override `proxy.description` does not refer to a mapping'


### PR DESCRIPTION
### Motivation

This 

```yaml
    - template: instances/tags
    - template: instances/service
    - template: instances/global
      overrides:
        min_collection_interval.value.default: 15
        min_collection_interval.value.example: 180
```

Should be

```yaml
    - template: instances/default
      overrides:
        min_collection_interval.value.default: 15
        min_collection_interval.value.example: 180
```