### PR TITLE
Add command to add Agent version to integrations CHANGELOG.md

### DIFF
--- a/active_directory/CHANGELOG.md
+++ b/active_directory/CHANGELOG.md
@@ -1,50 +1,50 @@
 # CHANGELOG - active_directory
 
-## 1.9.1 / 2020-08-10
+## 1.9.1 / 2020-08-10 / first included in Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 1.9.0 / 2020-06-29
+## 1.9.0 / 2020-06-29 / first included in Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.8.0 / 2020-05-17
+## 1.8.0 / 2020-05-17 / first included in Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.0 / 2020-04-04
+## 1.7.0 / 2020-04-04 / first included in Agent 7.19.0
 
 * [Added] Active Directory to not use agentConfig. See [#5938](https://github.com/DataDog/integrations-core/pull/5938).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.6.0 / 2019-12-02
+## 1.6.0 / 2019-12-02 / first included in Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 1.5.0 / 2019-10-11
+## 1.5.0 / 2019-10-11 / first included in Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 1.4.1 / 2019-06-18
+## 1.4.1 / 2019-06-18 / first included in Agent 6.13.0
 
 * [Fixed] Rename lower case manifest.in. See [#3858](https://github.com/DataDog/integrations-core/pull/3858).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / first included in Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3483](https://github.com/DataDog/integrations-core/pull/3483).
 
-## 1.3.0 / 2019-02-18
+## 1.3.0 / 2019-02-18 / first included in Agent 6.11.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2975](https://github.com/DataDog/integrations-core/pull/2975).
 
-## 1.2.0 / 2018-10-12
+## 1.2.0 / 2018-10-12 / first included in Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.1.1 / 2018-09-04
+## 1.1.1 / 2018-09-04 / first included in Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/active_directory/CHANGELOG.md
+++ b/active_directory/CHANGELOG.md
@@ -1,50 +1,50 @@
 # CHANGELOG - active_directory
 
-## 1.9.1 / 2020-08-10 / first included in Agent 7.22.0 / Agent 7.22.0
+## 1.9.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 1.9.0 / 2020-06-29 / first included in Agent 7.21.0 / Agent 7.21.0
+## 1.9.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.8.0 / 2020-05-17 / first included in Agent 7.20.0 / Agent 7.20.0
+## 1.8.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.0 / 2020-04-04 / first included in Agent 7.19.0 / Agent 7.19.0
+## 1.7.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Active Directory to not use agentConfig. See [#5938](https://github.com/DataDog/integrations-core/pull/5938).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.6.0 / 2019-12-02 / first included in Agent 7.16.0 / Agent 7.16.0
+## 1.6.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 1.5.0 / 2019-10-11 / first included in Agent 6.15.0 / Agent 6.15.0
+## 1.5.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 1.4.1 / 2019-06-18 / first included in Agent 6.13.0 / Agent 6.13.0
+## 1.4.1 / 2019-06-18 / Agent 6.13.0
 
 * [Fixed] Rename lower case manifest.in. See [#3858](https://github.com/DataDog/integrations-core/pull/3858).
 
-## 1.4.0 / 2019-05-14 / first included in Agent 6.12.0 / Agent 6.12.0
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3483](https://github.com/DataDog/integrations-core/pull/3483).
 
-## 1.3.0 / 2019-02-18 / first included in Agent 6.11.0 / Agent 6.11.0
+## 1.3.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2975](https://github.com/DataDog/integrations-core/pull/2975).
 
-## 1.2.0 / 2018-10-12 / first included in Agent 5.28.0 / Agent 5.28.0
+## 1.2.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.1.1 / 2018-09-04 / first included in Agent 5.28.0 / Agent 5.28.0
+## 1.1.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/active_directory/CHANGELOG.md
+++ b/active_directory/CHANGELOG.md
@@ -1,50 +1,50 @@
 # CHANGELOG - active_directory
 
-## 1.9.1 / 2020-08-10 / first included in Agent 7.22.0
+## 1.9.1 / 2020-08-10 / first included in Agent 7.22.0 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 1.9.0 / 2020-06-29 / first included in Agent 7.21.0
+## 1.9.0 / 2020-06-29 / first included in Agent 7.21.0 / Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.8.0 / 2020-05-17 / first included in Agent 7.20.0
+## 1.8.0 / 2020-05-17 / first included in Agent 7.20.0 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.0 / 2020-04-04 / first included in Agent 7.19.0
+## 1.7.0 / 2020-04-04 / first included in Agent 7.19.0 / Agent 7.19.0
 
 * [Added] Active Directory to not use agentConfig. See [#5938](https://github.com/DataDog/integrations-core/pull/5938).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.6.0 / 2019-12-02 / first included in Agent 7.16.0
+## 1.6.0 / 2019-12-02 / first included in Agent 7.16.0 / Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 1.5.0 / 2019-10-11 / first included in Agent 6.15.0
+## 1.5.0 / 2019-10-11 / first included in Agent 6.15.0 / Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 1.4.1 / 2019-06-18 / first included in Agent 6.13.0
+## 1.4.1 / 2019-06-18 / first included in Agent 6.13.0 / Agent 6.13.0
 
 * [Fixed] Rename lower case manifest.in. See [#3858](https://github.com/DataDog/integrations-core/pull/3858).
 
-## 1.4.0 / 2019-05-14 / first included in Agent 6.12.0
+## 1.4.0 / 2019-05-14 / first included in Agent 6.12.0 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3483](https://github.com/DataDog/integrations-core/pull/3483).
 
-## 1.3.0 / 2019-02-18 / first included in Agent 6.11.0
+## 1.3.0 / 2019-02-18 / first included in Agent 6.11.0 / Agent 6.11.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2975](https://github.com/DataDog/integrations-core/pull/2975).
 
-## 1.2.0 / 2018-10-12 / first included in Agent 5.28.0
+## 1.2.0 / 2018-10-12 / first included in Agent 5.28.0 / Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.1.1 / 2018-09-04 / first included in Agent 5.28.0
+## 1.1.1 / 2018-09-04 / first included in Agent 5.28.0 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/active_directory/CHANGELOG.md
+++ b/active_directory/CHANGELOG.md
@@ -1,6 +1,5 @@
 # CHANGELOG - active_directory
 
-<<<<<<< HEAD
 ## 1.9.1 / 2020-08-10
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
@@ -11,44 +10,41 @@
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
 ## 1.8.0 / 2020-05-17
-=======
-## 1.8.0 / 2020-05-17 / first included in Agent 7.20.0
->>>>>>> 2bb03f6ab... example
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.0 / 2020-04-04 / first included in Agent 7.19.0
+## 1.7.0 / 2020-04-04
 
 * [Added] Active Directory to not use agentConfig. See [#5938](https://github.com/DataDog/integrations-core/pull/5938).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.6.0 / 2019-12-02 / first included in Agent 7.16.0
+## 1.6.0 / 2019-12-02
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 1.5.0 / 2019-10-11 / first included in Agent 6.15.0
+## 1.5.0 / 2019-10-11
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 1.4.1 / 2019-06-18 / first included in Agent 6.13.0
+## 1.4.1 / 2019-06-18
 
 * [Fixed] Rename lower case manifest.in. See [#3858](https://github.com/DataDog/integrations-core/pull/3858).
 
-## 1.4.0 / 2019-05-14 / first included in Agent 6.12.0
+## 1.4.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3483](https://github.com/DataDog/integrations-core/pull/3483).
 
-## 1.3.0 / 2019-02-18 / first included in Agent 6.11.0
+## 1.3.0 / 2019-02-18
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2975](https://github.com/DataDog/integrations-core/pull/2975).
 
-## 1.2.0 / 2018-10-12 / first included in Agent 5.28.0
+## 1.2.0 / 2018-10-12
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.1.1 / 2018-09-04 / first included in Agent 5.28.0
+## 1.1.1 / 2018-09-04
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/active_directory/CHANGELOG.md
+++ b/active_directory/CHANGELOG.md
@@ -1,50 +1,50 @@
 # CHANGELOG - active_directory
 
-## 1.9.1 / 2020-08-10 / Agent 7.22.0
+## 1.9.1 / 2020-08-10
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 1.9.0 / 2020-06-29 / Agent 7.21.0
+## 1.9.0 / 2020-06-29
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.8.0 / 2020-05-17 / Agent 7.20.0
+## 1.8.0 / 2020-05-17
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.0 / 2020-04-04 / Agent 7.19.0
+## 1.7.0 / 2020-04-04
 
 * [Added] Active Directory to not use agentConfig. See [#5938](https://github.com/DataDog/integrations-core/pull/5938).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.6.0 / 2019-12-02 / Agent 7.16.0
+## 1.6.0 / 2019-12-02
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 1.5.0 / 2019-10-11 / Agent 6.15.0
+## 1.5.0 / 2019-10-11
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 1.4.1 / 2019-06-18 / Agent 6.13.0
+## 1.4.1 / 2019-06-18
 
 * [Fixed] Rename lower case manifest.in. See [#3858](https://github.com/DataDog/integrations-core/pull/3858).
 
-## 1.4.0 / 2019-05-14 / Agent 6.12.0
+## 1.4.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3483](https://github.com/DataDog/integrations-core/pull/3483).
 
-## 1.3.0 / 2019-02-18 / Agent 6.11.0
+## 1.3.0 / 2019-02-18
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2975](https://github.com/DataDog/integrations-core/pull/2975).
 
-## 1.2.0 / 2018-10-12 / Agent 5.28.0
+## 1.2.0 / 2018-10-12
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.1.1 / 2018-09-04 / Agent 5.28.0
+## 1.1.1 / 2018-09-04
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/active_directory/CHANGELOG.md
+++ b/active_directory/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG - active_directory
 
+<<<<<<< HEAD
 ## 1.9.1 / 2020-08-10
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
@@ -10,41 +11,44 @@
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
 ## 1.8.0 / 2020-05-17
+=======
+## 1.8.0 / 2020-05-17 / first included in Agent 7.20.0
+>>>>>>> 2bb03f6ab... example
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.0 / 2020-04-04
+## 1.7.0 / 2020-04-04 / first included in Agent 7.19.0
 
 * [Added] Active Directory to not use agentConfig. See [#5938](https://github.com/DataDog/integrations-core/pull/5938).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.6.0 / 2019-12-02
+## 1.6.0 / 2019-12-02 / first included in Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 1.5.0 / 2019-10-11
+## 1.5.0 / 2019-10-11 / first included in Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 1.4.1 / 2019-06-18
+## 1.4.1 / 2019-06-18 / first included in Agent 6.13.0
 
 * [Fixed] Rename lower case manifest.in. See [#3858](https://github.com/DataDog/integrations-core/pull/3858).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / first included in Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3483](https://github.com/DataDog/integrations-core/pull/3483).
 
-## 1.3.0 / 2019-02-18
+## 1.3.0 / 2019-02-18 / first included in Agent 6.11.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2975](https://github.com/DataDog/integrations-core/pull/2975).
 
-## 1.2.0 / 2018-10-12
+## 1.2.0 / 2018-10-12 / first included in Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.1.1 / 2018-09-04
+## 1.1.1 / 2018-09-04 / first included in Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/__init__.py
@@ -6,9 +6,10 @@ import click
 from ..console import CONTEXT_SETTINGS
 from .changelog import changelog
 from .integrations import integrations
+from .integrations_changelog import integrations_changelog
 from .requirements import requirements
 
-ALL_COMMANDS = (changelog, requirements, integrations)
+ALL_COMMANDS = (changelog, requirements, integrations, integrations_changelog)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='A collection of tasks related to the Datadog Agent')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
@@ -37,45 +37,8 @@ def changelog(since, to, write, force):
     tool will generate the whole changelog since Agent version 6.3.0
     (before that point we don't have enough information to build the log).
     """
-    agent_tags = get_agent_tags(since, to)
 
-    # store the changes in a mapping {agent_version --> {check_name --> current_version}}
-    changes_per_agent = {}
-
-    # to keep indexing easy, we run the loop off-by-one
-    for i in range(1, len(agent_tags)):
-        req_file_name = os.path.basename(get_agent_release_requirements())
-        current_tag = agent_tags[i - 1]
-        # Requirements for current tag
-        file_contents = git_show_file(req_file_name, current_tag)
-        catalog_now = parse_agent_req_file(file_contents)
-        # Requirements for previous tag
-        file_contents = git_show_file(req_file_name, agent_tags[i])
-        catalog_prev = parse_agent_req_file(file_contents)
-
-        changes_per_agent[current_tag] = {}
-
-        for name, ver in catalog_now.items():
-            # at some point in the git history, the requirements file erroneusly
-            # contained the folder name instead of the package name for each check,
-            # let's be resilient
-            old_ver = (
-                catalog_prev.get(name)
-                or catalog_prev.get(get_folder_name(name))
-                or catalog_prev.get(get_package_name(name))
-            )
-
-            # normalize the package name to the check_name
-            if name.startswith(DATADOG_PACKAGE_PREFIX):
-                name = get_folder_name(name)
-
-            if old_ver and old_ver != ver:
-                # determine whether major version changed
-                breaking = old_ver.split('.')[0] < ver.split('.')[0]
-                changes_per_agent[current_tag][name] = (ver, breaking)
-            elif not old_ver:
-                # New integration
-                changes_per_agent[current_tag][name] = (ver, False)
+    changes_per_agent = get_changes_per_agent(since, to)
 
     # store the changelog in memory
     changelog_contents = StringIO()
@@ -118,3 +81,44 @@ def changelog(since, to, write, force):
         write_file(dest, changelog_contents.getvalue())
     else:
         echo_info(changelog_contents.getvalue())
+
+
+def get_changes_per_agent(since, to):
+    agent_tags = get_agent_tags(since, to)
+    # store the changes in a mapping {agent_version --> {check_name --> current_version}}
+    changes_per_agent = {}
+    # to keep indexing easy, we run the loop off-by-one
+    for i in range(1, len(agent_tags)):
+        req_file_name = os.path.basename(get_agent_release_requirements())
+        current_tag = agent_tags[i - 1]
+        # Requirements for current tag
+        file_contents = git_show_file(req_file_name, current_tag)
+        catalog_now = parse_agent_req_file(file_contents)
+        # Requirements for previous tag
+        file_contents = git_show_file(req_file_name, agent_tags[i])
+        catalog_prev = parse_agent_req_file(file_contents)
+
+        changes_per_agent[current_tag] = {}
+
+        for name, ver in catalog_now.items():
+            # at some point in the git history, the requirements file erroneusly
+            # contained the folder name instead of the package name for each check,
+            # let's be resilient
+            old_ver = (
+                catalog_prev.get(name)
+                or catalog_prev.get(get_folder_name(name))
+                or catalog_prev.get(get_package_name(name))
+            )
+
+            # normalize the package name to the check_name
+            if name.startswith(DATADOG_PACKAGE_PREFIX):
+                name = get_folder_name(name)
+
+            if old_ver and old_ver != ver:
+                # determine whether major version changed
+                breaking = old_ver.split('.')[0] < ver.split('.')[0]
+                changes_per_agent[current_tag][name] = (ver, breaking)
+            elif not old_ver:
+                # New integration
+                changes_per_agent[current_tag][name] = (ver, False)
+    return changes_per_agent

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
@@ -8,12 +8,9 @@ from io import StringIO
 import click
 
 from ....utils import read_file, write_file
-from ...constants import get_agent_changelog, get_agent_release_requirements, get_root
-from ...git import git_show_file
-from ...release import DATADOG_PACKAGE_PREFIX, get_folder_name, get_package_name
-from ...utils import parse_agent_req_file
+from ...constants import get_agent_changelog, get_root
 from ..console import CONTEXT_SETTINGS, abort, echo_info
-from .common import get_agent_tags
+from .common import get_changes_per_agent
 
 
 @click.command(
@@ -81,44 +78,3 @@ def changelog(since, to, write, force):
         write_file(dest, changelog_contents.getvalue())
     else:
         echo_info(changelog_contents.getvalue())
-
-
-def get_changes_per_agent(since, to):
-    agent_tags = get_agent_tags(since, to)
-    # store the changes in a mapping {agent_version --> {check_name --> current_version}}
-    changes_per_agent = {}
-    # to keep indexing easy, we run the loop off-by-one
-    for i in range(1, len(agent_tags)):
-        req_file_name = os.path.basename(get_agent_release_requirements())
-        current_tag = agent_tags[i - 1]
-        # Requirements for current tag
-        file_contents = git_show_file(req_file_name, current_tag)
-        catalog_now = parse_agent_req_file(file_contents)
-        # Requirements for previous tag
-        file_contents = git_show_file(req_file_name, agent_tags[i])
-        catalog_prev = parse_agent_req_file(file_contents)
-
-        changes_per_agent[current_tag] = {}
-
-        for name, ver in catalog_now.items():
-            # at some point in the git history, the requirements file erroneusly
-            # contained the folder name instead of the package name for each check,
-            # let's be resilient
-            old_ver = (
-                catalog_prev.get(name)
-                or catalog_prev.get(get_folder_name(name))
-                or catalog_prev.get(get_package_name(name))
-            )
-
-            # normalize the package name to the check_name
-            if name.startswith(DATADOG_PACKAGE_PREFIX):
-                name = get_folder_name(name)
-
-            if old_ver and old_ver != ver:
-                # determine whether major version changed
-                breaking = old_ver.split('.')[0] < ver.split('.')[0]
-                changes_per_agent[current_tag][name] = (ver, breaking)
-            elif not old_ver:
-                # New integration
-                changes_per_agent[current_tag][name] = (ver, False)
-    return changes_per_agent

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/common.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/common.py
@@ -1,9 +1,14 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+
 from semver import parse_version_info
 
-from ...git import git_tag_list
+from ...constants import get_agent_release_requirements
+from ...git import git_show_file, git_tag_list
+from ...release import DATADOG_PACKAGE_PREFIX, get_folder_name, get_package_name
+from ...utils import parse_agent_req_file
 
 
 def get_agent_tags(since, to):
@@ -26,3 +31,68 @@ def get_agent_tags(since, to):
 
     # reverse so we have descendant order
     return [str(t) for t in reversed(agent_tags)]
+
+
+def get_changes_per_agent(since, to):
+    """
+    Return integration versions groups by Agent versions.
+    For each version, we also get a boolean indicating if the version has breaking changes.
+
+    Structure:
+
+    ```
+    {
+        '<AGENT_VERSION>': {
+            '<INTEGRATION_NAME>': ('<INTEGRATION_VERSION>', <IS_BREAKING_CHANGE>)
+        }
+    }
+    ```
+
+    Example output:
+
+    ```python
+    {
+        '7.20.0': {
+            'snmp': ('1.9.1', False)
+        }
+    }
+    ```
+    """
+    agent_tags = get_agent_tags(since, to)
+    # store the changes in a mapping {agent_version --> {check_name --> current_version}}
+    changes_per_agent = {}
+    # to keep indexing easy, we run the loop off-by-one
+    for i in range(1, len(agent_tags)):
+        req_file_name = os.path.basename(get_agent_release_requirements())
+        current_tag = agent_tags[i - 1]
+        # Requirements for current tag
+        file_contents = git_show_file(req_file_name, current_tag)
+        catalog_now = parse_agent_req_file(file_contents)
+        # Requirements for previous tag
+        file_contents = git_show_file(req_file_name, agent_tags[i])
+        catalog_prev = parse_agent_req_file(file_contents)
+
+        changes_per_agent[current_tag] = {}
+
+        for name, ver in catalog_now.items():
+            # at some point in the git history, the requirements file erroneusly
+            # contained the folder name instead of the package name for each check,
+            # let's be resilient
+            old_ver = (
+                catalog_prev.get(name)
+                or catalog_prev.get(get_folder_name(name))
+                or catalog_prev.get(get_package_name(name))
+            )
+
+            # normalize the package name to the check_name
+            if name.startswith(DATADOG_PACKAGE_PREFIX):
+                name = get_folder_name(name)
+
+            if old_ver and old_ver != ver:
+                # determine whether major version changed
+                breaking = old_ver.split('.')[0] < ver.split('.')[0]
+                changes_per_agent[current_tag][name] = (ver, breaking)
+            elif not old_ver:
+                # New integration
+                changes_per_agent[current_tag][name] = (ver, False)
+    return changes_per_agent

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -34,22 +34,15 @@ def integrations_changelog(write):
 
     for check in checks:
         changelog_file = get_integration_changelog(check)
-        print("changelog_file:", changelog_file)
         for line in read_file_lines(changelog_file):
             match = re.search(r'## (\d\.\d\.\d) / \d{4}-\d{2}-\d{2}', line)
             if match:
                 version = match.groups()[0]
                 tag = "{}-{}".format(check, version)
-                print("version", version)
-                print("tag", tag)
-
                 tag_list = sorted(git_tag_list(pattern=r"^\d+\.\d+\.\d+$", contains=tag))
                 if tag_list:
                     first_agent_version = tag_list[0]
-                    print("tag_list", tag_list)
-                    print("first_agent_version", first_agent_version)
-                    line = "{} / Agent {}\n".format(line.strip(), first_agent_version)
-                    print("line:", line)
+                    line = "{} / first included in Agent {}\n".format(line.strip(), first_agent_version)
             changelog_contents.write(line)
 
         # save the changelog on disk if --write was passed

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -1,0 +1,137 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+import os
+import re
+from io import StringIO
+
+import click
+
+from ....utils import read_file, write_file, read_file_lines
+from ...constants import get_agent_changelog, get_agent_release_requirements, get_root
+from ...git import git_show_file
+from ...release import DATADOG_PACKAGE_PREFIX, get_folder_name, get_package_name
+from ...utils import parse_agent_req_file, get_valid_checks
+from ..console import CONTEXT_SETTINGS, abort, echo_info
+from .common import get_agent_tags
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+    short_help="Provide a list of updated checks on a given Datadog Agent version, in changelog form",
+)
+@click.option('--since', help="Initial Agent version", default='6.3.0')
+@click.option('--to', help="Final Agent version")
+@click.option(
+    '--write', '-w', is_flag=True, help="Write to the changelog file, if omitted contents will be printed to stdout"
+)
+@click.option('--force', '-f', is_flag=True, default=False, help="Replace an existing file")
+def integrations_changelog(since, to, write, force):
+    """
+    Generates a markdown file containing the list of checks that changed for a
+    given Agent release. Agent version numbers are derived inspecting tags on
+    `integrations-core` so running this tool might provide unexpected results
+    if the repo is not up to date with the Agent release process.
+
+    If neither `--since` or `--to` are passed (the most common use case), the
+    tool will generate the whole changelog since Agent version 6.3.0
+    (before that point we don't have enough information to build the log).
+    """
+    checks = sorted(get_valid_checks())
+    for check in checks:
+        changelog_file = get_integration_changelog(check)
+        print("changelog_file:", changelog_file)
+        for line in read_file_lines(changelog_file):
+            match = re.search(r'## (\d\.\d\.\d) / \d{4}-\d{2}-\d{2}', line)
+            if match:
+                version = match.groups()[0]
+                print("version", version)
+        break
+
+    return
+    agent_tags = get_agent_tags(since, to)
+
+    # store the changes in a mapping {agent_version --> {check_name --> current_version}}
+    changes_per_agent = {}
+
+    # to keep indexing easy, we run the loop off-by-one
+    for i in range(1, len(agent_tags)):
+        req_file_name = os.path.basename(get_agent_release_requirements())
+        current_tag = agent_tags[i - 1]
+        # Requirements for current tag
+        file_contents = git_show_file(req_file_name, current_tag)
+        catalog_now = parse_agent_req_file(file_contents)
+        # Requirements for previous tag
+        file_contents = git_show_file(req_file_name, agent_tags[i])
+        catalog_prev = parse_agent_req_file(file_contents)
+
+        changes_per_agent[current_tag] = {}
+
+        for name, ver in catalog_now.items():
+            # at some point in the git history, the requirements file erroneusly
+            # contained the folder name instead of the package name for each check,
+            # let's be resilient
+            old_ver = (
+                catalog_prev.get(name)
+                or catalog_prev.get(get_folder_name(name))
+                or catalog_prev.get(get_package_name(name))
+            )
+
+            # normalize the package name to the check_name
+            if name.startswith(DATADOG_PACKAGE_PREFIX):
+                name = get_folder_name(name)
+
+            if old_ver and old_ver != ver:
+                # determine whether major version changed
+                breaking = old_ver.split('.')[0] < ver.split('.')[0]
+                changes_per_agent[current_tag][name] = (ver, breaking)
+            elif not old_ver:
+                # New integration
+                changes_per_agent[current_tag][name] = (ver, False)
+
+    # store the changelog in memory
+    changelog_contents = StringIO()
+
+    # prepare the links
+    agent_changelog_url = 'https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#{}'
+    check_changelog_url = 'https://github.com/DataDog/integrations-core/blob/master/{}/CHANGELOG.md'
+
+    # go through all the agent releases
+    for agent, version_changes in changes_per_agent.items():
+        url = agent_changelog_url.format(agent.replace('.', ''))  # Github removes dots from the anchor
+        changelog_contents.write(f'## Datadog Agent version [{agent}]({url})\n\n')
+
+        if not version_changes:
+            changelog_contents.write('* There were no integration updates for this version of the Agent.\n\n')
+        else:
+            for name, ver in version_changes.items():
+                # get the "display name" for the check
+                manifest_file = os.path.join(get_root(), name, 'manifest.json')
+                if os.path.exists(manifest_file):
+                    decoded = json.loads(read_file(manifest_file).strip())
+                    display_name = decoded.get('display_name')
+                else:
+                    display_name = name
+
+                breaking_notice = " **BREAKING CHANGE**" if ver[1] else ""
+                changelog_url = check_changelog_url.format(name)
+                changelog_contents.write(f'* {display_name} [{ver[0]}]({changelog_url}){breaking_notice}\n')
+            # add an extra line to separate the release block
+            changelog_contents.write('\n')
+
+    # save the changelog on disk if --write was passed
+    if write:
+        dest = get_agent_changelog()
+        # don't overwrite an existing file
+        if os.path.exists(dest) and not force:
+            msg = "Output file {} already exists, run the command again with --force to overwrite"
+            abort(msg.format(dest))
+
+        write_file(dest, changelog_contents.getvalue())
+    else:
+        echo_info(changelog_contents.getvalue())
+
+
+def get_integration_changelog(check):
+    return os.path.join(get_root(), check, 'CHANGELOG.md')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -10,7 +10,7 @@ import click
 
 from ....utils import read_file, write_file, read_file_lines
 from ...constants import get_agent_changelog, get_agent_release_requirements, get_root
-from ...git import git_show_file
+from ...git import git_show_file, git_tag_list
 from ...release import DATADOG_PACKAGE_PREFIX, get_folder_name, get_package_name
 from ...utils import parse_agent_req_file, get_valid_checks
 from ..console import CONTEXT_SETTINGS, abort, echo_info
@@ -19,26 +19,19 @@ from .common import get_agent_tags
 
 @click.command(
     context_settings=CONTEXT_SETTINGS,
-    short_help="Provide a list of updated checks on a given Datadog Agent version, in changelog form",
+    short_help="Update integration change logs with first Agent version containing each integration release",
 )
-@click.option('--since', help="Initial Agent version", default='6.3.0')
-@click.option('--to', help="Final Agent version")
 @click.option(
     '--write', '-w', is_flag=True, help="Write to the changelog file, if omitted contents will be printed to stdout"
 )
-@click.option('--force', '-f', is_flag=True, default=False, help="Replace an existing file")
-def integrations_changelog(since, to, write, force):
+def integrations_changelog(write):
     """
-    Generates a markdown file containing the list of checks that changed for a
-    given Agent release. Agent version numbers are derived inspecting tags on
-    `integrations-core` so running this tool might provide unexpected results
-    if the repo is not up to date with the Agent release process.
-
-    If neither `--since` or `--to` are passed (the most common use case), the
-    tool will generate the whole changelog since Agent version 6.3.0
-    (before that point we don't have enough information to build the log).
+    Update integration change logs with first Agent version containing each integration release
     """
     checks = sorted(get_valid_checks())
+    # store the changelog in memory
+    changelog_contents = StringIO()
+
     for check in checks:
         changelog_file = get_integration_changelog(check)
         print("changelog_file:", changelog_file)
@@ -46,91 +39,26 @@ def integrations_changelog(since, to, write, force):
             match = re.search(r'## (\d\.\d\.\d) / \d{4}-\d{2}-\d{2}', line)
             if match:
                 version = match.groups()[0]
+                tag = "{}-{}".format(check, version)
                 print("version", version)
-        break
+                print("tag", tag)
 
-    return
-    agent_tags = get_agent_tags(since, to)
+                tag_list = sorted(git_tag_list(pattern=r"^\d+\.\d+\.\d+$", contains=tag))
+                if tag_list:
+                    first_agent_version = tag_list[0]
+                    print("tag_list", tag_list)
+                    print("first_agent_version", first_agent_version)
+                    line = "{} / Agent {}\n".format(line.strip(), first_agent_version)
+                    print("line:", line)
+            changelog_contents.write(line)
 
-    # store the changes in a mapping {agent_version --> {check_name --> current_version}}
-    changes_per_agent = {}
-
-    # to keep indexing easy, we run the loop off-by-one
-    for i in range(1, len(agent_tags)):
-        req_file_name = os.path.basename(get_agent_release_requirements())
-        current_tag = agent_tags[i - 1]
-        # Requirements for current tag
-        file_contents = git_show_file(req_file_name, current_tag)
-        catalog_now = parse_agent_req_file(file_contents)
-        # Requirements for previous tag
-        file_contents = git_show_file(req_file_name, agent_tags[i])
-        catalog_prev = parse_agent_req_file(file_contents)
-
-        changes_per_agent[current_tag] = {}
-
-        for name, ver in catalog_now.items():
-            # at some point in the git history, the requirements file erroneusly
-            # contained the folder name instead of the package name for each check,
-            # let's be resilient
-            old_ver = (
-                catalog_prev.get(name)
-                or catalog_prev.get(get_folder_name(name))
-                or catalog_prev.get(get_package_name(name))
-            )
-
-            # normalize the package name to the check_name
-            if name.startswith(DATADOG_PACKAGE_PREFIX):
-                name = get_folder_name(name)
-
-            if old_ver and old_ver != ver:
-                # determine whether major version changed
-                breaking = old_ver.split('.')[0] < ver.split('.')[0]
-                changes_per_agent[current_tag][name] = (ver, breaking)
-            elif not old_ver:
-                # New integration
-                changes_per_agent[current_tag][name] = (ver, False)
-
-    # store the changelog in memory
-    changelog_contents = StringIO()
-
-    # prepare the links
-    agent_changelog_url = 'https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#{}'
-    check_changelog_url = 'https://github.com/DataDog/integrations-core/blob/master/{}/CHANGELOG.md'
-
-    # go through all the agent releases
-    for agent, version_changes in changes_per_agent.items():
-        url = agent_changelog_url.format(agent.replace('.', ''))  # Github removes dots from the anchor
-        changelog_contents.write(f'## Datadog Agent version [{agent}]({url})\n\n')
-
-        if not version_changes:
-            changelog_contents.write('* There were no integration updates for this version of the Agent.\n\n')
+        # save the changelog on disk if --write was passed
+        if write:
+            write_file(changelog_file, changelog_contents.getvalue())
         else:
-            for name, ver in version_changes.items():
-                # get the "display name" for the check
-                manifest_file = os.path.join(get_root(), name, 'manifest.json')
-                if os.path.exists(manifest_file):
-                    decoded = json.loads(read_file(manifest_file).strip())
-                    display_name = decoded.get('display_name')
-                else:
-                    display_name = name
+            echo_info(changelog_contents.getvalue())
 
-                breaking_notice = " **BREAKING CHANGE**" if ver[1] else ""
-                changelog_url = check_changelog_url.format(name)
-                changelog_contents.write(f'* {display_name} [{ver[0]}]({changelog_url}){breaking_notice}\n')
-            # add an extra line to separate the release block
-            changelog_contents.write('\n')
-
-    # save the changelog on disk if --write was passed
-    if write:
-        dest = get_agent_changelog()
-        # don't overwrite an existing file
-        if os.path.exists(dest) and not force:
-            msg = "Output file {} already exists, run the command again with --force to overwrite"
-            abort(msg.format(dest))
-
-        write_file(dest, changelog_contents.getvalue())
-    else:
-        echo_info(changelog_contents.getvalue())
+        break  # TODO: remove me
 
 
 def get_integration_changelog(check):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -57,7 +57,7 @@ def integrations_changelog(checks, write):
                     echo_debug("Agent version not found for integration {} line {}".format(check, line.strip()))
             changelog_contents.write(line)
 
-        # save the changelog on disk if --write was passed
+        # Save the changelog on disk if --write was passed
         if write:
             echo_info("Writing to {}".format(changelog_file))
             write_file(changelog_file, changelog_contents.getvalue())

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -8,13 +8,12 @@ from io import StringIO
 import click
 from six import iteritems
 
-from datadog_checks.dev.tooling.commands.agent.changelog import get_changes_per_agent
-from datadog_checks.dev.tooling.testing import complete_active_checks
-
 from ....utils import read_file_lines, write_file
 from ...constants import get_integration_changelog
+from ...testing import complete_active_checks
 from ...utils import get_valid_checks
 from ..console import CONTEXT_SETTINGS, echo_debug, echo_info
+from .common import get_changes_per_agent
 
 EXCLUDED_CHECKS = {
     'datadog_checks_dev',

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -16,7 +16,6 @@ from ..console import CONTEXT_SETTINGS, echo_debug, echo_info
 from .common import get_changes_per_agent
 
 INTEGRATION_CHANGELOG_PATTERN = r'^## (\d+\.\d+\.\d+) / \d{4}-\d{2}-\d{2}$'
-AGENT_TAG_PATTERN = r'^\d+\.\d+\.\d+$'
 
 
 @click.command(
@@ -43,11 +42,11 @@ def integrations_changelog(checks, since, to, write):
     changes_per_agent = get_changes_per_agent(since, to)
 
     integrations_versions = defaultdict(dict)
-    for agent, version_changes in changes_per_agent.items():
+    for agent_version, version_changes in changes_per_agent.items():
         for name, (ver, _) in version_changes.items():
             if name not in checks:
                 continue
-            integrations_versions[name][ver] = agent
+            integrations_versions[name][ver] = agent_version
 
     for check, versions in iteritems(integrations_versions):
         changelog_contents = StringIO()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -12,6 +12,11 @@ from ...git import git_tag_list
 from ...utils import get_valid_checks
 from ..console import CONTEXT_SETTINGS, echo_info
 
+EXCLUDED_CHECKS = {
+    'datadog_checks_dev',
+    'datadog_checks_downloader',
+}
+
 
 @click.command(
     context_settings=CONTEXT_SETTINGS,
@@ -24,7 +29,7 @@ def integrations_changelog(write):
     """
     Update integration change logs with first Agent version containing each integration release
     """
-    checks = sorted(get_valid_checks())
+    checks = sorted(set(get_valid_checks()) - EXCLUDED_CHECKS)
 
     for check in checks:
         changelog_contents = StringIO()
@@ -43,6 +48,7 @@ def integrations_changelog(write):
 
         # save the changelog on disk if --write was passed
         if write:
+            echo_info("Writing to {}".format(changelog_file))
             write_file(changelog_file, changelog_contents.getvalue())
         else:
             echo_info(changelog_contents.getvalue())

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -18,6 +18,8 @@ EXCLUDED_CHECKS = {
     'datadog_checks_dev',
     'datadog_checks_downloader',
 }
+INTEGRATION_CHANGELOG_PATTERN = r'^## (\d+\.\d+\.\d+) / \d{4}-\d{2}-\d{2}$'
+AGENT_TAG_PATTERN = r'^\d+\.\d+\.\d+$'
 
 
 @click.command(
@@ -39,14 +41,14 @@ def integrations_changelog(checks, write):
 
     for check in checks:
         changelog_contents = StringIO()
-
         changelog_file = get_integration_changelog(check)
+
         for line in read_file_lines(changelog_file):
-            match = re.search(r'^## (\d+\.\d+\.\d+) / \d{4}-\d{2}-\d{2}$', line)
+            match = re.search(INTEGRATION_CHANGELOG_PATTERN, line)
             if match:
                 version = match.groups()[0]
                 tag = "{}-{}".format(check, version)
-                tag_list = sorted(git_tag_list(pattern=r"^\d+\.\d+\.\d+$", contains=tag))
+                tag_list = sorted(git_tag_list(pattern=AGENT_TAG_PATTERN, contains=tag))
                 if tag_list:
                     first_agent_version = tag_list[0]
                     line = "{} / Agent {}\n".format(line.strip(), first_agent_version)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -47,13 +47,14 @@ def integrations_changelog(checks, write):
             match = re.search(INTEGRATION_CHANGELOG_PATTERN, line)
             if match:
                 version = match.groups()[0]
-                tag = "{}-{}".format(check, version)
-                tag_list = sorted(git_tag_list(pattern=AGENT_TAG_PATTERN, contains=tag))
-                if tag_list:
-                    first_agent_version = tag_list[0]
+                release_tag = "{}-{}".format(check, version)
+                tags = sorted(git_tag_list(pattern=AGENT_TAG_PATTERN, contains=release_tag))
+                if tags:
+                    # use the first agent version that include this release tag
+                    first_agent_version = tags[0]
                     line = "{} / Agent {}\n".format(line.strip(), first_agent_version)
                 else:
-                    echo_debug("Agent version not found for {}".format(line.strip()))
+                    echo_debug("Agent version not found for integration {} line {}".format(check, line.strip()))
             changelog_contents.write(line)
 
         # save the changelog on disk if --write was passed

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -10,7 +10,7 @@ from ....utils import read_file_lines, write_file
 from ...constants import get_integration_changelog
 from ...git import git_tag_list
 from ...utils import get_valid_checks
-from ..console import CONTEXT_SETTINGS, echo_info
+from ..console import CONTEXT_SETTINGS, echo_info, echo_debug
 
 EXCLUDED_CHECKS = {
     'datadog_checks_dev',
@@ -36,7 +36,7 @@ def integrations_changelog(write):
 
         changelog_file = get_integration_changelog(check)
         for line in read_file_lines(changelog_file):
-            match = re.search(r'^## (\d\.\d\.\d) / \d{4}-\d{2}-\d{2}$', line)
+            match = re.search(r'^## (\d+\.\d+\.\d+) / \d{4}-\d{2}-\d{2}$', line)
             if match:
                 version = match.groups()[0]
                 tag = "{}-{}".format(check, version)
@@ -44,6 +44,8 @@ def integrations_changelog(write):
                 if tag_list:
                     first_agent_version = tag_list[0]
                     line = "{} / Agent {}\n".format(line.strip(), first_agent_version)
+                else:
+                    echo_debug("Agent version not found for {}".format(line.strip()))
             changelog_contents.write(line)
 
         # save the changelog on disk if --write was passed

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -15,10 +15,6 @@ from ...utils import get_valid_checks
 from ..console import CONTEXT_SETTINGS, echo_debug, echo_info
 from .common import get_changes_per_agent
 
-EXCLUDED_CHECKS = {
-    'datadog_checks_dev',
-    'datadog_checks_downloader',
-}
 INTEGRATION_CHANGELOG_PATTERN = r'^## (\d+\.\d+\.\d+) / \d{4}-\d{2}-\d{2}$'
 AGENT_TAG_PATTERN = r'^\d+\.\d+\.\d+$'
 
@@ -40,7 +36,7 @@ def integrations_changelog(checks, since, to, write):
 
     # Process all checks if no check is passed
     if not checks:
-        checks = sorted(set(get_valid_checks()) - EXCLUDED_CHECKS)
+        checks = get_valid_checks()
 
     changes_per_agent = get_changes_per_agent(since, to)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -6,11 +6,13 @@ from io import StringIO
 
 import click
 
+from datadog_checks.dev.tooling.testing import complete_active_checks
+
 from ....utils import read_file_lines, write_file
 from ...constants import get_integration_changelog
 from ...git import git_tag_list
 from ...utils import get_valid_checks
-from ..console import CONTEXT_SETTINGS, echo_info, echo_debug
+from ..console import CONTEXT_SETTINGS, echo_debug, echo_info
 
 EXCLUDED_CHECKS = {
     'datadog_checks_dev',
@@ -22,14 +24,18 @@ EXCLUDED_CHECKS = {
     context_settings=CONTEXT_SETTINGS,
     short_help="Update integration change logs with first Agent version containing each integration release",
 )
+@click.argument('checks', autocompletion=complete_active_checks, nargs=-1)
 @click.option(
     '--write', '-w', is_flag=True, help="Write to the changelog file, if omitted contents will be printed to stdout"
 )
-def integrations_changelog(write):
+def integrations_changelog(checks, write):
     """
     Update integration change logs with first Agent version containing each integration release
     """
-    checks = sorted(set(get_valid_checks()) - EXCLUDED_CHECKS)
+
+    # Process all checks if no check is passed
+    if not checks:
+        checks = sorted(set(get_valid_checks()) - EXCLUDED_CHECKS)
 
     for check in checks:
         changelog_contents = StringIO()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -21,7 +21,7 @@ AGENT_TAG_PATTERN = r'^\d+\.\d+\.\d+$'
 
 @click.command(
     context_settings=CONTEXT_SETTINGS,
-    short_help="Update integration change logs with first Agent version containing each integration release",
+    short_help="Update integration CHANGELOG.md by adding the Agent version",
 )
 @click.argument('checks', autocompletion=complete_active_checks, nargs=-1)
 @click.option('--since', help="Initial Agent version", default='6.3.0')
@@ -31,7 +31,9 @@ AGENT_TAG_PATTERN = r'^\d+\.\d+\.\d+$'
 )
 def integrations_changelog(checks, since, to, write):
     """
-    Update integration change logs with first Agent version containing each integration release
+    Update integration CHANGELOG.md by adding the Agent version.
+
+    Agent version is only added to the integration versions released with a specific Agent release.
     """
 
     # Process all checks if no check is passed

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -1,20 +1,16 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import json
-import os
 import re
 from io import StringIO
 
 import click
 
-from ....utils import read_file, write_file, read_file_lines
-from ...constants import get_agent_changelog, get_agent_release_requirements, get_root
-from ...git import git_show_file, git_tag_list
-from ...release import DATADOG_PACKAGE_PREFIX, get_folder_name, get_package_name
-from ...utils import parse_agent_req_file, get_valid_checks
-from ..console import CONTEXT_SETTINGS, abort, echo_info
-from .common import get_agent_tags
+from ....utils import read_file_lines, write_file
+from ...constants import get_integration_changelog
+from ...git import git_tag_list
+from ...utils import get_valid_checks
+from ..console import CONTEXT_SETTINGS, echo_info
 
 
 @click.command(
@@ -29,10 +25,10 @@ def integrations_changelog(write):
     Update integration change logs with first Agent version containing each integration release
     """
     checks = sorted(get_valid_checks())
-    # store the changelog in memory
-    changelog_contents = StringIO()
 
     for check in checks:
+        changelog_contents = StringIO()
+
         changelog_file = get_integration_changelog(check)
         for line in read_file_lines(changelog_file):
             match = re.search(r'^## (\d\.\d\.\d) / \d{4}-\d{2}-\d{2}$', line)
@@ -50,9 +46,3 @@ def integrations_changelog(write):
             write_file(changelog_file, changelog_contents.getvalue())
         else:
             echo_info(changelog_contents.getvalue())
-
-        break  # TODO: remove me
-
-
-def get_integration_changelog(check):
-    return os.path.join(get_root(), check, 'CHANGELOG.md')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2018-present
+# (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -35,14 +35,14 @@ def integrations_changelog(write):
     for check in checks:
         changelog_file = get_integration_changelog(check)
         for line in read_file_lines(changelog_file):
-            match = re.search(r'## (\d\.\d\.\d) / \d{4}-\d{2}-\d{2}', line)
+            match = re.search(r'^## (\d\.\d\.\d) / \d{4}-\d{2}-\d{2}$', line)
             if match:
                 version = match.groups()[0]
                 tag = "{}-{}".format(check, version)
                 tag_list = sorted(git_tag_list(pattern=r"^\d+\.\d+\.\d+$", contains=tag))
                 if tag_list:
                     first_agent_version = tag_list[0]
-                    line = "{} / first included in Agent {}\n".format(line.strip(), first_agent_version)
+                    line = "{} / Agent {}\n".format(line.strip(), first_agent_version)
             changelog_contents.write(line)
 
         # save the changelog on disk if --write was passed

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py
@@ -43,14 +43,14 @@ def integrations_changelog(checks, since, to, write):
     if not checks:
         checks = sorted(set(get_valid_checks()) - EXCLUDED_CHECKS)
 
-    integrations_versions = defaultdict(dict)
     changes_per_agent = get_changes_per_agent(since, to)
-    for agent, version_changes in changes_per_agent.items():
-        # print(agent, version_changes)
-        for name, (ver, _) in version_changes.items():
-            integrations_versions[name][ver] = agent
 
-    integrations_versions = {intg: v for intg, v in iteritems(integrations_versions) if intg in checks}
+    integrations_versions = defaultdict(dict)
+    for agent, version_changes in changes_per_agent.items():
+        for name, (ver, _) in version_changes.items():
+            if name not in checks:
+                continue
+            integrations_versions[name][ver] = agent
 
     for check, versions in iteritems(integrations_versions):
         changelog_contents = StringIO()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -132,3 +132,10 @@ def get_agent_changelog():
     have changed with any Datadog Agent release.
     """
     return os.path.join(get_root(), 'AGENT_CHANGELOG.md')
+
+
+def get_integration_changelog(check):
+    """
+    Return the full path to the integration changelog.
+    """
+    return os.path.join(get_root(), check, 'CHANGELOG.md')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -126,13 +126,16 @@ def git_tag(tag_name, push=False):
         return result
 
 
-def git_tag_list(pattern=None):
+def git_tag_list(pattern=None, contains=None):
     """
     Return a list of all the tags in the git repo matching a regex passed in
     `pattern`. If `pattern` is None, return all the tags.
     """
     with chdir(get_root()):
-        result = run_command('git tag', capture=True).stdout
+        cmd = ['git', 'tag']
+        if contains:
+            cmd.extend(['--contains', contains])
+        result = run_command(cmd, capture=True).stdout
         result = result.splitlines()
 
     if not pattern:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add command to update integration changelog with Agent version

Related PRs:
- Add agent versions to integrations changelog https://github.com/DataDog/integrations-core/pull/7519
- Add `ddev agent integrations-changelog` to post release actions #7520


### Motivation

Sometimes we know that a feature has been release with integration version X and we want to know (easily) what was the first version of the agent containing that feature.

### Additional Notes

Does not interfere with existing `ddev release make`
