### PR TITLE
Normalize from datadog_checks_base to datadog-checks-base

### DIFF
--- a/active_directory/setup.py
+++ b/active_directory/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
 
 setup(
     name='datadog-active_directory',

--- a/activemq/setup.py
+++ b/activemq/setup.py
@@ -54,7 +54,7 @@ setup(
     # The package we're going to ship
     packages=['datadog_checks.activemq'],
     # Run-time dependencies
-    install_requires=['datadog_checks_base'],
+    install_requires=['datadog-checks-base'],
     extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/activemq_xml/setup.py
+++ b/activemq_xml/setup.py
@@ -29,7 +29,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-activemq_xml',

--- a/apache/setup.py
+++ b/apache/setup.py
@@ -37,7 +37,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-apache',

--- a/aspdotnet/setup.py
+++ b/aspdotnet/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
 
 setup(
     name='datadog-aspdotnet',

--- a/btrfs/setup.py
+++ b/btrfs/setup.py
@@ -26,7 +26,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-btrfs',

--- a/cacti/setup.py
+++ b/cacti/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-cacti',

--- a/cassandra/setup.py
+++ b/cassandra/setup.py
@@ -56,7 +56,7 @@ setup(
     # The package we're going to ship
     packages=['datadog_checks.cassandra'],
     # Run-time dependencies
-    install_requires=['datadog_checks_base>=11.0.0'],
+    install_requires=['datadog-checks-base>=11.0.0'],
     extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/cassandra_nodetool/setup.py
+++ b/cassandra_nodetool/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 
 setup(

--- a/ceph/setup.py
+++ b/ceph/setup.py
@@ -26,7 +26,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-ceph',

--- a/cisco_aci/setup.py
+++ b/cisco_aci/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-cisco_aci',

--- a/couch/setup.py
+++ b/couch/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-couch',

--- a/couchbase/setup.py
+++ b/couchbase/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-couchbase',

--- a/datadog_checks_base/setup.py
+++ b/datadog_checks_base/setup.py
@@ -40,7 +40,7 @@ def get_requirements(fpath, exclude=None, only=None):
 setup(
     # Version should always match one from an agent release
     version=ABOUT["__version__"],
-    name='datadog_checks_base',
+    name='datadog-checks-base',
     description='The Datadog Check Toolkit',
     long_description=LONG_DESC,
     long_description_content_type='text/markdown',

--- a/directory/setup.py
+++ b/directory/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-directory',

--- a/dns_check/setup.py
+++ b/dns_check/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-dns_check',

--- a/dotnetclr/setup.py
+++ b/dotnetclr/setup.py
@@ -25,7 +25,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.4.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.4.0'
 
 setup(
     name='datadog-dotnetclr',

--- a/ecs_fargate/setup.py
+++ b/ecs_fargate/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=5.1.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=5.1.0'
 
 setup(
     name='datadog-ecs_fargate',

--- a/envoy/setup.py
+++ b/envoy/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-envoy',

--- a/etcd/setup.py
+++ b/etcd/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-etcd',

--- a/exchange_server/setup.py
+++ b/exchange_server/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=4.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 setup(
     name='datadog-exchange_server',

--- a/external_dns/setup.py
+++ b/external_dns/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-external_dns',

--- a/fluentd/setup.py
+++ b/fluentd/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.1.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.1.0'
 
 setup(
     name='datadog-fluentd',

--- a/gearmand/setup.py
+++ b/gearmand/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-gearmand',

--- a/gitlab/setup.py
+++ b/gitlab/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-gitlab',

--- a/gitlab_runner/setup.py
+++ b/gitlab_runner/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-gitlab_runner',

--- a/go-metro/setup.py
+++ b/go-metro/setup.py
@@ -59,7 +59,7 @@ setup(
     packages=['datadog_checks.go-metro'],
 
     # Run-time dependencies
-    install_requires=['datadog_checks_base'],
+    install_requires=['datadog-checks-base'],
     extras_require={'deps': get_dependencies()},
 
     # Extra files to ship with the wheel package

--- a/go_expvar/setup.py
+++ b/go_expvar/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-go_expvar',

--- a/gunicorn/setup.py
+++ b/gunicorn/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-gunicorn',

--- a/haproxy/setup.py
+++ b/haproxy/setup.py
@@ -25,7 +25,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-haproxy',

--- a/hdfs_datanode/setup.py
+++ b/hdfs_datanode/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-hdfs_datanode',

--- a/http_check/setup.py
+++ b/http_check/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=4.6.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=4.6.0'
 
 setup(
     name='datadog-http_check',

--- a/iis/setup.py
+++ b/iis/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
 
 setup(
     name='datadog-iis',

--- a/istio/setup.py
+++ b/istio/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-istio',

--- a/kafka/setup.py
+++ b/kafka/setup.py
@@ -56,7 +56,7 @@ setup(
     # The package we're going to ship
     packages=['datadog_checks.kafka'],
     # Run-time dependencies
-    install_requires=['datadog_checks_base>=11.0.0'],
+    install_requires=['datadog-checks-base>=11.0.0'],
     extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/kong/setup.py
+++ b/kong/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-kong',

--- a/kube_dns/setup.py
+++ b/kube_dns/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-kube_dns',

--- a/kube_proxy/setup.py
+++ b/kube_proxy/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-kube-proxy',

--- a/kubelet/setup.py
+++ b/kubelet/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base >= 6.5.0'
+CHECKS_BASE_REQ = 'datadog-checks-base >= 6.5.0'
 
 setup(
     name='datadog-kubelet',

--- a/kubernetes_state/setup.py
+++ b/kubernetes_state/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-kubernetes_state',

--- a/kyototycoon/setup.py
+++ b/kyototycoon/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-kyototycoon',

--- a/lighttpd/setup.py
+++ b/lighttpd/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-lighttpd',

--- a/linkerd/setup.py
+++ b/linkerd/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-linkerd',

--- a/linux_proc_extras/setup.py
+++ b/linux_proc_extras/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-linux_proc_extras',

--- a/mapreduce/setup.py
+++ b/mapreduce/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-mapreduce',

--- a/marathon/setup.py
+++ b/marathon/setup.py
@@ -25,7 +25,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-marathon',

--- a/mesos_master/setup.py
+++ b/mesos_master/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-mesos_master',

--- a/mesos_slave/setup.py
+++ b/mesos_slave/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-mesos_slave',

--- a/nagios/setup.py
+++ b/nagios/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=4.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 setup(
     name='datadog-nagios',

--- a/network/setup.py
+++ b/network/setup.py
@@ -26,7 +26,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=13.1.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=13.1.0'
 
 setup(
     name='datadog-network',

--- a/nfsstat/setup.py
+++ b/nfsstat/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-nfsstat',

--- a/openstack/setup.py
+++ b/openstack/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-openstack',

--- a/oracle/setup.py
+++ b/oracle/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-oracle',

--- a/pdh_check/setup.py
+++ b/pdh_check/setup.py
@@ -29,7 +29,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
 
 setup(
     name='datadog-pdh_check',

--- a/pgbouncer/setup.py
+++ b/pgbouncer/setup.py
@@ -25,7 +25,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-pgbouncer',

--- a/php_fpm/setup.py
+++ b/php_fpm/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-php_fpm',

--- a/postfix/setup.py
+++ b/postfix/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-postfix',

--- a/powerdns_recursor/setup.py
+++ b/powerdns_recursor/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-powerdns_recursor',

--- a/process/setup.py
+++ b/process/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-process',

--- a/prometheus/setup.py
+++ b/prometheus/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-prometheus',

--- a/rabbitmq/setup.py
+++ b/rabbitmq/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-rabbitmq',

--- a/riak/setup.py
+++ b/riak/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-riak',

--- a/riakcs/setup.py
+++ b/riakcs/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-riakcs',

--- a/snmp/setup.py
+++ b/snmp/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-snmp',

--- a/solr/setup.py
+++ b/solr/setup.py
@@ -54,7 +54,7 @@ setup(
     # The package we're going to ship
     packages=['datadog_checks.solr'],
     # Run-time dependencies
-    install_requires=['datadog_checks_base'],
+    install_requires=['datadog-checks-base'],
     extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/sqlserver/setup.py
+++ b/sqlserver/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-sqlserver',

--- a/squid/setup.py
+++ b/squid/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-squid',

--- a/ssh_check/setup.py
+++ b/ssh_check/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-ssh_check',

--- a/statsd/setup.py
+++ b/statsd/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-statsd',

--- a/supervisord/setup.py
+++ b/supervisord/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-supervisord',

--- a/system_core/setup.py
+++ b/system_core/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-system_core',

--- a/system_swap/setup.py
+++ b/system_swap/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-system_swap',

--- a/tcp_check/setup.py
+++ b/tcp_check/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=4.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
 
 setup(
     name='datadog-tcp_check',

--- a/teamcity/setup.py
+++ b/teamcity/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-teamcity',

--- a/tokumx/setup.py
+++ b/tokumx/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-tokumx',

--- a/tomcat/setup.py
+++ b/tomcat/setup.py
@@ -54,7 +54,7 @@ setup(
     # The package we're going to ship
     packages=['datadog_checks.tomcat'],
     # Run-time dependencies
-    install_requires=['datadog_checks_base'],
+    install_requires=['datadog-checks-base'],
     extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/twemproxy/setup.py
+++ b/twemproxy/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-twemproxy',

--- a/varnish/setup.py
+++ b/varnish/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 setup(
     name='datadog-varnish',

--- a/vault/setup.py
+++ b/vault/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-vault',

--- a/vsphere/setup.py
+++ b/vsphere/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-vsphere',

--- a/win32_event_log/setup.py
+++ b/win32_event_log/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-win32_event_log',

--- a/windows_service/setup.py
+++ b/windows_service/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-windows_service',

--- a/wmi_check/setup.py
+++ b/wmi_check/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.6.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.6.0'
 
 setup(
     name='datadog-wmi_check',

--- a/zk/setup.py
+++ b/zk/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog_checks_base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-zk',


### PR DESCRIPTION
### What does this PR do?

Normalize from datadog_checks_base to datadog-checks-base

### Motivation

Currently we are using both `datadog_checks_base` and `datadog-checks-base`. 

When building wheel, both will be converted to `datadog-checks-base`. You can check that in the wheel's `METADATA` file, field `Requires-Dist`.

It makes more sense to use `datadog-checks-base` everywhere since it's the package name.