### PR TITLE
Add doc for `index_transform`

### DIFF
--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -254,7 +254,7 @@ metrics:
         tag: pdu_name
 ```
 
-In case the external table has different indexes, we can use `index_transform` to select a subset of the full index. `index_transform` is a list of `start`/`end` ranges to extract from the current table index to match the external table index. `start` and `end` are inclusive.
+If the external table has different indexes, use `index_transform` to select a subset of the full index. `index_transform` is a list of `start`/`end` ranges to extract from the current table index to match the external table index. `start` and `end` are inclusive.
 
 External table indexes must be a subset of the indexes of the current table, or same indexes in a different order.
 
@@ -277,7 +277,7 @@ External table indexes must be a subset of the indexes of the current table, or 
 
 ##### Using an index
 
-Note: here "_index_" refers to one of the values in the `INDEX` field of the table MIB definition.
+Note: Here, "_index_" refers to one of the values in the `INDEX` field of the table MIB definition.
 
 ```yaml
 metrics:

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -189,7 +189,7 @@ metrics:
 
 It is possible to add tags to metrics retrieved from a table in three ways:
 
-##### Using a column within the same table:
+##### Using a column within the same table
 
 ```yaml
 metrics:
@@ -254,13 +254,13 @@ metrics:
         tag: pdu_name
 ```
 
-In case the external table have a different indexes we can use `index_transform` to select a subset of the full index we want to use. `index_transform` is a list of `start`/`end` ranges to extract from the current table index to match the external table index. `start` and `end` are inclusive.
+In case the external table has different indexes, we can use `index_transform` to select a subset of the full index we want to use. `index_transform` is a list of `start`/`end` ranges to extract from the current table index to match the external table index. `start` and `end` are inclusive.
 
 External table indexes must be a subset of the indexes of the current table, or same indexes in a different order.
 
 !!! example
 
-    In the example above, the index of `cpiPduBranchTable` looks like `1.6.0.36.155.53.3.246`, the first digit is the `cpiPduBranchId` index and the rest is `cpiPduBranchMac` index. The index of `cpiPduTable` looks like `6.0.36.155.53.3.246` and represent `cpiPduMac` (equivalent to `cpiPduBranchMac`).
+    In the example above, the index of `cpiPduBranchTable` looks like `1.6.0.36.155.53.3.246`, the first digit is the `cpiPduBranchId` index and the rest is the `cpiPduBranchMac` index. The index of `cpiPduTable` looks like `6.0.36.155.53.3.246` and represents `cpiPduMac` (equivalent to `cpiPduBranchMac`).
 
     By using the `index_transform` with start 1 and end 7, we extract `6.0.36.155.53.3.246` from `1.6.0.36.155.53.3.246` (`cpiPduBranchTable` full index), and then use it to match `6.0.36.155.53.3.246` (`cpiPduTable` full index).
 
@@ -275,7 +275,9 @@ External table indexes must be a subset of the indexes of the current table, or 
     ```
 
 
-##### Using an "index", i.e. one of the values in the `INDEX` field of the table MIB definition:
+##### Using an index
+
+Note: here "_index_" refers to one of the values in the `INDEX` field of the table MIB definition.
 
 ```yaml
 metrics:

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -254,7 +254,7 @@ metrics:
         tag: pdu_name
 ```
 
-In case the external table has different indexes, we can use `index_transform` to select a subset of the full index we want to use. `index_transform` is a list of `start`/`end` ranges to extract from the current table index to match the external table index. `start` and `end` are inclusive.
+In case the external table has different indexes, we can use `index_transform` to select a subset of the full index. `index_transform` is a list of `start`/`end` ranges to extract from the current table index to match the external table index. `start` and `end` are inclusive.
 
 External table indexes must be a subset of the indexes of the current table, or same indexes in a different order.
 

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -189,7 +189,7 @@ metrics:
 
 It is possible to add tags to metrics retrieved from a table in three ways:
 
-- Using a column within the same table:
+##### Using a column within the same table:
 
 ```yaml
 metrics:
@@ -211,7 +211,7 @@ metrics:
           name: ifDescr
 ```
 
-- Using a column from a different table.
+##### Using a column from a different table with identical indexes
 
 ```yaml
 metrics:
@@ -232,7 +232,47 @@ metrics:
         tag: interface
 ```
 
-- Using an "index", i.e. one of the values in the `INDEX` field of the table MIB definition:
+##### Using a column from a different table with different indexes
+
+```yaml
+metrics:
+  - MIB: CPI-UNITY-MIB
+    table:
+      OID: 1.3.6.1.4.1.30932.1.10.1.3.110
+      name: cpiPduBranchTable
+    symbols:
+      - OID: 1.3.6.1.4.1.30932.1.10.1.3.110.1.3
+        name: cpiPduBranchCurrent
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.30932.1.10.1.2.10.1.3
+          name: cpiPduName
+        table: cpiPduTable
+        index_transform:
+          - start: 1
+            end: 7
+        tag: pdu_name
+```
+
+In case the external table have a different indexes we can use `index_transform` to select a subset of the full index we want to use. `index_transform` is a list of `start`/`end` ranges to extract from the current table index to match the external table index. `start` and `end` are inclusive.
+
+In the example above, the index of `cpiPduBranchTable` looks like `1.6.0.36.155.53.3.246`, the first digit is the `cpiPduBranchId` index and the rest is `cpiPduBranchMac` index. The index of `cpiPduTable` looks like `6.0.36.155.53.3.246` and represent `cpiPduMac` (equivalent to `cpiPduBranchMac`).
+
+By using the `index_transform` with start 1 and end 7, we extract `6.0.36.155.53.3.246` from `1.6.0.36.155.53.3.246` (`cpiPduBranchTable` full index), and then use it to match `6.0.36.155.53.3.246` (`cpiPduTable` full index).
+
+`index_transform` can be more complex, the following definition will extract `2.3.5.6.7` from `1.2.3.4.5.6.7`.
+
+```yaml
+        index_transform:
+          - start: 1
+            end: 2
+          - start: 4
+            end: 6
+```
+
+Note: External table indexes must be a subset of the indexes of the current table, or same indexes in a different order. 
+
+##### Using an "index", i.e. one of the values in the `INDEX` field of the table MIB definition:
 
 ```yaml
 metrics:

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -256,21 +256,24 @@ metrics:
 
 In case the external table have a different indexes we can use `index_transform` to select a subset of the full index we want to use. `index_transform` is a list of `start`/`end` ranges to extract from the current table index to match the external table index. `start` and `end` are inclusive.
 
-In the example above, the index of `cpiPduBranchTable` looks like `1.6.0.36.155.53.3.246`, the first digit is the `cpiPduBranchId` index and the rest is `cpiPduBranchMac` index. The index of `cpiPduTable` looks like `6.0.36.155.53.3.246` and represent `cpiPduMac` (equivalent to `cpiPduBranchMac`).
+External table indexes must be a subset of the indexes of the current table, or same indexes in a different order.
 
-By using the `index_transform` with start 1 and end 7, we extract `6.0.36.155.53.3.246` from `1.6.0.36.155.53.3.246` (`cpiPduBranchTable` full index), and then use it to match `6.0.36.155.53.3.246` (`cpiPduTable` full index).
+!!! example
 
-`index_transform` can be more complex, the following definition will extract `2.3.5.6.7` from `1.2.3.4.5.6.7`.
+    In the example above, the index of `cpiPduBranchTable` looks like `1.6.0.36.155.53.3.246`, the first digit is the `cpiPduBranchId` index and the rest is `cpiPduBranchMac` index. The index of `cpiPduTable` looks like `6.0.36.155.53.3.246` and represent `cpiPduMac` (equivalent to `cpiPduBranchMac`).
 
-```yaml
-        index_transform:
-          - start: 1
-            end: 2
-          - start: 4
-            end: 6
-```
+    By using the `index_transform` with start 1 and end 7, we extract `6.0.36.155.53.3.246` from `1.6.0.36.155.53.3.246` (`cpiPduBranchTable` full index), and then use it to match `6.0.36.155.53.3.246` (`cpiPduTable` full index).
 
-Note: External table indexes must be a subset of the indexes of the current table, or same indexes in a different order. 
+    `index_transform` can be more complex, the following definition will extract `2.3.5.6.7` from `1.2.3.4.5.6.7`.
+
+    ```yaml
+            index_transform:
+              - start: 1
+                end: 2
+              - start: 4
+                end: 6
+    ```
+
 
 ##### Using an "index", i.e. one of the values in the `INDEX` field of the table MIB definition:
 


### PR DESCRIPTION
### What does this PR do?

Add doc for `index_transform`

### Motivation

Add `index_transform` to support tagging using another table with different indexes #7489
 https://github.com/DataDog/integrations-core/pull/7489
