### PR TITLE
Strip integrations- prefix when detecting 'here'

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -200,7 +200,8 @@ def initialize_root(config, agent=False, core=False, extras=False, marketplace=F
 
         root = os.getcwd()
         if here:
-            config['repo_choice'] = os.path.basename(root)
+            # Repo choices use the integration repo name without the `integrations-` prefix
+            config['repo_choice'] = os.path.basename(root).replace('integrations-', '')
 
     set_root(root)
     return message


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Strip the `integrations-` prefix from the repo_choice we autodetect when using the -x/here global ddev option.
### Motivation
<!-- What inspired you to submit this pull request? -->
The autodetected repo_choice winds up being the dirname, which would be integrations-core/integrations-extras. However the repo_choice throughout the codebase expects these to just be `core` or `extras`

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Adding no-changelog since this hasn't been released yet. 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
