### PR TITLE
Add agent versions to integrations changelog

### DIFF
--- a/active_directory/CHANGELOG.md
+++ b/active_directory/CHANGELOG.md
@@ -35,16 +35,16 @@
 
 * [Added] Adhere to code style. See [#3483](https://github.com/DataDog/integrations-core/pull/3483).
 
-## 1.3.0 / 2019-02-18 / Agent 6.11.0
+## 1.3.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2975](https://github.com/DataDog/integrations-core/pull/2975).
 
-## 1.2.0 / 2018-10-12 / Agent 5.28.0
+## 1.2.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.1.1 / 2018-09-04 / Agent 5.28.0
+## 1.1.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/active_directory/CHANGELOG.md
+++ b/active_directory/CHANGELOG.md
@@ -1,50 +1,50 @@
 # CHANGELOG - active_directory
 
-## 1.9.1 / 2020-08-10
+## 1.9.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 1.9.0 / 2020-06-29
+## 1.9.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.8.0 / 2020-05-17
+## 1.8.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.0 / 2020-04-04
+## 1.7.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Active Directory to not use agentConfig. See [#5938](https://github.com/DataDog/integrations-core/pull/5938).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.6.0 / 2019-12-02
+## 1.6.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 1.5.0 / 2019-10-11
+## 1.5.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 1.4.1 / 2019-06-18
+## 1.4.1 / 2019-06-18 / Agent 6.13.0
 
 * [Fixed] Rename lower case manifest.in. See [#3858](https://github.com/DataDog/integrations-core/pull/3858).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3483](https://github.com/DataDog/integrations-core/pull/3483).
 
-## 1.3.0 / 2019-02-18
+## 1.3.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2975](https://github.com/DataDog/integrations-core/pull/2975).
 
-## 1.2.0 / 2018-10-12
+## 1.2.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.1.1 / 2018-09-04
+## 1.1.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/activemq/CHANGELOG.md
+++ b/activemq/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] Add domain to metrics.yaml. See [#7163](https://github.com/DataDog/integrations-core/pull/7163).
 
-## 1.5.2 / 2020-07-15 / Agent 7.22.0
+## 1.5.2 / 2020-07-15
 
 * [Fixed] Add new_gc_metrics to all jmx integrations. See [#7073](https://github.com/DataDog/integrations-core/pull/7073).
 
@@ -36,11 +36,11 @@
 
 * [Added] Add log section. See [#4013](https://github.com/DataDog/integrations-core/pull/4013).
 
-## 1.1.0 / 2018-10-12 / Agent 5.28.0
+## 1.1.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] [jmx] add rmi registry ssl config option. See [#2371][1].
 
-## 1.0.2 / 2018-09-04 / Agent 5.28.0
+## 1.0.2 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/activemq/CHANGELOG.md
+++ b/activemq/CHANGELOG.md
@@ -1,46 +1,46 @@
 # CHANGELOG - activemq
 
-## 1.6.0 / 2020-08-10
+## 1.6.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Convert jmx to in-app types for replay_check_run. See [#7275](https://github.com/DataDog/integrations-core/pull/7275).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] Add domain to metrics.yaml. See [#7163](https://github.com/DataDog/integrations-core/pull/7163).
 
-## 1.5.2 / 2020-07-15
+## 1.5.2 / 2020-07-15 / Agent 7.22.0
 
 * [Fixed] Add new_gc_metrics to all jmx integrations. See [#7073](https://github.com/DataDog/integrations-core/pull/7073).
 
-## 1.5.1 / 2020-06-29
+## 1.5.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 * [Fixed] Adjust jmxfetch config. See [#6864](https://github.com/DataDog/integrations-core/pull/6864).
 
-## 1.5.0 / 2020-05-17
+## 1.5.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add rmi_connection_timeout & rmi_client_timeout to config spec. See [#6459](https://github.com/DataDog/integrations-core/pull/6459).
 * [Added] Add default template to openmetrics & jmx config. See [#6328](https://github.com/DataDog/integrations-core/pull/6328).
 
-## 1.4.0 / 2020-04-04
+## 1.4.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add `service_check_prefix` config to jmx. See [#6163](https://github.com/DataDog/integrations-core/pull/6163).
 * [Added] Add config specs to activemq. See [#6115](https://github.com/DataDog/integrations-core/pull/6115).
 * [Fixed] Fix e2e test. See [#6167](https://github.com/DataDog/integrations-core/pull/6167).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.3.0 / 2019-12-02
+## 1.3.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.2.0 / 2019-07-04
+## 1.2.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Add log section. See [#4013](https://github.com/DataDog/integrations-core/pull/4013).
 
-## 1.1.0 / 2018-10-12
+## 1.1.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] [jmx] add rmi registry ssl config option. See [#2371][1].
 
-## 1.0.2 / 2018-09-04
+## 1.0.2 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/activemq_xml/CHANGELOG.md
+++ b/activemq_xml/CHANGELOG.md
@@ -1,50 +1,50 @@
 # CHANGELOG - activemq_xml
 
-## 1.8.1 / 2020-08-10
+## 1.8.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.8.0 / 2020-06-29
+## 1.8.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.7.0 / 2020-05-17
+## 1.7.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.6.1 / 2020-04-07
+## 1.6.1 / 2020-04-07 / Agent 7.20.0
 
 * [Fixed] Add `kerberos_cache` to HTTP config options. See [#6279](https://github.com/DataDog/integrations-core/pull/6279).
 
-## 1.6.0 / 2020-04-04
+## 1.6.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Added] Add config specs to activemq xml. See [#6116](https://github.com/DataDog/integrations-core/pull/6116).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.5.0 / 2019-12-02
+## 1.5.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Standardize logging format. See [#4896](https://github.com/DataDog/integrations-core/pull/4896).
 
-## 1.4.0 / 2019-10-11
+## 1.4.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.3.0 / 2019-08-24
+## 1.3.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Update with proxy settings . See [#3361](https://github.com/DataDog/integrations-core/pull/3361).
 
-## 1.2.0 / 2019-03-29
+## 1.2.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Adhere to code style. See [#3323](https://github.com/DataDog/integrations-core/pull/3323).
 
-## 1.1.0 / 2018-11-30
+## 1.1.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Add Python3 Support. See [#2583][1].
 
-## 1.0.1 / 2018-09-04
+## 1.0.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/activemq_xml/CHANGELOG.md
+++ b/activemq_xml/CHANGELOG.md
@@ -14,11 +14,11 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.6.1 / 2020-04-07 / Agent 7.20.0
+## 1.6.1 / 2020-04-07 / Agent 7.19.0
 
 * [Fixed] Add `kerberos_cache` to HTTP config options. See [#6279](https://github.com/DataDog/integrations-core/pull/6279).
 
-## 1.6.0 / 2020-04-04 / Agent 7.19.0
+## 1.6.0 / 2020-04-04
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Added] Add config specs to activemq xml. See [#6116](https://github.com/DataDog/integrations-core/pull/6116).
@@ -40,11 +40,11 @@
 
 * [Added] Adhere to code style. See [#3323](https://github.com/DataDog/integrations-core/pull/3323).
 
-## 1.1.0 / 2018-11-30 / Agent 5.30.0
+## 1.1.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Add Python3 Support. See [#2583][1].
 
-## 1.0.1 / 2018-09-04 / Agent 5.28.0
+## 1.0.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/aerospike/CHANGELOG.md
+++ b/aerospike/CHANGELOG.md
@@ -1,57 +1,57 @@
 # CHANGELOG - Aerospike
 
-## 1.8.3 / 2020-07-23
+## 1.8.3 / 2020-07-23 / Agent 7.22.0
 
 * [Fixed] Fix empty result case. See [#7192](https://github.com/DataDog/integrations-core/pull/7192).
 
-## 1.8.2 / 2020-07-22
+## 1.8.2 / 2020-07-22 / Agent 7.22.0
 
 * [Fixed] Add debug log for get info calls. See [#7182](https://github.com/DataDog/integrations-core/pull/7182).
 
-## 1.8.1 / 2020-07-10
+## 1.8.1 / 2020-07-10 / Agent 7.22.0
 
 * [Fixed] Parse batch-index read latency metrics. See [#6991](https://github.com/DataDog/integrations-core/pull/6991).
 
-## 1.8.0 / 2020-05-17
+## 1.8.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.1 / 2020-04-15
+## 1.7.1 / 2020-04-15 / Agent 7.20.0
 
 * [Fixed] Fix namespace valid chars matching regex. See [#6352](https://github.com/DataDog/integrations-core/pull/6352).
 * [Fixed] Fix namespace tagging for latency metrics. See [#6345](https://github.com/DataDog/integrations-core/pull/6345).
 
-## 1.7.0 / 2020-03-13
+## 1.7.0 / 2020-03-13 / Agent 7.19.0
 
 * [Added] Add TLS config. See [#6035](https://github.com/DataDog/integrations-core/pull/6035).
 
-## 1.6.0 / 2020-02-22
+## 1.6.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Upgrade `aerospike` dependency. See [#5779](https://github.com/DataDog/integrations-core/pull/5779).
 
-## 1.5.0 / 2020-01-13
+## 1.5.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Added] Add latency and datacenter metrics for Aerospike also collect version metadata information. See [#4969](https://github.com/DataDog/integrations-core/pull/4969).
 
-## 1.4.0 / 2019-12-02
+## 1.4.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Standardize logging format. See [#4897](https://github.com/DataDog/integrations-core/pull/4897).
 
-## 1.3.0 / 2019-05-14
+## 1.3.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3484](https://github.com/DataDog/integrations-core/pull/3484).
 
-## 1.2.0 / 2019-03-29
+## 1.2.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Upgrade aerospike dependency. See [#3235](https://github.com/DataDog/integrations-core/pull/3235).
 
-## 1.1.0 / 2019-02-27
+## 1.1.0 / 2019-02-27 / Agent 6.11.0
 
 * [Added] Add authentication and timeout options. See [#3214](https://github.com/DataDog/integrations-core/pull/3214).
 * [Added] Refactor check to use the official library. See [#3212](https://github.com/DataDog/integrations-core/pull/3212).
 
-## 1.0.0 / 2019-02-18
+## 1.0.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Officially support Aerospike. See [#3078](https://github.com/DataDog/integrations-core/pull/3078).
 

--- a/aerospike/CHANGELOG.md
+++ b/aerospike/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 * [Fixed] Fix empty result case. See [#7192](https://github.com/DataDog/integrations-core/pull/7192).
 
-## 1.8.2 / 2020-07-22 / Agent 7.22.0
+## 1.8.2 / 2020-07-22
 
 * [Fixed] Add debug log for get info calls. See [#7182](https://github.com/DataDog/integrations-core/pull/7182).
 
-## 1.8.1 / 2020-07-10 / Agent 7.22.0
+## 1.8.1 / 2020-07-10
 
 * [Fixed] Parse batch-index read latency metrics. See [#6991](https://github.com/DataDog/integrations-core/pull/6991).
 
@@ -16,7 +16,7 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.1 / 2020-04-15 / Agent 7.20.0
+## 1.7.1 / 2020-04-15
 
 * [Fixed] Fix namespace valid chars matching regex. See [#6352](https://github.com/DataDog/integrations-core/pull/6352).
 * [Fixed] Fix namespace tagging for latency metrics. See [#6345](https://github.com/DataDog/integrations-core/pull/6345).
@@ -46,12 +46,12 @@
 
 * [Added] Upgrade aerospike dependency. See [#3235](https://github.com/DataDog/integrations-core/pull/3235).
 
-## 1.1.0 / 2019-02-27 / Agent 6.11.0
+## 1.1.0 / 2019-02-27
 
 * [Added] Add authentication and timeout options. See [#3214](https://github.com/DataDog/integrations-core/pull/3214).
 * [Added] Refactor check to use the official library. See [#3212](https://github.com/DataDog/integrations-core/pull/3212).
 
-## 1.0.0 / 2019-02-18 / Agent 6.11.0
+## 1.0.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Officially support Aerospike. See [#3078](https://github.com/DataDog/integrations-core/pull/3078).
 

--- a/airflow/CHANGELOG.md
+++ b/airflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - Airflow
 
-## 1.5.0 / 2020-08-10
+## 1.5.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] airflow new metrics. See [#7112](https://github.com/DataDog/integrations-core/pull/7112).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
@@ -8,26 +8,26 @@
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 * [Fixed] DOCS-983 Airflow integration. See [#6971](https://github.com/DataDog/integrations-core/pull/6971).
 
-## 1.4.0 / 2020-06-29
+## 1.4.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.3.0 / 2020-05-17
+## 1.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Use config spec. See [#6305](https://github.com/DataDog/integrations-core/pull/6305).
 
-## 1.2.0 / 2020-04-04
+## 1.2.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add `ddev test` option to verify support of new metrics. See [#6141](https://github.com/DataDog/integrations-core/pull/6141).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.1.0 / 2020-02-22
+## 1.1.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add airflow logs. See [#5405](https://github.com/DataDog/integrations-core/pull/5405).
 
-## 1.0.0 / 2020-01-06
+## 1.0.0 / 2020-01-06 / Agent 7.17.0
 
 * [Added] Add Airflow integration. See [#5232](https://github.com/DataDog/integrations-core/pull/5232).
 

--- a/amazon_msk/CHANGELOG.md
+++ b/amazon_msk/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.0.0 / 2019-12-03 / Agent 7.17.0
+## 1.0.0 / 2019-12-03 / Agent 7.16.1
 
 * [Added] Add Amazon MSK integration. See [#5127](https://github.com/DataDog/integrations-core/pull/5127).
 

--- a/amazon_msk/CHANGELOG.md
+++ b/amazon_msk/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG - Amazon MSK
 
-## 1.1.0 / 2020-05-17
+## 1.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.0.0 / 2019-12-03
+## 1.0.0 / 2019-12-03 / Agent 7.17.0
 
 * [Added] Add Amazon MSK integration. See [#5127](https://github.com/DataDog/integrations-core/pull/5127).
 

--- a/ambari/CHANGELOG.md
+++ b/ambari/CHANGELOG.md
@@ -34,11 +34,11 @@
 
 * [Fixed] Fix typo TSL => TLS. See [#4072](https://github.com/DataDog/integrations-core/pull/4072).
 
-## 1.1.0 / 2019-07-04 / Agent 6.13.0
+## 1.1.0 / 2019-07-04
 
 * [Added] Add logs multiline managing. See [#3912](https://github.com/DataDog/integrations-core/pull/3912).
 
-## 1.0.1 / 2019-06-18 / Agent 6.13.0
+## 1.0.1 / 2019-06-18
 
 * [Fixed] Validate interval in metadata validation. See [#3857](https://github.com/DataDog/integrations-core/pull/3857).
 

--- a/ambari/CHANGELOG.md
+++ b/ambari/CHANGELOG.md
@@ -1,48 +1,48 @@
 # CHANGELOG - Ambari
 
-## 1.4.1 / 2020-08-10
+## 1.4.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.4.0 / 2020-06-29
+## 1.4.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.3.0 / 2020-05-17
+## 1.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add config spec. See [#6307](https://github.com/DataDog/integrations-core/pull/6307).
 
-## 1.2.1 / 2020-04-04
+## 1.2.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.2.0 / 2019-12-02
+## 1.2.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Standardize logging format. See [#4898](https://github.com/DataDog/integrations-core/pull/4898).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.1.2 / 2019-08-24
+## 1.1.2 / 2019-08-24 / Agent 6.14.0
 
 * [Fixed] Add custom tags to service checks. See [#4320](https://github.com/DataDog/integrations-core/pull/4320).
 
-## 1.1.1 / 2019-07-09
+## 1.1.1 / 2019-07-09 / Agent 6.13.0
 
 * [Fixed] Fix typo TSL => TLS. See [#4072](https://github.com/DataDog/integrations-core/pull/4072).
 
-## 1.1.0 / 2019-07-04
+## 1.1.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Add logs multiline managing. See [#3912](https://github.com/DataDog/integrations-core/pull/3912).
 
-## 1.0.1 / 2019-06-18
+## 1.0.1 / 2019-06-18 / Agent 6.13.0
 
 * [Fixed] Validate interval in metadata validation. See [#3857](https://github.com/DataDog/integrations-core/pull/3857).
 
-## 1.0.0 / 2019-06-01
+## 1.0.0 / 2019-06-01 / Agent 6.12.0
 
 * [Added] Ambari integration. See [#3670](https://github.com/DataDog/integrations-core/pull/3670).
 

--- a/apache/CHANGELOG.md
+++ b/apache/CHANGELOG.md
@@ -15,44 +15,44 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.11.1 / 2020-04-07 / Agent 7.20.0
+## 1.11.1 / 2020-04-07 / Agent 7.19.0
 
 * [Fixed] Add `kerberos_cache` to HTTP config options. See [#6279](https://github.com/DataDog/integrations-core/pull/6279).
 
-## 1.11.0 / 2020-04-04 / Agent 7.19.0
+## 1.11.0 / 2020-04-04
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.10.1 / 2020-02-25 / Agent 7.19.0
+## 1.10.1 / 2020-02-25 / Agent 7.18.0
 
 * [Fixed] Update datadog_checks_base dependencies. See [#5846](https://github.com/DataDog/integrations-core/pull/5846).
 
-## 1.10.0 / 2020-02-22 / Agent 7.18.0
+## 1.10.0 / 2020-02-22
 
 * [Added] Add `service` option to default configuration. See [#5805](https://github.com/DataDog/integrations-core/pull/5805).
 
-## 1.9.5 / 2020-01-17 / Agent 7.18.0
+## 1.9.5 / 2020-01-17 / Agent 7.17.0
 
 * [Fixed] Add support for full server version. See [#5484](https://github.com/DataDog/integrations-core/pull/5484).
 
-## 1.9.4 / 2019-12-26 / Agent 7.17.0
+## 1.9.4 / 2019-12-26
 
 * [Fixed] Don't ship incomplete config spec. See [#5338](https://github.com/DataDog/integrations-core/pull/5338).
 
-## 1.9.3 / 2019-12-24 / Agent 7.17.0
+## 1.9.3 / 2019-12-24
 
 * [Fixed] Fix version metadata submitted twice. See [#5325](https://github.com/DataDog/integrations-core/pull/5325).
 
-## 1.9.2 / 2019-12-20 / Agent 7.17.0
+## 1.9.2 / 2019-12-20 / Agent 7.16.1
 
 * [Fixed] Fix version collection again. See [#5252](https://github.com/DataDog/integrations-core/pull/5252).
 
-## 1.9.1 / 2019-12-04 / Agent 7.17.0
+## 1.9.1 / 2019-12-04 / Agent 7.16.0
 
 * [Fixed] Fix version collection. See [#5144](https://github.com/DataDog/integrations-core/pull/5144).
 
-## 1.9.0 / 2019-12-02 / Agent 7.16.0
+## 1.9.0 / 2019-12-02
 
 * [Added] Standardize logging format. See [#4899](https://github.com/DataDog/integrations-core/pull/4899).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
@@ -62,11 +62,11 @@
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.7.1 / 2019-08-30 / Agent 6.15.0
+## 1.7.1 / 2019-08-30 / Agent 6.14.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 1.7.0 / 2019-08-24 / Agent 6.14.0
+## 1.7.0 / 2019-08-24
 
 * [Added] Add support for proxy options. See [#3362](https://github.com/DataDog/integrations-core/pull/3362).
 
@@ -78,16 +78,16 @@
 
 * [Added] Adhere to code style. See [#3322](https://github.com/DataDog/integrations-core/pull/3322).
 
-## 1.4.0 / 2018-11-30 / Agent 5.30.0
+## 1.4.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Add python3 support. See [#2497][1].
 
-## 1.3.1 / 2018-09-04 / Agent 5.28.0
+## 1.3.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 
-## 1.3.0 / 2018-06-07 / Agent 5.25.0
+## 1.3.0 / 2018-06-07
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][4].
 

--- a/apache/CHANGELOG.md
+++ b/apache/CHANGELOG.md
@@ -1,93 +1,93 @@
 # CHANGELOG - apache
 
-## 1.13.1 / 2020-08-10
+## 1.13.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.13.0 / 2020-06-29
+## 1.13.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.12.0 / 2020-05-17
+## 1.12.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.11.1 / 2020-04-07
+## 1.11.1 / 2020-04-07 / Agent 7.20.0
 
 * [Fixed] Add `kerberos_cache` to HTTP config options. See [#6279](https://github.com/DataDog/integrations-core/pull/6279).
 
-## 1.11.0 / 2020-04-04
+## 1.11.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.10.1 / 2020-02-25
+## 1.10.1 / 2020-02-25 / Agent 7.19.0
 
 * [Fixed] Update datadog_checks_base dependencies. See [#5846](https://github.com/DataDog/integrations-core/pull/5846).
 
-## 1.10.0 / 2020-02-22
+## 1.10.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add `service` option to default configuration. See [#5805](https://github.com/DataDog/integrations-core/pull/5805).
 
-## 1.9.5 / 2020-01-17
+## 1.9.5 / 2020-01-17 / Agent 7.18.0
 
 * [Fixed] Add support for full server version. See [#5484](https://github.com/DataDog/integrations-core/pull/5484).
 
-## 1.9.4 / 2019-12-26
+## 1.9.4 / 2019-12-26 / Agent 7.17.0
 
 * [Fixed] Don't ship incomplete config spec. See [#5338](https://github.com/DataDog/integrations-core/pull/5338).
 
-## 1.9.3 / 2019-12-24
+## 1.9.3 / 2019-12-24 / Agent 7.17.0
 
 * [Fixed] Fix version metadata submitted twice. See [#5325](https://github.com/DataDog/integrations-core/pull/5325).
 
-## 1.9.2 / 2019-12-20
+## 1.9.2 / 2019-12-20 / Agent 7.17.0
 
 * [Fixed] Fix version collection again. See [#5252](https://github.com/DataDog/integrations-core/pull/5252).
 
-## 1.9.1 / 2019-12-04
+## 1.9.1 / 2019-12-04 / Agent 7.17.0
 
 * [Fixed] Fix version collection. See [#5144](https://github.com/DataDog/integrations-core/pull/5144).
 
-## 1.9.0 / 2019-12-02
+## 1.9.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Standardize logging format. See [#4899](https://github.com/DataDog/integrations-core/pull/4899).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 * [Added] Submit version metadata. See [#4818](https://github.com/DataDog/integrations-core/pull/4818).
 
-## 1.8.0 / 2019-10-11
+## 1.8.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.7.1 / 2019-08-30
+## 1.7.1 / 2019-08-30 / Agent 6.15.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 1.7.0 / 2019-08-24
+## 1.7.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add support for proxy options. See [#3362](https://github.com/DataDog/integrations-core/pull/3362).
 
-## 1.6.0 / 2019-05-02
+## 1.6.0 / 2019-05-02 / Agent 6.12.0
 
 * [Added] Add option to Suppress `InsecureRequestWarning` when disable_ssl_validation is set. See [#2475](https://github.com/DataDog/integrations-core/pull/2475).
 
-## 1.5.0 / 2019-03-29
+## 1.5.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Adhere to code style. See [#3322](https://github.com/DataDog/integrations-core/pull/3322).
 
-## 1.4.0 / 2018-11-30
+## 1.4.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Add python3 support. See [#2497][1].
 
-## 1.3.1 / 2018-09-04
+## 1.3.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 
-## 1.3.0 / 2018-06-07
+## 1.3.0 / 2018-06-07 / Agent 5.25.0
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][4].
 

--- a/aspdotnet/CHANGELOG.md
+++ b/aspdotnet/CHANGELOG.md
@@ -1,52 +1,52 @@
 # CHANGELOG - Aspdotnet
 
-## 1.6.0 / 2020-06-29
+## 1.6.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 
-## 1.5.0 / 2020-05-17
+## 1.5.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.4.1 / 2020-04-04
+## 1.4.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update to Agent 6 signature. See [#5939](https://github.com/DataDog/integrations-core/pull/5939).
 
-## 1.4.0 / 2019-12-02
+## 1.4.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 1.3.0 / 2019-10-11
+## 1.3.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 1.2.1 / 2019-06-18
+## 1.2.1 / 2019-06-18 / Agent 6.13.0
 
 * [Fixed] Rename lower case manifest.in. See [#3858](https://github.com/DataDog/integrations-core/pull/3858).
 
-## 1.2.0 / 2019-05-14
+## 1.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3486](https://github.com/DataDog/integrations-core/pull/3486).
 
-## 1.1.0 / 2019-02-18
+## 1.1.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2986](https://github.com/DataDog/integrations-core/pull/2986).
 
-## 1.0.1 / 2019-01-04
+## 1.0.1 / 2019-01-04 / Agent 5.31.0
 
 * [Fixed] Change example config from "localhost" to ".". See [#2779][1].
 
-## 1.0.0 / 2018-10-13
+## 1.0.0 / 2018-10-13 / Agent 5.30.0
 
 * [Added] moves aspdotnet and dotnet clr metrics to their own checks. See [#884][2].
 
-## 0.2.0 / 2018-10-12
+## 0.2.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][3].
 * [Fixed] Remove unused port config option for pdh checks. See [#2244][4].
 
-## 0.1.3 / 2018-09-04
+## 0.1.3 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 

--- a/aspdotnet/CHANGELOG.md
+++ b/aspdotnet/CHANGELOG.md
@@ -28,25 +28,25 @@
 
 * [Added] Adhere to code style. See [#3486](https://github.com/DataDog/integrations-core/pull/3486).
 
-## 1.1.0 / 2019-02-18 / Agent 6.11.0
+## 1.1.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2986](https://github.com/DataDog/integrations-core/pull/2986).
 
-## 1.0.1 / 2019-01-04 / Agent 5.31.0
+## 1.0.1 / 2019-01-04 / Agent 6.9.0
 
 * [Fixed] Change example config from "localhost" to ".". See [#2779][1].
 
-## 1.0.0 / 2018-10-13 / Agent 5.30.0
+## 1.0.0 / 2018-10-13 / Agent 6.6.0
 
 * [Added] moves aspdotnet and dotnet clr metrics to their own checks. See [#884][2].
 
-## 0.2.0 / 2018-10-12 / Agent 5.28.0
+## 0.2.0 / 2018-10-12
 
 * [Added] Pin pywin32 dependency. See [#2322][3].
 * [Fixed] Remove unused port config option for pdh checks. See [#2244][4].
 
-## 0.1.3 / 2018-09-04 / Agent 5.28.0
+## 0.1.3 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 

--- a/btrfs/CHANGELOG.md
+++ b/btrfs/CHANGELOG.md
@@ -1,56 +1,56 @@
 # CHANGELOG - btrfs
 
-## 1.10.0 / 2020-05-17
+## 1.10.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add config spec. See [#6561](https://github.com/DataDog/integrations-core/pull/6561).
 * [Fixed] Use agent 6 signature. See [#6441](https://github.com/DataDog/integrations-core/pull/6441).
 
-## 1.9.0 / 2020-04-04
+## 1.9.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.8.1 / 2019-12-13
+## 1.8.1 / 2019-12-13 / Agent 7.17.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 1.8.0 / 2019-12-02
+## 1.8.0 / 2019-12-02 / Agent 7.16.0
 
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
 * [Added] Standardize logging format. See [#4900](https://github.com/DataDog/integrations-core/pull/4900).
 
-## 1.7.1 / 2019-10-11
+## 1.7.1 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Upgrade psutil dependency to 5.6.3. See [#4442](https://github.com/DataDog/integrations-core/pull/4442).
 
-## 1.7.0 / 2019-05-14
+## 1.7.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Upgrade psutil dependency to 5.6.2. See [#3684](https://github.com/DataDog/integrations-core/pull/3684).
 
-## 1.6.0 / 2019-03-29
+## 1.6.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Adhere to code style. See [#3324](https://github.com/DataDog/integrations-core/pull/3324).
 
-## 1.5.0 / 2019-02-18
+## 1.5.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Upgrade psutil. See [#3019](https://github.com/DataDog/integrations-core/pull/3019).
 * [Added] Finish Py3 support. See [#2900](https://github.com/DataDog/integrations-core/pull/2900).
 
-## 1.4.0 / 2018-11-30
+## 1.4.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Add Python3 Support. See [#2579][1].
 * [Added] Update psutil. See [#2576][2].
 
-## 1.3.0 / 2018-10-12
+## 1.3.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Upgrade psutil. See [#2190][3].
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 
-## 1.2.0 / 2018-06-07
+## 1.2.0 / 2018-06-07 / Agent 5.25.0
 
 * [Added] Support for RAID 5 and 6 and GlobalReserve types. See [#1570][5].
 * [Added] Metric for unallocated bytes. See [#1559][6].

--- a/btrfs/CHANGELOG.md
+++ b/btrfs/CHANGELOG.md
@@ -11,11 +11,11 @@
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.8.1 / 2019-12-13 / Agent 7.17.0
+## 1.8.1 / 2019-12-13 / Agent 7.16.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 1.8.0 / 2019-12-02 / Agent 7.16.0
+## 1.8.0 / 2019-12-02
 
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
 * [Added] Standardize logging format. See [#4900](https://github.com/DataDog/integrations-core/pull/4900).
@@ -32,25 +32,25 @@
 
 * [Added] Adhere to code style. See [#3324](https://github.com/DataDog/integrations-core/pull/3324).
 
-## 1.5.0 / 2019-02-18 / Agent 6.11.0
+## 1.5.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Upgrade psutil. See [#3019](https://github.com/DataDog/integrations-core/pull/3019).
 * [Added] Finish Py3 support. See [#2900](https://github.com/DataDog/integrations-core/pull/2900).
 
-## 1.4.0 / 2018-11-30 / Agent 5.30.0
+## 1.4.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Add Python3 Support. See [#2579][1].
 * [Added] Update psutil. See [#2576][2].
 
-## 1.3.0 / 2018-10-12 / Agent 5.28.0
+## 1.3.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Upgrade psutil. See [#2190][3].
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 
-## 1.2.0 / 2018-06-07 / Agent 5.25.0
+## 1.2.0 / 2018-06-07
 
 * [Added] Support for RAID 5 and 6 and GlobalReserve types. See [#1570][5].
 * [Added] Metric for unallocated bytes. See [#1559][6].

--- a/cacti/CHANGELOG.md
+++ b/cacti/CHANGELOG.md
@@ -1,35 +1,35 @@
 # CHANGELOG - cacti
 
-## 1.7.0 / 2020-05-17
+## 1.7.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add config spec. See [#6551](https://github.com/DataDog/integrations-core/pull/6551).
 
-## 1.6.1 / 2020-04-04
+## 1.6.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.6.0 / 2019-12-02
+## 1.6.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Standardize logging format. See [#4901](https://github.com/DataDog/integrations-core/pull/4901).
 
-## 1.5.0 / 2019-10-11
+## 1.5.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Allow custom port for mysql access. See [#4654](https://github.com/DataDog/integrations-core/pull/4654).
 
-## 1.4.0 / 2019-03-29
+## 1.4.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Adhere to code style. See [#3325](https://github.com/DataDog/integrations-core/pull/3325).
 
-## 1.3.0 / 2019-02-18
+## 1.3.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Finish Python 3 Support. See [#2901](https://github.com/DataDog/integrations-core/pull/2901).
 
-## 1.2.0 / 2018-11-30
+## 1.2.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Support Python3. See [#2622][1].
 
-## 1.1.2 / 2018-09-04
+## 1.1.2 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/cacti/CHANGELOG.md
+++ b/cacti/CHANGELOG.md
@@ -21,19 +21,19 @@
 
 * [Added] Adhere to code style. See [#3325](https://github.com/DataDog/integrations-core/pull/3325).
 
-## 1.3.0 / 2019-02-18 / Agent 6.11.0
+## 1.3.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Finish Python 3 Support. See [#2901](https://github.com/DataDog/integrations-core/pull/2901).
 
-## 1.2.0 / 2018-11-30 / Agent 5.30.0
+## 1.2.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Support Python3. See [#2622][1].
 
-## 1.1.2 / 2018-09-04 / Agent 5.28.0
+## 1.1.2 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.1.1 / 2018-06-20
+## 1.1.1 / 2018-06-20 / Agent 6.4.0
 
 * [Fixed] Remove gauge timestamp so the check works with agent 6. See [#1768][3].
 

--- a/cassandra/CHANGELOG.md
+++ b/cassandra/CHANGELOG.md
@@ -1,38 +1,38 @@
 # CHANGELOG - cassandra
 
-## 1.7.0 / 2020-08-10
+## 1.7.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add config specs. See [#7308](https://github.com/DataDog/integrations-core/pull/7308).
 
-## 1.6.1 / 2020-06-29
+## 1.6.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Assert new jvm metrics. See [#6996](https://github.com/DataDog/integrations-core/pull/6996).
 
-## 1.6.0 / 2020-05-17
+## 1.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.5.0 / 2020-04-04
+## 1.5.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add e2e testing and TotalBlockedTasks metric. See [#5957](https://github.com/DataDog/integrations-core/pull/5957).
 * [Added] Add node up/down default metrics. See [#5948](https://github.com/DataDog/integrations-core/pull/5948). Thanks [djova](https://github.com/djova).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 * [Fixed] Pattern needs to be quoted. See [#6110](https://github.com/DataDog/integrations-core/pull/6110). Thanks [allyunion](https://github.com/allyunion).
 
-## 1.4.0 / 2020-01-13
+## 1.4.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Add multi_line log_processing_rules. See [#5426](https://github.com/DataDog/integrations-core/pull/5426).
 * [Fixed] Fix broken link to logs multi-line aggregation docs. See [#5353](https://github.com/DataDog/integrations-core/pull/5353).
 
-## 1.3.1 / 2019-05-14
+## 1.3.1 / 2019-05-14 / Agent 6.12.0
 
 * [Fixed] Fix example tags section. See [#3431](https://github.com/DataDog/integrations-core/pull/3431).
 
-## 1.3.0 / 2018-10-12
+## 1.3.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] [jmx] add rmi registry ssl config option. See [#2371][1].
 
-## 1.2.2 / 2018-09-04
+## 1.2.2 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/cassandra/CHANGELOG.md
+++ b/cassandra/CHANGELOG.md
@@ -28,11 +28,11 @@
 
 * [Fixed] Fix example tags section. See [#3431](https://github.com/DataDog/integrations-core/pull/3431).
 
-## 1.3.0 / 2018-10-12 / Agent 5.28.0
+## 1.3.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] [jmx] add rmi registry ssl config option. See [#2371][1].
 
-## 1.2.2 / 2018-09-04 / Agent 5.28.0
+## 1.2.2 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/cassandra_nodetool/CHANGELOG.md
+++ b/cassandra_nodetool/CHANGELOG.md
@@ -22,27 +22,27 @@
 
 * [Added] Support old nodetool output format. See [#3253](https://github.com/DataDog/integrations-core/pull/3253). Thanks [hitsumabushi](https://github.com/hitsumabushi).
 
-## 1.3.0 / 2019-02-18 / Agent 6.11.0
+## 1.3.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Finish Python3 Support. See [#2905](https://github.com/DataDog/integrations-core/pull/2905).
 
-## 1.2.0 / 2019-01-04 / Agent 5.31.0
+## 1.2.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2761][1].
 
-## 1.1.0 / 2018-11-21 / Agent 5.30.0
+## 1.1.0 / 2018-11-21 / Agent 6.8.0
 
 * [Added] Add --ssl option to cassandra_nodetool check. See [#2378][2]. Thanks [laurieodgers][3].
 
-## 1.0.0 / 2018-10-13 / Agent 5.30.0
+## 1.0.0 / 2018-10-13 / Agent 6.6.0
 
 * [Added] Add cassandra_nodetool check. See [#511][4].
 
-## 0.1.3 / 2018-09-04 / Agent 5.28.0
+## 0.1.3 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 0.1.2 / 2018-06-13 / Agent 5.26.0
+## 0.1.2 / 2018-06-13 / Agent 6.4.0
 
 * [Fixed] Convert port to a string before calling get_subprocess_output. See [#1549][6]. Thanks [jalaziz][7].
 

--- a/cassandra_nodetool/CHANGELOG.md
+++ b/cassandra_nodetool/CHANGELOG.md
@@ -1,48 +1,48 @@
 # CHANGELOG - Cassandra Nodetool Check
 
-## 1.6.0 / 2020-05-17
+## 1.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Use agent 6 signature. See [#6442](https://github.com/DataDog/integrations-core/pull/6442).
 
-## 1.5.2 / 2020-04-04
+## 1.5.2 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.5.1 / 2019-12-02
+## 1.5.1 / 2019-12-02 / Agent 7.16.0
 
 * [Fixed] Remove shlex. See [#5068](https://github.com/DataDog/integrations-core/pull/5068).
 
-## 1.5.0 / 2019-05-14
+## 1.5.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3487](https://github.com/DataDog/integrations-core/pull/3487).
 * [Fixed] Check error code of nodetool command. See [#3632](https://github.com/DataDog/integrations-core/pull/3632).
 
-## 1.4.0 / 2019-03-29
+## 1.4.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Support old nodetool output format. See [#3253](https://github.com/DataDog/integrations-core/pull/3253). Thanks [hitsumabushi](https://github.com/hitsumabushi).
 
-## 1.3.0 / 2019-02-18
+## 1.3.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Finish Python3 Support. See [#2905](https://github.com/DataDog/integrations-core/pull/2905).
 
-## 1.2.0 / 2019-01-04
+## 1.2.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2761][1].
 
-## 1.1.0 / 2018-11-21
+## 1.1.0 / 2018-11-21 / Agent 5.30.0
 
 * [Added] Add --ssl option to cassandra_nodetool check. See [#2378][2]. Thanks [laurieodgers][3].
 
-## 1.0.0 / 2018-10-13
+## 1.0.0 / 2018-10-13 / Agent 5.30.0
 
 * [Added] Add cassandra_nodetool check. See [#511][4].
 
-## 0.1.3 / 2018-09-04
+## 0.1.3 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 0.1.2 / 2018-06-13
+## 0.1.2 / 2018-06-13 / Agent 5.26.0
 
 * [Fixed] Convert port to a string before calling get_subprocess_output. See [#1549][6]. Thanks [jalaziz][7].
 

--- a/ceph/CHANGELOG.md
+++ b/ceph/CHANGELOG.md
@@ -33,24 +33,24 @@
 
 * [Added] Add log setup and configuration. See [#3960](https://github.com/DataDog/integrations-core/pull/3960).
 
-## 1.5.1 / 2019-06-05 / Agent 6.13.0
+## 1.5.1 / 2019-06-05 / Agent 6.12.0
 
 * [Fixed] Fix version discovery. See [#3874](https://github.com/DataDog/integrations-core/pull/3874).
 
-## 1.5.0 / 2019-05-14 / Agent 6.12.0
+## 1.5.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3488](https://github.com/DataDog/integrations-core/pull/3488).
 
-## 1.4.0 / 2019-02-18 / Agent 6.11.0
+## 1.4.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Support Python 3. See [#2837](https://github.com/DataDog/integrations-core/pull/2837).
 
-## 1.3.2 / 2018-11-30 / Agent 5.30.0
+## 1.3.2 / 2018-11-30 / Agent 6.8.0
 
 * [Fixed] Use raw string literals when \ is present. See [#2465][1].
 
-## 1.3.1 / 2018-09-04 / Agent 5.28.0
+## 1.3.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/ceph/CHANGELOG.md
+++ b/ceph/CHANGELOG.md
@@ -1,56 +1,56 @@
 # CHANGELOG - ceph
 
-## 2.1.2 / 2020-08-10
+## 2.1.2 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 2.1.1 / 2020-06-29
+## 2.1.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 2.1.0 / 2020-05-17
+## 2.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add ceph config spec. See [#6563](https://github.com/DataDog/integrations-core/pull/6563).
 * [Fixed] Capture type errors as well as key errors for osd perf metrics. See [#6381](https://github.com/DataDog/integrations-core/pull/6381).
 
-## 2.0.0 / 2020-04-04
+## 2.0.0 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Fix response handling. See [#6152](https://github.com/DataDog/integrations-core/pull/6152).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 * [Changed] Account for "osdstats" key in newer versions. See [#5855](https://github.com/DataDog/integrations-core/pull/5855).
 
-## 1.8.0 / 2019-10-11
+## 1.8.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Adhere to logging call convention. See [#4738](https://github.com/DataDog/integrations-core/pull/4738).
 
-## 1.7.0 / 2019-08-24
+## 1.7.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Remove unused version command. See [#4249](https://github.com/DataDog/integrations-core/pull/4249).
 
-## 1.6.0 / 2019-07-09
+## 1.6.0 / 2019-07-09 / Agent 6.13.0
 
 * [Added] Add log setup and configuration. See [#3960](https://github.com/DataDog/integrations-core/pull/3960).
 
-## 1.5.1 / 2019-06-05
+## 1.5.1 / 2019-06-05 / Agent 6.13.0
 
 * [Fixed] Fix version discovery. See [#3874](https://github.com/DataDog/integrations-core/pull/3874).
 
-## 1.5.0 / 2019-05-14
+## 1.5.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3488](https://github.com/DataDog/integrations-core/pull/3488).
 
-## 1.4.0 / 2019-02-18
+## 1.4.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Support Python 3. See [#2837](https://github.com/DataDog/integrations-core/pull/2837).
 
-## 1.3.2 / 2018-11-30
+## 1.3.2 / 2018-11-30 / Agent 5.30.0
 
 * [Fixed] Use raw string literals when \ is present. See [#2465][1].
 
-## 1.3.1 / 2018-09-04
+## 1.3.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/cilium/CHANGELOG.md
+++ b/cilium/CHANGELOG.md
@@ -18,10 +18,10 @@
 
 * [Fixed] Remove unused variables. See [#5173](https://github.com/DataDog/integrations-core/pull/5173).
 
-## 1.0.1 / 2019-12-06 / Agent 7.17.0
+## 1.0.1 / 2019-12-06 / Agent 7.16.1
 
 * [Fixed] Raise configuration errors. See [#5163](https://github.com/DataDog/integrations-core/pull/5163).
 
-## 1.0.0 / 2019-11-19 / Agent 7.16.0
+## 1.0.0 / 2019-11-19
 
 * [Added] New Integration: Cilium. See [#4665](https://github.com/DataDog/integrations-core/pull/4665).

--- a/cilium/CHANGELOG.md
+++ b/cilium/CHANGELOG.md
@@ -1,27 +1,27 @@
 # CHANGELOG - Cilium
 
-## 1.3.0 / 2020-08-10
+## 1.3.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add config specs. See [#7319](https://github.com/DataDog/integrations-core/pull/7319).
 
-## 1.2.0 / 2020-05-17
+## 1.2.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Add environment runner for Kubernetes' `kind`. See [#6522](https://github.com/DataDog/integrations-core/pull/6522).
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.1.0 / 2020-04-04
+## 1.1.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add Cilium version metadata. See [#5408](https://github.com/DataDog/integrations-core/pull/5408).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.0.2 / 2020-01-13
+## 1.0.2 / 2020-01-13 / Agent 7.17.0
 
 * [Fixed] Remove unused variables. See [#5173](https://github.com/DataDog/integrations-core/pull/5173).
 
-## 1.0.1 / 2019-12-06
+## 1.0.1 / 2019-12-06 / Agent 7.17.0
 
 * [Fixed] Raise configuration errors. See [#5163](https://github.com/DataDog/integrations-core/pull/5163).
 
-## 1.0.0 / 2019-11-19
+## 1.0.0 / 2019-11-19 / Agent 7.16.0
 
 * [Added] New Integration: Cilium. See [#4665](https://github.com/DataDog/integrations-core/pull/4665).

--- a/cisco_aci/CHANGELOG.md
+++ b/cisco_aci/CHANGELOG.md
@@ -1,85 +1,85 @@
 # CHANGELOG - cisco_aci
 
-## 1.10.1 / 2020-08-10
+## 1.10.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 
-## 1.10.0 / 2020-06-29
+## 1.10.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.9.0 / 2020-05-17
+## 1.9.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add config spec. See [#6314](https://github.com/DataDog/integrations-core/pull/6314).
 
-## 1.8.4 / 2020-04-04
+## 1.8.4 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.8.3 / 2020-02-22
+## 1.8.3 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Update request wrapper with password and A6 signature. See [#5684](https://github.com/DataDog/integrations-core/pull/5684).
 
-## 1.8.2 / 2019-12-27
+## 1.8.2 / 2019-12-27 / Agent 7.17.0
 
 * [Fixed] Ensure only one session object per url. See [#5334](https://github.com/DataDog/integrations-core/pull/5334).
 
-## 1.8.1 / 2019-12-02
+## 1.8.1 / 2019-12-02 / Agent 7.16.0
 
 * [Fixed] Use RequestsWrapper. See [#5037](https://github.com/DataDog/integrations-core/pull/5037).
 
-## 1.8.0 / 2019-11-20
+## 1.8.0 / 2019-11-20 / Agent 7.16.0
 
 * [Added] Upgrade cryptography to 2.8. See [#5047](https://github.com/DataDog/integrations-core/pull/5047).
 * [Fixed] Refresh auth token when it expires. See [#5039](https://github.com/DataDog/integrations-core/pull/5039).
 * [Added] Standardize logging format. See [#4902](https://github.com/DataDog/integrations-core/pull/4902).
 
-## 1.7.2 / 2019-08-24
+## 1.7.2 / 2019-08-24 / Agent 6.14.0
 
 * [Fixed] Use utcnow instead of now. See [#4192](https://github.com/DataDog/integrations-core/pull/4192).
 
-## 1.7.1 / 2019-07-08
+## 1.7.1 / 2019-07-08 / Agent 6.13.0
 
 * [Fixed] Fix event submission call. See [#4044](https://github.com/DataDog/integrations-core/pull/4044).
 
-## 1.7.0 / 2019-07-04
+## 1.7.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Update cryptography version. See [#4000](https://github.com/DataDog/integrations-core/pull/4000).
 
-## 1.6.0 / 2019-06-01
+## 1.6.0 / 2019-06-01 / Agent 6.12.0
 
 * [Added] Improve API logs. See [#3794](https://github.com/DataDog/integrations-core/pull/3794).
 * [Fixed] Sanitize external host tags. See [#3792](https://github.com/DataDog/integrations-core/pull/3792).
 
-## 1.5.0 / 2019-05-14
+## 1.5.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3489](https://github.com/DataDog/integrations-core/pull/3489).
 
-## 1.4.0 / 2019-02-18
+## 1.4.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Support Python 3. See [#3029](https://github.com/DataDog/integrations-core/pull/3029).
 
-## 1.3.0 / 2018-11-30
+## 1.3.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Upgrade cryptography. See [#2659][1].
 * [Fixed] Use raw string literals when \ is present. See [#2465][2].
 
-## 1.2.1 / 2018-10-12
+## 1.2.1 / 2018-10-12 / Agent 5.28.0
 
 * [Fixed] fixes cisco for username and password. See [#2267][3].
 
-## 1.2.0 / 2018-09-04
+## 1.2.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Use Certs in the Cisco Check as well as Passwords. See [#1986][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 1.1.0 / 2018-06-21
+## 1.1.0 / 2018-06-21 / Agent 5.26.0
 
 * [Fixed] Makes the Cisco Check more resilient. See [#1785][6].
 
-## 1.0.0 / 2018-06-07
+## 1.0.0 / 2018-06-07 / Agent 5.25.0
 
 * [FEATURE] adds CiscoACI integration.
 [1]: https://github.com/DataDog/integrations-core/pull/2659

--- a/cisco_aci/CHANGELOG.md
+++ b/cisco_aci/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 * [Fixed] Use RequestsWrapper. See [#5037](https://github.com/DataDog/integrations-core/pull/5037).
 
-## 1.8.0 / 2019-11-20 / Agent 7.16.0
+## 1.8.0 / 2019-11-20
 
 * [Added] Upgrade cryptography to 2.8. See [#5047](https://github.com/DataDog/integrations-core/pull/5047).
 * [Fixed] Refresh auth token when it expires. See [#5039](https://github.com/DataDog/integrations-core/pull/5039).
@@ -43,7 +43,7 @@
 
 * [Fixed] Fix event submission call. See [#4044](https://github.com/DataDog/integrations-core/pull/4044).
 
-## 1.7.0 / 2019-07-04 / Agent 6.13.0
+## 1.7.0 / 2019-07-04
 
 * [Added] Update cryptography version. See [#4000](https://github.com/DataDog/integrations-core/pull/4000).
 
@@ -52,34 +52,34 @@
 * [Added] Improve API logs. See [#3794](https://github.com/DataDog/integrations-core/pull/3794).
 * [Fixed] Sanitize external host tags. See [#3792](https://github.com/DataDog/integrations-core/pull/3792).
 
-## 1.5.0 / 2019-05-14 / Agent 6.12.0
+## 1.5.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3489](https://github.com/DataDog/integrations-core/pull/3489).
 
-## 1.4.0 / 2019-02-18 / Agent 6.11.0
+## 1.4.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Support Python 3. See [#3029](https://github.com/DataDog/integrations-core/pull/3029).
 
-## 1.3.0 / 2018-11-30 / Agent 5.30.0
+## 1.3.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Upgrade cryptography. See [#2659][1].
 * [Fixed] Use raw string literals when \ is present. See [#2465][2].
 
-## 1.2.1 / 2018-10-12 / Agent 5.28.0
+## 1.2.1 / 2018-10-12 / Agent 6.6.0
 
 * [Fixed] fixes cisco for username and password. See [#2267][3].
 
-## 1.2.0 / 2018-09-04 / Agent 5.28.0
+## 1.2.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Use Certs in the Cisco Check as well as Passwords. See [#1986][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 1.1.0 / 2018-06-21 / Agent 5.26.0
+## 1.1.0 / 2018-06-21 / Agent 6.4.0
 
 * [Fixed] Makes the Cisco Check more resilient. See [#1785][6].
 
-## 1.0.0 / 2018-06-07 / Agent 5.25.0
+## 1.0.0 / 2018-06-07
 
 * [FEATURE] adds CiscoACI integration.
 [1]: https://github.com/DataDog/integrations-core/pull/2659

--- a/clickhouse/CHANGELOG.md
+++ b/clickhouse/CHANGELOG.md
@@ -23,10 +23,10 @@
 * [Added] Add newly-documented metrics. See [#5795](https://github.com/DataDog/integrations-core/pull/5795).
 * [Added] Add new metric for tracking MySQL connections. See [#5700](https://github.com/DataDog/integrations-core/pull/5700).
 
-## 1.0.1 / 2020-01-24 / Agent 7.18.0
+## 1.0.1 / 2020-01-24 / Agent 7.17.0
 
 * [Fixed] Fix config. See [#5551](https://github.com/DataDog/integrations-core/pull/5551).
 
-## 1.0.0 / 2019-12-18 / Agent 7.17.0
+## 1.0.0 / 2019-12-18
 
 * [Added] Add ClickHouse integration. See [#4957](https://github.com/DataDog/integrations-core/pull/4957).

--- a/clickhouse/CHANGELOG.md
+++ b/clickhouse/CHANGELOG.md
@@ -1,32 +1,32 @@
 # CHANGELOG - ClickHouse
 
-## 1.3.2 / 2020-07-09
+## 1.3.2 / 2020-07-09 / Agent 7.22.0
 
 * [Fixed] Update `can_connect` service check status on each check run. See [#7006](https://github.com/DataDog/integrations-core/pull/7006). Thanks [isaachui](https://github.com/isaachui).
 
-## 1.3.1 / 2020-06-19
+## 1.3.1 / 2020-06-19 / Agent 7.21.0
 
 * [Fixed] Submit `can_connect` service check on each check run. See [#6926](https://github.com/DataDog/integrations-core/pull/6926).
 
-## 1.3.0 / 2020-05-17
+## 1.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.2.0 / 2020-04-04
+## 1.2.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add `ddev test` option to verify support of new metrics. See [#6141](https://github.com/DataDog/integrations-core/pull/6141).
 * [Added] Add new metrics: `cache_dictionary.update_queue.batches`, `cache_dictionary.update_queue.keys` . See [#5976](https://github.com/DataDog/integrations-core/pull/5976).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.1.0 / 2020-02-22
+## 1.1.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add newly-documented metrics. See [#5795](https://github.com/DataDog/integrations-core/pull/5795).
 * [Added] Add new metric for tracking MySQL connections. See [#5700](https://github.com/DataDog/integrations-core/pull/5700).
 
-## 1.0.1 / 2020-01-24
+## 1.0.1 / 2020-01-24 / Agent 7.18.0
 
 * [Fixed] Fix config. See [#5551](https://github.com/DataDog/integrations-core/pull/5551).
 
-## 1.0.0 / 2019-12-18
+## 1.0.0 / 2019-12-18 / Agent 7.17.0
 
 * [Added] Add ClickHouse integration. See [#4957](https://github.com/DataDog/integrations-core/pull/4957).

--- a/cloud_foundry_api/CHANGELOG.md
+++ b/cloud_foundry_api/CHANGELOG.md
@@ -1,12 +1,12 @@
 # CHANGELOG - Cloud Foundry API
 
-## 0.2.0 / 2020-08-10
+## 0.2.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add space and org names as tags to events. See [#7297](https://github.com/DataDog/integrations-core/pull/7297).
 * [Fixed] Stop sending events multiple times. See [#7293](https://github.com/DataDog/integrations-core/pull/7293).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 
-## 0.1.0 / 2020-06-29
+## 0.1.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 

--- a/cockroachdb/CHANGELOG.md
+++ b/cockroachdb/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 * [Added] Adhere to code style. See [#3490](https://github.com/DataDog/integrations-core/pull/3490).
 
-## 1.0.0 / 2018-10-13 / Agent 5.30.0
+## 1.0.0 / 2018-10-13 / Agent 6.6.0
 
 * [Added] Add cockroachdb integration. See [#2150][1].
 

--- a/cockroachdb/CHANGELOG.md
+++ b/cockroachdb/CHANGELOG.md
@@ -1,19 +1,19 @@
 # CHANGELOG - CockroachDB
 
-## 1.3.0 / 2020-05-17
+## 1.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.2.0 / 2020-04-04
+## 1.2.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Collect metadata for cockroachdb. See [#5924](https://github.com/DataDog/integrations-core/pull/5924).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.1.0 / 2019-05-14
+## 1.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3490](https://github.com/DataDog/integrations-core/pull/3490).
 
-## 1.0.0 / 2018-10-13
+## 1.0.0 / 2018-10-13 / Agent 5.30.0
 
 * [Added] Add cockroachdb integration. See [#2150][1].
 

--- a/confluent_platform/CHANGELOG.md
+++ b/confluent_platform/CHANGELOG.md
@@ -1,22 +1,22 @@
 # CHANGELOG - Confluent Platform
 
-## 1.1.2 / 2020-08-10
+## 1.1.2 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] Add new_gc_metrics to all jmx integrations. See [#7073](https://github.com/DataDog/integrations-core/pull/7073).
 
-## 1.1.1 / 2020-06-29
+## 1.1.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 * [Fixed] Adjust jmxfetch config. See [#6864](https://github.com/DataDog/integrations-core/pull/6864).
 
-## 1.1.0 / 2020-05-17
+## 1.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add rmi_connection_timeout & rmi_client_timeout to config spec. See [#6459](https://github.com/DataDog/integrations-core/pull/6459).
 * [Added] Add default template to openmetrics & jmx config. See [#6328](https://github.com/DataDog/integrations-core/pull/6328).
 
-## 1.0.0 / 2020-04-03
+## 1.0.0 / 2020-04-03 / Agent 7.19.0
 
 * [Added] Add Confluent Platform new integration. See [#5733](https://github.com/DataDog/integrations-core/pull/5733).
 

--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -1,89 +1,89 @@
 # CHANGELOG - consul
 
-## 1.15.1 / 2020-08-10
+## 1.15.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.15.0 / 2020-06-29
+## 1.15.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.14.0 / 2020-05-17
+## 1.14.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add config spec. See [#6317](https://github.com/DataDog/integrations-core/pull/6317).
 
-## 1.13.0 / 2020-04-04
+## 1.13.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Added] Add new metric to count services. See [#5992](https://github.com/DataDog/integrations-core/pull/5992).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.12.2 / 2020-02-25
+## 1.12.2 / 2020-02-25 / Agent 7.19.0
 
 * [Fixed] Change new added tag. See [#5856](https://github.com/DataDog/integrations-core/pull/5856).
 
-## 1.12.1 / 2020-02-25
+## 1.12.1 / 2020-02-25 / Agent 7.19.0
 
 * [Fixed] Bump minimun agent version. See [#5834](https://github.com/DataDog/integrations-core/pull/5834).
 
-## 1.12.0 / 2020-02-22
+## 1.12.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Create `consul_service` tag. See [#5519](https://github.com/DataDog/integrations-core/pull/5519). Thanks [nicbono](https://github.com/nicbono).
 * [Deprecated] Deprecate `service` tag. See [#5540](https://github.com/DataDog/integrations-core/pull/5540).
 
-## 1.11.0 / 2019-12-02
+## 1.11.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add version metadata. See [#4944](https://github.com/DataDog/integrations-core/pull/4944).
 * [Added] Standardize logging format. See [#4903](https://github.com/DataDog/integrations-core/pull/4903).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.10.0 / 2019-10-11
+## 1.10.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.9.1 / 2019-08-30
+## 1.9.1 / 2019-08-30 / Agent 6.15.0
 
 * [Fixed] Fix RequestsWrapper options. See [#4476](https://github.com/DataDog/integrations-core/pull/4476).
 
-## 1.9.0 / 2019-08-24
+## 1.9.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add support for proxy options. See [#3363](https://github.com/DataDog/integrations-core/pull/3363).
 * [Fixed] Fix Consul event timestamp. See [#4173](https://github.com/DataDog/integrations-core/pull/4173).
 
-## 1.8.0 / 2019-05-14
+## 1.8.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3491](https://github.com/DataDog/integrations-core/pull/3491).
 
-## 1.7.0 / 2019-02-18
+## 1.7.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Add `consul.can_connect` service check for every HTTP request to consul. See [#3003](https://github.com/DataDog/integrations-core/pull/3003).
 * [Added] Finish supporting Py3. See [#2906](https://github.com/DataDog/integrations-core/pull/2906).
 
-## 1.6.0 / 2018-11-30
+## 1.6.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Add option to run the full check on any node. See [#2461][1].
 * [Added] Support Python 3. See [#2446][2].
 
-## 1.5.2 / 2018-10-12
+## 1.5.2 / 2018-10-12 / Agent 5.28.0
 
 * [Fixed] Update consul timestamp to use supported python functions. See [#2199][3]. Thanks [hhansell][4].
 
-## 1.5.1 / 2018-09-04
+## 1.5.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Accept more standard boolean values for instance config options. See [#1954][5].
 * [Fixed] Add data files to the wheel package. See [#1727][6].
 
-## 1.5.0 / 2018-06-07
+## 1.5.0 / 2018-06-07 / Agent 5.25.0
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][7].
 * [Added] Include consul_datacenter tag in service checks. See [#1526][8]. Thanks [TylerLubeck][9].
 * [Added] Add a check to count all nodes in a consul cluster. See [#1479][10]. Thanks [TylerLubeck][9].
 
-## 1.4.0 / 2018-05-11
+## 1.4.0 / 2018-05-11 / Agent 5.24.0
 
 * [FEATURE] Hardcode the 8500 port in the Autodiscovery template. See [#1444][11] for more information.
 * [FEATURE] Include consul_datacenter tag in service checks

--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -22,15 +22,15 @@
 * [Added] Add new metric to count services. See [#5992](https://github.com/DataDog/integrations-core/pull/5992).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.12.2 / 2020-02-25 / Agent 7.19.0
+## 1.12.2 / 2020-02-25 / Agent 7.18.0
 
 * [Fixed] Change new added tag. See [#5856](https://github.com/DataDog/integrations-core/pull/5856).
 
-## 1.12.1 / 2020-02-25 / Agent 7.19.0
+## 1.12.1 / 2020-02-25
 
 * [Fixed] Bump minimun agent version. See [#5834](https://github.com/DataDog/integrations-core/pull/5834).
 
-## 1.12.0 / 2020-02-22 / Agent 7.18.0
+## 1.12.0 / 2020-02-22
 
 * [Added] Create `consul_service` tag. See [#5519](https://github.com/DataDog/integrations-core/pull/5519). Thanks [nicbono](https://github.com/nicbono).
 * [Deprecated] Deprecate `service` tag. See [#5540](https://github.com/DataDog/integrations-core/pull/5540).
@@ -45,11 +45,11 @@
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.9.1 / 2019-08-30 / Agent 6.15.0
+## 1.9.1 / 2019-08-30 / Agent 6.14.0
 
 * [Fixed] Fix RequestsWrapper options. See [#4476](https://github.com/DataDog/integrations-core/pull/4476).
 
-## 1.9.0 / 2019-08-24 / Agent 6.14.0
+## 1.9.0 / 2019-08-24
 
 * [Added] Add support for proxy options. See [#3363](https://github.com/DataDog/integrations-core/pull/3363).
 * [Fixed] Fix Consul event timestamp. See [#4173](https://github.com/DataDog/integrations-core/pull/4173).
@@ -58,32 +58,32 @@
 
 * [Added] Adhere to code style. See [#3491](https://github.com/DataDog/integrations-core/pull/3491).
 
-## 1.7.0 / 2019-02-18 / Agent 6.11.0
+## 1.7.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Add `consul.can_connect` service check for every HTTP request to consul. See [#3003](https://github.com/DataDog/integrations-core/pull/3003).
 * [Added] Finish supporting Py3. See [#2906](https://github.com/DataDog/integrations-core/pull/2906).
 
-## 1.6.0 / 2018-11-30 / Agent 5.30.0
+## 1.6.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Add option to run the full check on any node. See [#2461][1].
 * [Added] Support Python 3. See [#2446][2].
 
-## 1.5.2 / 2018-10-12 / Agent 5.28.0
+## 1.5.2 / 2018-10-12 / Agent 6.6.0
 
 * [Fixed] Update consul timestamp to use supported python functions. See [#2199][3]. Thanks [hhansell][4].
 
-## 1.5.1 / 2018-09-04 / Agent 5.28.0
+## 1.5.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Accept more standard boolean values for instance config options. See [#1954][5].
 * [Fixed] Add data files to the wheel package. See [#1727][6].
 
-## 1.5.0 / 2018-06-07 / Agent 5.25.0
+## 1.5.0 / 2018-06-07
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][7].
 * [Added] Include consul_datacenter tag in service checks. See [#1526][8]. Thanks [TylerLubeck][9].
 * [Added] Add a check to count all nodes in a consul cluster. See [#1479][10]. Thanks [TylerLubeck][9].
 
-## 1.4.0 / 2018-05-11 / Agent 5.24.0
+## 1.4.0 / 2018-05-11
 
 * [FEATURE] Hardcode the 8500 port in the Autodiscovery template. See [#1444][11] for more information.
 * [FEATURE] Include consul_datacenter tag in service checks

--- a/coredns/CHANGELOG.md
+++ b/coredns/CHANGELOG.md
@@ -22,11 +22,11 @@
 
 * [Added] Adhere to code style. See [#3492](https://github.com/DataDog/integrations-core/pull/3492).
 
-## 1.1.0 / 2018-11-30 / Agent 5.30.0
+## 1.1.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Add panic_count_total metric to CoreDNS integration. See [#2594][1]. Thanks [woopstar][2].
 
-## 1.0.0 / 2018-10-13 / Agent 5.30.0
+## 1.0.0 / 2018-10-13 / Agent 6.6.0
 
 * [Added] Add CoreDNS integration. See [#2091][3]. Thanks [shraykay][4].
 

--- a/coredns/CHANGELOG.md
+++ b/coredns/CHANGELOG.md
@@ -1,32 +1,32 @@
 # CHANGELOG - CoreDNS
 
-## 1.5.0 / 2020-07-16
+## 1.5.0 / 2020-07-16 / Agent 7.22.0
 
 * [Added] Adding new metrics for version 1.7.0 of CoreDNS. See [#6973](https://github.com/DataDog/integrations-core/pull/6973).
 
-## 1.4.0 / 2020-05-17
+## 1.4.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Agent 6 signature. See [#6444](https://github.com/DataDog/integrations-core/pull/6444).
 
-## 1.3.1 / 2020-04-04
+## 1.3.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Do not fail on octet stream content type for OpenMetrics. See [#5843](https://github.com/DataDog/integrations-core/pull/5843).
 
-## 1.3.0 / 2019-10-29
+## 1.3.0 / 2019-10-29 / Agent 7.16.0
 
 * [Added] Add forward metrics. See [#4850](https://github.com/DataDog/integrations-core/pull/4850). Thanks [therc](https://github.com/therc).
 
-## 1.2.0 / 2019-05-14
+## 1.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3492](https://github.com/DataDog/integrations-core/pull/3492).
 
-## 1.1.0 / 2018-11-30
+## 1.1.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Add panic_count_total metric to CoreDNS integration. See [#2594][1]. Thanks [woopstar][2].
 
-## 1.0.0 / 2018-10-13
+## 1.0.0 / 2018-10-13 / Agent 5.30.0
 
 * [Added] Add CoreDNS integration. See [#2091][3]. Thanks [shraykay][4].
 

--- a/couch/CHANGELOG.md
+++ b/couch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - couch
 
-## 3.11.0 / 2020-08-10
+## 3.11.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] couch config specs. See [#7160](https://github.com/DataDog/integrations-core/pull/7160).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
@@ -8,74 +8,74 @@
 * [Fixed] Use inclusive wording. See [#7159](https://github.com/DataDog/integrations-core/pull/7159).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 3.10.0 / 2020-06-29
+## 3.10.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 3.9.0 / 2020-05-17
+## 3.9.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 3.8.1 / 2020-04-04
+## 3.8.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 3.8.0 / 2020-02-22
+## 3.8.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add version metadata. See [#5615](https://github.com/DataDog/integrations-core/pull/5615).
 
-## 3.7.0 / 2020-01-13
+## 3.7.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 
-## 3.6.0 / 2019-12-02
+## 3.6.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Standardize logging format. See [#4904](https://github.com/DataDog/integrations-core/pull/4904).
 
-## 3.5.0 / 2019-10-11
+## 3.5.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 3.4.1 / 2019-08-30
+## 3.4.1 / 2019-08-30 / Agent 6.15.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 3.4.0 / 2019-08-24
+## 3.4.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add RequestsWrapper to couch. See [#4118](https://github.com/DataDog/integrations-core/pull/4118).
 
-## 3.3.0 / 2019-05-14
+## 3.3.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3493](https://github.com/DataDog/integrations-core/pull/3493).
 
-## 3.2.1 / 2019-03-29
+## 3.2.1 / 2019-03-29 / Agent 6.11.0
 
 * [Fixed] Include exception in connection error messages. See [#3262](https://github.com/DataDog/integrations-core/pull/3262).
 
-## 3.2.0 / 2019-02-18
+## 3.2.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Finish Python 3 Support. See [#2911](https://github.com/DataDog/integrations-core/pull/2911).
 
-## 3.1.0 / 2019-01-04
+## 3.1.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2721][1].
 
-## 3.0.0 / 2018-11-30
+## 3.0.0 / 2018-11-30 / Agent 5.30.0
 
 * [Removed] Add CouchDB 2.2.0 compatibility by dropping the `purge_seq` metric. See [#2287][2]. Thanks [janl][3].
 
-## 2.6.1 / 2018-09-04
+## 2.6.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 2.6.0 / 2018-06-07
+## 2.6.0 / 2018-06-07 / Agent 5.25.0
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][6].
 * [Added] Raise custom exceptions for specific errors instead of a generic `Exception`.
 
-## 2.5.0 / 2018-05-11
+## 2.5.0 / 2018-05-11 / Agent 5.24.0
 
 * [FEATURE] Hardcode the 5984 port in the Autodiscovery template. See [#1444][7] for more information.
 

--- a/couch/CHANGELOG.md
+++ b/couch/CHANGELOG.md
@@ -37,11 +37,11 @@
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 3.4.1 / 2019-08-30 / Agent 6.15.0
+## 3.4.1 / 2019-08-30 / Agent 6.14.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 3.4.0 / 2019-08-24 / Agent 6.14.0
+## 3.4.0 / 2019-08-24
 
 * [Added] Add RequestsWrapper to couch. See [#4118](https://github.com/DataDog/integrations-core/pull/4118).
 
@@ -53,29 +53,29 @@
 
 * [Fixed] Include exception in connection error messages. See [#3262](https://github.com/DataDog/integrations-core/pull/3262).
 
-## 3.2.0 / 2019-02-18 / Agent 6.11.0
+## 3.2.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Finish Python 3 Support. See [#2911](https://github.com/DataDog/integrations-core/pull/2911).
 
-## 3.1.0 / 2019-01-04 / Agent 5.31.0
+## 3.1.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2721][1].
 
-## 3.0.0 / 2018-11-30 / Agent 5.30.0
+## 3.0.0 / 2018-11-30 / Agent 6.8.0
 
 * [Removed] Add CouchDB 2.2.0 compatibility by dropping the `purge_seq` metric. See [#2287][2]. Thanks [janl][3].
 
-## 2.6.1 / 2018-09-04 / Agent 5.28.0
+## 2.6.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 2.6.0 / 2018-06-07 / Agent 5.25.0
+## 2.6.0 / 2018-06-07
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][6].
 * [Added] Raise custom exceptions for specific errors instead of a generic `Exception`.
 
-## 2.5.0 / 2018-05-11 / Agent 5.24.0
+## 2.5.0 / 2018-05-11
 
 * [FEATURE] Hardcode the 5984 port in the Autodiscovery template. See [#1444][7] for more information.
 

--- a/couchbase/CHANGELOG.md
+++ b/couchbase/CHANGELOG.md
@@ -18,11 +18,11 @@
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 * [Fixed] Update `conf.yaml.example` log collection section. See [#5977](https://github.com/DataDog/integrations-core/pull/5977).
 
-## 1.12.1 / 2019-12-06 / Agent 7.17.0
+## 1.12.1 / 2019-12-06 / Agent 7.16.0
 
 * [Fixed] Fix version metadata parsing. See [#5148](https://github.com/DataDog/integrations-core/pull/5148).
 
-## 1.12.0 / 2019-12-02 / Agent 7.16.0
+## 1.12.0 / 2019-12-02
 
 * [Added] add version metadata. See [#4985](https://github.com/DataDog/integrations-core/pull/4985).
 * [Added] Standardize logging format. See [#4905](https://github.com/DataDog/integrations-core/pull/4905).
@@ -33,15 +33,15 @@
 * [Fixed] Fix typo for couchbase.by_node.cluster_membership service check. See [#4565](https://github.com/DataDog/integrations-core/pull/4565).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.10.0 / 2019-09-16 / Agent 6.15.0
+## 1.10.0 / 2019-09-16
 
 * [Added] Add log documentation in the example configuration file. See [#4537](https://github.com/DataDog/integrations-core/pull/4537).
 
-## 1.9.1 / 2019-08-30 / Agent 6.15.0
+## 1.9.1 / 2019-08-30 / Agent 6.14.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 1.9.0 / 2019-08-24 / Agent 6.14.0
+## 1.9.0 / 2019-08-24
 
 * [Added] Add RequestsWrapper to couchbase. See [#4119](https://github.com/DataDog/integrations-core/pull/4119).
 
@@ -57,29 +57,29 @@
 
 * [Fixed] Fixed a typo in the example config file. See [#3173](https://github.com/DataDog/integrations-core/pull/3173).
 
-## 1.7.0 / 2019-01-04 / Agent 5.31.0
+## 1.7.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2851][1].
 * [Fixed] Stop using deprecated 'device_name' parameter.. See [#2847][2].
 
-## 1.6.1 / 2018-11-23 / Agent 5.30.0
+## 1.6.1 / 2018-11-23 / Agent 6.8.0
 
 * [Fixed] Keep running the check when one endpoint fails. See [#2638][3].
 
-## 1.6.0 / 2018-11-14 / Agent 5.30.0
+## 1.6.0 / 2018-11-14
 
 * [Added] Add ssl_verify option. See [#2584][4].
 * [Fixed] Use raw string literals when \ is present. See [#2465][5].
 
-## 1.5.1 / 2018-09-04 / Agent 5.28.0
+## 1.5.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][6].
 
-## 1.5.0 / 2018-06-20 / Agent 5.26.0
+## 1.5.0 / 2018-06-20 / Agent 6.4.0
 
 * [Added] Add Couchbase health and cluster membership service checks and alerts. See [#1593][7].
 
-## 1.4.0 / 2018-06-07 / Agent 5.25.0
+## 1.4.0 / 2018-06-07
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][8].
 * [Fixed] Couchbase integration was not working during server set up. See [#1571][9].

--- a/couchbase/CHANGELOG.md
+++ b/couchbase/CHANGELOG.md
@@ -1,85 +1,85 @@
 # CHANGELOG - couchbase
 
-## 1.14.1 / 2020-08-10
+## 1.14.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.14.0 / 2020-06-29
+## 1.14.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.13.0 / 2020-05-17
+## 1.13.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.12.2 / 2020-04-04
+## 1.12.2 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 * [Fixed] Update `conf.yaml.example` log collection section. See [#5977](https://github.com/DataDog/integrations-core/pull/5977).
 
-## 1.12.1 / 2019-12-06
+## 1.12.1 / 2019-12-06 / Agent 7.17.0
 
 * [Fixed] Fix version metadata parsing. See [#5148](https://github.com/DataDog/integrations-core/pull/5148).
 
-## 1.12.0 / 2019-12-02
+## 1.12.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] add version metadata. See [#4985](https://github.com/DataDog/integrations-core/pull/4985).
 * [Added] Standardize logging format. See [#4905](https://github.com/DataDog/integrations-core/pull/4905).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.11.0 / 2019-09-23
+## 1.11.0 / 2019-09-23 / Agent 6.15.0
 
 * [Fixed] Fix typo for couchbase.by_node.cluster_membership service check. See [#4565](https://github.com/DataDog/integrations-core/pull/4565).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.10.0 / 2019-09-16
+## 1.10.0 / 2019-09-16 / Agent 6.15.0
 
 * [Added] Add log documentation in the example configuration file. See [#4537](https://github.com/DataDog/integrations-core/pull/4537).
 
-## 1.9.1 / 2019-08-30
+## 1.9.1 / 2019-08-30 / Agent 6.15.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 1.9.0 / 2019-08-24
+## 1.9.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add RequestsWrapper to couchbase. See [#4119](https://github.com/DataDog/integrations-core/pull/4119).
 
-## 1.8.1 / 2019-07-12
+## 1.8.1 / 2019-07-12 / Agent 6.13.0
 
 * [Fixed] Change `couchbase.by_bucket.avg_bg_wait_time` metric unit from second to microsecond. See [#4078](https://github.com/DataDog/integrations-core/pull/4078).
 
-## 1.8.0 / 2019-05-14
+## 1.8.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3494](https://github.com/DataDog/integrations-core/pull/3494).
 
-## 1.7.1 / 2019-03-29
+## 1.7.1 / 2019-03-29 / Agent 6.11.0
 
 * [Fixed] Fixed a typo in the example config file. See [#3173](https://github.com/DataDog/integrations-core/pull/3173).
 
-## 1.7.0 / 2019-01-04
+## 1.7.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2851][1].
 * [Fixed] Stop using deprecated 'device_name' parameter.. See [#2847][2].
 
-## 1.6.1 / 2018-11-23
+## 1.6.1 / 2018-11-23 / Agent 5.30.0
 
 * [Fixed] Keep running the check when one endpoint fails. See [#2638][3].
 
-## 1.6.0 / 2018-11-14
+## 1.6.0 / 2018-11-14 / Agent 5.30.0
 
 * [Added] Add ssl_verify option. See [#2584][4].
 * [Fixed] Use raw string literals when \ is present. See [#2465][5].
 
-## 1.5.1 / 2018-09-04
+## 1.5.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][6].
 
-## 1.5.0 / 2018-06-20
+## 1.5.0 / 2018-06-20 / Agent 5.26.0
 
 * [Added] Add Couchbase health and cluster membership service checks and alerts. See [#1593][7].
 
-## 1.4.0 / 2018-06-07
+## 1.4.0 / 2018-06-07 / Agent 5.25.0
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][8].
 * [Fixed] Couchbase integration was not working during server set up. See [#1571][9].

--- a/crio/CHANGELOG.md
+++ b/crio/CHANGELOG.md
@@ -20,11 +20,11 @@
 
 * [Added] Adhere to code style. See [#3495](https://github.com/DataDog/integrations-core/pull/3495).
 
-## 1.1.0 / 2019-01-04 / Agent 5.31.0
+## 1.1.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Add nginx ingress controller integration. See [#2853][1].
 
-## 1.0.0 / 2018-10-13 / Agent 5.30.0
+## 1.0.0 / 2018-10-13 / Agent 6.6.0
 
 * [Added] Add a CRI-O check. See [#2231][2].
 

--- a/crio/CHANGELOG.md
+++ b/crio/CHANGELOG.md
@@ -1,30 +1,30 @@
 # CHANGELOG - Crio
 
-## 1.4.0 / 2020-05-17
+## 1.4.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.3.2 / 2020-04-04
+## 1.3.2 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.3.1 / 2020-02-22
+## 1.3.1 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Fix metric validation. See [#5581](https://github.com/DataDog/integrations-core/pull/5581).
 
-## 1.3.0 / 2020-01-13
+## 1.3.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Make OpenMetrics use the RequestsWrapper. See [#5414](https://github.com/DataDog/integrations-core/pull/5414).
 
-## 1.2.0 / 2019-05-14
+## 1.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3495](https://github.com/DataDog/integrations-core/pull/3495).
 
-## 1.1.0 / 2019-01-04
+## 1.1.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Add nginx ingress controller integration. See [#2853][1].
 
-## 1.0.0 / 2018-10-13
+## 1.0.0 / 2018-10-13 / Agent 5.30.0
 
 * [Added] Add a CRI-O check. See [#2231][2].
 

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -15,7 +15,7 @@
 * [Fixed] Bump jaydebeapi and jpype1. See [#6963](https://github.com/DataDog/integrations-core/pull/6963).
 * [Changed] Apply option to ignore InsecureRequestWarning permanently. See [#7424](https://github.com/DataDog/integrations-core/pull/7424).
 
-## 12.0.0 / 2020-08-10
+## 12.0.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Support "*" wildcard in type_overrides configuration. See [#7071](https://github.com/DataDog/integrations-core/pull/7071).
 * [Added] Add `get_check_logger`. See [#7126](https://github.com/DataDog/integrations-core/pull/7126).
@@ -25,32 +25,32 @@
 * [Changed] Use requests wrapper and remove httplib2 dependency. See [#7247](https://github.com/DataDog/integrations-core/pull/7247).
 * [Removed] Remove get_instance_proxy method from base class. See [#7036](https://github.com/DataDog/integrations-core/pull/7036).
 
-## 11.12.0 / 2020-06-29
+## 11.12.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 * [Added] Add MacOS Support. See [#6927](https://github.com/DataDog/integrations-core/pull/6927).
 
-## 11.11.1 / 2020-06-17
+## 11.11.1 / 2020-06-17 / Agent 7.21.0
 
 * [Fixed] Gracefully skip quantile-less summary metrics. See [#6909](https://github.com/DataDog/integrations-core/pull/6909).
 
-## 11.11.0 / 2020-06-11
+## 11.11.0 / 2020-06-11 / Agent 7.21.0
 
 * [Added] Document openmetrics interface and options. See [#6666](https://github.com/DataDog/integrations-core/pull/6666).
 * [Added] Add methods for the persistent cache Agent interface. See [#6819](https://github.com/DataDog/integrations-core/pull/6819).
 * [Added] Upgrade redis dependency to support `username` in connection strings. See [#6708](https://github.com/DataDog/integrations-core/pull/6708).
 * [Added] Support multiple properties in tag_by. See [#6614](https://github.com/DataDog/integrations-core/pull/6614).
 
-## 11.10.0 / 2020-05-25
+## 11.10.0 / 2020-05-25 / Agent 7.21.0
 
 * [Added] Override CaseInsensitiveDict `copy()` function. See [#6715](https://github.com/DataDog/integrations-core/pull/6715).
 
-## 11.9.0 / 2020-05-20
+## 11.9.0 / 2020-05-20 / Agent 7.21.0
 
 * [Added] Upgrade httplib2 to 0.18.1. See [#6702](https://github.com/DataDog/integrations-core/pull/6702).
 * [Fixed] Fix time utilities. See [#6692](https://github.com/DataDog/integrations-core/pull/6692).
 
-## 11.8.0 / 2020-05-17
+## 11.8.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Add utilities for working with time. See [#6663](https://github.com/DataDog/integrations-core/pull/6663).
 * [Added] Upgrade lxml to 4.5.0. See [#6661](https://github.com/DataDog/integrations-core/pull/6661).
@@ -59,13 +59,13 @@
 * [Fixed] Update scraper config with instance. See [#6664](https://github.com/DataDog/integrations-core/pull/6664).
 * [Fixed] Fix thread leak in wmi checks. See [#6644](https://github.com/DataDog/integrations-core/pull/6644).
 
-## 11.7.0 / 2020-05-08
+## 11.7.0 / 2020-05-08 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Fix a bug that caused win32_event_log integration to hang. See [#6576](https://github.com/DataDog/integrations-core/pull/6576).
 * [Fixed] Allow to verify that no special hostname was submitted with a metric. See [#6529](https://github.com/DataDog/integrations-core/pull/6529).
 
-## 11.6.0 / 2020-04-29
+## 11.6.0 / 2020-04-29 / Agent 7.20.0
 
 * [Added] Validate metrics using metadata.csv. See [#6027](https://github.com/DataDog/integrations-core/pull/6027).
 * [Added] [WinWMICheck] Support latest Agent signature. See [#6324](https://github.com/DataDog/integrations-core/pull/6324).
@@ -77,11 +77,11 @@
 
 * [Fixed] Fix a bug that caused win32_event_log integration to hang. See [#6576](https://github.com/DataDog/integrations-core/pull/6576).
 
-## 11.5.0 / 2020-04-07
+## 11.5.0 / 2020-04-07 / Agent 7.20.0
 
 * [Added] Update PyYAML to 5.3.1. See [#6276](https://github.com/DataDog/integrations-core/pull/6276).
 
-## 11.4.0 / 2020-04-04
+## 11.4.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
@@ -95,16 +95,16 @@
 * [Fixed] Prevent out of bounds on systems with an odd number of counter strings. See [#6052](https://github.com/DataDog/integrations-core/pull/6052). Thanks [AdrianFletcher](https://github.com/AdrianFletcher).
 * [Fixed] Update pdh agent signature. See [#6162](https://github.com/DataDog/integrations-core/pull/6162).
 
-## 11.3.1 / 2020-03-26
+## 11.3.1 / 2020-03-26 / Agent 7.19.0
 
 * [Fixed] Cast to float before computing temporal percent. See [#6146](https://github.com/DataDog/integrations-core/pull/6146).
 
-## 11.3.0 / 2020-03-26
+## 11.3.0 / 2020-03-26 / Agent 7.19.0
 
 * [Added] Use a faster JSON library. See [#6143](https://github.com/DataDog/integrations-core/pull/6143).
 * [Added] Add secrets sanitization helpers. See [#6107](https://github.com/DataDog/integrations-core/pull/6107).
 
-## 11.2.0 / 2020-03-24
+## 11.2.0 / 2020-03-24 / Agent 7.19.0
 
 * [Added] Add secrets sanitization helpers. See [#6107](https://github.com/DataDog/integrations-core/pull/6107).
 * [Added] Upgrade `contextlib2` to 0.6.0. See [#6131](https://github.com/DataDog/integrations-core/pull/6131).
@@ -125,11 +125,11 @@
 * [Fixed] Rename `to_string()` utility to `to_native_string()`. See [#5996](https://github.com/DataDog/integrations-core/pull/5996).
 * [Fixed] Do not fail on octet stream content type for OpenMetrics. See [#5843](https://github.com/DataDog/integrations-core/pull/5843).
 
-## 11.1.0 / 2020-02-26
+## 11.1.0 / 2020-02-26 / Agent 7.19.0
 
 * [Added] Bump securesystemslib to 0.14.2. See [#5890](https://github.com/DataDog/integrations-core/pull/5890).
 
-## 11.0.0 / 2020-02-22
+## 11.0.0 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Pin enum34 to 1.1.6. See [#5829](https://github.com/DataDog/integrations-core/pull/5829).
 * [Fixed] Fix thread leak in WMI sampler. See [#5659](https://github.com/DataDog/integrations-core/pull/5659). Thanks [rlaveycal](https://github.com/rlaveycal).
@@ -156,16 +156,16 @@
 * [Changed] Make deprecations apparent in UI. See [#5530](https://github.com/DataDog/integrations-core/pull/5530).
 * [Added] Add ability to submit time deltas to database query utility. See [#5524](https://github.com/DataDog/integrations-core/pull/5524).
 
-## 10.3.0 / 2020-01-21
+## 10.3.0 / 2020-01-21 / Agent 7.18.0
 
 * [Added] [pdh] Make the admin share configurable. See [#5485](https://github.com/DataDog/integrations-core/pull/5485).
 
-## 10.2.1 / 2020-01-15
+## 10.2.1 / 2020-01-15 / Agent 7.18.0
 
 * [Fixed] Fix Kubelet credentials handling. See [#5455](https://github.com/DataDog/integrations-core/pull/5455).
 * [Fixed] Re-introduce legacy cert option handling. See [#5443](https://github.com/DataDog/integrations-core/pull/5443).
 
-## 10.2.0 / 2020-01-13
+## 10.2.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Update TUF dependency. See [#5441](https://github.com/DataDog/integrations-core/pull/5441).
 * [Fixed] Fix http handler. See [#5434](https://github.com/DataDog/integrations-core/pull/5434).
@@ -174,7 +174,7 @@
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Fixed] Upgrade vertica to stop logging to /dev/null. See [#5352](https://github.com/DataDog/integrations-core/pull/5352).
 
-## 10.1.0 / 2020-01-03
+## 10.1.0 / 2020-01-03 / Agent 7.17.0
 
 * [Fixed] Ensure logs are lazily formatted. See [#5378](https://github.com/DataDog/integrations-core/pull/5378).
 * [Fixed] Remove Agent 5 conditional imports. See [#5322](https://github.com/DataDog/integrations-core/pull/5322).
@@ -189,19 +189,19 @@
 * [Fixed] Update SNMP requirements. See [#5234](https://github.com/DataDog/integrations-core/pull/5234).
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 10.0.2 / 2019-12-09
+## 10.0.2 / 2019-12-09 / Agent 7.17.0
 
 * [Fixed] Fix normalize for invalid chars and underscore. See [#5172](https://github.com/DataDog/integrations-core/pull/5172).
 
-## 10.0.1 / 2019-12-04
+## 10.0.1 / 2019-12-04 / Agent 7.17.0
 
 * [Fixed] Ensure metadata is submitted as strings. See [#5139](https://github.com/DataDog/integrations-core/pull/5139).
 
-## 10.0.0 / 2019-12-02
+## 10.0.0 / 2019-12-02 / Agent 7.16.0
 
 * [Changed] Aligns `no_proxy` behavior to general convention. See [#5081](https://github.com/DataDog/integrations-core/pull/5081).
 
-## 9.6.0 / 2019-11-28
+## 9.6.0 / 2019-11-28 / Agent 7.16.0
 
 * [Added] Support downloading universal and pure Python wheels. See [#4981](https://github.com/DataDog/integrations-core/pull/4981).
 * [Added] Require boto3. See [#5101](https://github.com/DataDog/integrations-core/pull/5101).
@@ -221,21 +221,21 @@
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 * [Fixed] Fix no instances case for AgentCheck signature and add more tests. See [#4784](https://github.com/DataDog/integrations-core/pull/4784).
 
-## 9.5.0 / 2019-10-22
+## 9.5.0 / 2019-10-22 / Agent 7.16.0
 
 * [Added] Upgrade psycopg2-binary to 2.8.4. See [#4840](https://github.com/DataDog/integrations-core/pull/4840).
 * [Added] Add mechanism to submit metadata from OpenMetrics checks. See [#4757](https://github.com/DataDog/integrations-core/pull/4757).
 * [Added] Properly fall back to wildcards when defined OpenMetrics transformers do not get a match. See [#4757](https://github.com/DataDog/integrations-core/pull/4757).
 
-## 9.4.2 / 2019-10-17
+## 9.4.2 / 2019-10-17 / Agent 7.16.0
 
 * [Fixed] Fix RequestsWrapper session `timeout`. See [#4811](https://github.com/DataDog/integrations-core/pull/4811).
 
-## 9.4.1 / 2019-10-17
+## 9.4.1 / 2019-10-17 / Agent 7.16.0
 
 * [Fixed] Avoid sending additional gauges for openmetrics histograms if using distribution metrics. See [#4780](https://github.com/DataDog/integrations-core/pull/4780).
 
-## 9.4.0 / 2019-10-11
+## 9.4.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add an option to send histograms/summary counts as monotonic counters. See [#4629](https://github.com/DataDog/integrations-core/pull/4629).
 * [Added] Add option for device testing in e2e. See [#4693](https://github.com/DataDog/integrations-core/pull/4693).
@@ -253,15 +253,15 @@
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 * [Fixed] Upgrade psutil dependency to 5.6.3. See [#4442](https://github.com/DataDog/integrations-core/pull/4442).
 
-## 9.3.2 / 2019-08-30
+## 9.3.2 / 2019-08-30 / Agent 6.15.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 9.3.1 / 2019-08-28
+## 9.3.1 / 2019-08-28 / Agent 6.15.0
 
 * [Fixed] Fix decumulating bucket on multiple contexts. See [#4446](https://github.com/DataDog/integrations-core/pull/4446).
 
-## 9.3.0 / 2019-08-24
+## 9.3.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add each checks' unique ID to logs. See [#4410](https://github.com/DataDog/integrations-core/pull/4410).
 * [Added] Support continuous memory profiling metric submission. See [#4409](https://github.com/DataDog/integrations-core/pull/4409).
@@ -279,30 +279,30 @@
 * [Fixed] Fix openmetrics telemetry memory usage in mixins. See [#4193](https://github.com/DataDog/integrations-core/pull/4193).
 * [Added] Add tuple timeout format to Request Remapper. See [#4172](https://github.com/DataDog/integrations-core/pull/4172).
 
-## 9.2.1 / 2019-07-19
+## 9.2.1 / 2019-07-19 / Agent 6.13.0
 
 * [Fixed] Fix openmetrics mixins telemetry metrics. See [#4155](https://github.com/DataDog/integrations-core/pull/4155).
 
-## 9.2.0 / 2019-07-19
+## 9.2.0 / 2019-07-19 / Agent 6.13.0
 
 * [Added] Add telemetry metrics counter by ksm collector. See [#4125](https://github.com/DataDog/integrations-core/pull/4125).
 
-## 9.1.0 / 2019-07-13
+## 9.1.0 / 2019-07-13 / Agent 6.13.0
 
 * [Added] Telemetry check's metrics. See [#4025](https://github.com/DataDog/integrations-core/pull/4025). Thanks [clamoriniere](https://github.com/clamoriniere).
 
-## 9.0.0 / 2019-07-12
+## 9.0.0 / 2019-07-12 / Agent 6.13.0
 
 * [Changed] Add SSL support for psycopg2, remove pg8000. See [#4096](https://github.com/DataDog/integrations-core/pull/4096).
 * [Added] Upgrade pymongo to 3.8. See [#4095](https://github.com/DataDog/integrations-core/pull/4095).
 * [Fixed] Fix label encoding. See [#4073](https://github.com/DataDog/integrations-core/pull/4073) and [#4089](https://github.com/DataDog/integrations-core/pull/4089).
 
-## 8.6.0 / 2019-07-09
+## 8.6.0 / 2019-07-09 / Agent 6.13.0
 
 * [Added] Output similar metrics on failed aggregator stub assertions to help debugging. See [#4035](https://github.com/DataDog/integrations-core/pull/4035) and [#4076](https://github.com/DataDog/integrations-core/pull/4076).
 * [Fixed] Avoid WMISampler inheriting from Thread. See [#4051](https://github.com/DataDog/integrations-core/pull/4051).
 
-## 8.5.0 / 2019-07-04
+## 8.5.0 / 2019-07-04 / Agent 6.13.0
 
 * [Fixed] Make WMISampler hashable. See [#4043](https://github.com/DataDog/integrations-core/pull/4043).
 * [Added] Support SOCKS proxies. See [#4021](https://github.com/DataDog/integrations-core/pull/4021).
@@ -312,43 +312,43 @@
 * [Added] Add others forms of auth to RequestsWrapper. See [#3956](https://github.com/DataDog/integrations-core/pull/3956).
 * [Added] Better log message for unsafe yaml loading/dumping. See [#3771](https://github.com/DataDog/integrations-core/pull/3771).
 
-## 8.4.1 / 2019-06-29
+## 8.4.1 / 2019-06-29 / Agent 6.13.0
 
 * [Fixed] Change WMISampler class to create a single thread, owned by the object. See [#3987](https://github.com/DataDog/integrations-core/pull/3987).
 
-## 8.4.0 / 2019-06-18
+## 8.4.0 / 2019-06-18 / Agent 6.13.0
 
 * [Added] Support E2E testing. See [#3896](https://github.com/DataDog/integrations-core/pull/3896).
 
-## 8.3.3 / 2019-06-05
+## 8.3.3 / 2019-06-05 / Agent 6.13.0
 
 * [Fixed] Revert "[openmetrics] allow blacklisting of strings". See [#3867](https://github.com/DataDog/integrations-core/pull/3867).
 * [Fixed] Encode hostname in set_external_tags. See [#3866](https://github.com/DataDog/integrations-core/pull/3866).
 
-## 8.3.2 / 2019-06-04
+## 8.3.2 / 2019-06-04 / Agent 6.13.0
 
 * [Fixed] Revert: Properly utilize the provided `metrics_mapper`. See [#3861](https://github.com/DataDog/integrations-core/pull/3861).
 
-## 8.3.1 / 2019-06-02
+## 8.3.1 / 2019-06-02 / Agent 6.12.0
 
 * [Fixed] Fix package order of `get_datadog_wheels`. See [#3847](https://github.com/DataDog/integrations-core/pull/3847).
 
-## 8.3.0 / 2019-06-01
+## 8.3.0 / 2019-06-01 / Agent 6.12.0
 
 * [Added] [openmetrics] Use Kube service account bearer token for authentication. See [#3829](https://github.com/DataDog/integrations-core/pull/3829).
 * [Fixed] Add upper_bound tag for the total count when collecting histograms buckets. See [#3777](https://github.com/DataDog/integrations-core/pull/3777).
 
-## 8.2.0 / 2019-05-21
+## 8.2.0 / 2019-05-21 / Agent 6.12.0
 
 * [Added] Upgrade requests to 2.22.0. See [#3778](https://github.com/DataDog/integrations-core/pull/3778).
 
-## 8.1.0 / 2019-05-14
+## 8.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Fixed] Fix the initialization of ignored metrics for OpenMetrics. See [#3736](https://github.com/DataDog/integrations-core/pull/3736).
 * [Fixed] Fixed decoding warning for None tags for python2 check base class. See [#3665](https://github.com/DataDog/integrations-core/pull/3665).
 * [Added] Add logging support to RequestsWrapper. See [#3737](https://github.com/DataDog/integrations-core/pull/3737).
 
-## 8.0.0 / 2019-05-06
+## 8.0.0 / 2019-05-06 / Agent 6.12.0
 
 * [Added] Add easier namespacing for data submission. See [#3718](https://github.com/DataDog/integrations-core/pull/3718).
 * [Added] Upgrade pyyaml to 5.1. See [#3698](https://github.com/DataDog/integrations-core/pull/3698).
@@ -360,27 +360,27 @@
 * [Fixed] Properly utilize the provided `metrics_mapper`. See [#3446](https://github.com/DataDog/integrations-core/pull/3446). Thanks [casidiablo](https://github.com/casidiablo).
 * [Added] Upgrade psycopg2-binary to 2.8.2. See [#3649](https://github.com/DataDog/integrations-core/pull/3649).
 
-## 7.0.0 / 2019-04-18
+## 7.0.0 / 2019-04-18 / Agent 6.12.0
 
 * [Added] Add service_identity dependency. See [#3256](https://github.com/DataDog/integrations-core/pull/3256).
 * [Changed] Standardize TLS/SSL protocol naming. See [#3620](https://github.com/DataDog/integrations-core/pull/3620).
 * [Fixed] Parse timeouts as floats in RequestsWrapper. See [#3448](https://github.com/DataDog/integrations-core/pull/3448).
 * [Added] Support Python 3. See [#3605](https://github.com/DataDog/integrations-core/pull/3605).
 
-## 6.6.1 / 2019-04-04
+## 6.6.1 / 2019-04-04 / Agent 6.12.0
 
 * [Fixed] Don't ship `pyodbc` on macOS as SQLServer integration is not shipped on macOS. See [#3461](https://github.com/DataDog/integrations-core/pull/3461).
 
-## 6.6.0 / 2019-03-29
+## 6.6.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Upgrade in-toto. See [#3411](https://github.com/DataDog/integrations-core/pull/3411).
 * [Added] Support Python 3. See [#3425](https://github.com/DataDog/integrations-core/pull/3425).
 
-## 6.5.0 / 2019-03-29
+## 6.5.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Add tagging utility and stub to access the new tagger API. See [#3413](https://github.com/DataDog/integrations-core/pull/3413).
 
-## 6.4.0 / 2019-03-22
+## 6.4.0 / 2019-03-22 / Agent 6.11.0
 
 * [Added] Add external_host_tags wrapper to checks_base. See [#3316](https://github.com/DataDog/integrations-core/pull/3316).
 * [Added] Add ability to debug checks with pdb. See [#2690](https://github.com/DataDog/integrations-core/pull/2690).
@@ -389,12 +389,12 @@
 * [Fixed] Remove uuid dependency. See [#3309](https://github.com/DataDog/integrations-core/pull/3309).
 * [Fixed] Properly ship flup on Python 3. See [#3304](https://github.com/DataDog/integrations-core/pull/3304).
 
-## 6.3.0 / 2019-03-14
+## 6.3.0 / 2019-03-14 / Agent 6.11.0
 
 * [Added] Add rfc3339 utilities. See [#3189](https://github.com/DataDog/integrations-core/pull/3189).
 * [Added] Backport Agent V6 utils to the AgentCheck class. See [#3261](https://github.com/DataDog/integrations-core/pull/3261).
 
-## 6.2.0 / 2019-03-10
+## 6.2.0 / 2019-03-10 / Agent 6.11.0
 
 * [Added] Upgrade protobuf to 3.7.0. See [#3272](https://github.com/DataDog/integrations-core/pull/3272).
 * [Added] Upgrade requests to 2.21.0. See [#3274](https://github.com/DataDog/integrations-core/pull/3274).
@@ -404,15 +404,15 @@
 * [Added] Upgrade aerospike dependency. See [#3235](https://github.com/DataDog/integrations-core/pull/3235).
 * [Fixed] ensure_unicode with normalize for py3 compatibility. See [#3218](https://github.com/DataDog/integrations-core/pull/3218).
 
-## 6.1.0 / 2019-02-20
+## 6.1.0 / 2019-02-20 / Agent 6.11.0
 
 * [Added] Add openstacksdk option to openstack_controller. See [#3109](https://github.com/DataDog/integrations-core/pull/3109).
 
-## 6.0.1 / 2019-02-20
+## 6.0.1 / 2019-02-20 / Agent 5.32.0
 
 * [Fixed] Import kubernetes lazily to reduce memory footprint. See [#3166](https://github.com/DataDog/integrations-core/pull/3166).
 
-## 6.0.0 / 2019-02-12
+## 6.0.0 / 2019-02-12 / Agent 6.11.0
 
 * [Added] Expose the single check instance as an attribute. See [#3093](https://github.com/DataDog/integrations-core/pull/3093).
 * [Added] Parse raw yaml instances and init_config with dedicated base class method. See [#3098](https://github.com/DataDog/integrations-core/pull/3098).
@@ -426,11 +426,11 @@
 * [Added] Support Python 3. See [#2835](https://github.com/DataDog/integrations-core/pull/2835).
 * [Fixed] Improve log messages for when tags aren't utf-8. See [#2966](https://github.com/DataDog/integrations-core/pull/2966).
 
-## 5.2.0 / 2019-01-16
+## 5.2.0 / 2019-01-16 / Agent 5.32.0
 
 * [Added] Make service check statuses available as constants. See [#2960][1].
 
-## 5.1.0 / 2019-01-15
+## 5.1.0 / 2019-01-15 / Agent 5.32.0
 
 * [Fixed] Always ensure_unicode for subprocess output. See [#2941][2].
 * [Added] Add round method to checks base. See [#2931][3].
@@ -438,11 +438,11 @@
 * [Fixed] Include count as an aggregate type in tests. See [#2920][5].
 * [Added] Support unicode for Python 3 bindings. See [#2869][6].
 
-## 5.0.1 / 2019-01-07
+## 5.0.1 / 2019-01-07 / Agent 5.32.0
 
 * [Fixed] Fix context limit logic for OpenMetrics checks. See [#2877][7].
 
-## 5.0.0 / 2019-01-04
+## 5.0.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Add kube_controller_manager integration. See [#2845][8].
 * [Added] Add kube_leader mixin to monitor leader elections. See [#2796][9].
@@ -457,16 +457,16 @@
 * [Changed] Bump kafka-python and kazoo. See [#2766][18].
 * [Added] Support Python 3. See [#2738][19].
 
-## 4.6.0 / 2018-12-07
+## 4.6.0 / 2018-12-07 / Agent 5.31.0
 
 * [Added] Fix unicode handling of log messages. See [#2698][20].
 * [Fixed] Ensure unicode for subprocess output. See [#2697][21].
 
-## 4.5.0 / 2018-12-02
+## 4.5.0 / 2018-12-02 / Agent 5.30.0
 
 * [Added] Improve OpenMetrics label joins. See [#2624][22].
 
-## 4.4.0 / 2018-11-30
+## 4.4.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Add linux as supported OS. See [#2614][23].
 * [Added] Upgrade cryptography. See [#2659][24].
@@ -475,7 +475,7 @@
 * [Added] Log line where `AgentCheck.warning` was called in the check. See [#2620][27].
 * [Fixed] Fix requirements-agent-release.txt updating. See [#2617][28].
 
-## 4.3.0 / 2018-11-12
+## 4.3.0 / 2018-11-12 / Agent 5.30.0
 
 * [Added] Add option to prevent subprocess command logging. See [#2565][29].
 * [Added] Support Kerberos auth. See [#2516][30].
@@ -486,45 +486,45 @@
 * [Fixed] Fix bug making the network check read /proc instead of /host/proc on containers. See [#2460][35].
 * [Added] Fix unicode handling on A6. See [#2435][36].
 
-## 4.2.0 / 2018-10-16
+## 4.2.0 / 2018-10-16 / Agent 5.30.0
 
 * [Added] Expose text conversion methods. See [#2420][37].
 * [Fixed] Handle unicode strings in non-float handler's error message. See [#2419][38].
 
-## 4.1.0 / 2018-10-12
+## 4.1.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Expose core functionality at the root. See [#2394][39].
 * [Added] base: add check name to Limiter warning message. See [#2391][40].
 * [Fixed] Fix import of _get_py_loglevel. See [#2383][41].
 * [Fixed] Fix hostname override and type for status_report.count metrics. See [#2372][42].
 
-## 4.0.0 / 2018-10-11
+## 4.0.0 / 2018-10-11 / Agent 5.28.0
 
 * [Added] Added generic error class ConfigurationError. See [#2367][43].
 * [Changed] Add base subpackage to datadog_checks_base. See [#2331][44].
 * [Added] Freeze Agent requirements. See [#2328][45].
 * [Added] Pin pywin32 dependency. See [#2322][46].
 
-## 3.0.0 / 2018-09-25
+## 3.0.0 / 2018-09-25 / Agent 5.28.0
 
 * [Added] Adds ability to Trace "check" function with DD APM. See [#2079][47].
 * [Changed] Catch exception when string sent as metric value. See [#2293][48].
 * [Changed] Revert default prometheus metric limit to 2000. See [#2248][49].
 * [Fixed] Fix base class imports for Agent 5. See [#2232][50].
 
-## 2.2.1 / 2018-09-11
+## 2.2.1 / 2018-09-11 / Agent 5.28.0
 
 * [Fixed] Temporarily increase the limit of prometheus metrics sent for 6.5. See [#2214][51].
 
-## 2.2.0 / 2018-09-06
+## 2.2.0 / 2018-09-06 / Agent 5.28.0
 
 * [Changed] Freeze pyVmomi dep in base check. See [#2181][52].
 
-## 2.1.0 / 2018-09-05
+## 2.1.0 / 2018-09-05 / Agent 5.28.0
 
 * [Changed] Change order of precedence of whitelist and blacklist for pattern filtering. See [#2174][53].
 
-## 2.0.0 / 2018-09-04
+## 2.0.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Add cluster-name suffix to node-names in kubernetes state. See [#2069][54].
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][55].
@@ -537,7 +537,7 @@
 * [Changed] Create OpenMetricsBaseCheck, an improved version of GenericPrometheusCheck. See [#1976][62].
 * [Fixed] Move RiakCS to pytest, fixes duped tags in RiakCS, adds google_cloud_engine pip dep. See [#2081][63].
 
-## 1.5.0 / 2018-08-19
+## 1.5.0 / 2018-08-19 / Agent 5.27.0
 
 * [Added] Allow installation of base dependencies. See [#2067][64].
 * [Fixed] Retrieve no_proxy directly from the Datadog Agent's configuration. See [#2004][65].
@@ -545,7 +545,7 @@
 * [Fixed] Properly skip proxy environment variables. See [#1935][67].
 * [Fixed] Update cryptography to 2.3. See [#1927][68].
 
-## 1.4.0 / 2018-07-18
+## 1.4.0 / 2018-07-18 / Agent 5.26.0
 
 * [Fixed] fix packaging of agent requirements. See [#1911][69].
 * [Fixed] Properly use skip_proxy for instance configuration. See [#1880][70].
@@ -554,16 +554,16 @@
 * [Changed] Bump prometheus client library to 0.3.0. See [#1866][73].
 * [Added] Make HTTP request timeout configurable in prometheus checks. See [#1790][74].
 
-## 1.3.2 / 2018-06-15
+## 1.3.2 / 2018-06-15 / Agent 5.26.0
 
 * [Changed] Bump requests to 2.19.1. See [#1743][75].
 
-## 1.3.1 / 2018-06-13
+## 1.3.1 / 2018-06-13 / Agent 5.26.0
 
 * [Fixed] upgrade requests dependency. See [#1734][76].
 * [Changed] Set requests stream option to false when scraping Prometheus endpoints. See [#1596][77].
 
-## 1.3.0 / 2018-06-07
+## 1.3.0 / 2018-06-07 / Agent 5.25.0
 
 * [Fixed] change default value of AgentCheck.check_id for Agent 6. See [#1652][78].
 * [Added] Support for gathering metrics from prometheus endpoint for the kubelet itself.. See [#1581][79].

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -30,27 +30,27 @@
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 * [Added] Add MacOS Support. See [#6927](https://github.com/DataDog/integrations-core/pull/6927).
 
-## 11.11.1 / 2020-06-17 / Agent 7.21.0
+## 11.11.1 / 2020-06-17
 
 * [Fixed] Gracefully skip quantile-less summary metrics. See [#6909](https://github.com/DataDog/integrations-core/pull/6909).
 
-## 11.11.0 / 2020-06-11 / Agent 7.21.0
+## 11.11.0 / 2020-06-11
 
 * [Added] Document openmetrics interface and options. See [#6666](https://github.com/DataDog/integrations-core/pull/6666).
 * [Added] Add methods for the persistent cache Agent interface. See [#6819](https://github.com/DataDog/integrations-core/pull/6819).
 * [Added] Upgrade redis dependency to support `username` in connection strings. See [#6708](https://github.com/DataDog/integrations-core/pull/6708).
 * [Added] Support multiple properties in tag_by. See [#6614](https://github.com/DataDog/integrations-core/pull/6614).
 
-## 11.10.0 / 2020-05-25 / Agent 7.21.0
+## 11.10.0 / 2020-05-25 / Agent 7.20.0
 
 * [Added] Override CaseInsensitiveDict `copy()` function. See [#6715](https://github.com/DataDog/integrations-core/pull/6715).
 
-## 11.9.0 / 2020-05-20 / Agent 7.21.0
+## 11.9.0 / 2020-05-20
 
 * [Added] Upgrade httplib2 to 0.18.1. See [#6702](https://github.com/DataDog/integrations-core/pull/6702).
 * [Fixed] Fix time utilities. See [#6692](https://github.com/DataDog/integrations-core/pull/6692).
 
-## 11.8.0 / 2020-05-17 / Agent 7.20.0
+## 11.8.0 / 2020-05-17
 
 * [Added] Add utilities for working with time. See [#6663](https://github.com/DataDog/integrations-core/pull/6663).
 * [Added] Upgrade lxml to 4.5.0. See [#6661](https://github.com/DataDog/integrations-core/pull/6661).
@@ -59,13 +59,13 @@
 * [Fixed] Update scraper config with instance. See [#6664](https://github.com/DataDog/integrations-core/pull/6664).
 * [Fixed] Fix thread leak in wmi checks. See [#6644](https://github.com/DataDog/integrations-core/pull/6644).
 
-## 11.7.0 / 2020-05-08 / Agent 7.20.0
+## 11.7.0 / 2020-05-08
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Fix a bug that caused win32_event_log integration to hang. See [#6576](https://github.com/DataDog/integrations-core/pull/6576).
 * [Fixed] Allow to verify that no special hostname was submitted with a metric. See [#6529](https://github.com/DataDog/integrations-core/pull/6529).
 
-## 11.6.0 / 2020-04-29 / Agent 7.20.0
+## 11.6.0 / 2020-04-29
 
 * [Added] Validate metrics using metadata.csv. See [#6027](https://github.com/DataDog/integrations-core/pull/6027).
 * [Added] [WinWMICheck] Support latest Agent signature. See [#6324](https://github.com/DataDog/integrations-core/pull/6324).
@@ -73,15 +73,15 @@
 * [Fixed] Break reference cycle with log formatter. See [#6470](https://github.com/DataDog/integrations-core/pull/6470).
 * [Fixed] Mark `instance` as non-`Optional`. See [#6350](https://github.com/DataDog/integrations-core/pull/6350).
 
-## 11.5.1 / 2020-05-11
+## 11.5.1 / 2020-05-11 / Agent 7.19.2
 
 * [Fixed] Fix a bug that caused win32_event_log integration to hang. See [#6576](https://github.com/DataDog/integrations-core/pull/6576).
 
-## 11.5.0 / 2020-04-07 / Agent 7.20.0
+## 11.5.0 / 2020-04-07 / Agent 7.19.0
 
 * [Added] Update PyYAML to 5.3.1. See [#6276](https://github.com/DataDog/integrations-core/pull/6276).
 
-## 11.4.0 / 2020-04-04 / Agent 7.19.0
+## 11.4.0 / 2020-04-04
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
@@ -95,16 +95,16 @@
 * [Fixed] Prevent out of bounds on systems with an odd number of counter strings. See [#6052](https://github.com/DataDog/integrations-core/pull/6052). Thanks [AdrianFletcher](https://github.com/AdrianFletcher).
 * [Fixed] Update pdh agent signature. See [#6162](https://github.com/DataDog/integrations-core/pull/6162).
 
-## 11.3.1 / 2020-03-26 / Agent 7.19.0
+## 11.3.1 / 2020-03-26
 
 * [Fixed] Cast to float before computing temporal percent. See [#6146](https://github.com/DataDog/integrations-core/pull/6146).
 
-## 11.3.0 / 2020-03-26 / Agent 7.19.0
+## 11.3.0 / 2020-03-26
 
 * [Added] Use a faster JSON library. See [#6143](https://github.com/DataDog/integrations-core/pull/6143).
 * [Added] Add secrets sanitization helpers. See [#6107](https://github.com/DataDog/integrations-core/pull/6107).
 
-## 11.2.0 / 2020-03-24 / Agent 7.19.0
+## 11.2.0 / 2020-03-24
 
 * [Added] Add secrets sanitization helpers. See [#6107](https://github.com/DataDog/integrations-core/pull/6107).
 * [Added] Upgrade `contextlib2` to 0.6.0. See [#6131](https://github.com/DataDog/integrations-core/pull/6131).
@@ -125,11 +125,11 @@
 * [Fixed] Rename `to_string()` utility to `to_native_string()`. See [#5996](https://github.com/DataDog/integrations-core/pull/5996).
 * [Fixed] Do not fail on octet stream content type for OpenMetrics. See [#5843](https://github.com/DataDog/integrations-core/pull/5843).
 
-## 11.1.0 / 2020-02-26 / Agent 7.19.0
+## 11.1.0 / 2020-02-26 / Agent 7.18.0
 
 * [Added] Bump securesystemslib to 0.14.2. See [#5890](https://github.com/DataDog/integrations-core/pull/5890).
 
-## 11.0.0 / 2020-02-22 / Agent 7.18.0
+## 11.0.0 / 2020-02-22
 
 * [Fixed] Pin enum34 to 1.1.6. See [#5829](https://github.com/DataDog/integrations-core/pull/5829).
 * [Fixed] Fix thread leak in WMI sampler. See [#5659](https://github.com/DataDog/integrations-core/pull/5659). Thanks [rlaveycal](https://github.com/rlaveycal).
@@ -156,16 +156,16 @@
 * [Changed] Make deprecations apparent in UI. See [#5530](https://github.com/DataDog/integrations-core/pull/5530).
 * [Added] Add ability to submit time deltas to database query utility. See [#5524](https://github.com/DataDog/integrations-core/pull/5524).
 
-## 10.3.0 / 2020-01-21 / Agent 7.18.0
+## 10.3.0 / 2020-01-21
 
 * [Added] [pdh] Make the admin share configurable. See [#5485](https://github.com/DataDog/integrations-core/pull/5485).
 
-## 10.2.1 / 2020-01-15 / Agent 7.18.0
+## 10.2.1 / 2020-01-15
 
 * [Fixed] Fix Kubelet credentials handling. See [#5455](https://github.com/DataDog/integrations-core/pull/5455).
 * [Fixed] Re-introduce legacy cert option handling. See [#5443](https://github.com/DataDog/integrations-core/pull/5443).
 
-## 10.2.0 / 2020-01-13 / Agent 7.17.0
+## 10.2.0 / 2020-01-13
 
 * [Added] Update TUF dependency. See [#5441](https://github.com/DataDog/integrations-core/pull/5441).
 * [Fixed] Fix http handler. See [#5434](https://github.com/DataDog/integrations-core/pull/5434).
@@ -174,7 +174,7 @@
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Fixed] Upgrade vertica to stop logging to /dev/null. See [#5352](https://github.com/DataDog/integrations-core/pull/5352).
 
-## 10.1.0 / 2020-01-03 / Agent 7.17.0
+## 10.1.0 / 2020-01-03
 
 * [Fixed] Ensure logs are lazily formatted. See [#5378](https://github.com/DataDog/integrations-core/pull/5378).
 * [Fixed] Remove Agent 5 conditional imports. See [#5322](https://github.com/DataDog/integrations-core/pull/5322).
@@ -189,19 +189,19 @@
 * [Fixed] Update SNMP requirements. See [#5234](https://github.com/DataDog/integrations-core/pull/5234).
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 10.0.2 / 2019-12-09 / Agent 7.17.0
+## 10.0.2 / 2019-12-09 / Agent 7.16.0
 
 * [Fixed] Fix normalize for invalid chars and underscore. See [#5172](https://github.com/DataDog/integrations-core/pull/5172).
 
-## 10.0.1 / 2019-12-04 / Agent 7.17.0
+## 10.0.1 / 2019-12-04
 
 * [Fixed] Ensure metadata is submitted as strings. See [#5139](https://github.com/DataDog/integrations-core/pull/5139).
 
-## 10.0.0 / 2019-12-02 / Agent 7.16.0
+## 10.0.0 / 2019-12-02
 
 * [Changed] Aligns `no_proxy` behavior to general convention. See [#5081](https://github.com/DataDog/integrations-core/pull/5081).
 
-## 9.6.0 / 2019-11-28 / Agent 7.16.0
+## 9.6.0 / 2019-11-28
 
 * [Added] Support downloading universal and pure Python wheels. See [#4981](https://github.com/DataDog/integrations-core/pull/4981).
 * [Added] Require boto3. See [#5101](https://github.com/DataDog/integrations-core/pull/5101).
@@ -221,21 +221,21 @@
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 * [Fixed] Fix no instances case for AgentCheck signature and add more tests. See [#4784](https://github.com/DataDog/integrations-core/pull/4784).
 
-## 9.5.0 / 2019-10-22 / Agent 7.16.0
+## 9.5.0 / 2019-10-22
 
 * [Added] Upgrade psycopg2-binary to 2.8.4. See [#4840](https://github.com/DataDog/integrations-core/pull/4840).
 * [Added] Add mechanism to submit metadata from OpenMetrics checks. See [#4757](https://github.com/DataDog/integrations-core/pull/4757).
 * [Added] Properly fall back to wildcards when defined OpenMetrics transformers do not get a match. See [#4757](https://github.com/DataDog/integrations-core/pull/4757).
 
-## 9.4.2 / 2019-10-17 / Agent 7.16.0
+## 9.4.2 / 2019-10-17 / Agent 6.15.0
 
 * [Fixed] Fix RequestsWrapper session `timeout`. See [#4811](https://github.com/DataDog/integrations-core/pull/4811).
 
-## 9.4.1 / 2019-10-17 / Agent 7.16.0
+## 9.4.1 / 2019-10-17
 
 * [Fixed] Avoid sending additional gauges for openmetrics histograms if using distribution metrics. See [#4780](https://github.com/DataDog/integrations-core/pull/4780).
 
-## 9.4.0 / 2019-10-11 / Agent 6.15.0
+## 9.4.0 / 2019-10-11
 
 * [Added] Add an option to send histograms/summary counts as monotonic counters. See [#4629](https://github.com/DataDog/integrations-core/pull/4629).
 * [Added] Add option for device testing in e2e. See [#4693](https://github.com/DataDog/integrations-core/pull/4693).
@@ -253,15 +253,15 @@
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 * [Fixed] Upgrade psutil dependency to 5.6.3. See [#4442](https://github.com/DataDog/integrations-core/pull/4442).
 
-## 9.3.2 / 2019-08-30 / Agent 6.15.0
+## 9.3.2 / 2019-08-30 / Agent 6.14.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 9.3.1 / 2019-08-28 / Agent 6.15.0
+## 9.3.1 / 2019-08-28
 
 * [Fixed] Fix decumulating bucket on multiple contexts. See [#4446](https://github.com/DataDog/integrations-core/pull/4446).
 
-## 9.3.0 / 2019-08-24 / Agent 6.14.0
+## 9.3.0 / 2019-08-24
 
 * [Added] Add each checks' unique ID to logs. See [#4410](https://github.com/DataDog/integrations-core/pull/4410).
 * [Added] Support continuous memory profiling metric submission. See [#4409](https://github.com/DataDog/integrations-core/pull/4409).
@@ -283,26 +283,26 @@
 
 * [Fixed] Fix openmetrics mixins telemetry metrics. See [#4155](https://github.com/DataDog/integrations-core/pull/4155).
 
-## 9.2.0 / 2019-07-19 / Agent 6.13.0
+## 9.2.0 / 2019-07-19
 
 * [Added] Add telemetry metrics counter by ksm collector. See [#4125](https://github.com/DataDog/integrations-core/pull/4125).
 
-## 9.1.0 / 2019-07-13 / Agent 6.13.0
+## 9.1.0 / 2019-07-13
 
 * [Added] Telemetry check's metrics. See [#4025](https://github.com/DataDog/integrations-core/pull/4025). Thanks [clamoriniere](https://github.com/clamoriniere).
 
-## 9.0.0 / 2019-07-12 / Agent 6.13.0
+## 9.0.0 / 2019-07-12
 
 * [Changed] Add SSL support for psycopg2, remove pg8000. See [#4096](https://github.com/DataDog/integrations-core/pull/4096).
 * [Added] Upgrade pymongo to 3.8. See [#4095](https://github.com/DataDog/integrations-core/pull/4095).
 * [Fixed] Fix label encoding. See [#4073](https://github.com/DataDog/integrations-core/pull/4073) and [#4089](https://github.com/DataDog/integrations-core/pull/4089).
 
-## 8.6.0 / 2019-07-09 / Agent 6.13.0
+## 8.6.0 / 2019-07-09
 
 * [Added] Output similar metrics on failed aggregator stub assertions to help debugging. See [#4035](https://github.com/DataDog/integrations-core/pull/4035) and [#4076](https://github.com/DataDog/integrations-core/pull/4076).
 * [Fixed] Avoid WMISampler inheriting from Thread. See [#4051](https://github.com/DataDog/integrations-core/pull/4051).
 
-## 8.5.0 / 2019-07-04 / Agent 6.13.0
+## 8.5.0 / 2019-07-04
 
 * [Fixed] Make WMISampler hashable. See [#4043](https://github.com/DataDog/integrations-core/pull/4043).
 * [Added] Support SOCKS proxies. See [#4021](https://github.com/DataDog/integrations-core/pull/4021).
@@ -312,43 +312,43 @@
 * [Added] Add others forms of auth to RequestsWrapper. See [#3956](https://github.com/DataDog/integrations-core/pull/3956).
 * [Added] Better log message for unsafe yaml loading/dumping. See [#3771](https://github.com/DataDog/integrations-core/pull/3771).
 
-## 8.4.1 / 2019-06-29 / Agent 6.13.0
+## 8.4.1 / 2019-06-29 / Agent 6.12.2
 
 * [Fixed] Change WMISampler class to create a single thread, owned by the object. See [#3987](https://github.com/DataDog/integrations-core/pull/3987).
 
-## 8.4.0 / 2019-06-18 / Agent 6.13.0
+## 8.4.0 / 2019-06-18
 
 * [Added] Support E2E testing. See [#3896](https://github.com/DataDog/integrations-core/pull/3896).
 
-## 8.3.3 / 2019-06-05 / Agent 6.13.0
+## 8.3.3 / 2019-06-05 / Agent 6.12.0
 
 * [Fixed] Revert "[openmetrics] allow blacklisting of strings". See [#3867](https://github.com/DataDog/integrations-core/pull/3867).
 * [Fixed] Encode hostname in set_external_tags. See [#3866](https://github.com/DataDog/integrations-core/pull/3866).
 
-## 8.3.2 / 2019-06-04 / Agent 6.13.0
+## 8.3.2 / 2019-06-04
 
 * [Fixed] Revert: Properly utilize the provided `metrics_mapper`. See [#3861](https://github.com/DataDog/integrations-core/pull/3861).
 
-## 8.3.1 / 2019-06-02 / Agent 6.12.0
+## 8.3.1 / 2019-06-02
 
 * [Fixed] Fix package order of `get_datadog_wheels`. See [#3847](https://github.com/DataDog/integrations-core/pull/3847).
 
-## 8.3.0 / 2019-06-01 / Agent 6.12.0
+## 8.3.0 / 2019-06-01
 
 * [Added] [openmetrics] Use Kube service account bearer token for authentication. See [#3829](https://github.com/DataDog/integrations-core/pull/3829).
 * [Fixed] Add upper_bound tag for the total count when collecting histograms buckets. See [#3777](https://github.com/DataDog/integrations-core/pull/3777).
 
-## 8.2.0 / 2019-05-21 / Agent 6.12.0
+## 8.2.0 / 2019-05-21
 
 * [Added] Upgrade requests to 2.22.0. See [#3778](https://github.com/DataDog/integrations-core/pull/3778).
 
-## 8.1.0 / 2019-05-14 / Agent 6.12.0
+## 8.1.0 / 2019-05-14
 
 * [Fixed] Fix the initialization of ignored metrics for OpenMetrics. See [#3736](https://github.com/DataDog/integrations-core/pull/3736).
 * [Fixed] Fixed decoding warning for None tags for python2 check base class. See [#3665](https://github.com/DataDog/integrations-core/pull/3665).
 * [Added] Add logging support to RequestsWrapper. See [#3737](https://github.com/DataDog/integrations-core/pull/3737).
 
-## 8.0.0 / 2019-05-06 / Agent 6.12.0
+## 8.0.0 / 2019-05-06
 
 * [Added] Add easier namespacing for data submission. See [#3718](https://github.com/DataDog/integrations-core/pull/3718).
 * [Added] Upgrade pyyaml to 5.1. See [#3698](https://github.com/DataDog/integrations-core/pull/3698).
@@ -360,27 +360,27 @@
 * [Fixed] Properly utilize the provided `metrics_mapper`. See [#3446](https://github.com/DataDog/integrations-core/pull/3446). Thanks [casidiablo](https://github.com/casidiablo).
 * [Added] Upgrade psycopg2-binary to 2.8.2. See [#3649](https://github.com/DataDog/integrations-core/pull/3649).
 
-## 7.0.0 / 2019-04-18 / Agent 6.12.0
+## 7.0.0 / 2019-04-18
 
 * [Added] Add service_identity dependency. See [#3256](https://github.com/DataDog/integrations-core/pull/3256).
 * [Changed] Standardize TLS/SSL protocol naming. See [#3620](https://github.com/DataDog/integrations-core/pull/3620).
 * [Fixed] Parse timeouts as floats in RequestsWrapper. See [#3448](https://github.com/DataDog/integrations-core/pull/3448).
 * [Added] Support Python 3. See [#3605](https://github.com/DataDog/integrations-core/pull/3605).
 
-## 6.6.1 / 2019-04-04 / Agent 6.12.0
+## 6.6.1 / 2019-04-04 / Agent 6.11.0
 
 * [Fixed] Don't ship `pyodbc` on macOS as SQLServer integration is not shipped on macOS. See [#3461](https://github.com/DataDog/integrations-core/pull/3461).
 
-## 6.6.0 / 2019-03-29 / Agent 6.11.0
+## 6.6.0 / 2019-03-29
 
 * [Added] Upgrade in-toto. See [#3411](https://github.com/DataDog/integrations-core/pull/3411).
 * [Added] Support Python 3. See [#3425](https://github.com/DataDog/integrations-core/pull/3425).
 
-## 6.5.0 / 2019-03-29 / Agent 6.11.0
+## 6.5.0 / 2019-03-29
 
 * [Added] Add tagging utility and stub to access the new tagger API. See [#3413](https://github.com/DataDog/integrations-core/pull/3413).
 
-## 6.4.0 / 2019-03-22 / Agent 6.11.0
+## 6.4.0 / 2019-03-22
 
 * [Added] Add external_host_tags wrapper to checks_base. See [#3316](https://github.com/DataDog/integrations-core/pull/3316).
 * [Added] Add ability to debug checks with pdb. See [#2690](https://github.com/DataDog/integrations-core/pull/2690).
@@ -389,12 +389,12 @@
 * [Fixed] Remove uuid dependency. See [#3309](https://github.com/DataDog/integrations-core/pull/3309).
 * [Fixed] Properly ship flup on Python 3. See [#3304](https://github.com/DataDog/integrations-core/pull/3304).
 
-## 6.3.0 / 2019-03-14 / Agent 6.11.0
+## 6.3.0 / 2019-03-14
 
 * [Added] Add rfc3339 utilities. See [#3189](https://github.com/DataDog/integrations-core/pull/3189).
 * [Added] Backport Agent V6 utils to the AgentCheck class. See [#3261](https://github.com/DataDog/integrations-core/pull/3261).
 
-## 6.2.0 / 2019-03-10 / Agent 6.11.0
+## 6.2.0 / 2019-03-10
 
 * [Added] Upgrade protobuf to 3.7.0. See [#3272](https://github.com/DataDog/integrations-core/pull/3272).
 * [Added] Upgrade requests to 2.21.0. See [#3274](https://github.com/DataDog/integrations-core/pull/3274).
@@ -404,15 +404,15 @@
 * [Added] Upgrade aerospike dependency. See [#3235](https://github.com/DataDog/integrations-core/pull/3235).
 * [Fixed] ensure_unicode with normalize for py3 compatibility. See [#3218](https://github.com/DataDog/integrations-core/pull/3218).
 
-## 6.1.0 / 2019-02-20 / Agent 6.11.0
+## 6.1.0 / 2019-02-20
 
 * [Added] Add openstacksdk option to openstack_controller. See [#3109](https://github.com/DataDog/integrations-core/pull/3109).
 
-## 6.0.1 / 2019-02-20 / Agent 5.32.0
+## 6.0.1 / 2019-02-20 / Agent 6.10.0
 
 * [Fixed] Import kubernetes lazily to reduce memory footprint. See [#3166](https://github.com/DataDog/integrations-core/pull/3166).
 
-## 6.0.0 / 2019-02-12 / Agent 6.11.0
+## 6.0.0 / 2019-02-12
 
 * [Added] Expose the single check instance as an attribute. See [#3093](https://github.com/DataDog/integrations-core/pull/3093).
 * [Added] Parse raw yaml instances and init_config with dedicated base class method. See [#3098](https://github.com/DataDog/integrations-core/pull/3098).
@@ -426,11 +426,11 @@
 * [Added] Support Python 3. See [#2835](https://github.com/DataDog/integrations-core/pull/2835).
 * [Fixed] Improve log messages for when tags aren't utf-8. See [#2966](https://github.com/DataDog/integrations-core/pull/2966).
 
-## 5.2.0 / 2019-01-16 / Agent 5.32.0
+## 5.2.0 / 2019-01-16
 
 * [Added] Make service check statuses available as constants. See [#2960][1].
 
-## 5.1.0 / 2019-01-15 / Agent 5.32.0
+## 5.1.0 / 2019-01-15
 
 * [Fixed] Always ensure_unicode for subprocess output. See [#2941][2].
 * [Added] Add round method to checks base. See [#2931][3].
@@ -438,11 +438,11 @@
 * [Fixed] Include count as an aggregate type in tests. See [#2920][5].
 * [Added] Support unicode for Python 3 bindings. See [#2869][6].
 
-## 5.0.1 / 2019-01-07 / Agent 5.32.0
+## 5.0.1 / 2019-01-07 / Agent 6.9.0
 
 * [Fixed] Fix context limit logic for OpenMetrics checks. See [#2877][7].
 
-## 5.0.0 / 2019-01-04 / Agent 5.31.0
+## 5.0.0 / 2019-01-04
 
 * [Added] Add kube_controller_manager integration. See [#2845][8].
 * [Added] Add kube_leader mixin to monitor leader elections. See [#2796][9].
@@ -457,16 +457,16 @@
 * [Changed] Bump kafka-python and kazoo. See [#2766][18].
 * [Added] Support Python 3. See [#2738][19].
 
-## 4.6.0 / 2018-12-07 / Agent 5.31.0
+## 4.6.0 / 2018-12-07 / Agent 6.8.0
 
 * [Added] Fix unicode handling of log messages. See [#2698][20].
 * [Fixed] Ensure unicode for subprocess output. See [#2697][21].
 
-## 4.5.0 / 2018-12-02 / Agent 5.30.0
+## 4.5.0 / 2018-12-02
 
 * [Added] Improve OpenMetrics label joins. See [#2624][22].
 
-## 4.4.0 / 2018-11-30 / Agent 5.30.0
+## 4.4.0 / 2018-11-30
 
 * [Added] Add linux as supported OS. See [#2614][23].
 * [Added] Upgrade cryptography. See [#2659][24].
@@ -475,7 +475,7 @@
 * [Added] Log line where `AgentCheck.warning` was called in the check. See [#2620][27].
 * [Fixed] Fix requirements-agent-release.txt updating. See [#2617][28].
 
-## 4.3.0 / 2018-11-12 / Agent 5.30.0
+## 4.3.0 / 2018-11-12
 
 * [Added] Add option to prevent subprocess command logging. See [#2565][29].
 * [Added] Support Kerberos auth. See [#2516][30].
@@ -486,45 +486,45 @@
 * [Fixed] Fix bug making the network check read /proc instead of /host/proc on containers. See [#2460][35].
 * [Added] Fix unicode handling on A6. See [#2435][36].
 
-## 4.2.0 / 2018-10-16 / Agent 5.30.0
+## 4.2.0 / 2018-10-16 / Agent 6.6.0
 
 * [Added] Expose text conversion methods. See [#2420][37].
 * [Fixed] Handle unicode strings in non-float handler's error message. See [#2419][38].
 
-## 4.1.0 / 2018-10-12 / Agent 5.28.0
+## 4.1.0 / 2018-10-12
 
 * [Added] Expose core functionality at the root. See [#2394][39].
 * [Added] base: add check name to Limiter warning message. See [#2391][40].
 * [Fixed] Fix import of _get_py_loglevel. See [#2383][41].
 * [Fixed] Fix hostname override and type for status_report.count metrics. See [#2372][42].
 
-## 4.0.0 / 2018-10-11 / Agent 5.28.0
+## 4.0.0 / 2018-10-11
 
 * [Added] Added generic error class ConfigurationError. See [#2367][43].
 * [Changed] Add base subpackage to datadog_checks_base. See [#2331][44].
 * [Added] Freeze Agent requirements. See [#2328][45].
 * [Added] Pin pywin32 dependency. See [#2322][46].
 
-## 3.0.0 / 2018-09-25 / Agent 5.28.0
+## 3.0.0 / 2018-09-25
 
 * [Added] Adds ability to Trace "check" function with DD APM. See [#2079][47].
 * [Changed] Catch exception when string sent as metric value. See [#2293][48].
 * [Changed] Revert default prometheus metric limit to 2000. See [#2248][49].
 * [Fixed] Fix base class imports for Agent 5. See [#2232][50].
 
-## 2.2.1 / 2018-09-11 / Agent 5.28.0
+## 2.2.1 / 2018-09-11 / Agent 6.5.0
 
 * [Fixed] Temporarily increase the limit of prometheus metrics sent for 6.5. See [#2214][51].
 
-## 2.2.0 / 2018-09-06 / Agent 5.28.0
+## 2.2.0 / 2018-09-06
 
 * [Changed] Freeze pyVmomi dep in base check. See [#2181][52].
 
-## 2.1.0 / 2018-09-05 / Agent 5.28.0
+## 2.1.0 / 2018-09-05
 
 * [Changed] Change order of precedence of whitelist and blacklist for pattern filtering. See [#2174][53].
 
-## 2.0.0 / 2018-09-04 / Agent 5.28.0
+## 2.0.0 / 2018-09-04
 
 * [Added] Add cluster-name suffix to node-names in kubernetes state. See [#2069][54].
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][55].
@@ -537,7 +537,7 @@
 * [Changed] Create OpenMetricsBaseCheck, an improved version of GenericPrometheusCheck. See [#1976][62].
 * [Fixed] Move RiakCS to pytest, fixes duped tags in RiakCS, adds google_cloud_engine pip dep. See [#2081][63].
 
-## 1.5.0 / 2018-08-19 / Agent 5.27.0
+## 1.5.0 / 2018-08-19
 
 * [Added] Allow installation of base dependencies. See [#2067][64].
 * [Fixed] Retrieve no_proxy directly from the Datadog Agent's configuration. See [#2004][65].
@@ -545,7 +545,7 @@
 * [Fixed] Properly skip proxy environment variables. See [#1935][67].
 * [Fixed] Update cryptography to 2.3. See [#1927][68].
 
-## 1.4.0 / 2018-07-18 / Agent 5.26.0
+## 1.4.0 / 2018-07-18 / Agent 6.4.0
 
 * [Fixed] fix packaging of agent requirements. See [#1911][69].
 * [Fixed] Properly use skip_proxy for instance configuration. See [#1880][70].
@@ -554,16 +554,16 @@
 * [Changed] Bump prometheus client library to 0.3.0. See [#1866][73].
 * [Added] Make HTTP request timeout configurable in prometheus checks. See [#1790][74].
 
-## 1.3.2 / 2018-06-15 / Agent 5.26.0
+## 1.3.2 / 2018-06-15
 
 * [Changed] Bump requests to 2.19.1. See [#1743][75].
 
-## 1.3.1 / 2018-06-13 / Agent 5.26.0
+## 1.3.1 / 2018-06-13
 
 * [Fixed] upgrade requests dependency. See [#1734][76].
 * [Changed] Set requests stream option to false when scraping Prometheus endpoints. See [#1596][77].
 
-## 1.3.0 / 2018-06-07 / Agent 5.25.0
+## 1.3.0 / 2018-06-07
 
 * [Fixed] change default value of AgentCheck.check_id for Agent 6. See [#1652][78].
 * [Added] Support for gathering metrics from prometheus endpoint for the kubelet itself.. See [#1581][79].

--- a/directory/CHANGELOG.md
+++ b/directory/CHANGELOG.md
@@ -1,43 +1,43 @@
 # CHANGELOG - directory
 
-## 1.8.0 / 2020-06-24
+## 1.8.0 / 2020-06-24 / Agent 7.21.0
 
 * [Added] Add option to not follow symlinks for stat. See [#6960](https://github.com/DataDog/integrations-core/pull/6960).
 * [Added] Make max file count configurable in the directory check. See [#6847](https://github.com/DataDog/integrations-core/pull/6847).
 * [Fixed] Simplify walker recursive condition. See [#6965](https://github.com/DataDog/integrations-core/pull/6965).
 * [Fixed] Refactor config. See [#6961](https://github.com/DataDog/integrations-core/pull/6961).
 
-## 1.7.0 / 2020-06-03
+## 1.7.0 / 2020-06-03 / Agent 7.21.0
 
 * [Added] Add `follow_symlinks` config option. See [#6800](https://github.com/DataDog/integrations-core/pull/6800).
 
-## 1.6.0 / 2020-05-17
+## 1.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Skip matched_files loop if countonly is set. See [#6477](https://github.com/DataDog/integrations-core/pull/6477).
 
-## 1.5.1 / 2020-04-04
+## 1.5.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Fix filegauge inconsistencies. See [#6060](https://github.com/DataDog/integrations-core/pull/6060).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.5.0 / 2020-01-13
+## 1.5.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 
-## 1.4.1 / 2019-10-09
+## 1.4.1 / 2019-10-09 / Agent 6.15.0
 
 * [Fixed] Explain filetagname logic in the example config file. See [#4524](https://github.com/DataDog/integrations-core/pull/4524).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3499](https://github.com/DataDog/integrations-core/pull/3499).
 
-## 1.3.1 / 2018-10-12
+## 1.3.1 / 2018-10-12 / Agent 5.28.0
 
 * [Fixed] Make the error message more clear in case a path is not accessible. See [#2369][1].
 
-## 1.3.0 / 2018-09-04
+## 1.3.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Add option to pattern-match full directory path. See [#2026][2].
 * [Added] Upgrade scandir to latest version. See [#2024][3].

--- a/directory/CHANGELOG.md
+++ b/directory/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [Fixed] Simplify walker recursive condition. See [#6965](https://github.com/DataDog/integrations-core/pull/6965).
 * [Fixed] Refactor config. See [#6961](https://github.com/DataDog/integrations-core/pull/6961).
 
-## 1.7.0 / 2020-06-03 / Agent 7.21.0
+## 1.7.0 / 2020-06-03
 
 * [Added] Add `follow_symlinks` config option. See [#6800](https://github.com/DataDog/integrations-core/pull/6800).
 
@@ -33,11 +33,11 @@
 
 * [Added] Adhere to code style. See [#3499](https://github.com/DataDog/integrations-core/pull/3499).
 
-## 1.3.1 / 2018-10-12 / Agent 5.28.0
+## 1.3.1 / 2018-10-12 / Agent 6.6.0
 
 * [Fixed] Make the error message more clear in case a path is not accessible. See [#2369][1].
 
-## 1.3.0 / 2018-09-04 / Agent 5.28.0
+## 1.3.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Add option to pattern-match full directory path. See [#2026][2].
 * [Added] Upgrade scandir to latest version. See [#2024][3].

--- a/disk/CHANGELOG.md
+++ b/disk/CHANGELOG.md
@@ -1,76 +1,76 @@
 # CHANGELOG - disk
 
-## 2.10.1 / 2020-06-11
+## 2.10.1 / 2020-06-11 / Agent 7.21.0
 
 * [Fixed] Rename disk check example config back to .default suffix. See [#6880](https://github.com/DataDog/integrations-core/pull/6880).
 
-## 2.10.0 / 2020-06-09
+## 2.10.0 / 2020-06-09 / Agent 7.21.0
 
 * [Added] Add disk timeout configuration option. See [#6826](https://github.com/DataDog/integrations-core/pull/6826).
 
-## 2.9.1 / 2020-06-11
+## 2.9.1 / 2020-06-11 / Agent 7.20.1
 
 * [Fixed] Rename disk check example config back to .default suffix. See [#6880](https://github.com/DataDog/integrations-core/pull/6880).
 
-## 2.9.0 / 2020-05-17
+## 2.9.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add config spec. See [#6553](https://github.com/DataDog/integrations-core/pull/6553).
 * [Added] Add device_name tag. See [#6332](https://github.com/DataDog/integrations-core/pull/6332).
 
-## 2.8.0 / 2020-04-04
+## 2.8.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
 
-## 2.7.0 / 2020-02-22
+## 2.7.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Read udev disk labels from the blkid cache file. See [#5515](https://github.com/DataDog/integrations-core/pull/5515).
 
-## 2.6.0 / 2020-01-13
+## 2.6.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 2.5.3 / 2019-12-13
+## 2.5.3 / 2019-12-13 / Agent 7.17.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 2.5.2 / 2019-12-02
+## 2.5.2 / 2019-12-02 / Agent 7.16.0
 
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
 
-## 2.5.1 / 2019-10-11
+## 2.5.1 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Upgrade psutil dependency to 5.6.3. See [#4442](https://github.com/DataDog/integrations-core/pull/4442).
 
-## 2.5.0 / 2019-08-24
+## 2.5.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Remove legacy collection method. See [#4417](https://github.com/DataDog/integrations-core/pull/4417).
 * [Added] Add `min_disk_size` option. See [#4317](https://github.com/DataDog/integrations-core/pull/4317).
 
-## 2.4.0 / 2019-07-12
+## 2.4.0 / 2019-07-12 / Agent 6.13.0
 
 * [Added] Remove legacy code. See [#4103](https://github.com/DataDog/integrations-core/pull/4103).
 
-## 2.3.0 / 2019-07-04
+## 2.3.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Add disk label. See [#3953](https://github.com/DataDog/integrations-core/pull/3953).
 
-## 2.2.0 / 2019-05-14
+## 2.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Upgrade psutil dependency to 5.6.2. See [#3684](https://github.com/DataDog/integrations-core/pull/3684).
 * [Added] Adhere to code style. See [#3500](https://github.com/DataDog/integrations-core/pull/3500).
 
-## 2.1.0 / 2019-02-18
+## 2.1.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Upgrade psutil. See [#3019](https://github.com/DataDog/integrations-core/pull/3019).
 * [Fixed] Use `device` tag instead of the deprecated `device_name` parameter. See [#2946](https://github.com/DataDog/integrations-core/pull/2946). Thanks [aerostitch](https://github.com/aerostitch).
 
-## 2.0.1 / 2019-01-04
+## 2.0.1 / 2019-01-04 / Agent 5.31.0
 
 * [Fixed] Fix regression on agent 5 only. See [#2848][1].
 
-## 2.0.0 / 2018-11-30
+## 2.0.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Update psutil. See [#2576][2].
 * [Added] Add new filtering options, continue deprecations. See [#2483][3].
@@ -78,16 +78,16 @@
 * [Added] Support Python 3. See [#2468][5].
 * [Fixed] Use raw string literals when \ is present. See [#2465][6].
 
-## 1.4.0 / 2018-10-12
+## 1.4.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Upgrade psutil. See [#2190][7].
 
-## 1.3.0 / 2018-09-04
+## 1.3.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Adding optional service_check_rw parameter to check for read-only filesystem. See [#2086][8]. Thanks [bberezov][9].
 * [Fixed] Add data files to the wheel package. See [#1727][10].
 
-## 1.2.0 / 2018-03-23
+## 1.2.0 / 2018-03-23 / Agent 6.1.1
 
 * [FEATURE] Adds custom tag support
 

--- a/disk/CHANGELOG.md
+++ b/disk/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [Fixed] Rename disk check example config back to .default suffix. See [#6880](https://github.com/DataDog/integrations-core/pull/6880).
 
-## 2.10.0 / 2020-06-09 / Agent 7.21.0
+## 2.10.0 / 2020-06-09
 
 * [Added] Add disk timeout configuration option. See [#6826](https://github.com/DataDog/integrations-core/pull/6826).
 
@@ -31,11 +31,11 @@
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 2.5.3 / 2019-12-13 / Agent 7.17.0
+## 2.5.3 / 2019-12-13 / Agent 7.16.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 2.5.2 / 2019-12-02 / Agent 7.16.0
+## 2.5.2 / 2019-12-02
 
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
 
@@ -52,7 +52,7 @@
 
 * [Added] Remove legacy code. See [#4103](https://github.com/DataDog/integrations-core/pull/4103).
 
-## 2.3.0 / 2019-07-04 / Agent 6.13.0
+## 2.3.0 / 2019-07-04
 
 * [Added] Add disk label. See [#3953](https://github.com/DataDog/integrations-core/pull/3953).
 
@@ -61,16 +61,16 @@
 * [Added] Upgrade psutil dependency to 5.6.2. See [#3684](https://github.com/DataDog/integrations-core/pull/3684).
 * [Added] Adhere to code style. See [#3500](https://github.com/DataDog/integrations-core/pull/3500).
 
-## 2.1.0 / 2019-02-18 / Agent 6.11.0
+## 2.1.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Upgrade psutil. See [#3019](https://github.com/DataDog/integrations-core/pull/3019).
 * [Fixed] Use `device` tag instead of the deprecated `device_name` parameter. See [#2946](https://github.com/DataDog/integrations-core/pull/2946). Thanks [aerostitch](https://github.com/aerostitch).
 
-## 2.0.1 / 2019-01-04 / Agent 5.31.0
+## 2.0.1 / 2019-01-04 / Agent 6.9.0
 
 * [Fixed] Fix regression on agent 5 only. See [#2848][1].
 
-## 2.0.0 / 2018-11-30 / Agent 5.30.0
+## 2.0.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Update psutil. See [#2576][2].
 * [Added] Add new filtering options, continue deprecations. See [#2483][3].
@@ -78,16 +78,16 @@
 * [Added] Support Python 3. See [#2468][5].
 * [Fixed] Use raw string literals when \ is present. See [#2465][6].
 
-## 1.4.0 / 2018-10-12 / Agent 5.28.0
+## 1.4.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Upgrade psutil. See [#2190][7].
 
-## 1.3.0 / 2018-09-04 / Agent 5.28.0
+## 1.3.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Adding optional service_check_rw parameter to check for read-only filesystem. See [#2086][8]. Thanks [bberezov][9].
 * [Fixed] Add data files to the wheel package. See [#1727][10].
 
-## 1.2.0 / 2018-03-23 / Agent 6.1.1
+## 1.2.0 / 2018-03-23
 
 * [FEATURE] Adds custom tag support
 

--- a/dns_check/CHANGELOG.md
+++ b/dns_check/CHANGELOG.md
@@ -1,47 +1,47 @@
 # CHANGELOG - dns_check
 
-## 1.7.0 / 2020-06-29
+## 1.7.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Refactor and remove legacy hack for Agent 5's build system. See [#6682](https://github.com/DataDog/integrations-core/pull/6682).
 
-## 1.6.0 / 2020-05-17
+## 1.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add config spec. See [#6560](https://github.com/DataDog/integrations-core/pull/6560).
 
-## 1.5.2 / 2020-04-24
+## 1.5.2 / 2020-04-24 / Agent 7.20.0
 
 * [Fixed] Fix missing `time.clock` attribute in Python 3.8. See [#6478](https://github.com/DataDog/integrations-core/pull/6478).
 
-## 1.5.1 / 2020-04-04
+## 1.5.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.5.0 / 2020-01-13
+## 1.5.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.4.1 / 2019-08-24
+## 1.4.1 / 2019-08-24 / Agent 6.14.0
 
 * [Fixed] Make nameserver optional in the configuration. See [#4283](https://github.com/DataDog/integrations-core/pull/4283).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3501](https://github.com/DataDog/integrations-core/pull/3501).
 
-## 1.3.0 / 2019-03-29
+## 1.3.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#3425](https://github.com/DataDog/integrations-core/pull/3425).
 
-## 1.2.0 / 2018-11-30
+## 1.2.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] add ability to check A, CNAME and MX results. See [#2615][1]. Thanks [volksman][2].
 
-## 1.1.2 / 2018-09-04
+## 1.1.2 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 
-## 1.1.1 / 2018-06-13
+## 1.1.1 / 2018-06-13 / Agent 5.26.0
 
 * [Fixed] Fix parsing of requirements file so that `dnspython` is listed as a req. See [#1603][4].
 

--- a/dns_check/CHANGELOG.md
+++ b/dns_check/CHANGELOG.md
@@ -9,11 +9,11 @@
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add config spec. See [#6560](https://github.com/DataDog/integrations-core/pull/6560).
 
-## 1.5.2 / 2020-04-24 / Agent 7.20.0
+## 1.5.2 / 2020-04-24 / Agent 7.19.0
 
 * [Fixed] Fix missing `time.clock` attribute in Python 3.8. See [#6478](https://github.com/DataDog/integrations-core/pull/6478).
 
-## 1.5.1 / 2020-04-04 / Agent 7.19.0
+## 1.5.1 / 2020-04-04
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
@@ -33,15 +33,15 @@
 
 * [Added] Support Python 3. See [#3425](https://github.com/DataDog/integrations-core/pull/3425).
 
-## 1.2.0 / 2018-11-30 / Agent 5.30.0
+## 1.2.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] add ability to check A, CNAME and MX results. See [#2615][1]. Thanks [volksman][2].
 
-## 1.1.2 / 2018-09-04 / Agent 5.28.0
+## 1.1.2 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 
-## 1.1.1 / 2018-06-13 / Agent 5.26.0
+## 1.1.1 / 2018-06-13 / Agent 6.4.0
 
 * [Fixed] Fix parsing of requirements file so that `dnspython` is listed as a req. See [#1603][4].
 

--- a/dotnetclr/CHANGELOG.md
+++ b/dotnetclr/CHANGELOG.md
@@ -26,21 +26,21 @@
 
 * [Added] Adhere to code style. See [#3502](https://github.com/DataDog/integrations-core/pull/3502).
 
-## 1.2.0 / 2019-02-18 / Agent 6.11.0
+## 1.2.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2987](https://github.com/DataDog/integrations-core/pull/2987).
 
-## 1.1.1 / 2019-01-04 / Agent 5.31.0
+## 1.1.1 / 2019-01-04 / Agent 6.9.0
 
 * [Fixed] Change example config from "localhost" to ".". See [#2779][1].
 
-## 1.1.0 / 2018-10-12 / Agent 5.28.0
+## 1.1.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Pin pywin32 dependency. See [#2322][2].
 * [Fixed] Remove unused port config option for pdh checks. See [#2244][3].
 
-## 1.0.1 / 2018-09-04 / Agent 5.28.0
+## 1.0.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 

--- a/dotnetclr/CHANGELOG.md
+++ b/dotnetclr/CHANGELOG.md
@@ -1,46 +1,46 @@
 # CHANGELOG - Dotnetclr
 
-## 1.7.0 / 2020-06-29
+## 1.7.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 * [Added] Add config specs. See [#6727](https://github.com/DataDog/integrations-core/pull/6727).
 
-## 1.6.0 / 2020-05-17
+## 1.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Agent 6 signature. See [#6445](https://github.com/DataDog/integrations-core/pull/6445).
 
-## 1.5.0 / 2019-12-02
+## 1.5.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 1.4.0 / 2019-10-11
+## 1.4.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 1.3.1 / 2019-06-18
+## 1.3.1 / 2019-06-18 / Agent 6.13.0
 
 * [Fixed] Rename lower case manifest.in. See [#3858](https://github.com/DataDog/integrations-core/pull/3858).
 
-## 1.3.0 / 2019-05-14
+## 1.3.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3502](https://github.com/DataDog/integrations-core/pull/3502).
 
-## 1.2.0 / 2019-02-18
+## 1.2.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2987](https://github.com/DataDog/integrations-core/pull/2987).
 
-## 1.1.1 / 2019-01-04
+## 1.1.1 / 2019-01-04 / Agent 5.31.0
 
 * [Fixed] Change example config from "localhost" to ".". See [#2779][1].
 
-## 1.1.0 / 2018-10-12
+## 1.1.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][2].
 * [Fixed] Remove unused port config option for pdh checks. See [#2244][3].
 
-## 1.0.1 / 2018-09-04
+## 1.0.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 

--- a/druid/CHANGELOG.md
+++ b/druid/CHANGELOG.md
@@ -25,11 +25,11 @@
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 * [Added] Upgrade psycopg2-binary to 2.8.4. See [#4840](https://github.com/DataDog/integrations-core/pull/4840).
 
-## 1.1.0 / 2019-10-17 / Agent 7.16.0
+## 1.1.0 / 2019-10-17 / Agent 6.15.0
 
 * [Added] Add druid logs. See [#4561](https://github.com/DataDog/integrations-core/pull/4561).
 
-## 1.0.0 / 2019-10-11 / Agent 6.15.0
+## 1.0.0 / 2019-10-11
 
 * [Added] Adhere to logging call convention. See [#4735](https://github.com/DataDog/integrations-core/pull/4735).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).

--- a/druid/CHANGELOG.md
+++ b/druid/CHANGELOG.md
@@ -1,35 +1,35 @@
 # CHANGELOG - druid
 
-## 1.4.1 / 2020-08-10
+## 1.4.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.4.0 / 2020-06-29
+## 1.4.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Added] Add config specs. See [#6728](https://github.com/DataDog/integrations-core/pull/6728).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.3.0 / 2020-05-17
+## 1.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.2.1 / 2020-04-04
+## 1.2.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.2.0 / 2019-12-02
+## 1.2.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 * [Added] Upgrade psycopg2-binary to 2.8.4. See [#4840](https://github.com/DataDog/integrations-core/pull/4840).
 
-## 1.1.0 / 2019-10-17
+## 1.1.0 / 2019-10-17 / Agent 7.16.0
 
 * [Added] Add druid logs. See [#4561](https://github.com/DataDog/integrations-core/pull/4561).
 
-## 1.0.0 / 2019-10-11
+## 1.0.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Adhere to logging call convention. See [#4735](https://github.com/DataDog/integrations-core/pull/4735).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).

--- a/ecs_fargate/CHANGELOG.md
+++ b/ecs_fargate/CHANGELOG.md
@@ -41,7 +41,7 @@
 
 * [Fixed] Use tagger with container_id prefix. See [#4126](https://github.com/DataDog/integrations-core/pull/4126).
 
-## 2.2.1 / 2019-06-28 / Agent 6.13.0
+## 2.2.1 / 2019-06-28 / Agent 6.12.1
 
 * [Fixed] Make the kubelet and ECS fargate checks resilient to the tagger returning None. See [#4004](https://github.com/DataDog/integrations-core/pull/4004).
 
@@ -49,19 +49,19 @@
 
 * [Added] Adhere to code style. See [#3503](https://github.com/DataDog/integrations-core/pull/3503).
 
-## 2.1.0 / 2019-02-18 / Agent 6.11.0
+## 2.1.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#2885](https://github.com/DataDog/integrations-core/pull/2885).
 
-## 2.0.0 / 2018-11-30 / Agent 5.30.0
+## 2.0.0 / 2018-11-30 / Agent 6.8.0
 
 * [Changed] Rework tagging to be consistent with the live container view and Autodiscovery. See [#2601][1].
 
-## 1.3.0 / 2018-09-11 / Agent 5.28.0
+## 1.3.0 / 2018-09-11 / Agent 6.5.0
 
 * [Added] Add cpu percent metric and fix container stopped behaviour. See [#2206][2].
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04
 
 * [Fixed] Fix key errors. See [#1959][3].
 * [Fixed] Update metadata of the cpu metrics from gauges to rates. See [#1518][4].

--- a/ecs_fargate/CHANGELOG.md
+++ b/ecs_fargate/CHANGELOG.md
@@ -1,67 +1,67 @@
 # CHANGELOG - ECS Fargate
 
-## 2.10.0 / 2020-08-10
+## 2.10.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Support include/exclude containers in ECS Fargate. See [#7165](https://github.com/DataDog/integrations-core/pull/7165).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 2.9.0 / 2020-06-29
+## 2.9.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 2.8.0 / 2020-05-17
+## 2.8.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.7.0 / 2020-04-04
+## 2.7.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Collect network metrics for ECS Fargate. See [#6216](https://github.com/DataDog/integrations-core/pull/6216).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 2.6.0 / 2020-01-13
+## 2.6.0 / 2020-01-13 / Agent 7.17.0
 
 * [Fixed] Fix CPU metrics. See [#5404](https://github.com/DataDog/integrations-core/pull/5404).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 2.5.0 / 2019-12-02
+## 2.5.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 2.4.0 / 2019-10-11
+## 2.4.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 * [Fixed] Fix ecs_fargate timeout. See [#4518](https://github.com/DataDog/integrations-core/pull/4518).
 
-## 2.3.0 / 2019-08-24
+## 2.3.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Update with proxy settings and request wrapper. See [#3477](https://github.com/DataDog/integrations-core/pull/3477).
 
-## 2.2.2 / 2019-07-17
+## 2.2.2 / 2019-07-17 / Agent 6.13.0
 
 * [Fixed] Use tagger with container_id prefix. See [#4126](https://github.com/DataDog/integrations-core/pull/4126).
 
-## 2.2.1 / 2019-06-28
+## 2.2.1 / 2019-06-28 / Agent 6.13.0
 
 * [Fixed] Make the kubelet and ECS fargate checks resilient to the tagger returning None. See [#4004](https://github.com/DataDog/integrations-core/pull/4004).
 
-## 2.2.0 / 2019-05-14
+## 2.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3503](https://github.com/DataDog/integrations-core/pull/3503).
 
-## 2.1.0 / 2019-02-18
+## 2.1.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#2885](https://github.com/DataDog/integrations-core/pull/2885).
 
-## 2.0.0 / 2018-11-30
+## 2.0.0 / 2018-11-30 / Agent 5.30.0
 
 * [Changed] Rework tagging to be consistent with the live container view and Autodiscovery. See [#2601][1].
 
-## 1.3.0 / 2018-09-11
+## 1.3.0 / 2018-09-11 / Agent 5.28.0
 
 * [Added] Add cpu percent metric and fix container stopped behaviour. See [#2206][2].
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Fix key errors. See [#1959][3].
 * [Fixed] Update metadata of the cpu metrics from gauges to rates. See [#1518][4].

--- a/eks_fargate/CHANGELOG.md
+++ b/eks_fargate/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG - eks_fargate
 
-## 1.1.0 / 2020-05-17
+## 1.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.0.0 / 2020-02-22
+## 1.0.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Introducing the eks_fargate check. See [#5417](https://github.com/DataDog/integrations-core/pull/5417).
 

--- a/elastic/CHANGELOG.md
+++ b/elastic/CHANGELOG.md
@@ -1,88 +1,88 @@
 # CHANGELOG - elastic
 
-## 1.19.0 / 2020-08-10
+## 1.19.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Include Node system stats. See [#6590](https://github.com/DataDog/integrations-core/pull/6590).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.18.0 / 2020-06-29
+## 1.18.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Added] Add config specs. See [#6773](https://github.com/DataDog/integrations-core/pull/6773).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.17.0 / 2020-05-17
+## 1.17.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.16.1 / 2020-04-04
+## 1.16.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.16.0 / 2020-01-13
+## 1.16.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Added] Add OOTB support for AWS Signature Version 4 Signing. See [#5289](https://github.com/DataDog/integrations-core/pull/5289).
 
-## 1.15.0 / 2019-12-02
+## 1.15.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.14.0 / 2019-10-11
+## 1.14.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Submit version metadata. See [#4724](https://github.com/DataDog/integrations-core/pull/4724).
 * [Added] Add external refresh metrics. See [#4554](https://github.com/DataDog/integrations-core/pull/4554). Thanks [clandry94](https://github.com/clandry94).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.13.2 / 2019-08-30
+## 1.13.2 / 2019-08-30 / Agent 6.15.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 1.13.1 / 2019-07-18
+## 1.13.1 / 2019-07-18 / Agent 6.13.0
 
 * [Fixed] Add missing HTTP options to example config. See [#4129](https://github.com/DataDog/integrations-core/pull/4129).
 
-## 1.13.0 / 2019-07-13
+## 1.13.0 / 2019-07-13 / Agent 6.13.0
 
 * [Added] Use the new RequestsWrapper for connecting to services. See [#4100](https://github.com/DataDog/integrations-core/pull/4100).
 
-## 1.12.0 / 2019-05-14
+## 1.12.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3504](https://github.com/DataDog/integrations-core/pull/3504).
 
-## 1.11.0 / 2019-02-18
+## 1.11.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support unicode for Python 3 bindings. See [#2869](https://github.com/DataDog/integrations-core/pull/2869).
 
-## 1.10.0 / 2019-01-04
+## 1.10.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Add completed metric for all ES thread pools. See [#2803][1].
 * [Added] Capture metrics for ES scroll requests . See [#2687][2].
 
-## 1.9.1 / 2018-11-30
+## 1.9.1 / 2018-11-30 / Agent 5.30.0
 
 * [Fixed] Add elasticsearch-oss as an auto_conf.yaml Elasticsearch identifier. See [#2644][3]. Thanks [jcassee][4].
 
-## 1.9.0 / 2018-10-23
+## 1.9.0 / 2018-10-23 / Agent 5.30.0
 
 * [Added] Add option to prevent duplicate hostnames. See [#2453][5].
 * [Added] Support Python 3. See [#2417][6].
 * [Fixed] Move metrics definition and logic into its own module. See [#2381][7].
 
-## 1.8.0 / 2018-10-12
+## 1.8.0 / 2018-10-12 / Agent 5.28.0
 
 * [Fixed] Move config parser to its own module. See [#2370][8].
 * [Added] Added delayed_unassigned_shards metric. See [#2361][9].
 * [Added] Added inflight_requests metrics (version 5.4 and later).. See [#2360][10].
 
-## 1.7.1 / 2018-09-04
+## 1.7.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add thread write queue to fix Elasticsearch 6.3.x compatibility. See [#1943][11].
 * [Fixed] Add data files to the wheel package. See [#1727][12].
 
-## 1.7.0 / 2018-06-07
+## 1.7.0 / 2018-06-07 / Agent 5.25.0
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][13].
 * [Fixed] [FIXED] Ensure base url path isn't removed when admin_forwarder is used. See [#1202][14].

--- a/elastic/CHANGELOG.md
+++ b/elastic/CHANGELOG.md
@@ -36,7 +36,7 @@
 * [Added] Add external refresh metrics. See [#4554](https://github.com/DataDog/integrations-core/pull/4554). Thanks [clandry94](https://github.com/clandry94).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.13.2 / 2019-08-30 / Agent 6.15.0
+## 1.13.2 / 2019-08-30 / Agent 6.14.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
@@ -44,7 +44,7 @@
 
 * [Fixed] Add missing HTTP options to example config. See [#4129](https://github.com/DataDog/integrations-core/pull/4129).
 
-## 1.13.0 / 2019-07-13 / Agent 6.13.0
+## 1.13.0 / 2019-07-13
 
 * [Added] Use the new RequestsWrapper for connecting to services. See [#4100](https://github.com/DataDog/integrations-core/pull/4100).
 
@@ -52,37 +52,37 @@
 
 * [Added] Adhere to code style. See [#3504](https://github.com/DataDog/integrations-core/pull/3504).
 
-## 1.11.0 / 2019-02-18 / Agent 6.11.0
+## 1.11.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support unicode for Python 3 bindings. See [#2869](https://github.com/DataDog/integrations-core/pull/2869).
 
-## 1.10.0 / 2019-01-04 / Agent 5.31.0
+## 1.10.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Add completed metric for all ES thread pools. See [#2803][1].
 * [Added] Capture metrics for ES scroll requests . See [#2687][2].
 
-## 1.9.1 / 2018-11-30 / Agent 5.30.0
+## 1.9.1 / 2018-11-30 / Agent 6.8.0
 
 * [Fixed] Add elasticsearch-oss as an auto_conf.yaml Elasticsearch identifier. See [#2644][3]. Thanks [jcassee][4].
 
-## 1.9.0 / 2018-10-23 / Agent 5.30.0
+## 1.9.0 / 2018-10-23
 
 * [Added] Add option to prevent duplicate hostnames. See [#2453][5].
 * [Added] Support Python 3. See [#2417][6].
 * [Fixed] Move metrics definition and logic into its own module. See [#2381][7].
 
-## 1.8.0 / 2018-10-12 / Agent 5.28.0
+## 1.8.0 / 2018-10-12 / Agent 6.6.0
 
 * [Fixed] Move config parser to its own module. See [#2370][8].
 * [Added] Added delayed_unassigned_shards metric. See [#2361][9].
 * [Added] Added inflight_requests metrics (version 5.4 and later).. See [#2360][10].
 
-## 1.7.1 / 2018-09-04 / Agent 5.28.0
+## 1.7.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add thread write queue to fix Elasticsearch 6.3.x compatibility. See [#1943][11].
 * [Fixed] Add data files to the wheel package. See [#1727][12].
 
-## 1.7.0 / 2018-06-07 / Agent 5.25.0
+## 1.7.0 / 2018-06-07
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][13].
 * [Fixed] [FIXED] Ensure base url path isn't removed when admin_forwarder is used. See [#1202][14].

--- a/envoy/CHANGELOG.md
+++ b/envoy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - Envoy
 
-## 1.17.0 / 2020-08-10
+## 1.17.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] envoy config specs. See [#7157](https://github.com/DataDog/integrations-core/pull/7157).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
@@ -8,83 +8,83 @@
 * [Fixed] Use inclusive naming. See [#7156](https://github.com/DataDog/integrations-core/pull/7156).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.16.0 / 2020-06-29
+## 1.16.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.15.2 / 2020-05-26
+## 1.15.2 / 2020-05-26 / Agent 7.21.0
 
 * [Fixed] Handle server info for envoy <= 1.8. See [#6740](https://github.com/DataDog/integrations-core/pull/6740).
 
-## 1.15.1 / 2020-05-19
+## 1.15.1 / 2020-05-19 / Agent 7.21.0
 
 * [Fixed] Safer metadata error handling. See [#6685](https://github.com/DataDog/integrations-core/pull/6685).
 
-## 1.15.0 / 2020-05-17
+## 1.15.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Collect version metadata. See [#6595](https://github.com/DataDog/integrations-core/pull/6595).
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Fix style to account for new flake8 rules. See [#6620](https://github.com/DataDog/integrations-core/pull/6620).
 
-## 1.14.0 / 2020-04-04
+## 1.14.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Update doc about whitelist and blacklist. See [#5875](https://github.com/DataDog/integrations-core/pull/5875).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.13.0 / 2020-02-22
+## 1.13.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add support for more metrics in Envoy integration. See [#5537](https://github.com/DataDog/integrations-core/pull/5537). Thanks [csssuf](https://github.com/csssuf).
 
-## 1.12.0 / 2020-01-13
+## 1.12.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.11.0 / 2019-12-02
+## 1.11.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add new metrics for Redis. See [#4946](https://github.com/DataDog/integrations-core/pull/4946). Thanks [tony612](https://github.com/tony612).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.10.0 / 2019-10-11
+## 1.10.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add xDS-related metrics. See [#4634](https://github.com/DataDog/integrations-core/pull/4634). Thanks [csssuf](https://github.com/csssuf).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.9.0 / 2019-08-24
+## 1.9.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add RequestsWrapper to envoy. See [#4120](https://github.com/DataDog/integrations-core/pull/4120).
 
-## 1.8.0 / 2019-07-04
+## 1.8.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Add cluster.ssl metrics to Envoy integration. See [#3976](https://github.com/DataDog/integrations-core/pull/3976). Thanks [csssuf](https://github.com/csssuf).
 * [Added] Add Envoy upstream_rq_completed cluster metrics. See [#3955](https://github.com/DataDog/integrations-core/pull/3955). Thanks [csssuf](https://github.com/csssuf).
 
-## 1.7.0 / 2019-06-19
+## 1.7.0 / 2019-06-19 / Agent 6.13.0
 
 * [Added] Add more listener metrics. See [#3922](https://github.com/DataDog/integrations-core/pull/3922).
 
-## 1.6.0 / 2019-06-18
+## 1.6.0 / 2019-06-18 / Agent 6.13.0
 
 * [Added] Add logs config to envoy. See [#3918](https://github.com/DataDog/integrations-core/pull/3918).
 
-## 1.5.0 / 2019-03-29
+## 1.5.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Adhere to style. See [#3366](https://github.com/DataDog/integrations-core/pull/3366).
 
-## 1.4.0 / 2018-09-05
+## 1.4.0 / 2018-09-05 / Agent 5.28.0
 
 * [Changed] Change order of precedence of whitelist and blacklist for pattern filtering. See [#2174][1].
 
-## 1.3.0 / 2018-08-06
+## 1.3.0 / 2018-08-06 / Agent 5.27.0
 
 * [Added] Add ability to whitelist/blacklist metrics. See [#1975][2].
 * [Changed] Add data files to the wheel package. See [#1727][3].
 
-## 1.2.1 / 2018-06-14
+## 1.2.1 / 2018-06-14 / Agent 5.26.0
 
 * [Fixed] properly send tags for histograms. See [#1741][4].
 
-## 1.2.0 / 2018-06-07
+## 1.2.0 / 2018-06-07 / Agent 5.25.0
 
 * [Added] support histograms, fix count submission. See [#1616][5].
 

--- a/envoy/CHANGELOG.md
+++ b/envoy/CHANGELOG.md
@@ -12,15 +12,15 @@
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.15.2 / 2020-05-26 / Agent 7.21.0
+## 1.15.2 / 2020-05-26 / Agent 7.20.0
 
 * [Fixed] Handle server info for envoy <= 1.8. See [#6740](https://github.com/DataDog/integrations-core/pull/6740).
 
-## 1.15.1 / 2020-05-19 / Agent 7.21.0
+## 1.15.1 / 2020-05-19
 
 * [Fixed] Safer metadata error handling. See [#6685](https://github.com/DataDog/integrations-core/pull/6685).
 
-## 1.15.0 / 2020-05-17 / Agent 7.20.0
+## 1.15.0 / 2020-05-17
 
 * [Added] Collect version metadata. See [#6595](https://github.com/DataDog/integrations-core/pull/6595).
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
@@ -59,11 +59,11 @@
 * [Added] Add cluster.ssl metrics to Envoy integration. See [#3976](https://github.com/DataDog/integrations-core/pull/3976). Thanks [csssuf](https://github.com/csssuf).
 * [Added] Add Envoy upstream_rq_completed cluster metrics. See [#3955](https://github.com/DataDog/integrations-core/pull/3955). Thanks [csssuf](https://github.com/csssuf).
 
-## 1.7.0 / 2019-06-19 / Agent 6.13.0
+## 1.7.0 / 2019-06-19
 
 * [Added] Add more listener metrics. See [#3922](https://github.com/DataDog/integrations-core/pull/3922).
 
-## 1.6.0 / 2019-06-18 / Agent 6.13.0
+## 1.6.0 / 2019-06-18
 
 * [Added] Add logs config to envoy. See [#3918](https://github.com/DataDog/integrations-core/pull/3918).
 
@@ -71,20 +71,20 @@
 
 * [Added] Adhere to style. See [#3366](https://github.com/DataDog/integrations-core/pull/3366).
 
-## 1.4.0 / 2018-09-05 / Agent 5.28.0
+## 1.4.0 / 2018-09-05 / Agent 6.5.0
 
 * [Changed] Change order of precedence of whitelist and blacklist for pattern filtering. See [#2174][1].
 
-## 1.3.0 / 2018-08-06 / Agent 5.27.0
+## 1.3.0 / 2018-08-06
 
 * [Added] Add ability to whitelist/blacklist metrics. See [#1975][2].
 * [Changed] Add data files to the wheel package. See [#1727][3].
 
-## 1.2.1 / 2018-06-14 / Agent 5.26.0
+## 1.2.1 / 2018-06-14 / Agent 6.4.0
 
 * [Fixed] properly send tags for histograms. See [#1741][4].
 
-## 1.2.0 / 2018-06-07 / Agent 5.25.0
+## 1.2.0 / 2018-06-07
 
 * [Added] support histograms, fix count submission. See [#1616][5].
 

--- a/etcd/CHANGELOG.md
+++ b/etcd/CHANGELOG.md
@@ -1,67 +1,67 @@
 # CHANGELOG - etcd
 
-## 2.4.1 / 2020-08-10
+## 2.4.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 2.4.0 / 2020-06-29
+## 2.4.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 2.3.0 / 2020-05-17
+## 2.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.2.1 / 2020-02-22
+## 2.2.1 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Update auto_conf yaml to default to preview. See [#5661](https://github.com/DataDog/integrations-core/pull/5661).
 
-## 2.2.0 / 2020-01-13
+## 2.2.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 2.1.0 / 2019-11-06
+## 2.1.0 / 2019-11-06 / Agent 7.16.0
 
 * [Fixed] Add ssl config options necessary for Openmetrics base. See [#4951](https://github.com/DataDog/integrations-core/pull/4951).
 * [Added] Add version metadata. See [#4950](https://github.com/DataDog/integrations-core/pull/4950).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 2.0.1 / 2019-10-16
+## 2.0.1 / 2019-10-16 / Agent 7.16.0
 
 * [Fixed] Set use_preview to True in init as well. See [#4792](https://github.com/DataDog/integrations-core/pull/4792).
 
-## 2.0.0 / 2019-10-11
+## 2.0.0 / 2019-10-11 / Agent 6.15.0
 
 * [Changed] Etcd uses V3 preview by default. See [#4656](https://github.com/DataDog/integrations-core/pull/4656).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.9.0 / 2019-08-24
+## 1.9.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add requests wrapper to etcd. See [#4323](https://github.com/DataDog/integrations-core/pull/4323).
 
-## 1.8.0 / 2019-05-14
+## 1.8.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3505](https://github.com/DataDog/integrations-core/pull/3505).
 
-## 1.7.0 / 2019-02-18
+## 1.7.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Use alpha grpc gateway endpoint. See [#3125](https://github.com/DataDog/integrations-core/pull/3125).
 * [Added] Make `is_leader` tag optional. See [#3114](https://github.com/DataDog/integrations-core/pull/3114).
 
-## 1.6.1 / 2019-01-04
+## 1.6.1 / 2019-01-04 / Agent 5.31.0
 
 * [Fixed] Postpone deprecation warning to 6.10. See [#2844][1].
 * [Fixed] Fix indentation for end of .example file. See [#2843][2].
 
-## 1.6.0 / 2018-11-07
+## 1.6.0 / 2018-11-07 / Agent 5.30.0
 
 * [Added] Add support for ETCD v3 API, begin deprecation of ETCD < v3. See [#2506][3].
 
-## 1.5.1 / 2018-09-04
+## 1.5.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 
-## 1.5.0 / 2018-06-13
+## 1.5.0 / 2018-06-13 / Agent 5.26.0
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][5].
 

--- a/etcd/CHANGELOG.md
+++ b/etcd/CHANGELOG.md
@@ -26,11 +26,11 @@
 * [Added] Add version metadata. See [#4950](https://github.com/DataDog/integrations-core/pull/4950).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 2.0.1 / 2019-10-16 / Agent 7.16.0
+## 2.0.1 / 2019-10-16 / Agent 6.15.0
 
 * [Fixed] Set use_preview to True in init as well. See [#4792](https://github.com/DataDog/integrations-core/pull/4792).
 
-## 2.0.0 / 2019-10-11 / Agent 6.15.0
+## 2.0.0 / 2019-10-11
 
 * [Changed] Etcd uses V3 preview by default. See [#4656](https://github.com/DataDog/integrations-core/pull/4656).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
@@ -43,25 +43,25 @@
 
 * [Added] Adhere to code style. See [#3505](https://github.com/DataDog/integrations-core/pull/3505).
 
-## 1.7.0 / 2019-02-18 / Agent 6.11.0
+## 1.7.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Use alpha grpc gateway endpoint. See [#3125](https://github.com/DataDog/integrations-core/pull/3125).
 * [Added] Make `is_leader` tag optional. See [#3114](https://github.com/DataDog/integrations-core/pull/3114).
 
-## 1.6.1 / 2019-01-04 / Agent 5.31.0
+## 1.6.1 / 2019-01-04 / Agent 6.9.0
 
 * [Fixed] Postpone deprecation warning to 6.10. See [#2844][1].
 * [Fixed] Fix indentation for end of .example file. See [#2843][2].
 
-## 1.6.0 / 2018-11-07 / Agent 5.30.0
+## 1.6.0 / 2018-11-07 / Agent 6.8.0
 
 * [Added] Add support for ETCD v3 API, begin deprecation of ETCD < v3. See [#2506][3].
 
-## 1.5.1 / 2018-09-04 / Agent 5.28.0
+## 1.5.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 
-## 1.5.0 / 2018-06-13 / Agent 5.26.0
+## 1.5.0 / 2018-06-13 / Agent 6.4.0
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][5].
 

--- a/exchange_server/CHANGELOG.md
+++ b/exchange_server/CHANGELOG.md
@@ -25,20 +25,20 @@
 
 * [Added] Adhere to code style. See [#3506](https://github.com/DataDog/integrations-core/pull/3506).
 
-## 1.3.0 / 2019-02-18 / Agent 6.11.0
+## 1.3.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2988](https://github.com/DataDog/integrations-core/pull/2988).
 
-## 1.2.1 / 2019-01-04 / Agent 5.31.0
+## 1.2.1 / 2019-01-04 / Agent 6.9.0
 
 * [Fixed] Change example config from "localhost" to ".". See [#2779][1].
 
-## 1.2.0 / 2018-10-12 / Agent 5.28.0
+## 1.2.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Pin pywin32 dependency. See [#2322][2].
 
-## 1.1.1 / 2018-09-04 / Agent 5.28.0
+## 1.1.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 

--- a/exchange_server/CHANGELOG.md
+++ b/exchange_server/CHANGELOG.md
@@ -1,44 +1,44 @@
 # CHANGELOG - exchange_server
 
-## 1.8.0 / 2020-06-29
+## 1.8.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 
-## 1.7.0 / 2020-05-17
+## 1.7.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Agent 6 signature. See [#6446](https://github.com/DataDog/integrations-core/pull/6446).
 
-## 1.6.0 / 2019-12-02
+## 1.6.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 1.5.0 / 2019-10-11
+## 1.5.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 1.4.1 / 2019-06-18
+## 1.4.1 / 2019-06-18 / Agent 6.13.0
 
 * [Fixed] Rename lower case manifest.in. See [#3858](https://github.com/DataDog/integrations-core/pull/3858).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3506](https://github.com/DataDog/integrations-core/pull/3506).
 
-## 1.3.0 / 2019-02-18
+## 1.3.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#2988](https://github.com/DataDog/integrations-core/pull/2988).
 
-## 1.2.1 / 2019-01-04
+## 1.2.1 / 2019-01-04 / Agent 5.31.0
 
 * [Fixed] Change example config from "localhost" to ".". See [#2779][1].
 
-## 1.2.0 / 2018-10-12
+## 1.2.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][2].
 
-## 1.1.1 / 2018-09-04
+## 1.1.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 

--- a/external_dns/CHANGELOG.md
+++ b/external_dns/CHANGELOG.md
@@ -1,14 +1,14 @@
 # CHANGELOG - External DNS
 
-## 1.1.0 / 2020-05-17
+## 1.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.0.0 / 2019-12-18
+## 1.0.0 / 2019-12-18 / Agent 7.17.0
 
 * [Added] Add External DNS integration. See [#4340](https://github.com/DataDog/integrations-core/pull/4340). Thanks [davidgibbons](https://github.com/davidgibbons).
 
-## 0.0.2 / 2019-12-04
+## 0.0.2 / 2019-12-04 / Agent 7.17.0
 
 * [Fixed] Fix docs and AD config. See [#5145](https://github.com/DataDog/integrations-core/pull/5145).
 

--- a/external_dns/CHANGELOG.md
+++ b/external_dns/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * [Added] Add External DNS integration. See [#4340](https://github.com/DataDog/integrations-core/pull/4340). Thanks [davidgibbons](https://github.com/davidgibbons).
 
-## 0.0.2 / 2019-12-04 / Agent 7.17.0
+## 0.0.2 / 2019-12-04 / Agent 7.16.1
 
 * [Fixed] Fix docs and AD config. See [#5145](https://github.com/DataDog/integrations-core/pull/5145).
 

--- a/flink/CHANGELOG.md
+++ b/flink/CHANGELOG.md
@@ -17,10 +17,10 @@
 * [Added] Add config spec support for logs-only integrations. See [#5932](https://github.com/DataDog/integrations-core/pull/5932).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.0.1 / 2020-02-28 / Agent 7.19.0
+## 1.0.1 / 2020-02-28 / Agent 7.18.0
 
 * [Fixed] Remove instances from flink conf.yaml. See [#5912](https://github.com/DataDog/integrations-core/pull/5912).
 
-## 1.0.0 / 2020-02-21 / Agent 7.18.0
+## 1.0.0 / 2020-02-21
 
 * [Added] Add flink integration. See [#5613](https://github.com/DataDog/integrations-core/pull/5613).

--- a/flink/CHANGELOG.md
+++ b/flink/CHANGELOG.md
@@ -1,26 +1,26 @@
 # CHANGELOG - Flink
 
-## 1.2.2 / 2020-08-10
+## 1.2.2 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 1.2.1 / 2020-06-29
+## 1.2.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.2.0 / 2020-05-17
+## 1.2.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.1.0 / 2020-04-04
+## 1.1.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add config spec support for logs-only integrations. See [#5932](https://github.com/DataDog/integrations-core/pull/5932).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.0.1 / 2020-02-28
+## 1.0.1 / 2020-02-28 / Agent 7.19.0
 
 * [Fixed] Remove instances from flink conf.yaml. See [#5912](https://github.com/DataDog/integrations-core/pull/5912).
 
-## 1.0.0 / 2020-02-21
+## 1.0.0 / 2020-02-21 / Agent 7.18.0
 
 * [Added] Add flink integration. See [#5613](https://github.com/DataDog/integrations-core/pull/5613).

--- a/fluentd/CHANGELOG.md
+++ b/fluentd/CHANGELOG.md
@@ -1,32 +1,32 @@
 # CHANGELOG - fluentd
 
-## 1.9.1 / 2020-08-10
+## 1.9.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.9.0 / 2020-06-29
+## 1.9.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Reduce log level of version collection warnings to DEBUG. See [#6930](https://github.com/DataDog/integrations-core/pull/6930).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.8.0 / 2020-05-17
+## 1.8.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.1 / 2020-04-07
+## 1.7.1 / 2020-04-07 / Agent 7.20.0
 
 * [Fixed] Add `kerberos_cache` to HTTP config options. See [#6279](https://github.com/DataDog/integrations-core/pull/6279).
 
-## 1.7.0 / 2020-04-04
+## 1.7.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Added] Add config specs. See [#6147](https://github.com/DataDog/integrations-core/pull/6147).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.6.0 / 2020-03-18
+## 1.6.0 / 2020-03-18 / Agent 7.19.0
 
 * [Added] Support Fluentd config API endpoint for metadata collection. See [#6062](https://github.com/DataDog/integrations-core/pull/6062).
 * [Added] Allow disabling metadata collection in fluentd. See [#6061](https://github.com/DataDog/integrations-core/pull/6061).
@@ -36,29 +36,29 @@
 * [Added] Collect version metadata for Fluentd. See [#5057](https://github.com/DataDog/integrations-core/pull/5057).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.4.0 / 2019-10-11
+## 1.4.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.3.0 / 2019-08-24
+## 1.3.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Fix request wrapper timeout and add test. See [#4375](https://github.com/DataDog/integrations-core/pull/4375).
 * [Fixed] Update __init__ method params. See [#4243](https://github.com/DataDog/integrations-core/pull/4243).
 * [Added] Add support for proxy settings. See [#3479](https://github.com/DataDog/integrations-core/pull/3479).
 
-## 1.2.0 / 2019-05-14
+## 1.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3507](https://github.com/DataDog/integrations-core/pull/3507).
 
-## 1.1.1 / 2019-03-29
+## 1.1.1 / 2019-03-29 / Agent 6.11.0
 
 * [Fixed] Support fluentd v1's monitor_agent metrics. See [#2965](https://github.com/DataDog/integrations-core/pull/2965). Thanks [repeatedly](https://github.com/repeatedly).
 
-## 1.1.0 / 2019-01-04
+## 1.1.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2735][1].
 
-## 1.0.1 / 2018-09-04
+## 1.0.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/fluentd/CHANGELOG.md
+++ b/fluentd/CHANGELOG.md
@@ -15,23 +15,23 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.1 / 2020-04-07 / Agent 7.20.0
+## 1.7.1 / 2020-04-07 / Agent 7.19.0
 
 * [Fixed] Add `kerberos_cache` to HTTP config options. See [#6279](https://github.com/DataDog/integrations-core/pull/6279).
 
-## 1.7.0 / 2020-04-04 / Agent 7.19.0
+## 1.7.0 / 2020-04-04
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Added] Add config specs. See [#6147](https://github.com/DataDog/integrations-core/pull/6147).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.6.0 / 2020-03-18 / Agent 7.19.0
+## 1.6.0 / 2020-03-18
 
 * [Added] Support Fluentd config API endpoint for metadata collection. See [#6062](https://github.com/DataDog/integrations-core/pull/6062).
 * [Added] Allow disabling metadata collection in fluentd. See [#6061](https://github.com/DataDog/integrations-core/pull/6061).
 
-## 1.5.0 / 2019-11-26
+## 1.5.0 / 2019-11-26 / Agent 7.16.0
 
 * [Added] Collect version metadata for Fluentd. See [#5057](https://github.com/DataDog/integrations-core/pull/5057).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
@@ -54,11 +54,11 @@
 
 * [Fixed] Support fluentd v1's monitor_agent metrics. See [#2965](https://github.com/DataDog/integrations-core/pull/2965). Thanks [repeatedly](https://github.com/repeatedly).
 
-## 1.1.0 / 2019-01-04 / Agent 5.31.0
+## 1.1.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2735][1].
 
-## 1.0.1 / 2018-09-04 / Agent 5.28.0
+## 1.0.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/gearmand/CHANGELOG.md
+++ b/gearmand/CHANGELOG.md
@@ -1,31 +1,31 @@
 # CHANGELOG - gearmand
 
-## 1.6.0 / 2020-05-17
+## 1.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.5.0 / 2020-04-04
+## 1.5.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Collect version metadata. See [#5927](https://github.com/DataDog/integrations-core/pull/5927).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.4.0 / 2020-01-13
+## 1.4.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.3.1 / 2019-10-11
+## 1.3.1 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Fix misleading gearman.workers metric (#4515). See [#4520](https://github.com/DataDog/integrations-core/pull/4520). Thanks [orgito](https://github.com/orgito).
 
-## 1.3.0 / 2019-05-14
+## 1.3.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3508](https://github.com/DataDog/integrations-core/pull/3508).
 
-## 1.2.0 / 2019-01-04
+## 1.2.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2738][1].
 
-## 1.1.1 / 2018-09-04
+## 1.1.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/gearmand/CHANGELOG.md
+++ b/gearmand/CHANGELOG.md
@@ -21,11 +21,11 @@
 
 * [Added] Adhere to code style. See [#3508](https://github.com/DataDog/integrations-core/pull/3508).
 
-## 1.2.0 / 2019-01-04 / Agent 5.31.0
+## 1.2.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2738][1].
 
-## 1.1.1 / 2018-09-04 / Agent 5.28.0
+## 1.1.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/gitlab/CHANGELOG.md
+++ b/gitlab/CHANGELOG.md
@@ -40,19 +40,19 @@
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 2.6.1 / 2019-10-17 / Agent 7.16.0
+## 2.6.1 / 2019-10-17 / Agent 6.15.0
 
 * [Fixed] Add missing go_memstats_stack_sys_bytes metric in conf file. See [#4800](https://github.com/DataDog/integrations-core/pull/4800).
 
-## 2.6.0 / 2019-10-11 / Agent 6.15.0
+## 2.6.0 / 2019-10-11
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 2.5.1 / 2019-08-30 / Agent 6.15.0
+## 2.5.1 / 2019-08-30 / Agent 6.14.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 2.5.0 / 2019-08-24 / Agent 6.14.0
+## 2.5.0 / 2019-08-24
 
 * [Added] Add requests wrapper to gitlab. See [#4216](https://github.com/DataDog/integrations-core/pull/4216).
 
@@ -68,15 +68,15 @@
 
 * [Added] Upgrade protobuf to 3.7.0. See [#3272](https://github.com/DataDog/integrations-core/pull/3272).
 
-## 2.1.0 / 2019-01-04 / Agent 5.31.0
+## 2.1.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2751][1].
 
-## 2.0.0 / 2018-10-12 / Agent 5.28.0
+## 2.0.0 / 2018-10-12 / Agent 6.6.0
 
 * [Changed] Update gitlab to use the new OpenMetricsBaseCheck. See [#1977][2].
 
-## 1.2.0 / 2018-09-04 / Agent 5.28.0
+## 1.2.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][3].
 * [Fixed] Add data files to the wheel package. See [#1727][4].

--- a/gitlab/CHANGELOG.md
+++ b/gitlab/CHANGELOG.md
@@ -1,24 +1,24 @@
 # CHANGELOG - gitlab
 
-## 4.2.0 / 2020-08-10
+## 4.2.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Support "*" wildcard in type_overrides configuration. See [#7071](https://github.com/DataDog/integrations-core/pull/7071).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 4.1.0 / 2020-06-29
+## 4.1.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 4.0.0 / 2020-05-17
+## 4.0.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add config spec. See [#6151](https://github.com/DataDog/integrations-core/pull/6151).
 * [Changed] Remove duplicates in metadata and assert metrics with metadata. See [#6516](https://github.com/DataDog/integrations-core/pull/6516).
 
-## 3.0.0 / 2020-04-04
+## 3.0.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add new gitlab metrics. See [#6166](https://github.com/DataDog/integrations-core/pull/6166).
 * [Added] Include gitlab host and port tag for all metrics. See [#6177](https://github.com/DataDog/integrations-core/pull/6177).
@@ -28,55 +28,55 @@
 * [Changed] Remap gitlab metrics. See [#6150](https://github.com/DataDog/integrations-core/pull/6150).
 * [Changed] Gitlab revamp. See [#5971](https://github.com/DataDog/integrations-core/pull/5971).
 
-## 2.8.1 / 2020-02-22
+## 2.8.1 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Fix metric validation. See [#5581](https://github.com/DataDog/integrations-core/pull/5581).
 
-## 2.8.0 / 2020-01-13
+## 2.8.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 
-## 2.7.0 / 2019-12-02
+## 2.7.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 2.6.1 / 2019-10-17
+## 2.6.1 / 2019-10-17 / Agent 7.16.0
 
 * [Fixed] Add missing go_memstats_stack_sys_bytes metric in conf file. See [#4800](https://github.com/DataDog/integrations-core/pull/4800).
 
-## 2.6.0 / 2019-10-11
+## 2.6.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 2.5.1 / 2019-08-30
+## 2.5.1 / 2019-08-30 / Agent 6.15.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 2.5.0 / 2019-08-24
+## 2.5.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add requests wrapper to gitlab. See [#4216](https://github.com/DataDog/integrations-core/pull/4216).
 
-## 2.4.0 / 2019-07-04
+## 2.4.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Add logs. See [#3948](https://github.com/DataDog/integrations-core/pull/3948).
 
-## 2.3.0 / 2019-05-14
+## 2.3.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3509](https://github.com/DataDog/integrations-core/pull/3509).
 
-## 2.2.0 / 2019-03-29
+## 2.2.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Upgrade protobuf to 3.7.0. See [#3272](https://github.com/DataDog/integrations-core/pull/3272).
 
-## 2.1.0 / 2019-01-04
+## 2.1.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2751][1].
 
-## 2.0.0 / 2018-10-12
+## 2.0.0 / 2018-10-12 / Agent 5.28.0
 
 * [Changed] Update gitlab to use the new OpenMetricsBaseCheck. See [#1977][2].
 
-## 1.2.0 / 2018-09-04
+## 1.2.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][3].
 * [Fixed] Add data files to the wheel package. See [#1727][4].

--- a/gitlab_runner/CHANGELOG.md
+++ b/gitlab_runner/CHANGELOG.md
@@ -33,11 +33,11 @@
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 2.4.1 / 2019-08-30 / Agent 6.15.0
+## 2.4.1 / 2019-08-30 / Agent 6.14.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 2.4.0 / 2019-08-24 / Agent 6.14.0
+## 2.4.0 / 2019-08-24
 
 * [Fixed] Update RequestsWrapper with read/connect timeout. See [#4241](https://github.com/DataDog/integrations-core/pull/4241).
 * [Added] Add requests wrapper to gitlab_runner. See [#4218](https://github.com/DataDog/integrations-core/pull/4218).
@@ -50,15 +50,15 @@
 
 * [Added] Upgrade protobuf to 3.7.0. See [#3272](https://github.com/DataDog/integrations-core/pull/3272).
 
-## 2.1.0 / 2019-02-18 / Agent 6.11.0
+## 2.1.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#2886](https://github.com/DataDog/integrations-core/pull/2886).
 
-## 2.0.0 / 2018-10-12 / Agent 5.28.0
+## 2.0.0 / 2018-10-12 / Agent 6.6.0
 
 * [Changed] Update gitlab_runner to use the new OpenMetricsBaseCheck. See [#1978][1].
 
-## 1.2.0 / 2018-09-04 / Agent 5.28.0
+## 1.2.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].

--- a/gitlab_runner/CHANGELOG.md
+++ b/gitlab_runner/CHANGELOG.md
@@ -1,64 +1,64 @@
 # CHANGELOG - gitlab_runner
 
-## 2.9.1 / 2020-08-10
+## 2.9.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 2.9.0 / 2020-06-29
+## 2.9.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Added] Collect version metadata. See [#6894](https://github.com/DataDog/integrations-core/pull/6894).
 
-## 2.8.0 / 2020-05-17
+## 2.8.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.7.2 / 2020-04-04
+## 2.7.2 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 2.7.1 / 2020-02-22
+## 2.7.1 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Fix metric validation. See [#5581](https://github.com/DataDog/integrations-core/pull/5581).
 
-## 2.7.0 / 2020-01-13
+## 2.7.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 
-## 2.6.0 / 2019-11-06
+## 2.6.0 / 2019-11-06 / Agent 7.16.0
 
 * [Added] update gitlab_runner metrics. See [#4799](https://github.com/DataDog/integrations-core/pull/4799).
 
-## 2.5.0 / 2019-10-11
+## 2.5.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 2.4.1 / 2019-08-30
+## 2.4.1 / 2019-08-30 / Agent 6.15.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 2.4.0 / 2019-08-24
+## 2.4.0 / 2019-08-24 / Agent 6.14.0
 
 * [Fixed] Update RequestsWrapper with read/connect timeout. See [#4241](https://github.com/DataDog/integrations-core/pull/4241).
 * [Added] Add requests wrapper to gitlab_runner. See [#4218](https://github.com/DataDog/integrations-core/pull/4218).
 
-## 2.3.0 / 2019-05-14
+## 2.3.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3510](https://github.com/DataDog/integrations-core/pull/3510).
 
-## 2.2.0 / 2019-03-29
+## 2.2.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Upgrade protobuf to 3.7.0. See [#3272](https://github.com/DataDog/integrations-core/pull/3272).
 
-## 2.1.0 / 2019-02-18
+## 2.1.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#2886](https://github.com/DataDog/integrations-core/pull/2886).
 
-## 2.0.0 / 2018-10-12
+## 2.0.0 / 2018-10-12 / Agent 5.28.0
 
 * [Changed] Update gitlab_runner to use the new OpenMetricsBaseCheck. See [#1978][1].
 
-## 1.2.0 / 2018-09-04
+## 1.2.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].

--- a/go-metro/CHANGELOG.md
+++ b/go-metro/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG - go-metro
 
-## 1.2.0 / 2020-05-17
+## 1.2.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.1.0 / 2018-11-30
+## 1.1.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Fixed manifests and added validation in ddev. See [#2002][1].
 

--- a/go_expvar/CHANGELOG.md
+++ b/go_expvar/CHANGELOG.md
@@ -18,11 +18,11 @@
 * [Added] Add go_expvar.memstats.total_alloc.count . See [#6005](https://github.com/DataDog/integrations-core/pull/6005).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.7.2 / 2020-03-05 / Agent 7.19.0
+## 1.7.2 / 2020-03-05 / Agent 7.18.0
 
 * [Fixed] Revert "Submit total_alloc as monotonic count". See [#5972](https://github.com/DataDog/integrations-core/pull/5972).
 
-## 1.7.1 / 2020-02-22 / Agent 7.18.0
+## 1.7.1 / 2020-02-22
 
 * [Fixed] Submit total_alloc as monotonic count. See [#5703](https://github.com/DataDog/integrations-core/pull/5703).
 
@@ -36,11 +36,11 @@
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.5.1 / 2019-09-04 / Agent 6.15.0
+## 1.5.1 / 2019-09-04 / Agent 6.14.0
 
 * [Fixed] Fix error handling. See [#4505](https://github.com/DataDog/integrations-core/pull/4505).
 
-## 1.5.0 / 2019-08-24 / Agent 6.14.0
+## 1.5.0 / 2019-08-24
 
 * [Fixed] Update __init__ method params. See [#4243](https://github.com/DataDog/integrations-core/pull/4243).
 * [Added] Add proxy settings support. See [#3743](https://github.com/DataDog/integrations-core/pull/3743).
@@ -49,23 +49,23 @@
 
 * [Added] Add monotonic_counter support to go_expvar. See [#3992](https://github.com/DataDog/integrations-core/pull/3992).
 
-## 1.3.0 / 2019-06-20 / Agent 6.13.0
+## 1.3.0 / 2019-06-20 / Agent 6.12.0
 
 * [Added] Do not compile regexes on each run. See [#3949](https://github.com/DataDog/integrations-core/pull/3949).
 
-## 1.2.0 / 2019-05-14 / Agent 6.12.0
+## 1.2.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3511](https://github.com/DataDog/integrations-core/pull/3511).
 
-## 1.1.0 / 2019-01-04 / Agent 5.31.0
+## 1.1.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2833][1].
 
-## 1.0.5 / 2018-11-30 / Agent 5.30.0
+## 1.0.5 / 2018-11-30 / Agent 6.8.0
 
 * [Fixed] Use raw string literals when \ is present. See [#2465][2].
 
-## 1.0.4 / 2018-09-04 / Agent 5.28.0
+## 1.0.4 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Move Goexpvar to pytest. See [#2089][3].
 * [Fixed] Add data files to the wheel package. See [#1727][4].

--- a/go_expvar/CHANGELOG.md
+++ b/go_expvar/CHANGELOG.md
@@ -1,71 +1,71 @@
 # CHANGELOG - go_expvar
 
-## 1.10.1 / 2020-08-10
+## 1.10.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.10.0 / 2020-06-29
+## 1.10.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.9.0 / 2020-05-17
+## 1.9.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.8.0 / 2020-04-04
+## 1.8.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add additional logging. See [#6128](https://github.com/DataDog/integrations-core/pull/6128).
 * [Added] Add go_expvar.memstats.total_alloc.count . See [#6005](https://github.com/DataDog/integrations-core/pull/6005).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.7.2 / 2020-03-05
+## 1.7.2 / 2020-03-05 / Agent 7.19.0
 
 * [Fixed] Revert "Submit total_alloc as monotonic count". See [#5972](https://github.com/DataDog/integrations-core/pull/5972).
 
-## 1.7.1 / 2020-02-22
+## 1.7.1 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Submit total_alloc as monotonic count. See [#5703](https://github.com/DataDog/integrations-core/pull/5703).
 
-## 1.7.0 / 2019-12-02
+## 1.7.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Adhere to logging style. See [#5106](https://github.com/DataDog/integrations-core/pull/5106).
 * [Added] Add count type to go_expvar. See [#5097](https://github.com/DataDog/integrations-core/pull/5097).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.6.0 / 2019-10-11
+## 1.6.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.5.1 / 2019-09-04
+## 1.5.1 / 2019-09-04 / Agent 6.15.0
 
 * [Fixed] Fix error handling. See [#4505](https://github.com/DataDog/integrations-core/pull/4505).
 
-## 1.5.0 / 2019-08-24
+## 1.5.0 / 2019-08-24 / Agent 6.14.0
 
 * [Fixed] Update __init__ method params. See [#4243](https://github.com/DataDog/integrations-core/pull/4243).
 * [Added] Add proxy settings support. See [#3743](https://github.com/DataDog/integrations-core/pull/3743).
 
-## 1.4.0 / 2019-06-27
+## 1.4.0 / 2019-06-27 / Agent 6.13.0
 
 * [Added] Add monotonic_counter support to go_expvar. See [#3992](https://github.com/DataDog/integrations-core/pull/3992).
 
-## 1.3.0 / 2019-06-20
+## 1.3.0 / 2019-06-20 / Agent 6.13.0
 
 * [Added] Do not compile regexes on each run. See [#3949](https://github.com/DataDog/integrations-core/pull/3949).
 
-## 1.2.0 / 2019-05-14
+## 1.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3511](https://github.com/DataDog/integrations-core/pull/3511).
 
-## 1.1.0 / 2019-01-04
+## 1.1.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2833][1].
 
-## 1.0.5 / 2018-11-30
+## 1.0.5 / 2018-11-30 / Agent 5.30.0
 
 * [Fixed] Use raw string literals when \ is present. See [#2465][2].
 
-## 1.0.4 / 2018-09-04
+## 1.0.4 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Move Goexpvar to pytest. See [#2089][3].
 * [Fixed] Add data files to the wheel package. See [#1727][4].

--- a/gunicorn/CHANGELOG.md
+++ b/gunicorn/CHANGELOG.md
@@ -1,65 +1,65 @@
 # CHANGELOG - gunicorn
 
-## 1.12.0 / 2020-08-10
+## 1.12.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add config specs. See [#7258](https://github.com/DataDog/integrations-core/pull/7258).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] Debug logs for failing to retrieve metadata, also add ability to disa…. See [#7255](https://github.com/DataDog/integrations-core/pull/7255).
 
-## 1.11.0 / 2020-05-17
+## 1.11.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.10.0 / 2020-04-04
+## 1.10.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.9.0 / 2020-01-13
+## 1.9.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.8.1 / 2019-12-13
+## 1.8.1 / 2019-12-13 / Agent 7.17.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 1.8.0 / 2019-12-02
+## 1.8.0 / 2019-12-02 / Agent 7.16.0
 
 * [Fixed] Remove shlex. See [#5064](https://github.com/DataDog/integrations-core/pull/5064).
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
 * [Added] Add version metadata. See [#4968](https://github.com/DataDog/integrations-core/pull/4968).
 
-## 1.7.2 / 2019-10-11
+## 1.7.2 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Upgrade psutil dependency to 5.6.3. See [#4442](https://github.com/DataDog/integrations-core/pull/4442).
 
-## 1.7.1 / 2019-06-06
+## 1.7.1 / 2019-06-06 / Agent 6.13.0
 
 * [Fixed] Fix mac compatibility. See [#3853](https://github.com/DataDog/integrations-core/pull/3853).
 
-## 1.7.0 / 2019-05-14
+## 1.7.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Upgrade psutil dependency to 5.6.2. See [#3684](https://github.com/DataDog/integrations-core/pull/3684).
 * [Added] Adhere to code style. See [#3512](https://github.com/DataDog/integrations-core/pull/3512).
 
-## 1.6.0 / 2019-02-18
+## 1.6.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Upgrade psutil. See [#3019](https://github.com/DataDog/integrations-core/pull/3019).
 
-## 1.5.0 / 2019-01-04
+## 1.5.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2752][1].
 
-## 1.4.0 / 2018-11-30
+## 1.4.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Update psutil. See [#2576][2].
 
-## 1.3.0 / 2018-10-12
+## 1.3.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Upgrade psutil. See [#2190][3].
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Gunicorn intergration - fix problem with multiple master processes. See [#1839][4]. Thanks [mrmm][5].
 * [Fixed] Add data files to the wheel package. See [#1727][6].

--- a/gunicorn/CHANGELOG.md
+++ b/gunicorn/CHANGELOG.md
@@ -20,11 +20,11 @@
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.8.1 / 2019-12-13 / Agent 7.17.0
+## 1.8.1 / 2019-12-13 / Agent 7.16.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 1.8.0 / 2019-12-02 / Agent 7.16.0
+## 1.8.0 / 2019-12-02
 
 * [Fixed] Remove shlex. See [#5064](https://github.com/DataDog/integrations-core/pull/5064).
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
@@ -34,32 +34,32 @@
 
 * [Fixed] Upgrade psutil dependency to 5.6.3. See [#4442](https://github.com/DataDog/integrations-core/pull/4442).
 
-## 1.7.1 / 2019-06-06 / Agent 6.13.0
+## 1.7.1 / 2019-06-06 / Agent 6.12.0
 
 * [Fixed] Fix mac compatibility. See [#3853](https://github.com/DataDog/integrations-core/pull/3853).
 
-## 1.7.0 / 2019-05-14 / Agent 6.12.0
+## 1.7.0 / 2019-05-14
 
 * [Added] Upgrade psutil dependency to 5.6.2. See [#3684](https://github.com/DataDog/integrations-core/pull/3684).
 * [Added] Adhere to code style. See [#3512](https://github.com/DataDog/integrations-core/pull/3512).
 
-## 1.6.0 / 2019-02-18 / Agent 6.11.0
+## 1.6.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Upgrade psutil. See [#3019](https://github.com/DataDog/integrations-core/pull/3019).
 
-## 1.5.0 / 2019-01-04 / Agent 5.31.0
+## 1.5.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2752][1].
 
-## 1.4.0 / 2018-11-30 / Agent 5.30.0
+## 1.4.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Update psutil. See [#2576][2].
 
-## 1.3.0 / 2018-10-12 / Agent 5.28.0
+## 1.3.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Upgrade psutil. See [#2190][3].
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Gunicorn intergration - fix problem with multiple master processes. See [#1839][4]. Thanks [mrmm][5].
 * [Fixed] Add data files to the wheel package. See [#1727][6].

--- a/haproxy/CHANGELOG.md
+++ b/haproxy/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.8.1 / 2020-05-05 / Agent 7.20.0
+## 2.8.1 / 2020-05-05 / Agent 7.19.2
 
 * [Fixed] Handle empty response from show table. See [#6579](https://github.com/DataDog/integrations-core/pull/6579).
 
@@ -22,18 +22,18 @@
 * [Added] Gather stick-table metrics. See [#6158](https://github.com/DataDog/integrations-core/pull/6158).
 * [Fixed] Revert `to_native_string` to `to_string` for integrations. See [#6238](https://github.com/DataDog/integrations-core/pull/6238).
 
-## 2.7.2 / 2020-03-24 / Agent 7.19.0
+## 2.7.2 / 2020-03-24
 
 * [Fixed] Fix event submission on Python 3. See [#6138](https://github.com/DataDog/integrations-core/pull/6138).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 * [Fixed] Rename `to_string()` utility to `to_native_string()`. See [#5996](https://github.com/DataDog/integrations-core/pull/5996).
 
-## 2.7.1 / 2020-02-25 / Agent 7.19.0
+## 2.7.1 / 2020-02-25 / Agent 7.18.0
 
 * [Fixed] Document disable_legacy_service_tag and bump checks_base requirement. See [#5835](https://github.com/DataDog/integrations-core/pull/5835).
 
-## 2.7.0 / 2020-02-22 / Agent 7.18.0
+## 2.7.0 / 2020-02-22
 
 * [Added] Add an option to skip reporting during restarts. See [#5571](https://github.com/DataDog/integrations-core/pull/5571). Thanks [dd-adn](https://github.com/dd-adn).
 * [Deprecated] Deprecate `service` tag. See [#5550](https://github.com/DataDog/integrations-core/pull/5550).
@@ -43,11 +43,11 @@
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 2.5.1 / 2019-12-13 / Agent 7.17.0
+## 2.5.1 / 2019-12-13 / Agent 7.16.0
 
 * [Fixed] Handle failure on version endpoint. See [#5208](https://github.com/DataDog/integrations-core/pull/5208).
 
-## 2.5.0 / 2019-12-02 / Agent 7.16.0
+## 2.5.0 / 2019-12-02
 
 * [Added] Submit version metadata. See [#4851](https://github.com/DataDog/integrations-core/pull/4851).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
@@ -65,38 +65,38 @@
 * [Added] Add `requests.tot_rate`, `connections.rate`, `connections.tot_rate`, and `requests.intercepted`. See [#3797](https://github.com/DataDog/integrations-core/pull/3797).
 * [Added] `collect_aggregates_only` now collects all values when set to `false`. See [#3797](https://github.com/DataDog/integrations-core/pull/3797).
 
-## 2.1.0 / 2019-05-14 / Agent 6.12.0
+## 2.1.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3513](https://github.com/DataDog/integrations-core/pull/3513).
 
-## 2.0.0 / 2019-02-18 / Agent 6.11.0
+## 2.0.0 / 2019-02-18 / Agent 6.10.0
 
 * [Changed] Only send 'haproxy.backend_hosts' metrics for backend. See [#3073](https://github.com/DataDog/integrations-core/pull/3073).
 * [Changed] Put service check behind a flag, false by default. See [#3083](https://github.com/DataDog/integrations-core/pull/3083).
 * [Added] Support unicode for Python 3 bindings. See [#2869](https://github.com/DataDog/integrations-core/pull/2869).
 
-## 1.4.0 / 2019-01-04 / Agent 5.31.0
+## 1.4.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2849][1].
 * [Added] tcp scheme support for stats socket. See [#2731][2].
 * [Added] Add server_address tag when available. See [#2727][3].
 
-## 1.3.2 / 2018-11-30 / Agent 5.30.0
+## 1.3.2 / 2018-11-30 / Agent 6.8.0
 
 * [Fixed] Use raw string literals when \ is present. See [#2465][4].
 
-## 1.3.1 / 2018-09-04 / Agent 5.28.0
+## 1.3.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][5].
 * [Fixed] Fix error in case of empty stat info. See [#1944][6].
 * [Fixed] Add data files to the wheel package. See [#1727][7].
 
-## 1.3.0 / 2018-06-04 / Agent 5.25.0
+## 1.3.0 / 2018-06-04
 
 * [Added] Add optional 'active' tag to metrics. See [#1478][8].
 * [Changed] Upgrade requests dependency to 2.18.4. See [#1264][9].
 
-## 1.2.1 / 2018-02-13 / Agent 5.23.0
+## 1.2.1 / 2018-02-13
 
 * [DOC] Adding configuration for log collection in `conf.yaml`
 

--- a/haproxy/CHANGELOG.md
+++ b/haproxy/CHANGELOG.md
@@ -1,102 +1,102 @@
 # CHANGELOG - haproxy
 
-## 2.10.1 / 2020-08-10
+## 2.10.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 2.10.0 / 2020-06-29
+## 2.10.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix version parsing with haproxy enterprise version. See [#6774](https://github.com/DataDog/integrations-core/pull/6774).
 
-## 2.9.0 / 2020-05-17
+## 2.9.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.8.1 / 2020-05-05
+## 2.8.1 / 2020-05-05 / Agent 7.20.0
 
 * [Fixed] Handle empty response from show table. See [#6579](https://github.com/DataDog/integrations-core/pull/6579).
 
-## 2.8.0 / 2020-04-04
+## 2.8.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Gather stick-table metrics. See [#6158](https://github.com/DataDog/integrations-core/pull/6158).
 * [Fixed] Revert `to_native_string` to `to_string` for integrations. See [#6238](https://github.com/DataDog/integrations-core/pull/6238).
 
-## 2.7.2 / 2020-03-24
+## 2.7.2 / 2020-03-24 / Agent 7.19.0
 
 * [Fixed] Fix event submission on Python 3. See [#6138](https://github.com/DataDog/integrations-core/pull/6138).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 * [Fixed] Rename `to_string()` utility to `to_native_string()`. See [#5996](https://github.com/DataDog/integrations-core/pull/5996).
 
-## 2.7.1 / 2020-02-25
+## 2.7.1 / 2020-02-25 / Agent 7.19.0
 
 * [Fixed] Document disable_legacy_service_tag and bump checks_base requirement. See [#5835](https://github.com/DataDog/integrations-core/pull/5835).
 
-## 2.7.0 / 2020-02-22
+## 2.7.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add an option to skip reporting during restarts. See [#5571](https://github.com/DataDog/integrations-core/pull/5571). Thanks [dd-adn](https://github.com/dd-adn).
 * [Deprecated] Deprecate `service` tag. See [#5550](https://github.com/DataDog/integrations-core/pull/5550).
 
-## 2.6.0 / 2020-01-13
+## 2.6.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 2.5.1 / 2019-12-13
+## 2.5.1 / 2019-12-13 / Agent 7.17.0
 
 * [Fixed] Handle failure on version endpoint. See [#5208](https://github.com/DataDog/integrations-core/pull/5208).
 
-## 2.5.0 / 2019-12-02
+## 2.5.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Submit version metadata. See [#4851](https://github.com/DataDog/integrations-core/pull/4851).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 2.4.0 / 2019-10-11
+## 2.4.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 2.3.0 / 2019-08-24
+## 2.3.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add requests wrapper to haproxy. See [#4219](https://github.com/DataDog/integrations-core/pull/4219).
 
-## 2.2.0 / 2019-06-01
+## 2.2.0 / 2019-06-01 / Agent 6.12.0
 
 * [Added] Add `requests.tot_rate`, `connections.rate`, `connections.tot_rate`, and `requests.intercepted`. See [#3797](https://github.com/DataDog/integrations-core/pull/3797).
 * [Added] `collect_aggregates_only` now collects all values when set to `false`. See [#3797](https://github.com/DataDog/integrations-core/pull/3797).
 
-## 2.1.0 / 2019-05-14
+## 2.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3513](https://github.com/DataDog/integrations-core/pull/3513).
 
-## 2.0.0 / 2019-02-18
+## 2.0.0 / 2019-02-18 / Agent 6.11.0
 
 * [Changed] Only send 'haproxy.backend_hosts' metrics for backend. See [#3073](https://github.com/DataDog/integrations-core/pull/3073).
 * [Changed] Put service check behind a flag, false by default. See [#3083](https://github.com/DataDog/integrations-core/pull/3083).
 * [Added] Support unicode for Python 3 bindings. See [#2869](https://github.com/DataDog/integrations-core/pull/2869).
 
-## 1.4.0 / 2019-01-04
+## 1.4.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2849][1].
 * [Added] tcp scheme support for stats socket. See [#2731][2].
 * [Added] Add server_address tag when available. See [#2727][3].
 
-## 1.3.2 / 2018-11-30
+## 1.3.2 / 2018-11-30 / Agent 5.30.0
 
 * [Fixed] Use raw string literals when \ is present. See [#2465][4].
 
-## 1.3.1 / 2018-09-04
+## 1.3.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][5].
 * [Fixed] Fix error in case of empty stat info. See [#1944][6].
 * [Fixed] Add data files to the wheel package. See [#1727][7].
 
-## 1.3.0 / 2018-06-04
+## 1.3.0 / 2018-06-04 / Agent 5.25.0
 
 * [Added] Add optional 'active' tag to metrics. See [#1478][8].
 * [Changed] Upgrade requests dependency to 2.18.4. See [#1264][9].
 
-## 1.2.1 / 2018-02-13
+## 1.2.1 / 2018-02-13 / Agent 5.23.0
 
 * [DOC] Adding configuration for log collection in `conf.yaml`
 

--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.5.0 / 2020-06-23 / Agent 7.21.0
+## 1.5.0 / 2020-06-23
 
 * [Added] Add status check for Harbor's read-only status. See [#6917](https://github.com/DataDog/integrations-core/pull/6917). Thanks [bksteiny](https://github.com/bksteiny).
 
@@ -12,11 +12,11 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.3.1 / 2020-02-25 / Agent 7.19.0
+## 1.3.1 / 2020-02-25 / Agent 7.18.0
 
 * [Fixed] Update base dependency for harbor. See [#5841](https://github.com/DataDog/integrations-core/pull/5841).
 
-## 1.3.0 / 2020-01-15 / Agent 7.18.0
+## 1.3.0 / 2020-01-15 / Agent 7.17.0
 
 * [Added] Refactor authentication to add support for Harbor 1.9 and 1.10. See [#5468](https://github.com/DataDog/integrations-core/pull/5468).
 
@@ -29,6 +29,6 @@
 * [Added] Fix up doc and conf. See [#4358](https://github.com/DataDog/integrations-core/pull/4358).
 * [Fixed] Update __init__ method params. See [#4243](https://github.com/DataDog/integrations-core/pull/4243).
 
-## 1.0.0 / 2019-07-11 / Agent 6.13.0
+## 1.0.0 / 2019-07-11
 
 * [Added] Harbor - New integration. See [#3799](https://github.com/DataDog/integrations-core/pull/3799).

--- a/harbor/CHANGELOG.md
+++ b/harbor/CHANGELOG.md
@@ -1,34 +1,34 @@
 # CHANGELOG - Harbor
 
-## 1.6.0 / 2020-06-29
+## 1.6.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.5.0 / 2020-06-23
+## 1.5.0 / 2020-06-23 / Agent 7.21.0
 
 * [Added] Add status check for Harbor's read-only status. See [#6917](https://github.com/DataDog/integrations-core/pull/6917). Thanks [bksteiny](https://github.com/bksteiny).
 
-## 1.4.0 / 2020-05-17
+## 1.4.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.3.1 / 2020-02-25
+## 1.3.1 / 2020-02-25 / Agent 7.19.0
 
 * [Fixed] Update base dependency for harbor. See [#5841](https://github.com/DataDog/integrations-core/pull/5841).
 
-## 1.3.0 / 2020-01-15
+## 1.3.0 / 2020-01-15 / Agent 7.18.0
 
 * [Added] Refactor authentication to add support for Harbor 1.9 and 1.10. See [#5468](https://github.com/DataDog/integrations-core/pull/5468).
 
-## 1.2.0 / 2019-12-02
+## 1.2.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.1.0 / 2019-08-24
+## 1.1.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Fix up doc and conf. See [#4358](https://github.com/DataDog/integrations-core/pull/4358).
 * [Fixed] Update __init__ method params. See [#4243](https://github.com/DataDog/integrations-core/pull/4243).
 
-## 1.0.0 / 2019-07-11
+## 1.0.0 / 2019-07-11 / Agent 6.13.0
 
 * [Added] Harbor - New integration. See [#3799](https://github.com/DataDog/integrations-core/pull/3799).

--- a/hazelcast/CHANGELOG.md
+++ b/hazelcast/CHANGELOG.md
@@ -11,15 +11,15 @@
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 * [Fixed] Adjust jmxfetch config. See [#6864](https://github.com/DataDog/integrations-core/pull/6864).
 
-## 1.1.1 / 2020-05-21 / Agent 7.21.0
+## 1.1.1 / 2020-05-21 / Agent 7.20.0
 
 * [Fixed] Document `mc_cluster_states` configuration option. See [#6704](https://github.com/DataDog/integrations-core/pull/6704).
 
-## 1.1.0 / 2020-05-17 / Agent 7.20.0
+## 1.1.0 / 2020-05-17
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.0.0 / 2020-04-23 / Agent 7.20.0
+## 1.0.0 / 2020-04-23
 
 * [Added] Add Hazelcast integration. See [#6236](https://github.com/DataDog/integrations-core/pull/6236).
 

--- a/hazelcast/CHANGELOG.md
+++ b/hazelcast/CHANGELOG.md
@@ -1,25 +1,25 @@
 # CHANGELOG - Hazelcast
 
-## 1.1.3 / 2020-08-10
+## 1.1.3 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] Add new_gc_metrics to all jmx integrations. See [#7073](https://github.com/DataDog/integrations-core/pull/7073).
 
-## 1.1.2 / 2020-06-29
+## 1.1.2 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Assert new jvm metrics. See [#6996](https://github.com/DataDog/integrations-core/pull/6996).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 * [Fixed] Adjust jmxfetch config. See [#6864](https://github.com/DataDog/integrations-core/pull/6864).
 
-## 1.1.1 / 2020-05-21
+## 1.1.1 / 2020-05-21 / Agent 7.21.0
 
 * [Fixed] Document `mc_cluster_states` configuration option. See [#6704](https://github.com/DataDog/integrations-core/pull/6704).
 
-## 1.1.0 / 2020-05-17
+## 1.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.0.0 / 2020-04-23
+## 1.0.0 / 2020-04-23 / Agent 7.20.0
 
 * [Added] Add Hazelcast integration. See [#6236](https://github.com/DataDog/integrations-core/pull/6236).
 

--- a/hdfs_datanode/CHANGELOG.md
+++ b/hdfs_datanode/CHANGELOG.md
@@ -44,19 +44,19 @@
 
 * [Added] Adhere to code style. See [#3514](https://github.com/DataDog/integrations-core/pull/3514).
 
-## 1.6.0 / 2019-01-04 / Agent 5.31.0
+## 1.6.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2856][1].
 
-## 1.5.0 / 2018-11-14 / Agent 5.30.0
+## 1.5.0 / 2018-11-14 / Agent 6.8.0
 
 * [Added] Support keytab files for kerberos. See [#2591][2].
 
-## 1.4.0 / 2018-11-07 / Agent 5.30.0
+## 1.4.0 / 2018-11-07
 
 * [Added] Support Kerberos auth. See [#2516][3].
 
-## 1.3.1 / 2018-09-04 / Agent 5.28.0
+## 1.3.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 

--- a/hdfs_datanode/CHANGELOG.md
+++ b/hdfs_datanode/CHANGELOG.md
@@ -1,62 +1,62 @@
 # CHANGELOG - hdfs_datanode
 
-## 1.14.1 / 2020-08-10
+## 1.14.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.14.0 / 2020-06-29
+## 1.14.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Added] Add config specs. See [#6900](https://github.com/DataDog/integrations-core/pull/6900).
 
-## 1.13.0 / 2020-05-17
+## 1.13.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.12.1 / 2020-04-04
+## 1.12.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.12.0 / 2020-02-22
+## 1.12.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add log section to hdfs integrations. See [#4632](https://github.com/DataDog/integrations-core/pull/4632).
 
-## 1.11.0 / 2020-01-13
+## 1.11.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Added] Collect version metadata for hdfs_datanode. See [#5088](https://github.com/DataDog/integrations-core/pull/5088).
 
-## 1.10.0 / 2019-12-02
+## 1.10.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.9.0 / 2019-10-11
+## 1.9.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.8.0 / 2019-07-09
+## 1.8.0 / 2019-07-09 / Agent 6.13.0
 
 * [Added] Use the new RequestsWrapper for connecting to services. See [#4056](https://github.com/DataDog/integrations-core/pull/4056).
 
-## 1.7.0 / 2019-05-14
+## 1.7.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3514](https://github.com/DataDog/integrations-core/pull/3514).
 
-## 1.6.0 / 2019-01-04
+## 1.6.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2856][1].
 
-## 1.5.0 / 2018-11-14
+## 1.5.0 / 2018-11-14 / Agent 5.30.0
 
 * [Added] Support keytab files for kerberos. See [#2591][2].
 
-## 1.4.0 / 2018-11-07
+## 1.4.0 / 2018-11-07 / Agent 5.30.0
 
 * [Added] Support Kerberos auth. See [#2516][3].
 
-## 1.3.1 / 2018-09-04
+## 1.3.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 

--- a/hdfs_namenode/CHANGELOG.md
+++ b/hdfs_namenode/CHANGELOG.md
@@ -1,58 +1,58 @@
 # CHANGELOG - hdfs_namenode
 
-## 1.13.1 / 2020-08-10
+## 1.13.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.13.0 / 2020-06-29
+## 1.13.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Added] Add config specs. See [#6904](https://github.com/DataDog/integrations-core/pull/6904).
 
-## 1.12.0 / 2020-05-17
+## 1.12.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.11.1 / 2020-04-04
+## 1.11.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.11.0 / 2020-02-22
+## 1.11.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add log section to hdfs integrations. See [#4632](https://github.com/DataDog/integrations-core/pull/4632).
 
-## 1.10.0 / 2020-01-13
+## 1.10.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Added] Collect version metadata for hdfs_namenode. See [#5103](https://github.com/DataDog/integrations-core/pull/5103).
 
-## 1.9.0 / 2019-12-02
+## 1.9.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.8.0 / 2019-10-11
+## 1.8.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.7.0 / 2019-07-09
+## 1.7.0 / 2019-07-09 / Agent 6.13.0
 
 * [Added] Use the new RequestsWrapper for connecting to services. See [#4057](https://github.com/DataDog/integrations-core/pull/4057).
 
-## 1.6.0 / 2019-05-14
+## 1.6.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3515](https://github.com/DataDog/integrations-core/pull/3515).
 
-## 1.5.0 / 2019-02-18
+## 1.5.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Kerberos auth. See [#2823](https://github.com/DataDog/integrations-core/pull/2823).
 
-## 1.4.0 / 2019-01-04
+## 1.4.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2857][1].
 
-## 1.3.1 / 2018-09-04
+## 1.3.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/hdfs_namenode/CHANGELOG.md
+++ b/hdfs_namenode/CHANGELOG.md
@@ -44,15 +44,15 @@
 
 * [Added] Adhere to code style. See [#3515](https://github.com/DataDog/integrations-core/pull/3515).
 
-## 1.5.0 / 2019-02-18 / Agent 6.11.0
+## 1.5.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Kerberos auth. See [#2823](https://github.com/DataDog/integrations-core/pull/2823).
 
-## 1.4.0 / 2019-01-04 / Agent 5.31.0
+## 1.4.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2857][1].
 
-## 1.3.1 / 2018-09-04 / Agent 5.28.0
+## 1.3.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/hive/CHANGELOG.md
+++ b/hive/CHANGELOG.md
@@ -1,22 +1,22 @@
 # CHANGELOG - Hive
 
-## 1.3.2 / 2020-08-10
+## 1.3.2 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] Add new_gc_metrics to all jmx integrations. See [#7073](https://github.com/DataDog/integrations-core/pull/7073).
 
-## 1.3.1 / 2020-06-29
+## 1.3.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 * [Fixed] Adjust jmxfetch config. See [#6864](https://github.com/DataDog/integrations-core/pull/6864).
 
-## 1.3.0 / 2020-05-17
+## 1.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add rmi_connection_timeout & rmi_client_timeout to config spec. See [#6459](https://github.com/DataDog/integrations-core/pull/6459).
 * [Added] Add default template to openmetrics & jmx config. See [#6328](https://github.com/DataDog/integrations-core/pull/6328).
 
-## 1.2.0 / 2020-04-04
+## 1.2.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add `service_check_prefix` config to jmx. See [#6163](https://github.com/DataDog/integrations-core/pull/6163).
 * [Added] Use config spec. See [#5979](https://github.com/DataDog/integrations-core/pull/5979).
@@ -24,27 +24,27 @@
 * [Fixed] Fix JMX spec doc. See [#6074](https://github.com/DataDog/integrations-core/pull/6074).
 * [Fixed] Remove examples from jmx template. See [#6006](https://github.com/DataDog/integrations-core/pull/6006).
 
-## 1.1.2 / 2019-12-04
+## 1.1.2 / 2019-12-04 / Agent 7.17.0
 
 * [Fixed] Fix bean name of directsql_errors metric. See [#5141](https://github.com/DataDog/integrations-core/pull/5141).
 
-## 1.1.1 / 2019-12-02
+## 1.1.1 / 2019-12-02 / Agent 7.16.0
 
 * [Fixed] Fix directsql_error metric bean in config. See [#5074](https://github.com/DataDog/integrations-core/pull/5074).
 
-## 1.1.0 / 2019-06-19
+## 1.1.0 / 2019-06-19 / Agent 6.13.0
 
 * [Added] Add log section. See [#3891](https://github.com/DataDog/integrations-core/pull/3891).
 
-## 1.0.2 / 2019-06-18
+## 1.0.2 / 2019-06-18 / Agent 6.13.0
 
 * [Fixed] Fix metric type. See [#3885](https://github.com/DataDog/integrations-core/pull/3885).
 * [Fixed] Fix Hive metadatas. See [#3851](https://github.com/DataDog/integrations-core/pull/3851).
 
-## 1.0.1 / 2019-06-05
+## 1.0.1 / 2019-06-05 / Agent 6.13.0
 
 * [Fixed] Fix init file. See [#3855](https://github.com/DataDog/integrations-core/pull/3855).
 
-## 1.0.0 / 2019-06-01
+## 1.0.0 / 2019-06-01 / Agent 6.12.0
 
 * [Added] Hive integration. See [#3723](https://github.com/DataDog/integrations-core/pull/3723).

--- a/hive/CHANGELOG.md
+++ b/hive/CHANGELOG.md
@@ -24,11 +24,11 @@
 * [Fixed] Fix JMX spec doc. See [#6074](https://github.com/DataDog/integrations-core/pull/6074).
 * [Fixed] Remove examples from jmx template. See [#6006](https://github.com/DataDog/integrations-core/pull/6006).
 
-## 1.1.2 / 2019-12-04 / Agent 7.17.0
+## 1.1.2 / 2019-12-04 / Agent 7.16.0
 
 * [Fixed] Fix bean name of directsql_errors metric. See [#5141](https://github.com/DataDog/integrations-core/pull/5141).
 
-## 1.1.1 / 2019-12-02 / Agent 7.16.0
+## 1.1.1 / 2019-12-02
 
 * [Fixed] Fix directsql_error metric bean in config. See [#5074](https://github.com/DataDog/integrations-core/pull/5074).
 
@@ -36,15 +36,15 @@
 
 * [Added] Add log section. See [#3891](https://github.com/DataDog/integrations-core/pull/3891).
 
-## 1.0.2 / 2019-06-18 / Agent 6.13.0
+## 1.0.2 / 2019-06-18
 
 * [Fixed] Fix metric type. See [#3885](https://github.com/DataDog/integrations-core/pull/3885).
 * [Fixed] Fix Hive metadatas. See [#3851](https://github.com/DataDog/integrations-core/pull/3851).
 
-## 1.0.1 / 2019-06-05 / Agent 6.13.0
+## 1.0.1 / 2019-06-05 / Agent 6.12.0
 
 * [Fixed] Fix init file. See [#3855](https://github.com/DataDog/integrations-core/pull/3855).
 
-## 1.0.0 / 2019-06-01 / Agent 6.12.0
+## 1.0.0 / 2019-06-01
 
 * [Added] Hive integration. See [#3723](https://github.com/DataDog/integrations-core/pull/3723).

--- a/hivemq/CHANGELOG.md
+++ b/hivemq/CHANGELOG.md
@@ -11,11 +11,11 @@
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 * [Fixed] Adjust jmxfetch config. See [#6864](https://github.com/DataDog/integrations-core/pull/6864).
 
-## 1.0.1 / 2020-05-28 / Agent 7.21.0
+## 1.0.1 / 2020-05-28 / Agent 7.20.0
 
 * [Fixed] Fix metric definitions to match the unnormalized bean names. See [#6768](https://github.com/DataDog/integrations-core/pull/6768).
 
-## 1.0.0 / 2020-05-14 / Agent 7.20.0
+## 1.0.0 / 2020-05-14
 
 * [Added] Add HiveMQ integration. See [#6600](https://github.com/DataDog/integrations-core/pull/6600).
 

--- a/hivemq/CHANGELOG.md
+++ b/hivemq/CHANGELOG.md
@@ -1,21 +1,21 @@
 # CHANGELOG - HiveMQ
 
-## 1.1.1 / 2020-08-10
+## 1.1.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] Add new_gc_metrics to all jmx integrations. See [#7073](https://github.com/DataDog/integrations-core/pull/7073).
 
-## 1.1.0 / 2020-06-29
+## 1.1.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add event log file to example config. See [#6843](https://github.com/DataDog/integrations-core/pull/6843).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 * [Fixed] Adjust jmxfetch config. See [#6864](https://github.com/DataDog/integrations-core/pull/6864).
 
-## 1.0.1 / 2020-05-28
+## 1.0.1 / 2020-05-28 / Agent 7.21.0
 
 * [Fixed] Fix metric definitions to match the unnormalized bean names. See [#6768](https://github.com/DataDog/integrations-core/pull/6768).
 
-## 1.0.0 / 2020-05-14
+## 1.0.0 / 2020-05-14 / Agent 7.20.0
 
 * [Added] Add HiveMQ integration. See [#6600](https://github.com/DataDog/integrations-core/pull/6600).
 

--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [Added] Add config specs to http check. See [#7245](https://github.com/DataDog/integrations-core/pull/7245).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 4.9.1 / 2020-07-09 / Agent 7.22.0
+## 4.9.1 / 2020-07-09
 
 * [Fixed] Raise http service check message limit. See [#7008](https://github.com/DataDog/integrations-core/pull/7008).
 
@@ -17,11 +17,11 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 4.7.1 / 2020-04-09 / Agent 7.20.0
+## 4.7.1 / 2020-04-09 / Agent 7.19.0
 
 * [Fixed] Fix new option name in config sample. See [#6296](https://github.com/DataDog/integrations-core/pull/6296).
 
-## 4.7.0 / 2020-04-04 / Agent 7.19.0
+## 4.7.0 / 2020-04-04
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
@@ -31,19 +31,19 @@
 
 * [Fixed] Apply strptime thread-safety fix only on Python 2. See [#5618](https://github.com/DataDog/integrations-core/pull/5618).
 
-## 4.6.3 / 2020-01-24 / Agent 7.18.0
+## 4.6.3 / 2020-01-24 / Agent 7.17.0
 
 * [Fixed] Document that tls_verify is False by default. See [#5547](https://github.com/DataDog/integrations-core/pull/5547).
 
-## 4.6.2 / 2020-01-21 / Agent 7.18.0
+## 4.6.2 / 2020-01-21
 
 * [Fixed] Properly enable TLS/SSL verification when `tls_verify` is true. See [#5507](https://github.com/DataDog/integrations-core/pull/5507).
 
-## 4.6.1 / 2020-01-17 / Agent 7.18.0
+## 4.6.1 / 2020-01-17
 
 * [Fixed] Avoid cross instance data sharing. See [#5499](https://github.com/DataDog/integrations-core/pull/5499).
 
-## 4.6.0 / 2020-01-13 / Agent 7.17.0
+## 4.6.0 / 2020-01-13
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
@@ -51,17 +51,17 @@
 
 * [Added] Upgrade cryptography to 2.8. See [#5047](https://github.com/DataDog/integrations-core/pull/5047).
 
-## 4.4.0 / 2019-11-15 / Agent 7.16.0
+## 4.4.0 / 2019-11-15
 
 * [Fixed] Update response_time metric source. See [#5025](https://github.com/DataDog/integrations-core/pull/5025).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 * [Fixed] Improve config constructor syntax. See [#4841](https://github.com/DataDog/integrations-core/pull/4841).
 
-## 4.3.1 / 2019-10-18 / Agent 7.16.0
+## 4.3.1 / 2019-10-18 / Agent 6.15.0
 
 * [Fixed] Ensure the correct tls_ca_cert value is used. See [#4819](https://github.com/DataDog/integrations-core/pull/4819).
 
-## 4.3.0 / 2019-10-11 / Agent 6.15.0
+## 4.3.0 / 2019-10-11
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
@@ -73,7 +73,7 @@
 
 * [Fixed] Fix detection of the embedded Agent directory. See [#4158](https://github.com/DataDog/integrations-core/pull/4158).
 
-## 4.1.0 / 2019-07-04 / Agent 6.13.0
+## 4.1.0 / 2019-07-04
 
 * [Added] Update cryptography version. See [#4000](https://github.com/DataDog/integrations-core/pull/4000).
 
@@ -87,16 +87,16 @@
 * [Fixed] Fix Python 3.7 support. See [#3293](https://github.com/DataDog/integrations-core/pull/3293).
 * [Fixed] ensure_unicode with normalize for py3 compatibility. See [#3218](https://github.com/DataDog/integrations-core/pull/3218).
 
-## 3.2.0 / 2019-02-18 / Agent 6.11.0
+## 3.2.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Add url as tag. See [#3080](https://github.com/DataDog/integrations-core/pull/3080).
 * [Added] [http_check] adds instance tag to metrics. See [#3065](https://github.com/DataDog/integrations-core/pull/3065).
 
-## 3.1.1 / 2018-12-07 / Agent 5.31.0
+## 3.1.1 / 2018-12-07 / Agent 6.8.0
 
 * [Fixed] Fix unicode handling of log messages. See [#2700][1].
 
-## 3.1.0 / 2018-11-30 / Agent 5.30.0
+## 3.1.0 / 2018-11-30
 
 * [Added] Add option to set `stream` parameter on requests. See [#2658][2]. Thanks [syskill][3].
 * [Added] Upgrade cryptography. See [#2659][4].
@@ -105,36 +105,36 @@
 * [Added] Fix unicode handling on A6. See [#2435][7].
 * [Added] Validate that the url starts with the scheme. See [#2393][8].
 
-## 3.0.0 / 2018-10-12 / Agent 5.28.0
+## 3.0.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Handle SSL exception and send a DOWN service check status. See [#2332][9].
 * [Changed] Refactoring: isolate config parsing. See [#2321][10].
 
-## 2.4.0 / 2018-10-01 / Agent 5.28.0
+## 2.4.0 / 2018-10-01
 
 * [Fixed] Fix fetching ca_certs from init_config. See [#2318][11].
 * [Added] Allow configuring cert expiration time in seconds. See [#2290][12].
 
-## 2.3.0 / 2018-09-04 / Agent 5.28.0
+## 2.3.0 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Update cryptography to 2.3. See [#1927][13].
 * [Fixed] fix link in config option description. See [#1865][14].
 * [Added] support NTLM auth. See [#1812][15].
 * [Fixed] Add data files to the wheel package. See [#1727][16].
 
-## 2.2.0 / 2018-06-20 / Agent 5.26.0
+## 2.2.0 / 2018-06-20 / Agent 6.3.1
 
 * [Fixed] Add support client auth for http check cert expiration.. See [#1754][17].
 * [Fixed] Check will now send data with PUT, DELETE, and PATCH methods--not just POST. See [#1718][18].
 
-## 2.1.0 / 2018-06-06 / Agent 5.25.0
+## 2.1.0 / 2018-06-06
 
 * [Fixed] fixes AttributeError when running on 6.2.1. See [#1617][19].
 * [Fixed] Suppress InsecureRequestWarning for urllib3 for http_check. See [#1574][20].
 * [Added] Allow users to disable matching hostnames verification in ssl cert verification. See [#1519][21].
 * [Changed] Emit a warning if disable_ssl_validation is unset. See [#1517][22].
 
-## 2.0.1 / 2018-05-11 / Agent 5.24.0
+## 2.0.1 / 2018-05-11
 
 * [BUGFIX] Properly detect default certificate file for all supported Platforms. See [#1340][23]
 

--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -1,102 +1,102 @@
 # CHANGELOG - http_check
 
-## 4.10.0 / 2020-08-10
+## 4.10.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add config specs to http check. See [#7245](https://github.com/DataDog/integrations-core/pull/7245).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 4.9.1 / 2020-07-09
+## 4.9.1 / 2020-07-09 / Agent 7.22.0
 
 * [Fixed] Raise http service check message limit. See [#7008](https://github.com/DataDog/integrations-core/pull/7008).
 
-## 4.9.0 / 2020-06-29
+## 4.9.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 4.8.0 / 2020-05-17
+## 4.8.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 4.7.1 / 2020-04-09
+## 4.7.1 / 2020-04-09 / Agent 7.20.0
 
 * [Fixed] Fix new option name in config sample. See [#6296](https://github.com/DataDog/integrations-core/pull/6296).
 
-## 4.7.0 / 2020-04-04
+## 4.7.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Update reference to `disable_ssl_validation`. See [#5945](https://github.com/DataDog/integrations-core/pull/5945).
 
-## 4.6.4 / 2020-02-22
+## 4.6.4 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Apply strptime thread-safety fix only on Python 2. See [#5618](https://github.com/DataDog/integrations-core/pull/5618).
 
-## 4.6.3 / 2020-01-24
+## 4.6.3 / 2020-01-24 / Agent 7.18.0
 
 * [Fixed] Document that tls_verify is False by default. See [#5547](https://github.com/DataDog/integrations-core/pull/5547).
 
-## 4.6.2 / 2020-01-21
+## 4.6.2 / 2020-01-21 / Agent 7.18.0
 
 * [Fixed] Properly enable TLS/SSL verification when `tls_verify` is true. See [#5507](https://github.com/DataDog/integrations-core/pull/5507).
 
-## 4.6.1 / 2020-01-17
+## 4.6.1 / 2020-01-17 / Agent 7.18.0
 
 * [Fixed] Avoid cross instance data sharing. See [#5499](https://github.com/DataDog/integrations-core/pull/5499).
 
-## 4.6.0 / 2020-01-13
+## 4.6.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 4.5.0 / 2019-12-02
+## 4.5.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade cryptography to 2.8. See [#5047](https://github.com/DataDog/integrations-core/pull/5047).
 
-## 4.4.0 / 2019-11-15
+## 4.4.0 / 2019-11-15 / Agent 7.16.0
 
 * [Fixed] Update response_time metric source. See [#5025](https://github.com/DataDog/integrations-core/pull/5025).
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 * [Fixed] Improve config constructor syntax. See [#4841](https://github.com/DataDog/integrations-core/pull/4841).
 
-## 4.3.1 / 2019-10-18
+## 4.3.1 / 2019-10-18 / Agent 7.16.0
 
 * [Fixed] Ensure the correct tls_ca_cert value is used. See [#4819](https://github.com/DataDog/integrations-core/pull/4819).
 
-## 4.3.0 / 2019-10-11
+## 4.3.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 4.2.0 / 2019-08-24
+## 4.2.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add request wrapper to http_check. See [#4363](https://github.com/DataDog/integrations-core/pull/4363).
 
-## 4.1.1 / 2019-07-22
+## 4.1.1 / 2019-07-22 / Agent 6.13.0
 
 * [Fixed] Fix detection of the embedded Agent directory. See [#4158](https://github.com/DataDog/integrations-core/pull/4158).
 
-## 4.1.0 / 2019-07-04
+## 4.1.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Update cryptography version. See [#4000](https://github.com/DataDog/integrations-core/pull/4000).
 
-## 4.0.0 / 2019-05-14
+## 4.0.0 / 2019-05-14 / Agent 6.12.0
 
 * [Changed] Remove every default header except `User-Agent`. See [#3644](https://github.com/DataDog/integrations-core/pull/3644).
 * [Added] Adhere to code style. See [#3516](https://github.com/DataDog/integrations-core/pull/3516).
 
-## 3.2.1 / 2019-03-29
+## 3.2.1 / 2019-03-29 / Agent 6.11.0
 
 * [Fixed] Fix Python 3.7 support. See [#3293](https://github.com/DataDog/integrations-core/pull/3293).
 * [Fixed] ensure_unicode with normalize for py3 compatibility. See [#3218](https://github.com/DataDog/integrations-core/pull/3218).
 
-## 3.2.0 / 2019-02-18
+## 3.2.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Add url as tag. See [#3080](https://github.com/DataDog/integrations-core/pull/3080).
 * [Added] [http_check] adds instance tag to metrics. See [#3065](https://github.com/DataDog/integrations-core/pull/3065).
 
-## 3.1.1 / 2018-12-07
+## 3.1.1 / 2018-12-07 / Agent 5.31.0
 
 * [Fixed] Fix unicode handling of log messages. See [#2700][1].
 
-## 3.1.0 / 2018-11-30
+## 3.1.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Add option to set `stream` parameter on requests. See [#2658][2]. Thanks [syskill][3].
 * [Added] Upgrade cryptography. See [#2659][4].
@@ -105,36 +105,36 @@
 * [Added] Fix unicode handling on A6. See [#2435][7].
 * [Added] Validate that the url starts with the scheme. See [#2393][8].
 
-## 3.0.0 / 2018-10-12
+## 3.0.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Handle SSL exception and send a DOWN service check status. See [#2332][9].
 * [Changed] Refactoring: isolate config parsing. See [#2321][10].
 
-## 2.4.0 / 2018-10-01
+## 2.4.0 / 2018-10-01 / Agent 5.28.0
 
 * [Fixed] Fix fetching ca_certs from init_config. See [#2318][11].
 * [Added] Allow configuring cert expiration time in seconds. See [#2290][12].
 
-## 2.3.0 / 2018-09-04
+## 2.3.0 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Update cryptography to 2.3. See [#1927][13].
 * [Fixed] fix link in config option description. See [#1865][14].
 * [Added] support NTLM auth. See [#1812][15].
 * [Fixed] Add data files to the wheel package. See [#1727][16].
 
-## 2.2.0 / 2018-06-20
+## 2.2.0 / 2018-06-20 / Agent 5.26.0
 
 * [Fixed] Add support client auth for http check cert expiration.. See [#1754][17].
 * [Fixed] Check will now send data with PUT, DELETE, and PATCH methods--not just POST. See [#1718][18].
 
-## 2.1.0 / 2018-06-06
+## 2.1.0 / 2018-06-06 / Agent 5.25.0
 
 * [Fixed] fixes AttributeError when running on 6.2.1. See [#1617][19].
 * [Fixed] Suppress InsecureRequestWarning for urllib3 for http_check. See [#1574][20].
 * [Added] Allow users to disable matching hostnames verification in ssl cert verification. See [#1519][21].
 * [Changed] Emit a warning if disable_ssl_validation is unset. See [#1517][22].
 
-## 2.0.1 / 2018-05-11
+## 2.0.1 / 2018-05-11 / Agent 5.24.0
 
 * [BUGFIX] Properly detect default certificate file for all supported Platforms. See [#1340][23]
 

--- a/hyperv/CHANGELOG.md
+++ b/hyperv/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 * [Fixed] Add tags option to hyperv. See [#3337](https://github.com/DataDog/integrations-core/pull/3337).
 
-## 1.0.0 / 2019-01-03 / Agent 5.31.0
+## 1.0.0 / 2019-01-03 / Agent 6.9.0
 
 * [Added] Add Hyper-V integration. See [#2607][1].
 

--- a/hyperv/CHANGELOG.md
+++ b/hyperv/CHANGELOG.md
@@ -1,22 +1,22 @@
 # CHANGELOG - Hyper-V
 
-## 1.3.0 / 2020-06-29
+## 1.3.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add config and use new agent signature. See [#6779](https://github.com/DataDog/integrations-core/pull/6779).
 
-## 1.2.0 / 2020-05-17
+## 1.2.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.1.0 / 2019-05-14
+## 1.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3517](https://github.com/DataDog/integrations-core/pull/3517).
 
-## 1.0.1 / 2019-03-29
+## 1.0.1 / 2019-03-29 / Agent 6.11.0
 
 * [Fixed] Add tags option to hyperv. See [#3337](https://github.com/DataDog/integrations-core/pull/3337).
 
-## 1.0.0 / 2019-01-03
+## 1.0.0 / 2019-01-03 / Agent 5.31.0
 
 * [Added] Add Hyper-V integration. See [#2607][1].
 

--- a/ibm_db2/CHANGELOG.md
+++ b/ibm_db2/CHANGELOG.md
@@ -18,7 +18,7 @@
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Added] Add version metadata. See [#5262](https://github.com/DataDog/integrations-core/pull/5262).
 
-## 1.2.0 / 2019-12-16 / Agent 7.17.0
+## 1.2.0 / 2019-12-16
 
 * [Added] Retry connection after closed connection. See [#5194](https://github.com/DataDog/integrations-core/pull/5194).
 
@@ -26,11 +26,11 @@
 
 * [Added] Adhere to code style. See [#3518](https://github.com/DataDog/integrations-core/pull/3518).
 
-## 1.0.1 / 2019-04-10 / Agent 6.12.0
+## 1.0.1 / 2019-04-10 / Agent 6.11.0
 
 * [Fixed] Change `ibm_db2.connection.max` to gauge. See [#3602](https://github.com/DataDog/integrations-core/pull/3602).
 
-## 1.0.0 / 2019-03-29 / Agent 6.11.0
+## 1.0.0 / 2019-03-29
 
 * [Added] Add IBM Db2. See [#3095](https://github.com/DataDog/integrations-core/pull/3095).
 

--- a/ibm_db2/CHANGELOG.md
+++ b/ibm_db2/CHANGELOG.md
@@ -1,36 +1,36 @@
 # CHANGELOG - IBM Db2
 
-## 1.5.0 / 2020-05-17
+## 1.5.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.4.1 / 2020-04-04
+## 1.4.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.4.0 / 2020-01-30
+## 1.4.0 / 2020-01-30 / Agent 7.18.0
 
 * [Added] Add parameters for SSL configuration. See [#5587](https://github.com/DataDog/integrations-core/pull/5587).
 
-## 1.3.0 / 2020-01-13
+## 1.3.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Added] Add version metadata. See [#5262](https://github.com/DataDog/integrations-core/pull/5262).
 
-## 1.2.0 / 2019-12-16
+## 1.2.0 / 2019-12-16 / Agent 7.17.0
 
 * [Added] Retry connection after closed connection. See [#5194](https://github.com/DataDog/integrations-core/pull/5194).
 
-## 1.1.0 / 2019-05-14
+## 1.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3518](https://github.com/DataDog/integrations-core/pull/3518).
 
-## 1.0.1 / 2019-04-10
+## 1.0.1 / 2019-04-10 / Agent 6.12.0
 
 * [Fixed] Change `ibm_db2.connection.max` to gauge. See [#3602](https://github.com/DataDog/integrations-core/pull/3602).
 
-## 1.0.0 / 2019-03-29
+## 1.0.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Add IBM Db2. See [#3095](https://github.com/DataDog/integrations-core/pull/3095).
 

--- a/ibm_mq/CHANGELOG.md
+++ b/ibm_mq/CHANGELOG.md
@@ -1,16 +1,16 @@
 # CHANGELOG - IBM MQ
 
-## 3.8.1 / 2020-08-10
+## 3.8.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 3.8.0 / 2020-07-23
+## 3.8.0 / 2020-07-23 / Agent 7.22.0
 
 * [Added] IBM MQ metadata. See [#6979](https://github.com/DataDog/integrations-core/pull/6979).
 * [Added] Collect metrics from Statistics Messages. See [#6945](https://github.com/DataDog/integrations-core/pull/6945).
 * [Fixed] Avoid shadowing depth_percent function. See [#7132](https://github.com/DataDog/integrations-core/pull/7132).
 
-## 3.7.0 / 2020-06-29
+## 3.7.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add MacOS Support. See [#6927](https://github.com/DataDog/integrations-core/pull/6927).
 * [Fixed] Refactor to make encoding more consistent. See [#6995](https://github.com/DataDog/integrations-core/pull/6995).
@@ -18,80 +18,80 @@
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 * [Fixed] Move metrics collection logic to separate files. See [#6752](https://github.com/DataDog/integrations-core/pull/6752).
 
-## 3.6.0 / 2020-05-17
+## 3.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 3.5.1 / 2020-04-08
+## 3.5.1 / 2020-04-08 / Agent 7.20.0
 
 * [Fixed] Don't import pymqi unconditionally. See [#6286](https://github.com/DataDog/integrations-core/pull/6286).
 
-## 3.5.0 / 2020-04-04
+## 3.5.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Apply config specs to IBM MQ. See [#5903](https://github.com/DataDog/integrations-core/pull/5903).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 3.4.0 / 2020-03-11
+## 3.4.0 / 2020-03-11 / Agent 7.19.0
 
 * [Added] Add `connection_name` configuration. See [#6015](https://github.com/DataDog/integrations-core/pull/6015).
 * [Added] Add configuration option for the Channel Definition API version. See [#5905](https://github.com/DataDog/integrations-core/pull/5905).
 * [Added] Upgrade pymqi to 1.10.1. See [#5955](https://github.com/DataDog/integrations-core/pull/5955).
 * [Fixed] IBM MQ refactor. See [#5902](https://github.com/DataDog/integrations-core/pull/5902).
 
-## 3.3.1 / 2020-01-17
+## 3.3.1 / 2020-01-17 / Agent 7.18.0
 
 * [Fixed] Fix metric type and missing metrics in metadata.csv. See [#5470](https://github.com/DataDog/integrations-core/pull/5470).
 
-## 3.3.0 / 2020-01-13
+## 3.3.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Added] Add channel metrics. See [#5116](https://github.com/DataDog/integrations-core/pull/5116).
 
-## 3.2.1 / 2019-09-18
+## 3.2.1 / 2019-09-18 / Agent 6.15.0
 
 * [Fixed] Improve IBM MQ docs and logging. See [#4540](https://github.com/DataDog/integrations-core/pull/4540).
 * [Fixed] Fix duplicate service checks. See [#4525](https://github.com/DataDog/integrations-core/pull/4525).
 
-## 3.2.0 / 2019-08-21
+## 3.2.0 / 2019-08-21 / Agent 6.14.0
 
 * [Added] Add channel_status_mapping config. See [#4395](https://github.com/DataDog/integrations-core/pull/4395).
 
-## 3.1.1 / 2019-07-29
+## 3.1.1 / 2019-07-29 / Agent 6.14.0
 
 * [Fixed] Fix ibm_mq e2e import issue. See [#4140](https://github.com/DataDog/integrations-core/pull/4140).
 
-## 3.1.0 / 2019-07-04
+## 3.1.0 / 2019-07-04 / Agent 6.13.0
 
 * [Fixed] Use MQCMD_INQUIRE_Q instead of queue.inquire. See [#3997](https://github.com/DataDog/integrations-core/pull/3997).
 * [Added] Add ibm_mq.channel.count metric and ibm_mq.channel.status service check. See [#3958](https://github.com/DataDog/integrations-core/pull/3958).
 
-## 3.0.0 / 2019-06-20
+## 3.0.0 / 2019-06-20 / Agent 6.13.0
 
 * [Changed] [ibm_mq] fix queue auto discovery to include any type in addition to qmodel and included regex matching on queue names. See [#3893](https://github.com/DataDog/integrations-core/pull/3893).
 
-## 2.0.0 / 2019-04-16
+## 2.0.0 / 2019-04-16 / Agent 6.12.0
 
 * [Changed] Breaking change: Change host tag for mq_host. Dashboards and monitors may be affected. See [#3608](https://github.com/DataDog/integrations-core/pull/3608).
 * [Added] Adhere to code style. See [#3519](https://github.com/DataDog/integrations-core/pull/3519).
 * [Fixed] fix queue_manager variable naming of IBM MQ. See [#3592](https://github.com/DataDog/integrations-core/pull/3592).
 
-## 1.2.0 / 2019-03-29
+## 1.2.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Add ability to add additional tags to queues matching a regex. See [#3399](https://github.com/DataDog/integrations-core/pull/3399).
 * [Added] adds channel metrics. See [#3360](https://github.com/DataDog/integrations-core/pull/3360).
 * [Fixed] fix ssl variable naming for IBM MQ. See [#3312](https://github.com/DataDog/integrations-core/pull/3312).
 
-## 1.1.0 / 2019-02-18
+## 1.1.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Autodiscover queues. See [#3061](https://github.com/DataDog/integrations-core/pull/3061).
 
-## 1.0.1 / 2019-01-04
+## 1.0.1 / 2019-01-04 / Agent 5.31.0
 
 * [Fixed] Fix Oldest Message Age. See [#2859][1].
 
-## 1.0.0 / 2018-12-09
+## 1.0.0 / 2018-12-09 / Agent 5.31.0
 
 * [Added] IBM MQ Integration. See [#2154][2].
 

--- a/ibm_mq/CHANGELOG.md
+++ b/ibm_mq/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 3.8.0 / 2020-07-23 / Agent 7.22.0
+## 3.8.0 / 2020-07-23
 
 * [Added] IBM MQ metadata. See [#6979](https://github.com/DataDog/integrations-core/pull/6979).
 * [Added] Collect metrics from Statistics Messages. See [#6945](https://github.com/DataDog/integrations-core/pull/6945).
@@ -22,28 +22,28 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 3.5.1 / 2020-04-08 / Agent 7.20.0
+## 3.5.1 / 2020-04-08 / Agent 7.19.0
 
 * [Fixed] Don't import pymqi unconditionally. See [#6286](https://github.com/DataDog/integrations-core/pull/6286).
 
-## 3.5.0 / 2020-04-04 / Agent 7.19.0
+## 3.5.0 / 2020-04-04
 
 * [Added] Apply config specs to IBM MQ. See [#5903](https://github.com/DataDog/integrations-core/pull/5903).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 3.4.0 / 2020-03-11 / Agent 7.19.0
+## 3.4.0 / 2020-03-11
 
 * [Added] Add `connection_name` configuration. See [#6015](https://github.com/DataDog/integrations-core/pull/6015).
 * [Added] Add configuration option for the Channel Definition API version. See [#5905](https://github.com/DataDog/integrations-core/pull/5905).
 * [Added] Upgrade pymqi to 1.10.1. See [#5955](https://github.com/DataDog/integrations-core/pull/5955).
 * [Fixed] IBM MQ refactor. See [#5902](https://github.com/DataDog/integrations-core/pull/5902).
 
-## 3.3.1 / 2020-01-17 / Agent 7.18.0
+## 3.3.1 / 2020-01-17 / Agent 7.17.0
 
 * [Fixed] Fix metric type and missing metrics in metadata.csv. See [#5470](https://github.com/DataDog/integrations-core/pull/5470).
 
-## 3.3.0 / 2020-01-13 / Agent 7.17.0
+## 3.3.0 / 2020-01-13
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
@@ -58,7 +58,7 @@
 
 * [Added] Add channel_status_mapping config. See [#4395](https://github.com/DataDog/integrations-core/pull/4395).
 
-## 3.1.1 / 2019-07-29 / Agent 6.14.0
+## 3.1.1 / 2019-07-29
 
 * [Fixed] Fix ibm_mq e2e import issue. See [#4140](https://github.com/DataDog/integrations-core/pull/4140).
 
@@ -67,7 +67,7 @@
 * [Fixed] Use MQCMD_INQUIRE_Q instead of queue.inquire. See [#3997](https://github.com/DataDog/integrations-core/pull/3997).
 * [Added] Add ibm_mq.channel.count metric and ibm_mq.channel.status service check. See [#3958](https://github.com/DataDog/integrations-core/pull/3958).
 
-## 3.0.0 / 2019-06-20 / Agent 6.13.0
+## 3.0.0 / 2019-06-20
 
 * [Changed] [ibm_mq] fix queue auto discovery to include any type in addition to qmodel and included regex matching on queue names. See [#3893](https://github.com/DataDog/integrations-core/pull/3893).
 
@@ -83,15 +83,15 @@
 * [Added] adds channel metrics. See [#3360](https://github.com/DataDog/integrations-core/pull/3360).
 * [Fixed] fix ssl variable naming for IBM MQ. See [#3312](https://github.com/DataDog/integrations-core/pull/3312).
 
-## 1.1.0 / 2019-02-18 / Agent 6.11.0
+## 1.1.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Autodiscover queues. See [#3061](https://github.com/DataDog/integrations-core/pull/3061).
 
-## 1.0.1 / 2019-01-04 / Agent 5.31.0
+## 1.0.1 / 2019-01-04 / Agent 6.9.0
 
 * [Fixed] Fix Oldest Message Age. See [#2859][1].
 
-## 1.0.0 / 2018-12-09 / Agent 5.31.0
+## 1.0.0 / 2018-12-09 / Agent 6.8.0
 
 * [Added] IBM MQ Integration. See [#2154][2].
 

--- a/ibm_was/CHANGELOG.md
+++ b/ibm_was/CHANGELOG.md
@@ -1,56 +1,56 @@
 # CHANGELOG - IBM WAS
 
-## 1.7.0 / 2020-06-29
+## 1.7.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.6.0 / 2020-05-17
+## 1.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Upgrade lxml to 4.5.0. See [#6661](https://github.com/DataDog/integrations-core/pull/6661).
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.5.1 / 2020-04-04
+## 1.5.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.5.0 / 2020-01-13
+## 1.5.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.4.0 / 2019-12-02
+## 1.4.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.3.1 / 2019-10-17
+## 1.3.1 / 2019-10-17 / Agent 7.16.0
 
 * [Fixed] Fix character casing logic for custom_queries_units_gauge option. See [#4796](https://github.com/DataDog/integrations-core/pull/4796).
 
-## 1.3.0 / 2019-10-11
+## 1.3.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add an option for custom count with units. See [#4628](https://github.com/DataDog/integrations-core/pull/4628).
 
-## 1.2.3 / 2019-09-23
+## 1.2.3 / 2019-09-23 / Agent 6.15.0
 
 * [Fixed] Don't assume nested tags exist. See [#4605](https://github.com/DataDog/integrations-core/pull/4605).
 
-## 1.2.2 / 2019-09-02
+## 1.2.2 / 2019-09-02 / Agent 6.15.0
 
 * [Fixed] Fix bug where multinode clusters would report wrong server/node tag combination and duplicate metric values. See [#4491](https://github.com/DataDog/integrations-core/pull/4491).
 
-## 1.2.1 / 2019-08-30
+## 1.2.1 / 2019-08-30 / Agent 6.15.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 1.2.0 / 2019-08-02
+## 1.2.0 / 2019-08-02 / Agent 6.14.0
 
 * [Added] Update metric type for JVM Metrics. See [#4085](https://github.com/DataDog/integrations-core/pull/4085).
 
-## 1.1.0 / 2019-05-14
+## 1.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Use request wrapper. See [#3650](https://github.com/DataDog/integrations-core/pull/3650).
 * [Added] Adhere to code style. See [#3520](https://github.com/DataDog/integrations-core/pull/3520).
 
-## 1.0.0 / 2019-02-20
+## 1.0.0 / 2019-02-20 / Agent 6.11.0
 
 * [Added] Create IBM WAS Integration. See [#2846](https://github.com/DataDog/integrations-core/pull/2846).
 

--- a/ibm_was/CHANGELOG.md
+++ b/ibm_was/CHANGELOG.md
@@ -21,27 +21,27 @@
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.3.1 / 2019-10-17 / Agent 7.16.0
+## 1.3.1 / 2019-10-17 / Agent 6.15.0
 
 * [Fixed] Fix character casing logic for custom_queries_units_gauge option. See [#4796](https://github.com/DataDog/integrations-core/pull/4796).
 
-## 1.3.0 / 2019-10-11 / Agent 6.15.0
+## 1.3.0 / 2019-10-11
 
 * [Added] Add an option for custom count with units. See [#4628](https://github.com/DataDog/integrations-core/pull/4628).
 
-## 1.2.3 / 2019-09-23 / Agent 6.15.0
+## 1.2.3 / 2019-09-23
 
 * [Fixed] Don't assume nested tags exist. See [#4605](https://github.com/DataDog/integrations-core/pull/4605).
 
-## 1.2.2 / 2019-09-02 / Agent 6.15.0
+## 1.2.2 / 2019-09-02 / Agent 6.14.0
 
 * [Fixed] Fix bug where multinode clusters would report wrong server/node tag combination and duplicate metric values. See [#4491](https://github.com/DataDog/integrations-core/pull/4491).
 
-## 1.2.1 / 2019-08-30 / Agent 6.15.0
+## 1.2.1 / 2019-08-30
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 1.2.0 / 2019-08-02 / Agent 6.14.0
+## 1.2.0 / 2019-08-02
 
 * [Added] Update metric type for JVM Metrics. See [#4085](https://github.com/DataDog/integrations-core/pull/4085).
 
@@ -50,7 +50,7 @@
 * [Added] Use request wrapper. See [#3650](https://github.com/DataDog/integrations-core/pull/3650).
 * [Added] Adhere to code style. See [#3520](https://github.com/DataDog/integrations-core/pull/3520).
 
-## 1.0.0 / 2019-02-20 / Agent 6.11.0
+## 1.0.0 / 2019-02-20 / Agent 6.10.0
 
 * [Added] Create IBM WAS Integration. See [#2846](https://github.com/DataDog/integrations-core/pull/2846).
 

--- a/ignite/CHANGELOG.md
+++ b/ignite/CHANGELOG.md
@@ -1,18 +1,18 @@
 # CHANGELOG - ignite
 
-## 1.1.0 / 2020-08-10
+## 1.1.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Convert jmx to in-app types for replay_check_run. See [#7275](https://github.com/DataDog/integrations-core/pull/7275).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] Add new_gc_metrics to all jmx integrations. See [#7073](https://github.com/DataDog/integrations-core/pull/7073).
 
-## 1.0.1 / 2020-06-29
+## 1.0.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Assert new jvm metrics. See [#6996](https://github.com/DataDog/integrations-core/pull/6996).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 * [Fixed] Adjust jmxfetch config. See [#6864](https://github.com/DataDog/integrations-core/pull/6864).
 
-## 1.0.0 / 2020-05-17
+## 1.0.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Add new integration Apache Ignite. See [#5767](https://github.com/DataDog/integrations-core/pull/5767).
 

--- a/iis/CHANGELOG.md
+++ b/iis/CHANGELOG.md
@@ -34,7 +34,7 @@
 
 * [Added] Handle the refresh_counters flag. See [#3840](https://github.com/DataDog/integrations-core/pull/3840).
 
-## 2.5.0 / 2019-05-14 / Agent 6.12.0
+## 2.5.0 / 2019-05-14
 
 * [Added] Cosmetic cleanups. See [#3706](https://github.com/DataDog/integrations-core/pull/3706).
 * [Added] Adhere to code style. See [#3521](https://github.com/DataDog/integrations-core/pull/3521).
@@ -44,20 +44,20 @@
 * [Added] adds `iis_host` tag to metrics. See [#3294](https://github.com/DataDog/integrations-core/pull/3294).
 * [Fixed] ensure_unicode with normalize for py3 compatibility. See [#3218](https://github.com/DataDog/integrations-core/pull/3218).
 
-## 2.3.0 / 2019-02-18 / Agent 6.11.0
+## 2.3.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Support Python 3. See [#2999](https://github.com/DataDog/integrations-core/pull/2999).
 
-## 2.2.1 / 2019-01-04 / Agent 5.31.0
+## 2.2.1 / 2019-01-04 / Agent 6.9.0
 
 * [Fixed] Change example config from "localhost" to ".". See [#2779][1].
 
-## 2.2.0 / 2018-10-12 / Agent 5.28.0
+## 2.2.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Pin pywin32 dependency. See [#2322][2].
 
-## 2.1.1 / 2018-09-04 / Agent 5.28.0
+## 2.1.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Fix 'attempted connection' metrics. See [#1970][3].
 * [Fixed] Add data files to the wheel package. See [#1727][4].

--- a/iis/CHANGELOG.md
+++ b/iis/CHANGELOG.md
@@ -4,60 +4,60 @@
 
 * [Fixed] Add debug lines on skipped metrics. See [#7394](https://github.com/DataDog/integrations-core/pull/7394).
 
-## 2.10.0 / 2020-06-29
+## 2.10.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 
-## 2.9.0 / 2020-05-17
+## 2.9.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Monitor application pools. See [#6549](https://github.com/DataDog/integrations-core/pull/6549).
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.8.1 / 2020-04-04
+## 2.8.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 2.8.0 / 2019-12-02
+## 2.8.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 2.7.0 / 2019-10-11
+## 2.7.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 2.6.1 / 2019-06-18
+## 2.6.1 / 2019-06-18 / Agent 6.13.0
 
 * [Fixed] Rename lower case manifest.in. See [#3858](https://github.com/DataDog/integrations-core/pull/3858).
 
-## 2.6.0 / 2019-06-01
+## 2.6.0 / 2019-06-01 / Agent 6.12.0
 
 * [Added] Handle the refresh_counters flag. See [#3840](https://github.com/DataDog/integrations-core/pull/3840).
 
-## 2.5.0 / 2019-05-14
+## 2.5.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Cosmetic cleanups. See [#3706](https://github.com/DataDog/integrations-core/pull/3706).
 * [Added] Adhere to code style. See [#3521](https://github.com/DataDog/integrations-core/pull/3521).
 
-## 2.4.0 / 2019-03-29
+## 2.4.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] adds `iis_host` tag to metrics. See [#3294](https://github.com/DataDog/integrations-core/pull/3294).
 * [Fixed] ensure_unicode with normalize for py3 compatibility. See [#3218](https://github.com/DataDog/integrations-core/pull/3218).
 
-## 2.3.0 / 2019-02-18
+## 2.3.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Support Python 3. See [#2999](https://github.com/DataDog/integrations-core/pull/2999).
 
-## 2.2.1 / 2019-01-04
+## 2.2.1 / 2019-01-04 / Agent 5.31.0
 
 * [Fixed] Change example config from "localhost" to ".". See [#2779][1].
 
-## 2.2.0 / 2018-10-12
+## 2.2.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][2].
 
-## 2.1.1 / 2018-09-04
+## 2.1.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Fix 'attempted connection' metrics. See [#1970][3].
 * [Fixed] Add data files to the wheel package. See [#1727][4].

--- a/istio/CHANGELOG.md
+++ b/istio/CHANGELOG.md
@@ -11,20 +11,20 @@
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 3.3.0 / 2020-06-09 / Agent 7.21.0
+## 3.3.0 / 2020-06-09
 
 * [Added] Enable `send_monotonic_with_gauge` to submit mesh metrics as monotonic counts. See [#5707](https://github.com/DataDog/integrations-core/pull/5707).
 
-## 3.2.1 / 2020-05-22 / Agent 7.21.0
+## 3.2.1 / 2020-05-22 / Agent 7.20.0
 
 * [Fixed] Remove `destination_service` and `source_workload` from label blacklist. See [#6712](https://github.com/DataDog/integrations-core/pull/6712).
 
-## 3.2.0 / 2020-05-17 / Agent 7.20.0
+## 3.2.0 / 2020-05-17
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add TCP mesh metrics mapping. See [#6466](https://github.com/DataDog/integrations-core/pull/6466).
 
-## 3.1.0 / 2020-04-23 / Agent 7.20.0
+## 3.1.0 / 2020-04-23
 
 * [Added] Add autodiscovery config and default tag exclusion. See [#6375](https://github.com/DataDog/integrations-core/pull/6375).
 * [Added] Support istiod metrics. See [#6426](https://github.com/DataDog/integrations-core/pull/6426).
@@ -38,7 +38,7 @@
 * [Fixed] Do not fail on octet stream content type for OpenMetrics. See [#5843](https://github.com/DataDog/integrations-core/pull/5843).
 * [Changed] Blacklist metric `mcp_source.request_acks_total` due to high cardinality. See [#6185](https://github.com/DataDog/integrations-core/pull/6185).
 
-## 2.4.2 / 2019-08-26 / Agent 6.15.0
+## 2.4.2 / 2019-08-26 / Agent 6.14.0
 
 * [Fixed] Blacklist `galley_mcp_source_message_size_bytes` histogram. See [#4433](https://github.com/DataDog/integrations-core/pull/4433).
 
@@ -46,11 +46,11 @@
 
 * [Fixed] Comment out mixer and mesh by default from configuration. See [#4121](https://github.com/DataDog/integrations-core/pull/4121).
 
-## 2.4.0 / 2019-06-24 / Agent 6.13.0
+## 2.4.0 / 2019-06-24
 
 * [Added] Support citadel endpoint. See [#3962](https://github.com/DataDog/integrations-core/pull/3962).
 
-## 2.3.1 / 2019-06-19 / Agent 6.13.0
+## 2.3.1 / 2019-06-19
 
 * [Fixed] Istio Mixer and Mesh endpoints should be optional. See [#3875](https://github.com/DataDog/integrations-core/pull/3875). Thanks [mikekatica](https://github.com/mikekatica).
 
@@ -58,16 +58,16 @@
 
 * [Added] Support pilot and galley metrics. See [#3734](https://github.com/DataDog/integrations-core/pull/3734).
 
-## 2.2.0 / 2019-05-14 / Agent 6.12.0
+## 2.2.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3522](https://github.com/DataDog/integrations-core/pull/3522).
 
-## 2.1.0 / 2019-02-18 / Agent 6.11.0
+## 2.1.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Update example config to match docs. See [#3046](https://github.com/DataDog/integrations-core/pull/3046).
 * [Added] Support Python 3. See [#3014](https://github.com/DataDog/integrations-core/pull/3014).
 
-## 2.0.0 / 2018-09-04 / Agent 5.28.0
+## 2.0.0 / 2018-09-04 / Agent 6.5.0
 
 * [Changed] Update istio to use the new OpenMetricsBaseCheck. See [#1979][1].
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][2].

--- a/istio/CHANGELOG.md
+++ b/istio/CHANGELOG.md
@@ -1,30 +1,30 @@
 # CHANGELOG - istio
 
-## 3.5.0 / 2020-08-10
+## 3.5.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Support "*" wildcard in type_overrides configuration. See [#7071](https://github.com/DataDog/integrations-core/pull/7071).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 3.4.0 / 2020-06-29
+## 3.4.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 3.3.0 / 2020-06-09
+## 3.3.0 / 2020-06-09 / Agent 7.21.0
 
 * [Added] Enable `send_monotonic_with_gauge` to submit mesh metrics as monotonic counts. See [#5707](https://github.com/DataDog/integrations-core/pull/5707).
 
-## 3.2.1 / 2020-05-22
+## 3.2.1 / 2020-05-22 / Agent 7.21.0
 
 * [Fixed] Remove `destination_service` and `source_workload` from label blacklist. See [#6712](https://github.com/DataDog/integrations-core/pull/6712).
 
-## 3.2.0 / 2020-05-17
+## 3.2.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add TCP mesh metrics mapping. See [#6466](https://github.com/DataDog/integrations-core/pull/6466).
 
-## 3.1.0 / 2020-04-23
+## 3.1.0 / 2020-04-23 / Agent 7.20.0
 
 * [Added] Add autodiscovery config and default tag exclusion. See [#6375](https://github.com/DataDog/integrations-core/pull/6375).
 * [Added] Support istiod metrics. See [#6426](https://github.com/DataDog/integrations-core/pull/6426).
@@ -32,42 +32,42 @@
 * [Added] Add configuration template spec. See [#6320](https://github.com/DataDog/integrations-core/pull/6320).
 * [Added] Refactor check and support new Agent signature. See [#6341](https://github.com/DataDog/integrations-core/pull/6341).
 
-## 3.0.0 / 2020-04-04
+## 3.0.0 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Do not fail on octet stream content type for OpenMetrics. See [#5843](https://github.com/DataDog/integrations-core/pull/5843).
 * [Changed] Blacklist metric `mcp_source.request_acks_total` due to high cardinality. See [#6185](https://github.com/DataDog/integrations-core/pull/6185).
 
-## 2.4.2 / 2019-08-26
+## 2.4.2 / 2019-08-26 / Agent 6.15.0
 
 * [Fixed] Blacklist `galley_mcp_source_message_size_bytes` histogram. See [#4433](https://github.com/DataDog/integrations-core/pull/4433).
 
-## 2.4.1 / 2019-07-16
+## 2.4.1 / 2019-07-16 / Agent 6.13.0
 
 * [Fixed] Comment out mixer and mesh by default from configuration. See [#4121](https://github.com/DataDog/integrations-core/pull/4121).
 
-## 2.4.0 / 2019-06-24
+## 2.4.0 / 2019-06-24 / Agent 6.13.0
 
 * [Added] Support citadel endpoint. See [#3962](https://github.com/DataDog/integrations-core/pull/3962).
 
-## 2.3.1 / 2019-06-19
+## 2.3.1 / 2019-06-19 / Agent 6.13.0
 
 * [Fixed] Istio Mixer and Mesh endpoints should be optional. See [#3875](https://github.com/DataDog/integrations-core/pull/3875). Thanks [mikekatica](https://github.com/mikekatica).
 
-## 2.3.0 / 2019-05-31
+## 2.3.0 / 2019-05-31 / Agent 6.12.0
 
 * [Added] Support pilot and galley metrics. See [#3734](https://github.com/DataDog/integrations-core/pull/3734).
 
-## 2.2.0 / 2019-05-14
+## 2.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3522](https://github.com/DataDog/integrations-core/pull/3522).
 
-## 2.1.0 / 2019-02-18
+## 2.1.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Update example config to match docs. See [#3046](https://github.com/DataDog/integrations-core/pull/3046).
 * [Added] Support Python 3. See [#3014](https://github.com/DataDog/integrations-core/pull/3014).
 
-## 2.0.0 / 2018-09-04
+## 2.0.0 / 2018-09-04 / Agent 5.28.0
 
 * [Changed] Update istio to use the new OpenMetricsBaseCheck. See [#1979][1].
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][2].

--- a/jboss_wildfly/CHANGELOG.md
+++ b/jboss_wildfly/CHANGELOG.md
@@ -1,37 +1,37 @@
 # CHANGELOG - JBoss/WildFly
 
-## 1.3.2 / 2020-08-10
+## 1.3.2 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] Add new_gc_metrics to all jmx integrations. See [#7073](https://github.com/DataDog/integrations-core/pull/7073).
 
-## 1.3.1 / 2020-06-29
+## 1.3.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Assert new jvm metrics. See [#6996](https://github.com/DataDog/integrations-core/pull/6996).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 * [Fixed] Adjust jmxfetch config. See [#6864](https://github.com/DataDog/integrations-core/pull/6864).
 
-## 1.3.0 / 2020-05-17
+## 1.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add rmi_connection_timeout & rmi_client_timeout to config spec. See [#6459](https://github.com/DataDog/integrations-core/pull/6459).
 * [Added] Add default template to openmetrics & jmx config. See [#6328](https://github.com/DataDog/integrations-core/pull/6328).
 
-## 1.2.0 / 2020-04-04
+## 1.2.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Fix service check name and add config spec. See [#6225](https://github.com/DataDog/integrations-core/pull/6225).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 * [Fixed] Various doc fixes. See [#5944](https://github.com/DataDog/integrations-core/pull/5944).
 
-## 1.1.1 / 2019-12-02
+## 1.1.1 / 2019-12-02 / Agent 7.16.0
 
 * [Fixed] Update example config to require `username` and `password`. See [#4445](https://github.com/DataDog/integrations-core/pull/4445).
 
-## 1.1.0 / 2019-06-18
+## 1.1.0 / 2019-06-18 / Agent 6.13.0
 
 * [Added] Add log setup and configuration. See [#3672](https://github.com/DataDog/integrations-core/pull/3672).
 
-## 1.0.0 / 2019-03-29
+## 1.0.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] JBoss/WildFly JMX Integration. See [#3320](https://github.com/DataDog/integrations-core/pull/3320).
 

--- a/kafka/CHANGELOG.md
+++ b/kafka/CHANGELOG.md
@@ -30,23 +30,23 @@
 
 * [Changed] Fix unit type of `kafka.request.produce.time.avg` & `kafka.request.produce.time.99percentile`. See [#3834](https://github.com/DataDog/integrations-core/pull/3834).
 
-## 1.4.0 / 2019-02-18 / Agent 6.11.0
+## 1.4.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Add extra Kafka broker metrics. See [#2484](https://github.com/DataDog/integrations-core/pull/2484). Thanks [jalaziz](https://github.com/jalaziz).
 
-## 1.3.0 / 2019-01-04 / Agent 5.31.0
+## 1.3.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Add Per Topic IncomingMessages metric for Kafka.. See [#2732][1].
 
-## 1.2.1 / 2018-11-30 / Agent 5.30.0
+## 1.2.1 / 2018-11-30 / Agent 6.8.0
 
 * [Fixed] Updated kafka.producer.record_error_rate to gauge. See [#2253][2].
 
-## 1.2.0 / 2018-10-12 / Agent 5.28.0
+## 1.2.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] [jmx] add rmi registry ssl config option. See [#2371][3].
 
-## 1.1.1 / 2018-09-04 / Agent 5.28.0
+## 1.1.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 

--- a/kafka/CHANGELOG.md
+++ b/kafka/CHANGELOG.md
@@ -1,52 +1,52 @@
 # CHANGELOG - kafka
 
-## 2.2.0 / 2020-08-10
+## 2.2.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add config specs. See [#7271](https://github.com/DataDog/integrations-core/pull/7271).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 2.1.1 / 2020-06-29
+## 2.1.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Assert new jvm metrics. See [#6996](https://github.com/DataDog/integrations-core/pull/6996).
 
-## 2.1.0 / 2020-05-17
+## 2.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.0.3 / 2020-04-04
+## 2.0.3 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 * [Fixed] Fix metric name for e2e test. See [#5985](https://github.com/DataDog/integrations-core/pull/5985).
 
-## 2.0.2 / 2019-10-11
+## 2.0.2 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Fix the missing Kafka producer metrics. See [#4737](https://github.com/DataDog/integrations-core/pull/4737). Thanks [Epokhe](https://github.com/Epokhe).
 
-## 2.0.1 / 2019-08-24
+## 2.0.1 / 2019-08-24 / Agent 6.14.0
 
 * [Fixed] Treat `kafka.producer.compression_rate` as a ratio. See [#4293](https://github.com/DataDog/integrations-core/pull/4293).
 
-## 2.0.0 / 2019-06-01
+## 2.0.0 / 2019-06-01 / Agent 6.12.0
 
 * [Changed] Fix unit type of `kafka.request.produce.time.avg` & `kafka.request.produce.time.99percentile`. See [#3834](https://github.com/DataDog/integrations-core/pull/3834).
 
-## 1.4.0 / 2019-02-18
+## 1.4.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Add extra Kafka broker metrics. See [#2484](https://github.com/DataDog/integrations-core/pull/2484). Thanks [jalaziz](https://github.com/jalaziz).
 
-## 1.3.0 / 2019-01-04
+## 1.3.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Add Per Topic IncomingMessages metric for Kafka.. See [#2732][1].
 
-## 1.2.1 / 2018-11-30
+## 1.2.1 / 2018-11-30 / Agent 5.30.0
 
 * [Fixed] Updated kafka.producer.record_error_rate to gauge. See [#2253][2].
 
-## 1.2.0 / 2018-10-12
+## 1.2.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] [jmx] add rmi registry ssl config option. See [#2371][3].
 
-## 1.1.1 / 2018-09-04
+## 1.1.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 

--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -1,46 +1,46 @@
 # CHANGELOG - kafka_consumer
 
-## 2.6.0 / 2020-07-27
+## 2.6.0 / 2020-07-27 / Agent 7.22.0
 
 * [Added] Smaller batches when fetching highwater offsets. See [#7093](https://github.com/DataDog/integrations-core/pull/7093).
 * [Fixed] Limit the number of reported contexts. See [#7084](https://github.com/DataDog/integrations-core/pull/7084).
 
-## 2.5.0 / 2020-05-17
+## 2.5.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.4.0 / 2020-02-22
+## 2.4.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Re-enable `kafka_client_api_version` option. See [#5726](https://github.com/DataDog/integrations-core/pull/5726).
 * [Added] Use top-level kafka imports to be more future-proof. See [#5702](https://github.com/DataDog/integrations-core/pull/5702).
 * [Added] Upgrade kafka-python to 2.0.0. See [#5696](https://github.com/DataDog/integrations-core/pull/5696).
 * [Fixed] Anticipate potential bug when instantiating the Kafka admin client. See [#5464](https://github.com/DataDog/integrations-core/pull/5464).
 
-## 2.3.0 / 2020-01-28
+## 2.3.0 / 2020-01-28 / Agent 7.18.0
 
 * [Added] Update imports for newer versions of kafka-python. See [#5489](https://github.com/DataDog/integrations-core/pull/5489).
 
-## 2.2.0 / 2020-01-13
+## 2.2.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Fixed] Fix `kafka_client_api_version`. See [#5007](https://github.com/DataDog/integrations-core/pull/5007).
 
-## 2.1.1 / 2019-11-27
+## 2.1.1 / 2019-11-27 / Agent 7.16.0
 
 * [Fixed] Handle missing partitions. See [#5035](https://github.com/DataDog/integrations-core/pull/5035).
 * [Fixed] Handle topics set to empty dict. See [#4974](https://github.com/DataDog/integrations-core/pull/4974).
 * [Fixed] Fix error on missing config. See [#4959](https://github.com/DataDog/integrations-core/pull/4959).
 
-## 2.1.0 / 2019-10-09
+## 2.1.0 / 2019-10-09 / Agent 6.15.0
 
 * [Added] Add support for fetching consumer offsets stored in Kafka to `monitor_unlisted_consumer_groups`. See [#3957](https://github.com/DataDog/integrations-core/pull/3957). Thanks [jeffwidman](https://github.com/jeffwidman).
 
-## 2.0.1 / 2019-08-27
+## 2.0.1 / 2019-08-27 / Agent 6.15.0
 
 * [Fixed] Fix logger call during exceptions. See [#4440](https://github.com/DataDog/integrations-core/pull/4440).
 
-## 2.0.0 / 2019-08-24
+## 2.0.0 / 2019-08-24 / Agent 6.14.0
 
 * [Changed] Drop `source:kafka` from tags.. See [#4400](https://github.com/DataDog/integrations-core/pull/4400). Thanks [jeffwidman](https://github.com/jeffwidman).
 * [Added] Force initial population of the cluster cache. See [#4394](https://github.com/DataDog/integrations-core/pull/4394). Thanks [jeffwidman](https://github.com/jeffwidman).
@@ -55,51 +55,51 @@
 * [Added] Bump Kazoo to 2.6.1 to pull in some minor bugfixes. See [#4260](https://github.com/DataDog/integrations-core/pull/4260). Thanks [jeffwidman](https://github.com/jeffwidman).
 * [Added] Remove unnecessary constants and cleanup error handling. See [#4256](https://github.com/DataDog/integrations-core/pull/4256). Thanks [jeffwidman](https://github.com/jeffwidman).
 
-## 1.10.0 / 2019-06-19
+## 1.10.0 / 2019-06-19 / Agent 6.13.0
 
 * [Added] Refactor check to support different versions easily. See [#3929](https://github.com/DataDog/integrations-core/pull/3929).
 
-## 1.9.2 / 2019-06-04
+## 1.9.2 / 2019-06-04 / Agent 6.13.0
 
 * [Fixed] Fix example conf file. See [#3860](https://github.com/DataDog/integrations-core/pull/3860).
 
-## 1.9.1 / 2019-06-01
+## 1.9.1 / 2019-06-01 / Agent 6.12.0
 
 * [Fixed] Fix code style. See [#3838](https://github.com/DataDog/integrations-core/pull/3838).
 * [Fixed] Handle empty topics and partitions. See [#3807](https://github.com/DataDog/integrations-core/pull/3807).
 
-## 1.9.0 / 2019-05-14
+## 1.9.0 / 2019-05-14 / Agent 6.12.0
 
 * [Fixed] Fix kafka_consumer conf file. See [#3757](https://github.com/DataDog/integrations-core/pull/3757).
 * [Added] Adhere to code style. See [#3523](https://github.com/DataDog/integrations-core/pull/3523).
 
-## 1.8.1 / 2019-03-29
+## 1.8.1 / 2019-03-29 / Agent 6.11.0
 
 * [Fixed] Properly cache zookeeper connection strings. See [#3333](https://github.com/DataDog/integrations-core/pull/3333).
 
-## 1.8.0 / 2019-03-08
+## 1.8.0 / 2019-03-08 / Agent 6.11.0
 
 * [Added] Add support for SASL_PLAINTEXT authentication with Kafka broker. See [#3056](https://github.com/DataDog/integrations-core/pull/3056).
 
-## 1.7.0 / 2019-02-18
+## 1.7.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Finish Python 3 Support. See [#2912](https://github.com/DataDog/integrations-core/pull/2912).
 
-## 1.6.0 / 2019-01-04
+## 1.6.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] [kafka_consumer] Bump vendored kazoo to 2.6.0. See [#2729][1]. Thanks [jeffwidman][2].
 * [Added] [kafka_consumer] Bump kafka-python to 1.4.4. See [#2728][3]. Thanks [jeffwidman][2].
 
-## 1.5.0 / 2018-11-30
+## 1.5.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Support Python 3. See [#2648][4].
 
-## 1.4.1 / 2018-09-04
+## 1.4.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 1.4.0 / 2018-06-04
+## 1.4.0 / 2018-06-04 / Agent 5.25.0
 
 * [Changed] Bump to kafka-python 1.4.3. See [#1627][6]. Thanks [jeffwidman][2].
 

--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -16,11 +16,11 @@
 * [Added] Upgrade kafka-python to 2.0.0. See [#5696](https://github.com/DataDog/integrations-core/pull/5696).
 * [Fixed] Anticipate potential bug when instantiating the Kafka admin client. See [#5464](https://github.com/DataDog/integrations-core/pull/5464).
 
-## 2.3.0 / 2020-01-28 / Agent 7.18.0
+## 2.3.0 / 2020-01-28 / Agent 7.17.0
 
 * [Added] Update imports for newer versions of kafka-python. See [#5489](https://github.com/DataDog/integrations-core/pull/5489).
 
-## 2.2.0 / 2020-01-13 / Agent 7.17.0
+## 2.2.0 / 2020-01-13
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
@@ -36,11 +36,11 @@
 
 * [Added] Add support for fetching consumer offsets stored in Kafka to `monitor_unlisted_consumer_groups`. See [#3957](https://github.com/DataDog/integrations-core/pull/3957). Thanks [jeffwidman](https://github.com/jeffwidman).
 
-## 2.0.1 / 2019-08-27 / Agent 6.15.0
+## 2.0.1 / 2019-08-27 / Agent 6.14.0
 
 * [Fixed] Fix logger call during exceptions. See [#4440](https://github.com/DataDog/integrations-core/pull/4440).
 
-## 2.0.0 / 2019-08-24 / Agent 6.14.0
+## 2.0.0 / 2019-08-24
 
 * [Changed] Drop `source:kafka` from tags.. See [#4400](https://github.com/DataDog/integrations-core/pull/4400). Thanks [jeffwidman](https://github.com/jeffwidman).
 * [Added] Force initial population of the cluster cache. See [#4394](https://github.com/DataDog/integrations-core/pull/4394). Thanks [jeffwidman](https://github.com/jeffwidman).
@@ -59,16 +59,16 @@
 
 * [Added] Refactor check to support different versions easily. See [#3929](https://github.com/DataDog/integrations-core/pull/3929).
 
-## 1.9.2 / 2019-06-04 / Agent 6.13.0
+## 1.9.2 / 2019-06-04 / Agent 6.12.0
 
 * [Fixed] Fix example conf file. See [#3860](https://github.com/DataDog/integrations-core/pull/3860).
 
-## 1.9.1 / 2019-06-01 / Agent 6.12.0
+## 1.9.1 / 2019-06-01
 
 * [Fixed] Fix code style. See [#3838](https://github.com/DataDog/integrations-core/pull/3838).
 * [Fixed] Handle empty topics and partitions. See [#3807](https://github.com/DataDog/integrations-core/pull/3807).
 
-## 1.9.0 / 2019-05-14 / Agent 6.12.0
+## 1.9.0 / 2019-05-14
 
 * [Fixed] Fix kafka_consumer conf file. See [#3757](https://github.com/DataDog/integrations-core/pull/3757).
 * [Added] Adhere to code style. See [#3523](https://github.com/DataDog/integrations-core/pull/3523).
@@ -77,29 +77,29 @@
 
 * [Fixed] Properly cache zookeeper connection strings. See [#3333](https://github.com/DataDog/integrations-core/pull/3333).
 
-## 1.8.0 / 2019-03-08 / Agent 6.11.0
+## 1.8.0 / 2019-03-08
 
 * [Added] Add support for SASL_PLAINTEXT authentication with Kafka broker. See [#3056](https://github.com/DataDog/integrations-core/pull/3056).
 
-## 1.7.0 / 2019-02-18 / Agent 6.11.0
+## 1.7.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Finish Python 3 Support. See [#2912](https://github.com/DataDog/integrations-core/pull/2912).
 
-## 1.6.0 / 2019-01-04 / Agent 5.31.0
+## 1.6.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] [kafka_consumer] Bump vendored kazoo to 2.6.0. See [#2729][1]. Thanks [jeffwidman][2].
 * [Added] [kafka_consumer] Bump kafka-python to 1.4.4. See [#2728][3]. Thanks [jeffwidman][2].
 
-## 1.5.0 / 2018-11-30 / Agent 5.30.0
+## 1.5.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Support Python 3. See [#2648][4].
 
-## 1.4.1 / 2018-09-04 / Agent 5.28.0
+## 1.4.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 1.4.0 / 2018-06-04 / Agent 5.25.0
+## 1.4.0 / 2018-06-04
 
 * [Changed] Bump to kafka-python 1.4.3. See [#1627][6]. Thanks [jeffwidman][2].
 

--- a/kong/CHANGELOG.md
+++ b/kong/CHANGELOG.md
@@ -1,56 +1,56 @@
 # CHANGELOG - kong
 
-## 1.10.1 / 2020-08-10
+## 1.10.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.10.0 / 2020-06-29
+## 1.10.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.9.0 / 2020-05-17
+## 1.9.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.8.1 / 2020-04-07
+## 1.8.1 / 2020-04-07 / Agent 7.20.0
 
 * [Fixed] Add `kerberos_cache` to HTTP config options. See [#6279](https://github.com/DataDog/integrations-core/pull/6279).
 
-## 1.8.0 / 2020-04-04
+## 1.8.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.7.1 / 2020-02-25
+## 1.7.1 / 2020-02-25 / Agent 7.19.0
 
 * [Fixed] Update datadog_checks_base dependencies. See [#5846](https://github.com/DataDog/integrations-core/pull/5846).
 
-## 1.7.0 / 2020-02-22
+## 1.7.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add `service` option to default configuration. See [#5805](https://github.com/DataDog/integrations-core/pull/5805).
 * [Added] Adds RequestsWrapper to Kong. See [#5807](https://github.com/DataDog/integrations-core/pull/5807).
 
-## 1.6.0 / 2020-01-13
+## 1.6.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 
-## 1.5.0 / 2019-05-14
+## 1.5.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3524](https://github.com/DataDog/integrations-core/pull/3524).
 
-## 1.4.0 / 2019-03-29
+## 1.4.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Update the kong integration with log instruction. See [#2935](https://github.com/DataDog/integrations-core/pull/2935).
 
-## 1.3.0 / 2019-01-04
+## 1.3.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2772][1].
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/kong/CHANGELOG.md
+++ b/kong/CHANGELOG.md
@@ -15,21 +15,21 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.8.1 / 2020-04-07 / Agent 7.20.0
+## 1.8.1 / 2020-04-07 / Agent 7.19.0
 
 * [Fixed] Add `kerberos_cache` to HTTP config options. See [#6279](https://github.com/DataDog/integrations-core/pull/6279).
 
-## 1.8.0 / 2020-04-04 / Agent 7.19.0
+## 1.8.0 / 2020-04-04
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.7.1 / 2020-02-25 / Agent 7.19.0
+## 1.7.1 / 2020-02-25 / Agent 7.18.0
 
 * [Fixed] Update datadog_checks_base dependencies. See [#5846](https://github.com/DataDog/integrations-core/pull/5846).
 
-## 1.7.0 / 2020-02-22 / Agent 7.18.0
+## 1.7.0 / 2020-02-22
 
 * [Added] Add `service` option to default configuration. See [#5805](https://github.com/DataDog/integrations-core/pull/5805).
 * [Added] Adds RequestsWrapper to Kong. See [#5807](https://github.com/DataDog/integrations-core/pull/5807).
@@ -46,11 +46,11 @@
 
 * [Added] Update the kong integration with log instruction. See [#2935](https://github.com/DataDog/integrations-core/pull/2935).
 
-## 1.3.0 / 2019-01-04 / Agent 5.31.0
+## 1.3.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2772][1].
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/kube_apiserver_metrics/CHANGELOG.md
+++ b/kube_apiserver_metrics/CHANGELOG.md
@@ -1,54 +1,54 @@
 # CHANGELOG - Kube_apiserver_metrics
 
-## 1.5.0 / 2020-08-10
+## 1.5.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Support "*" wildcard in type_overrides configuration. See [#7071](https://github.com/DataDog/integrations-core/pull/7071).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.4.1 / 2020-07-02
+## 1.4.1 / 2020-07-02 / Agent 7.22.0
 
 * [Fixed] Fix default value in example configuration file. See [#7034](https://github.com/DataDog/integrations-core/pull/7034).
 
-## 1.4.0 / 2020-06-29
+## 1.4.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Added] kube apiserver signature and specs. See [#6831](https://github.com/DataDog/integrations-core/pull/6831).
 * [Fixed] Sync example configs. See [#6920](https://github.com/DataDog/integrations-core/pull/6920).
 
-## 1.3.0 / 2020-05-17
+## 1.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add admission controller metrics. See [#6502](https://github.com/DataDog/integrations-core/pull/6502).
 
-## 1.2.3 / 2020-04-04
+## 1.2.3 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.2.2 / 2020-01-13
+## 1.2.2 / 2020-01-13 / Agent 7.17.0
 
 * [Fixed] Update Kube_apiserver_metrics annotations documentation. See [#5199](https://github.com/DataDog/integrations-core/pull/5199).
 
-## 1.2.1 / 2019-12-13
+## 1.2.1 / 2019-12-13 / Agent 7.17.0
 
 * [Fixed] Fix scrapper config cache issue. See [#5202](https://github.com/DataDog/integrations-core/pull/5202).
 
-## 1.2.0 / 2019-12-02
+## 1.2.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Handle scheme in `prometheus_url` instead of the separate `scheme` option, which is now deprecated. See [#4913](https://github.com/DataDog/integrations-core/pull/4913).
 
-## 1.1.1 / 2019-10-16
+## 1.1.1 / 2019-10-16 / Agent 7.16.0
 
 * [Fixed] Use default port for kube apiserver metrics auto conf. See [#4785](https://github.com/DataDog/integrations-core/pull/4785).
 
-## 1.1.0 / 2019-10-11
+## 1.1.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Scrape apiserver_request_total metric introduced in v1.15. See [#4546](https://github.com/DataDog/integrations-core/pull/4546).
 
-## 1.0.1 / 2019-06-06
+## 1.0.1 / 2019-06-06 / Agent 6.13.0
 
 * [Fixed] Fix default for bearer_token and ssl_verify. See [#3882](https://github.com/DataDog/integrations-core/pull/3882).
 
-## 1.0.0 / 2019-05-31
+## 1.0.0 / 2019-05-31 / Agent 6.12.0
 
 * [Added] Introducing the Kubernetes APIServer metrics check. See [#3746](https://github.com/DataDog/integrations-core/pull/3746).

--- a/kube_apiserver_metrics/CHANGELOG.md
+++ b/kube_apiserver_metrics/CHANGELOG.md
@@ -6,11 +6,11 @@
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.4.1 / 2020-07-02 / Agent 7.22.0
+## 1.4.1 / 2020-07-02 / Agent 7.21.0
 
 * [Fixed] Fix default value in example configuration file. See [#7034](https://github.com/DataDog/integrations-core/pull/7034).
 
-## 1.4.0 / 2020-06-29 / Agent 7.21.0
+## 1.4.0 / 2020-06-29
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Added] kube apiserver signature and specs. See [#6831](https://github.com/DataDog/integrations-core/pull/6831).
@@ -29,26 +29,26 @@
 
 * [Fixed] Update Kube_apiserver_metrics annotations documentation. See [#5199](https://github.com/DataDog/integrations-core/pull/5199).
 
-## 1.2.1 / 2019-12-13 / Agent 7.17.0
+## 1.2.1 / 2019-12-13 / Agent 7.16.0
 
 * [Fixed] Fix scrapper config cache issue. See [#5202](https://github.com/DataDog/integrations-core/pull/5202).
 
-## 1.2.0 / 2019-12-02 / Agent 7.16.0
+## 1.2.0 / 2019-12-02
 
 * [Added] Handle scheme in `prometheus_url` instead of the separate `scheme` option, which is now deprecated. See [#4913](https://github.com/DataDog/integrations-core/pull/4913).
 
-## 1.1.1 / 2019-10-16 / Agent 7.16.0
+## 1.1.1 / 2019-10-16 / Agent 6.15.0
 
 * [Fixed] Use default port for kube apiserver metrics auto conf. See [#4785](https://github.com/DataDog/integrations-core/pull/4785).
 
-## 1.1.0 / 2019-10-11 / Agent 6.15.0
+## 1.1.0 / 2019-10-11
 
 * [Added] Scrape apiserver_request_total metric introduced in v1.15. See [#4546](https://github.com/DataDog/integrations-core/pull/4546).
 
-## 1.0.1 / 2019-06-06 / Agent 6.13.0
+## 1.0.1 / 2019-06-06 / Agent 6.12.0
 
 * [Fixed] Fix default for bearer_token and ssl_verify. See [#3882](https://github.com/DataDog/integrations-core/pull/3882).
 
-## 1.0.0 / 2019-05-31 / Agent 6.12.0
+## 1.0.0 / 2019-05-31
 
 * [Added] Introducing the Kubernetes APIServer metrics check. See [#3746](https://github.com/DataDog/integrations-core/pull/3746).

--- a/kube_controller_manager/CHANGELOG.md
+++ b/kube_controller_manager/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 * [Added] Add telemetry metrics counter by ksm collector. See [#4125](https://github.com/DataDog/integrations-core/pull/4125).
 
-## 1.3.0 / 2019-07-04 / Agent 6.13.0
+## 1.3.0 / 2019-07-04
 
 * [Added] Add support for new metrics introduced in kubernetes v1.14. See [#3905](https://github.com/DataDog/integrations-core/pull/3905).
 
@@ -30,7 +30,7 @@
 * [Fixed] Fix the list of default rate limiters. See [#3724](https://github.com/DataDog/integrations-core/pull/3724).
 * [Added] Adhere to code style. See [#3527](https://github.com/DataDog/integrations-core/pull/3527).
 
-## 1.1.0 / 2019-02-18 / Agent 6.11.0
+## 1.1.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Track leader election status. See [#3101](https://github.com/DataDog/integrations-core/pull/3101).
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).

--- a/kube_controller_manager/CHANGELOG.md
+++ b/kube_controller_manager/CHANGELOG.md
@@ -1,36 +1,36 @@
 # CHANGELOG - Kube_controller_manager
 
-## 1.7.0 / 2020-05-17
+## 1.7.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.6.1 / 2020-04-04
+## 1.6.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.6.0 / 2020-02-22
+## 1.6.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add auto_conf.yaml files. See [#5678](https://github.com/DataDog/integrations-core/pull/5678).
 
-## 1.5.0 / 2020-01-13
+## 1.5.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Make OpenMetrics use the RequestsWrapper. See [#5414](https://github.com/DataDog/integrations-core/pull/5414).
 * [Fixed] Fix logger method bug. See [#5395](https://github.com/DataDog/integrations-core/pull/5395).
 
-## 1.4.0 / 2019-07-19
+## 1.4.0 / 2019-07-19 / Agent 6.13.0
 
 * [Added] Add telemetry metrics counter by ksm collector. See [#4125](https://github.com/DataDog/integrations-core/pull/4125).
 
-## 1.3.0 / 2019-07-04
+## 1.3.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Add support for new metrics introduced in kubernetes v1.14. See [#3905](https://github.com/DataDog/integrations-core/pull/3905).
 
-## 1.2.0 / 2019-05-14
+## 1.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Fixed] Fix the list of default rate limiters. See [#3724](https://github.com/DataDog/integrations-core/pull/3724).
 * [Added] Adhere to code style. See [#3527](https://github.com/DataDog/integrations-core/pull/3527).
 
-## 1.1.0 / 2019-02-18
+## 1.1.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Track leader election status. See [#3101](https://github.com/DataDog/integrations-core/pull/3101).
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).

--- a/kube_dns/CHANGELOG.md
+++ b/kube_dns/CHANGELOG.md
@@ -20,23 +20,23 @@
 
 * [Added] Upgrade protobuf to 3.7.0. See [#3272](https://github.com/DataDog/integrations-core/pull/3272).
 
-## 2.1.0 / 2019-02-18 / Agent 6.11.0
+## 2.1.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Fix growing CPU and memory usage. See [#3066](https://github.com/DataDog/integrations-core/pull/3066).
 * [Added] Support Python 3. See [#2896](https://github.com/DataDog/integrations-core/pull/2896).
 
-## 2.0.1 / 2018-10-12 / Agent 5.28.0
+## 2.0.1 / 2018-10-12 / Agent 6.6.0
 
 * [Fixed] Submit metrics with instance tags. See [#2299][1].
 
-## 2.0.0 / 2018-09-04 / Agent 5.28.0
+## 2.0.0 / 2018-09-04 / Agent 6.5.0
 
 * [Changed] Update kube_dns to use the new OpenMetricsBaseCheck. See [#1980][2].
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][3].
 * [Added] Make HTTP request timeout configurable in prometheus checks. See [#1790][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 1.4.0 / 2018-06-13 / Agent 5.26.0
+## 1.4.0 / 2018-06-13 / Agent 6.4.0
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][6].
 

--- a/kube_dns/CHANGELOG.md
+++ b/kube_dns/CHANGELOG.md
@@ -1,42 +1,42 @@
 # CHANGELOG - Kube-dns
 
-## 2.4.1 / 2020-06-29
+## 2.4.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Use agent 6 signature. See [#6907](https://github.com/DataDog/integrations-core/pull/6907).
 
-## 2.4.0 / 2020-05-17
+## 2.4.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.3.1 / 2020-04-04
+## 2.3.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 2.3.0 / 2019-05-14
+## 2.3.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3528](https://github.com/DataDog/integrations-core/pull/3528).
 
-## 2.2.0 / 2019-03-29
+## 2.2.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Upgrade protobuf to 3.7.0. See [#3272](https://github.com/DataDog/integrations-core/pull/3272).
 
-## 2.1.0 / 2019-02-18
+## 2.1.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Fix growing CPU and memory usage. See [#3066](https://github.com/DataDog/integrations-core/pull/3066).
 * [Added] Support Python 3. See [#2896](https://github.com/DataDog/integrations-core/pull/2896).
 
-## 2.0.1 / 2018-10-12
+## 2.0.1 / 2018-10-12 / Agent 5.28.0
 
 * [Fixed] Submit metrics with instance tags. See [#2299][1].
 
-## 2.0.0 / 2018-09-04
+## 2.0.0 / 2018-09-04 / Agent 5.28.0
 
 * [Changed] Update kube_dns to use the new OpenMetricsBaseCheck. See [#1980][2].
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][3].
 * [Added] Make HTTP request timeout configurable in prometheus checks. See [#1790][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 1.4.0 / 2018-06-13
+## 1.4.0 / 2018-06-13 / Agent 5.26.0
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][6].
 

--- a/kube_metrics_server/CHANGELOG.md
+++ b/kube_metrics_server/CHANGELOG.md
@@ -1,21 +1,21 @@
 # CHANGELOG - Kube Metrics Server
 
-## 1.2.0 / 2020-05-17
+## 1.2.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.1.1 / 2020-02-22
+## 1.1.1 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Fix metric validation. See [#5581](https://github.com/DataDog/integrations-core/pull/5581).
 
-## 1.1.0 / 2020-01-13
+## 1.1.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Make OpenMetrics use the RequestsWrapper. See [#5414](https://github.com/DataDog/integrations-core/pull/5414).
 
-## 1.0.1 / 2019-08-24
+## 1.0.1 / 2019-08-24 / Agent 6.14.0
 
 * [Fixed] Fix prometheus_url conf. See [#4175](https://github.com/DataDog/integrations-core/pull/4175).
 
-## 1.0.0 / 2019-06-01
+## 1.0.0 / 2019-06-01 / Agent 6.12.0
 
 * [Added] Add Kube metrics server integration. See [#3666](https://github.com/DataDog/integrations-core/pull/3666).

--- a/kube_proxy/CHANGELOG.md
+++ b/kube_proxy/CHANGELOG.md
@@ -1,30 +1,30 @@
 # CHANGELOG - Kube_proxy
 
-## 3.4.0 / 2020-05-17
+## 3.4.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 3.3.1 / 2020-04-04
+## 3.3.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 3.3.0 / 2020-01-13
+## 3.3.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Make OpenMetrics use the RequestsWrapper. See [#5414](https://github.com/DataDog/integrations-core/pull/5414).
 
-## 3.2.0 / 2019-05-14
+## 3.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3529](https://github.com/DataDog/integrations-core/pull/3529).
 
-## 3.1.0 / 2019-02-18
+## 3.1.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#2919](https://github.com/DataDog/integrations-core/pull/2919).
 
-## 3.0.0 / 2018-10-12
+## 3.0.0 / 2018-10-12 / Agent 5.28.0
 
 * [Changed] Update kube_proxy to use the new OpenMetricsBaseCheck. See [#1981][1].
 
-## 2.0.0 / 2018-09-04
+## 2.0.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][2].
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][3].

--- a/kube_proxy/CHANGELOG.md
+++ b/kube_proxy/CHANGELOG.md
@@ -16,15 +16,15 @@
 
 * [Added] Adhere to code style. See [#3529](https://github.com/DataDog/integrations-core/pull/3529).
 
-## 3.1.0 / 2019-02-18 / Agent 6.11.0
+## 3.1.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#2919](https://github.com/DataDog/integrations-core/pull/2919).
 
-## 3.0.0 / 2018-10-12 / Agent 5.28.0
+## 3.0.0 / 2018-10-12 / Agent 6.6.0
 
 * [Changed] Update kube_proxy to use the new OpenMetricsBaseCheck. See [#1981][1].
 
-## 2.0.0 / 2018-09-04 / Agent 5.28.0
+## 2.0.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][2].
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][3].

--- a/kube_scheduler/CHANGELOG.md
+++ b/kube_scheduler/CHANGELOG.md
@@ -1,29 +1,29 @@
 # CHANGELOG - Kube_scheduler
 
-## 1.4.0 / 2020-05-17
+## 1.4.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.3.1 / 2020-04-04
+## 1.3.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.3.0 / 2020-02-22
+## 1.3.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add auto_conf.yaml files. See [#5678](https://github.com/DataDog/integrations-core/pull/5678).
 * [Fixed] Fix metric validation. See [#5581](https://github.com/DataDog/integrations-core/pull/5581).
 
-## 1.2.0 / 2020-01-13
+## 1.2.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Make OpenMetrics use the RequestsWrapper. See [#5414](https://github.com/DataDog/integrations-core/pull/5414).
 * [Fixed] Move unit conversion helpers to openmetrics mixin. See [#5364](https://github.com/DataDog/integrations-core/pull/5364).
 * [Fixed] Correct conversions from microseconds to seconds. See [#5354](https://github.com/DataDog/integrations-core/pull/5354).
 
-## 1.1.0 / 2019-05-14
+## 1.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3530](https://github.com/DataDog/integrations-core/pull/3530).
 
-## 1.0.0 / 2019-03-29
+## 1.0.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Added kube_scheduler check. See [#3371](https://github.com/DataDog/integrations-core/pull/3371).
 

--- a/kubelet/CHANGELOG.md
+++ b/kubelet/CHANGELOG.md
@@ -1,35 +1,35 @@
 # CHANGELOG - kubelet
 
-## 4.1.1 / 2020-06-29
+## 4.1.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Fix missing metrics for static pods. See [#6736](https://github.com/DataDog/integrations-core/pull/6736).
 
-## 4.1.0 / 2020-05-17
+## 4.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add parsing from `/stats/summary` for Windows. See [#6497](https://github.com/DataDog/integrations-core/pull/6497).
 * [Added] Expose number of cfs enforcement periods. See [#6093](https://github.com/DataDog/integrations-core/pull/6093). Thanks [adammw](https://github.com/adammw).
 
-## 4.0.0 / 2020-04-04
+## 4.0.0 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update prometheus_client. See [#6200](https://github.com/DataDog/integrations-core/pull/6200).
 * [Fixed] Fix support for kubernetes v1.18. See [#6203](https://github.com/DataDog/integrations-core/pull/6203).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Changed] Pass namespace to `is_excluded`. See [#6217](https://github.com/DataDog/integrations-core/pull/6217).
 
-## 3.6.0 / 2020-02-22
+## 3.6.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add pod tags to volume metrics. See [#5453](https://github.com/DataDog/integrations-core/pull/5453).
 
-## 3.5.2 / 2020-01-31
+## 3.5.2 / 2020-01-31 / Agent 7.18.0
 
 * [Fixed] Ignore insecure warnings for kubelet requests. See [#5607](https://github.com/DataDog/integrations-core/pull/5607).
 
-## 3.5.1 / 2020-01-15
+## 3.5.1 / 2020-01-15 / Agent 7.18.0
 
 * [Fixed] Fix Kubelet credentials handling. See [#5455](https://github.com/DataDog/integrations-core/pull/5455).
 
-## 3.5.0 / 2020-01-13
+## 3.5.0 / 2020-01-13 / Agent 7.17.0
 
 * [Fixed] Improve url join to not mutate the base url when proxying a call. See [#5416](https://github.com/DataDog/integrations-core/pull/5416).
 * [Added] Make OpenMetrics use the RequestsWrapper. See [#5414](https://github.com/DataDog/integrations-core/pull/5414).
@@ -39,80 +39,80 @@
 * [Added] Add kubelet and runtime cpu and mem metrics. See [#5370](https://github.com/DataDog/integrations-core/pull/5370).
 * [Added] Update metrics for >= 1.14. See [#5336](https://github.com/DataDog/integrations-core/pull/5336).
 
-## 3.4.0 / 2019-12-02
+## 3.4.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Collect a new metric: kubelet.evictions. See [#5076](https://github.com/DataDog/integrations-core/pull/5076).
 * [Added] Add a gauge for effective usage of ephemeral storage per POD. See [#5052](https://github.com/DataDog/integrations-core/pull/5052).
 
-## 3.3.4 / 2019-10-30
+## 3.3.4 / 2019-10-30 / Agent 7.16.0
 
 * [Fixed] Fix container collection for k8s 1.16. See [#4925](https://github.com/DataDog/integrations-core/pull/4925).
 
-## 3.3.3 / 2019-10-11
+## 3.3.3 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Send kubelet metrics with tags only. See [#4659](https://github.com/DataDog/integrations-core/pull/4659).
 
-## 3.3.2 / 2019-08-14
+## 3.3.2 / 2019-08-14 / Agent 6.14.0
 
 * [Fixed] Enforce unicode output in requests.iter_lines call. See [#4360](https://github.com/DataDog/integrations-core/pull/4360).
 
-## 3.3.1 / 2019-07-16
+## 3.3.1 / 2019-07-16 / Agent 6.13.0
 
 * [Fixed] Update tagger usage to match prefix update. See [#4109](https://github.com/DataDog/integrations-core/pull/4109).
 
-## 3.3.0 / 2019-07-04
+## 3.3.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Add swap memory checks to cadvisor kubelet checks. See [#3808](https://github.com/DataDog/integrations-core/pull/3808). Thanks [adammw](https://github.com/adammw).
 
-## 3.2.1 / 2019-06-28
+## 3.2.1 / 2019-06-28 / Agent 6.13.0
 
 * [Fixed] Make the kubelet and ECS fargate checks resilient to the tagger returning None. See [#4004](https://github.com/DataDog/integrations-core/pull/4004).
 
-## 3.2.0 / 2019-06-13
+## 3.2.0 / 2019-06-13 / Agent 6.13.0
 
 * [Fixed] Revert "Collect network usage metrics (#3740)". See [#3914](https://github.com/DataDog/integrations-core/pull/3914).
 
-## 3.1.0 / 2019-05-14
+## 3.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Collect network usage metrics. See [#3740](https://github.com/DataDog/integrations-core/pull/3740).
 * [Added] add useful prometheus labels to metric tags. See [#3735](https://github.com/DataDog/integrations-core/pull/3735).
 * [Added] Adhere to code style. See [#3525](https://github.com/DataDog/integrations-core/pull/3525).
 
-## 3.0.1 / 2019-04-04
+## 3.0.1 / 2019-04-04 / Agent 6.12.0
 
 * [Fixed] Fix podlist multiple iterations when using pod expiration. See [#3456](https://github.com/DataDog/integrations-core/pull/3456).
 * [Fixed] Fix health check during first check run. See [#3457](https://github.com/DataDog/integrations-core/pull/3457).
 
-## 3.0.0 / 2019-03-29
+## 3.0.0 / 2019-03-29 / Agent 6.11.0
 
 * [Changed] Do not tag container restarts/state metrics by container_id anymore. See [#3424](https://github.com/DataDog/integrations-core/pull/3424).
 * [Added] Allow to filter out old pods when parsing the podlist to reduce memory usage. See [#3189](https://github.com/DataDog/integrations-core/pull/3189).
 
-## 2.4.0 / 2019-02-18
+## 2.4.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Fix usage metrics collection for static pods. See [#3079](https://github.com/DataDog/integrations-core/pull/3079).
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Support Python 3. See [#3028](https://github.com/DataDog/integrations-core/pull/3028).
 * [Fixed] Fix pods/container.running metrics to exclude non running ones. See [#3025](https://github.com/DataDog/integrations-core/pull/3025).
 
-## 2.3.1 / 2019-01-04
+## 2.3.1 / 2019-01-04 / Agent 5.31.0
 
 * [Fixed] document kubernetes.pods.running and kubernetes.containers.running. See [#2792][1].
 * [Fixed] Fix default yaml instance. See [#2756][2].
 * [Fixed] Make the check robust to an unresponsive kubelet. See [#2719][3].
 
-## 2.3.0 / 2018-11-30
+## 2.3.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Add restart and container state metrics to kubelet. See [#2605][4]. Thanks [schleyfox][5].
 * [Added] Add more cpu metrics. See [#2595][6].
 * [Added] Add kubelet volume metrics. See [#2256][7]. Thanks [derekchan][8].
 * [Fixed] [kubelet] correctly ignore pods that are neither running or pending for resource limits&requests. See [#2597][9].
 
-## 2.2.0 / 2018-10-12
+## 2.2.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Add kubelet rss and working set memory metrics. See [#2390][10].
 
-## 2.1.0 / 2018-10-10
+## 2.1.0 / 2018-10-10 / Agent 5.28.0
 
 * [Fixed] Fix parsing errors when the podlist is in an inconsistent state. See [#2338][11].
 * [Fixed] Fix kubelet input filtering. See [#2344][12].
@@ -120,7 +120,7 @@
 * [Added] Add additional kubelet metrics. See [#2245][14].
 * [Added] Add the kubernetes.containers.running metric. See [#2191][15]. Thanks [Devatoria][16].
 
-## 2.0.0 / 2018-09-04
+## 2.0.0 / 2018-09-04 / Agent 5.28.0
 
 * [Changed] Update kubelet to use the new OpenMetricsBaseCheck. See [#1982][17].
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][18].
@@ -131,7 +131,7 @@
 * [Fixed] Reduce log spam on kubernetes tagging. See [#1830][23].
 * [Fixed] Add data files to the wheel package. See [#1727][24].
 
-## 1.4.0 / 2018-06-14
+## 1.4.0 / 2018-06-14 / Agent 5.26.0
 
 * [Changed] Kubelet check: better encapsulate the pod list retrieval. See [#1648][25].
 

--- a/kubelet/CHANGELOG.md
+++ b/kubelet/CHANGELOG.md
@@ -21,15 +21,15 @@
 
 * [Added] Add pod tags to volume metrics. See [#5453](https://github.com/DataDog/integrations-core/pull/5453).
 
-## 3.5.2 / 2020-01-31 / Agent 7.18.0
+## 3.5.2 / 2020-01-31 / Agent 7.17.1
 
 * [Fixed] Ignore insecure warnings for kubelet requests. See [#5607](https://github.com/DataDog/integrations-core/pull/5607).
 
-## 3.5.1 / 2020-01-15 / Agent 7.18.0
+## 3.5.1 / 2020-01-15 / Agent 7.17.0
 
 * [Fixed] Fix Kubelet credentials handling. See [#5455](https://github.com/DataDog/integrations-core/pull/5455).
 
-## 3.5.0 / 2020-01-13 / Agent 7.17.0
+## 3.5.0 / 2020-01-13
 
 * [Fixed] Improve url join to not mutate the base url when proxying a call. See [#5416](https://github.com/DataDog/integrations-core/pull/5416).
 * [Added] Make OpenMetrics use the RequestsWrapper. See [#5414](https://github.com/DataDog/integrations-core/pull/5414).
@@ -44,11 +44,11 @@
 * [Added] Collect a new metric: kubelet.evictions. See [#5076](https://github.com/DataDog/integrations-core/pull/5076).
 * [Added] Add a gauge for effective usage of ephemeral storage per POD. See [#5052](https://github.com/DataDog/integrations-core/pull/5052).
 
-## 3.3.4 / 2019-10-30 / Agent 7.16.0
+## 3.3.4 / 2019-10-30 / Agent 6.15.0
 
 * [Fixed] Fix container collection for k8s 1.16. See [#4925](https://github.com/DataDog/integrations-core/pull/4925).
 
-## 3.3.3 / 2019-10-11 / Agent 6.15.0
+## 3.3.3 / 2019-10-11
 
 * [Fixed] Send kubelet metrics with tags only. See [#4659](https://github.com/DataDog/integrations-core/pull/4659).
 
@@ -60,59 +60,59 @@
 
 * [Fixed] Update tagger usage to match prefix update. See [#4109](https://github.com/DataDog/integrations-core/pull/4109).
 
-## 3.3.0 / 2019-07-04 / Agent 6.13.0
+## 3.3.0 / 2019-07-04
 
 * [Added] Add swap memory checks to cadvisor kubelet checks. See [#3808](https://github.com/DataDog/integrations-core/pull/3808). Thanks [adammw](https://github.com/adammw).
 
-## 3.2.1 / 2019-06-28 / Agent 6.13.0
+## 3.2.1 / 2019-06-28 / Agent 6.12.1
 
 * [Fixed] Make the kubelet and ECS fargate checks resilient to the tagger returning None. See [#4004](https://github.com/DataDog/integrations-core/pull/4004).
 
-## 3.2.0 / 2019-06-13 / Agent 6.13.0
+## 3.2.0 / 2019-06-13 / Agent 6.12.0
 
 * [Fixed] Revert "Collect network usage metrics (#3740)". See [#3914](https://github.com/DataDog/integrations-core/pull/3914).
 
-## 3.1.0 / 2019-05-14 / Agent 6.12.0
+## 3.1.0 / 2019-05-14
 
 * [Added] Collect network usage metrics. See [#3740](https://github.com/DataDog/integrations-core/pull/3740).
 * [Added] add useful prometheus labels to metric tags. See [#3735](https://github.com/DataDog/integrations-core/pull/3735).
 * [Added] Adhere to code style. See [#3525](https://github.com/DataDog/integrations-core/pull/3525).
 
-## 3.0.1 / 2019-04-04 / Agent 6.12.0
+## 3.0.1 / 2019-04-04 / Agent 6.11.0
 
 * [Fixed] Fix podlist multiple iterations when using pod expiration. See [#3456](https://github.com/DataDog/integrations-core/pull/3456).
 * [Fixed] Fix health check during first check run. See [#3457](https://github.com/DataDog/integrations-core/pull/3457).
 
-## 3.0.0 / 2019-03-29 / Agent 6.11.0
+## 3.0.0 / 2019-03-29
 
 * [Changed] Do not tag container restarts/state metrics by container_id anymore. See [#3424](https://github.com/DataDog/integrations-core/pull/3424).
 * [Added] Allow to filter out old pods when parsing the podlist to reduce memory usage. See [#3189](https://github.com/DataDog/integrations-core/pull/3189).
 
-## 2.4.0 / 2019-02-18 / Agent 6.11.0
+## 2.4.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Fix usage metrics collection for static pods. See [#3079](https://github.com/DataDog/integrations-core/pull/3079).
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Support Python 3. See [#3028](https://github.com/DataDog/integrations-core/pull/3028).
 * [Fixed] Fix pods/container.running metrics to exclude non running ones. See [#3025](https://github.com/DataDog/integrations-core/pull/3025).
 
-## 2.3.1 / 2019-01-04 / Agent 5.31.0
+## 2.3.1 / 2019-01-04 / Agent 6.9.0
 
 * [Fixed] document kubernetes.pods.running and kubernetes.containers.running. See [#2792][1].
 * [Fixed] Fix default yaml instance. See [#2756][2].
 * [Fixed] Make the check robust to an unresponsive kubelet. See [#2719][3].
 
-## 2.3.0 / 2018-11-30 / Agent 5.30.0
+## 2.3.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Add restart and container state metrics to kubelet. See [#2605][4]. Thanks [schleyfox][5].
 * [Added] Add more cpu metrics. See [#2595][6].
 * [Added] Add kubelet volume metrics. See [#2256][7]. Thanks [derekchan][8].
 * [Fixed] [kubelet] correctly ignore pods that are neither running or pending for resource limits&requests. See [#2597][9].
 
-## 2.2.0 / 2018-10-12 / Agent 5.28.0
+## 2.2.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Add kubelet rss and working set memory metrics. See [#2390][10].
 
-## 2.1.0 / 2018-10-10 / Agent 5.28.0
+## 2.1.0 / 2018-10-10
 
 * [Fixed] Fix parsing errors when the podlist is in an inconsistent state. See [#2338][11].
 * [Fixed] Fix kubelet input filtering. See [#2344][12].
@@ -120,7 +120,7 @@
 * [Added] Add additional kubelet metrics. See [#2245][14].
 * [Added] Add the kubernetes.containers.running metric. See [#2191][15]. Thanks [Devatoria][16].
 
-## 2.0.0 / 2018-09-04 / Agent 5.28.0
+## 2.0.0 / 2018-09-04 / Agent 6.5.0
 
 * [Changed] Update kubelet to use the new OpenMetricsBaseCheck. See [#1982][17].
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][18].
@@ -131,7 +131,7 @@
 * [Fixed] Reduce log spam on kubernetes tagging. See [#1830][23].
 * [Fixed] Add data files to the wheel package. See [#1727][24].
 
-## 1.4.0 / 2018-06-14 / Agent 5.26.0
+## 1.4.0 / 2018-06-14 / Agent 6.3.1
 
 * [Changed] Kubelet check: better encapsulate the pod list retrieval. See [#1648][25].
 

--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -6,11 +6,11 @@
 * [Fixed] Fix debug log line for job metrics. See [#6700](https://github.com/DataDog/integrations-core/pull/6700).
 * [Fixed] Fix issue when the storage class of a persistent volume is empty and add test. See [#6615](https://github.com/DataDog/integrations-core/pull/6615).
 
-## 5.4.1 / 2020-05-21 / Agent 7.21.0
+## 5.4.1 / 2020-05-21 / Agent 7.20.0
 
 * [Fixed] Document join_standard_tags setting in conf.example.yaml. See [#6707](https://github.com/DataDog/integrations-core/pull/6707).
 
-## 5.4.0 / 2020-05-17 / Agent 7.20.0
+## 5.4.0 / 2020-05-17
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Introduce join_standard_tags setting. See [#6253](https://github.com/DataDog/integrations-core/pull/6253).
@@ -22,11 +22,11 @@
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Do not fail on octet stream content type for OpenMetrics. See [#5843](https://github.com/DataDog/integrations-core/pull/5843).
 
-## 5.2.1 / 2020-02-27 / Agent 7.19.0
+## 5.2.1 / 2020-02-27 / Agent 7.18.0
 
 * [Fixed] Fix type error. See [#5904](https://github.com/DataDog/integrations-core/pull/5904).
 
-## 5.2.0 / 2020-02-22 / Agent 7.18.0
+## 5.2.0 / 2020-02-22
 
 * [Added] Add an option to enable KSM experimental metrics and add some new metrics from KSM 1.9. See [#5447](https://github.com/DataDog/integrations-core/pull/5447).
 * [Fixed] Fix metric validation. See [#5581](https://github.com/DataDog/integrations-core/pull/5581).
@@ -41,11 +41,11 @@
 * [Changed] Improves tagging compliancy. See [#5105](https://github.com/DataDog/integrations-core/pull/5105).
 * [Fixed] Fix job metrics. See [#4943](https://github.com/DataDog/integrations-core/pull/4943).
 
-## 4.7.1 / 2019-08-26 / Agent 6.15.0
+## 4.7.1 / 2019-08-26 / Agent 6.14.0
 
 * [Fixed] Properly ignore `kube_pod_created` and `kube_pod_container_info`. See [#4435](https://github.com/DataDog/integrations-core/pull/4435).
 
-## 4.7.0 / 2019-08-24 / Agent 6.14.0
+## 4.7.0 / 2019-08-24
 
 * [Added] Grab kube_node_info as kubernetes_state.node.count. See [#4383](https://github.com/DataDog/integrations-core/pull/4383). Thanks [therc](https://github.com/therc).
 * [Added] Add VPA metrics to kubernetes_state integration. See [#4353](https://github.com/DataDog/integrations-core/pull/4353). Thanks [dturn](https://github.com/dturn).
@@ -55,16 +55,16 @@
 
 * [Fixed] Fix openmetrics mixins telemetry metrics. See [#4155](https://github.com/DataDog/integrations-core/pull/4155).
 
-## 4.6.0 / 2019-07-19 / Agent 6.13.0
+## 4.6.0 / 2019-07-19
 
 * [Fixed] Fix kubernetes_state avoid tags collision. See [#4149](https://github.com/DataDog/integrations-core/pull/4149).
 * [Added] Add telemetry metrics counter by ksm collector. See [#4125](https://github.com/DataDog/integrations-core/pull/4125).
 
-## 4.5.0 / 2019-07-13 / Agent 6.13.0
+## 4.5.0 / 2019-07-13
 
 * [Added] Telemetry check's metrics. See [#4025](https://github.com/DataDog/integrations-core/pull/4025).
 
-## 4.4.1 / 2019-06-19 / Agent 6.13.0
+## 4.4.1 / 2019-06-19
 
 * [Fixed] Correct service check for ksm - cronjob. See [#3937](https://github.com/DataDog/integrations-core/pull/3937).
 
@@ -76,7 +76,7 @@
 
 * [Added] Upgrade protobuf to 3.7.0. See [#3272](https://github.com/DataDog/integrations-core/pull/3272).
 
-## 4.2.0 / 2019-02-18 / Agent 6.11.0
+## 4.2.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Collect .hpa.condition gauges. See [#3107](https://github.com/DataDog/integrations-core/pull/3107).
 * [Added] Collect PodDisruptionBudget metrics. See [#3111](https://github.com/DataDog/integrations-core/pull/3111).
@@ -84,16 +84,16 @@
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Support Python 3. See [#3030](https://github.com/DataDog/integrations-core/pull/3030).
 
-## 4.1.0 / 2018-12-02 / Agent 5.30.0
+## 4.1.0 / 2018-12-02 / Agent 6.8.0
 
 * [Added] Add phase tag to pod metrics. See [#2624][1].
 
-## 4.0.0 / 2018-11-30 / Agent 5.30.0
+## 4.0.0 / 2018-11-30
 
 * [Removed] Remove KSM deprecated pod phase service checks. See [#2631][2].
 * [Fixed] Use raw string literals when \ is present. See [#2465][3].
 
-## 3.1.0 / 2018-10-12 / Agent 5.28.0
+## 3.1.0 / 2018-10-12 / Agent 6.6.0
 
 * [Fixed] Fix job metrics tagging on KSM 1.4+. See [#2384][4].
 * [Fixed] include node condition value in check message. See [#2362][5]. Thanks [dwradcliffe][6].
@@ -103,7 +103,7 @@
 * [Fixed] Fix KSM deprecation warning on A5. See [#2317][10].
 * [Fixed] Include ContainerCreating in pod waiting status reasons. See [#2063][11]. Thanks [deiwin][12].
 
-## 3.0.0 / 2018-09-04 / Agent 5.28.0
+## 3.0.0 / 2018-09-04 / Agent 6.5.0
 
 * [Changed] Update kubernetes_state to use the new OpenMetricsBaseCheck. See [#1983][13].
 * [Added] Add cluster-name suffix to node-names in kubernetes state. See [#2069][14].
@@ -118,12 +118,12 @@
 * [Changed] kubernetes_state: plumb more container waiting reasons. See [#1763][26]. Thanks [stevvooe][27].
 * [Added] Make HTTP request timeout configurable in prometheus checks. See [#1790][28].
 
-## 2.7.0 / 2018-06-26 / Agent 5.26.0
+## 2.7.0 / 2018-06-26 / Agent 6.3.1
 
 * [Added] Add an option to disable hostname override. See [#1800][29].
 * [Changed] Add data files to the wheel package. See [#1727][30].
 
-## 2.6.0 / 2018-06-13 / Agent 5.26.0
+## 2.6.0 / 2018-06-13
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][31].
 

--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -1,82 +1,82 @@
 # CHANGELOG - kubernetes_state
 
-## 5.5.0 / 2020-06-29
+## 5.5.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Refactor to use Agent 6+ signature. See [#6906](https://github.com/DataDog/integrations-core/pull/6906).
 * [Fixed] Fix debug log line for job metrics. See [#6700](https://github.com/DataDog/integrations-core/pull/6700).
 * [Fixed] Fix issue when the storage class of a persistent volume is empty and add test. See [#6615](https://github.com/DataDog/integrations-core/pull/6615).
 
-## 5.4.1 / 2020-05-21
+## 5.4.1 / 2020-05-21 / Agent 7.21.0
 
 * [Fixed] Document join_standard_tags setting in conf.example.yaml. See [#6707](https://github.com/DataDog/integrations-core/pull/6707).
 
-## 5.4.0 / 2020-05-17
+## 5.4.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Introduce join_standard_tags setting. See [#6253](https://github.com/DataDog/integrations-core/pull/6253).
 * [Fixed] Remove use of `label_to_match` to prevent deprecation warnings. See [#6503](https://github.com/DataDog/integrations-core/pull/6503).
 
-## 5.3.0 / 2020-04-04
+## 5.3.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Allow automatic joins to all kube_{object}_labels in KSM check. See [#5650](https://github.com/DataDog/integrations-core/pull/5650).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Do not fail on octet stream content type for OpenMetrics. See [#5843](https://github.com/DataDog/integrations-core/pull/5843).
 
-## 5.2.1 / 2020-02-27
+## 5.2.1 / 2020-02-27 / Agent 7.19.0
 
 * [Fixed] Fix type error. See [#5904](https://github.com/DataDog/integrations-core/pull/5904).
 
-## 5.2.0 / 2020-02-22
+## 5.2.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add an option to enable KSM experimental metrics and add some new metrics from KSM 1.9. See [#5447](https://github.com/DataDog/integrations-core/pull/5447).
 * [Fixed] Fix metric validation. See [#5581](https://github.com/DataDog/integrations-core/pull/5581).
 
-## 5.1.0 / 2020-01-13
+## 5.1.0 / 2020-01-13 / Agent 7.17.0
 
 * [Fixed] Fix logger method bug. See [#5395](https://github.com/DataDog/integrations-core/pull/5395).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 5.0.0 / 2019-12-02
+## 5.0.0 / 2019-12-02 / Agent 7.16.0
 
 * [Changed] Improves tagging compliancy. See [#5105](https://github.com/DataDog/integrations-core/pull/5105).
 * [Fixed] Fix job metrics. See [#4943](https://github.com/DataDog/integrations-core/pull/4943).
 
-## 4.7.1 / 2019-08-26
+## 4.7.1 / 2019-08-26 / Agent 6.15.0
 
 * [Fixed] Properly ignore `kube_pod_created` and `kube_pod_container_info`. See [#4435](https://github.com/DataDog/integrations-core/pull/4435).
 
-## 4.7.0 / 2019-08-24
+## 4.7.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Grab kube_node_info as kubernetes_state.node.count. See [#4383](https://github.com/DataDog/integrations-core/pull/4383). Thanks [therc](https://github.com/therc).
 * [Added] Add VPA metrics to kubernetes_state integration. See [#4353](https://github.com/DataDog/integrations-core/pull/4353). Thanks [dturn](https://github.com/dturn).
 * [Fixed] Fix job metrics. See [#4224](https://github.com/DataDog/integrations-core/pull/4224).
 
-## 4.6.1 / 2019-07-19
+## 4.6.1 / 2019-07-19 / Agent 6.13.0
 
 * [Fixed] Fix openmetrics mixins telemetry metrics. See [#4155](https://github.com/DataDog/integrations-core/pull/4155).
 
-## 4.6.0 / 2019-07-19
+## 4.6.0 / 2019-07-19 / Agent 6.13.0
 
 * [Fixed] Fix kubernetes_state avoid tags collision. See [#4149](https://github.com/DataDog/integrations-core/pull/4149).
 * [Added] Add telemetry metrics counter by ksm collector. See [#4125](https://github.com/DataDog/integrations-core/pull/4125).
 
-## 4.5.0 / 2019-07-13
+## 4.5.0 / 2019-07-13 / Agent 6.13.0
 
 * [Added] Telemetry check's metrics. See [#4025](https://github.com/DataDog/integrations-core/pull/4025).
 
-## 4.4.1 / 2019-06-19
+## 4.4.1 / 2019-06-19 / Agent 6.13.0
 
 * [Fixed] Correct service check for ksm - cronjob. See [#3937](https://github.com/DataDog/integrations-core/pull/3937).
 
-## 4.4.0 / 2019-05-14
+## 4.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3526](https://github.com/DataDog/integrations-core/pull/3526).
 
-## 4.3.0 / 2019-03-29
+## 4.3.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Upgrade protobuf to 3.7.0. See [#3272](https://github.com/DataDog/integrations-core/pull/3272).
 
-## 4.2.0 / 2019-02-18
+## 4.2.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Collect .hpa.condition gauges. See [#3107](https://github.com/DataDog/integrations-core/pull/3107).
 * [Added] Collect PodDisruptionBudget metrics. See [#3111](https://github.com/DataDog/integrations-core/pull/3111).
@@ -84,16 +84,16 @@
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Support Python 3. See [#3030](https://github.com/DataDog/integrations-core/pull/3030).
 
-## 4.1.0 / 2018-12-02
+## 4.1.0 / 2018-12-02 / Agent 5.30.0
 
 * [Added] Add phase tag to pod metrics. See [#2624][1].
 
-## 4.0.0 / 2018-11-30
+## 4.0.0 / 2018-11-30 / Agent 5.30.0
 
 * [Removed] Remove KSM deprecated pod phase service checks. See [#2631][2].
 * [Fixed] Use raw string literals when \ is present. See [#2465][3].
 
-## 3.1.0 / 2018-10-12
+## 3.1.0 / 2018-10-12 / Agent 5.28.0
 
 * [Fixed] Fix job metrics tagging on KSM 1.4+. See [#2384][4].
 * [Fixed] include node condition value in check message. See [#2362][5]. Thanks [dwradcliffe][6].
@@ -103,7 +103,7 @@
 * [Fixed] Fix KSM deprecation warning on A5. See [#2317][10].
 * [Fixed] Include ContainerCreating in pod waiting status reasons. See [#2063][11]. Thanks [deiwin][12].
 
-## 3.0.0 / 2018-09-04
+## 3.0.0 / 2018-09-04 / Agent 5.28.0
 
 * [Changed] Update kubernetes_state to use the new OpenMetricsBaseCheck. See [#1983][13].
 * [Added] Add cluster-name suffix to node-names in kubernetes state. See [#2069][14].
@@ -118,12 +118,12 @@
 * [Changed] kubernetes_state: plumb more container waiting reasons. See [#1763][26]. Thanks [stevvooe][27].
 * [Added] Make HTTP request timeout configurable in prometheus checks. See [#1790][28].
 
-## 2.7.0 / 2018-06-26
+## 2.7.0 / 2018-06-26 / Agent 5.26.0
 
 * [Added] Add an option to disable hostname override. See [#1800][29].
 * [Changed] Add data files to the wheel package. See [#1727][30].
 
-## 2.6.0 / 2018-06-13
+## 2.6.0 / 2018-06-13 / Agent 5.26.0
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][31].
 

--- a/kyototycoon/CHANGELOG.md
+++ b/kyototycoon/CHANGELOG.md
@@ -1,42 +1,42 @@
 # CHANGELOG - kyototycoon
 
-## 1.11.1 / 2020-08-10
+## 1.11.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.11.0 / 2020-06-29
+## 1.11.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.10.0 / 2020-05-17
+## 1.10.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.9.1 / 2020-04-04
+## 1.9.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.9.0 / 2019-12-02
+## 1.9.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.8.0 / 2019-10-11
+## 1.8.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.7.0 / 2019-08-24
+## 1.7.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add Requests Wrapper to Kyototycoon. See [#4199](https://github.com/DataDog/integrations-core/pull/4199).
 
-## 1.6.0 / 2019-05-14
+## 1.6.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3531](https://github.com/DataDog/integrations-core/pull/3531).
 
-## 1.5.0 / 2019-02-18
+## 1.5.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#3013](https://github.com/DataDog/integrations-core/pull/3013).
 
-## 1.4.1 / 2018-09-04
+## 1.4.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][1].
 

--- a/kyototycoon/CHANGELOG.md
+++ b/kyototycoon/CHANGELOG.md
@@ -32,11 +32,11 @@
 
 * [Added] Adhere to code style. See [#3531](https://github.com/DataDog/integrations-core/pull/3531).
 
-## 1.5.0 / 2019-02-18 / Agent 6.11.0
+## 1.5.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#3013](https://github.com/DataDog/integrations-core/pull/3013).
 
-## 1.4.1 / 2018-09-04 / Agent 5.28.0
+## 1.4.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][1].
 

--- a/lighttpd/CHANGELOG.md
+++ b/lighttpd/CHANGELOG.md
@@ -41,11 +41,11 @@
 
 * [Added] Adhere to code style. See [#3532](https://github.com/DataDog/integrations-core/pull/3532).
 
-## 1.3.0 / 2019-01-04 / Agent 5.31.0
+## 1.3.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2834][1].
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/lighttpd/CHANGELOG.md
+++ b/lighttpd/CHANGELOG.md
@@ -1,51 +1,51 @@
 # CHANGELOG - lighttpd
 
-## 1.11.0 / 2020-08-10
+## 1.11.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add config specs. See [#7057](https://github.com/DataDog/integrations-core/pull/7057).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.10.0 / 2020-06-29
+## 1.10.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.9.0 / 2020-05-17
+## 1.9.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.8.1 / 2020-04-04
+## 1.8.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.8.0 / 2020-02-22
+## 1.8.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add version metadata. See [#5600](https://github.com/DataDog/integrations-core/pull/5600).
 
-## 1.7.0 / 2019-12-02
+## 1.7.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.6.0 / 2019-10-11
+## 1.6.0 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Fix lighttpd logging format. See [#4716](https://github.com/DataDog/integrations-core/pull/4716).
 * [Fixed] Fix support for no authentication. See [#4689](https://github.com/DataDog/integrations-core/pull/4689).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.5.0 / 2019-08-24
+## 1.5.0 / 2019-08-24 / Agent 6.14.0
 
 * [Fixed] Update __init__ method params. See [#4243](https://github.com/DataDog/integrations-core/pull/4243).
 * [Added] Add requests wrapper to lighttpd. See [#4220](https://github.com/DataDog/integrations-core/pull/4220).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3532](https://github.com/DataDog/integrations-core/pull/3532).
 
-## 1.3.0 / 2019-01-04
+## 1.3.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2834][1].
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/linkerd/CHANGELOG.md
+++ b/linkerd/CHANGELOG.md
@@ -1,35 +1,35 @@
 # CHANGELOG - Linkerd
 
-## 2.5.0 / 2020-05-17
+## 2.5.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.4.1 / 2020-04-04
+## 2.4.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 2.4.0 / 2020-01-13
+## 2.4.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Make OpenMetrics use the RequestsWrapper. See [#5414](https://github.com/DataDog/integrations-core/pull/5414).
 * [Fixed] Raise exception to report when openmetrics process fails. See [#5392](https://github.com/DataDog/integrations-core/pull/5392).
 
-## 2.3.0 / 2019-06-24
+## 2.3.0 / 2019-06-24 / Agent 6.13.0
 
 * [Added] Support v2. See [#3911](https://github.com/DataDog/integrations-core/pull/3911).
 
-## 2.2.0 / 2019-05-14
+## 2.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3533](https://github.com/DataDog/integrations-core/pull/3533).
 
-## 2.1.0 / 2019-02-18
+## 2.1.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#3032](https://github.com/DataDog/integrations-core/pull/3032).
 
-## 2.0.0 / 2018-10-12
+## 2.0.0 / 2018-10-12 / Agent 5.28.0
 
 * [Changed] Update linkerd to use the new OpenMetricsBaseCheck. See [#1984][1].
 
-## 1.2.0 / 2018-09-04
+## 1.2.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][2].
 * [Added] Make HTTP request timeout configurable in prometheus checks. See [#1790][3].

--- a/linkerd/CHANGELOG.md
+++ b/linkerd/CHANGELOG.md
@@ -21,15 +21,15 @@
 
 * [Added] Adhere to code style. See [#3533](https://github.com/DataDog/integrations-core/pull/3533).
 
-## 2.1.0 / 2019-02-18 / Agent 6.11.0
+## 2.1.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#3032](https://github.com/DataDog/integrations-core/pull/3032).
 
-## 2.0.0 / 2018-10-12 / Agent 5.28.0
+## 2.0.0 / 2018-10-12 / Agent 6.6.0
 
 * [Changed] Update linkerd to use the new OpenMetricsBaseCheck. See [#1984][1].
 
-## 1.2.0 / 2018-09-04 / Agent 5.28.0
+## 1.2.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][2].
 * [Added] Make HTTP request timeout configurable in prometheus checks. See [#1790][3].

--- a/linux_proc_extras/CHANGELOG.md
+++ b/linux_proc_extras/CHANGELOG.md
@@ -16,11 +16,11 @@
 
 * [Added] Adhere to code style. See [#3534](https://github.com/DataDog/integrations-core/pull/3534).
 
-## 1.1.0 / 2019-01-04 / Agent 5.31.0
+## 1.1.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2852][1].
 
-## 1.0.1 / 2018-09-04 / Agent 5.28.0
+## 1.0.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/linux_proc_extras/CHANGELOG.md
+++ b/linux_proc_extras/CHANGELOG.md
@@ -1,26 +1,26 @@
 # CHANGELOG - linux_proc_extras
 
-## 1.4.0 / 2020-08-10
+## 1.4.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Adding interrupts stats. See [#7166](https://github.com/DataDog/integrations-core/pull/7166).
 
-## 1.3.0 / 2020-05-17
+## 1.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.2.1 / 2020-04-04
+## 1.2.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.2.0 / 2019-05-14
+## 1.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3534](https://github.com/DataDog/integrations-core/pull/3534).
 
-## 1.1.0 / 2019-01-04
+## 1.1.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2852][1].
 
-## 1.0.1 / 2018-09-04
+## 1.0.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/mapr/CHANGELOG.md
+++ b/mapr/CHANGELOG.md
@@ -1,23 +1,23 @@
 # CHANGELOG - mapr
 
-## 1.3.0 / 2020-05-17
+## 1.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.2.0 / 2020-02-10
+## 1.2.0 / 2020-02-10 / Agent 7.18.0
 
 * [Fixed] Fix service check "topic" tag. See [#5679](https://github.com/DataDog/integrations-core/pull/5679).
 * [Added] Improve logging and documentation. See [#5644](https://github.com/DataDog/integrations-core/pull/5644).
 
-## 1.1.0 / 2020-01-13
+## 1.1.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.0.1 / 2019-12-02
+## 1.0.1 / 2019-12-02 / Agent 7.16.0
 
 * [Fixed] Fix use of format in logging. See [#4973](https://github.com/DataDog/integrations-core/pull/4973).
 
-## 1.0.0 / 2019-10-11
+## 1.0.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] New MapR integration. See [#4380](https://github.com/DataDog/integrations-core/pull/4380).
 

--- a/mapreduce/CHANGELOG.md
+++ b/mapreduce/CHANGELOG.md
@@ -37,21 +37,21 @@
 
 * [Added] Adhere to code style. See [#3535](https://github.com/DataDog/integrations-core/pull/3535).
 
-## 1.3.0 / 2019-02-18 / Agent 6.11.0
+## 1.3.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#2870](https://github.com/DataDog/integrations-core/pull/2870).
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Fix bug and typo in DEFAULT_CLUSTER_NAME for YARN check. See [#1814][1]. Thanks [eplanet][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 
-## 1.2.0 / 2018-06-06 / Agent 5.25.0
+## 1.2.0 / 2018-06-06
 
 * [Added] Add support for HTTP authentication. See [#1678][4].
 * [Added] Adds skip ssl validation. See [#1470][5].
 
-## 1.1.0 / 2018-03-23 / Agent 5.24.0
+## 1.1.0 / 2018-03-23
 
 * [FEATURE] Adds custom tag support to service check.
 

--- a/mapreduce/CHANGELOG.md
+++ b/mapreduce/CHANGELOG.md
@@ -1,57 +1,57 @@
 # CHANGELOG - mapreduce
 
-## 1.11.1 / 2020-08-10
+## 1.11.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.11.0 / 2020-06-29
+## 1.11.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.10.0 / 2020-05-17
+## 1.10.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.9.0 / 2020-04-04
+## 1.9.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Version metadata. See [#5448](https://github.com/DataDog/integrations-core/pull/5448).
 
-## 1.8.0 / 2020-01-13
+## 1.8.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.7.0 / 2019-12-02
+## 1.7.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.6.0 / 2019-10-11
+## 1.6.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.5.0 / 2019-07-12
+## 1.5.0 / 2019-07-12 / Agent 6.13.0
 
 * [Added] Use the new RequestsWrapper for connecting to services. See [#4094](https://github.com/DataDog/integrations-core/pull/4094).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3535](https://github.com/DataDog/integrations-core/pull/3535).
 
-## 1.3.0 / 2019-02-18
+## 1.3.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#2870](https://github.com/DataDog/integrations-core/pull/2870).
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Fix bug and typo in DEFAULT_CLUSTER_NAME for YARN check. See [#1814][1]. Thanks [eplanet][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 
-## 1.2.0 / 2018-06-06
+## 1.2.0 / 2018-06-06 / Agent 5.25.0
 
 * [Added] Add support for HTTP authentication. See [#1678][4].
 * [Added] Adds skip ssl validation. See [#1470][5].
 
-## 1.1.0 / 2018-03-23
+## 1.1.0 / 2018-03-23 / Agent 5.24.0
 
 * [FEATURE] Adds custom tag support to service check.
 

--- a/marathon/CHANGELOG.md
+++ b/marathon/CHANGELOG.md
@@ -43,16 +43,16 @@
 
 * [Added] Adhere to code style. See [#3536](https://github.com/DataDog/integrations-core/pull/3536).
 
-## 1.6.0 / 2019-02-18 / Agent 6.11.0
+## 1.6.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#2871](https://github.com/DataDog/integrations-core/pull/2871).
 
-## 1.5.0 / 2018-10-12 / Agent 5.28.0
+## 1.5.0 / 2018-10-12 / Agent 6.6.0
 
 * [Fixed] Removed default arguments from process_apps. See [#2337][1].
 * [Added] Add ability to tag metrics based on marathon labels. See [#2165][2]. Thanks [ashirley][3].
 
-## 1.4.1 / 2018-09-04 / Agent 5.28.0
+## 1.4.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 
@@ -61,7 +61,7 @@
 * [Fixed] Ensure marathon queue count reports 0 for apps not in queue. See [#1548][5].
 * [Changed] [marathon] add task counts metrics for groups. See [#1513][6].
 
-## 1.3.0 / 2018-05-11 / Agent 5.24.0
+## 1.3.0 / 2018-05-11
 
 * [FEATURE] Adds custom tag support for service checks.
 

--- a/marathon/CHANGELOG.md
+++ b/marathon/CHANGELOG.md
@@ -1,58 +1,58 @@
 # CHANGELOG - marathon
 
-## 1.15.0 / 2020-08-10
+## 1.15.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add config specs. See [#7254](https://github.com/DataDog/integrations-core/pull/7254).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.14.0 / 2020-06-29
+## 1.14.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.13.0 / 2020-05-17
+## 1.13.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.12.1 / 2020-04-04
+## 1.12.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.12.0 / 2020-01-13
+## 1.12.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.11.0 / 2019-12-02
+## 1.11.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add auth type to RequestsWrapper. See [#4708](https://github.com/DataDog/integrations-core/pull/4708).
 
-## 1.10.0 / 2019-10-11
+## 1.10.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.9.0 / 2019-08-24
+## 1.9.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add request wrapper to marathon. See [#4324](https://github.com/DataDog/integrations-core/pull/4324).
 
-## 1.8.0 / 2019-07-13
+## 1.8.0 / 2019-07-13 / Agent 6.13.0
 
 * [Added] Add log section. See [#4014](https://github.com/DataDog/integrations-core/pull/4014).
 
-## 1.7.0 / 2019-05-14
+## 1.7.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3536](https://github.com/DataDog/integrations-core/pull/3536).
 
-## 1.6.0 / 2019-02-18
+## 1.6.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#2871](https://github.com/DataDog/integrations-core/pull/2871).
 
-## 1.5.0 / 2018-10-12
+## 1.5.0 / 2018-10-12 / Agent 5.28.0
 
 * [Fixed] Removed default arguments from process_apps. See [#2337][1].
 * [Added] Add ability to tag metrics based on marathon labels. See [#2165][2]. Thanks [ashirley][3].
 
-## 1.4.1 / 2018-09-04
+## 1.4.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 
@@ -61,7 +61,7 @@
 * [Fixed] Ensure marathon queue count reports 0 for apps not in queue. See [#1548][5].
 * [Changed] [marathon] add task counts metrics for groups. See [#1513][6].
 
-## 1.3.0 / 2018-05-11
+## 1.3.0 / 2018-05-11 / Agent 5.24.0
 
 * [FEATURE] Adds custom tag support for service checks.
 

--- a/mcache/CHANGELOG.md
+++ b/mcache/CHANGELOG.md
@@ -1,51 +1,51 @@
 # CHANGELOG - mcache
 
-## 1.10.0 / 2020-05-17
+## 1.10.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.9.1 / 2020-04-04
+## 1.9.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.9.0 / 2020-01-13
+## 1.9.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.8.0 / 2019-12-02
+## 1.8.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add version metadata. See [#4935](https://github.com/DataDog/integrations-core/pull/4935).
 
-## 1.7.0 / 2019-10-29
+## 1.7.0 / 2019-10-29 / Agent 7.16.0
 
 * [Added] Add log section in the example configuration file. See [#4885](https://github.com/DataDog/integrations-core/pull/4885).
 
-## 1.6.0 / 2019-05-14
+## 1.6.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3537](https://github.com/DataDog/integrations-core/pull/3537).
 
-## 1.5.0 / 2019-02-18
+## 1.5.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Finish Python 3 support. See [#2915](https://github.com/DataDog/integrations-core/pull/2915).
 
-## 1.4.0 / 2019-01-04
+## 1.4.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2783][1].
 
-## 1.3.2 / 2018-09-04
+## 1.3.2 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.3.1 / 2018-06-20
+## 1.3.1 / 2018-06-20 / Agent 5.26.0
 
 * [Fixed] Fix connection to unix socket for new binary. See [#1755][3].
 
-## 1.3.0 / 2018-06-07
+## 1.3.0 / 2018-06-07 / Agent 5.25.0
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][4].
 * [FEATURE] Add support for SASL authentication.
 
-## 1.2.0 / 2018-05-11
+## 1.2.0 / 2018-05-11 / Agent 5.24.0
 
 * [FEATURE] Add custom tag support for service check.
 * [FEATURE] Hardcode the 11211 port in the Autodiscovery template. See [#1444][5] for more information.

--- a/mcache/CHANGELOG.md
+++ b/mcache/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 * [Added] Add version metadata. See [#4935](https://github.com/DataDog/integrations-core/pull/4935).
 
-## 1.7.0 / 2019-10-29 / Agent 7.16.0
+## 1.7.0 / 2019-10-29
 
 * [Added] Add log section in the example configuration file. See [#4885](https://github.com/DataDog/integrations-core/pull/4885).
 
@@ -24,28 +24,28 @@
 
 * [Added] Adhere to code style. See [#3537](https://github.com/DataDog/integrations-core/pull/3537).
 
-## 1.5.0 / 2019-02-18 / Agent 6.11.0
+## 1.5.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Finish Python 3 support. See [#2915](https://github.com/DataDog/integrations-core/pull/2915).
 
-## 1.4.0 / 2019-01-04 / Agent 5.31.0
+## 1.4.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2783][1].
 
-## 1.3.2 / 2018-09-04 / Agent 5.28.0
+## 1.3.2 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.3.1 / 2018-06-20 / Agent 5.26.0
+## 1.3.1 / 2018-06-20 / Agent 6.4.0
 
 * [Fixed] Fix connection to unix socket for new binary. See [#1755][3].
 
-## 1.3.0 / 2018-06-07 / Agent 5.25.0
+## 1.3.0 / 2018-06-07
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][4].
 * [FEATURE] Add support for SASL authentication.
 
-## 1.2.0 / 2018-05-11 / Agent 5.24.0
+## 1.2.0 / 2018-05-11
 
 * [FEATURE] Add custom tag support for service check.
 * [FEATURE] Hardcode the 11211 port in the Autodiscovery template. See [#1444][5] for more information.

--- a/mesos_master/CHANGELOG.md
+++ b/mesos_master/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.2 / 2020-04-24 / Agent 7.20.0
+## 1.7.2 / 2020-04-24
 
 * [Fixed] Handle missing role metrics for mesos_master. See [#6422](https://github.com/DataDog/integrations-core/pull/6422).
 
@@ -30,11 +30,11 @@
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.5.1 / 2019-08-28 / Agent 6.15.0
+## 1.5.1 / 2019-08-28 / Agent 6.14.0
 
 * [Fixed] Fix mesos_master service check. See [#4452](https://github.com/DataDog/integrations-core/pull/4452).
 
-## 1.5.0 / 2019-08-24 / Agent 6.14.0
+## 1.5.0 / 2019-08-24
 
 * [Added] Add requests wrapper to mesos_master. See [#4221](https://github.com/DataDog/integrations-core/pull/4221).
 * [Added] Add support for /state and /roles endpoints. See [#4053](https://github.com/DataDog/integrations-core/pull/4053).
@@ -43,11 +43,11 @@
 
 * [Added] Adhere to code style. See [#3538](https://github.com/DataDog/integrations-core/pull/3538).
 
-## 1.3.0 / 2019-02-18 / Agent 6.11.0
+## 1.3.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#2873](https://github.com/DataDog/integrations-core/pull/2873).
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][1].
 

--- a/mesos_master/CHANGELOG.md
+++ b/mesos_master/CHANGELOG.md
@@ -1,53 +1,53 @@
 # CHANGELOG - mesos_master
 
-## 1.9.1 / 2020-08-10
+## 1.9.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.9.0 / 2020-06-29
+## 1.9.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.8.0 / 2020-05-17
+## 1.8.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.2 / 2020-04-24
+## 1.7.2 / 2020-04-24 / Agent 7.20.0
 
 * [Fixed] Handle missing role metrics for mesos_master. See [#6422](https://github.com/DataDog/integrations-core/pull/6422).
 
-## 1.7.1 / 2020-04-04
+## 1.7.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.7.0 / 2020-01-13
+## 1.7.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Submit version metadata. See [#5216](https://github.com/DataDog/integrations-core/pull/5216).
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.6.0 / 2019-10-11
+## 1.6.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.5.1 / 2019-08-28
+## 1.5.1 / 2019-08-28 / Agent 6.15.0
 
 * [Fixed] Fix mesos_master service check. See [#4452](https://github.com/DataDog/integrations-core/pull/4452).
 
-## 1.5.0 / 2019-08-24
+## 1.5.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add requests wrapper to mesos_master. See [#4221](https://github.com/DataDog/integrations-core/pull/4221).
 * [Added] Add support for /state and /roles endpoints. See [#4053](https://github.com/DataDog/integrations-core/pull/4053).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3538](https://github.com/DataDog/integrations-core/pull/3538).
 
-## 1.3.0 / 2019-02-18
+## 1.3.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#2873](https://github.com/DataDog/integrations-core/pull/2873).
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][1].
 

--- a/mesos_slave/CHANGELOG.md
+++ b/mesos_slave/CHANGELOG.md
@@ -1,61 +1,61 @@
 # CHANGELOG - mesos_slave
 
-## 2.4.0 / 2020-08-10
+## 2.4.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add config specs. See [#7292](https://github.com/DataDog/integrations-core/pull/7292).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 2.3.0 / 2020-06-29
+## 2.3.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 2.2.0 / 2020-05-17
+## 2.2.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.1.1 / 2020-04-04
+## 2.1.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 2.1.0 / 2020-01-13
+## 2.1.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 2.0.1 / 2019-12-04
+## 2.0.1 / 2019-12-04 / Agent 7.17.0
 
 * [Fixed] Propagate tags properly to stats metrics. See [#5140](https://github.com/DataDog/integrations-core/pull/5140).
 
-## 2.0.0 / 2019-12-02
+## 2.0.0 / 2019-12-02 / Agent 7.16.0
 
 * [Changed] Refactor code and properly send a service check for each endpoint. See [#4891](https://github.com/DataDog/integrations-core/pull/4891).
 * [Fixed] Fix service check message. See [#4771](https://github.com/DataDog/integrations-core/pull/4771).
 
-## 1.6.0 / 2019-10-11
+## 1.6.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.5.1 / 2019-08-28
+## 1.5.1 / 2019-08-28 / Agent 6.15.0
 
 * [Fixed] Fix mesos_slave service check. See [#4448](https://github.com/DataDog/integrations-core/pull/4448).
 
-## 1.5.0 / 2019-08-24
+## 1.5.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add requests wrapper to mesos_slave. See [#4222](https://github.com/DataDog/integrations-core/pull/4222).
 * [Added] Add support for /state endpoint. See [#4054](https://github.com/DataDog/integrations-core/pull/4054).
 
-## 1.4.1 / 2019-06-01
+## 1.4.1 / 2019-06-01 / Agent 6.12.0
 
 * [Fixed] Fix code style. See [#3838](https://github.com/DataDog/integrations-core/pull/3838).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3539](https://github.com/DataDog/integrations-core/pull/3539).
 
-## 1.3.0 / 2019-02-18
+## 1.3.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#2874](https://github.com/DataDog/integrations-core/pull/2874).
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][1].
 

--- a/mesos_slave/CHANGELOG.md
+++ b/mesos_slave/CHANGELOG.md
@@ -21,11 +21,11 @@
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 2.0.1 / 2019-12-04 / Agent 7.17.0
+## 2.0.1 / 2019-12-04 / Agent 7.16.0
 
 * [Fixed] Propagate tags properly to stats metrics. See [#5140](https://github.com/DataDog/integrations-core/pull/5140).
 
-## 2.0.0 / 2019-12-02 / Agent 7.16.0
+## 2.0.0 / 2019-12-02
 
 * [Changed] Refactor code and properly send a service check for each endpoint. See [#4891](https://github.com/DataDog/integrations-core/pull/4891).
 * [Fixed] Fix service check message. See [#4771](https://github.com/DataDog/integrations-core/pull/4771).
@@ -34,11 +34,11 @@
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.5.1 / 2019-08-28 / Agent 6.15.0
+## 1.5.1 / 2019-08-28 / Agent 6.14.0
 
 * [Fixed] Fix mesos_slave service check. See [#4448](https://github.com/DataDog/integrations-core/pull/4448).
 
-## 1.5.0 / 2019-08-24 / Agent 6.14.0
+## 1.5.0 / 2019-08-24
 
 * [Added] Add requests wrapper to mesos_slave. See [#4222](https://github.com/DataDog/integrations-core/pull/4222).
 * [Added] Add support for /state endpoint. See [#4054](https://github.com/DataDog/integrations-core/pull/4054).
@@ -47,15 +47,15 @@
 
 * [Fixed] Fix code style. See [#3838](https://github.com/DataDog/integrations-core/pull/3838).
 
-## 1.4.0 / 2019-05-14 / Agent 6.12.0
+## 1.4.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3539](https://github.com/DataDog/integrations-core/pull/3539).
 
-## 1.3.0 / 2019-02-18 / Agent 6.11.0
+## 1.3.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#2874](https://github.com/DataDog/integrations-core/pull/2874).
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][1].
 

--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -4,84 +4,84 @@
 
 * [Fixed] Avoid depleting collection_metric_names. See [#7393](https://github.com/DataDog/integrations-core/pull/7393).
 
-## 1.16.3 / 2020-08-10
+## 1.16.3 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 1.16.2 / 2020-06-29
+## 1.16.2 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 * [Fixed] Raise an error if only one of `username` or `password` is set. See [#6688](https://github.com/DataDog/integrations-core/pull/6688).
 
-## 1.16.1 / 2020-05-19
+## 1.16.1 / 2020-05-19 / Agent 7.21.0
 
 * [Fixed] Fix encoding and parsing issues when processing connection configuration. See [#6686](https://github.com/DataDog/integrations-core/pull/6686).
 
-## 1.16.0 / 2020-05-17
+## 1.16.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.15.0 / 2020-05-05
+## 1.15.0 / 2020-05-05 / Agent 7.20.0
 
 * [Deprecated] Refactor connection configuration. See [#6574](https://github.com/DataDog/integrations-core/pull/6574).
 
-## 1.14.0 / 2020-04-04
+## 1.14.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add config specs. See [#6145](https://github.com/DataDog/integrations-core/pull/6145).
 * [Fixed] Use new agent signature. See [#6085](https://github.com/DataDog/integrations-core/pull/6085).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 * [Fixed] Replace deprecated method `database_names` by `list_database_names`. See [#5864](https://github.com/DataDog/integrations-core/pull/5864).
 
-## 1.13.0 / 2020-01-13
+## 1.13.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.12.0 / 2019-10-11
+## 1.12.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Submit version metadata. See [#4722](https://github.com/DataDog/integrations-core/pull/4722).
 
-## 1.11.0 / 2019-07-13
+## 1.11.0 / 2019-07-13 / Agent 6.13.0
 
 * [Added] Upgrade pymongo to 3.8. See [#4095](https://github.com/DataDog/integrations-core/pull/4095).
 
-## 1.10.3 / 2019-06-18
+## 1.10.3 / 2019-06-18 / Agent 6.13.0
 
 * [Fixed] Reduce doc in configuration file in favor of official documentation. See [#3892](https://github.com/DataDog/integrations-core/pull/3892).
 
-## 1.10.2 / 2019-06-06
+## 1.10.2 / 2019-06-06 / Agent 6.13.0
 
 * [Fixed] Custom queries: add examples and fix logging. See [#3871](https://github.com/DataDog/integrations-core/pull/3871).
 
-## 1.10.1 / 2019-06-05
+## 1.10.1 / 2019-06-05 / Agent 6.13.0
 
 * [Fixed] Add missing metrics. See [#3856](https://github.com/DataDog/integrations-core/pull/3856).
 * [Fixed] Fix 'custom_queries' field name. See [#3868](https://github.com/DataDog/integrations-core/pull/3868).
 
-## 1.10.0 / 2019-06-01
+## 1.10.0 / 2019-06-01 / Agent 6.12.0
 
 * [Added] Add custom query capabilities. See [#3796](https://github.com/DataDog/integrations-core/pull/3796).
 
-## 1.9.0 / 2019-05-14
+## 1.9.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Add tcmalloc.spinlock_total_delay_ns to mongodb stats. See [#3643](https://github.com/DataDog/integrations-core/pull/3643). Thanks [glenjamin](https://github.com/glenjamin).
 * [Added] Adhere to code style. See [#3540](https://github.com/DataDog/integrations-core/pull/3540).
 
-## 1.8.0 / 2019-02-18
+## 1.8.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Finish Support Python 3. See [#2916](https://github.com/DataDog/integrations-core/pull/2916).
 * [Fixed] Only run `top` against the admin database. See [#2937](https://github.com/DataDog/integrations-core/pull/2937).
 * [Added] Support unicode for Python 3 bindings. See [#2869](https://github.com/DataDog/integrations-core/pull/2869).
 
-## 1.7.0 / 2018-11-30
+## 1.7.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Support Python 3. See [#2623][1].
 * [Fixed] Use raw string literals when \ is present. See [#2465][2].
 
-## 1.6.1 / 2018-09-04
+## 1.6.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 
-## 1.6.0 / 2018-06-13
+## 1.6.0 / 2018-06-13 / Agent 5.26.0
 
 * [Added] [mongo] allow disabling of replica access. See [#1516][4].
 * [Changed] [mongo] properly parse metric. See [#1498][5].
@@ -90,7 +90,7 @@
 
 * [IMPROVEMENT] Allow disabling of replica access. See #1516
 
-## 1.5.3 / 2018-05-11
+## 1.5.3 / 2018-05-11 / Agent 5.25.0
 
 * [BUGFIX] Added `top` metrics ending in `countps` that properly submit as `rate`s. See #1491
 

--- a/mongo/CHANGELOG.md
+++ b/mongo/CHANGELOG.md
@@ -13,15 +13,15 @@
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 * [Fixed] Raise an error if only one of `username` or `password` is set. See [#6688](https://github.com/DataDog/integrations-core/pull/6688).
 
-## 1.16.1 / 2020-05-19 / Agent 7.21.0
+## 1.16.1 / 2020-05-19 / Agent 7.20.0
 
 * [Fixed] Fix encoding and parsing issues when processing connection configuration. See [#6686](https://github.com/DataDog/integrations-core/pull/6686).
 
-## 1.16.0 / 2020-05-17 / Agent 7.20.0
+## 1.16.0 / 2020-05-17
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.15.0 / 2020-05-05 / Agent 7.20.0
+## 1.15.0 / 2020-05-05
 
 * [Deprecated] Refactor connection configuration. See [#6574](https://github.com/DataDog/integrations-core/pull/6574).
 
@@ -44,44 +44,44 @@
 
 * [Added] Upgrade pymongo to 3.8. See [#4095](https://github.com/DataDog/integrations-core/pull/4095).
 
-## 1.10.3 / 2019-06-18 / Agent 6.13.0
+## 1.10.3 / 2019-06-18
 
 * [Fixed] Reduce doc in configuration file in favor of official documentation. See [#3892](https://github.com/DataDog/integrations-core/pull/3892).
 
-## 1.10.2 / 2019-06-06 / Agent 6.13.0
+## 1.10.2 / 2019-06-06 / Agent 6.12.0
 
 * [Fixed] Custom queries: add examples and fix logging. See [#3871](https://github.com/DataDog/integrations-core/pull/3871).
 
-## 1.10.1 / 2019-06-05 / Agent 6.13.0
+## 1.10.1 / 2019-06-05
 
 * [Fixed] Add missing metrics. See [#3856](https://github.com/DataDog/integrations-core/pull/3856).
 * [Fixed] Fix 'custom_queries' field name. See [#3868](https://github.com/DataDog/integrations-core/pull/3868).
 
-## 1.10.0 / 2019-06-01 / Agent 6.12.0
+## 1.10.0 / 2019-06-01
 
 * [Added] Add custom query capabilities. See [#3796](https://github.com/DataDog/integrations-core/pull/3796).
 
-## 1.9.0 / 2019-05-14 / Agent 6.12.0
+## 1.9.0 / 2019-05-14
 
 * [Added] Add tcmalloc.spinlock_total_delay_ns to mongodb stats. See [#3643](https://github.com/DataDog/integrations-core/pull/3643). Thanks [glenjamin](https://github.com/glenjamin).
 * [Added] Adhere to code style. See [#3540](https://github.com/DataDog/integrations-core/pull/3540).
 
-## 1.8.0 / 2019-02-18 / Agent 6.11.0
+## 1.8.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Finish Support Python 3. See [#2916](https://github.com/DataDog/integrations-core/pull/2916).
 * [Fixed] Only run `top` against the admin database. See [#2937](https://github.com/DataDog/integrations-core/pull/2937).
 * [Added] Support unicode for Python 3 bindings. See [#2869](https://github.com/DataDog/integrations-core/pull/2869).
 
-## 1.7.0 / 2018-11-30 / Agent 5.30.0
+## 1.7.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Support Python 3. See [#2623][1].
 * [Fixed] Use raw string literals when \ is present. See [#2465][2].
 
-## 1.6.1 / 2018-09-04 / Agent 5.28.0
+## 1.6.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 
-## 1.6.0 / 2018-06-13 / Agent 5.26.0
+## 1.6.0 / 2018-06-13 / Agent 6.4.0
 
 * [Added] [mongo] allow disabling of replica access. See [#1516][4].
 * [Changed] [mongo] properly parse metric. See [#1498][5].
@@ -90,7 +90,7 @@
 
 * [IMPROVEMENT] Allow disabling of replica access. See #1516
 
-## 1.5.3 / 2018-05-11 / Agent 5.25.0
+## 1.5.3 / 2018-05-11
 
 * [BUGFIX] Added `top` metrics ending in `countps` that properly submit as `rate`s. See #1491
 

--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 * [Fixed] Parse byte string versions. See [#7425](https://github.com/DataDog/integrations-core/pull/7425).
 
-## 2.0.1 / 2020-08-14
+## 2.0.1 / 2020-08-14 / Agent 7.22.0
 
 * [Fixed] Update config spec default values. See [#7340](https://github.com/DataDog/integrations-core/pull/7340).
 
-## 2.0.0 / 2020-08-10 / Agent 7.22.0
+## 2.0.0 / 2020-08-10
 
 * [Added] Send more useful metrics for wsrep flow control. See [#7316](https://github.com/DataDog/integrations-core/pull/7316). Thanks [sayap](https://github.com/sayap).
 * [Added] Add ability to specify which charset to use when connecting to mysql. See [#7216](https://github.com/DataDog/integrations-core/pull/7216).
@@ -23,7 +23,7 @@
 * [Added] Catch unicode error. See [#6947](https://github.com/DataDog/integrations-core/pull/6947).
 * [Fixed] Add config spec. See [#6908](https://github.com/DataDog/integrations-core/pull/6908).
 
-## 1.14.0 / 2020-06-03 / Agent 7.21.0
+## 1.14.0 / 2020-06-03
 
 * [Added] Add custom queries. See [#6776](https://github.com/DataDog/integrations-core/pull/6776).
 
@@ -40,7 +40,7 @@
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.11.0 / 2019-12-20 / Agent 7.17.0
+## 1.11.0 / 2019-12-20
 
 * [Added] Document log_processing_rules for MySQL slow query logs. See [#5237](https://github.com/DataDog/integrations-core/pull/5237).
 * [Fixed] Fix formatting and typos in the MySQL documentation. See [#5238](https://github.com/DataDog/integrations-core/pull/5238).
@@ -64,26 +64,26 @@
 
 * [Added] Adhere to code style. See [#3541](https://github.com/DataDog/integrations-core/pull/3541).
 
-## 1.7.0 / 2019-02-27 / Agent 6.11.0
+## 1.7.0 / 2019-02-27 / Agent 6.10.0
 
 * [Added] Remove Encrypted column from results. See [#3174](https://github.com/DataDog/integrations-core/pull/3174).
 
-## 1.6.0 / 2019-02-18 / Agent 6.11.0
+## 1.6.0 / 2019-02-18
 
 * [Added] Finish Python 3 Support. See [#2948](https://github.com/DataDog/integrations-core/pull/2948).
 
-## 1.5.0 / 2018-11-30 / Agent 5.30.0
+## 1.5.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Support Python 3. See [#2630][1].
 * [Fixed] Use raw string literals when \ is present. See [#2465][2].
 
-## 1.4.0 / 2018-09-04 / Agent 5.28.0
+## 1.4.0 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][3].
 * [Added] Add channel tag to replica metrics. See [#1753][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 1.3.0 / 2018-06-13 / Agent 5.26.0
+## 1.3.0 / 2018-06-13
 
 * [Added] Make the max custom queries configurable in the yaml file. See [#1713][6].
 

--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * [Fixed] Update config spec default values. See [#7340](https://github.com/DataDog/integrations-core/pull/7340).
 
-## 2.0.0 / 2020-08-10
+## 2.0.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Send more useful metrics for wsrep flow control. See [#7316](https://github.com/DataDog/integrations-core/pull/7316). Thanks [sayap](https://github.com/sayap).
 * [Added] Add ability to specify which charset to use when connecting to mysql. See [#7216](https://github.com/DataDog/integrations-core/pull/7216).
@@ -18,72 +18,72 @@
 * [Fixed] Split config out. See [#7195](https://github.com/DataDog/integrations-core/pull/7195).
 * [Changed] Fix mysql metric for innodb row lock time. See [#7289](https://github.com/DataDog/integrations-core/pull/7289). Thanks [sayap](https://github.com/sayap).
 
-## 1.15.0 / 2020-06-29
+## 1.15.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Catch unicode error. See [#6947](https://github.com/DataDog/integrations-core/pull/6947).
 * [Fixed] Add config spec. See [#6908](https://github.com/DataDog/integrations-core/pull/6908).
 
-## 1.14.0 / 2020-06-03
+## 1.14.0 / 2020-06-03 / Agent 7.21.0
 
 * [Added] Add custom queries. See [#6776](https://github.com/DataDog/integrations-core/pull/6776).
 
-## 1.13.0 / 2020-05-17
+## 1.13.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.12.1 / 2020-04-04
+## 1.12.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.12.0 / 2020-01-13
+## 1.12.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.11.0 / 2019-12-20
+## 1.11.0 / 2019-12-20 / Agent 7.17.0
 
 * [Added] Document log_processing_rules for MySQL slow query logs. See [#5237](https://github.com/DataDog/integrations-core/pull/5237).
 * [Fixed] Fix formatting and typos in the MySQL documentation. See [#5238](https://github.com/DataDog/integrations-core/pull/5238).
 * [Fixed] Improve perf (minor) by only defining metadata namedtuple once. See [#5138](https://github.com/DataDog/integrations-core/pull/5138).
 
-## 1.10.0 / 2019-12-02
+## 1.10.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade cryptography to 2.8. See [#5047](https://github.com/DataDog/integrations-core/pull/5047).
 * [Fixed] Fix TypeError in schema size check. See [#5043](https://github.com/DataDog/integrations-core/pull/5043). Thanks [rayatbuzzfeed](https://github.com/rayatbuzzfeed).
 * [Added] Submit version metadata. See [#4814](https://github.com/DataDog/integrations-core/pull/4814).
 
-## 1.9.1 / 2019-10-11
+## 1.9.1 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Fix typo in logs (Instace -> Instance). See [#4715](https://github.com/DataDog/integrations-core/pull/4715). Thanks [ajacoutot](https://github.com/ajacoutot).
 
-## 1.9.0 / 2019-07-04
+## 1.9.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Update cryptography version. See [#4000](https://github.com/DataDog/integrations-core/pull/4000).
 
-## 1.8.0 / 2019-05-14
+## 1.8.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3541](https://github.com/DataDog/integrations-core/pull/3541).
 
-## 1.7.0 / 2019-02-27
+## 1.7.0 / 2019-02-27 / Agent 6.11.0
 
 * [Added] Remove Encrypted column from results. See [#3174](https://github.com/DataDog/integrations-core/pull/3174).
 
-## 1.6.0 / 2019-02-18
+## 1.6.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Finish Python 3 Support. See [#2948](https://github.com/DataDog/integrations-core/pull/2948).
 
-## 1.5.0 / 2018-11-30
+## 1.5.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Support Python 3. See [#2630][1].
 * [Fixed] Use raw string literals when \ is present. See [#2465][2].
 
-## 1.4.0 / 2018-09-04
+## 1.4.0 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][3].
 * [Added] Add channel tag to replica metrics. See [#1753][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 1.3.0 / 2018-06-13
+## 1.3.0 / 2018-06-13 / Agent 5.26.0
 
 * [Added] Make the max custom queries configurable in the yaml file. See [#1713][6].
 

--- a/nagios/CHANGELOG.md
+++ b/nagios/CHANGELOG.md
@@ -5,48 +5,48 @@
 * [Fixed] Fix tailer on missing file. See [#7447](https://github.com/DataDog/integrations-core/pull/7447).
 * [Fixed] Fix style for the latest release of Black. See [#7438](https://github.com/DataDog/integrations-core/pull/7438).
 
-## 1.6.1 / 2020-08-10
+## 1.6.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Fix logging. See [#7239](https://github.com/DataDog/integrations-core/pull/7239).
 
-## 1.6.0 / 2020-05-17
+## 1.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.5.1 / 2019-11-07
+## 1.5.1 / 2019-11-07 / Agent 7.16.0
 
 * [Fixed] Fix use of format in logging. See [#4973](https://github.com/DataDog/integrations-core/pull/4973).
 
-## 1.5.0 / 2019-11-06
+## 1.5.0 / 2019-11-06 / Agent 7.16.0
 
 * [Fixed] Refactor tailers logic. See [#4942](https://github.com/DataDog/integrations-core/pull/4942).
 * [Added] Support centreon additional field in event logs. See [#4941](https://github.com/DataDog/integrations-core/pull/4941).
 
-## 1.4.1 / 2019-07-04
+## 1.4.1 / 2019-07-04 / Agent 6.13.0
 
 * [Fixed] Fix event payload so the check name is parsed correctly. See [#3979](https://github.com/DataDog/integrations-core/pull/3979).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3542](https://github.com/DataDog/integrations-core/pull/3542).
 
-## 1.3.0 / 2019-02-18
+## 1.3.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#2835](https://github.com/DataDog/integrations-core/pull/2835).
 
-## 1.2.0 / 2018-12-19
+## 1.2.0 / 2018-12-19 / Agent 5.31.0
 
 * [Added] Add instance level tags to Nagios Events. See [#2778][1].
 
-## 1.1.3 / 2018-11-30
+## 1.1.3 / 2018-11-30 / Agent 5.30.0
 
 * [Fixed] Use raw string literals when \ is present. See [#2465][2].
 
-## 1.1.2 / 2018-10-12
+## 1.1.2 / 2018-10-12 / Agent 5.28.0
 
 * [Fixed] Fix empty event issue with Agent 6. See [#2348][3].
 
-## 1.1.1 / 2018-09-04
+## 1.1.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add Agent 6 compatibility by not sending timestamps for gauge metrics (Agent 6 only). See [#1822][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].

--- a/nagios/CHANGELOG.md
+++ b/nagios/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 * [Fixed] Fix use of format in logging. See [#4973](https://github.com/DataDog/integrations-core/pull/4973).
 
-## 1.5.0 / 2019-11-06 / Agent 7.16.0
+## 1.5.0 / 2019-11-06
 
 * [Fixed] Refactor tailers logic. See [#4942](https://github.com/DataDog/integrations-core/pull/4942).
 * [Added] Support centreon additional field in event logs. See [#4941](https://github.com/DataDog/integrations-core/pull/4941).
@@ -30,23 +30,23 @@
 
 * [Added] Adhere to code style. See [#3542](https://github.com/DataDog/integrations-core/pull/3542).
 
-## 1.3.0 / 2019-02-18 / Agent 6.11.0
+## 1.3.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#2835](https://github.com/DataDog/integrations-core/pull/2835).
 
-## 1.2.0 / 2018-12-19 / Agent 5.31.0
+## 1.2.0 / 2018-12-19 / Agent 6.9.0
 
 * [Added] Add instance level tags to Nagios Events. See [#2778][1].
 
-## 1.1.3 / 2018-11-30 / Agent 5.30.0
+## 1.1.3 / 2018-11-30 / Agent 6.8.0
 
 * [Fixed] Use raw string literals when \ is present. See [#2465][2].
 
-## 1.1.2 / 2018-10-12 / Agent 5.28.0
+## 1.1.2 / 2018-10-12 / Agent 6.6.0
 
 * [Fixed] Fix empty event issue with Agent 6. See [#2348][3].
 
-## 1.1.1 / 2018-09-04 / Agent 5.28.0
+## 1.1.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add Agent 6 compatibility by not sending timestamps for gauge metrics (Agent 6 only). See [#1822][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].

--- a/network/CHANGELOG.md
+++ b/network/CHANGELOG.md
@@ -8,11 +8,11 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.15.1 / 2020-04-08 / Agent 7.20.0
+## 1.15.1 / 2020-04-08 / Agent 7.19.0
 
 * [Fixed] Fix error message. See [#6285](https://github.com/DataDog/integrations-core/pull/6285).
 
-## 1.15.0 / 2020-04-04 / Agent 7.19.0
+## 1.15.0 / 2020-04-04
 
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
 * [Fixed] Handle invalid type for excluded_interfaces. See [#5986](https://github.com/DataDog/integrations-core/pull/5986).
@@ -21,19 +21,19 @@
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.13.0 / 2020-01-02 / Agent 7.17.0
+## 1.13.0 / 2020-01-02
 
 * [Added] Gracefully handle /proc errors in network check. See [#5245](https://github.com/DataDog/integrations-core/pull/5245).
 
-## 1.12.2 / 2019-12-13 / Agent 7.17.0
+## 1.12.2 / 2019-12-13 / Agent 7.16.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 1.12.1 / 2019-12-02 / Agent 7.16.0
+## 1.12.1 / 2019-12-02
 
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
 
-## 1.12.0 / 2019-10-30 / Agent 7.16.0
+## 1.12.0 / 2019-10-30
 
 * [Added] Add use_sudo option for collecting conntrack metrics with containers. See [#4920](https://github.com/DataDog/integrations-core/pull/4920).
 * [Fixed] Fix examples in conf.yaml.default. See [#4887](https://github.com/DataDog/integrations-core/pull/4887). Thanks [q42jaap](https://github.com/q42jaap).
@@ -42,15 +42,15 @@
 
 * [Fixed] Upgrade psutil dependency to 5.6.3. See [#4442](https://github.com/DataDog/integrations-core/pull/4442).
 
-## 1.11.4 / 2019-08-30 / Agent 6.15.0
+## 1.11.4 / 2019-08-30 / Agent 6.14.0
 
 * [Fixed] Fix metric submission for combined connection state. See [#4473](https://github.com/DataDog/integrations-core/pull/4473).
 
-## 1.11.3 / 2019-08-14 / Agent 6.14.0
+## 1.11.3 / 2019-08-14
 
 * [Fixed] Drastically reduce `ss` output. See [#4346](https://github.com/DataDog/integrations-core/pull/4346).
 
-## 1.11.1 / 2019-08-02 / Agent 6.14.0
+## 1.11.1 / 2019-08-02
 
 * [Fixed] Fix proc location for conntrack files. See [#4150](https://github.com/DataDog/integrations-core/pull/4150).
 
@@ -64,7 +64,7 @@
 
 * [Added] Strip white space when reading from proc_conntrack_max_path. See [#3365](https://github.com/DataDog/integrations-core/pull/3365).
 
-## 1.9.0 / 2019-02-18 / Agent 6.11.0
+## 1.9.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Add conntrack basic metrics to the network integration.. See [#2981](https://github.com/DataDog/integrations-core/pull/2981). Thanks [aerostitch](https://github.com/aerostitch).
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
@@ -72,21 +72,21 @@
 * [Added] Support Python 3. See [#3005](https://github.com/DataDog/integrations-core/pull/3005).
 * [Fixed] Use `device` tag instead of the deprecated `device_name` parameter. See [#2945](https://github.com/DataDog/integrations-core/pull/2945). Thanks [aerostitch](https://github.com/aerostitch).
 
-## 1.8.0 / 2018-11-30 / Agent 5.30.0
+## 1.8.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Update psutil. See [#2576][1].
 * [Fixed] Use raw string literals when \ is present. See [#2465][2].
 
-## 1.7.0 / 2018-10-12 / Agent 5.28.0
+## 1.7.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Upgrade psutil. See [#2190][3].
 
-## 1.6.1 / 2018-09-04 / Agent 5.28.0
+## 1.6.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Retrieve no_proxy directly from the Datadog Agent's configuration. See [#2004][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 1.6.0 / 2018-06-07 / Agent 5.25.0
+## 1.6.0 / 2018-06-07
 
 * [Added] Add monotonic counts for some metrics. See [#1551][6]. Thanks [jalaziz][7].
 

--- a/network/CHANGELOG.md
+++ b/network/CHANGELOG.md
@@ -1,70 +1,70 @@
 # CHANGELOG - network
 
-## 1.17.0 / 2020-06-29
+## 1.17.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add network spec. See [#6889](https://github.com/DataDog/integrations-core/pull/6889).
 
-## 1.16.0 / 2020-05-17
+## 1.16.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.15.1 / 2020-04-08
+## 1.15.1 / 2020-04-08 / Agent 7.20.0
 
 * [Fixed] Fix error message. See [#6285](https://github.com/DataDog/integrations-core/pull/6285).
 
-## 1.15.0 / 2020-04-04
+## 1.15.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
 * [Fixed] Handle invalid type for excluded_interfaces. See [#5986](https://github.com/DataDog/integrations-core/pull/5986).
 
-## 1.14.0 / 2020-01-13
+## 1.14.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.13.0 / 2020-01-02
+## 1.13.0 / 2020-01-02 / Agent 7.17.0
 
 * [Added] Gracefully handle /proc errors in network check. See [#5245](https://github.com/DataDog/integrations-core/pull/5245).
 
-## 1.12.2 / 2019-12-13
+## 1.12.2 / 2019-12-13 / Agent 7.17.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 1.12.1 / 2019-12-02
+## 1.12.1 / 2019-12-02 / Agent 7.16.0
 
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
 
-## 1.12.0 / 2019-10-30
+## 1.12.0 / 2019-10-30 / Agent 7.16.0
 
 * [Added] Add use_sudo option for collecting conntrack metrics with containers. See [#4920](https://github.com/DataDog/integrations-core/pull/4920).
 * [Fixed] Fix examples in conf.yaml.default. See [#4887](https://github.com/DataDog/integrations-core/pull/4887). Thanks [q42jaap](https://github.com/q42jaap).
 
-## 1.11.5 / 2019-10-11
+## 1.11.5 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Upgrade psutil dependency to 5.6.3. See [#4442](https://github.com/DataDog/integrations-core/pull/4442).
 
-## 1.11.4 / 2019-08-30
+## 1.11.4 / 2019-08-30 / Agent 6.15.0
 
 * [Fixed] Fix metric submission for combined connection state. See [#4473](https://github.com/DataDog/integrations-core/pull/4473).
 
-## 1.11.3 / 2019-08-14
+## 1.11.3 / 2019-08-14 / Agent 6.14.0
 
 * [Fixed] Drastically reduce `ss` output. See [#4346](https://github.com/DataDog/integrations-core/pull/4346).
 
-## 1.11.1 / 2019-08-02
+## 1.11.1 / 2019-08-02 / Agent 6.14.0
 
 * [Fixed] Fix proc location for conntrack files. See [#4150](https://github.com/DataDog/integrations-core/pull/4150).
 
-## 1.11.0 / 2019-05-14
+## 1.11.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Upgrade psutil dependency to 5.6.2. See [#3684](https://github.com/DataDog/integrations-core/pull/3684).
 * [Added] Add conntrack metrics. See [#3624](https://github.com/DataDog/integrations-core/pull/3624).
 * [Added] Adhere to code style. See [#3543](https://github.com/DataDog/integrations-core/pull/3543).
 
-## 1.10.0 / 2019-03-29
+## 1.10.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Strip white space when reading from proc_conntrack_max_path. See [#3365](https://github.com/DataDog/integrations-core/pull/3365).
 
-## 1.9.0 / 2019-02-18
+## 1.9.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Add conntrack basic metrics to the network integration.. See [#2981](https://github.com/DataDog/integrations-core/pull/2981). Thanks [aerostitch](https://github.com/aerostitch).
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
@@ -72,21 +72,21 @@
 * [Added] Support Python 3. See [#3005](https://github.com/DataDog/integrations-core/pull/3005).
 * [Fixed] Use `device` tag instead of the deprecated `device_name` parameter. See [#2945](https://github.com/DataDog/integrations-core/pull/2945). Thanks [aerostitch](https://github.com/aerostitch).
 
-## 1.8.0 / 2018-11-30
+## 1.8.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Update psutil. See [#2576][1].
 * [Fixed] Use raw string literals when \ is present. See [#2465][2].
 
-## 1.7.0 / 2018-10-12
+## 1.7.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Upgrade psutil. See [#2190][3].
 
-## 1.6.1 / 2018-09-04
+## 1.6.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Retrieve no_proxy directly from the Datadog Agent's configuration. See [#2004][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 1.6.0 / 2018-06-07
+## 1.6.0 / 2018-06-07 / Agent 5.25.0
 
 * [Added] Add monotonic counts for some metrics. See [#1551][6]. Thanks [jalaziz][7].
 

--- a/nfsstat/CHANGELOG.md
+++ b/nfsstat/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 * [Fixed] Fix non-ascii mounted folder name. See [#3805](https://github.com/DataDog/integrations-core/pull/3805).
 
-## 1.4.0 / 2019-05-14 / Agent 6.12.0
+## 1.4.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3544](https://github.com/DataDog/integrations-core/pull/3544).
 
@@ -26,19 +26,19 @@
 
 * [Added] Support Python 3. See [#3228](https://github.com/DataDog/integrations-core/pull/3228).
 
-## 1.2.0 / 2019-02-18 / Agent 6.11.0
+## 1.2.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Don't raise Exception when No NFS mounts could be found. See [#3069](https://github.com/DataDog/integrations-core/pull/3069).
 
-## 1.1.0 / 2019-01-04 / Agent 5.31.0
+## 1.1.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2775][1].
 
-## 1.0.0 / 2018-10-13 / Agent 5.30.0
+## 1.0.0 / 2018-10-13 / Agent 6.6.0
 
 * [Added] NFSIOStat Check. See [#720][2].
 
-## 0.2.1 / 2018-09-04 / Agent 5.28.0
+## 0.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 

--- a/nfsstat/CHANGELOG.md
+++ b/nfsstat/CHANGELOG.md
@@ -1,44 +1,44 @@
 # CHANGELOG - Nfsstat
 
-## 1.6.0 / 2020-06-29
+## 1.6.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Avoid logging warnings if AutoFS is enabled. See [#6903](https://github.com/DataDog/integrations-core/pull/6903).
 * [Added] Add specs and use new signature. See [#6780](https://github.com/DataDog/integrations-core/pull/6780).
 
-## 1.5.0 / 2020-05-17
+## 1.5.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Fix nfsiostat command. See [#6650](https://github.com/DataDog/integrations-core/pull/6650).
 
-## 1.4.2 / 2020-04-04
+## 1.4.2 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.4.1 / 2019-05-30
+## 1.4.1 / 2019-05-30 / Agent 6.12.0
 
 * [Fixed] Fix non-ascii mounted folder name. See [#3805](https://github.com/DataDog/integrations-core/pull/3805).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3544](https://github.com/DataDog/integrations-core/pull/3544).
 
-## 1.3.0 / 2019-03-29
+## 1.3.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#3228](https://github.com/DataDog/integrations-core/pull/3228).
 
-## 1.2.0 / 2019-02-18
+## 1.2.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Don't raise Exception when No NFS mounts could be found. See [#3069](https://github.com/DataDog/integrations-core/pull/3069).
 
-## 1.1.0 / 2019-01-04
+## 1.1.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2775][1].
 
-## 1.0.0 / 2018-10-13
+## 1.0.0 / 2018-10-13 / Agent 5.30.0
 
 * [Added] NFSIOStat Check. See [#720][2].
 
-## 0.2.1 / 2018-09-04
+## 0.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 

--- a/nginx/CHANGELOG.md
+++ b/nginx/CHANGELOG.md
@@ -1,63 +1,63 @@
 # CHANGELOG - nginx
 
-## 3.8.1 / 2020-08-10
+## 3.8.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 3.8.0 / 2020-06-29
+## 3.8.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Added] Add config specs. See [#6797](https://github.com/DataDog/integrations-core/pull/6797).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 3.7.0 / 2020-05-17
+## 3.7.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 3.6.1 / 2020-04-04
+## 3.6.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 3.6.0 / 2020-01-13
+## 3.6.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Fixed] Handle missing version. See [#5250](https://github.com/DataDog/integrations-core/pull/5250).
 
-## 3.5.0 / 2019-12-02
+## 3.5.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Submit version metadata. See [#4736](https://github.com/DataDog/integrations-core/pull/4736).
 
-## 3.4.0 / 2019-10-11
+## 3.4.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 3.3.0 / 2019-08-24
+## 3.3.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add requests wrapper to Nginx. See [#4268](https://github.com/DataDog/integrations-core/pull/4268).
 
-## 3.2.0 / 2019-05-14
+## 3.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Simplify JSON flattening for timestamps and bool. See [#3648](https://github.com/DataDog/integrations-core/pull/3648). Thanks [jd](https://github.com/jd).
 * [Added] Adhere to code style. See [#3545](https://github.com/DataDog/integrations-core/pull/3545).
 
-## 3.1.0 / 2019-01-04
+## 3.1.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2716][1].
 
-## 3.0.0 / 2018-09-04
+## 3.0.0 / 2018-09-04 / Agent 5.28.0
 
 * [Changed] Send correct count values for NGINX ever increasing counters. See [#2041][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 
-## 2.2.0 / 2018-06-04
+## 2.2.0 / 2018-06-04 / Agent 5.25.0
 
 * [Changed] Log warning, not exception, when trying to collect stream metrics. See [#1536][4].
 * [Added] Add support for VTS module. See [#1295][5]. Thanks [mattjbray][6]
 
-## 2.1.0 / 2018-05-11
+## 2.1.0 / 2018-05-11 / Agent 5.24.0
 
 * [FEATURE] Add custom tag support to service checks.
 

--- a/nginx/CHANGELOG.md
+++ b/nginx/CHANGELOG.md
@@ -43,21 +43,21 @@
 * [Added] Simplify JSON flattening for timestamps and bool. See [#3648](https://github.com/DataDog/integrations-core/pull/3648). Thanks [jd](https://github.com/jd).
 * [Added] Adhere to code style. See [#3545](https://github.com/DataDog/integrations-core/pull/3545).
 
-## 3.1.0 / 2019-01-04 / Agent 5.31.0
+## 3.1.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2716][1].
 
-## 3.0.0 / 2018-09-04 / Agent 5.28.0
+## 3.0.0 / 2018-09-04 / Agent 6.5.0
 
 * [Changed] Send correct count values for NGINX ever increasing counters. See [#2041][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 
-## 2.2.0 / 2018-06-04 / Agent 5.25.0
+## 2.2.0 / 2018-06-04
 
 * [Changed] Log warning, not exception, when trying to collect stream metrics. See [#1536][4].
 * [Added] Add support for VTS module. See [#1295][5]. Thanks [mattjbray][6]
 
-## 2.1.0 / 2018-05-11 / Agent 5.24.0
+## 2.1.0 / 2018-05-11
 
 * [FEATURE] Add custom tag support to service checks.
 

--- a/nginx_ingress_controller/CHANGELOG.md
+++ b/nginx_ingress_controller/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.4.0 / 2020-06-12 / Agent 7.21.0
+## 1.4.0 / 2020-06-12
 
 * [Added] Add flag to collect subset of histogram metrics. See [#6860](https://github.com/DataDog/integrations-core/pull/6860).
 * [Added] Add configuration spec. See [#6857](https://github.com/DataDog/integrations-core/pull/6857).

--- a/nginx_ingress_controller/CHANGELOG.md
+++ b/nginx_ingress_controller/CHANGELOG.md
@@ -1,38 +1,38 @@
 # CHANGELOG - nginx-ingress-controller
 
-## 1.6.0 / 2020-08-10
+## 1.6.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Support "*" wildcard in type_overrides configuration. See [#7071](https://github.com/DataDog/integrations-core/pull/7071).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.5.0 / 2020-06-29
+## 1.5.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.4.0 / 2020-06-12
+## 1.4.0 / 2020-06-12 / Agent 7.21.0
 
 * [Added] Add flag to collect subset of histogram metrics. See [#6860](https://github.com/DataDog/integrations-core/pull/6860).
 * [Added] Add configuration spec. See [#6857](https://github.com/DataDog/integrations-core/pull/6857).
 * [Added] Add response duration metric to nginx ingress controller check. See [#6836](https://github.com/DataDog/integrations-core/pull/6836).
 
-## 1.3.0 / 2020-05-17
+## 1.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.2.2 / 2020-04-04
+## 1.2.2 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.2.1 / 2020-02-22
+## 1.2.1 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Fix metric validation. See [#5581](https://github.com/DataDog/integrations-core/pull/5581).
 
-## 1.2.0 / 2020-01-13
+## 1.2.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Make OpenMetrics use the RequestsWrapper. See [#5414](https://github.com/DataDog/integrations-core/pull/5414).
 
-## 1.1.0 / 2019-05-14
+## 1.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3546](https://github.com/DataDog/integrations-core/pull/3546).

--- a/openldap/CHANGELOG.md
+++ b/openldap/CHANGELOG.md
@@ -17,17 +17,17 @@
 
 * [Added] Adhere to code style. See [#3548](https://github.com/DataDog/integrations-core/pull/3548).
 
-## 1.2.0 / 2019-01-04 / Agent 5.31.0
+## 1.2.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2760][1].
 * [Fixed] Remove spurious tab from config file. See [#2758][2].
 
-## 1.1.0 / 2018-11-30 / Agent 5.30.0
+## 1.1.0 / 2018-11-30 / Agent 6.8.0
 
 * [Fixed] Correctly catch LDAP exception when failing to connect to server. See [#2574][3].
 * [Added] Fixed manifests and added validation in ddev. See [#2002][4].
 
-## 1.0.0 / 2018-07-20 / Agent 5.26.0
+## 1.0.0 / 2018-07-20 / Agent 6.5.0
 
 * [Added] Add OpenLDAP integration. See [#1870][5].
 [1]: https://github.com/DataDog/integrations-core/pull/2760

--- a/openldap/CHANGELOG.md
+++ b/openldap/CHANGELOG.md
@@ -1,33 +1,33 @@
 # CHANGELOG - openldap
 
-## 1.5.0 / 2020-05-17
+## 1.5.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.4.1 / 2020-04-04
+## 1.4.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.4.0 / 2019-07-08
+## 1.4.0 / 2019-07-08 / Agent 6.13.0
 
 * [Added] Add log section. See [#3974](https://github.com/DataDog/integrations-core/pull/3974).
 
-## 1.3.0 / 2019-05-14
+## 1.3.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3548](https://github.com/DataDog/integrations-core/pull/3548).
 
-## 1.2.0 / 2019-01-04
+## 1.2.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2760][1].
 * [Fixed] Remove spurious tab from config file. See [#2758][2].
 
-## 1.1.0 / 2018-11-30
+## 1.1.0 / 2018-11-30 / Agent 5.30.0
 
 * [Fixed] Correctly catch LDAP exception when failing to connect to server. See [#2574][3].
 * [Added] Fixed manifests and added validation in ddev. See [#2002][4].
 
-## 1.0.0 / 2018-07-20
+## 1.0.0 / 2018-07-20 / Agent 5.26.0
 
 * [Added] Add OpenLDAP integration. See [#1870][5].
 [1]: https://github.com/DataDog/integrations-core/pull/2760

--- a/openmetrics/CHANGELOG.md
+++ b/openmetrics/CHANGELOG.md
@@ -17,11 +17,11 @@
 * [Added] Add default template to openmetrics & jmx config. See [#6328](https://github.com/DataDog/integrations-core/pull/6328).
 * [Fixed] Hide openmetrics template options that are typically overridden. See [#6338](https://github.com/DataDog/integrations-core/pull/6338).
 
-## 1.6.1 / 2020-04-07 / Agent 7.20.0
+## 1.6.1 / 2020-04-07 / Agent 7.19.0
 
 * [Fixed] Add `kerberos_cache` to HTTP config options. See [#6279](https://github.com/DataDog/integrations-core/pull/6279).
 
-## 1.6.0 / 2020-04-04 / Agent 7.19.0
+## 1.6.0 / 2020-04-04
 
 * [Added] Add OpenMetrics config spec template. See [#6142](https://github.com/DataDog/integrations-core/pull/6142).
 * [Added] Allow option to submit histogram/summary sum metric as monotonic count. See [#6127](https://github.com/DataDog/integrations-core/pull/6127).
@@ -46,12 +46,12 @@
 
 * [Added] Use Kube service account bearer token for authentication. See [#3829](https://github.com/DataDog/integrations-core/pull/3829).
 
-## 1.1.0 / 2019-05-14 / Agent 6.12.0
+## 1.1.0 / 2019-05-14
 
 * [Fixed] Fix type override values in example config. See [#3717](https://github.com/DataDog/integrations-core/pull/3717).
 * [Added] Adhere to code style. See [#3549](https://github.com/DataDog/integrations-core/pull/3549).
 
-## 1.0.0 / 2018-10-13 / Agent 5.30.0
+## 1.0.0 / 2018-10-13 / Agent 6.6.0
 
 * [Added] Add OpenMetrics integration. See [#2148][1].
 

--- a/openmetrics/CHANGELOG.md
+++ b/openmetrics/CHANGELOG.md
@@ -1,27 +1,27 @@
 # CHANGELOG - OpenMetrics
 
-## 1.9.0 / 2020-08-10
+## 1.9.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Support "*" wildcard in type_overrides configuration. See [#7071](https://github.com/DataDog/integrations-core/pull/7071).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.8.0 / 2020-06-29
+## 1.8.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.7.0 / 2020-05-17
+## 1.7.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add default template to openmetrics & jmx config. See [#6328](https://github.com/DataDog/integrations-core/pull/6328).
 * [Fixed] Hide openmetrics template options that are typically overridden. See [#6338](https://github.com/DataDog/integrations-core/pull/6338).
 
-## 1.6.1 / 2020-04-07
+## 1.6.1 / 2020-04-07 / Agent 7.20.0
 
 * [Fixed] Add `kerberos_cache` to HTTP config options. See [#6279](https://github.com/DataDog/integrations-core/pull/6279).
 
-## 1.6.0 / 2020-04-04
+## 1.6.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add OpenMetrics config spec template. See [#6142](https://github.com/DataDog/integrations-core/pull/6142).
 * [Added] Allow option to submit histogram/summary sum metric as monotonic count. See [#6127](https://github.com/DataDog/integrations-core/pull/6127).
@@ -30,28 +30,28 @@
 * [Fixed] Update prometheus_client. See [#6200](https://github.com/DataDog/integrations-core/pull/6200).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.5.0 / 2020-02-22
+## 1.5.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Make `ignore_metrics` support `*` wildcard for OpenMetrics. See [#5759](https://github.com/DataDog/integrations-core/pull/5759).
 
-## 1.4.0 / 2020-01-13
+## 1.4.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Make OpenMetrics use the RequestsWrapper. See [#5414](https://github.com/DataDog/integrations-core/pull/5414).
 
-## 1.3.0 / 2019-10-11
+## 1.3.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add an option to send histograms/summary counts as monotonic counters. See [#4629](https://github.com/DataDog/integrations-core/pull/4629).
 
-## 1.2.0 / 2019-06-01
+## 1.2.0 / 2019-06-01 / Agent 6.12.0
 
 * [Added] Use Kube service account bearer token for authentication. See [#3829](https://github.com/DataDog/integrations-core/pull/3829).
 
-## 1.1.0 / 2019-05-14
+## 1.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Fixed] Fix type override values in example config. See [#3717](https://github.com/DataDog/integrations-core/pull/3717).
 * [Added] Adhere to code style. See [#3549](https://github.com/DataDog/integrations-core/pull/3549).
 
-## 1.0.0 / 2018-10-13
+## 1.0.0 / 2018-10-13 / Agent 5.30.0
 
 * [Added] Add OpenMetrics integration. See [#2148][1].
 

--- a/openstack/CHANGELOG.md
+++ b/openstack/CHANGELOG.md
@@ -30,29 +30,29 @@
 * [Fixed] Fix code style. See [#3838](https://github.com/DataDog/integrations-core/pull/3838).
 * [Fixed] Sanitize external host tags. See [#3792](https://github.com/DataDog/integrations-core/pull/3792).
 
-## 1.8.0 / 2019-05-14 / Agent 6.12.0
+## 1.8.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3550](https://github.com/DataDog/integrations-core/pull/3550).
 
-## 1.7.0 / 2019-02-18 / Agent 6.11.0
+## 1.7.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#3035](https://github.com/DataDog/integrations-core/pull/3035).
 
-## 1.6.0 / 2019-01-04 / Agent 5.31.0
+## 1.6.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Adds ability to Trace "check" function with DD APM. See [#2079][1].
 
-## 1.5.0 / 2018-08-29 / Agent 5.27.0
+## 1.5.0 / 2018-08-29 / Agent 6.5.0
 
 * [Fixed] Remove duplicate project call and reword os_host config option. See [#2066][2].
 * [Fixed] Use is_affirmative on boolean options. See [#2071][3].
 
-## 1.4.0 / 2018-08-17 / Agent 5.27.0
+## 1.4.0 / 2018-08-17
 
 * [Fixed] Only use the short hostname when making "host" queries to Nova. See [#2070][4].
 * [Changed] Add data files to the wheel package. See [#1727][5].
 
-## 1.3.0 / 2018-06-06 / Agent 5.25.0
+## 1.3.0 / 2018-06-06
 
 * [Added]  Added support for unscoped access, implemented caching mechanism to reduce API calls to Nova. See [#1276][6].
 

--- a/openstack/CHANGELOG.md
+++ b/openstack/CHANGELOG.md
@@ -1,58 +1,58 @@
 # CHANGELOG - openstack
 
-## 1.10.1 / 2020-06-29
+## 1.10.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Use agent v6 init signature. See [#6830](https://github.com/DataDog/integrations-core/pull/6830).
 
-## 1.10.0 / 2020-05-17
+## 1.10.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.9.1 / 2020-04-04
+## 1.9.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.9.0 / 2020-01-13
+## 1.9.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.8.3 / 2019-10-11
+## 1.8.3 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Fix documented default for `use_agent_proxy`. See [#4517](https://github.com/DataDog/integrations-core/pull/4517).
 
-## 1.8.2 / 2019-08-24
+## 1.8.2 / 2019-08-24 / Agent 6.14.0
 
 * [Fixed] Use utcnow instead of now. See [#4192](https://github.com/DataDog/integrations-core/pull/4192).
 
-## 1.8.1 / 2019-06-01
+## 1.8.1 / 2019-06-01 / Agent 6.12.0
 
 * [Fixed] Fix code style. See [#3838](https://github.com/DataDog/integrations-core/pull/3838).
 * [Fixed] Sanitize external host tags. See [#3792](https://github.com/DataDog/integrations-core/pull/3792).
 
-## 1.8.0 / 2019-05-14
+## 1.8.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3550](https://github.com/DataDog/integrations-core/pull/3550).
 
-## 1.7.0 / 2019-02-18
+## 1.7.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#3035](https://github.com/DataDog/integrations-core/pull/3035).
 
-## 1.6.0 / 2019-01-04
+## 1.6.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Adds ability to Trace "check" function with DD APM. See [#2079][1].
 
-## 1.5.0 / 2018-08-29
+## 1.5.0 / 2018-08-29 / Agent 5.27.0
 
 * [Fixed] Remove duplicate project call and reword os_host config option. See [#2066][2].
 * [Fixed] Use is_affirmative on boolean options. See [#2071][3].
 
-## 1.4.0 / 2018-08-17
+## 1.4.0 / 2018-08-17 / Agent 5.27.0
 
 * [Fixed] Only use the short hostname when making "host" queries to Nova. See [#2070][4].
 * [Changed] Add data files to the wheel package. See [#1727][5].
 
-## 1.3.0 / 2018-06-06
+## 1.3.0 / 2018-06-06 / Agent 5.25.0
 
 * [Added]  Added support for unscoped access, implemented caching mechanism to reduce API calls to Nova. See [#1276][6].
 

--- a/openstack_controller/CHANGELOG.md
+++ b/openstack_controller/CHANGELOG.md
@@ -1,81 +1,81 @@
 # CHANGELOG - Openstack_controller
 
-## 1.10.1 / 2020-08-10
+## 1.10.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.10.0 / 2020-06-29
+## 1.10.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.9.0 / 2020-05-17
+## 1.9.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.8.1 / 2020-02-25
+## 1.8.1 / 2020-02-25 / Agent 7.19.0
 
 * [Fixed] Bump datadog_checks_base dependency to 11.0.0. See [#5838](https://github.com/DataDog/integrations-core/pull/5838).
 
-## 1.8.0 / 2020-02-22
+## 1.8.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Refactor traced decorator and remove wrapt import. See [#5586](https://github.com/DataDog/integrations-core/pull/5586).
 
-## 1.7.0 / 2020-01-13
+## 1.7.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.6.0 / 2019-10-11
+## 1.6.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.5.1 / 2019-08-30
+## 1.5.1 / 2019-08-30 / Agent 6.15.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 1.5.0 / 2019-08-24
+## 1.5.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add requests wrapper to openstack_controller. See [#4365](https://github.com/DataDog/integrations-core/pull/4365).
 * [Added] Deployment environment with Terraform. See [#4039](https://github.com/DataDog/integrations-core/pull/4039).
 
-## 1.4.0 / 2019-07-12
+## 1.4.0 / 2019-07-12 / Agent 6.13.0
 
 * [Added] Retrieve floating IPs from network quotas. See [#4079](https://github.com/DataDog/integrations-core/pull/4079).
 
-## 1.3.0 / 2019-07-09
+## 1.3.0 / 2019-07-09 / Agent 6.13.0
 
 * [Added] Make keystone_server_url config optional in openstack_controller config. See [#3920](https://github.com/DataDog/integrations-core/pull/3920).
 * [Added] Openstack: introduce artificial metric in controller to distinguish from legacy integration. See [#4036](https://github.com/DataDog/integrations-core/pull/4036).
 
-## 1.2.1 / 2019-06-01
+## 1.2.1 / 2019-06-01 / Agent 6.12.0
 
 * [Fixed] Fix code style. See [#3838](https://github.com/DataDog/integrations-core/pull/3838).
 * [Fixed] Sanitize external host tags. See [#3792](https://github.com/DataDog/integrations-core/pull/3792).
 
-## 1.2.0 / 2019-05-14
+## 1.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3551](https://github.com/DataDog/integrations-core/pull/3551).
 
-## 1.1.2 / 2019-04-15
+## 1.1.2 / 2019-04-15 / Agent 6.12.0
 
 * [Fixed] Get details for both private and public flavors. See [#3621](https://github.com/DataDog/integrations-core/pull/3621).
 
-## 1.1.1 / 2019-03-21
+## 1.1.1 / 2019-03-21 / Agent 6.11.0
 
 * [Fixed] Fix issue with exception handling preventing re-authentication in case of token expiration. See [#3321](https://github.com/DataDog/integrations-core/pull/3321).
 
-## 1.1.0 / 2019-03-15
+## 1.1.0 / 2019-03-15 / Agent 6.11.0
 
 * [Added] Add project tags to hypervisor metrics. See [#3277](https://github.com/DataDog/integrations-core/pull/3277).
 * [Fixed] Fix pagination logic when making request to get servers/flavors details. See [#3301](https://github.com/DataDog/integrations-core/pull/3301).
 * [Added] Add openstacksdk option to openstack_controller. See [#3109](https://github.com/DataDog/integrations-core/pull/3109).
 * [Fixed] Refactor openstack_controller check api and back caches. See [#3142](https://github.com/DataDog/integrations-core/pull/3142).
 
-## 1.0.1 / 2019-02-18
+## 1.0.1 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Refactor openstack_controller check cache. See [#3120](https://github.com/DataDog/integrations-core/pull/3120).
 
-## 1.0.0 / 2019-02-04
+## 1.0.0 / 2019-02-04 / Agent 5.32.0
 
 * [Added] OpenStack Controller. See [#2496](https://github.com/DataDog/integrations-core/pull/2496).
 

--- a/openstack_controller/CHANGELOG.md
+++ b/openstack_controller/CHANGELOG.md
@@ -12,11 +12,11 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.8.1 / 2020-02-25 / Agent 7.19.0
+## 1.8.1 / 2020-02-25 / Agent 7.18.0
 
 * [Fixed] Bump datadog_checks_base dependency to 11.0.0. See [#5838](https://github.com/DataDog/integrations-core/pull/5838).
 
-## 1.8.0 / 2020-02-22 / Agent 7.18.0
+## 1.8.0 / 2020-02-22
 
 * [Added] Refactor traced decorator and remove wrapt import. See [#5586](https://github.com/DataDog/integrations-core/pull/5586).
 
@@ -29,11 +29,11 @@
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.5.1 / 2019-08-30 / Agent 6.15.0
+## 1.5.1 / 2019-08-30 / Agent 6.14.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 1.5.0 / 2019-08-24 / Agent 6.14.0
+## 1.5.0 / 2019-08-24
 
 * [Added] Add requests wrapper to openstack_controller. See [#4365](https://github.com/DataDog/integrations-core/pull/4365).
 * [Added] Deployment environment with Terraform. See [#4039](https://github.com/DataDog/integrations-core/pull/4039).
@@ -42,7 +42,7 @@
 
 * [Added] Retrieve floating IPs from network quotas. See [#4079](https://github.com/DataDog/integrations-core/pull/4079).
 
-## 1.3.0 / 2019-07-09 / Agent 6.13.0
+## 1.3.0 / 2019-07-09
 
 * [Added] Make keystone_server_url config optional in openstack_controller config. See [#3920](https://github.com/DataDog/integrations-core/pull/3920).
 * [Added] Openstack: introduce artificial metric in controller to distinguish from legacy integration. See [#4036](https://github.com/DataDog/integrations-core/pull/4036).
@@ -52,11 +52,11 @@
 * [Fixed] Fix code style. See [#3838](https://github.com/DataDog/integrations-core/pull/3838).
 * [Fixed] Sanitize external host tags. See [#3792](https://github.com/DataDog/integrations-core/pull/3792).
 
-## 1.2.0 / 2019-05-14 / Agent 6.12.0
+## 1.2.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3551](https://github.com/DataDog/integrations-core/pull/3551).
 
-## 1.1.2 / 2019-04-15 / Agent 6.12.0
+## 1.1.2 / 2019-04-15
 
 * [Fixed] Get details for both private and public flavors. See [#3621](https://github.com/DataDog/integrations-core/pull/3621).
 
@@ -64,18 +64,18 @@
 
 * [Fixed] Fix issue with exception handling preventing re-authentication in case of token expiration. See [#3321](https://github.com/DataDog/integrations-core/pull/3321).
 
-## 1.1.0 / 2019-03-15 / Agent 6.11.0
+## 1.1.0 / 2019-03-15
 
 * [Added] Add project tags to hypervisor metrics. See [#3277](https://github.com/DataDog/integrations-core/pull/3277).
 * [Fixed] Fix pagination logic when making request to get servers/flavors details. See [#3301](https://github.com/DataDog/integrations-core/pull/3301).
 * [Added] Add openstacksdk option to openstack_controller. See [#3109](https://github.com/DataDog/integrations-core/pull/3109).
 * [Fixed] Refactor openstack_controller check api and back caches. See [#3142](https://github.com/DataDog/integrations-core/pull/3142).
 
-## 1.0.1 / 2019-02-18 / Agent 6.11.0
+## 1.0.1 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Refactor openstack_controller check cache. See [#3120](https://github.com/DataDog/integrations-core/pull/3120).
 
-## 1.0.0 / 2019-02-04 / Agent 5.32.0
+## 1.0.0 / 2019-02-04
 
 * [Added] OpenStack Controller. See [#2496](https://github.com/DataDog/integrations-core/pull/2496).
 

--- a/oracle/CHANGELOG.md
+++ b/oracle/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 * [Changed] Migrate to QueryManager. See [#5529](https://github.com/DataDog/integrations-core/pull/5529).
 
-## 1.12.0 / 2020-02-04 / Agent 7.18.0
+## 1.12.0 / 2020-02-04
 
 * [Added] Add ability to only collect data defined in `custom_queries`. See [#5217](https://github.com/DataDog/integrations-core/pull/5217). Thanks [nowhammies](https://github.com/nowhammies).
 
@@ -38,7 +38,7 @@
 
 * [Added] Support multiple results in custom queries. See [#3765](https://github.com/DataDog/integrations-core/pull/3765).
 
-## 1.7.0 / 2019-05-14 / Agent 6.12.0
+## 1.7.0 / 2019-05-14
 
 * [Added] Turn an info log into debug. See [#3661](https://github.com/DataDog/integrations-core/pull/3661).
 * [Added] Adhere to code style. See [#3552](https://github.com/DataDog/integrations-core/pull/3552).
@@ -47,23 +47,23 @@
 
 * [Added] Add custom_queries config globally. See [#3231](https://github.com/DataDog/integrations-core/pull/3231).
 
-## 1.5.0 / 2019-02-18 / Agent 6.11.0
+## 1.5.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#3037](https://github.com/DataDog/integrations-core/pull/3037).
 * [Fixed] Fix tablespace metrics. See [#2841](https://github.com/DataDog/integrations-core/pull/2841).
 
-## 1.4.0 / 2018-09-04 / Agent 5.28.0
+## 1.4.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Add process metrics. See [#1856][1].
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.3.0 / 2018-06-07 / Agent 5.25.0
+## 1.3.0 / 2018-06-07
 
 * [Added] Support custom queries. See [#1528][3].
 * [Added] [oracle]  Add ability to use the JDBC Driver instead of cx_Oracle. See [#1459][4].
 * [FEATURE] ability to use the JDBC Driver instead of `cx_Oracle` to connect to the database. See [#1459][5]
 
-## 1.2.0 / 2018-05-11 / Agent 5.24.0
+## 1.2.0 / 2018-05-11
 
 * [FEATURE] adds metric `oracle.tablespace.offline`. See [#1402][6]
 * [BUGFIX] fix for DB with offline tablespace. See #1402

--- a/oracle/CHANGELOG.md
+++ b/oracle/CHANGELOG.md
@@ -1,69 +1,69 @@
 # CHANGELOG - oracle
 
-## 2.1.0 / 2020-05-17
+## 2.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.0.1 / 2020-04-04
+## 2.0.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Lazy import of JDBC libraries. See [#6118](https://github.com/DataDog/integrations-core/pull/6118).
 
-## 2.0.0 / 2020-02-22
+## 2.0.0 / 2020-02-22 / Agent 7.18.0
 
 * [Changed] Migrate to QueryManager. See [#5529](https://github.com/DataDog/integrations-core/pull/5529).
 
-## 1.12.0 / 2020-02-04
+## 1.12.0 / 2020-02-04 / Agent 7.18.0
 
 * [Added] Add ability to only collect data defined in `custom_queries`. See [#5217](https://github.com/DataDog/integrations-core/pull/5217). Thanks [nowhammies](https://github.com/nowhammies).
 
-## 1.11.0 / 2020-01-13
+## 1.11.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Fixed] Fix deprecated exception. See [#5182](https://github.com/DataDog/integrations-core/pull/5182).
 
-## 1.10.1 / 2019-10-07
+## 1.10.1 / 2019-10-07 / Agent 6.15.0
 
 * [Fixed] Use fetchall instead of iterating cursor for custom queries. This fixes an issue with the JDBC driver. See [#4664](https://github.com/DataDog/integrations-core/pull/4664).
 
-## 1.10.0 / 2019-08-24
+## 1.10.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Upgrade JPype1 to 0.7.0. See [#4211](https://github.com/DataDog/integrations-core/pull/4211).
 
-## 1.9.0 / 2019-07-08
+## 1.9.0 / 2019-07-08 / Agent 6.13.0
 
 * [Added] Upgrade dependencies for Python 3.7 binary wheels. See [#4030](https://github.com/DataDog/integrations-core/pull/4030).
 
-## 1.8.0 / 2019-06-01
+## 1.8.0 / 2019-06-01 / Agent 6.12.0
 
 * [Added] Support multiple results in custom queries. See [#3765](https://github.com/DataDog/integrations-core/pull/3765).
 
-## 1.7.0 / 2019-05-14
+## 1.7.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Turn an info log into debug. See [#3661](https://github.com/DataDog/integrations-core/pull/3661).
 * [Added] Adhere to code style. See [#3552](https://github.com/DataDog/integrations-core/pull/3552).
 
-## 1.6.0 / 2019-03-29
+## 1.6.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Add custom_queries config globally. See [#3231](https://github.com/DataDog/integrations-core/pull/3231).
 
-## 1.5.0 / 2019-02-18
+## 1.5.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#3037](https://github.com/DataDog/integrations-core/pull/3037).
 * [Fixed] Fix tablespace metrics. See [#2841](https://github.com/DataDog/integrations-core/pull/2841).
 
-## 1.4.0 / 2018-09-04
+## 1.4.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Add process metrics. See [#1856][1].
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.3.0 / 2018-06-07
+## 1.3.0 / 2018-06-07 / Agent 5.25.0
 
 * [Added] Support custom queries. See [#1528][3].
 * [Added] [oracle]  Add ability to use the JDBC Driver instead of cx_Oracle. See [#1459][4].
 * [FEATURE] ability to use the JDBC Driver instead of `cx_Oracle` to connect to the database. See [#1459][5]
 
-## 1.2.0 / 2018-05-11
+## 1.2.0 / 2018-05-11 / Agent 5.24.0
 
 * [FEATURE] adds metric `oracle.tablespace.offline`. See [#1402][6]
 * [BUGFIX] fix for DB with offline tablespace. See #1402

--- a/pdh_check/CHANGELOG.md
+++ b/pdh_check/CHANGELOG.md
@@ -1,56 +1,56 @@
 # CHANGELOG - pdh_check
 
-## 1.12.0 / 2020-08-10
+## 1.12.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add config spec. See [#7153](https://github.com/DataDog/integrations-core/pull/7153).
 
-## 1.11.0 / 2020-06-29
+## 1.11.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 
-## 1.10.0 / 2020-05-17
+## 1.10.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.9.1 / 2020-04-04
+## 1.9.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] PDH check to use new agent signature. See [#6159](https://github.com/DataDog/integrations-core/pull/6159).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.9.0 / 2020-01-21
+## 1.9.0 / 2020-01-21 / Agent 7.18.0
 
 * [Added] Make the admin share configurable. See [#5485](https://github.com/DataDog/integrations-core/pull/5485).
 
-## 1.8.0 / 2019-12-02
+## 1.8.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 1.7.0 / 2019-10-11
+## 1.7.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 1.6.1 / 2019-06-18
+## 1.6.1 / 2019-06-18 / Agent 6.13.0
 
 * [Fixed] Rename lower case manifest.in. See [#3858](https://github.com/DataDog/integrations-core/pull/3858).
 
-## 1.6.0 / 2019-06-01
+## 1.6.0 / 2019-06-01 / Agent 6.12.0
 
 * [Added] Make PDHCheck use PDHBaseCHeck. See [#3818](https://github.com/DataDog/integrations-core/pull/3818).
 
-## 1.5.0 / 2019-05-14
+## 1.5.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3553](https://github.com/DataDog/integrations-core/pull/3553).
 
-## 1.4.0 / 2019-02-18
+## 1.4.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#3049](https://github.com/DataDog/integrations-core/pull/3049).
 
-## 1.3.0 / 2018-10-12
+## 1.3.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/pdh_check/CHANGELOG.md
+++ b/pdh_check/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [Fixed] PDH check to use new agent signature. See [#6159](https://github.com/DataDog/integrations-core/pull/6159).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.9.0 / 2020-01-21 / Agent 7.18.0
+## 1.9.0 / 2020-01-21 / Agent 7.17.0
 
 * [Added] Make the admin share configurable. See [#5485](https://github.com/DataDog/integrations-core/pull/5485).
 
@@ -37,20 +37,20 @@
 
 * [Added] Make PDHCheck use PDHBaseCHeck. See [#3818](https://github.com/DataDog/integrations-core/pull/3818).
 
-## 1.5.0 / 2019-05-14 / Agent 6.12.0
+## 1.5.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3553](https://github.com/DataDog/integrations-core/pull/3553).
 
-## 1.4.0 / 2019-02-18 / Agent 6.11.0
+## 1.4.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Fix flake8. See [#3077](https://github.com/DataDog/integrations-core/pull/3077).
 * [Added] Support Python 3. See [#3049](https://github.com/DataDog/integrations-core/pull/3049).
 
-## 1.3.0 / 2018-10-12 / Agent 5.28.0
+## 1.3.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/pgbouncer/CHANGELOG.md
+++ b/pgbouncer/CHANGELOG.md
@@ -1,11 +1,11 @@
 # CHANGELOG - pgbouncer
 
-## 1.10.0 / 2020-05-17
+## 1.10.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Support more recent version in metadata. See [#6634](https://github.com/DataDog/integrations-core/pull/6634).
 
-## 1.9.0 / 2020-04-01
+## 1.9.0 / 2020-04-01 / Agent 7.19.0
 
 * [Added] Adding maxwait_us, total_wait_time, and avg_wait_time metrics. See [#6180](https://github.com/DataDog/integrations-core/pull/6180). Thanks [blaines](https://github.com/blaines).
 * [Added] Add pgbouncer version metadata. See [#5761](https://github.com/DataDog/integrations-core/pull/5761).
@@ -13,40 +13,40 @@
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.8.0 / 2019-12-02
+## 1.8.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade psycopg2-binary to 2.8.4. See [#4840](https://github.com/DataDog/integrations-core/pull/4840).
 
-## 1.7.0 / 2019-07-04
+## 1.7.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Add logs section. See [#3961](https://github.com/DataDog/integrations-core/pull/3961).
 
-## 1.6.0 / 2019-05-14
+## 1.6.0 / 2019-05-14 / Agent 6.12.0
 
 * [Fixed] Use name instead of db to identify databases from SHOW DATABASES. See [#3459](https://github.com/DataDog/integrations-core/pull/3459). Thanks [joekohlsdorf](https://github.com/joekohlsdorf).
 * [Added] Upgrade psycopg2-binary to 2.8.2. See [#3649](https://github.com/DataDog/integrations-core/pull/3649).
 * [Added] Adhere to code style. See [#3554](https://github.com/DataDog/integrations-core/pull/3554).
 
-## 1.5.0 / 2019-02-18
+## 1.5.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Add support for database metrics. See [#2777](https://github.com/DataDog/integrations-core/pull/2777). Thanks [joekohlsdorf](https://github.com/joekohlsdorf).
 * [Added] Support Python 3. See [#3039](https://github.com/DataDog/integrations-core/pull/3039).
 
-## 1.4.0 / 2019-01-04
+## 1.4.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Bump psycopg2-binary version to 2.7.5. See [#2799][1].
 
-## 1.3.1 / 2018-11-30
+## 1.3.1 / 2018-11-30 / Agent 5.30.0
 
 * [Fixed] Failure to reconnect to PGBouncer when using database URL. See [#2587][2]. Thanks [VSpike][3].
 
-## 1.3.0 / 2018-08-07
+## 1.3.0 / 2018-08-07 / Agent 5.28.0
 
 * [Added] Add the ability to specify 'use_cached' connections in config. See [#2000][4]. Thanks [kellydunn][5].
 * [Changed] Rename dependency psycopg2 to pyscopg2-binary. See [#1842][6].
 * [Changed] Add data files to the wheel package. See [#1727][7].
 
-## 1.2.1 / 2018-06-07
+## 1.2.1 / 2018-06-07 / Agent 5.25.0
 
 * [Security] Update psycopg2 for security fixes. See [#1538][8].
 

--- a/pgbouncer/CHANGELOG.md
+++ b/pgbouncer/CHANGELOG.md
@@ -27,26 +27,26 @@
 * [Added] Upgrade psycopg2-binary to 2.8.2. See [#3649](https://github.com/DataDog/integrations-core/pull/3649).
 * [Added] Adhere to code style. See [#3554](https://github.com/DataDog/integrations-core/pull/3554).
 
-## 1.5.0 / 2019-02-18 / Agent 6.11.0
+## 1.5.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Add support for database metrics. See [#2777](https://github.com/DataDog/integrations-core/pull/2777). Thanks [joekohlsdorf](https://github.com/joekohlsdorf).
 * [Added] Support Python 3. See [#3039](https://github.com/DataDog/integrations-core/pull/3039).
 
-## 1.4.0 / 2019-01-04 / Agent 5.31.0
+## 1.4.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Bump psycopg2-binary version to 2.7.5. See [#2799][1].
 
-## 1.3.1 / 2018-11-30 / Agent 5.30.0
+## 1.3.1 / 2018-11-30 / Agent 6.8.0
 
 * [Fixed] Failure to reconnect to PGBouncer when using database URL. See [#2587][2]. Thanks [VSpike][3].
 
-## 1.3.0 / 2018-08-07 / Agent 5.28.0
+## 1.3.0 / 2018-08-07 / Agent 6.5.0
 
 * [Added] Add the ability to specify 'use_cached' connections in config. See [#2000][4]. Thanks [kellydunn][5].
 * [Changed] Rename dependency psycopg2 to pyscopg2-binary. See [#1842][6].
 * [Changed] Add data files to the wheel package. See [#1727][7].
 
-## 1.2.1 / 2018-06-07 / Agent 5.25.0
+## 1.2.1 / 2018-06-07
 
 * [Security] Update psycopg2 for security fixes. See [#1538][8].
 

--- a/php_fpm/CHANGELOG.md
+++ b/php_fpm/CHANGELOG.md
@@ -1,54 +1,54 @@
 # CHANGELOG - php_fpm
 
-## 1.10.1 / 2020-08-10
+## 1.10.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.10.0 / 2020-06-29
+## 1.10.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.9.0 / 2020-05-17
+## 1.9.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.8.1 / 2020-04-04
+## 1.8.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.8.0 / 2020-01-13
+## 1.8.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.7.0 / 2019-10-11
+## 1.7.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.6.0 / 2019-08-24
+## 1.6.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add request wrappers to php_fpm. See [#4264](https://github.com/DataDog/integrations-core/pull/4264).
 
-## 1.5.0 / 2019-05-14
+## 1.5.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3555](https://github.com/DataDog/integrations-core/pull/3555).
 
-## 1.4.1 / 2019-03-29
+## 1.4.1 / 2019-03-29 / Agent 6.11.0
 
 * [Fixed] Properly ship flup on Python 3. See [#3304](https://github.com/DataDog/integrations-core/pull/3304).
 
-## 1.4.0 / 2018-11-27
+## 1.4.0 / 2018-11-27 / Agent 5.30.0
 
 * [Added] Added unix socket support. See [#2636][1]. Thanks [pperegrina][2].
 
-## 1.3.1 / 2018-10-12
+## 1.3.1 / 2018-10-12 / Agent 5.28.0
 
 * [Fixed] Make the status route-agnostic when using fastcgi. See [#2282][3].
 
-## 1.3.0 / 2018-09-04
+## 1.3.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Support fastcgi requests. See [#1997][4].
 
-## 1.2.0 / 2018-07-06
+## 1.2.0 / 2018-07-06 / Agent 5.26.0
 
 * [Added] Add exponential backoff when status returns 503. See [#1851][5].
 * [Changed] Add data files to the wheel package. See [#1727][6].

--- a/php_fpm/CHANGELOG.md
+++ b/php_fpm/CHANGELOG.md
@@ -36,19 +36,19 @@
 
 * [Fixed] Properly ship flup on Python 3. See [#3304](https://github.com/DataDog/integrations-core/pull/3304).
 
-## 1.4.0 / 2018-11-27 / Agent 5.30.0
+## 1.4.0 / 2018-11-27 / Agent 6.8.0
 
 * [Added] Added unix socket support. See [#2636][1]. Thanks [pperegrina][2].
 
-## 1.3.1 / 2018-10-12 / Agent 5.28.0
+## 1.3.1 / 2018-10-12 / Agent 6.6.0
 
 * [Fixed] Make the status route-agnostic when using fastcgi. See [#2282][3].
 
-## 1.3.0 / 2018-09-04 / Agent 5.28.0
+## 1.3.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Support fastcgi requests. See [#1997][4].
 
-## 1.2.0 / 2018-07-06 / Agent 5.26.0
+## 1.2.0 / 2018-07-06 / Agent 6.4.0
 
 * [Added] Add exponential backoff when status returns 503. See [#1851][5].
 * [Changed] Add data files to the wheel package. See [#1727][6].

--- a/postfix/CHANGELOG.md
+++ b/postfix/CHANGELOG.md
@@ -1,49 +1,49 @@
 # CHANGELOG - postfix
 
-## 1.7.0 / 2020-05-17
+## 1.7.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.6.2 / 2020-04-04
+## 1.6.2 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.6.1 / 2020-02-22
+## 1.6.1 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Fix possible IndexError. See [#5494](https://github.com/DataDog/integrations-core/pull/5494).
 
-## 1.6.0 / 2020-01-13
+## 1.6.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.5.1 / 2019-12-04
+## 1.5.1 / 2019-12-04 / Agent 7.17.0
 
 * [Fixed] Properly collect metadata when `postqueue` is false. See [#5142](https://github.com/DataDog/integrations-core/pull/5142).
 
-## 1.5.0 / 2019-12-02
+## 1.5.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add version metadata. See [#4949](https://github.com/DataDog/integrations-core/pull/4949).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3556](https://github.com/DataDog/integrations-core/pull/3556).
 
-## 1.3.0 / 2019-02-18
+## 1.3.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Add logs section. See [#3097](https://github.com/DataDog/integrations-core/pull/3097).
 * [Added] Support Python 3. See [#3038](https://github.com/DataDog/integrations-core/pull/3038).
 
-## 1.2.3 / 2018-10-12
+## 1.2.3 / 2018-10-12 / Agent 5.28.0
 
 * [Fixed] Use subprocess to get sudo capabilities instead of system(). See [#2353][1].
 
-## 1.2.2 / 2018-09-04
+## 1.2.2 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.2.1 / 2018-06-20
+## 1.2.1 / 2018-06-20 / Agent 5.26.0
 
 * [Tooling] Bump check to be in sync with new release tooling.
 

--- a/postfix/CHANGELOG.md
+++ b/postfix/CHANGELOG.md
@@ -18,11 +18,11 @@
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.5.1 / 2019-12-04 / Agent 7.17.0
+## 1.5.1 / 2019-12-04 / Agent 7.16.0
 
 * [Fixed] Properly collect metadata when `postqueue` is false. See [#5142](https://github.com/DataDog/integrations-core/pull/5142).
 
-## 1.5.0 / 2019-12-02 / Agent 7.16.0
+## 1.5.0 / 2019-12-02
 
 * [Added] Add version metadata. See [#4949](https://github.com/DataDog/integrations-core/pull/4949).
 
@@ -30,20 +30,20 @@
 
 * [Added] Adhere to code style. See [#3556](https://github.com/DataDog/integrations-core/pull/3556).
 
-## 1.3.0 / 2019-02-18 / Agent 6.11.0
+## 1.3.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Add logs section. See [#3097](https://github.com/DataDog/integrations-core/pull/3097).
 * [Added] Support Python 3. See [#3038](https://github.com/DataDog/integrations-core/pull/3038).
 
-## 1.2.3 / 2018-10-12 / Agent 5.28.0
+## 1.2.3 / 2018-10-12 / Agent 6.6.0
 
 * [Fixed] Use subprocess to get sudo capabilities instead of system(). See [#2353][1].
 
-## 1.2.2 / 2018-09-04 / Agent 5.28.0
+## 1.2.2 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.2.1 / 2018-06-20 / Agent 5.26.0
+## 1.2.1 / 2018-06-20 / Agent 6.4.0
 
 * [Tooling] Bump check to be in sync with new release tooling.
 

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 5.0.1 / 2020-07-16 / Agent 7.22.0
+## 5.0.1 / 2020-07-16
 
 * [Fixed] Avoid aurora pg warnings. See [#7123](https://github.com/DataDog/integrations-core/pull/7123).
 
@@ -33,15 +33,15 @@
 * [Fixed] Fix service check on unexpected exception. See [#6196](https://github.com/DataDog/integrations-core/pull/6196).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 3.5.3 / 2020-02-26 / Agent 7.19.0
+## 3.5.3 / 2020-02-26 / Agent 7.18.0
 
 * [Fixed] Rollback db connection when we get a 'FeatureNotSupported' exception. See [#5882](https://github.com/DataDog/integrations-core/pull/5882).
 
-## 3.5.2 / 2020-02-22 / Agent 7.18.0
+## 3.5.2 / 2020-02-22
 
 * [Fixed] Handle FeatureNotSupported errors in queries. See [#5749](https://github.com/DataDog/integrations-core/pull/5749).
 
-## 3.5.1 / 2020-02-13 / Agent 7.18.0
+## 3.5.1 / 2020-02-13
 
 * [Fixed] Filter out schemas in the queries directly. See [#5710](https://github.com/DataDog/integrations-core/pull/5710).
 * [Fixed] Refactor query_scope utility method. See [#5433](https://github.com/DataDog/integrations-core/pull/5433).
@@ -56,7 +56,7 @@
 * [Added] Add lock_type tag to lock metric. See [#5006](https://github.com/DataDog/integrations-core/pull/5006). Thanks [tjwp](https://github.com/tjwp).
 * [Added] Extract version utils and use semver for version comparison. See [#4844](https://github.com/DataDog/integrations-core/pull/4844).
 
-## 3.3.0 / 2019-10-30 / Agent 7.16.0
+## 3.3.0 / 2019-10-30
 
 * [Fixed] Remove multi instance from code. See [#4831](https://github.com/DataDog/integrations-core/pull/4831).
 * [Added] Upgrade psycopg2-binary to 2.8.4. See [#4840](https://github.com/DataDog/integrations-core/pull/4840).
@@ -65,23 +65,23 @@
 
 * [Fixed] Add cache invalidation and better thread lock. See [#4723](https://github.com/DataDog/integrations-core/pull/4723).
 
-## 3.2.0 / 2019-09-10 / Agent 6.15.0
+## 3.2.0 / 2019-09-10
 
 * [Added] Add schema tag to Lock and Size metrics. See [#3721](https://github.com/DataDog/integrations-core/pull/3721). Thanks [fischaz](https://github.com/fischaz).
 
-## 3.1.3 / 2019-09-04 / Agent 6.15.0
+## 3.1.3 / 2019-09-04 / Agent 6.14.0
 
 * [Fixed] Catch statement timeouts correctly. See [#4501](https://github.com/DataDog/integrations-core/pull/4501).
 
-## 3.1.2 / 2019-08-31 / Agent 6.15.0
+## 3.1.2 / 2019-08-31
 
 * [Fixed] Document new config option. See [#4480](https://github.com/DataDog/integrations-core/pull/4480).
 
-## 3.1.1 / 2019-08-30 / Agent 6.15.0
+## 3.1.1 / 2019-08-30
 
 * [Fixed] Fix query condition. See [#4484](https://github.com/DataDog/integrations-core/pull/4484). Thanks [dpierce-aledade](https://github.com/dpierce-aledade).
 
-## 3.1.0 / 2019-08-24 / Agent 6.14.0
+## 3.1.0 / 2019-08-24
 
 * [Added] Make table_count_limit a parameter. See [#3729](https://github.com/DataDog/integrations-core/pull/3729). Thanks [fischaz](https://github.com/fischaz).
 * [Added] Add postgresql application name to connection. See [#4295](https://github.com/DataDog/integrations-core/pull/4295).
@@ -90,11 +90,11 @@
 
 * [Changed] Add SSL support for psycopg2, remove pg8000. See [#4096](https://github.com/DataDog/integrations-core/pull/4096).
 
-## 2.9.1 / 2019-07-04 / Agent 6.13.0
+## 2.9.1 / 2019-07-04
 
 * [Fixed] Fix tagging for custom queries using custom tags. See [#3930](https://github.com/DataDog/integrations-core/pull/3930).
 
-## 2.9.0 / 2019-06-20 / Agent 6.13.0
+## 2.9.0 / 2019-06-20
 
 * [Added] Add regex matching for per-relation metrics. See [#3916](https://github.com/DataDog/integrations-core/pull/3916).
 
@@ -105,42 +105,42 @@
 * [Added] Upgrade psycopg2-binary to 2.8.2. See [#3649](https://github.com/DataDog/integrations-core/pull/3649).
 * [Added] Adhere to code style. See [#3557](https://github.com/DataDog/integrations-core/pull/3557).
 
-## 2.7.0 / 2019-04-05 / Agent 6.12.0
+## 2.7.0 / 2019-04-05 / Agent 6.11.0
 
 * [Added] Adds an option to tag metrics with `replication_role`. See [#2929](https://github.com/DataDog/integrations-core/pull/2929).
 * [Added] Add `server` tag to metrics and service_check. See [#2928](https://github.com/DataDog/integrations-core/pull/2928).
 
-## 2.6.0 / 2019-03-11 / Agent 6.11.0
+## 2.6.0 / 2019-03-11
 
 * [Added] Support multiple rows for custom queries. See [#3242](https://github.com/DataDog/integrations-core/pull/3242).
 
-## 2.5.0 / 2019-02-18 / Agent 6.11.0
+## 2.5.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Finish Python3 Support. See [#2949](https://github.com/DataDog/integrations-core/pull/2949).
 
-## 2.4.0 / 2019-01-04 / Agent 5.31.0
+## 2.4.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Bump psycopg2-binary version to 2.7.5. See [#2799][1].
 
-## 2.3.0 / 2018-11-30 / Agent 5.30.0
+## 2.3.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Include db tag with postgresql.locks metrics. See [#2567][2]. Thanks [sj26][3].
 * [Added] Support Python 3. See [#2616][4].
 
-## 2.2.3 / 2018-10-14 / Agent 5.30.0
+## 2.2.3 / 2018-10-14 / Agent 6.6.0
 
 * [Fixed] Fix version detection for new development releases. See [#2401][5].
 
-## 2.2.2 / 2018-09-11 / Agent 5.28.0
+## 2.2.2 / 2018-09-11 / Agent 6.5.0
 
 * [Fixed] Fix version detection for Postgres v10+. See [#2208][6].
 
-## 2.2.1 / 2018-09-06 / Agent 5.28.0
+## 2.2.1 / 2018-09-06
 
 * [Fixed]  Gracefully handle errors when performing custom_queries. See [#2184][7].
 * [Fixed] Gracefully handle failed version regex match. See [#2178][8].
 
-## 2.2.0 / 2018-09-04 / Agent 5.28.0
+## 2.2.0 / 2018-09-04
 
 * [Added] Add number of "idle in transaction" transactions and open transactions. See [#2118][9].
 * [Added] Implement custom_queries and start deprecating custom_metrics. See [#2043][10].
@@ -150,11 +150,11 @@
 * [Added] Correcting duplicate metric name, add index_rows_fetched. See [#1762][14].
 * [Fixed] Add data files to the wheel package. See [#1727][15].
 
-## 2.1.3 / 2018-06-20 / Agent 5.26.0
+## 2.1.3 / 2018-06-20 / Agent 6.4.0
 
 * [Fixed] Fixed postgres verification script. See [#1764][16].
 
-## 2.1.2 / 2018-06-07 / Agent 5.25.0
+## 2.1.2 / 2018-06-07
 
 * [Fixed] Fix function metrics tagging issue for no-args functions. See [#1452][17]. Thanks [zorgz][18].
 * [Security] Update psycopg2 for security fixes. See [#1538][19].

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -6,15 +6,15 @@
 * [Fixed] Fix style for the latest release of Black. See [#7438](https://github.com/DataDog/integrations-core/pull/7438).
 * [Fixed] [datadog_checks_dev] Use consistent formatting for boolean values. See [#7405](https://github.com/DataDog/integrations-core/pull/7405).
 
-## 5.0.2 / 2020-08-10
+## 5.0.2 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 5.0.1 / 2020-07-16
+## 5.0.1 / 2020-07-16 / Agent 7.22.0
 
 * [Fixed] Avoid aurora pg warnings. See [#7123](https://github.com/DataDog/integrations-core/pull/7123).
 
-## 5.0.0 / 2020-06-29
+## 5.0.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add config specs. See [#6547](https://github.com/DataDog/integrations-core/pull/6547).
 * [Fixed] Remove references to `use_psycopg2`. See [#6975](https://github.com/DataDog/integrations-core/pull/6975).
@@ -22,125 +22,125 @@
 * [Fixed] Extract config to new class. See [#6500](https://github.com/DataDog/integrations-core/pull/6500).
 * [Changed] Add `max_relations` config. See [#6725](https://github.com/DataDog/integrations-core/pull/6725).
 
-## 4.0.0 / 2020-05-17
+## 4.0.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Refactor multiple instance to single instance. See [#6510](https://github.com/DataDog/integrations-core/pull/6510).
 * [Changed] Postgres lock metrics are relation metrics. See [#6498](https://github.com/DataDog/integrations-core/pull/6498).
 
-## 3.5.4 / 2020-04-04
+## 3.5.4 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Fix service check on unexpected exception. See [#6196](https://github.com/DataDog/integrations-core/pull/6196).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 3.5.3 / 2020-02-26
+## 3.5.3 / 2020-02-26 / Agent 7.19.0
 
 * [Fixed] Rollback db connection when we get a 'FeatureNotSupported' exception. See [#5882](https://github.com/DataDog/integrations-core/pull/5882).
 
-## 3.5.2 / 2020-02-22
+## 3.5.2 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Handle FeatureNotSupported errors in queries. See [#5749](https://github.com/DataDog/integrations-core/pull/5749).
 
-## 3.5.1 / 2020-02-13
+## 3.5.1 / 2020-02-13 / Agent 7.18.0
 
 * [Fixed] Filter out schemas in the queries directly. See [#5710](https://github.com/DataDog/integrations-core/pull/5710).
 * [Fixed] Refactor query_scope utility method. See [#5433](https://github.com/DataDog/integrations-core/pull/5433).
 
-## 3.5.0 / 2019-12-30
+## 3.5.0 / 2019-12-30 / Agent 7.17.0
 
 * [Fixed] Handle connection closed. See [#5350](https://github.com/DataDog/integrations-core/pull/5350).
 * [Added] Add version metadata. See [#4874](https://github.com/DataDog/integrations-core/pull/4874).
 
-## 3.4.0 / 2019-12-02
+## 3.4.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add lock_type tag to lock metric. See [#5006](https://github.com/DataDog/integrations-core/pull/5006). Thanks [tjwp](https://github.com/tjwp).
 * [Added] Extract version utils and use semver for version comparison. See [#4844](https://github.com/DataDog/integrations-core/pull/4844).
 
-## 3.3.0 / 2019-10-30
+## 3.3.0 / 2019-10-30 / Agent 7.16.0
 
 * [Fixed] Remove multi instance from code. See [#4831](https://github.com/DataDog/integrations-core/pull/4831).
 * [Added] Upgrade psycopg2-binary to 2.8.4. See [#4840](https://github.com/DataDog/integrations-core/pull/4840).
 
-## 3.2.1 / 2019-10-11
+## 3.2.1 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Add cache invalidation and better thread lock. See [#4723](https://github.com/DataDog/integrations-core/pull/4723).
 
-## 3.2.0 / 2019-09-10
+## 3.2.0 / 2019-09-10 / Agent 6.15.0
 
 * [Added] Add schema tag to Lock and Size metrics. See [#3721](https://github.com/DataDog/integrations-core/pull/3721). Thanks [fischaz](https://github.com/fischaz).
 
-## 3.1.3 / 2019-09-04
+## 3.1.3 / 2019-09-04 / Agent 6.15.0
 
 * [Fixed] Catch statement timeouts correctly. See [#4501](https://github.com/DataDog/integrations-core/pull/4501).
 
-## 3.1.2 / 2019-08-31
+## 3.1.2 / 2019-08-31 / Agent 6.15.0
 
 * [Fixed] Document new config option. See [#4480](https://github.com/DataDog/integrations-core/pull/4480).
 
-## 3.1.1 / 2019-08-30
+## 3.1.1 / 2019-08-30 / Agent 6.15.0
 
 * [Fixed] Fix query condition. See [#4484](https://github.com/DataDog/integrations-core/pull/4484). Thanks [dpierce-aledade](https://github.com/dpierce-aledade).
 
-## 3.1.0 / 2019-08-24
+## 3.1.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Make table_count_limit a parameter. See [#3729](https://github.com/DataDog/integrations-core/pull/3729). Thanks [fischaz](https://github.com/fischaz).
 * [Added] Add postgresql application name to connection. See [#4295](https://github.com/DataDog/integrations-core/pull/4295).
 
-## 3.0.0 / 2019-07-12
+## 3.0.0 / 2019-07-12 / Agent 6.13.0
 
 * [Changed] Add SSL support for psycopg2, remove pg8000. See [#4096](https://github.com/DataDog/integrations-core/pull/4096).
 
-## 2.9.1 / 2019-07-04
+## 2.9.1 / 2019-07-04 / Agent 6.13.0
 
 * [Fixed] Fix tagging for custom queries using custom tags. See [#3930](https://github.com/DataDog/integrations-core/pull/3930).
 
-## 2.9.0 / 2019-06-20
+## 2.9.0 / 2019-06-20 / Agent 6.13.0
 
 * [Added] Add regex matching for per-relation metrics. See [#3916](https://github.com/DataDog/integrations-core/pull/3916).
 
-## 2.8.0 / 2019-05-14
+## 2.8.0 / 2019-05-14 / Agent 6.12.0
 
 * [Fixed] Use configuration user for pgsql activity metric. See [#3720](https://github.com/DataDog/integrations-core/pull/3720). Thanks [fischaz](https://github.com/fischaz).
 * [Fixed] Fix schema filtering on query relations. See [#3449](https://github.com/DataDog/integrations-core/pull/3449). Thanks [fischaz](https://github.com/fischaz).
 * [Added] Upgrade psycopg2-binary to 2.8.2. See [#3649](https://github.com/DataDog/integrations-core/pull/3649).
 * [Added] Adhere to code style. See [#3557](https://github.com/DataDog/integrations-core/pull/3557).
 
-## 2.7.0 / 2019-04-05
+## 2.7.0 / 2019-04-05 / Agent 6.12.0
 
 * [Added] Adds an option to tag metrics with `replication_role`. See [#2929](https://github.com/DataDog/integrations-core/pull/2929).
 * [Added] Add `server` tag to metrics and service_check. See [#2928](https://github.com/DataDog/integrations-core/pull/2928).
 
-## 2.6.0 / 2019-03-11
+## 2.6.0 / 2019-03-11 / Agent 6.11.0
 
 * [Added] Support multiple rows for custom queries. See [#3242](https://github.com/DataDog/integrations-core/pull/3242).
 
-## 2.5.0 / 2019-02-18
+## 2.5.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Finish Python3 Support. See [#2949](https://github.com/DataDog/integrations-core/pull/2949).
 
-## 2.4.0 / 2019-01-04
+## 2.4.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Bump psycopg2-binary version to 2.7.5. See [#2799][1].
 
-## 2.3.0 / 2018-11-30
+## 2.3.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Include db tag with postgresql.locks metrics. See [#2567][2]. Thanks [sj26][3].
 * [Added] Support Python 3. See [#2616][4].
 
-## 2.2.3 / 2018-10-14
+## 2.2.3 / 2018-10-14 / Agent 5.30.0
 
 * [Fixed] Fix version detection for new development releases. See [#2401][5].
 
-## 2.2.2 / 2018-09-11
+## 2.2.2 / 2018-09-11 / Agent 5.28.0
 
 * [Fixed] Fix version detection for Postgres v10+. See [#2208][6].
 
-## 2.2.1 / 2018-09-06
+## 2.2.1 / 2018-09-06 / Agent 5.28.0
 
 * [Fixed]  Gracefully handle errors when performing custom_queries. See [#2184][7].
 * [Fixed] Gracefully handle failed version regex match. See [#2178][8].
 
-## 2.2.0 / 2018-09-04
+## 2.2.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Add number of "idle in transaction" transactions and open transactions. See [#2118][9].
 * [Added] Implement custom_queries and start deprecating custom_metrics. See [#2043][10].
@@ -150,11 +150,11 @@
 * [Added] Correcting duplicate metric name, add index_rows_fetched. See [#1762][14].
 * [Fixed] Add data files to the wheel package. See [#1727][15].
 
-## 2.1.3 / 2018-06-20
+## 2.1.3 / 2018-06-20 / Agent 5.26.0
 
 * [Fixed] Fixed postgres verification script. See [#1764][16].
 
-## 2.1.2 / 2018-06-07
+## 2.1.2 / 2018-06-07 / Agent 5.25.0
 
 * [Fixed] Fix function metrics tagging issue for no-args functions. See [#1452][17]. Thanks [zorgz][18].
 * [Security] Update psycopg2 for security fixes. See [#1538][19].

--- a/powerdns_recursor/CHANGELOG.md
+++ b/powerdns_recursor/CHANGELOG.md
@@ -1,39 +1,39 @@
 # CHANGELOG - powerdns_recursor
 
-## 1.7.1 / 2020-08-10
+## 1.7.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.7.0 / 2020-06-29
+## 1.7.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Added] Add version metadata. See [#6916](https://github.com/DataDog/integrations-core/pull/6916).
 
-## 1.6.0 / 2020-05-17
+## 1.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.5.1 / 2020-04-04
+## 1.5.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.5.0 / 2019-10-11
+## 1.5.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.4.0 / 2019-08-24
+## 1.4.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add requests wrapper to powerdns_recursor. See [#4261](https://github.com/DataDog/integrations-core/pull/4261).
 
-## 1.3.0 / 2019-05-14
+## 1.3.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3558](https://github.com/DataDog/integrations-core/pull/3558).
 
-## 1.2.0 / 2019-01-04
+## 1.2.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2789][1].
 
-## 1.1.1 / 2018-09-04
+## 1.1.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].

--- a/powerdns_recursor/CHANGELOG.md
+++ b/powerdns_recursor/CHANGELOG.md
@@ -29,11 +29,11 @@
 
 * [Added] Adhere to code style. See [#3558](https://github.com/DataDog/integrations-core/pull/3558).
 
-## 1.2.0 / 2019-01-04 / Agent 5.31.0
+## 1.2.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2789][1].
 
-## 1.1.1 / 2018-09-04 / Agent 5.28.0
+## 1.1.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].

--- a/presto/CHANGELOG.md
+++ b/presto/CHANGELOG.md
@@ -8,15 +8,15 @@
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 2.0.1 / 2019-06-05 / Agent 6.13.0
+## 2.0.1 / 2019-06-05 / Agent 6.12.0
 
 * [Fixed] Fix version discovery. See [#3874](https://github.com/DataDog/integrations-core/pull/3874).
 
-## 2.0.0 / 2019-06-01 / Agent 6.12.0
+## 2.0.0 / 2019-06-01
 
 * [Changed] Fix metric aliases. See [#3766](https://github.com/DataDog/integrations-core/pull/3766).
 
-## 1.0.1 / 2019-05-14 / Agent 6.12.0
+## 1.0.1 / 2019-05-14
 
 * [Fixed] Update the log path for the presto integration. See [#3416](https://github.com/DataDog/integrations-core/pull/3416).
 

--- a/presto/CHANGELOG.md
+++ b/presto/CHANGELOG.md
@@ -1,25 +1,25 @@
 # CHANGELOG - Presto
 
-## 2.1.0 / 2020-05-17
+## 2.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.0.2 / 2020-04-04
+## 2.0.2 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 2.0.1 / 2019-06-05
+## 2.0.1 / 2019-06-05 / Agent 6.13.0
 
 * [Fixed] Fix version discovery. See [#3874](https://github.com/DataDog/integrations-core/pull/3874).
 
-## 2.0.0 / 2019-06-01
+## 2.0.0 / 2019-06-01 / Agent 6.12.0
 
 * [Changed] Fix metric aliases. See [#3766](https://github.com/DataDog/integrations-core/pull/3766).
 
-## 1.0.1 / 2019-05-14
+## 1.0.1 / 2019-05-14 / Agent 6.12.0
 
 * [Fixed] Update the log path for the presto integration. See [#3416](https://github.com/DataDog/integrations-core/pull/3416).
 
-## 1.0.0 / 2019-03-29
+## 1.0.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Adds Presto Integration. See [#3131](https://github.com/DataDog/integrations-core/pull/3131).

--- a/process/CHANGELOG.md
+++ b/process/CHANGELOG.md
@@ -1,80 +1,80 @@
 # CHANGELOG - process
 
-## 1.15.1 / 2020-07-02
+## 1.15.1 / 2020-07-02 / Agent 7.22.0
 
 * [Fixed] Fix NoSuchProcess log message level. See [#7045](https://github.com/DataDog/integrations-core/pull/7045).
 
-## 1.15.0 / 2020-06-29
+## 1.15.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Config specs and new agent signature. See [#6781](https://github.com/DataDog/integrations-core/pull/6781).
 
-## 1.14.0 / 2020-05-17
+## 1.14.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.13.0 / 2020-04-04
+## 1.13.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.12.0 / 2020-03-13
+## 1.12.0 / 2020-03-13 / Agent 7.19.0
 
 * [Added] Improve check performance. See [#5920](https://github.com/DataDog/integrations-core/pull/5920).
 
-## 1.11.1 / 2020-01-15
+## 1.11.1 / 2020-01-15 / Agent 7.18.0
 
 * [Fixed] Fix debug logging. See [#5460](https://github.com/DataDog/integrations-core/pull/5460).
 
-## 1.11.0 / 2020-01-13
+## 1.11.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Fixed] Uncomment required config: search_string. See [#5359](https://github.com/DataDog/integrations-core/pull/5359).
 
-## 1.10.4 / 2019-12-23
+## 1.10.4 / 2019-12-23 / Agent 7.17.0
 
 * [Fixed] Add debug logging when processes are not found. See [#5313](https://github.com/DataDog/integrations-core/pull/5313).
 
-## 1.10.3 / 2019-12-13
+## 1.10.3 / 2019-12-13 / Agent 7.17.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 1.10.2 / 2019-12-02
+## 1.10.2 / 2019-12-02 / Agent 7.16.0
 
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
 
-## 1.10.1 / 2019-10-11
+## 1.10.1 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Make iowrite_bytes and ioread_bytes counts. See [#4655](https://github.com/DataDog/integrations-core/pull/4655).
 * [Fixed] Upgrade psutil dependency to 5.6.3. See [#4442](https://github.com/DataDog/integrations-core/pull/4442).
 
-## 1.10.0 / 2019-05-14
+## 1.10.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Upgrade psutil dependency to 5.6.2. See [#3684](https://github.com/DataDog/integrations-core/pull/3684).
 
-## 1.9.0 / 2019-04-15
+## 1.9.0 / 2019-04-15 / Agent 6.12.0
 
 * [Fixed] Do not return prematurely when calling `memory_info` on windows and solaris. See [#3618](https://github.com/DataDog/integrations-core/pull/3618).
 * [Added] Adhere to code style. See [#3559](https://github.com/DataDog/integrations-core/pull/3559).
 
-## 1.8.0 / 2019-02-18
+## 1.8.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Upgrade psutil. See [#3019](https://github.com/DataDog/integrations-core/pull/3019).
 * [Added] Finish Python 3 Support. See [#2950](https://github.com/DataDog/integrations-core/pull/2950).
 
-## 1.7.0 / 2019-01-04
+## 1.7.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2812][1].
 
-## 1.6.0 / 2018-11-30
+## 1.6.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Update psutil. See [#2576][2].
 
-## 1.5.0 / 2018-10-12
+## 1.5.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Upgrade psutil. See [#2190][3].
 
-## 1.4.0 / 2018-09-04
+## 1.4.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Added regex support to process check when exact_match is False.. See [#2055][4]. Thanks [asandeep][5].
 * [Added] [Add] Add cpu.normalized_pct metric. See [#1729][6].

--- a/process/CHANGELOG.md
+++ b/process/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG - process
 
-## 1.15.1 / 2020-07-02 / Agent 7.22.0
+## 1.15.1 / 2020-07-02 / Agent 7.21.0
 
 * [Fixed] Fix NoSuchProcess log message level. See [#7045](https://github.com/DataDog/integrations-core/pull/7045).
 
-## 1.15.0 / 2020-06-29 / Agent 7.21.0
+## 1.15.0 / 2020-06-29
 
 * [Added] Config specs and new agent signature. See [#6781](https://github.com/DataDog/integrations-core/pull/6781).
 
@@ -17,29 +17,29 @@
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.12.0 / 2020-03-13 / Agent 7.19.0
+## 1.12.0 / 2020-03-13
 
 * [Added] Improve check performance. See [#5920](https://github.com/DataDog/integrations-core/pull/5920).
 
-## 1.11.1 / 2020-01-15 / Agent 7.18.0
+## 1.11.1 / 2020-01-15 / Agent 7.17.0
 
 * [Fixed] Fix debug logging. See [#5460](https://github.com/DataDog/integrations-core/pull/5460).
 
-## 1.11.0 / 2020-01-13 / Agent 7.17.0
+## 1.11.0 / 2020-01-13
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Fixed] Uncomment required config: search_string. See [#5359](https://github.com/DataDog/integrations-core/pull/5359).
 
-## 1.10.4 / 2019-12-23 / Agent 7.17.0
+## 1.10.4 / 2019-12-23
 
 * [Fixed] Add debug logging when processes are not found. See [#5313](https://github.com/DataDog/integrations-core/pull/5313).
 
-## 1.10.3 / 2019-12-13 / Agent 7.17.0
+## 1.10.3 / 2019-12-13 / Agent 7.16.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 1.10.2 / 2019-12-02 / Agent 7.16.0
+## 1.10.2 / 2019-12-02
 
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
 
@@ -52,29 +52,29 @@
 
 * [Added] Upgrade psutil dependency to 5.6.2. See [#3684](https://github.com/DataDog/integrations-core/pull/3684).
 
-## 1.9.0 / 2019-04-15 / Agent 6.12.0
+## 1.9.0 / 2019-04-15
 
 * [Fixed] Do not return prematurely when calling `memory_info` on windows and solaris. See [#3618](https://github.com/DataDog/integrations-core/pull/3618).
 * [Added] Adhere to code style. See [#3559](https://github.com/DataDog/integrations-core/pull/3559).
 
-## 1.8.0 / 2019-02-18 / Agent 6.11.0
+## 1.8.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Upgrade psutil. See [#3019](https://github.com/DataDog/integrations-core/pull/3019).
 * [Added] Finish Python 3 Support. See [#2950](https://github.com/DataDog/integrations-core/pull/2950).
 
-## 1.7.0 / 2019-01-04 / Agent 5.31.0
+## 1.7.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2812][1].
 
-## 1.6.0 / 2018-11-30 / Agent 5.30.0
+## 1.6.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Update psutil. See [#2576][2].
 
-## 1.5.0 / 2018-10-12 / Agent 5.28.0
+## 1.5.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Upgrade psutil. See [#2190][3].
 
-## 1.4.0 / 2018-09-04 / Agent 5.28.0
+## 1.4.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Added regex support to process check when exact_match is False.. See [#2055][4]. Thanks [asandeep][5].
 * [Added] [Add] Add cpu.normalized_pct metric. See [#1729][6].

--- a/prometheus/CHANGELOG.md
+++ b/prometheus/CHANGELOG.md
@@ -1,34 +1,34 @@
 # CHANGELOG - Prometheus
 
-## 3.3.0 / 2020-05-17
+## 3.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 3.2.1 / 2020-04-04
+## 3.2.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update prometheus_client. See [#6200](https://github.com/DataDog/integrations-core/pull/6200).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 3.2.0 / 2019-05-14
+## 3.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Fixed] Fix type override values in example config. See [#3717](https://github.com/DataDog/integrations-core/pull/3717).
 * [Added] Adhere to code style. See [#3560](https://github.com/DataDog/integrations-core/pull/3560).
 
-## 3.1.0 / 2019-02-18
+## 3.1.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#3048](https://github.com/DataDog/integrations-core/pull/3048).
 
-## 3.0.1 / 2019-01-04
+## 3.0.1 / 2019-01-04 / Agent 5.31.0
 
 * [Fixed] Added crucial words to make sentence clearer. See [#2811][1]. Thanks [someword][2].
 * [Fixed] Change the prometheus example to use prometheus_url. See [#2790][3]. Thanks [someword][2].
 
-## 3.0.0 / 2018-10-12
+## 3.0.0 / 2018-10-12 / Agent 5.28.0
 
 * [Changed] Change default prometheus metric limit to 2000. See [#2248][4].
 * [Fixed] Temporarily increase the limit of prometheus metrics sent for 6.5. See [#2214][5].
 
-## 2.0.0 / 2018-09-04
+## 2.0.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][6].
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][7].

--- a/prometheus/CHANGELOG.md
+++ b/prometheus/CHANGELOG.md
@@ -14,21 +14,21 @@
 * [Fixed] Fix type override values in example config. See [#3717](https://github.com/DataDog/integrations-core/pull/3717).
 * [Added] Adhere to code style. See [#3560](https://github.com/DataDog/integrations-core/pull/3560).
 
-## 3.1.0 / 2019-02-18 / Agent 6.11.0
+## 3.1.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#3048](https://github.com/DataDog/integrations-core/pull/3048).
 
-## 3.0.1 / 2019-01-04 / Agent 5.31.0
+## 3.0.1 / 2019-01-04 / Agent 6.9.0
 
 * [Fixed] Added crucial words to make sentence clearer. See [#2811][1]. Thanks [someword][2].
 * [Fixed] Change the prometheus example to use prometheus_url. See [#2790][3]. Thanks [someword][2].
 
-## 3.0.0 / 2018-10-12 / Agent 5.28.0
+## 3.0.0 / 2018-10-12 / Agent 6.6.0
 
 * [Changed] Change default prometheus metric limit to 2000. See [#2248][4].
 * [Fixed] Temporarily increase the limit of prometheus metrics sent for 6.5. See [#2214][5].
 
-## 2.0.0 / 2018-09-04 / Agent 5.28.0
+## 2.0.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Limit Prometheus/OpenMetrics checks to 2000 metrics per run by default. See [#2093][6].
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][7].

--- a/proxysql/CHANGELOG.md
+++ b/proxysql/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG - ProxySQL
 
-## 1.2.1 / 2020-07-03 / Agent 7.22.0
+## 1.2.1 / 2020-07-03 / Agent 7.21.0
 
 * [Fixed] Revert/Remove unnecessary `database_name` config. See [#7049](https://github.com/DataDog/integrations-core/pull/7049).
 
-## 1.2.0 / 2020-06-29 / Agent 7.21.0
+## 1.2.0 / 2020-06-29
 
 * [Added] Allow proxysql checks to specify stats database name. See [#6835](https://github.com/DataDog/integrations-core/pull/6835). Thanks [tabacco](https://github.com/tabacco).
 

--- a/proxysql/CHANGELOG.md
+++ b/proxysql/CHANGELOG.md
@@ -1,18 +1,18 @@
 # CHANGELOG - ProxySQL
 
-## 1.2.1 / 2020-07-03
+## 1.2.1 / 2020-07-03 / Agent 7.22.0
 
 * [Fixed] Revert/Remove unnecessary `database_name` config. See [#7049](https://github.com/DataDog/integrations-core/pull/7049).
 
-## 1.2.0 / 2020-06-29
+## 1.2.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Allow proxysql checks to specify stats database name. See [#6835](https://github.com/DataDog/integrations-core/pull/6835). Thanks [tabacco](https://github.com/tabacco).
 
-## 1.1.0 / 2020-05-17
+## 1.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.0.0 / 2020-04-03
+## 1.0.0 / 2020-04-03 / Agent 7.19.0
 
 * [Added] New Integration ProxySQL. See [#6144](https://github.com/DataDog/integrations-core/pull/6144).
 

--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -1,77 +1,77 @@
 # CHANGELOG - rabbitmq
 
-## 1.15.1 / 2020-08-10
+## 1.15.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.15.0 / 2020-06-29
+## 1.15.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Added] Add head_message_timestamp metric. See [#6809](https://github.com/DataDog/integrations-core/pull/6809).
 * [Fixed] Continue check execution when only a few vhosts are unhealthy. See [#6954](https://github.com/DataDog/integrations-core/pull/6954).
 
-## 1.14.0 / 2020-05-17
+## 1.14.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.13.1 / 2020-04-04
+## 1.13.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.13.0 / 2020-02-22
+## 1.13.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add option to disable node metrics in rabbitmq. See [#5750](https://github.com/DataDog/integrations-core/pull/5750).
 
-## 1.12.0 / 2020-01-13
+## 1.12.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.11.0 / 2019-12-02
+## 1.11.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add version metadata to RabbitMQ check. See [#4918](https://github.com/DataDog/integrations-core/pull/4918).
 
-## 1.10.1 / 2019-10-18
+## 1.10.1 / 2019-10-18 / Agent 7.16.0
 
 * [Fixed] Fix for rabbit 3.1 queue_totals introduced in #4668. See [#4805](https://github.com/DataDog/integrations-core/pull/4805).
 
-## 1.10.0 / 2019-10-11
+## 1.10.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] verifies if `root` is dict before doing `.get`. See [#4668](https://github.com/DataDog/integrations-core/pull/4668).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.9.2 / 2019-09-18
+## 1.9.2 / 2019-09-18 / Agent 6.15.0
 
 * [Fixed] Ignore empty data for metrics limit. See [#4544](https://github.com/DataDog/integrations-core/pull/4544).
 
-## 1.9.1 / 2019-08-29
+## 1.9.1 / 2019-08-29 / Agent 6.15.0
 
 * [Fixed] Revert "Fix queue, node and echange limit". See [#4467](https://github.com/DataDog/integrations-core/pull/4467).
 
-## 1.9.0 / 2019-08-24
+## 1.9.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add mem_limit to RabbitMQ Checks. See [#4250](https://github.com/DataDog/integrations-core/pull/4250). Thanks [ParthKolekar](https://github.com/ParthKolekar).
 * [Added] Add requests wrapper to RabbitMQ. See [#4257](https://github.com/DataDog/integrations-core/pull/4257).
 * [Fixed] Fix queue, node and echange limit. See [#4108](https://github.com/DataDog/integrations-core/pull/4108).
 
-## 1.8.0 / 2019-05-14
+## 1.8.0 / 2019-05-14 / Agent 6.12.0
 
 * [Fixed] Fix default log path. See [#3611](https://github.com/DataDog/integrations-core/pull/3611).
 * [Added] Adhere to code style. See [#3561](https://github.com/DataDog/integrations-core/pull/3561).
 
-## 1.7.0 / 2019-01-04
+## 1.7.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2791][1].
 * [Fixed] adds ignore_ssl_warning to rabbit file. See [#2706][2].
 
-## 1.6.0 / 2018-11-30
+## 1.6.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Option to ignore SSL warnings. See [#2472][3]. Thanks [tebriel][4].
 * [Fixed] Use raw string literals when \ is present. See [#2465][5].
 * [Added] Add cluster wide metrics. See [#2449][6].
 
-## 1.5.2 / 2018-09-04
+## 1.5.2 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][7].
 

--- a/rabbitmq/CHANGELOG.md
+++ b/rabbitmq/CHANGELOG.md
@@ -32,24 +32,24 @@
 
 * [Added] Add version metadata to RabbitMQ check. See [#4918](https://github.com/DataDog/integrations-core/pull/4918).
 
-## 1.10.1 / 2019-10-18 / Agent 7.16.0
+## 1.10.1 / 2019-10-18 / Agent 6.15.0
 
 * [Fixed] Fix for rabbit 3.1 queue_totals introduced in #4668. See [#4805](https://github.com/DataDog/integrations-core/pull/4805).
 
-## 1.10.0 / 2019-10-11 / Agent 6.15.0
+## 1.10.0 / 2019-10-11
 
 * [Added] verifies if `root` is dict before doing `.get`. See [#4668](https://github.com/DataDog/integrations-core/pull/4668).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.9.2 / 2019-09-18 / Agent 6.15.0
+## 1.9.2 / 2019-09-18
 
 * [Fixed] Ignore empty data for metrics limit. See [#4544](https://github.com/DataDog/integrations-core/pull/4544).
 
-## 1.9.1 / 2019-08-29 / Agent 6.15.0
+## 1.9.1 / 2019-08-29 / Agent 6.14.0
 
 * [Fixed] Revert "Fix queue, node and echange limit". See [#4467](https://github.com/DataDog/integrations-core/pull/4467).
 
-## 1.9.0 / 2019-08-24 / Agent 6.14.0
+## 1.9.0 / 2019-08-24
 
 * [Added] Add mem_limit to RabbitMQ Checks. See [#4250](https://github.com/DataDog/integrations-core/pull/4250). Thanks [ParthKolekar](https://github.com/ParthKolekar).
 * [Added] Add requests wrapper to RabbitMQ. See [#4257](https://github.com/DataDog/integrations-core/pull/4257).
@@ -60,18 +60,18 @@
 * [Fixed] Fix default log path. See [#3611](https://github.com/DataDog/integrations-core/pull/3611).
 * [Added] Adhere to code style. See [#3561](https://github.com/DataDog/integrations-core/pull/3561).
 
-## 1.7.0 / 2019-01-04 / Agent 5.31.0
+## 1.7.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2791][1].
 * [Fixed] adds ignore_ssl_warning to rabbit file. See [#2706][2].
 
-## 1.6.0 / 2018-11-30 / Agent 5.30.0
+## 1.6.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Option to ignore SSL warnings. See [#2472][3]. Thanks [tebriel][4].
 * [Fixed] Use raw string literals when \ is present. See [#2465][5].
 * [Added] Add cluster wide metrics. See [#2449][6].
 
-## 1.5.2 / 2018-09-04 / Agent 5.28.0
+## 1.5.2 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][7].
 

--- a/redisdb/CHANGELOG.md
+++ b/redisdb/CHANGELOG.md
@@ -1,100 +1,100 @@
 # CHANGELOG - redisdb
 
-## 3.1.0 / 2020-08-10
+## 3.1.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add auto_conf.yaml spec for redisdb. See [#7161](https://github.com/DataDog/integrations-core/pull/7161).
 * [Added] Add redis config spec. See [#7091](https://github.com/DataDog/integrations-core/pull/7091).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] Refactor instance argument. See [#7018](https://github.com/DataDog/integrations-core/pull/7018).
 
-## 3.0.0 / 2020-06-29
+## 3.0.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Upgrade redis dependency to support `username` in connection strings. See [#6708](https://github.com/DataDog/integrations-core/pull/6708).
 * [Fixed] Add flag to enable CLIENT command metrics. See [#6877](https://github.com/DataDog/integrations-core/pull/6877).
 * [Changed] Collect port and host from same source in _generate_instance_key. See [#6680](https://github.com/DataDog/integrations-core/pull/6680).
 
-## 2.1.1 / 2020-06-11
+## 2.1.1 / 2020-06-11 / Agent 7.20.2
 
 * [Fixed] Add flag to enable CLIENT command metrics. See [#6877](https://github.com/DataDog/integrations-core/pull/6877).
 
-## 2.1.0 / 2020-05-17
+## 2.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add 'redis.net.connections' metric to count connections by client. See [#6495](https://github.com/DataDog/integrations-core/pull/6495). Thanks [remicalixte](https://github.com/remicalixte).
 * [Fixed] Reduce slow-log log message. See [#6631](https://github.com/DataDog/integrations-core/pull/6631).
 * [Fixed] Use agent 6 signature. See [#6424](https://github.com/DataDog/integrations-core/pull/6424).
 
-## 2.0.2 / 2020-04-04
+## 2.0.2 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 2.0.1 / 2020-02-10
+## 2.0.1 / 2020-02-10 / Agent 7.18.0
 
 * [Fixed] Handle error in config_get. See [#5676](https://github.com/DataDog/integrations-core/pull/5676).
 
-## 2.0.0 / 2020-02-05
+## 2.0.0 / 2020-02-05 / Agent 7.18.0
 
 * [Changed] Submit `redis.key.length` metric regardless of `warn_on_missing_keys`. See [#5591](https://github.com/DataDog/integrations-core/pull/5591).
 * [Added] Add aof loading metrics. See [#5431](https://github.com/DataDog/integrations-core/pull/5431). Thanks [tanner-bruce](https://github.com/tanner-bruce).
 
-## 1.15.0 / 2020-01-13
+## 1.15.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Added] Upgrade `redis` to 3.3.11. See [#5150](https://github.com/DataDog/integrations-core/pull/5150).
 * [Added] Report maxclients. See [#5207](https://github.com/DataDog/integrations-core/pull/5207). Thanks [jd](https://github.com/jd).
 
-## 1.14.0 / 2019-12-02
+## 1.14.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add active defragmentation gauges. See [#5022](https://github.com/DataDog/integrations-core/pull/5022).
 * [Fixed] Fix example keys config. See [#4939](https://github.com/DataDog/integrations-core/pull/4939). Thanks [sileht](https://github.com/sileht).
 * [Added] Use a stub class for metadata testing. See [#4919](https://github.com/DataDog/integrations-core/pull/4919).
 
-## 1.13.0 / 2019-10-11
+## 1.13.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Submit version metadata. See [#4705](https://github.com/DataDog/integrations-core/pull/4705).
 
-## 1.12.2 / 2019-10-04
+## 1.12.2 / 2019-10-04 / Agent 6.15.0
 
 * [Fixed] Don't display warning for default keys value. See [#4641](https://github.com/DataDog/integrations-core/pull/4641).
 
-## 1.12.1 / 2019-08-24
+## 1.12.1 / 2019-08-24 / Agent 6.14.0
 
 * [Fixed] Always publish a value for missing keys. See [#4386](https://github.com/DataDog/integrations-core/pull/4386).
 
-## 1.12.0 / 2019-06-01
+## 1.12.0 / 2019-06-01 / Agent 6.12.0
 
 * [Added] Add redis.mem.overhead and redis.mem.startup. See [#3760](https://github.com/DataDog/integrations-core/pull/3760). Thanks [maximebedard](https://github.com/maximebedard).
 
-## 1.11.0 / 2019-05-14
+## 1.11.0 / 2019-05-14 / Agent 6.12.0
 
 * [Fixed] Adjust latency tracking in redisdb integration. See [#3689](https://github.com/DataDog/integrations-core/pull/3689). Thanks [Firehed](https://github.com/Firehed).
 * [Added] Adhere to code style. See [#3562](https://github.com/DataDog/integrations-core/pull/3562).
 
-## 1.10.0 / 2019-02-18
+## 1.10.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Add redis_db tag to redis.key.length. See [#3008](https://github.com/DataDog/integrations-core/pull/3008).
 
-## 1.9.0 / 2019-01-22
+## 1.9.0 / 2019-01-22 / Agent 5.32.0
 
 * [Fixed] Only try to decode slowlog command entrypoint. See [#2998][1].
 * [Added] Finish Python 3 Support. See [#2951][2].
 
-## 1.8.0 / 2018-11-30
+## 1.8.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Support Python 3. See [#2422][3].
 
-## 1.7.1 / 2018-10-12
+## 1.7.1 / 2018-10-12 / Agent 5.28.0
 
 * [Fixed] Handle `host:` command when parsing commandstats output. See [#2356][4].
 * [Fixed] Fix multiple db key length. See [#2187][5].
 
-## 1.7.0 / 2018-09-04
+## 1.7.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Support finding key lengths on any db. See [#1948][6].
 * [Fixed] Add data files to the wheel package. See [#1727][7].
 
-## 1.6.0 / 2018-06-06
+## 1.6.0 / 2018-06-06 / Agent 5.25.0
 
 * [Added] Add a config option to disable connection cache. See [#1668][8].
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][9].

--- a/redisdb/CHANGELOG.md
+++ b/redisdb/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 * [Fixed] Handle error in config_get. See [#5676](https://github.com/DataDog/integrations-core/pull/5676).
 
-## 2.0.0 / 2020-02-05 / Agent 7.18.0
+## 2.0.0 / 2020-02-05
 
 * [Changed] Submit `redis.key.length` metric regardless of `warn_on_missing_keys`. See [#5591](https://github.com/DataDog/integrations-core/pull/5591).
 * [Added] Add aof loading metrics. See [#5431](https://github.com/DataDog/integrations-core/pull/5431). Thanks [tanner-bruce](https://github.com/tanner-bruce).
@@ -54,7 +54,7 @@
 
 * [Added] Submit version metadata. See [#4705](https://github.com/DataDog/integrations-core/pull/4705).
 
-## 1.12.2 / 2019-10-04 / Agent 6.15.0
+## 1.12.2 / 2019-10-04
 
 * [Fixed] Don't display warning for default keys value. See [#4641](https://github.com/DataDog/integrations-core/pull/4641).
 
@@ -66,35 +66,35 @@
 
 * [Added] Add redis.mem.overhead and redis.mem.startup. See [#3760](https://github.com/DataDog/integrations-core/pull/3760). Thanks [maximebedard](https://github.com/maximebedard).
 
-## 1.11.0 / 2019-05-14 / Agent 6.12.0
+## 1.11.0 / 2019-05-14
 
 * [Fixed] Adjust latency tracking in redisdb integration. See [#3689](https://github.com/DataDog/integrations-core/pull/3689). Thanks [Firehed](https://github.com/Firehed).
 * [Added] Adhere to code style. See [#3562](https://github.com/DataDog/integrations-core/pull/3562).
 
-## 1.10.0 / 2019-02-18 / Agent 6.11.0
+## 1.10.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Add redis_db tag to redis.key.length. See [#3008](https://github.com/DataDog/integrations-core/pull/3008).
 
-## 1.9.0 / 2019-01-22 / Agent 5.32.0
+## 1.9.0 / 2019-01-22 / Agent 6.9.0
 
 * [Fixed] Only try to decode slowlog command entrypoint. See [#2998][1].
 * [Added] Finish Python 3 Support. See [#2951][2].
 
-## 1.8.0 / 2018-11-30 / Agent 5.30.0
+## 1.8.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Support Python 3. See [#2422][3].
 
-## 1.7.1 / 2018-10-12 / Agent 5.28.0
+## 1.7.1 / 2018-10-12 / Agent 6.6.0
 
 * [Fixed] Handle `host:` command when parsing commandstats output. See [#2356][4].
 * [Fixed] Fix multiple db key length. See [#2187][5].
 
-## 1.7.0 / 2018-09-04 / Agent 5.28.0
+## 1.7.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Support finding key lengths on any db. See [#1948][6].
 * [Fixed] Add data files to the wheel package. See [#1727][7].
 
-## 1.6.0 / 2018-06-06 / Agent 5.25.0
+## 1.6.0 / 2018-06-06
 
 * [Added] Add a config option to disable connection cache. See [#1668][8].
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][9].

--- a/rethinkdb/CHANGELOG.md
+++ b/rethinkdb/CHANGELOG.md
@@ -1,23 +1,23 @@
 # CHANGELOG - RethinkDB
 
-## 1.2.1 / 2020-08-10
+## 1.2.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 1.2.0 / 2020-06-29
+## 1.2.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add an out-of-the-box dashboard for RethinkDB. See [#6837](https://github.com/DataDog/integrations-core/pull/6837). Thanks [ptgott](https://github.com/ptgott).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.1.0 / 2020-05-17
+## 1.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.0.1 / 2020-04-09
+## 1.0.1 / 2020-04-09 / Agent 7.20.0
 
 * [Fixed] Submit server tags with a namespace. See [#6295](https://github.com/DataDog/integrations-core/pull/6295).
 
-## 1.0.0 / 2020-04-03
+## 1.0.0 / 2020-04-03 / Agent 7.19.0
 
 * [Added] Add RethinkDB integration. See [#5715](https://github.com/DataDog/integrations-core/pull/5715).
 

--- a/rethinkdb/CHANGELOG.md
+++ b/rethinkdb/CHANGELOG.md
@@ -13,11 +13,11 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.0.1 / 2020-04-09 / Agent 7.20.0
+## 1.0.1 / 2020-04-09 / Agent 7.19.0
 
 * [Fixed] Submit server tags with a namespace. See [#6295](https://github.com/DataDog/integrations-core/pull/6295).
 
-## 1.0.0 / 2020-04-03 / Agent 7.19.0
+## 1.0.0 / 2020-04-03
 
 * [Added] Add RethinkDB integration. See [#5715](https://github.com/DataDog/integrations-core/pull/5715).
 

--- a/riak/CHANGELOG.md
+++ b/riak/CHANGELOG.md
@@ -6,11 +6,11 @@
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Changed] Use requests wrapper and remove httplib2 dependency. See [#7247](https://github.com/DataDog/integrations-core/pull/7247).
 
-## 1.9.0 / 2020-05-20 / Agent 7.21.0
+## 1.9.0 / 2020-05-20 / Agent 7.20.0
 
 * [Added] Upgrade httplib2 to 0.18.1. See [#6702](https://github.com/DataDog/integrations-core/pull/6702).
 
-## 1.8.0 / 2020-05-17 / Agent 7.20.0
+## 1.8.0 / 2020-05-17
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Use Agent 6 signature. See [#6448](https://github.com/DataDog/integrations-core/pull/6448).
@@ -32,15 +32,15 @@
 
 * [Added] Adhere to code style. See [#3563](https://github.com/DataDog/integrations-core/pull/3563).
 
-## 1.4.0 / 2019-01-04 / Agent 5.31.0
+## 1.4.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2774][1].
 
-## 1.3.1 / 2018-09-04 / Agent 5.28.0
+## 1.3.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.3.0 / 2018-06-07 / Agent 5.25.0
+## 1.3.0 / 2018-06-07
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][3].
 

--- a/riak/CHANGELOG.md
+++ b/riak/CHANGELOG.md
@@ -1,46 +1,46 @@
 # CHANGELOG - riak
 
-## 2.0.0 / 2020-08-10
+## 2.0.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add config specs. See [#7068](https://github.com/DataDog/integrations-core/pull/7068).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Changed] Use requests wrapper and remove httplib2 dependency. See [#7247](https://github.com/DataDog/integrations-core/pull/7247).
 
-## 1.9.0 / 2020-05-20
+## 1.9.0 / 2020-05-20 / Agent 7.21.0
 
 * [Added] Upgrade httplib2 to 0.18.1. See [#6702](https://github.com/DataDog/integrations-core/pull/6702).
 
-## 1.8.0 / 2020-05-17
+## 1.8.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Use Agent 6 signature. See [#6448](https://github.com/DataDog/integrations-core/pull/6448).
 
-## 1.7.1 / 2020-04-04
+## 1.7.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.7.0 / 2020-01-13
+## 1.7.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 
-## 1.6.0 / 2019-07-12
+## 1.6.0 / 2019-07-12 / Agent 6.13.0
 
 * [Added] Add logs section. See [#3995](https://github.com/DataDog/integrations-core/pull/3995).
 
-## 1.5.0 / 2019-05-14
+## 1.5.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3563](https://github.com/DataDog/integrations-core/pull/3563).
 
-## 1.4.0 / 2019-01-04
+## 1.4.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2774][1].
 
-## 1.3.1 / 2018-09-04
+## 1.3.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.3.0 / 2018-06-07
+## 1.3.0 / 2018-06-07 / Agent 5.25.0
 
 * [Added] Package `auto_conf.yaml` for appropriate integrations. See [#1664][3].
 

--- a/riakcs/CHANGELOG.md
+++ b/riakcs/CHANGELOG.md
@@ -1,30 +1,30 @@
 # CHANGELOG - riakcs
 
-## 2.3.0 / 2020-05-17
+## 2.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.2.1 / 2020-04-04
+## 2.2.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 2.2.0 / 2020-01-13
+## 2.2.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 
-## 2.1.0 / 2019-05-14
+## 2.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3564](https://github.com/DataDog/integrations-core/pull/3564).
 
-## 2.0.0 / 2019-02-18
+## 2.0.0 / 2019-02-18 / Agent 6.11.0
 
 * [Changed] Fix riakcs dependencies. See [#3033](https://github.com/DataDog/integrations-core/pull/3033).
 
-## 1.2.0 / 2019-01-04
+## 1.2.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2780][1].
 
-## 1.1.1 / 2018-09-04
+## 1.1.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Move RiakCS to pytest, fixes duped tags in RiakCS, adds google_cloud_engine pip dep. See [#2081][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].

--- a/riakcs/CHANGELOG.md
+++ b/riakcs/CHANGELOG.md
@@ -16,15 +16,15 @@
 
 * [Added] Adhere to code style. See [#3564](https://github.com/DataDog/integrations-core/pull/3564).
 
-## 2.0.0 / 2019-02-18 / Agent 6.11.0
+## 2.0.0 / 2019-02-18 / Agent 6.10.0
 
 * [Changed] Fix riakcs dependencies. See [#3033](https://github.com/DataDog/integrations-core/pull/3033).
 
-## 1.2.0 / 2019-01-04 / Agent 5.31.0
+## 1.2.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2780][1].
 
-## 1.1.1 / 2018-09-04 / Agent 5.28.0
+## 1.1.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Move RiakCS to pytest, fixes duped tags in RiakCS, adds google_cloud_engine pip dep. See [#2081][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].

--- a/sap_hana/CHANGELOG.md
+++ b/sap_hana/CHANGELOG.md
@@ -1,14 +1,14 @@
 # CHANGELOG - SAP HANA
 
-## 1.2.0 / 2020-05-17
+## 1.2.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.1.0 / 2020-01-13
+## 1.1.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.0.0 / 2019-11-11
+## 1.0.0 / 2019-11-11 / Agent 7.16.0
 
 * [Added] Add SAP HANA integration. See [#4502](https://github.com/DataDog/integrations-core/pull/4502).
 

--- a/sap_hana/CHANGELOG.md
+++ b/sap_hana/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.0.0 / 2019-11-11 / Agent 7.16.0
+## 1.0.0 / 2019-11-11 / Agent 7.16.1
 
 * [Added] Add SAP HANA integration. See [#4502](https://github.com/DataDog/integrations-core/pull/4502).
 

--- a/scylla/CHANGELOG.md
+++ b/scylla/CHANGELOG.md
@@ -1,26 +1,26 @@
 # CHANGELOG - Scylla
 
-## 1.2.0 / 2020-06-29
+## 1.2.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.1.0 / 2020-05-17
+## 1.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.0.3 / 2020-04-04
+## 1.0.3 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.0.2 / 2020-02-26
+## 1.0.2 / 2020-02-26 / Agent 7.19.0
 
 * [Fixed] Fix discrepancies in `batchlog_manager`, `execution_stages`, `io_queue` and `query_processor` metric group names. See [#5885](https://github.com/DataDog/integrations-core/pull/5885).
 
-## 1.0.1 / 2020-02-25
+## 1.0.1 / 2020-02-25 / Agent 7.19.0
 
 * [Fixed] Fix typo in explicit send_histograms_buckets option. See [#5867](https://github.com/DataDog/integrations-core/pull/5867).
 
-## 1.0.0 / 2020-02-21
+## 1.0.0 / 2020-02-21 / Agent 7.18.0
 
 * [Added] Scylla new integration. See [#5440](https://github.com/DataDog/integrations-core/pull/5440).
 

--- a/scylla/CHANGELOG.md
+++ b/scylla/CHANGELOG.md
@@ -12,15 +12,15 @@
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.0.2 / 2020-02-26 / Agent 7.19.0
+## 1.0.2 / 2020-02-26 / Agent 7.18.0
 
 * [Fixed] Fix discrepancies in `batchlog_manager`, `execution_stages`, `io_queue` and `query_processor` metric group names. See [#5885](https://github.com/DataDog/integrations-core/pull/5885).
 
-## 1.0.1 / 2020-02-25 / Agent 7.19.0
+## 1.0.1 / 2020-02-25
 
 * [Fixed] Fix typo in explicit send_histograms_buckets option. See [#5867](https://github.com/DataDog/integrations-core/pull/5867).
 
-## 1.0.0 / 2020-02-21 / Agent 7.18.0
+## 1.0.0 / 2020-02-21
 
 * [Added] Scylla new integration. See [#5440](https://github.com/DataDog/integrations-core/pull/5440).
 

--- a/sidekiq/CHANGELOG.md
+++ b/sidekiq/CHANGELOG.md
@@ -1,18 +1,18 @@
 # CHANGELOG - Sidekiq
 
-## 1.1.2 / 2020-08-10
+## 1.1.2 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 1.1.1 / 2020-06-29
+## 1.1.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.1.0 / 2020-05-17
+## 1.1.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.0.0 / 2020-04-03
+## 1.0.0 / 2020-04-03 / Agent 7.19.0
 
 * [Added] Add sidekiq tile. See [#6098](https://github.com/DataDog/integrations-core/pull/6098).
 

--- a/snmp/CHANGELOG.md
+++ b/snmp/CHANGELOG.md
@@ -6,12 +6,12 @@
 * [Fixed] Validate SNMP profile hierarchy. See [#6798](https://github.com/DataDog/integrations-core/pull/6798).
 * [Fixed] Fix style for the latest release of Black. See [#7438](https://github.com/DataDog/integrations-core/pull/7438).
 
-## 3.7.1 / 2020-08-12
+## 3.7.1 / 2020-08-12 / Agent 7.22.0
 
 * [Fixed] Fix apc ups profile. See [#7351](https://github.com/DataDog/integrations-core/pull/7351).
 * [Fixed] Revert Fix wrong indentation of `table` key in column metric tags #7024. See [#7349](https://github.com/DataDog/integrations-core/pull/7349).
 
-## 3.7.0 / 2020-08-03 / Agent 7.22.0
+## 3.7.0 / 2020-08-03
 
 * [Added] Add OID caching. See [#7231](https://github.com/DataDog/integrations-core/pull/7231).
 * [Fixed] Refactor how OIDs are managed. See [#7230](https://github.com/DataDog/integrations-core/pull/7230).
@@ -19,7 +19,7 @@
 * [Fixed] Rename all_oids to scalar_oids. See [#7229](https://github.com/DataDog/integrations-core/pull/7229).
 * [Fixed] Better logging for submit_metric. See [#7188](https://github.com/DataDog/integrations-core/pull/7188).
 
-## 3.6.0 / 2020-07-24 / Agent 7.22.0
+## 3.6.0 / 2020-07-24
 
 * [Added] Check tag for table metric. See [#6933](https://github.com/DataDog/integrations-core/pull/6933).
 * [Added] Add new `flag_stream` type. See [#7072](https://github.com/DataDog/integrations-core/pull/7072).
@@ -30,19 +30,19 @@
 * [Fixed] Use OID instead of MIB for sysName. See [#7104](https://github.com/DataDog/integrations-core/pull/7104).
 * [Fixed] Submit additional rate metrics in fortigate profile. See [#7058](https://github.com/DataDog/integrations-core/pull/7058).
 
-## 3.5.3 / 2020-07-01 / Agent 7.22.0
+## 3.5.3 / 2020-07-01 / Agent 7.21.0
 
 * [Fixed] Fix autodiscovery_subnet var in auto_conf.yaml. See [#7029](https://github.com/DataDog/integrations-core/pull/7029).
 
-## 3.5.2 / 2020-06-30 / Agent 7.22.0
+## 3.5.2 / 2020-06-30
 
 * [Fixed] Fix tag names for cisco asa profile. See [#7027](https://github.com/DataDog/integrations-core/pull/7027).
 
-## 3.5.1 / 2020-06-30 / Agent 7.22.0
+## 3.5.1 / 2020-06-30
 
 * [Fixed] Fix wrong indentation of `table` key in column metric tags. See [#7024](https://github.com/DataDog/integrations-core/pull/7024).
 
-## 3.5.0 / 2020-06-29 / Agent 7.21.0
+## 3.5.0 / 2020-06-29
 
 * [Added] Add regex match support for Tables. See [#6951](https://github.com/DataDog/integrations-core/pull/6951).
 * [Added] Add snmp.devices_monitored metric. See [#6941](https://github.com/DataDog/integrations-core/pull/6941).
@@ -53,12 +53,12 @@
 * [Fixed] [Refactor] Clean up batching implementation. See [#6952](https://github.com/DataDog/integrations-core/pull/6952).
 * [Fixed] Add index tagging to cfwConnectionStatValue. See [#6897](https://github.com/DataDog/integrations-core/pull/6897).
 
-## 3.4.0 / 2020-06-11 / Agent 7.21.0
+## 3.4.0 / 2020-06-11
 
 * [Added] Add NetApp profile. See [#6841](https://github.com/DataDog/integrations-core/pull/6841).
 * [Fixed] Fix `instance_number` tag on Cisco voice router metrics. See [#6867](https://github.com/DataDog/integrations-core/pull/6867).
 
-## 3.3.0 / 2020-06-10 / Agent 7.21.0
+## 3.3.0 / 2020-06-10
 
 * [Added] Add Fortinet FortiGate profile. See [#6504](https://github.com/DataDog/integrations-core/pull/6504). Thanks [lindseyferretti](https://github.com/lindseyferretti).
 * [Added] Reuse MIB builder objects per SNMP engine. See [#6716](https://github.com/DataDog/integrations-core/pull/6716).
@@ -74,21 +74,21 @@
 * [Fixed] Remove iDRAC/poweredge profile inheritance. See [#6754](https://github.com/DataDog/integrations-core/pull/6754).
 * [Fixed] Make profiles compatible with previous parsing. See [#6750](https://github.com/DataDog/integrations-core/pull/6750).
 
-## 3.2.2 / 2020-05-21 / Agent 7.21.0
+## 3.2.2 / 2020-05-21 / Agent 7.20.0
 
 * [Fixed] Fix error handling in getnext. See [#6701](https://github.com/DataDog/integrations-core/pull/6701).
 
-## 3.2.1 / 2020-05-19 / Agent 7.21.0
+## 3.2.1 / 2020-05-19
 
 * [Fixed] Add missing auto_conf. See [#6687](https://github.com/DataDog/integrations-core/pull/6687).
 
-## 3.2.0 / 2020-05-17 / Agent 7.20.0
+## 3.2.0 / 2020-05-17
 
 * [Added] Add diskStatus tag to Isilon profile. See [#6660](https://github.com/DataDog/integrations-core/pull/6660).
 * [Added] Add BPG metrics to more profiles. See [#6655](https://github.com/DataDog/integrations-core/pull/6655).
 * [Added] Add voice metrics and profiles. See [#6629](https://github.com/DataDog/integrations-core/pull/6629).
 
-## 3.1.0 / 2020-05-14 / Agent 7.20.0
+## 3.1.0 / 2020-05-14
 
 * [Added] Add `chatsworth` legacy metrics. See [#6624](https://github.com/DataDog/integrations-core/pull/6624).
 * [Added] Add ifHighSpeed. See [#6602](https://github.com/DataDog/integrations-core/pull/6602).
@@ -98,7 +98,7 @@
 * [Fixed] Don't use ifDescr for metric tagging. See [#6601](https://github.com/DataDog/integrations-core/pull/6601).
 * [Fixed] Optimize away useless GET calls. See [#6456](https://github.com/DataDog/integrations-core/pull/6456).
 
-## 3.0.0 / 2020-05-04 / Agent 7.20.0
+## 3.0.0 / 2020-05-04
 
 * [Added] Add base BGP4 and Cisco-CSR1000v profiles. See [#6315](https://github.com/DataDog/integrations-core/pull/6315).
 * [Added] Collect OSPF routing metrics. See [#6554](https://github.com/DataDog/integrations-core/pull/6554).
@@ -133,7 +133,7 @@
 * [Fixed] Only load installed profiles once. See [#6231](https://github.com/DataDog/integrations-core/pull/6231).
 * [Fixed] Fix tag matching documentation. See [#6226](https://github.com/DataDog/integrations-core/pull/6226).
 
-## 2.6.0 / 2020-03-24 / Agent 7.19.0
+## 2.6.0 / 2020-03-24
 
 * [Added] Support regular expressions in dynamic tags. See [#6096](https://github.com/DataDog/integrations-core/pull/6096).
 * [Added] Aruba, Arista and PDU profiles. See [#6002](https://github.com/DataDog/integrations-core/pull/6002).
@@ -154,16 +154,16 @@
 * [Fixed] Add OIDs to router profiles. See [#5991](https://github.com/DataDog/integrations-core/pull/5991).
 * [Fixed] Validate and cast `discovery_interval` to a number. See [#5887](https://github.com/DataDog/integrations-core/pull/5887).
 
-## 2.5.0 / 2020-02-27 / Agent 7.19.0
+## 2.5.0 / 2020-02-27 / Agent 7.18.0
 
 * [Added] Query discovered devices in threads. See [#5462](https://github.com/DataDog/integrations-core/pull/5462).
 * [Fixed] Fix issue with tags leaking between discovered instances. See [#5899](https://github.com/DataDog/integrations-core/pull/5899).
 
-## 2.4.1 / 2020-02-25 / Agent 7.19.0
+## 2.4.1 / 2020-02-25
 
 * [Fixed] Handle case when servers report two values for entries in `metric_tags`. See [#5853](https://github.com/DataDog/integrations-core/pull/5853).
 
-## 2.4.0 / 2020-02-22 / Agent 7.18.0
+## 2.4.0 / 2020-02-22
 
 * [Added] Add extension mechanism for SNMP profiles. See [#5821](https://github.com/DataDog/integrations-core/pull/5821).
 * [Fixed] Switch back to most specific profile matching. See [#5813](https://github.com/DataDog/integrations-core/pull/5813).
@@ -178,15 +178,15 @@
 * [Added] Fetch sysUpTimeInstance automatically. See [#5752](https://github.com/DataDog/integrations-core/pull/5752).
 * [Added] Add Dell Poweredge profile. See [#5723](https://github.com/DataDog/integrations-core/pull/5723).
 
-## 2.3.2 / 2020-01-15 / Agent 7.18.0
+## 2.3.2 / 2020-01-15 / Agent 7.17.0
 
 * [Fixed] Tweak behavior related to discovery. See [#5466](https://github.com/DataDog/integrations-core/pull/5466).
 
-## 2.3.1 / 2020-01-13 / Agent 7.17.0
+## 2.3.1 / 2020-01-13
 
 * [Fixed] Fix usage of old OID list attributes on InstanceConfig. See [#5412](https://github.com/DataDog/integrations-core/pull/5412).
 
-## 2.3.0 / 2020-01-07 / Agent 7.17.0
+## 2.3.0 / 2020-01-07
 
 * [Added] Remove MIB requirement in profiles. See [#5397](https://github.com/DataDog/integrations-core/pull/5397).
 * [Added] Implement table browsing with OIDs. See [#5368](https://github.com/DataDog/integrations-core/pull/5368).
@@ -194,7 +194,7 @@
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Added] Add a profile for Meraki cloud devices. See [#5215](https://github.com/DataDog/integrations-core/pull/5215).
 
-## 2.2.0 / 2020-01-02 / Agent 7.17.0
+## 2.2.0 / 2020-01-02
 
 * [Added] Add profile for Cisco Nexus switches. See [#5363](https://github.com/DataDog/integrations-core/pull/5363).
 * [Added] Add profile for Intel IDRAC devices. See [#5227](https://github.com/DataDog/integrations-core/pull/5227).
@@ -205,11 +205,11 @@
 * [Fixed] Disable MIB autofetch. See [#5094](https://github.com/DataDog/integrations-core/pull/5094).
 * [Added] Add Cisco 3850 profile. See [#5090](https://github.com/DataDog/integrations-core/pull/5090).
 
-## 2.0.1 / 2019-11-21 / Agent 7.16.0
+## 2.0.1 / 2019-11-21
 
 * [Fixed] Handle total_time_to_temporal_percent missing. See [#5055](https://github.com/DataDog/integrations-core/pull/5055).
 
-## 2.0.0 / 2019-11-15 / Agent 7.16.0
+## 2.0.0 / 2019-11-15
 
 * [Added] Add interface statuses to profiles. See [#5004](https://github.com/DataDog/integrations-core/pull/5004).
 * [Added] Ignore metrics that are not retrieved. See [#5003](https://github.com/DataDog/integrations-core/pull/5003).
@@ -219,23 +219,23 @@
 * [Added] Generic network router profile. See [#4937](https://github.com/DataDog/integrations-core/pull/4937).
 * [Added] Allow tagging through different MIBs. See [#4853](https://github.com/DataDog/integrations-core/pull/4853).
 
-## 1.14.1 / 2019-10-16 / Agent 7.16.0
+## 1.14.1 / 2019-10-16 / Agent 6.15.0
 
 * [Fixed] Fix allowed host failure retry logic. See [#4782](https://github.com/DataDog/integrations-core/pull/4782).
 
-## 1.14.0 / 2019-10-14 / Agent 7.16.0
+## 1.14.0 / 2019-10-14
 
 * [Added] Store discovered hosts. See [#4712](https://github.com/DataDog/integrations-core/pull/4712).
 
-## 1.13.0 / 2019-10-11 / Agent 6.15.0
+## 1.13.0 / 2019-10-11
 
 * [Added] Automatically fetch MIBs that we don't know about. See [#4732](https://github.com/DataDog/integrations-core/pull/4732).
 
-## 1.12.0 / 2019-10-10 / Agent 6.15.0
+## 1.12.0 / 2019-10-10
 
 * [Added] Add profile for F5 BIG-IP devices. See [#4674](https://github.com/DataDog/integrations-core/pull/4674).
 
-## 1.11.0 / 2019-09-19 / Agent 6.15.0
+## 1.11.0 / 2019-09-19
 
 * [Fixed] Handle bytes in network_address. See [#4577](https://github.com/DataDog/integrations-core/pull/4577).
 * [Added] Use bulk call when possible. See [#4530](https://github.com/DataDog/integrations-core/pull/4530).
@@ -253,7 +253,7 @@
 
 * [Added] Add support for string types. See [#4087](https://github.com/DataDog/integrations-core/pull/4087).
 
-## 1.8.0 / 2019-07-04 / Agent 6.13.0
+## 1.8.0 / 2019-07-04
 
 * [Added] Match OIDs with leading dots. See [#3854](https://github.com/DataDog/integrations-core/pull/3854).
 
@@ -265,17 +265,17 @@
 
 * [Added] Add metrics config globally. See [#3230](https://github.com/DataDog/integrations-core/pull/3230).
 
-## 1.5.0 / 2019-02-18 / Agent 6.11.0
+## 1.5.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Improve performance by querying only necessary columns from a table. See [#3059](https://github.com/DataDog/integrations-core/pull/3059).
 * [Fixed] Log the correct information about snmpnext result. See [#3021](https://github.com/DataDog/integrations-core/pull/3021).
 * [Added] Support Python 3. See [#3016](https://github.com/DataDog/integrations-core/pull/3016).
 
-## 1.4.2 / 2018-10-12 / Agent 5.28.0
+## 1.4.2 / 2018-10-12 / Agent 6.6.0
 
 * [Fixed] Fix `enforce_mib_constraints` parameter having no effect.. See [#2340][1].
 
-## 1.4.1 / 2018-09-04 / Agent 5.28.0
+## 1.4.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/snmp/CHANGELOG.md
+++ b/snmp/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [Fixed] Fix apc ups profile. See [#7351](https://github.com/DataDog/integrations-core/pull/7351).
 * [Fixed] Revert Fix wrong indentation of `table` key in column metric tags #7024. See [#7349](https://github.com/DataDog/integrations-core/pull/7349).
 
-## 3.7.0 / 2020-08-03
+## 3.7.0 / 2020-08-03 / Agent 7.22.0
 
 * [Added] Add OID caching. See [#7231](https://github.com/DataDog/integrations-core/pull/7231).
 * [Fixed] Refactor how OIDs are managed. See [#7230](https://github.com/DataDog/integrations-core/pull/7230).
@@ -19,7 +19,7 @@
 * [Fixed] Rename all_oids to scalar_oids. See [#7229](https://github.com/DataDog/integrations-core/pull/7229).
 * [Fixed] Better logging for submit_metric. See [#7188](https://github.com/DataDog/integrations-core/pull/7188).
 
-## 3.6.0 / 2020-07-24
+## 3.6.0 / 2020-07-24 / Agent 7.22.0
 
 * [Added] Check tag for table metric. See [#6933](https://github.com/DataDog/integrations-core/pull/6933).
 * [Added] Add new `flag_stream` type. See [#7072](https://github.com/DataDog/integrations-core/pull/7072).
@@ -30,19 +30,19 @@
 * [Fixed] Use OID instead of MIB for sysName. See [#7104](https://github.com/DataDog/integrations-core/pull/7104).
 * [Fixed] Submit additional rate metrics in fortigate profile. See [#7058](https://github.com/DataDog/integrations-core/pull/7058).
 
-## 3.5.3 / 2020-07-01
+## 3.5.3 / 2020-07-01 / Agent 7.22.0
 
 * [Fixed] Fix autodiscovery_subnet var in auto_conf.yaml. See [#7029](https://github.com/DataDog/integrations-core/pull/7029).
 
-## 3.5.2 / 2020-06-30
+## 3.5.2 / 2020-06-30 / Agent 7.22.0
 
 * [Fixed] Fix tag names for cisco asa profile. See [#7027](https://github.com/DataDog/integrations-core/pull/7027).
 
-## 3.5.1 / 2020-06-30
+## 3.5.1 / 2020-06-30 / Agent 7.22.0
 
 * [Fixed] Fix wrong indentation of `table` key in column metric tags. See [#7024](https://github.com/DataDog/integrations-core/pull/7024).
 
-## 3.5.0 / 2020-06-29
+## 3.5.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add regex match support for Tables. See [#6951](https://github.com/DataDog/integrations-core/pull/6951).
 * [Added] Add snmp.devices_monitored metric. See [#6941](https://github.com/DataDog/integrations-core/pull/6941).
@@ -53,12 +53,12 @@
 * [Fixed] [Refactor] Clean up batching implementation. See [#6952](https://github.com/DataDog/integrations-core/pull/6952).
 * [Fixed] Add index tagging to cfwConnectionStatValue. See [#6897](https://github.com/DataDog/integrations-core/pull/6897).
 
-## 3.4.0 / 2020-06-11
+## 3.4.0 / 2020-06-11 / Agent 7.21.0
 
 * [Added] Add NetApp profile. See [#6841](https://github.com/DataDog/integrations-core/pull/6841).
 * [Fixed] Fix `instance_number` tag on Cisco voice router metrics. See [#6867](https://github.com/DataDog/integrations-core/pull/6867).
 
-## 3.3.0 / 2020-06-10
+## 3.3.0 / 2020-06-10 / Agent 7.21.0
 
 * [Added] Add Fortinet FortiGate profile. See [#6504](https://github.com/DataDog/integrations-core/pull/6504). Thanks [lindseyferretti](https://github.com/lindseyferretti).
 * [Added] Reuse MIB builder objects per SNMP engine. See [#6716](https://github.com/DataDog/integrations-core/pull/6716).
@@ -74,21 +74,21 @@
 * [Fixed] Remove iDRAC/poweredge profile inheritance. See [#6754](https://github.com/DataDog/integrations-core/pull/6754).
 * [Fixed] Make profiles compatible with previous parsing. See [#6750](https://github.com/DataDog/integrations-core/pull/6750).
 
-## 3.2.2 / 2020-05-21
+## 3.2.2 / 2020-05-21 / Agent 7.21.0
 
 * [Fixed] Fix error handling in getnext. See [#6701](https://github.com/DataDog/integrations-core/pull/6701).
 
-## 3.2.1 / 2020-05-19
+## 3.2.1 / 2020-05-19 / Agent 7.21.0
 
 * [Fixed] Add missing auto_conf. See [#6687](https://github.com/DataDog/integrations-core/pull/6687).
 
-## 3.2.0 / 2020-05-17
+## 3.2.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Add diskStatus tag to Isilon profile. See [#6660](https://github.com/DataDog/integrations-core/pull/6660).
 * [Added] Add BPG metrics to more profiles. See [#6655](https://github.com/DataDog/integrations-core/pull/6655).
 * [Added] Add voice metrics and profiles. See [#6629](https://github.com/DataDog/integrations-core/pull/6629).
 
-## 3.1.0 / 2020-05-14
+## 3.1.0 / 2020-05-14 / Agent 7.20.0
 
 * [Added] Add `chatsworth` legacy metrics. See [#6624](https://github.com/DataDog/integrations-core/pull/6624).
 * [Added] Add ifHighSpeed. See [#6602](https://github.com/DataDog/integrations-core/pull/6602).
@@ -98,7 +98,7 @@
 * [Fixed] Don't use ifDescr for metric tagging. See [#6601](https://github.com/DataDog/integrations-core/pull/6601).
 * [Fixed] Optimize away useless GET calls. See [#6456](https://github.com/DataDog/integrations-core/pull/6456).
 
-## 3.0.0 / 2020-05-04
+## 3.0.0 / 2020-05-04 / Agent 7.20.0
 
 * [Added] Add base BGP4 and Cisco-CSR1000v profiles. See [#6315](https://github.com/DataDog/integrations-core/pull/6315).
 * [Added] Collect OSPF routing metrics. See [#6554](https://github.com/DataDog/integrations-core/pull/6554).
@@ -126,14 +126,14 @@
 * [Fixed] Fix misleading `metric_tags` naming on `ParsedMetric`. See [#6387](https://github.com/DataDog/integrations-core/pull/6387).
 * [Changed] Throw error if two profiles have the same sysObjectID. See [#6501](https://github.com/DataDog/integrations-core/pull/6501).
 
-## 2.6.1 / 2020-04-04
+## 2.6.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Small profiles cleanups. See [#6233](https://github.com/DataDog/integrations-core/pull/6233).
 * [Fixed] Remove duplicated idrac metrics from poweredge profile. See [#6232](https://github.com/DataDog/integrations-core/pull/6232).
 * [Fixed] Only load installed profiles once. See [#6231](https://github.com/DataDog/integrations-core/pull/6231).
 * [Fixed] Fix tag matching documentation. See [#6226](https://github.com/DataDog/integrations-core/pull/6226).
 
-## 2.6.0 / 2020-03-24
+## 2.6.0 / 2020-03-24 / Agent 7.19.0
 
 * [Added] Support regular expressions in dynamic tags. See [#6096](https://github.com/DataDog/integrations-core/pull/6096).
 * [Added] Aruba, Arista and PDU profiles. See [#6002](https://github.com/DataDog/integrations-core/pull/6002).
@@ -154,16 +154,16 @@
 * [Fixed] Add OIDs to router profiles. See [#5991](https://github.com/DataDog/integrations-core/pull/5991).
 * [Fixed] Validate and cast `discovery_interval` to a number. See [#5887](https://github.com/DataDog/integrations-core/pull/5887).
 
-## 2.5.0 / 2020-02-27
+## 2.5.0 / 2020-02-27 / Agent 7.19.0
 
 * [Added] Query discovered devices in threads. See [#5462](https://github.com/DataDog/integrations-core/pull/5462).
 * [Fixed] Fix issue with tags leaking between discovered instances. See [#5899](https://github.com/DataDog/integrations-core/pull/5899).
 
-## 2.4.1 / 2020-02-25
+## 2.4.1 / 2020-02-25 / Agent 7.19.0
 
 * [Fixed] Handle case when servers report two values for entries in `metric_tags`. See [#5853](https://github.com/DataDog/integrations-core/pull/5853).
 
-## 2.4.0 / 2020-02-22
+## 2.4.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add extension mechanism for SNMP profiles. See [#5821](https://github.com/DataDog/integrations-core/pull/5821).
 * [Fixed] Switch back to most specific profile matching. See [#5813](https://github.com/DataDog/integrations-core/pull/5813).
@@ -178,15 +178,15 @@
 * [Added] Fetch sysUpTimeInstance automatically. See [#5752](https://github.com/DataDog/integrations-core/pull/5752).
 * [Added] Add Dell Poweredge profile. See [#5723](https://github.com/DataDog/integrations-core/pull/5723).
 
-## 2.3.2 / 2020-01-15
+## 2.3.2 / 2020-01-15 / Agent 7.18.0
 
 * [Fixed] Tweak behavior related to discovery. See [#5466](https://github.com/DataDog/integrations-core/pull/5466).
 
-## 2.3.1 / 2020-01-13
+## 2.3.1 / 2020-01-13 / Agent 7.17.0
 
 * [Fixed] Fix usage of old OID list attributes on InstanceConfig. See [#5412](https://github.com/DataDog/integrations-core/pull/5412).
 
-## 2.3.0 / 2020-01-07
+## 2.3.0 / 2020-01-07 / Agent 7.17.0
 
 * [Added] Remove MIB requirement in profiles. See [#5397](https://github.com/DataDog/integrations-core/pull/5397).
 * [Added] Implement table browsing with OIDs. See [#5368](https://github.com/DataDog/integrations-core/pull/5368).
@@ -194,22 +194,22 @@
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Added] Add a profile for Meraki cloud devices. See [#5215](https://github.com/DataDog/integrations-core/pull/5215).
 
-## 2.2.0 / 2020-01-02
+## 2.2.0 / 2020-01-02 / Agent 7.17.0
 
 * [Added] Add profile for Cisco Nexus switches. See [#5363](https://github.com/DataDog/integrations-core/pull/5363).
 * [Added] Add profile for Intel IDRAC devices. See [#5227](https://github.com/DataDog/integrations-core/pull/5227).
 * [Fixed] Fetch table OIDs per table. See [#5192](https://github.com/DataDog/integrations-core/pull/5192).
 
-## 2.1.0 / 2019-11-27
+## 2.1.0 / 2019-11-27 / Agent 7.16.0
 
 * [Fixed] Disable MIB autofetch. See [#5094](https://github.com/DataDog/integrations-core/pull/5094).
 * [Added] Add Cisco 3850 profile. See [#5090](https://github.com/DataDog/integrations-core/pull/5090).
 
-## 2.0.1 / 2019-11-21
+## 2.0.1 / 2019-11-21 / Agent 7.16.0
 
 * [Fixed] Handle total_time_to_temporal_percent missing. See [#5055](https://github.com/DataDog/integrations-core/pull/5055).
 
-## 2.0.0 / 2019-11-15
+## 2.0.0 / 2019-11-15 / Agent 7.16.0
 
 * [Added] Add interface statuses to profiles. See [#5004](https://github.com/DataDog/integrations-core/pull/5004).
 * [Added] Ignore metrics that are not retrieved. See [#5003](https://github.com/DataDog/integrations-core/pull/5003).
@@ -219,23 +219,23 @@
 * [Added] Generic network router profile. See [#4937](https://github.com/DataDog/integrations-core/pull/4937).
 * [Added] Allow tagging through different MIBs. See [#4853](https://github.com/DataDog/integrations-core/pull/4853).
 
-## 1.14.1 / 2019-10-16
+## 1.14.1 / 2019-10-16 / Agent 7.16.0
 
 * [Fixed] Fix allowed host failure retry logic. See [#4782](https://github.com/DataDog/integrations-core/pull/4782).
 
-## 1.14.0 / 2019-10-14
+## 1.14.0 / 2019-10-14 / Agent 7.16.0
 
 * [Added] Store discovered hosts. See [#4712](https://github.com/DataDog/integrations-core/pull/4712).
 
-## 1.13.0 / 2019-10-11
+## 1.13.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Automatically fetch MIBs that we don't know about. See [#4732](https://github.com/DataDog/integrations-core/pull/4732).
 
-## 1.12.0 / 2019-10-10
+## 1.12.0 / 2019-10-10 / Agent 6.15.0
 
 * [Added] Add profile for F5 BIG-IP devices. See [#4674](https://github.com/DataDog/integrations-core/pull/4674).
 
-## 1.11.0 / 2019-09-19
+## 1.11.0 / 2019-09-19 / Agent 6.15.0
 
 * [Fixed] Handle bytes in network_address. See [#4577](https://github.com/DataDog/integrations-core/pull/4577).
 * [Added] Use bulk call when possible. See [#4530](https://github.com/DataDog/integrations-core/pull/4530).
@@ -243,39 +243,39 @@
 * [Added] Basic discovery mechanism and test. See [#4511](https://github.com/DataDog/integrations-core/pull/4511).
 * [Added] Allow autoconfiguration of instances by sysObjectId. See [#4391](https://github.com/DataDog/integrations-core/pull/4391).
 
-## 1.10.0 / 2019-08-24
+## 1.10.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Support referencing metrics by profile. See [#4329](https://github.com/DataDog/integrations-core/pull/4329).
 * [Added] Upgrade pyasn1. See [#4289](https://github.com/DataDog/integrations-core/pull/4289).
 * [Added] Reimplement config load logic. See [#4160](https://github.com/DataDog/integrations-core/pull/4160).
 
-## 1.9.0 / 2019-07-13
+## 1.9.0 / 2019-07-13 / Agent 6.13.0
 
 * [Added] Add support for string types. See [#4087](https://github.com/DataDog/integrations-core/pull/4087).
 
-## 1.8.0 / 2019-07-04
+## 1.8.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Match OIDs with leading dots. See [#3854](https://github.com/DataDog/integrations-core/pull/3854).
 
-## 1.7.0 / 2019-05-14
+## 1.7.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3565](https://github.com/DataDog/integrations-core/pull/3565).
 
-## 1.6.0 / 2019-03-29
+## 1.6.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Add metrics config globally. See [#3230](https://github.com/DataDog/integrations-core/pull/3230).
 
-## 1.5.0 / 2019-02-18
+## 1.5.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Improve performance by querying only necessary columns from a table. See [#3059](https://github.com/DataDog/integrations-core/pull/3059).
 * [Fixed] Log the correct information about snmpnext result. See [#3021](https://github.com/DataDog/integrations-core/pull/3021).
 * [Added] Support Python 3. See [#3016](https://github.com/DataDog/integrations-core/pull/3016).
 
-## 1.4.2 / 2018-10-12
+## 1.4.2 / 2018-10-12 / Agent 5.28.0
 
 * [Fixed] Fix `enforce_mib_constraints` parameter having no effect.. See [#2340][1].
 
-## 1.4.1 / 2018-09-04
+## 1.4.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/solr/CHANGELOG.md
+++ b/solr/CHANGELOG.md
@@ -17,16 +17,16 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.3.0 / 2020-04-28 / Agent 7.20.0
+## 1.3.0 / 2020-04-28
 
 * [Added] Update metrics and use config spec. See [#6496](https://github.com/DataDog/integrations-core/pull/6496).
 
-## 1.2.0 / 2018-10-12 / Agent 5.28.0
+## 1.2.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] [jmx] add rmi registry ssl config option. See [#2371][1].
 * [Fixed] Fix Solr file indenting. See [#2189][2].
 
-## 1.1.0 / 2018-09-04 / Agent 5.28.0
+## 1.1.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Add metrics for Solr 7. See [#2042][3].
 * [Fixed] Add data files to the wheel package. See [#1727][4].

--- a/solr/CHANGELOG.md
+++ b/solr/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG - solr
 
-## 1.5.0 / 2020-08-10
+## 1.5.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Convert jmx to in-app types for replay_check_run. See [#7275](https://github.com/DataDog/integrations-core/pull/7275).
 * [Added] Add documentation for solr logs. See [#7162](https://github.com/DataDog/integrations-core/pull/7162).
@@ -8,25 +8,25 @@
 * [Fixed] Add domain to metrics.yaml. See [#7164](https://github.com/DataDog/integrations-core/pull/7164).
 * [Fixed] Add new_gc_metrics to all jmx integrations. See [#7073](https://github.com/DataDog/integrations-core/pull/7073).
 
-## 1.4.1 / 2020-06-29
+## 1.4.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Assert new jvm metrics. See [#6996](https://github.com/DataDog/integrations-core/pull/6996).
 * [Fixed] Adjust jmxfetch config. See [#6864](https://github.com/DataDog/integrations-core/pull/6864).
 
-## 1.4.0 / 2020-05-17
+## 1.4.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.3.0 / 2020-04-28
+## 1.3.0 / 2020-04-28 / Agent 7.20.0
 
 * [Added] Update metrics and use config spec. See [#6496](https://github.com/DataDog/integrations-core/pull/6496).
 
-## 1.2.0 / 2018-10-12
+## 1.2.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] [jmx] add rmi registry ssl config option. See [#2371][1].
 * [Fixed] Fix Solr file indenting. See [#2189][2].
 
-## 1.1.0 / 2018-09-04
+## 1.1.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Add metrics for Solr 7. See [#2042][3].
 * [Fixed] Add data files to the wheel package. See [#1727][4].

--- a/spark/CHANGELOG.md
+++ b/spark/CHANGELOG.md
@@ -6,82 +6,82 @@
 * [Added] Add RequestsWrapper option to support UTF-8 for basic auth. See [#7441](https://github.com/DataDog/integrations-core/pull/7441).
 * [Fixed] Update proxy section in conf.yaml. See [#7336](https://github.com/DataDog/integrations-core/pull/7336).
 
-## 1.14.0 / 2020-08-10
+## 1.14.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add documentation for spark logs. See [#7109](https://github.com/DataDog/integrations-core/pull/7109).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.13.0 / 2020-06-29
+## 1.13.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Added] Add config specs. See [#6921](https://github.com/DataDog/integrations-core/pull/6921).
 
-## 1.12.0 / 2020-05-17
+## 1.12.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.11.4 / 2020-02-22
+## 1.11.4 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Update documentation in example config. See [#5508](https://github.com/DataDog/integrations-core/pull/5508).
 
-## 1.11.3 / 2020-01-30
+## 1.11.3 / 2020-01-30 / Agent 7.18.0
 
 * [Fixed] Handle warning message from proxy. See [#5525](https://github.com/DataDog/integrations-core/pull/5525).
 
-## 1.11.2 / 2020-01-29
+## 1.11.2 / 2020-01-29 / Agent 7.18.0
 
 * [Fixed] Prevent crash when a single app fails. See [#5552](https://github.com/DataDog/integrations-core/pull/5552).
 
-## 1.11.1 / 2020-01-15
+## 1.11.1 / 2020-01-15 / Agent 7.18.0
 
 * [Fixed] Make sure version collection fails gracefully. See [#5465](https://github.com/DataDog/integrations-core/pull/5465).
 
-## 1.11.0 / 2020-01-13
+## 1.11.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Added] Collect version metadata. See [#5032](https://github.com/DataDog/integrations-core/pull/5032).
 
-## 1.10.1 / 2019-12-06
+## 1.10.1 / 2019-12-06 / Agent 7.17.0
 
 * [Fixed] Remove reference to Kubernetes in the service check message for `spark_driver_mode`. See [#5159](https://github.com/DataDog/integrations-core/pull/5159).
 
-## 1.10.0 / 2019-12-02
+## 1.10.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add Spark driver support. See [#4631](https://github.com/DataDog/integrations-core/pull/4631). Thanks [mrmuggymuggy](https://github.com/mrmuggymuggy).
 
-## 1.9.0 / 2019-10-11
+## 1.9.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.8.1 / 2019-07-18
+## 1.8.1 / 2019-07-18 / Agent 6.13.0
 
 * [Fixed] Remove unused configs and code for spark check. See [#4133](https://github.com/DataDog/integrations-core/pull/4133).
 
-## 1.8.0 / 2019-07-09
+## 1.8.0 / 2019-07-09 / Agent 6.13.0
 
 * [Added] Use the new RequestsWrapper for connecting to services. See [#4058](https://github.com/DataDog/integrations-core/pull/4058).
 
-## 1.7.0 / 2019-05-14
+## 1.7.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3566](https://github.com/DataDog/integrations-core/pull/3566).
 
-## 1.6.0 / 2019-01-08
+## 1.6.0 / 2019-01-08 / Agent 6.11.0
 
 * [Added] Allow disabling of streaming metrics. See [#2889][1].
 * [Added] Support Kerberos auth. See [#2825][2].
 
-## 1.5.0 / 2018-12-20
+## 1.5.0 / 2018-12-20 / Agent 5.31.0
 
 * [Added] Add streaming statistics metrics to the spark integration. See [#2437][3].
 
-## 1.4.1 / 2018-09-04
+## 1.4.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 
-## 1.4.0 / 2018-06-07
+## 1.4.0 / 2018-06-07 / Agent 5.25.0
 
 * [Added] Add support for HTTP authentication. See [#1680][5].
 

--- a/spark/CHANGELOG.md
+++ b/spark/CHANGELOG.md
@@ -26,29 +26,29 @@
 
 * [Fixed] Update documentation in example config. See [#5508](https://github.com/DataDog/integrations-core/pull/5508).
 
-## 1.11.3 / 2020-01-30 / Agent 7.18.0
+## 1.11.3 / 2020-01-30
 
 * [Fixed] Handle warning message from proxy. See [#5525](https://github.com/DataDog/integrations-core/pull/5525).
 
-## 1.11.2 / 2020-01-29 / Agent 7.18.0
+## 1.11.2 / 2020-01-29
 
 * [Fixed] Prevent crash when a single app fails. See [#5552](https://github.com/DataDog/integrations-core/pull/5552).
 
-## 1.11.1 / 2020-01-15 / Agent 7.18.0
+## 1.11.1 / 2020-01-15 / Agent 7.17.0
 
 * [Fixed] Make sure version collection fails gracefully. See [#5465](https://github.com/DataDog/integrations-core/pull/5465).
 
-## 1.11.0 / 2020-01-13 / Agent 7.17.0
+## 1.11.0 / 2020-01-13
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Added] Collect version metadata. See [#5032](https://github.com/DataDog/integrations-core/pull/5032).
 
-## 1.10.1 / 2019-12-06 / Agent 7.17.0
+## 1.10.1 / 2019-12-06 / Agent 7.16.0
 
 * [Fixed] Remove reference to Kubernetes in the service check message for `spark_driver_mode`. See [#5159](https://github.com/DataDog/integrations-core/pull/5159).
 
-## 1.10.0 / 2019-12-02 / Agent 7.16.0
+## 1.10.0 / 2019-12-02
 
 * [Added] Add Spark driver support. See [#4631](https://github.com/DataDog/integrations-core/pull/4631). Thanks [mrmuggymuggy](https://github.com/mrmuggymuggy).
 
@@ -60,7 +60,7 @@
 
 * [Fixed] Remove unused configs and code for spark check. See [#4133](https://github.com/DataDog/integrations-core/pull/4133).
 
-## 1.8.0 / 2019-07-09 / Agent 6.13.0
+## 1.8.0 / 2019-07-09
 
 * [Added] Use the new RequestsWrapper for connecting to services. See [#4058](https://github.com/DataDog/integrations-core/pull/4058).
 
@@ -68,20 +68,20 @@
 
 * [Added] Adhere to code style. See [#3566](https://github.com/DataDog/integrations-core/pull/3566).
 
-## 1.6.0 / 2019-01-08 / Agent 6.11.0
+## 1.6.0 / 2019-01-08 / Agent 6.10.0
 
 * [Added] Allow disabling of streaming metrics. See [#2889][1].
 * [Added] Support Kerberos auth. See [#2825][2].
 
-## 1.5.0 / 2018-12-20 / Agent 5.31.0
+## 1.5.0 / 2018-12-20 / Agent 6.9.0
 
 * [Added] Add streaming statistics metrics to the spark integration. See [#2437][3].
 
-## 1.4.1 / 2018-09-04 / Agent 5.28.0
+## 1.4.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 
-## 1.4.0 / 2018-06-07 / Agent 5.25.0
+## 1.4.0 / 2018-06-07
 
 * [Added] Add support for HTTP authentication. See [#1680][5].
 

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -1,87 +1,87 @@
 # CHANGELOG - sqlserver
 
-## 1.18.1 / 2020-08-10
+## 1.18.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 1.18.0 / 2020-06-29
+## 1.18.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 * [Added] Add default `freetds` driver for Docker Agent. See [#6636](https://github.com/DataDog/integrations-core/pull/6636).
 * [Added] Add log support. See [#6625](https://github.com/DataDog/integrations-core/pull/6625).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.17.0 / 2020-05-17
+## 1.17.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Install `pyodbc` for MacOS and fix local test setup. See [#6633](https://github.com/DataDog/integrations-core/pull/6633).
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Use agent 6 signature. See [#6447](https://github.com/DataDog/integrations-core/pull/6447).
 
-## 1.16.3 / 2020-04-04
+## 1.16.3 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.16.2 / 2020-03-10
+## 1.16.2 / 2020-03-10 / Agent 7.19.0
 
 * [Fixed] Streamline exception handling. See [#6003](https://github.com/DataDog/integrations-core/pull/6003).
 
-## 1.16.1 / 2020-02-22
+## 1.16.1 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Fix small capitalization error in log. See [#5509](https://github.com/DataDog/integrations-core/pull/5509).
 
-## 1.16.0 / 2020-01-13
+## 1.16.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.15.0 / 2019-12-02
+## 1.15.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 1.14.0 / 2019-10-11
+## 1.14.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 1.13.0 / 2019-07-13
+## 1.13.0 / 2019-07-13 / Agent 6.13.0
 
 * [Added] Allow SQLNCLI11 provider in SQL server. See [#4097](https://github.com/DataDog/integrations-core/pull/4097).
 
-## 1.12.0 / 2019-07-08
+## 1.12.0 / 2019-07-08 / Agent 6.13.0
 
 * [Added] Upgrade dependencies for Python 3.7 binary wheels. See [#4030](https://github.com/DataDog/integrations-core/pull/4030).
 
-## 1.11.0 / 2019-05-14
+## 1.11.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3567](https://github.com/DataDog/integrations-core/pull/3567).
 
-## 1.10.1 / 2019-04-04
+## 1.10.1 / 2019-04-04 / Agent 6.12.0
 
 * [Fixed] Don't ship `pyodbc` on macOS as SQLServer integration is not shipped on macOS. See [#3461](https://github.com/DataDog/integrations-core/pull/3461).
 
-## 1.10.0 / 2019-03-29
+## 1.10.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Add custom instance tags to storedproc metrics. See [#3237](https://github.com/DataDog/integrations-core/pull/3237).
 * [Fixed] Use execute instead of callproc if using (py)odbc. See [#3236](https://github.com/DataDog/integrations-core/pull/3236).
 
-## 1.9.0 / 2019-02-18
+## 1.9.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#3027](https://github.com/DataDog/integrations-core/pull/3027).
 
-## 1.8.1 / 2019-01-04
+## 1.8.1 / 2019-01-04 / Agent 5.31.0
 
 * [Fixed] Bump pyodbc for python3.7 compatibility. See [#2801][1].
 
-## 1.8.0 / 2018-11-30
+## 1.8.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Add linux as supported OS. See [#2614][2].
 * [Fixed] Additional debug logging when calling a stored procedure. See [#2151][3].
 * [Fixed] Use raw string literals when \ is present. See [#2465][4].
 
-## 1.7.0 / 2018-10-12
+## 1.7.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][5].
 
-## 1.6.0 / 2018-09-04
+## 1.6.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Support higher query granularity. See [#2017][6].
 * [Added] Add ability to support (via configuration flag) the newer ADO provider. See [#1673][7].
@@ -90,7 +90,7 @@
 * [Fixed] Fix for case sensitivity in the `proc_type_mapping` dict.. See [#1860][10].
 * [Fixed] Add data files to the wheel package. See [#1727][11].
 
-## 1.5.0 / 2018-06-20
+## 1.5.0 / 2018-06-20 / Agent 5.26.0
 
 * [Added] support object_name metric identifiers. See [#1679][12].
 

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -21,11 +21,11 @@
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.16.2 / 2020-03-10 / Agent 7.19.0
+## 1.16.2 / 2020-03-10 / Agent 7.18.0
 
 * [Fixed] Streamline exception handling. See [#6003](https://github.com/DataDog/integrations-core/pull/6003).
 
-## 1.16.1 / 2020-02-22 / Agent 7.18.0
+## 1.16.1 / 2020-02-22
 
 * [Fixed] Fix small capitalization error in log. See [#5509](https://github.com/DataDog/integrations-core/pull/5509).
 
@@ -46,7 +46,7 @@
 
 * [Added] Allow SQLNCLI11 provider in SQL server. See [#4097](https://github.com/DataDog/integrations-core/pull/4097).
 
-## 1.12.0 / 2019-07-08 / Agent 6.13.0
+## 1.12.0 / 2019-07-08
 
 * [Added] Upgrade dependencies for Python 3.7 binary wheels. See [#4030](https://github.com/DataDog/integrations-core/pull/4030).
 
@@ -54,34 +54,34 @@
 
 * [Added] Adhere to code style. See [#3567](https://github.com/DataDog/integrations-core/pull/3567).
 
-## 1.10.1 / 2019-04-04 / Agent 6.12.0
+## 1.10.1 / 2019-04-04 / Agent 6.11.0
 
 * [Fixed] Don't ship `pyodbc` on macOS as SQLServer integration is not shipped on macOS. See [#3461](https://github.com/DataDog/integrations-core/pull/3461).
 
-## 1.10.0 / 2019-03-29 / Agent 6.11.0
+## 1.10.0 / 2019-03-29
 
 * [Added] Add custom instance tags to storedproc metrics. See [#3237](https://github.com/DataDog/integrations-core/pull/3237).
 * [Fixed] Use execute instead of callproc if using (py)odbc. See [#3236](https://github.com/DataDog/integrations-core/pull/3236).
 
-## 1.9.0 / 2019-02-18 / Agent 6.11.0
+## 1.9.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#3027](https://github.com/DataDog/integrations-core/pull/3027).
 
-## 1.8.1 / 2019-01-04 / Agent 5.31.0
+## 1.8.1 / 2019-01-04 / Agent 6.9.0
 
 * [Fixed] Bump pyodbc for python3.7 compatibility. See [#2801][1].
 
-## 1.8.0 / 2018-11-30 / Agent 5.30.0
+## 1.8.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Add linux as supported OS. See [#2614][2].
 * [Fixed] Additional debug logging when calling a stored procedure. See [#2151][3].
 * [Fixed] Use raw string literals when \ is present. See [#2465][4].
 
-## 1.7.0 / 2018-10-12 / Agent 5.28.0
+## 1.7.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Pin pywin32 dependency. See [#2322][5].
 
-## 1.6.0 / 2018-09-04 / Agent 5.28.0
+## 1.6.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Support higher query granularity. See [#2017][6].
 * [Added] Add ability to support (via configuration flag) the newer ADO provider. See [#1673][7].
@@ -90,7 +90,7 @@
 * [Fixed] Fix for case sensitivity in the `proc_type_mapping` dict.. See [#1860][10].
 * [Fixed] Add data files to the wheel package. See [#1727][11].
 
-## 1.5.0 / 2018-06-20 / Agent 5.26.0
+## 1.5.0 / 2018-06-20 / Agent 6.4.0
 
 * [Added] support object_name metric identifiers. See [#1679][12].
 

--- a/squid/CHANGELOG.md
+++ b/squid/CHANGELOG.md
@@ -38,15 +38,15 @@
 
 * [Added] Adhere to code style. See [#3568](https://github.com/DataDog/integrations-core/pull/3568).
 
-## 1.1.0 / 2019-01-04 / Agent 5.31.0
+## 1.1.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2788][1].
 
-## 1.0.2 / 2018-09-04 / Agent 5.28.0
+## 1.0.2 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.0.1 / 2018-06-07 / Agent 5.25.0
+## 1.0.1 / 2018-06-07
 
 * [Fixed] Fix bug parsing squid metrics. See [#1643][3]. Thanks [mnussbaum][4].
 

--- a/squid/CHANGELOG.md
+++ b/squid/CHANGELOG.md
@@ -1,52 +1,52 @@
 # CHANGELOG - Squid
 
-## 1.7.1 / 2020-08-10
+## 1.7.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.7.0 / 2020-06-29
+## 1.7.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix formatting of a log line. See [#6990](https://github.com/DataDog/integrations-core/pull/6990).
 
-## 1.6.0 / 2020-05-17
+## 1.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.5.1 / 2020-04-04
+## 1.5.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.5.0 / 2020-02-22
+## 1.5.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add version metadata. See [#5603](https://github.com/DataDog/integrations-core/pull/5603).
 
-## 1.4.1 / 2019-11-07
+## 1.4.1 / 2019-11-07 / Agent 7.16.0
 
 * [Fixed] Adding log section. See [#4824](https://github.com/DataDog/integrations-core/pull/4824).
 
-## 1.4.0 / 2019-10-11
+## 1.4.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.3.0 / 2019-08-24
+## 1.3.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add requests wrapper to squid. See [#4200](https://github.com/DataDog/integrations-core/pull/4200).
 
-## 1.2.0 / 2019-05-14
+## 1.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3568](https://github.com/DataDog/integrations-core/pull/3568).
 
-## 1.1.0 / 2019-01-04
+## 1.1.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2788][1].
 
-## 1.0.2 / 2018-09-04
+## 1.0.2 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.0.1 / 2018-06-07
+## 1.0.1 / 2018-06-07 / Agent 5.25.0
 
 * [Fixed] Fix bug parsing squid metrics. See [#1643][3]. Thanks [mnussbaum][4].
 

--- a/ssh_check/CHANGELOG.md
+++ b/ssh_check/CHANGELOG.md
@@ -1,54 +1,54 @@
 # CHANGELOG - ssh_check
 
-## 1.11.1 / 2020-06-29
+## 1.11.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Add config specs. See [#6923](https://github.com/DataDog/integrations-core/pull/6923).
 * [Fixed] Agent6 style init. See [#6924](https://github.com/DataDog/integrations-core/pull/6924).
 
-## 1.11.0 / 2020-05-17
+## 1.11.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.10.1 / 2020-04-04
+## 1.10.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.10.0 / 2020-01-13
+## 1.10.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Added] Add version metadata. See [#5016](https://github.com/DataDog/integrations-core/pull/5016).
 
-## 1.9.0 / 2019-10-09
+## 1.9.0 / 2019-10-09 / Agent 6.15.0
 
 * [Added] Upgrade Paramiko to version 2.6.0. See [#4685](https://github.com/DataDog/integrations-core/pull/4685). Thanks [daniel-savo](https://github.com/daniel-savo).
 
-## 1.8.0 / 2019-08-24
+## 1.8.0 / 2019-08-24 / Agent 6.14.0
 
 * [Fixed] Remove unused dependencies. See [#4405](https://github.com/DataDog/integrations-core/pull/4405).
 * [Added] Upgrade pyasn1. See [#4289](https://github.com/DataDog/integrations-core/pull/4289).
 
-## 1.7.0 / 2019-07-04
+## 1.7.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Update cryptography version. See [#4000](https://github.com/DataDog/integrations-core/pull/4000).
 
-## 1.6.0 / 2019-05-14
+## 1.6.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3569](https://github.com/DataDog/integrations-core/pull/3569).
 
-## 1.5.0 / 2019-01-04
+## 1.5.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2836][1].
 
-## 1.4.0 / 2018-11-30
+## 1.4.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Upgrade cryptography. See [#2659][2].
 
-## 1.3.1 / 2018-09-04
+## 1.3.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Update cryptography to 2.3. See [#1927][3].
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 
-## 1.3.0 / 2018-06-20
+## 1.3.0 / 2018-06-20 / Agent 5.26.0
 
 * [Changed] Bump requests to 2.19.1. See [#1743][5].
 

--- a/ssh_check/CHANGELOG.md
+++ b/ssh_check/CHANGELOG.md
@@ -35,20 +35,20 @@
 
 * [Added] Adhere to code style. See [#3569](https://github.com/DataDog/integrations-core/pull/3569).
 
-## 1.5.0 / 2019-01-04 / Agent 5.31.0
+## 1.5.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2836][1].
 
-## 1.4.0 / 2018-11-30 / Agent 5.30.0
+## 1.4.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Upgrade cryptography. See [#2659][2].
 
-## 1.3.1 / 2018-09-04 / Agent 5.28.0
+## 1.3.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Update cryptography to 2.3. See [#1927][3].
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 
-## 1.3.0 / 2018-06-20 / Agent 5.26.0
+## 1.3.0 / 2018-06-20 / Agent 6.4.0
 
 * [Changed] Bump requests to 2.19.1. See [#1743][5].
 

--- a/statsd/CHANGELOG.md
+++ b/statsd/CHANGELOG.md
@@ -12,11 +12,11 @@
 
 * [Added] Adhere to code style. See [#3570](https://github.com/DataDog/integrations-core/pull/3570).
 
-## 1.2.0 / 2019-01-04 / Agent 5.31.0
+## 1.2.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2831][1].
 
-## 1.1.1 / 2018-09-04 / Agent 5.28.0
+## 1.1.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/statsd/CHANGELOG.md
+++ b/statsd/CHANGELOG.md
@@ -1,22 +1,22 @@
 # CHANGELOG - statsd
 
-## 1.4.0 / 2020-05-17
+## 1.4.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.3.1 / 2020-04-04
+## 1.3.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.3.0 / 2019-05-14
+## 1.3.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3570](https://github.com/DataDog/integrations-core/pull/3570).
 
-## 1.2.0 / 2019-01-04
+## 1.2.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2831][1].
 
-## 1.1.1 / 2018-09-04
+## 1.1.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 

--- a/supervisord/CHANGELOG.md
+++ b/supervisord/CHANGELOG.md
@@ -1,37 +1,37 @@
 # CHANGELOG - supervisord
 
-## 1.6.0 / 2020-05-17
+## 1.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.5.0 / 2020-04-04
+## 1.5.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Make error message more explicit. See [#6211](https://github.com/DataDog/integrations-core/pull/6211).
 * [Added] Enable basic authentication for socket option (unix_http_server). See [#6239](https://github.com/DataDog/integrations-core/pull/6239).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.4.0 / 2020-02-22
+## 1.4.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Upgrade supervisor dependency. See [#5627](https://github.com/DataDog/integrations-core/pull/5627).
 
-## 1.3.0 / 2019-12-02
+## 1.3.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add version metadata. See [#4979](https://github.com/DataDog/integrations-core/pull/4979).
 
-## 1.2.0 / 2019-05-14
+## 1.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Support Python 3. See [#3605](https://github.com/DataDog/integrations-core/pull/3605).
 * [Added] Adhere to code style. See [#3571](https://github.com/DataDog/integrations-core/pull/3571).
 
-## 1.1.4 / 2018-10-29
+## 1.1.4 / 2018-10-29 / Agent 5.30.0
 
 * [Fixed] Fix AgentCheck import. See [#2482][1].
 
-## 1.1.3 / 2018-09-04
+## 1.1.3 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.1.2 / 2018-06-20
+## 1.1.2 / 2018-06-20 / Agent 5.26.0
 
 * [Tooling] Bump check to be in sync with new release tooling
 

--- a/supervisord/CHANGELOG.md
+++ b/supervisord/CHANGELOG.md
@@ -23,15 +23,15 @@
 * [Added] Support Python 3. See [#3605](https://github.com/DataDog/integrations-core/pull/3605).
 * [Added] Adhere to code style. See [#3571](https://github.com/DataDog/integrations-core/pull/3571).
 
-## 1.1.4 / 2018-10-29 / Agent 5.30.0
+## 1.1.4 / 2018-10-29 / Agent 6.8.0
 
 * [Fixed] Fix AgentCheck import. See [#2482][1].
 
-## 1.1.3 / 2018-09-04 / Agent 5.28.0
+## 1.1.3 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.1.2 / 2018-06-20 / Agent 5.26.0
+## 1.1.2 / 2018-06-20 / Agent 6.4.0
 
 * [Tooling] Bump check to be in sync with new release tooling
 

--- a/system_core/CHANGELOG.md
+++ b/system_core/CHANGELOG.md
@@ -1,48 +1,48 @@
 # CHANGELOG - system_core
 
-## 1.7.0 / 2020-05-17
+## 1.7.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.6.0 / 2020-04-04
+## 1.6.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.5.3 / 2019-12-13
+## 1.5.3 / 2019-12-13 / Agent 7.17.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 1.5.2 / 2019-12-02
+## 1.5.2 / 2019-12-02 / Agent 7.16.0
 
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
 
-## 1.5.1 / 2019-10-11
+## 1.5.1 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Upgrade psutil dependency to 5.6.3. See [#4442](https://github.com/DataDog/integrations-core/pull/4442).
 
-## 1.5.0 / 2019-05-14
+## 1.5.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Upgrade psutil dependency to 5.6.2. See [#3684](https://github.com/DataDog/integrations-core/pull/3684).
 * [Added] Adhere to code style. See [#3572](https://github.com/DataDog/integrations-core/pull/3572).
 
-## 1.4.0 / 2019-02-18
+## 1.4.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Upgrade psutil. See [#3019](https://github.com/DataDog/integrations-core/pull/3019).
 
-## 1.3.0 / 2019-01-04
+## 1.3.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2805][1].
 
-## 1.2.0 / 2018-11-30
+## 1.2.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Update psutil. See [#2576][2].
 
-## 1.1.0 / 2018-10-12
+## 1.1.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Upgrade psutil. See [#2190][3].
 
-## 1.0.2 / 2018-09-04
+## 1.0.2 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 

--- a/system_core/CHANGELOG.md
+++ b/system_core/CHANGELOG.md
@@ -9,11 +9,11 @@
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.5.3 / 2019-12-13 / Agent 7.17.0
+## 1.5.3 / 2019-12-13 / Agent 7.16.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 1.5.2 / 2019-12-02 / Agent 7.16.0
+## 1.5.2 / 2019-12-02
 
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
 
@@ -26,23 +26,23 @@
 * [Added] Upgrade psutil dependency to 5.6.2. See [#3684](https://github.com/DataDog/integrations-core/pull/3684).
 * [Added] Adhere to code style. See [#3572](https://github.com/DataDog/integrations-core/pull/3572).
 
-## 1.4.0 / 2019-02-18 / Agent 6.11.0
+## 1.4.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Upgrade psutil. See [#3019](https://github.com/DataDog/integrations-core/pull/3019).
 
-## 1.3.0 / 2019-01-04 / Agent 5.31.0
+## 1.3.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2805][1].
 
-## 1.2.0 / 2018-11-30 / Agent 5.30.0
+## 1.2.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Update psutil. See [#2576][2].
 
-## 1.1.0 / 2018-10-12 / Agent 5.28.0
+## 1.1.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Upgrade psutil. See [#2190][3].
 
-## 1.0.2 / 2018-09-04 / Agent 5.28.0
+## 1.0.2 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 

--- a/system_swap/CHANGELOG.md
+++ b/system_swap/CHANGELOG.md
@@ -1,48 +1,48 @@
 # CHANGELOG - system_swap
 
-## 1.8.0 / 2020-05-17
+## 1.8.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.0 / 2020-04-04
+## 1.7.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.6.3 / 2019-12-13
+## 1.6.3 / 2019-12-13 / Agent 7.17.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 1.6.2 / 2019-12-02
+## 1.6.2 / 2019-12-02 / Agent 7.16.0
 
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
 
-## 1.6.1 / 2019-10-11
+## 1.6.1 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Upgrade psutil dependency to 5.6.3. See [#4442](https://github.com/DataDog/integrations-core/pull/4442).
 
-## 1.6.0 / 2019-05-14
+## 1.6.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Upgrade psutil dependency to 5.6.2. See [#3684](https://github.com/DataDog/integrations-core/pull/3684).
 * [Added] Adhere to code style. See [#3573](https://github.com/DataDog/integrations-core/pull/3573).
 
-## 1.5.0 / 2019-02-18
+## 1.5.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Upgrade psutil. See [#3019](https://github.com/DataDog/integrations-core/pull/3019).
 
-## 1.4.0 / 2019-01-04
+## 1.4.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2830][1].
 
-## 1.3.0 / 2018-11-30
+## 1.3.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Update psutil. See [#2576][2].
 
-## 1.2.0 / 2018-10-12
+## 1.2.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Upgrade psutil. See [#2190][3].
 
-## 1.1.1 / 2018-09-04
+## 1.1.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 

--- a/system_swap/CHANGELOG.md
+++ b/system_swap/CHANGELOG.md
@@ -9,11 +9,11 @@
 * [Added] Upgrade psutil to 5.7.0. See [#6243](https://github.com/DataDog/integrations-core/pull/6243).
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.6.3 / 2019-12-13 / Agent 7.17.0
+## 1.6.3 / 2019-12-13 / Agent 7.16.0
 
 * [Fixed] Bump psutil to 5.6.7. See [#5210](https://github.com/DataDog/integrations-core/pull/5210).
 
-## 1.6.2 / 2019-12-02 / Agent 7.16.0
+## 1.6.2 / 2019-12-02
 
 * [Fixed] Upgrade psutil dependency to 5.6.5. See [#5059](https://github.com/DataDog/integrations-core/pull/5059).
 
@@ -26,23 +26,23 @@
 * [Added] Upgrade psutil dependency to 5.6.2. See [#3684](https://github.com/DataDog/integrations-core/pull/3684).
 * [Added] Adhere to code style. See [#3573](https://github.com/DataDog/integrations-core/pull/3573).
 
-## 1.5.0 / 2019-02-18 / Agent 6.11.0
+## 1.5.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Upgrade psutil. See [#3019](https://github.com/DataDog/integrations-core/pull/3019).
 
-## 1.4.0 / 2019-01-04 / Agent 5.31.0
+## 1.4.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2830][1].
 
-## 1.3.0 / 2018-11-30 / Agent 5.30.0
+## 1.3.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Update psutil. See [#2576][2].
 
-## 1.2.0 / 2018-10-12 / Agent 5.28.0
+## 1.2.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Upgrade psutil. See [#2190][3].
 
-## 1.1.1 / 2018-09-04 / Agent 5.28.0
+## 1.1.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][4].
 

--- a/tcp_check/CHANGELOG.md
+++ b/tcp_check/CHANGELOG.md
@@ -1,50 +1,50 @@
 # CHANGELOG - tcp_check
 
-## 2.5.0 / 2020-06-16
+## 2.5.0 / 2020-06-16 / Agent 7.21.0
 
 * [Added] Use higher precision clock measurements for Python 3. See [#6849](https://github.com/DataDog/integrations-core/pull/6849).
 
-## 2.4.0 / 2020-05-17
+## 2.4.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.3.4 / 2020-03-11
+## 2.3.4 / 2020-03-11 / Agent 7.19.0
 
 * [Fixed] Reattempt to resolve IP on failure. See [#6012](https://github.com/DataDog/integrations-core/pull/6012).
 
-## 2.3.3 / 2019-12-24
+## 2.3.3 / 2019-12-24 / Agent 7.17.0
 
 * [Fixed] Don't report response time when connection fails. See [#5271](https://github.com/DataDog/integrations-core/pull/5271).
 
-## 2.3.2 / 2019-12-17
+## 2.3.2 / 2019-12-17 / Agent 7.17.0
 
 * [Fixed] Fix service_checks submission. See [#5229](https://github.com/DataDog/integrations-core/pull/5229).
 
-## 2.3.1 / 2019-10-11
+## 2.3.1 / 2019-10-11 / Agent 6.15.0
 
 * [Fixed] Remove legacy network check tcp. See [#4580](https://github.com/DataDog/integrations-core/pull/4580).
 
-## 2.3.0 / 2019-05-14
+## 2.3.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3574](https://github.com/DataDog/integrations-core/pull/3574).
 
-## 2.2.1 / 2019-03-29
+## 2.2.1 / 2019-03-29 / Agent 6.11.0
 
 * [Fixed] ensure_unicode with normalize for py3 compatibility. See [#3218](https://github.com/DataDog/integrations-core/pull/3218).
 
-## 2.2.0 / 2019-02-18
+## 2.2.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#2964](https://github.com/DataDog/integrations-core/pull/2964).
 
-## 2.1.0 / 2018-11-30
+## 2.1.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Send service check as metric. See [#2509][1].
 
-## 2.0.2 / 2018-09-04
+## 2.0.2 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 2.0.1 / 2018-06-20
+## 2.0.1 / 2018-06-20 / Agent 5.26.0
 
 * [Fixed] Fix error message when TCP check fails. See [#1745][3]. Thanks [Siecje][4].
 

--- a/tcp_check/CHANGELOG.md
+++ b/tcp_check/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 * [Fixed] Don't report response time when connection fails. See [#5271](https://github.com/DataDog/integrations-core/pull/5271).
 
-## 2.3.2 / 2019-12-17 / Agent 7.17.0
+## 2.3.2 / 2019-12-17
 
 * [Fixed] Fix service_checks submission. See [#5229](https://github.com/DataDog/integrations-core/pull/5229).
 
@@ -32,19 +32,19 @@
 
 * [Fixed] ensure_unicode with normalize for py3 compatibility. See [#3218](https://github.com/DataDog/integrations-core/pull/3218).
 
-## 2.2.0 / 2019-02-18 / Agent 6.11.0
+## 2.2.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#2964](https://github.com/DataDog/integrations-core/pull/2964).
 
-## 2.1.0 / 2018-11-30 / Agent 5.30.0
+## 2.1.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Send service check as metric. See [#2509][1].
 
-## 2.0.2 / 2018-09-04 / Agent 5.28.0
+## 2.0.2 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 2.0.1 / 2018-06-20 / Agent 5.26.0
+## 2.0.1 / 2018-06-20 / Agent 6.4.0
 
 * [Fixed] Fix error message when TCP check fails. See [#1745][3]. Thanks [Siecje][4].
 

--- a/teamcity/CHANGELOG.md
+++ b/teamcity/CHANGELOG.md
@@ -21,11 +21,11 @@
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.5.1 / 2019-08-31 / Agent 6.15.0
+## 1.5.1 / 2019-08-31 / Agent 6.14.0
 
 * [Fixed] Fix RequestsWrapper usage. See [#4486](https://github.com/DataDog/integrations-core/pull/4486).
 
-## 1.5.0 / 2019-08-24 / Agent 6.14.0
+## 1.5.0 / 2019-08-24
 
 * [Fixed] Update __init__ method params. See [#4243](https://github.com/DataDog/integrations-core/pull/4243).
 * [Fixed] Fix wording for config option description. See [#4217](https://github.com/DataDog/integrations-core/pull/4217).
@@ -35,21 +35,21 @@
 
 * [Added] Adhere to code style. See [#3575](https://github.com/DataDog/integrations-core/pull/3575).
 
-## 1.3.0 / 2019-02-18 / Agent 6.11.0
+## 1.3.0 / 2019-02-18 / Agent 6.10.0
 
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Support unicode for Python 3 bindings. See [#2869](https://github.com/DataDog/integrations-core/pull/2869).
 
-## 1.2.0 / 2019-01-04 / Agent 5.31.0
+## 1.2.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2829][1].
 
-## 1.1.1 / 2018-09-04 / Agent 5.28.0
+## 1.1.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 
-## 1.1.0 / 2018-06-07 / Agent 5.25.0
+## 1.1.0 / 2018-06-07
 
 * [Added] Allow users to specify scheme in server URLs. See [#1649][4].
 

--- a/teamcity/CHANGELOG.md
+++ b/teamcity/CHANGELOG.md
@@ -1,55 +1,55 @@
 # CHANGELOG - teamcity
 
-## 1.9.0 / 2020-06-29
+## 1.9.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.8.0 / 2020-05-17
+## 1.8.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.7.1 / 2020-04-04
+## 1.7.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.7.0 / 2020-01-13
+## 1.7.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.6.0 / 2019-10-11
+## 1.6.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.5.1 / 2019-08-31
+## 1.5.1 / 2019-08-31 / Agent 6.15.0
 
 * [Fixed] Fix RequestsWrapper usage. See [#4486](https://github.com/DataDog/integrations-core/pull/4486).
 
-## 1.5.0 / 2019-08-24
+## 1.5.0 / 2019-08-24 / Agent 6.14.0
 
 * [Fixed] Update __init__ method params. See [#4243](https://github.com/DataDog/integrations-core/pull/4243).
 * [Fixed] Fix wording for config option description. See [#4217](https://github.com/DataDog/integrations-core/pull/4217).
 * [Added] Add requests wrapper to teamcity. See [#4209](https://github.com/DataDog/integrations-core/pull/4209).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3575](https://github.com/DataDog/integrations-core/pull/3575).
 
-## 1.3.0 / 2019-02-18
+## 1.3.0 / 2019-02-18 / Agent 6.11.0
 
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Support unicode for Python 3 bindings. See [#2869](https://github.com/DataDog/integrations-core/pull/2869).
 
-## 1.2.0 / 2019-01-04
+## 1.2.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2829][1].
 
-## 1.1.1 / 2018-09-04
+## 1.1.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 
-## 1.1.0 / 2018-06-07
+## 1.1.0 / 2018-06-07 / Agent 5.25.0
 
 * [Added] Allow users to specify scheme in server URLs. See [#1649][4].
 

--- a/tenable/CHANGELOG.md
+++ b/tenable/CHANGELOG.md
@@ -17,11 +17,11 @@
 * [Added] Add config spec support for logs-only integrations. See [#5932](https://github.com/DataDog/integrations-core/pull/5932).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.0.1 / 2020-02-27 / Agent 7.19.0
+## 1.0.1 / 2020-02-27 / Agent 7.18.0
 
 * [Fixed] Update README.md and example log section. See [#5898](https://github.com/DataDog/integrations-core/pull/5898).
 
-## 1.0.0 / 2020-02-22 / Agent 7.18.0
+## 1.0.0 / 2020-02-22
 
 * [Added] Inital commit for Tenable integration. See [#5743](https://github.com/DataDog/integrations-core/pull/5743).
 

--- a/tenable/CHANGELOG.md
+++ b/tenable/CHANGELOG.md
@@ -1,27 +1,27 @@
 # CHANGELOG - Tenable
 
-## 1.2.2 / 2020-08-10
+## 1.2.2 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 1.2.1 / 2020-06-29
+## 1.2.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.2.0 / 2020-05-17
+## 1.2.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.1.0 / 2020-04-04
+## 1.1.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add config spec support for logs-only integrations. See [#5932](https://github.com/DataDog/integrations-core/pull/5932).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.0.1 / 2020-02-27
+## 1.0.1 / 2020-02-27 / Agent 7.19.0
 
 * [Fixed] Update README.md and example log section. See [#5898](https://github.com/DataDog/integrations-core/pull/5898).
 
-## 1.0.0 / 2020-02-22
+## 1.0.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Inital commit for Tenable integration. See [#5743](https://github.com/DataDog/integrations-core/pull/5743).
 

--- a/tls/CHANGELOG.md
+++ b/tls/CHANGELOG.md
@@ -1,30 +1,30 @@
 # CHANGELOG - TLS
 
-## 1.5.0 / 2020-05-17
+## 1.5.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.4.1 / 2020-02-12
+## 1.4.1 / 2020-02-12 / Agent 7.18.0
 
 * [Fixed] Don't rely on file extension for local cert loading. See [#5694](https://github.com/DataDog/integrations-core/pull/5694).
 
-## 1.4.0 / 2020-01-13
+## 1.4.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 
-## 1.3.0 / 2019-12-02
+## 1.3.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade cryptography to 2.8. See [#5047](https://github.com/DataDog/integrations-core/pull/5047).
 
-## 1.2.0 / 2019-07-04
+## 1.2.0 / 2019-07-04 / Agent 6.13.0
 
 * [Added] Update cryptography version. See [#4000](https://github.com/DataDog/integrations-core/pull/4000).
 
-## 1.1.0 / 2019-06-24
+## 1.1.0 / 2019-06-24 / Agent 6.13.0
 
 * [Added] Allow certificate validation to be completely disabled. See [#3966](https://github.com/DataDog/integrations-core/pull/3966).
 
-## 1.0.0 / 2019-04-22
+## 1.0.0 / 2019-04-22 / Agent 6.12.0
 
 * [Added] Add TLS integration. See [#3256](https://github.com/DataDog/integrations-core/pull/3256).
 

--- a/tls/CHANGELOG.md
+++ b/tls/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 * [Added] Update cryptography version. See [#4000](https://github.com/DataDog/integrations-core/pull/4000).
 
-## 1.1.0 / 2019-06-24 / Agent 6.13.0
+## 1.1.0 / 2019-06-24
 
 * [Added] Allow certificate validation to be completely disabled. See [#3966](https://github.com/DataDog/integrations-core/pull/3966).
 

--- a/tokumx/CHANGELOG.md
+++ b/tokumx/CHANGELOG.md
@@ -20,17 +20,17 @@
 
 * [Added] Adhere to code style. See [#3576](https://github.com/DataDog/integrations-core/pull/3576).
 
-## 2.0.0 / 2019-02-18 / Agent 6.11.0
+## 2.0.0 / 2019-02-18 / Agent 6.10.0
 
 * [Changed] Vendor pymongo into tokumx check. See [#3001](https://github.com/DataDog/integrations-core/pull/3001).
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Finish Python 3 Support. See [#2926](https://github.com/DataDog/integrations-core/pull/2926).
 
-## 1.3.0 / 2019-01-04 / Agent 5.31.0
+## 1.3.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2832][1].
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Moves Tokumx to pytest. See [#2134][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].

--- a/tokumx/CHANGELOG.md
+++ b/tokumx/CHANGELOG.md
@@ -1,36 +1,36 @@
 # CHANGELOG - tokumx
 
-## 2.3.1 / 2020-06-29
+## 2.3.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Add config specs and change signature. See [#6729](https://github.com/DataDog/integrations-core/pull/6729).
 
-## 2.3.0 / 2020-05-17
+## 2.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.2.1 / 2020-04-04
+## 2.2.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 2.2.0 / 2020-01-13
+## 2.2.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 2.1.0 / 2019-05-14
+## 2.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3576](https://github.com/DataDog/integrations-core/pull/3576).
 
-## 2.0.0 / 2019-02-18
+## 2.0.0 / 2019-02-18 / Agent 6.11.0
 
 * [Changed] Vendor pymongo into tokumx check. See [#3001](https://github.com/DataDog/integrations-core/pull/3001).
 * [Fixed] Resolve flake8 issues. See [#3060](https://github.com/DataDog/integrations-core/pull/3060).
 * [Added] Finish Python 3 Support. See [#2926](https://github.com/DataDog/integrations-core/pull/2926).
 
-## 1.3.0 / 2019-01-04
+## 1.3.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2832][1].
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Moves Tokumx to pytest. See [#2134][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].

--- a/tomcat/CHANGELOG.md
+++ b/tomcat/CHANGELOG.md
@@ -23,15 +23,15 @@
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.2.0 / 2018-10-12 / Agent 5.28.0
+## 1.2.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] [jmx] add rmi registry ssl config option. See [#2371][1].
 
-## 1.1.1 / 2018-09-04 / Agent 5.28.0
+## 1.1.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.1.0 / 2018-06-13 / Agent 5.26.0
+## 1.1.0 / 2018-06-13
 
 * [Added] [Update] Update auto_conf.yaml template. See [#1523][3].
 

--- a/tomcat/CHANGELOG.md
+++ b/tomcat/CHANGELOG.md
@@ -1,37 +1,37 @@
 # CHANGELOG - tomcat
 
-## 1.3.2 / 2020-08-10
+## 1.3.2 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] add Catalina domain specification to tomcat bean includes. See [#7054](https://github.com/DataDog/integrations-core/pull/7054). Thanks [binaryphile](https://github.com/binaryphile).
 * [Fixed] Add new_gc_metrics to all jmx integrations. See [#7073](https://github.com/DataDog/integrations-core/pull/7073).
 
-## 1.3.1 / 2020-06-29
+## 1.3.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Assert new jvm metrics. See [#6996](https://github.com/DataDog/integrations-core/pull/6996).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 * [Fixed] Adjust jmxfetch config. See [#6864](https://github.com/DataDog/integrations-core/pull/6864).
 
-## 1.3.0 / 2020-05-17
+## 1.3.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add rmi_connection_timeout & rmi_client_timeout to config spec. See [#6459](https://github.com/DataDog/integrations-core/pull/6459).
 * [Added] Add string cache and web cache metrics. See [#6404](https://github.com/DataDog/integrations-core/pull/6404).
 * [Added] Use config spec. See [#6301](https://github.com/DataDog/integrations-core/pull/6301).
 
-## 1.2.1 / 2020-04-04
+## 1.2.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.2.0 / 2018-10-12
+## 1.2.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] [jmx] add rmi registry ssl config option. See [#2371][1].
 
-## 1.1.1 / 2018-09-04
+## 1.1.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][2].
 
-## 1.1.0 / 2018-06-13
+## 1.1.0 / 2018-06-13 / Agent 5.26.0
 
 * [Added] [Update] Update auto_conf.yaml template. See [#1523][3].
 

--- a/twemproxy/CHANGELOG.md
+++ b/twemproxy/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG - twemproxy
 
-## 1.7.1 / 2020-07-03 / Agent 7.22.0
+## 1.7.1 / 2020-07-03 / Agent 7.21.0
 
 * [Fixed] Don't collect version if metadata is not enabled. See [#7010](https://github.com/DataDog/integrations-core/pull/7010).
 
-## 1.7.0 / 2020-06-29 / Agent 7.21.0
+## 1.7.0 / 2020-06-29
 
 * [Added] Collect version metadata. See [#6899](https://github.com/DataDog/integrations-core/pull/6899).
 
@@ -20,12 +20,12 @@
 
 * [Added] Adhere to code style. See [#3577](https://github.com/DataDog/integrations-core/pull/3577).
 
-## 1.3.0 / 2019-01-04 / Agent 5.31.0
+## 1.3.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Refactor Twemproxy tests and add E2E. See [#2820][1].
 * [Added] Support Python 3. See [#2817][2].
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 

--- a/twemproxy/CHANGELOG.md
+++ b/twemproxy/CHANGELOG.md
@@ -1,31 +1,31 @@
 # CHANGELOG - twemproxy
 
-## 1.7.1 / 2020-07-03
+## 1.7.1 / 2020-07-03 / Agent 7.22.0
 
 * [Fixed] Don't collect version if metadata is not enabled. See [#7010](https://github.com/DataDog/integrations-core/pull/7010).
 
-## 1.7.0 / 2020-06-29
+## 1.7.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Collect version metadata. See [#6899](https://github.com/DataDog/integrations-core/pull/6899).
 
-## 1.6.0 / 2020-05-17
+## 1.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.5.0 / 2020-01-13
+## 1.5.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3577](https://github.com/DataDog/integrations-core/pull/3577).
 
-## 1.3.0 / 2019-01-04
+## 1.3.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Refactor Twemproxy tests and add E2E. See [#2820][1].
 * [Added] Support Python 3. See [#2817][2].
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 

--- a/twistlock/CHANGELOG.md
+++ b/twistlock/CHANGELOG.md
@@ -1,60 +1,60 @@
 # CHANGELOG - Twistlock
 
-## 1.8.1 / 2020-08-10
+## 1.8.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 1.8.0 / 2020-06-29
+## 1.8.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Added] Add config specs. See [#6795](https://github.com/DataDog/integrations-core/pull/6795).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 1.7.0 / 2020-05-17
+## 1.7.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.6.0 / 2020-04-04
+## 1.6.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Use a faster JSON library. See [#6143](https://github.com/DataDog/integrations-core/pull/6143).
 
-## 1.5.0 / 2020-01-13
+## 1.5.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Add Prisma Cloud compatibility. See [#5360](https://github.com/DataDog/integrations-core/pull/5360).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.4.1 / 2020-01-02
+## 1.4.1 / 2020-01-02 / Agent 7.17.0
 
 * [Fixed] Fix possible TypeError due to NoneType in parser.isoparse. See [#5265](https://github.com/DataDog/integrations-core/pull/5265).
 * [Fixed] Fix possible KeyError in _report_compliance_information. See [#5248](https://github.com/DataDog/integrations-core/pull/5248).
 
-## 1.4.0 / 2019-11-06
+## 1.4.0 / 2019-11-06 / Agent 7.16.0
 
 * [Added] Allow passing a "project" query parameter. See [#4667](https://github.com/DataDog/integrations-core/pull/4667).
 
-## 1.3.0 / 2019-10-11
+## 1.3.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.2.2 / 2019-08-30
+## 1.2.2 / 2019-08-30 / Agent 6.15.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 1.2.1 / 2019-08-13
+## 1.2.1 / 2019-08-13 / Agent 6.14.0
 
 * [Fixed] Fix date format matching. See [#4304](https://github.com/DataDog/integrations-core/pull/4304).
 
-## 1.2.0 / 2019-08-02
+## 1.2.0 / 2019-08-02 / Agent 6.14.0
 
 * [Added] Add RequestsWrapper to twistlock. See [#4122](https://github.com/DataDog/integrations-core/pull/4122).
 * [Fixed] Use utcnow instead of now. See [#4192](https://github.com/DataDog/integrations-core/pull/4192).
 
-## 1.1.0 / 2019-05-14
+## 1.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3578](https://github.com/DataDog/integrations-core/pull/3578).
 
-## 1.0.0 / 2019-03-29
+## 1.0.0 / 2019-03-29 / Agent 6.11.0
 
 * [Added] Adds Twistlock Integration. See [#3074](https://github.com/DataDog/integrations-core/pull/3074).
 

--- a/twistlock/CHANGELOG.md
+++ b/twistlock/CHANGELOG.md
@@ -24,7 +24,7 @@
 * [Added] Add Prisma Cloud compatibility. See [#5360](https://github.com/DataDog/integrations-core/pull/5360).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.4.1 / 2020-01-02 / Agent 7.17.0
+## 1.4.1 / 2020-01-02
 
 * [Fixed] Fix possible TypeError due to NoneType in parser.isoparse. See [#5265](https://github.com/DataDog/integrations-core/pull/5265).
 * [Fixed] Fix possible KeyError in _report_compliance_information. See [#5248](https://github.com/DataDog/integrations-core/pull/5248).
@@ -37,15 +37,15 @@
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.2.2 / 2019-08-30 / Agent 6.15.0
+## 1.2.2 / 2019-08-30 / Agent 6.14.0
 
 * [Fixed] Update class signature to support the RequestsWrapper. See [#4469](https://github.com/DataDog/integrations-core/pull/4469).
 
-## 1.2.1 / 2019-08-13 / Agent 6.14.0
+## 1.2.1 / 2019-08-13
 
 * [Fixed] Fix date format matching. See [#4304](https://github.com/DataDog/integrations-core/pull/4304).
 
-## 1.2.0 / 2019-08-02 / Agent 6.14.0
+## 1.2.0 / 2019-08-02
 
 * [Added] Add RequestsWrapper to twistlock. See [#4122](https://github.com/DataDog/integrations-core/pull/4122).
 * [Fixed] Use utcnow instead of now. See [#4192](https://github.com/DataDog/integrations-core/pull/4192).

--- a/varnish/CHANGELOG.md
+++ b/varnish/CHANGELOG.md
@@ -1,36 +1,36 @@
 # CHANGELOG - varnish
 
-## 1.7.0 / 2020-05-17
+## 1.7.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.6.1 / 2020-04-04
+## 1.6.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.6.0 / 2020-01-13
+## 1.6.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 1.5.0 / 2019-12-02
+## 1.5.0 / 2019-12-02 / Agent 7.16.0
 
 * [Fixed] Remove shlex. See [#5065](https://github.com/DataDog/integrations-core/pull/5065).
 * [Added] Add version metadata. See [#4952](https://github.com/DataDog/integrations-core/pull/4952).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3579](https://github.com/DataDog/integrations-core/pull/3579).
 
-## 1.3.1 / 2019-03-29
+## 1.3.1 / 2019-03-29 / Agent 6.11.0
 
 * [Fixed] ensure_unicode with normalize for py3 compatibility. See [#3218](https://github.com/DataDog/integrations-core/pull/3218).
 
-## 1.3.0 / 2019-01-04
+## 1.3.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2810][1].
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].

--- a/varnish/CHANGELOG.md
+++ b/varnish/CHANGELOG.md
@@ -26,11 +26,11 @@
 
 * [Fixed] ensure_unicode with normalize for py3 compatibility. See [#3218](https://github.com/DataDog/integrations-core/pull/3218).
 
-## 1.3.0 / 2019-01-04 / Agent 5.31.0
+## 1.3.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2810][1].
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Make sure all checks' versions are exposed. See [#1945][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].

--- a/vault/CHANGELOG.md
+++ b/vault/CHANGELOG.md
@@ -15,59 +15,59 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.4.0 / 2020-05-04 / Agent 7.20.0
+## 2.4.0 / 2020-05-04
 
 * [Added] Add Raft storage backend metrics. See [#6492](https://github.com/DataDog/integrations-core/pull/6492). Thanks [fabienrenaud](https://github.com/fabienrenaud).
 
-## 2.3.2 / 2020-05-04 / Agent 7.20.0
+## 2.3.2 / 2020-05-04 / Agent 7.19.2
 
 * [Fixed] Fixed infinite stream of Vault leader detection events. See [#6552](https://github.com/DataDog/integrations-core/pull/6552). Thanks [fabienrenaud](https://github.com/fabienrenaud).
 
-## 2.3.1 / 2020-04-07 / Agent 7.20.0
+## 2.3.1 / 2020-04-07 / Agent 7.19.0
 
 * [Fixed] Add `kerberos_cache` to HTTP config options. See [#6279](https://github.com/DataDog/integrations-core/pull/6279).
 
-## 2.3.0 / 2020-04-04 / Agent 7.19.0
+## 2.3.0 / 2020-04-04
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 * [Fixed] Fix event submission on leader change. See [#6039](https://github.com/DataDog/integrations-core/pull/6039).
 
-## 2.2.1 / 2020-02-25 / Agent 7.19.0
+## 2.2.1 / 2020-02-25 / Agent 7.18.0
 
 * [Fixed] Update datadog_checks_base dependencies. See [#5846](https://github.com/DataDog/integrations-core/pull/5846).
 
-## 2.2.0 / 2020-02-22 / Agent 7.18.0
+## 2.2.0 / 2020-02-22
 
 * [Added] Add `service` option to default configuration. See [#5805](https://github.com/DataDog/integrations-core/pull/5805).
 * [Added] Add missing vault summary metric. See [#5670](https://github.com/DataDog/integrations-core/pull/5670).
 
-## 2.1.2 / 2020-01-24 / Agent 7.18.0
+## 2.1.2 / 2020-01-24 / Agent 7.17.0
 
 * [Fixed] Send summary count metrics as a count. See [#5538](https://github.com/DataDog/integrations-core/pull/5538).
 
-## 2.1.1 / 2020-01-13 / Agent 7.17.0
+## 2.1.1 / 2020-01-13
 
 * [Fixed] Fix http handler. See [#5434](https://github.com/DataDog/integrations-core/pull/5434).
 
-## 2.1.0 / 2020-01-09 / Agent 7.17.0
+## 2.1.0 / 2020-01-09
 
 * [Added] Add support for metric collection without a token. See [#5424](https://github.com/DataDog/integrations-core/pull/5424).
 * [Added] Make OpenMetrics use the RequestsWrapper. See [#5414](https://github.com/DataDog/integrations-core/pull/5414).
 
-## 2.0.0 / 2019-12-21 / Agent 7.17.0
+## 2.0.0 / 2019-12-21
 
 * [Changed] Collect prometheus metrics if a client token is available. See [#5177](https://github.com/DataDog/integrations-core/pull/5177).
 
-## 1.7.1 / 2019-10-21 / Agent 7.16.0
+## 1.7.1 / 2019-10-21 / Agent 6.15.0
 
 * [Fixed] Fix is_leader when vault sealed. See [#4838](https://github.com/DataDog/integrations-core/pull/4838).
 
-## 1.7.0 / 2019-10-18 / Agent 7.16.0
+## 1.7.0 / 2019-10-18
 
 * [Added] Allows certain expected HTTP error status_codes for the `/sys/health` endpoint. See [#4745](https://github.com/DataDog/integrations-core/pull/4745).
 
-## 1.6.0 / 2019-10-07 / Agent 6.15.0
+## 1.6.0 / 2019-10-07
 
 * [Fixed] Fix crash in HA mode. See [#4698](https://github.com/DataDog/integrations-core/pull/4698).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
@@ -76,7 +76,7 @@
 
 * [Added] Add requests wrapper to vault. See [#4259](https://github.com/DataDog/integrations-core/pull/4259).
 
-## 1.4.1 / 2019-07-31 / Agent 6.14.0
+## 1.4.1 / 2019-07-31
 
 * [Fixed] Submit critical service check with 500 server errors. See [#4242](https://github.com/DataDog/integrations-core/pull/4242).
 
@@ -84,24 +84,24 @@
 
 * [Added] Adhere to code style. See [#3580](https://github.com/DataDog/integrations-core/pull/3580).
 
-## 1.3.1 / 2019-01-04 / Agent 5.31.0
+## 1.3.1 / 2019-01-04 / Agent 6.9.0
 
 * [Fixed] Fix unsupported API version fallback. See [#2793][1].
 
-## 1.3.0 / 2018-11-30 / Agent 5.30.0
+## 1.3.0 / 2018-11-30 / Agent 6.8.0
 
 * [Added] Support custom certificates. See [#2657][2]. Thanks [eedwards-sk][3].
 
-## 1.2.0 / 2018-08-15 / Agent 5.27.0
+## 1.2.0 / 2018-08-15 / Agent 6.5.0
 
 * [Added] Add is_leader metric. See [#2057][4].
 
-## 1.1.0 / 2018-08-08 / Agent 5.27.0
+## 1.1.0 / 2018-08-08
 
 * [Added] Add option to disable urllib3 warnings. See [#2009][5].
 * [Changed] Add data files to the wheel package. See [#1727][6].
 
-## 1.0.0 / 2018-06-19 / Agent 5.26.0
+## 1.0.0 / 2018-06-19
 
 * [Added] Add Vault integration. See [#1759][7].
 [1]: https://github.com/DataDog/integrations-core/pull/2793

--- a/vault/CHANGELOG.md
+++ b/vault/CHANGELOG.md
@@ -1,107 +1,107 @@
 # CHANGELOG - Vault
 
-## 2.6.1 / 2020-08-10
+## 2.6.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 * [Fixed] DOCS-838 Template wording. See [#7038](https://github.com/DataDog/integrations-core/pull/7038).
 * [Fixed] Update ntlm_domain example. See [#7118](https://github.com/DataDog/integrations-core/pull/7118).
 
-## 2.6.0 / 2020-06-29
+## 2.6.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Fixed] Fix template specs typos. See [#6912](https://github.com/DataDog/integrations-core/pull/6912).
 
-## 2.5.0 / 2020-05-17
+## 2.5.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.4.0 / 2020-05-04
+## 2.4.0 / 2020-05-04 / Agent 7.20.0
 
 * [Added] Add Raft storage backend metrics. See [#6492](https://github.com/DataDog/integrations-core/pull/6492). Thanks [fabienrenaud](https://github.com/fabienrenaud).
 
-## 2.3.2 / 2020-05-04
+## 2.3.2 / 2020-05-04 / Agent 7.20.0
 
 * [Fixed] Fixed infinite stream of Vault leader detection events. See [#6552](https://github.com/DataDog/integrations-core/pull/6552). Thanks [fabienrenaud](https://github.com/fabienrenaud).
 
-## 2.3.1 / 2020-04-07
+## 2.3.1 / 2020-04-07 / Agent 7.20.0
 
 * [Fixed] Add `kerberos_cache` to HTTP config options. See [#6279](https://github.com/DataDog/integrations-core/pull/6279).
 
-## 2.3.0 / 2020-04-04
+## 2.3.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] Add option to set SNI hostname via the `Host` header for RequestsWrapper. See [#5833](https://github.com/DataDog/integrations-core/pull/5833).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 * [Fixed] Fix event submission on leader change. See [#6039](https://github.com/DataDog/integrations-core/pull/6039).
 
-## 2.2.1 / 2020-02-25
+## 2.2.1 / 2020-02-25 / Agent 7.19.0
 
 * [Fixed] Update datadog_checks_base dependencies. See [#5846](https://github.com/DataDog/integrations-core/pull/5846).
 
-## 2.2.0 / 2020-02-22
+## 2.2.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add `service` option to default configuration. See [#5805](https://github.com/DataDog/integrations-core/pull/5805).
 * [Added] Add missing vault summary metric. See [#5670](https://github.com/DataDog/integrations-core/pull/5670).
 
-## 2.1.2 / 2020-01-24
+## 2.1.2 / 2020-01-24 / Agent 7.18.0
 
 * [Fixed] Send summary count metrics as a count. See [#5538](https://github.com/DataDog/integrations-core/pull/5538).
 
-## 2.1.1 / 2020-01-13
+## 2.1.1 / 2020-01-13 / Agent 7.17.0
 
 * [Fixed] Fix http handler. See [#5434](https://github.com/DataDog/integrations-core/pull/5434).
 
-## 2.1.0 / 2020-01-09
+## 2.1.0 / 2020-01-09 / Agent 7.17.0
 
 * [Added] Add support for metric collection without a token. See [#5424](https://github.com/DataDog/integrations-core/pull/5424).
 * [Added] Make OpenMetrics use the RequestsWrapper. See [#5414](https://github.com/DataDog/integrations-core/pull/5414).
 
-## 2.0.0 / 2019-12-21
+## 2.0.0 / 2019-12-21 / Agent 7.17.0
 
 * [Changed] Collect prometheus metrics if a client token is available. See [#5177](https://github.com/DataDog/integrations-core/pull/5177).
 
-## 1.7.1 / 2019-10-21
+## 1.7.1 / 2019-10-21 / Agent 7.16.0
 
 * [Fixed] Fix is_leader when vault sealed. See [#4838](https://github.com/DataDog/integrations-core/pull/4838).
 
-## 1.7.0 / 2019-10-18
+## 1.7.0 / 2019-10-18 / Agent 7.16.0
 
 * [Added] Allows certain expected HTTP error status_codes for the `/sys/health` endpoint. See [#4745](https://github.com/DataDog/integrations-core/pull/4745).
 
-## 1.6.0 / 2019-10-07
+## 1.6.0 / 2019-10-07 / Agent 6.15.0
 
 * [Fixed] Fix crash in HA mode. See [#4698](https://github.com/DataDog/integrations-core/pull/4698).
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.5.0 / 2019-08-24
+## 1.5.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add requests wrapper to vault. See [#4259](https://github.com/DataDog/integrations-core/pull/4259).
 
-## 1.4.1 / 2019-07-31
+## 1.4.1 / 2019-07-31 / Agent 6.14.0
 
 * [Fixed] Submit critical service check with 500 server errors. See [#4242](https://github.com/DataDog/integrations-core/pull/4242).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3580](https://github.com/DataDog/integrations-core/pull/3580).
 
-## 1.3.1 / 2019-01-04
+## 1.3.1 / 2019-01-04 / Agent 5.31.0
 
 * [Fixed] Fix unsupported API version fallback. See [#2793][1].
 
-## 1.3.0 / 2018-11-30
+## 1.3.0 / 2018-11-30 / Agent 5.30.0
 
 * [Added] Support custom certificates. See [#2657][2]. Thanks [eedwards-sk][3].
 
-## 1.2.0 / 2018-08-15
+## 1.2.0 / 2018-08-15 / Agent 5.27.0
 
 * [Added] Add is_leader metric. See [#2057][4].
 
-## 1.1.0 / 2018-08-08
+## 1.1.0 / 2018-08-08 / Agent 5.27.0
 
 * [Added] Add option to disable urllib3 warnings. See [#2009][5].
 * [Changed] Add data files to the wheel package. See [#1727][6].
 
-## 1.0.0 / 2018-06-19
+## 1.0.0 / 2018-06-19 / Agent 5.26.0
 
 * [Added] Add Vault integration. See [#1759][7].
 [1]: https://github.com/DataDog/integrations-core/pull/2793

--- a/vertica/CHANGELOG.md
+++ b/vertica/CHANGELOG.md
@@ -1,44 +1,44 @@
 # CHANGELOG - Vertica
 
-## 1.6.0 / 2020-08-10
+## 1.6.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Improve collection of library logs for debug flares. See [#7252](https://github.com/DataDog/integrations-core/pull/7252).
 * [Fixed] Use DEBUG log level for Vertica when Agent log level is DEBUG or TRACE. See [#7264](https://github.com/DataDog/integrations-core/pull/7264).
 
-## 1.5.0 / 2020-05-17
+## 1.5.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add version metadata. See [#6346](https://github.com/DataDog/integrations-core/pull/6346).
 
-## 1.4.1 / 2020-04-04
+## 1.4.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 1.4.0 / 2020-01-13
+## 1.4.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Fixed] Upgrade vertica to stop logging to /dev/null. See [#5352](https://github.com/DataDog/integrations-core/pull/5352).
 
-## 1.3.1 / 2019-11-14
+## 1.3.1 / 2019-11-14 / Agent 7.16.0
 
 * [Fixed] Fix client log. See [#5011](https://github.com/DataDog/integrations-core/pull/5011).
 
-## 1.3.0 / 2019-11-14
+## 1.3.0 / 2019-11-14 / Agent 7.16.0
 
 * [Added] Add vertica lib log config. See [#5005](https://github.com/DataDog/integrations-core/pull/5005).
 
-## 1.2.0 / 2019-11-11
+## 1.2.0 / 2019-11-11 / Agent 7.16.0
 
 * [Added] Create a new connection at every check run when necessary. See [#4983](https://github.com/DataDog/integrations-core/pull/4983).
 
-## 1.1.1 / 2019-11-06
+## 1.1.1 / 2019-11-06 / Agent 7.16.0
 
 * [Fixed] Recreate connection when closed. See [#4958](https://github.com/DataDog/integrations-core/pull/4958).
 
-## 1.1.0 / 2019-10-11
+## 1.1.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add more Vertica metrics. See [#4649](https://github.com/DataDog/integrations-core/pull/4649).
 
-## 1.0.0 / 2019-08-24
+## 1.0.0 / 2019-08-24 / Agent 6.14.0
 
 * [Added] Add Vertica integration. See [#3890](https://github.com/DataDog/integrations-core/pull/3890).

--- a/vertica/CHANGELOG.md
+++ b/vertica/CHANGELOG.md
@@ -23,15 +23,15 @@
 
 * [Fixed] Fix client log. See [#5011](https://github.com/DataDog/integrations-core/pull/5011).
 
-## 1.3.0 / 2019-11-14 / Agent 7.16.0
+## 1.3.0 / 2019-11-14
 
 * [Added] Add vertica lib log config. See [#5005](https://github.com/DataDog/integrations-core/pull/5005).
 
-## 1.2.0 / 2019-11-11 / Agent 7.16.0
+## 1.2.0 / 2019-11-11
 
 * [Added] Create a new connection at every check run when necessary. See [#4983](https://github.com/DataDog/integrations-core/pull/4983).
 
-## 1.1.1 / 2019-11-06 / Agent 7.16.0
+## 1.1.1 / 2019-11-06
 
 * [Fixed] Recreate connection when closed. See [#4958](https://github.com/DataDog/integrations-core/pull/4958).
 

--- a/vsphere/CHANGELOG.md
+++ b/vsphere/CHANGELOG.md
@@ -19,16 +19,16 @@
 * [Added] Add version metadata. See [#6364](https://github.com/DataDog/integrations-core/pull/6364).
 * [Fixed] Properly error when filtering resources by the `tag` property but `collect_tags` is disabled. See [#6638](https://github.com/DataDog/integrations-core/pull/6638).
 
-## 5.1.2 / 2020-04-14 / Agent 7.20.0
+## 5.1.2 / 2020-04-14 / Agent 7.19.0
 
 * [Fixed] Renew REST API session on failure. See [#6330](https://github.com/DataDog/integrations-core/pull/6330).
 * [Fixed] Fix vsphere capitalization. See [#6278](https://github.com/DataDog/integrations-core/pull/6278).
 
-## 5.1.1 / 2020-04-10 / Agent 7.20.0
+## 5.1.1 / 2020-04-10
 
 * [Fixed] Fix tags race conditions with filtering. See [#6297](https://github.com/DataDog/integrations-core/pull/6297).
 
-## 5.1.0 / 2020-04-04 / Agent 7.19.0
+## 5.1.0 / 2020-04-04
 
 * [Added] resource filters: allow blacklist and tag filtering. See [#6194](https://github.com/DataDog/integrations-core/pull/6194).
 * [Added] Add type annotations. See [#6036](https://github.com/DataDog/integrations-core/pull/6036).
@@ -41,16 +41,16 @@
 * [Fixed] Rename `to_string()` utility to `to_native_string()`. See [#5996](https://github.com/DataDog/integrations-core/pull/5996).
 * [Fixed] Improve logging of the legacy implementation. See [#5993](https://github.com/DataDog/integrations-core/pull/5993).
 
-## 5.0.2 / 2020-02-29 / Agent 7.19.0
+## 5.0.2 / 2020-02-29 / Agent 7.18.0
 
 * [Fixed] Disconnect vSphere connection to the server on refresh. See [#5929](https://github.com/DataDog/integrations-core/pull/5929).
 
-## 5.0.1 / 2020-02-28 / Agent 7.19.0
+## 5.0.1 / 2020-02-28
 
 * [Fixed] Remove some unnecessary warnings. See [#5916](https://github.com/DataDog/integrations-core/pull/5916).
 * [Fixed] Add tags section in conf.yaml. See [#5911](https://github.com/DataDog/integrations-core/pull/5911).
 
-## 5.0.0 / 2020-02-22 / Agent 7.18.0
+## 5.0.0 / 2020-02-22
 
 * [Added] Add `tls_ignore_warning` option. See [#5777](https://github.com/DataDog/integrations-core/pull/5777).
 * [Fixed] Submit collected vsphere tags as host tags for realtime resources. See [#5776](https://github.com/DataDog/integrations-core/pull/5776).
@@ -65,7 +65,7 @@
 
 * [Added] Add ability to exclude specific host tags from host metadata. See [#5201](https://github.com/DataDog/integrations-core/pull/5201).
 
-## 4.2.2 / 2019-12-11 / Agent 7.17.0
+## 4.2.2 / 2019-12-11
 
 * [Fixed] Creating container views using a context manager. See [#5187](https://github.com/DataDog/integrations-core/pull/5187).
 * [Fixed] Add warning log on historical metrics collection failure. See [#5161](https://github.com/DataDog/integrations-core/pull/5161).
@@ -74,7 +74,7 @@
 
 * [Fixed] Collect the latest non-negative value for historical metrics. See [#5026](https://github.com/DataDog/integrations-core/pull/5026).
 
-## 4.2.0 / 2019-10-28 / Agent 7.16.0
+## 4.2.0 / 2019-10-28
 
 * [Added] Adds the ability to collect realtime and historical metrics in two different instances for better performance. See [#4337](https://github.com/DataDog/integrations-core/pull/4337).
 
@@ -82,7 +82,7 @@
 
 * [Fixed] Filters VMs in excluded hosts. See [#3933](https://github.com/DataDog/integrations-core/pull/3933).
 
-## 4.1.2 / 2019-06-17 / Agent 6.13.0
+## 4.1.2 / 2019-06-17
 
 * [Fixed] [vsphere] update metric_to_check. See [#3904](https://github.com/DataDog/integrations-core/pull/3904).
 * [Fixed] Fix handling of gray events. See [#3864](https://github.com/DataDog/integrations-core/pull/3864).
@@ -92,47 +92,47 @@
 * [Fixed] Fix event alarms publishing. See [#3831](https://github.com/DataDog/integrations-core/pull/3831).
 * [Fixed] Fix unit for vsphere.mem.usage.avg. See [#3827](https://github.com/DataDog/integrations-core/pull/3827).
 
-## 4.1.0 / 2019-04-25 / Agent 6.12.0
+## 4.1.0 / 2019-04-25
 
 * [Added] Adhere to code style. See [#3581](https://github.com/DataDog/integrations-core/pull/3581).
 * [Added] Support Python 3. See [#3250](https://github.com/DataDog/integrations-core/pull/3250).
 
-## 4.0.0 / 2019-01-29 / Agent 5.32.0
+## 4.0.0 / 2019-01-29 / Agent 6.10.0
 
 * [Changed] Wait for jobs to finish before returning from check function. See [#3034](https://github.com/DataDog/integrations-core/pull/3034).
 
-## 3.6.2 / 2019-01-10 / Agent 5.32.0
+## 3.6.2 / 2019-01-10 / Agent 6.9.0
 
 * [Fixed] Fix tags normalization. See [#2918][1].
 
-## 3.6.1 / 2019-01-04 / Agent 5.31.0
+## 3.6.1 / 2019-01-04
 
 * [Fixed] Demote critical log levels to error. See [#2795][2].
 
-## 3.6.0 / 2018-11-29 / Agent 5.30.0
+## 3.6.0 / 2018-11-29 / Agent 6.8.0
 
 * [Added] Add option to collect cluster, datacenter and datastore metrics. See [#2655][3].
 
-## 3.5.0 / 2018-11-21 / Agent 5.30.0
+## 3.5.0 / 2018-11-21
 
 * [Added] Handle unicode characters in vSphere object names. See [#2596][4].
 
-## 3.4.0 / 2018-10-31 / Agent 5.30.0
+## 3.4.0 / 2018-10-31
 
 * [Added] Add option to use guest hostname instead of VM name. See [#2479][5].
 * [Added] Upgrade requests. See [#2481][6].
 * [Fixed] Fix "insufficient permission" error message formatting. See [#2480][7].
 
-## 3.3.1 / 2018-09-19 / Agent 5.28.0
+## 3.3.1 / 2018-09-19 / Agent 6.5.2
 
 * [Fixed] Fix batch implementation logic. See [#2265][8].
 
-## 3.3.0 / 2018-09-17 / Agent 5.28.0
+## 3.3.0 / 2018-09-17
 
 * [Added]  Add ability to filter metrics by collection level. See [#2226][9].
 * [Changed] Precompute list of metric IDs to improve performance. See [#2221][10].
 
-## 3.2.0 / 2018-09-11 / Agent 5.28.0
+## 3.2.0 / 2018-09-11
 
 * [Fixed] Handle missing attributes in property collector result. See [#2205][11].
 * [Fixed] Make the metadata cache thread safe. See [#2212][12].
@@ -140,33 +140,33 @@
 * [Fixed] Check that objects queue is initialized before processing it, and process it entirely. See [#2192][14].
 * [Changed] Rewrite the Mor cache. See [#2173][15].
 
-## 3.1.0 / 2018-09-06 / Agent 5.28.0
+## 3.1.0 / 2018-09-06 / Agent 6.5.0
 
 * [Changed] Downgrade pyvmomi to v6.5.0.2017.5-1. See [#2180][16].
 
-## 3.0.0 / 2018-09-04 / Agent 5.28.0
+## 3.0.0 / 2018-09-04
 
 * [Changed] Upgrade pyvmomi to 6.7.0. See [#2153][17].
 * [Changed] Make first level cache thread safe. See [#2146][18].
 
-## 2.4.0 / 2018-08-30 / Agent 5.27.0
+## 2.4.0 / 2018-08-30
 
 * [Fixed] Control size of the thread pool job queue. See [#2131][19].
 * [Changed] Make the cache configuration thread safe. See [#2125][20].
 * [Changed] Removed unused `_clean` method, added more unit tests. See [#2120][21].
 
-## 2.3.1 / 2018-08-28 / Agent 5.27.0
+## 2.3.1 / 2018-08-28
 
 * [Fixed]  Fix `KeyError` due to race condition on the cache. See [#2099][22].
 
-## 2.3.0 / 2018-08-21 / Agent 5.27.0
+## 2.3.0 / 2018-08-21
 
 * [Fixed] Drastically improve check performance by reducing number of calls to vSphere API. See [#2039][23].
 * [Fixed] Retry connection once on failure, and correctly send CRITICAL service check if the connection still cannot be made. See [#2060][24].
 * [Fixed] fix race condition and keyerror. See [#1893][25].
 * [Changed] Add data files to the wheel package. See [#1727][26].
 
-## 2.2.0 / 2018-06-20 / Agent 5.26.0
+## 2.2.0 / 2018-06-20 / Agent 6.4.0
 
 * [Changed] Bump requests to 2.19.1. See [#1743][27].
 

--- a/vsphere/CHANGELOG.md
+++ b/vsphere/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG - vsphere
 
-## 5.4.0 / 2020-08-10
+## 5.4.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Collect and submit vSphere attributes. See [#7180](https://github.com/DataDog/integrations-core/pull/7180).
 
-## 5.3.0 / 2020-06-29
+## 5.3.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 * [Added] Add collect events fallback. See [#6658](https://github.com/DataDog/integrations-core/pull/6658).
@@ -13,22 +13,22 @@
 * [Fixed] Move event to non legacy folder. See [#6751](https://github.com/DataDog/integrations-core/pull/6751).
 * [Fixed] Avoid calling get_latest_event_timestamp. See [#6656](https://github.com/DataDog/integrations-core/pull/6656).
 
-## 5.2.0 / 2020-05-17
+## 5.2.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add version metadata. See [#6364](https://github.com/DataDog/integrations-core/pull/6364).
 * [Fixed] Properly error when filtering resources by the `tag` property but `collect_tags` is disabled. See [#6638](https://github.com/DataDog/integrations-core/pull/6638).
 
-## 5.1.2 / 2020-04-14
+## 5.1.2 / 2020-04-14 / Agent 7.20.0
 
 * [Fixed] Renew REST API session on failure. See [#6330](https://github.com/DataDog/integrations-core/pull/6330).
 * [Fixed] Fix vsphere capitalization. See [#6278](https://github.com/DataDog/integrations-core/pull/6278).
 
-## 5.1.1 / 2020-04-10
+## 5.1.1 / 2020-04-10 / Agent 7.20.0
 
 * [Fixed] Fix tags race conditions with filtering. See [#6297](https://github.com/DataDog/integrations-core/pull/6297).
 
-## 5.1.0 / 2020-04-04
+## 5.1.0 / 2020-04-04 / Agent 7.19.0
 
 * [Added] resource filters: allow blacklist and tag filtering. See [#6194](https://github.com/DataDog/integrations-core/pull/6194).
 * [Added] Add type annotations. See [#6036](https://github.com/DataDog/integrations-core/pull/6036).
@@ -41,16 +41,16 @@
 * [Fixed] Rename `to_string()` utility to `to_native_string()`. See [#5996](https://github.com/DataDog/integrations-core/pull/5996).
 * [Fixed] Improve logging of the legacy implementation. See [#5993](https://github.com/DataDog/integrations-core/pull/5993).
 
-## 5.0.2 / 2020-02-29
+## 5.0.2 / 2020-02-29 / Agent 7.19.0
 
 * [Fixed] Disconnect vSphere connection to the server on refresh. See [#5929](https://github.com/DataDog/integrations-core/pull/5929).
 
-## 5.0.1 / 2020-02-28
+## 5.0.1 / 2020-02-28 / Agent 7.19.0
 
 * [Fixed] Remove some unnecessary warnings. See [#5916](https://github.com/DataDog/integrations-core/pull/5916).
 * [Fixed] Add tags section in conf.yaml. See [#5911](https://github.com/DataDog/integrations-core/pull/5911).
 
-## 5.0.0 / 2020-02-22
+## 5.0.0 / 2020-02-22 / Agent 7.18.0
 
 * [Added] Add `tls_ignore_warning` option. See [#5777](https://github.com/DataDog/integrations-core/pull/5777).
 * [Fixed] Submit collected vsphere tags as host tags for realtime resources. See [#5776](https://github.com/DataDog/integrations-core/pull/5776).
@@ -61,78 +61,78 @@
 * [Added] Add per instance values as tag. See [#5584](https://github.com/DataDog/integrations-core/pull/5584).
 * [Changed] vSphere new implementation. See [#5251](https://github.com/DataDog/integrations-core/pull/5251).
 
-## 4.3.0 / 2019-12-13
+## 4.3.0 / 2019-12-13 / Agent 7.17.0
 
 * [Added] Add ability to exclude specific host tags from host metadata. See [#5201](https://github.com/DataDog/integrations-core/pull/5201).
 
-## 4.2.2 / 2019-12-11
+## 4.2.2 / 2019-12-11 / Agent 7.17.0
 
 * [Fixed] Creating container views using a context manager. See [#5187](https://github.com/DataDog/integrations-core/pull/5187).
 * [Fixed] Add warning log on historical metrics collection failure. See [#5161](https://github.com/DataDog/integrations-core/pull/5161).
 
-## 4.2.1 / 2019-11-15
+## 4.2.1 / 2019-11-15 / Agent 7.16.0
 
 * [Fixed] Collect the latest non-negative value for historical metrics. See [#5026](https://github.com/DataDog/integrations-core/pull/5026).
 
-## 4.2.0 / 2019-10-28
+## 4.2.0 / 2019-10-28 / Agent 7.16.0
 
 * [Added] Adds the ability to collect realtime and historical metrics in two different instances for better performance. See [#4337](https://github.com/DataDog/integrations-core/pull/4337).
 
-## 4.1.3 / 2019-06-19
+## 4.1.3 / 2019-06-19 / Agent 6.13.0
 
 * [Fixed] Filters VMs in excluded hosts. See [#3933](https://github.com/DataDog/integrations-core/pull/3933).
 
-## 4.1.2 / 2019-06-17
+## 4.1.2 / 2019-06-17 / Agent 6.13.0
 
 * [Fixed] [vsphere] update metric_to_check. See [#3904](https://github.com/DataDog/integrations-core/pull/3904).
 * [Fixed] Fix handling of gray events. See [#3864](https://github.com/DataDog/integrations-core/pull/3864).
 
-## 4.1.1 / 2019-06-01
+## 4.1.1 / 2019-06-01 / Agent 6.12.0
 
 * [Fixed] Fix event alarms publishing. See [#3831](https://github.com/DataDog/integrations-core/pull/3831).
 * [Fixed] Fix unit for vsphere.mem.usage.avg. See [#3827](https://github.com/DataDog/integrations-core/pull/3827).
 
-## 4.1.0 / 2019-04-25
+## 4.1.0 / 2019-04-25 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3581](https://github.com/DataDog/integrations-core/pull/3581).
 * [Added] Support Python 3. See [#3250](https://github.com/DataDog/integrations-core/pull/3250).
 
-## 4.0.0 / 2019-01-29
+## 4.0.0 / 2019-01-29 / Agent 5.32.0
 
 * [Changed] Wait for jobs to finish before returning from check function. See [#3034](https://github.com/DataDog/integrations-core/pull/3034).
 
-## 3.6.2 / 2019-01-10
+## 3.6.2 / 2019-01-10 / Agent 5.32.0
 
 * [Fixed] Fix tags normalization. See [#2918][1].
 
-## 3.6.1 / 2019-01-04
+## 3.6.1 / 2019-01-04 / Agent 5.31.0
 
 * [Fixed] Demote critical log levels to error. See [#2795][2].
 
-## 3.6.0 / 2018-11-29
+## 3.6.0 / 2018-11-29 / Agent 5.30.0
 
 * [Added] Add option to collect cluster, datacenter and datastore metrics. See [#2655][3].
 
-## 3.5.0 / 2018-11-21
+## 3.5.0 / 2018-11-21 / Agent 5.30.0
 
 * [Added] Handle unicode characters in vSphere object names. See [#2596][4].
 
-## 3.4.0 / 2018-10-31
+## 3.4.0 / 2018-10-31 / Agent 5.30.0
 
 * [Added] Add option to use guest hostname instead of VM name. See [#2479][5].
 * [Added] Upgrade requests. See [#2481][6].
 * [Fixed] Fix "insufficient permission" error message formatting. See [#2480][7].
 
-## 3.3.1 / 2018-09-19
+## 3.3.1 / 2018-09-19 / Agent 5.28.0
 
 * [Fixed] Fix batch implementation logic. See [#2265][8].
 
-## 3.3.0 / 2018-09-17
+## 3.3.0 / 2018-09-17 / Agent 5.28.0
 
 * [Added]  Add ability to filter metrics by collection level. See [#2226][9].
 * [Changed] Precompute list of metric IDs to improve performance. See [#2221][10].
 
-## 3.2.0 / 2018-09-11
+## 3.2.0 / 2018-09-11 / Agent 5.28.0
 
 * [Fixed] Handle missing attributes in property collector result. See [#2205][11].
 * [Fixed] Make the metadata cache thread safe. See [#2212][12].
@@ -140,33 +140,33 @@
 * [Fixed] Check that objects queue is initialized before processing it, and process it entirely. See [#2192][14].
 * [Changed] Rewrite the Mor cache. See [#2173][15].
 
-## 3.1.0 / 2018-09-06
+## 3.1.0 / 2018-09-06 / Agent 5.28.0
 
 * [Changed] Downgrade pyvmomi to v6.5.0.2017.5-1. See [#2180][16].
 
-## 3.0.0 / 2018-09-04
+## 3.0.0 / 2018-09-04 / Agent 5.28.0
 
 * [Changed] Upgrade pyvmomi to 6.7.0. See [#2153][17].
 * [Changed] Make first level cache thread safe. See [#2146][18].
 
-## 2.4.0 / 2018-08-30
+## 2.4.0 / 2018-08-30 / Agent 5.27.0
 
 * [Fixed] Control size of the thread pool job queue. See [#2131][19].
 * [Changed] Make the cache configuration thread safe. See [#2125][20].
 * [Changed] Removed unused `_clean` method, added more unit tests. See [#2120][21].
 
-## 2.3.1 / 2018-08-28
+## 2.3.1 / 2018-08-28 / Agent 5.27.0
 
 * [Fixed]  Fix `KeyError` due to race condition on the cache. See [#2099][22].
 
-## 2.3.0 / 2018-08-21
+## 2.3.0 / 2018-08-21 / Agent 5.27.0
 
 * [Fixed] Drastically improve check performance by reducing number of calls to vSphere API. See [#2039][23].
 * [Fixed] Retry connection once on failure, and correctly send CRITICAL service check if the connection still cannot be made. See [#2060][24].
 * [Fixed] fix race condition and keyerror. See [#1893][25].
 * [Changed] Add data files to the wheel package. See [#1727][26].
 
-## 2.2.0 / 2018-06-20
+## 2.2.0 / 2018-06-20 / Agent 5.26.0
 
 * [Changed] Bump requests to 2.19.1. See [#1743][27].
 

--- a/win32_event_log/CHANGELOG.md
+++ b/win32_event_log/CHANGELOG.md
@@ -16,7 +16,7 @@
 * [Fixed] Add wmi integration test and fix filter sampler. See [#6576](https://github.com/DataDog/integrations-core/pull/6576).
 * [Fixed] WMI base typing and instance free API. See [#6329](https://github.com/DataDog/integrations-core/pull/6329).
 
-## 2.3.4 / 2020-04-16 / Agent 7.20.0
+## 2.3.4 / 2020-04-16
 
 * [Fixed] Normalize integers. See [#6357](https://github.com/DataDog/integrations-core/pull/6357).
 
@@ -24,11 +24,11 @@
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 2.3.2 / 2020-02-25 / Agent 7.19.0
+## 2.3.2 / 2020-02-25 / Agent 7.18.0
 
 * [Fixed] Bump minimum base check on wmi checks. See [#5860](https://github.com/DataDog/integrations-core/pull/5860).
 
-## 2.3.1 / 2020-02-22 / Agent 7.18.0
+## 2.3.1 / 2020-02-22
 
 * [Fixed] Fix thread leak in WMI sampler. See [#5659](https://github.com/DataDog/integrations-core/pull/5659). Thanks [rlaveycal](https://github.com/rlaveycal).
 
@@ -54,15 +54,15 @@
 * [Changed] Require the use of filters. See [#3652](https://github.com/DataDog/integrations-core/pull/3652).
 * [Added] Adhere to code style. See [#3582](https://github.com/DataDog/integrations-core/pull/3582).
 
-## 1.4.0 / 2019-02-18 / Agent 6.11.0
+## 1.4.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3. See [#3040](https://github.com/DataDog/integrations-core/pull/3040).
 
-## 1.3.0 / 2018-10-12 / Agent 5.28.0
+## 1.3.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.2.0 / 2018-09-04 / Agent 5.28.0
+## 1.2.0 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Fix syntax. See [#2115][2].
 * [Added] Check events between system boot and DataDog agent start. See [#1929][3]. Thanks [jvanlieshout][4].

--- a/win32_event_log/CHANGELOG.md
+++ b/win32_event_log/CHANGELOG.md
@@ -4,65 +4,65 @@
 
 * [Added] Introduce new, more performant implementation. See [#7005](https://github.com/DataDog/integrations-core/pull/7005).
 
-## 2.5.0 / 2020-06-29
+## 2.5.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 * [Added] Override CaseInsensitiveDict `copy()` function. See [#6715](https://github.com/DataDog/integrations-core/pull/6715).
 
-## 2.4.0 / 2020-05-17
+## 2.4.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Refactor check to support new implementation. See [#6639](https://github.com/DataDog/integrations-core/pull/6639).
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Fixed] Add wmi integration test and fix filter sampler. See [#6576](https://github.com/DataDog/integrations-core/pull/6576).
 * [Fixed] WMI base typing and instance free API. See [#6329](https://github.com/DataDog/integrations-core/pull/6329).
 
-## 2.3.4 / 2020-04-16
+## 2.3.4 / 2020-04-16 / Agent 7.20.0
 
 * [Fixed] Normalize integers. See [#6357](https://github.com/DataDog/integrations-core/pull/6357).
 
-## 2.3.3 / 2020-04-04
+## 2.3.3 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 2.3.2 / 2020-02-25
+## 2.3.2 / 2020-02-25 / Agent 7.19.0
 
 * [Fixed] Bump minimum base check on wmi checks. See [#5860](https://github.com/DataDog/integrations-core/pull/5860).
 
-## 2.3.1 / 2020-02-22
+## 2.3.1 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Fix thread leak in WMI sampler. See [#5659](https://github.com/DataDog/integrations-core/pull/5659). Thanks [rlaveycal](https://github.com/rlaveycal).
 
-## 2.3.0 / 2020-01-13
+## 2.3.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 2.2.0 / 2019-12-02
+## 2.2.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 2.1.0 / 2019-10-11
+## 2.1.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 2.0.1 / 2019-08-24
+## 2.0.1 / 2019-08-24 / Agent 6.14.0
 
 * [Fixed] Remove check for user filter. See [#4342](https://github.com/DataDog/integrations-core/pull/4342).
 
-## 2.0.0 / 2019-05-14
+## 2.0.0 / 2019-05-14 / Agent 6.12.0
 
 * [Changed] Require the use of filters. See [#3652](https://github.com/DataDog/integrations-core/pull/3652).
 * [Added] Adhere to code style. See [#3582](https://github.com/DataDog/integrations-core/pull/3582).
 
-## 1.4.0 / 2019-02-18
+## 1.4.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3. See [#3040](https://github.com/DataDog/integrations-core/pull/3040).
 
-## 1.3.0 / 2018-10-12
+## 1.3.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.2.0 / 2018-09-04
+## 1.2.0 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Fix syntax. See [#2115][2].
 * [Added] Check events between system boot and DataDog agent start. See [#1929][3]. Thanks [jvanlieshout][4].

--- a/windows_service/CHANGELOG.md
+++ b/windows_service/CHANGELOG.md
@@ -12,11 +12,11 @@
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 2.5.1 / 2020-02-25 / Agent 7.19.0
+## 2.5.1 / 2020-02-25 / Agent 7.18.0
 
 * [Fixed] Bump minimun agent version. See [#5834](https://github.com/DataDog/integrations-core/pull/5834).
 
-## 2.5.0 / 2020-02-22 / Agent 7.18.0
+## 2.5.0 / 2020-02-22
 
 * [Deprecated] Deprecate `service` tag. See [#5545](https://github.com/DataDog/integrations-core/pull/5545).
 
@@ -38,12 +38,12 @@
 * [Fixed] Add debug to compare short names, service names and patterns. See [#3427](https://github.com/DataDog/integrations-core/pull/3427).
 * [Added] Adhere to code style. See [#3583](https://github.com/DataDog/integrations-core/pull/3583).
 
-## 2.0.0 / 2018-10-12 / Agent 5.28.0
+## 2.0.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 * [Removed] Make windows_service use scm api instead of wmi. See [#2305][2].
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 

--- a/windows_service/CHANGELOG.md
+++ b/windows_service/CHANGELOG.md
@@ -1,49 +1,49 @@
 # CHANGELOG - windows_service
 
-## 2.7.0 / 2020-06-29
+## 2.7.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 
-## 2.6.0 / 2020-05-17
+## 2.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.5.2 / 2020-04-04
+## 2.5.2 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 2.5.1 / 2020-02-25
+## 2.5.1 / 2020-02-25 / Agent 7.19.0
 
 * [Fixed] Bump minimun agent version. See [#5834](https://github.com/DataDog/integrations-core/pull/5834).
 
-## 2.5.0 / 2020-02-22
+## 2.5.0 / 2020-02-22 / Agent 7.18.0
 
 * [Deprecated] Deprecate `service` tag. See [#5545](https://github.com/DataDog/integrations-core/pull/5545).
 
-## 2.4.0 / 2020-01-13
+## 2.4.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 
-## 2.3.0 / 2019-12-02
+## 2.3.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 2.2.0 / 2019-10-11
+## 2.2.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 * [Fixed] Search patterns in reverse sort order. See [#4503](https://github.com/DataDog/integrations-core/pull/4503).
 
-## 2.1.0 / 2019-05-14
+## 2.1.0 / 2019-05-14 / Agent 6.12.0
 
 * [Fixed] Add debug to compare short names, service names and patterns. See [#3427](https://github.com/DataDog/integrations-core/pull/3427).
 * [Added] Adhere to code style. See [#3583](https://github.com/DataDog/integrations-core/pull/3583).
 
-## 2.0.0 / 2018-10-12
+## 2.0.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 * [Removed] Make windows_service use scm api instead of wmi. See [#2305][2].
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 

--- a/wmi_check/CHANGELOG.md
+++ b/wmi_check/CHANGELOG.md
@@ -20,11 +20,11 @@
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.7.2 / 2020-02-25 / Agent 7.19.0
+## 1.7.2 / 2020-02-25 / Agent 7.18.0
 
 * [Fixed] Bump minimum base check on wmi checks. See [#5860](https://github.com/DataDog/integrations-core/pull/5860).
 
-## 1.7.1 / 2020-02-22 / Agent 7.18.0
+## 1.7.1 / 2020-02-22
 
 * [Fixed] Fix thread leak in WMI sampler. See [#5659](https://github.com/DataDog/integrations-core/pull/5659). Thanks [rlaveycal](https://github.com/rlaveycal).
 * [Fixed] Change wmi_check to use lists instead of tuples for filters. See [#5510](https://github.com/DataDog/integrations-core/pull/5510).
@@ -45,7 +45,7 @@
 
 * [Fixed] Avoid WMISampler inheriting from Thread. See [#4051](https://github.com/DataDog/integrations-core/pull/4051).
 
-## 1.4.1 / 2019-07-04 / Agent 6.13.0
+## 1.4.1 / 2019-07-04
 
 * [Fixed] Make WMISampler hashable. See [#4043](https://github.com/DataDog/integrations-core/pull/4043).
 
@@ -53,15 +53,15 @@
 
 * [Added] Adhere to code style. See [#3584](https://github.com/DataDog/integrations-core/pull/3584).
 
-## 1.3.0 / 2019-02-18 / Agent 6.11.0
+## 1.3.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Python 3 for WMI. See [#3031](https://github.com/DataDog/integrations-core/pull/3031).
 
-## 1.2.0 / 2018-10-12 / Agent 5.28.0
+## 1.2.0 / 2018-10-12 / Agent 6.6.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.1.2 / 2018-09-04 / Agent 5.28.0
+## 1.1.2 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Moves WMI Check to Pytest. See [#2133][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].

--- a/wmi_check/CHANGELOG.md
+++ b/wmi_check/CHANGELOG.md
@@ -1,67 +1,67 @@
 # CHANGELOG - wmi_check
 
-## 1.9.1 / 2020-08-10
+## 1.9.1 / 2020-08-10 / Agent 7.22.0
 
 * [Fixed] Fix namespace default value. See [#7179](https://github.com/DataDog/integrations-core/pull/7179).
 
-## 1.9.0 / 2020-06-29
+## 1.9.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Upgrade pywin32 to 228. See [#6980](https://github.com/DataDog/integrations-core/pull/6980).
 * [Added] Support multiple properties in tag_by. See [#6614](https://github.com/DataDog/integrations-core/pull/6614).
 * [Fixed] Remove multi-instances support. See [#6325](https://github.com/DataDog/integrations-core/pull/6325).
 
-## 1.8.0 / 2020-05-17
+## 1.8.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 * [Added] Add config specs. See [#6409](https://github.com/DataDog/integrations-core/pull/6409).
 * [Fixed] WMI base typing and instance free API. See [#6329](https://github.com/DataDog/integrations-core/pull/6329).
 
-## 1.7.3 / 2020-04-04
+## 1.7.3 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.7.2 / 2020-02-25
+## 1.7.2 / 2020-02-25 / Agent 7.19.0
 
 * [Fixed] Bump minimum base check on wmi checks. See [#5860](https://github.com/DataDog/integrations-core/pull/5860).
 
-## 1.7.1 / 2020-02-22
+## 1.7.1 / 2020-02-22 / Agent 7.18.0
 
 * [Fixed] Fix thread leak in WMI sampler. See [#5659](https://github.com/DataDog/integrations-core/pull/5659). Thanks [rlaveycal](https://github.com/rlaveycal).
 * [Fixed] Change wmi_check to use lists instead of tuples for filters. See [#5510](https://github.com/DataDog/integrations-core/pull/5510).
 
-## 1.7.0 / 2020-01-13
+## 1.7.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 
-## 1.6.0 / 2019-12-02
+## 1.6.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Upgrade pywin32 to 227. See [#5036](https://github.com/DataDog/integrations-core/pull/5036).
 
-## 1.5.0 / 2019-10-11
+## 1.5.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Upgrade pywin32 to 225. See [#4563](https://github.com/DataDog/integrations-core/pull/4563).
 
-## 1.4.2 / 2019-07-13
+## 1.4.2 / 2019-07-13 / Agent 6.13.0
 
 * [Fixed] Avoid WMISampler inheriting from Thread. See [#4051](https://github.com/DataDog/integrations-core/pull/4051).
 
-## 1.4.1 / 2019-07-04
+## 1.4.1 / 2019-07-04 / Agent 6.13.0
 
 * [Fixed] Make WMISampler hashable. See [#4043](https://github.com/DataDog/integrations-core/pull/4043).
 
-## 1.4.0 / 2019-05-14
+## 1.4.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3584](https://github.com/DataDog/integrations-core/pull/3584).
 
-## 1.3.0 / 2019-02-18
+## 1.3.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Python 3 for WMI. See [#3031](https://github.com/DataDog/integrations-core/pull/3031).
 
-## 1.2.0 / 2018-10-12
+## 1.2.0 / 2018-10-12 / Agent 5.28.0
 
 * [Added] Pin pywin32 dependency. See [#2322][1].
 
-## 1.1.2 / 2018-09-04
+## 1.1.2 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Moves WMI Check to Pytest. See [#2133][2].
 * [Fixed] Add data files to the wheel package. See [#1727][3].

--- a/yarn/CHANGELOG.md
+++ b/yarn/CHANGELOG.md
@@ -1,69 +1,69 @@
 # CHANGELOG - yarn
 
-## 1.15.0 / 2020-08-10
+## 1.15.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Add config specs for YARN integration. See [#7167](https://github.com/DataDog/integrations-core/pull/7167).
 * [Added] Add ability to split YARN application tags into Datadog tags. See [#7101](https://github.com/DataDog/integrations-core/pull/7101). Thanks [nicodv](https://github.com/nicodv).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 1.14.0 / 2020-06-29
+## 1.14.0 / 2020-06-29 / Agent 7.21.0
 
 * [Added] Add note about warning concurrency. See [#6967](https://github.com/DataDog/integrations-core/pull/6967).
 
-## 1.13.0 / 2020-05-17
+## 1.13.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 1.12.1 / 2020-04-04
+## 1.12.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 
-## 1.12.0 / 2020-01-13
+## 1.12.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 * [Added] Use lazy logging format. See [#5377](https://github.com/DataDog/integrations-core/pull/5377).
 * [Fixed] Add additional mapping tests. See [#5146](https://github.com/DataDog/integrations-core/pull/5146).
 
-## 1.11.0 / 2019-12-02
+## 1.11.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add version metadata. See [#4986](https://github.com/DataDog/integrations-core/pull/4986).
 * [Added] Add yarn application status mapping. See [#4642](https://github.com/DataDog/integrations-core/pull/4642).
 
-## 1.10.0 / 2019-10-11
+## 1.10.0 / 2019-10-11 / Agent 6.15.0
 
 * [Added] Add option to override KRB5CCNAME env var. See [#4578](https://github.com/DataDog/integrations-core/pull/4578).
 
-## 1.9.0 / 2019-07-09
+## 1.9.0 / 2019-07-09 / Agent 6.13.0
 
 * [Added] Use the new RequestsWrapper for connecting to services. See [#4059](https://github.com/DataDog/integrations-core/pull/4059).
 
-## 1.8.0 / 2019-06-19
+## 1.8.0 / 2019-06-19 / Agent 6.13.0
 
 * [Deprecated] Add yarn.apps.<METRIC>_gauge metrics and deprecate yarn.apps.<METRIC> metrics. See [#3927](https://github.com/DataDog/integrations-core/pull/3927).
 
-## 1.7.1 / 2019-06-13
+## 1.7.1 / 2019-06-13 / Agent 6.13.0
 
 * [Fixed] Fix `application_tags` in conf file. See [#3908](https://github.com/DataDog/integrations-core/pull/3908).
 
-## 1.7.0 / 2019-05-14
+## 1.7.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3585](https://github.com/DataDog/integrations-core/pull/3585).
 
-## 1.6.0 / 2019-02-18
+## 1.6.0 / 2019-02-18 / Agent 6.11.0
 
 * [Added] Support Kerberos auth. See [#2824](https://github.com/DataDog/integrations-core/pull/2824).
 
-## 1.5.0 / 2019-01-04
+## 1.5.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2786][1].
 
-## 1.4.0 / 2018-09-04
+## 1.4.0 / 2018-09-04 / Agent 5.28.0
 
 * [Added] Add option to verify ssl certificate. See [#1739][2].
 * [Fixed] Fix bug and typo in DEFAULT_CLUSTER_NAME for YARN check. See [#1814][3]. Thanks [eplanet][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 1.3.0 / 2018-06-13
+## 1.3.0 / 2018-06-13 / Agent 5.26.0
 
 * [Added] Add support for HTTP authentication. See [#1684][6].
 

--- a/yarn/CHANGELOG.md
+++ b/yarn/CHANGELOG.md
@@ -37,33 +37,33 @@
 
 * [Added] Use the new RequestsWrapper for connecting to services. See [#4059](https://github.com/DataDog/integrations-core/pull/4059).
 
-## 1.8.0 / 2019-06-19 / Agent 6.13.0
+## 1.8.0 / 2019-06-19
 
 * [Deprecated] Add yarn.apps.<METRIC>_gauge metrics and deprecate yarn.apps.<METRIC> metrics. See [#3927](https://github.com/DataDog/integrations-core/pull/3927).
 
-## 1.7.1 / 2019-06-13 / Agent 6.13.0
+## 1.7.1 / 2019-06-13 / Agent 6.12.0
 
 * [Fixed] Fix `application_tags` in conf file. See [#3908](https://github.com/DataDog/integrations-core/pull/3908).
 
-## 1.7.0 / 2019-05-14 / Agent 6.12.0
+## 1.7.0 / 2019-05-14
 
 * [Added] Adhere to code style. See [#3585](https://github.com/DataDog/integrations-core/pull/3585).
 
-## 1.6.0 / 2019-02-18 / Agent 6.11.0
+## 1.6.0 / 2019-02-18 / Agent 6.10.0
 
 * [Added] Support Kerberos auth. See [#2824](https://github.com/DataDog/integrations-core/pull/2824).
 
-## 1.5.0 / 2019-01-04 / Agent 5.31.0
+## 1.5.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2786][1].
 
-## 1.4.0 / 2018-09-04 / Agent 5.28.0
+## 1.4.0 / 2018-09-04 / Agent 6.5.0
 
 * [Added] Add option to verify ssl certificate. See [#1739][2].
 * [Fixed] Fix bug and typo in DEFAULT_CLUSTER_NAME for YARN check. See [#1814][3]. Thanks [eplanet][4].
 * [Fixed] Add data files to the wheel package. See [#1727][5].
 
-## 1.3.0 / 2018-06-13 / Agent 5.26.0
+## 1.3.0 / 2018-06-13
 
 * [Added] Add support for HTTP authentication. See [#1684][6].
 

--- a/zk/CHANGELOG.md
+++ b/zk/CHANGELOG.md
@@ -1,52 +1,52 @@
 # CHANGELOG - zk
 
-## 2.7.0 / 2020-08-10
+## 2.7.0 / 2020-08-10 / Agent 7.22.0
 
 * [Added] Use config specs. See [#6950](https://github.com/DataDog/integrations-core/pull/6950).
 * [Fixed] Update logs config service field to optional. See [#7209](https://github.com/DataDog/integrations-core/pull/7209).
 
-## 2.6.1 / 2020-06-29
+## 2.6.1 / 2020-06-29 / Agent 7.21.0
 
 * [Fixed] Use Agent6 style init. See [#6949](https://github.com/DataDog/integrations-core/pull/6949).
 
-## 2.6.0 / 2020-05-17
+## 2.6.0 / 2020-05-17 / Agent 7.20.0
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.5.0 / 2020-05-04
+## 2.5.0 / 2020-05-04 / Agent 7.20.0
 
 * [Added] Add new metrics for ZK version 3.6. See [#6421](https://github.com/DataDog/integrations-core/pull/6421).
 
-## 2.4.2 / 2020-04-13
+## 2.4.2 / 2020-04-13 / Agent 7.20.0
 
 * [Fixed] Handle non-integers when parsing latency values. See [#6323](https://github.com/DataDog/integrations-core/pull/6323).
 
-## 2.4.1 / 2020-04-04
+## 2.4.1 / 2020-04-04 / Agent 7.19.0
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
 
-## 2.4.0 / 2020-01-13
+## 2.4.0 / 2020-01-13 / Agent 7.17.0
 
 * [Added] Use lazy logging format. See [#5398](https://github.com/DataDog/integrations-core/pull/5398).
 
-## 2.3.0 / 2019-12-02
+## 2.3.0 / 2019-12-02 / Agent 7.16.0
 
 * [Added] Add version metadata. See [#4927](https://github.com/DataDog/integrations-core/pull/4927).
 
-## 2.2.0 / 2019-05-14
+## 2.2.0 / 2019-05-14 / Agent 6.12.0
 
 * [Added] Adhere to code style. See [#3586](https://github.com/DataDog/integrations-core/pull/3586).
 
-## 2.1.0 / 2019-01-04
+## 2.1.0 / 2019-01-04 / Agent 5.31.0
 
 * [Added] Support Python 3. See [#2781][1].
 
-## 2.0.0 / 2018-11-30
+## 2.0.0 / 2018-11-30 / Agent 5.30.0
 
 * [Removed] Removed incorrect metric name 'bytes_outstanding'. See [#2476][2].
 
-## 1.2.1 / 2018-09-04
+## 1.2.1 / 2018-09-04 / Agent 5.28.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 

--- a/zk/CHANGELOG.md
+++ b/zk/CHANGELOG.md
@@ -13,15 +13,15 @@
 
 * [Added] Allow optional dependency installation for all checks. See [#6589](https://github.com/DataDog/integrations-core/pull/6589).
 
-## 2.5.0 / 2020-05-04 / Agent 7.20.0
+## 2.5.0 / 2020-05-04
 
 * [Added] Add new metrics for ZK version 3.6. See [#6421](https://github.com/DataDog/integrations-core/pull/6421).
 
-## 2.4.2 / 2020-04-13 / Agent 7.20.0
+## 2.4.2 / 2020-04-13 / Agent 7.19.0
 
 * [Fixed] Handle non-integers when parsing latency values. See [#6323](https://github.com/DataDog/integrations-core/pull/6323).
 
-## 2.4.1 / 2020-04-04 / Agent 7.19.0
+## 2.4.1 / 2020-04-04
 
 * [Fixed] Update deprecated imports. See [#6088](https://github.com/DataDog/integrations-core/pull/6088).
 * [Fixed] Remove logs sourcecategory. See [#6121](https://github.com/DataDog/integrations-core/pull/6121).
@@ -38,15 +38,15 @@
 
 * [Added] Adhere to code style. See [#3586](https://github.com/DataDog/integrations-core/pull/3586).
 
-## 2.1.0 / 2019-01-04 / Agent 5.31.0
+## 2.1.0 / 2019-01-04 / Agent 6.9.0
 
 * [Added] Support Python 3. See [#2781][1].
 
-## 2.0.0 / 2018-11-30 / Agent 5.30.0
+## 2.0.0 / 2018-11-30 / Agent 6.8.0
 
 * [Removed] Removed incorrect metric name 'bytes_outstanding'. See [#2476][2].
 
-## 1.2.1 / 2018-09-04 / Agent 5.28.0
+## 1.2.1 / 2018-09-04 / Agent 6.5.0
 
 * [Fixed] Add data files to the wheel package. See [#1727][3].
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add agent versions to integrations changelog

Related PR: https://github.com/DataDog/integrations-core/pull/7518

### Motivation
<!-- What inspired you to submit this pull request? -->


Sometimes we know that a feature has been release with integration version X and we want to know (easily) what was the first version of the agent containing that feature.
