### PR TITLE
Add device_index to idrac (AI-938)

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/_dell-rac.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_dell-rac.yaml
@@ -204,6 +204,10 @@ metrics:
           name: memoryDeviceType
         tag: device_type
       - column:
+          OID: 1.3.6.1.4.1.674.10892.5.4.1100.50.1.2
+          name: memoryDeviceIndex
+        tag: device_index
+      - column:
           OID: 1.3.6.1.4.1.674.10892.5.4.1100.50.1.1
           name: memoryDevicechassisIndex
         tag: chassis_index

--- a/snmp/datadog_checks/snmp/data/profiles/dell-poweredge.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/dell-poweredge.yaml
@@ -141,6 +141,10 @@ metrics:
           name: memoryDevicechassisIndex
         tag: chassis_index
       - column:
+          OID: 1.3.6.1.4.1.674.10892.5.4.1100.50.1.2
+          name: memoryDeviceIndex
+        tag: device_index
+      - column:
           OID: 1.3.6.1.4.1.674.10892.1.1100.50.1.23
           name: memoryDeviceSerialNumberName
         tag: serial_number_name

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -691,8 +691,9 @@ def test_idrac(aggregator):
 
     indexes = ['29', '22']
     device_types = ['26', '4']
-    for index, device_type in zip(indexes, device_types):
-        tags = ['chassis_index:{}'.format(index), 'device_type:{}'.format(device_type)] + common_tags
+    device_indexes = ['4', '21']
+    for index, device_type, device_index in zip(indexes, device_types, device_indexes):
+        tags = ['chassis_index:{}'.format(index), 'device_type:{}'.format(device_type), 'device_index:{}'.format(device_index)] + common_tags
         aggregator.assert_metric(
             'snmp.{}'.format("memoryDeviceStatus"), metric_type=aggregator.GAUGE, tags=tags, count=1
         )

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -693,7 +693,11 @@ def test_idrac(aggregator):
     device_types = ['26', '4']
     device_indexes = ['4', '21']
     for index, device_type, device_index in zip(indexes, device_types, device_indexes):
-        tags = ['chassis_index:{}'.format(index), 'device_type:{}'.format(device_type), 'device_index:{}'.format(device_index)] + common_tags
+        tags = [
+            'chassis_index:{}'.format(index),
+            'device_type:{}'.format(device_type),
+            'device_index:{}'.format(device_index),
+        ] + common_tags
         aggregator.assert_metric(
             'snmp.{}'.format("memoryDeviceStatus"), metric_type=aggregator.GAUGE, tags=tags, count=1
         )


### PR DESCRIPTION
### What does this PR do?

Add device_index to idrac

### Motivation

To discriminate each row of the table, we need to tag by device_index too.