### PR TITLE
Ignore . prefixed folders for isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,5 +43,5 @@ known_first_party = 'datadog_checks'
 src_paths = ''
 line_length = 120
 multi_line_output = 3
-skip_glob = '*/datadog_checks/dev/tooling/signing.py,*/datadog_checks/dev/tooling/templates/*,*/datadog_checks/*/vendor/*'
+skip_glob = '.*,*/datadog_checks/dev/tooling/signing.py,*/datadog_checks/dev/tooling/templates/*,*/datadog_checks/*/vendor/*'
 use_parentheses = true


### PR DESCRIPTION
### What does this PR do?

Ignore . prefixed folders for isort

### Motivation

Needed for https://github.com/PyCQA/isort/pull/1473