### PR TITLE
Normalize metric when asserting with metadata

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -4,12 +4,17 @@
 from __future__ import division
 
 from collections import OrderedDict, defaultdict
+import re
 
 from six import iteritems
 
 from ..utils.common import ensure_unicode, to_native_string
 from .common import HistogramBucketStub, MetricStub, ServiceCheckStub
 from .similar import build_similar_elements_msg
+
+
+METRIC_REPLACEMENT = re.compile(r"([^a-zA-Z0-9_.]+)|(^[^a-zA-Z]+)")
+METRIC_DOTUNDERSCORE_CLEANUP = re.compile(r"_*\._*")
 
 
 def normalize_tags(tags, sort=False):
@@ -21,6 +26,15 @@ def normalize_tags(tags, sort=False):
         else:
             return [to_native_string(tag) for tag in tags]
     return tags
+
+
+def backend_normalize_metric_name(metric_name):
+    """
+    Normalize a metric name for the backend to understand it.
+    This is the same metric that is used to validate the metadata.csv file
+    """
+    metric_name = METRIC_REPLACEMENT.sub("_", metric_name)
+    return METRIC_DOTUNDERSCORE_CLEANUP.sub(".", metric_name).strip("_")
 
 
 class AggregatorStub(object):
@@ -326,19 +340,19 @@ class AggregatorStub(object):
             if metric_name in exclude:
                 continue
             for metric_stub in metric_stubs:
-
-                if metric_stub.name not in metadata_metrics:
-                    errors.add("Expect `{}` to be in metadata.csv.".format(metric_stub.name))
+                normalized_metric_stub_name = backend_normalize_metric_name(metric_stub.name)
+                if normalized_metric_stub_name not in metadata_metrics:
+                    errors.add("Expect `{}` to be in metadata.csv.".format(normalized_metric_stub_name))
                     continue
 
                 if check_metric_type:
-                    expected_metric_type = metadata_metrics[metric_stub.name]['metric_type']
+                    expected_metric_type = metadata_metrics[normalized_metric_stub_name]['metric_type']
                     actual_metric_type = AggregatorStub.METRIC_ENUM_MAP_REV[metric_stub.type]
 
                     if expected_metric_type != actual_metric_type:
                         errors.add(
                             "Expect `{}` to have type `{}` but got `{}`.".format(
-                                metric_stub.name, expected_metric_type, actual_metric_type
+                                normalized_metric_stub_name, expected_metric_type, actual_metric_type
                             )
                         )
 

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -3,15 +3,14 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
-from collections import OrderedDict, defaultdict
 import re
+from collections import OrderedDict, defaultdict
 
 from six import iteritems
 
 from ..utils.common import ensure_unicode, to_native_string
 from .common import HistogramBucketStub, MetricStub, ServiceCheckStub
 from .similar import build_similar_elements_msg
-
 
 METRIC_REPLACEMENT = re.compile(r"([^a-zA-Z0-9_.]+)|(^[^a-zA-Z]+)")
 METRIC_DOTUNDERSCORE_CLEANUP = re.compile(r"_*\._*")

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -339,19 +339,19 @@ class AggregatorStub(object):
             if metric_name in exclude:
                 continue
             for metric_stub in metric_stubs:
-                normalized_metric_stub_name = backend_normalize_metric_name(metric_stub.name)
-                if normalized_metric_stub_name not in metadata_metrics:
-                    errors.add("Expect `{}` to be in metadata.csv.".format(normalized_metric_stub_name))
+                metric_stub_name = backend_normalize_metric_name(metric_stub.name)
+                if metric_stub_name not in metadata_metrics:
+                    errors.add("Expect `{}` to be in metadata.csv.".format(metric_stub_name))
                     continue
 
                 if check_metric_type:
-                    expected_metric_type = metadata_metrics[normalized_metric_stub_name]['metric_type']
+                    expected_metric_type = metadata_metrics[metric_stub_name]['metric_type']
                     actual_metric_type = AggregatorStub.METRIC_ENUM_MAP_REV[metric_stub.type]
 
                     if expected_metric_type != actual_metric_type:
                         errors.add(
                             "Expect `{}` to have type `{}` but got `{}`.".format(
-                                normalized_metric_stub_name, expected_metric_type, actual_metric_type
+                                metric_stub_name, expected_metric_type, actual_metric_type
                             )
                         )
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Metrics name are also normalized here https://github.com/DataDog/integrations-core/blob/a3de7a27db9e29e138ba3ab9e27f3d0b0f45afc8/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py#L201-L211
So we need to normalize them when asserting with metadata

### Motivation
<!-- What inspired you to submit this pull request? -->
Needed to `assert_metrics_using_metadata` for MarkLogic https://github.com/DataDog/integrations-core/pull/6524

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
