### PR TITLE
When postgres is not an aurora it is giving error in the execution of agent

### DIFF
--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -27,7 +27,7 @@ def is_aurora(db):
     try:
         cursor.execute("select * from pg_proc where proname = 'AURORA_VERSION';")
         return cursor.fetchone() is not None
-    except:
+    except Exception:
         db.rollback()
         return False
 

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -25,8 +25,8 @@ def get_raw_version(db):
 def is_aurora(db):
     cursor = db.cursor()
     try:
-        cursor.execute("select * from pg_proc where proname = 'aurora_version';")
-        return cursor.fetchone() is not None
+        cursor.execute("select exists(select 1 from pg_proc where proname = 'aurora_version');")
+        return cursor.fetchone()[0]
     except Exception:
         db.rollback()
         return False

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -3,7 +3,6 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import re
 
-import psycopg2
 import semver
 from semver import VersionInfo
 

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -25,7 +25,7 @@ def get_raw_version(db):
 def is_aurora(db):
     cursor = db.cursor()
     try:
-        cursor.execute("select * from pg_proc where proname = 'AURORA_VERSION';")
+        cursor.execute("select * from pg_proc where proname = 'aurora_version';")
         return cursor.fetchone() is not None
     except Exception:
         db.rollback()

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -26,9 +26,9 @@ def get_raw_version(db):
 def is_aurora(db):
     cursor = db.cursor()
     try:
-        cursor.execute('select AURORA_VERSION();')
-        return True
-    except psycopg2.errors.UndefinedFunction:
+        cursor.execute("select * from pg_proc where proname = 'AURORA_VERSION';")
+        return cursor.fetchone() is not None
+    except:
         db.rollback()
         return False
 


### PR DESCRIPTION
### What does this PR do?

On postgres servers that are not aurora it is giving the following error in the log: "ERROR: function aurora_version () does not exist at character 8". From now on it will only be checked if there is a function, if there is, it is understood that it is an aurora.

### Motivation

Because my Postgres servers (which are not aurora) in production have this error in the log very often

### Additional Notes

No aurora_version function value was used, so I think that just seeing if it exists in pg_proc is enough

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
