### PR TITLE
Pin transient dependency pyrsistent to < 0.17.0

### DIFF
--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -87,7 +87,7 @@ setup(
             'virtualenv>=20.0.8',
             'wheel>=0.31.0',
             # TODO: Remove when tobgu/pyrsistent#206 gets merged
-            'pyrsistent<0.17.0'
+            'pyrsistent<0.17.0',
         ]
     },
     entry_points={

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -86,6 +86,7 @@ setup(
             'twine>=1.11.0',
             'virtualenv>=20.0.8',
             'wheel>=0.31.0',
+            'pyrsistent<0.17.0'
         ]
     },
     entry_points={

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -86,6 +86,7 @@ setup(
             'twine>=1.11.0',
             'virtualenv>=20.0.8',
             'wheel>=0.31.0',
+            # TODO: Remove when tobgu/pyrsistent#206 gets merged
             'pyrsistent<0.17.0'
         ]
     },


### PR DESCRIPTION
### What does this PR do?
Add flag to pip install to resolve dependencies

### Motivation
https://github.com/tobgu/pyrsistent/blob/97190f8ad43553603a95a83361d4c0fe02e86970/CHANGES.txt#L4-L5

Dropped py2 support resulting in CI failing https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=23293&view=logs&j=910f82a4-622d-5ace-f877-8b75c045486c&t=b8a76c45-01d6-50b1-e11b-d9fedb0dbe38&l=230

### Additional Notes
Use https://github.com/DataDog/integrations-core/pull/7545 when issue is resolved via https://github.com/tobgu/pyrsistent/pull/206
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
