### PR TITLE
Add marketplace to repo choices and make -x set repo_choice

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/cli.py
@@ -22,13 +22,14 @@ from .utils import initialize_root
 @click.option('--core', '-c', is_flag=True, help='Work on `integrations-core`.')
 @click.option('--extras', '-e', is_flag=True, help='Work on `integrations-extras`.')
 @click.option('--agent', '-a', is_flag=True, help='Work on `datadog-agent`.')
+@click.option('--marketplace', '-m', is_flag=True, help='Work on `marketplace`.')
 @click.option('--here', '-x', is_flag=True, help='Work on the current location.')
 @click.option('--color/--no-color', default=None, help='Whether or not to display colored output (default true).')
 @click.option('--quiet', '-q', help='Silence output', is_flag=True)
 @click.option('--debug', '-d', help='Include debug output', is_flag=True)
 @click.version_option()
 @click.pass_context
-def ddev(ctx, core, extras, agent, here, color, quiet, debug):
+def ddev(ctx, core, extras, agent, marketplace, here, color, quiet, debug):
     if not quiet and not config_file_exists():
         echo_waiting('No config file found, creating one with default settings now...')
 
@@ -41,7 +42,7 @@ def ddev(ctx, core, extras, agent, here, color, quiet, debug):
     # Load and store configuration for sub-commands.
     config = load_config()
 
-    msg = initialize_root(config, agent, core, extras, here)
+    msg = initialize_root(config, agent, core, extras, marketplace, here)
     if not quiet:
         if msg:
             echo_warning(msg)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/config.py
@@ -104,7 +104,7 @@ def set_value(ctx, key, value):
         scrubbing = any(fnmatch(key, pattern) for pattern in SECRET_KEYS)
         value = click.prompt(f'Value for `{key}`', hide_input=scrubbing)
 
-    if key in ('repos.core', 'repos.extras', 'repos.agent') and not value.startswith('~'):
+    if key in ('repos.core', 'repos.extras', 'repos.agent', 'repos.marketplace') and not value.startswith('~'):
         value = os.path.abspath(value)
 
     user_config = new_config = ctx.obj

--- a/datadog_checks_dev/datadog_checks/dev/tooling/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/config.py
@@ -39,6 +39,7 @@ DEFAULT_CONFIG = {
         'core': os.path.join('~', 'dd', 'integrations-core'),
         'extras': os.path.join('~', 'dd', 'integrations-extras'),
         'agent': os.path.join('~', 'dd', 'datadog-agent'),
+        'marketplace': os.path.join('~', 'dd', 'marketplace'),
     },
     'agents': {
         'master': {'docker': 'datadog/agent-dev:master', 'local': 'latest'},

--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -20,6 +20,8 @@ REPO_OPTIONS_MAP = {
     '-e': 'extras',
     '--agent': 'agent',
     '-a': 'agent',
+    '--marketplace': 'marketplace',
+    '-m': 'marketplace',
     '--here': 'here',
     '-x': 'here',
 }
@@ -29,6 +31,7 @@ REPO_CHOICES = {
     'extras': 'integrations-extras',
     'internal': 'integrations-internal',
     'agent': 'datadog-agent',
+    'marketplace': 'marketplace',
 }
 
 VERSION_BUMP = {

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -165,25 +165,42 @@ def check_root():
     return False
 
 
-def initialize_root(config, agent=False, core=False, extras=False, here=False):
+def initialize_root(config, agent=False, core=False, extras=False, marketplace=False, here=False):
     """Initialize root directory based on config and options"""
     if check_root():
         return
 
-    repo_choice = 'core' if core else 'extras' if extras else 'agent' if agent else config.get('repo', 'core')
+    repo_choice = (
+        'core'
+        if core
+        else 'extras'
+        if extras
+        else 'agent'
+        if agent
+        else 'marketplace'
+        if marketplace
+        else config.get('repo', 'core')
+    )
     config['repo_choice'] = repo_choice
     config['repo_name'] = REPO_CHOICES.get(repo_choice, repo_choice)
-
     message = None
     # TODO: remove this legacy fallback lookup in any future major version bump
     legacy_option = None if repo_choice == 'agent' else config.get(repo_choice)
     root = os.path.expanduser(legacy_option or config.get('repos', {}).get(repo_choice, ''))
     if here or not dir_exists(root):
         if not here:
-            repo = 'datadog-agent' if repo_choice == 'agent' else f'integrations-{repo_choice}'
+            repo = (
+                'datadog-agent'
+                if repo_choice == 'agent'
+                else 'marketplace'
+                if repo_choice == 'marketplace'
+                else f'integrations-{repo_choice}'
+            )
             message = f'`{repo}` directory `{root}` does not exist, defaulting to the current location.'
 
         root = os.getcwd()
+        if here:
+            config['repo_choice'] = os.path.basename(root)
 
     set_root(root)
     return message


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds marketplace to the allowed set of repo choices in ddev
This also fully ties the `-x/here` global ddev option to repo choice, so using `-x` will now make `repo_choice` use whatever the directory name you're in is. 
### Motivation
<!-- What inspired you to submit this pull request? -->
Eases working on marketplace integrations
Makes `-x` tied to repo_choice. There are a few places in ddev where logic is different depending on the repo choice, like which validations to perform for example. This ensures that no matter what the repo choice is, `-x` will use the logic designated for whichever repo directory you're in. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This may cause issues if you're using -x in a repo you cloned under a different name than the original 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
