### PR TITLE
Put interrupt metrics behind a config option

### DIFF
--- a/linux_proc_extras/datadog_checks/linux_proc_extras/data/conf.yaml.example
+++ b/linux_proc_extras/datadog_checks/linux_proc_extras/data/conf.yaml.example
@@ -12,3 +12,9 @@ instances:
     # tags:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
+
+    ## @param include_interrupts_metrics - boolean - optional - default: false
+    ## Optionally include cpu/irq interrupt metrics.  Note this can dramatically increase cardinality
+    ## for large systems, use with caution.
+    ##
+    # include_interrupts_metrics: false

--- a/linux_proc_extras/datadog_checks/linux_proc_extras/data/conf.yaml.example
+++ b/linux_proc_extras/datadog_checks/linux_proc_extras/data/conf.yaml.example
@@ -13,8 +13,8 @@ instances:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
 
-    ## @param include_interrupts_metrics - boolean - optional - default: false
-    ## Optionally include cpu/irq interrupt metrics.  Note this can dramatically increase cardinality
-    ## for large systems, use with caution.
+    ## @param include_interrupt_metrics - boolean - optional - default: false
+    ## Optionally include CPU/IRQ interrupt metrics.  This can dramatically increase cardinality
+    ## for large systems, so use with caution.
     ##
-    # include_interrupts_metrics: false
+    # include_interrupt_metrics: false

--- a/linux_proc_extras/datadog_checks/linux_proc_extras/data/conf.yaml.example
+++ b/linux_proc_extras/datadog_checks/linux_proc_extras/data/conf.yaml.example
@@ -16,5 +16,5 @@ instances:
     ## @param include_interrupt_metrics - boolean - optional - default: false
     ## Optionally include CPU/IRQ interrupt metrics.  This can dramatically increase cardinality
     ## for large systems, so use with caution.
-    ##
+    #
     # include_interrupt_metrics: false

--- a/linux_proc_extras/datadog_checks/linux_proc_extras/linux_proc_extras.py
+++ b/linux_proc_extras/datadog_checks/linux_proc_extras/linux_proc_extras.py
@@ -40,7 +40,7 @@ class MoreUnixCheck(AgentCheck):
         self.get_stat_info()
         self.get_entropy_info()
         self.get_process_states()
-        if self.instance.get('include_interrupts_metrics', False):
+        if self.instance.get('include_interrupt_metrics', False):
             self.get_interrupts_info()
 
     def set_paths(self):

--- a/linux_proc_extras/datadog_checks/linux_proc_extras/linux_proc_extras.py
+++ b/linux_proc_extras/datadog_checks/linux_proc_extras/linux_proc_extras.py
@@ -40,7 +40,8 @@ class MoreUnixCheck(AgentCheck):
         self.get_stat_info()
         self.get_entropy_info()
         self.get_process_states()
-        self.get_interrupts_info()
+        if self.instance.get('include_interrupts_metrics', False):
+            self.get_interrupts_info()
 
     def set_paths(self):
         proc_location = (datadog_agent.get_config('procfs_path') or '/proc').rstrip('/')

--- a/linux_proc_extras/tests/common.py
+++ b/linux_proc_extras/tests/common.py
@@ -10,21 +10,23 @@ CHECK_NAME = 'linux_proc_extras'
 HERE = get_here()
 FIXTURE_DIR = os.path.join(HERE, "fixtures")
 
-INSTANCE = {"tags": ["foo:bar"]}
+INSTANCE = {"tags": ["foo:bar"], "include_interrupt_metrics": True}
+INSTANCE_NO_INTERRUPT = {"tags": ["foo:bar"], "include_interrupt_metrics": False}
 
 EXPECTED_TAG = "foo:bar"
 
-EXPECTED_METRICS = [
+EXPECTED_BASE_METRICS = [
     'system.inodes.total',
     'system.inodes.used',
     'system.linux.context_switches',
     'system.linux.processes_created',
     'system.linux.interrupts',
-    'system.linux.irq',
     'system.entropy.available',
     'system.processes.states',
     'system.processes.priorities',
 ]
+
+EXPECTED_METRICS = EXPECTED_BASE_METRICS + ['system.linux.irq']
 
 CPU_COUNT = 4
 INTERRUPTS_IDS = [

--- a/linux_proc_extras/tests/test_integration.py
+++ b/linux_proc_extras/tests/test_integration.py
@@ -17,6 +17,14 @@ def test_check(aggregator, check):
         aggregator.assert_metric_has_tag(metric, common.EXPECTED_TAG)
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures("dd_environment")
+def test_check_no_irq(aggregator, check):
+    check.check(deepcopy(common.INSTANCE))
+
+    for metric in common.EXPECTED_BASE_METRICS:
+        aggregator.assert_metric_has_tag(metric, common.EXPECTED_TAG)
+
 @pytest.mark.e2e
 def test_check_e2e(dd_agent_check):
     aggregator = dd_agent_check(deepcopy(common.INSTANCE), rate=True)

--- a/linux_proc_extras/tests/test_integration.py
+++ b/linux_proc_extras/tests/test_integration.py
@@ -25,6 +25,7 @@ def test_check_no_irq(aggregator, check):
     for metric in common.EXPECTED_BASE_METRICS:
         aggregator.assert_metric_has_tag(metric, common.EXPECTED_TAG)
 
+
 @pytest.mark.e2e
 def test_check_e2e(dd_agent_check):
     aggregator = dd_agent_check(deepcopy(common.INSTANCE), rate=True)


### PR DESCRIPTION
Puts #7166 metrics behind config option that is disabled by default.