### PR TITLE
Fixed missing tags_regex: tags for some Metrics

### DIFF
--- a/haproxy/datadog_checks/haproxy/haproxy.py
+++ b/haproxy/datadog_checks/haproxy/haproxy.py
@@ -440,25 +440,25 @@ class HAProxy(AgentCheck):
                     custom_tags=line_tags,
                 )
 
-        if collect_status_metrics:
-            self._process_status_metric(
-                self.hosts_statuses,
-                collect_status_metrics_by_host,
-                services_incl_filter=services_incl_filter,
-                services_excl_filter=services_excl_filter,
-                collate_status_tags_per_host=collate_status_tags_per_host,
-                count_status_by_service=count_status_by_service,
-                custom_tags=line_tags,
-                active_tag=active_tag,
-            )
+            if collect_status_metrics:
+                self._process_status_metric(
+                    self.hosts_statuses,
+                    collect_status_metrics_by_host,
+                    services_incl_filter=services_incl_filter,
+                    services_excl_filter=services_excl_filter,
+                    collate_status_tags_per_host=collate_status_tags_per_host,
+                    count_status_by_service=count_status_by_service,
+                    custom_tags=line_tags,
+                    active_tag=active_tag,
+                )
 
-            self._process_backend_hosts_metric(
-                self.hosts_statuses,
-                services_incl_filter=services_incl_filter,
-                services_excl_filter=services_excl_filter,
-                custom_tags=line_tags,
-                active_tag=active_tag,
-            )
+                self._process_backend_hosts_metric(
+                    self.hosts_statuses,
+                    services_incl_filter=services_incl_filter,
+                    services_excl_filter=services_excl_filter,
+                    custom_tags=line_tags,
+                    active_tag=active_tag,
+                )
 
         return data
 


### PR DESCRIPTION
### What does this PR do?
Certain HAProxy metrics (e.g. haproxy.count_per_status) don't include the tags set by the tags_regex option while other HAProxy metrics include them. This seems to be due to an if statement not being correctly indented.

### Motivation
Issue raised here: https://github.com/DataDog/integrations-core/issues/7492

### Additional Notes
This indentation fix was tested on my sandbox account but I have not rigorously tested the modification with unit tests etc.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
