### PR TITLE
[documentation] Add minor fixes to the OOM kill check documentation.

### DIFF
--- a/oom_kill/README.md
+++ b/oom_kill/README.md
@@ -24,17 +24,17 @@ yum install -y kernel-headers-$(uname -r)
 
 ### Configuration
 
-In the `system-probe.yaml` file at the root of your Agent's configuration directory, the following configuration must be set:
+1. In the `system-probe.yaml` file at the root of your Agent's configuration directory, add the following configuration:
 
-```yaml
-system_probe_config:
-    enabled: true
-    enable_oom_kill: true
-```
+    ```yaml
+    system_probe_config:
+        enabled: true
+        enable_oom_kill: true
+    ```
 
-Also ensure that the `oom_kill.d/conf.yaml` file is present in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your OOM Kill metrics.
+2. Ensure that the `oom_kill.d/conf.yaml` file is present in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your OOM Kill metrics.
 
-Finally, [restart the Agent][2].
+3. [Restart the Agent][2].
 
 ### Configuration with Helm
 

--- a/oom_kill/README.md
+++ b/oom_kill/README.md
@@ -24,9 +24,7 @@ yum install -y kernel-headers-$(uname -r)
 
 ### Configuration
 
-1. Ensure that the `oom_kill.d/conf.yaml` file is present in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your OOM Kill metrics.
-
-2. Ensure the following configuration is set in `system_probe.yaml`:
+In the `system-probe.yaml` file at the root of your Agent's configuration directory, the following configuration must be set:
 
 ```yaml
 system_probe_config:
@@ -34,7 +32,9 @@ system_probe_config:
     enable_oom_kill: true
 ```
 
-3. [Restart the Agent][2].
+Also ensure that the `oom_kill.d/conf.yaml` file is present in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your OOM Kill metrics.
+
+Finally, [restart the Agent][2].
 
 ### Configuration with Helm
 


### PR DESCRIPTION
# What does this PR do?
- Correct name of system-probe.yaml
- Fix indentation issue in the system-probe.yaml code snippet, which
  resulted from the snippet being embedded in a Markdown list.

### Motivation
Following the documentation as it was led to errors when loading the check config.

### Additional Notes
I used the docs for the TCP queue length check (https://docs.datadoghq.com/integrations/tcp_queue_length/) as a reference for formatting the code snippet. Though a numbered list would be a bit clearer, I thought it would look awkward to include a list for only two of the three steps in the instructions.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
