### PR TITLE
Add minItems to pricing and better validation error message

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -144,6 +144,7 @@ def get_manifest_schema():
                             "pricing": {
                                 "description": "Available pricing options",
                                 "type": "array",
+                                "minItems": 1,
                                 "items": {
                                     "description": "Attributes of pricing plans available for this integration",
                                     "type": "object",
@@ -317,7 +318,7 @@ def manifest(ctx, fix, include_extras, repo_url):
             if errors:
                 file_failures += 1
                 for error in errors:
-                    display_queue.append((echo_failure, f'  {error.message}'))
+                    display_queue.append((echo_failure, f'  {"->".join(error.absolute_path)}:{error.message}'))
 
             # guid
             guid = decoded.get('guid')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
An empty pricing object in the manifest should result in an error, but was passing. This adds a min items count of 1 for this field

I also updated the error message when jsonschema validation fails. Currently the `messages` don't include the actual part of the schema thats failing. 
The output of `ddev validate manifest` now looks like this:
```
test_int/manifest.json... FAILED
  pricing:[] is too short
  short_description:'' is too short
```

where its currently this:

```
test_int/manifest.json... FAILED
  '' is too short
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
