### PR TITLE
Try normal connection before SSL connection

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/connection.py
+++ b/ibm_mq/datadog_checks/ibm_mq/connection.py
@@ -28,7 +28,7 @@ def get_queue_manager_connection(config):
             get_normal_connection(config)
         except pymqi.MQMIError as e:
             log.debug("Tried normal connection before SSL connection. It failed with: %s", e)
-            if e.reason == pymqi.CMQC.MQRC_HOST_NOT_AVAILABLE:
+            if e.reason in [pymqi.CMQC.MQRC_HOST_NOT_AVAILABLE, pymqi.CMQC.MQRC_UNKNOWN_CHANNEL_NAME]:
                 raise
         return get_ssl_connection(config)
     else:

--- a/ibm_mq/datadog_checks/ibm_mq/connection.py
+++ b/ibm_mq/datadog_checks/ibm_mq/connection.py
@@ -27,6 +27,7 @@ def get_queue_manager_connection(config):
         try:
             get_normal_connection(config)
         except pymqi.MQMIError as e:
+            log.debug("Tried normal connection before SSL connection. It failed with: %s", e)
             if e.reason == pymqi.CMQC.MQRC_HOST_NOT_AVAILABLE:
                 raise
         return get_ssl_connection(config)

--- a/ibm_mq/datadog_checks/ibm_mq/connection.py
+++ b/ibm_mq/datadog_checks/ibm_mq/connection.py
@@ -22,7 +22,7 @@ def get_queue_manager_connection(config):
     if config.ssl:
         # There is a memory leak when SSL connections fail.
         # By testing with a normal connection first, we avoid making unnecessary SSL connections.
-        # This does not fix the memory leak but mitigate it's likelihood.
+        # This does not fix the memory leak but mitigate its likelihood.
         # Details: https://github.com/dsuch/pymqi/issues/208
         try:
             get_normal_connection(config)

--- a/ibm_mq/tests/conftest.py
+++ b/ibm_mq/tests/conftest.py
@@ -59,6 +59,15 @@ def instance_queue_regex_tag():
 
 
 @pytest.fixture
+def instance_ssl_dummy():
+    inst = copy.deepcopy(common.INSTANCE)
+    inst['ssl_auth'] = 'yes'
+    inst['ssl_cipher_spec'] = 'TLS_RSA_WITH_AES_256_CBC_SHA256'
+    inst['ssl_key_repository_location'] = '/dummy'
+    return inst
+
+
+@pytest.fixture
 def seed_data():
     publish()
     consume()

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -218,7 +218,7 @@ def test_ssl_check_normal_connection_before_ssl_connection(instance_ssl_dummy):
             get_normal_connection.assert_called_with(config)
             assert not get_ssl_connection.called
 
-    # normal connection failed with with error other than MQRC_HOST_NOT_AVAILABLE
+    # normal connection failed with with error other those listed in get_queue_manager_connection
     error = pymqi.MQMIError(pymqi.CMQC.MQCC_FAILED, pymqi.CMQC.MQRC_SSL_CONFIG_ERROR)
     with mock.patch(
         'datadog_checks.ibm_mq.connection.get_normal_connection', side_effect=error
@@ -229,7 +229,7 @@ def test_ssl_check_normal_connection_before_ssl_connection(instance_ssl_dummy):
         get_normal_connection.assert_called_with(config)
         get_ssl_connection.assert_called_with(config)
 
-    # no issue with normal connect
+    # no issue with normal connection
     with mock.patch('datadog_checks.ibm_mq.connection.get_normal_connection') as get_normal_connection, mock.patch(
         'datadog_checks.ibm_mq.connection.get_ssl_connection'
     ) as get_ssl_connection:

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -1,13 +1,14 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
+import mock
 import pytest
 from six import iteritems
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.ibm_mq import IbmMqCheck
 from datadog_checks.ibm_mq.config import IBMMQConfig
+from datadog_checks.ibm_mq.connection import get_queue_manager_connection
 
 pytestmark = pytest.mark.unit
 
@@ -195,3 +196,45 @@ def test_ssl_connection_creation(instance):
     assert 'bytes' not in warning
     assert 'unicode' not in warning
     assert 'MQRC_KEY_REPOSITORY_ERROR' in warning
+
+
+def test_ssl_check_normal_connection_before_ssl_connection(instance):
+    import pymqi
+
+    instance['ssl_auth'] = 'yes'
+    instance['ssl_cipher_spec'] = 'TLS_RSA_WITH_AES_256_CBC_SHA256'
+    instance['ssl_key_repository_location'] = '/dummy'
+    config = IBMMQConfig(instance)
+
+    # normal connection failed with with MQRC_HOST_NOT_AVAILABLE
+    error = pymqi.MQMIError(pymqi.CMQC.MQCC_FAILED, pymqi.CMQC.MQRC_HOST_NOT_AVAILABLE)
+    with mock.patch(
+        'datadog_checks.ibm_mq.connection.get_normal_connection', side_effect=error
+    ) as get_normal_connection, mock.patch('datadog_checks.ibm_mq.connection.get_ssl_connection') as get_ssl_connection:
+
+        with pytest.raises(pymqi.MQMIError):
+            get_queue_manager_connection(config)
+
+        get_normal_connection.assert_called_with(config)
+        assert not get_ssl_connection.called
+
+    # normal connection failed with with error other than MQRC_HOST_NOT_AVAILABLE
+    error = pymqi.MQMIError(pymqi.CMQC.MQCC_FAILED, pymqi.CMQC.MQRC_SSL_CONFIG_ERROR)
+    with mock.patch(
+        'datadog_checks.ibm_mq.connection.get_normal_connection', side_effect=error
+    ) as get_normal_connection, mock.patch('datadog_checks.ibm_mq.connection.get_ssl_connection') as get_ssl_connection:
+
+        get_queue_manager_connection(config)
+
+        get_normal_connection.assert_called_with(config)
+        get_ssl_connection.assert_called_with(config)
+
+    # no issue with normal connect
+    with mock.patch('datadog_checks.ibm_mq.connection.get_normal_connection') as get_normal_connection, mock.patch(
+        'datadog_checks.ibm_mq.connection.get_ssl_connection'
+    ) as get_ssl_connection:
+
+        get_queue_manager_connection(config)
+
+        get_normal_connection.assert_called_with(config)
+        get_ssl_connection.assert_called_with(config)


### PR DESCRIPTION
### What does this PR do?

Try normal connection before SSL connection

### Motivation

```
        # There is a memory leak when SSL connections fail.
        # By testing with a normal connection first, we avoid making unnecessary SSL connections.
        # This does not fix the memory leak but mitigate it's likelihood.
```

Details: https://github.com/dsuch/pymqi/issues/208
