### PR TITLE
Raise exception on connection error

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -51,7 +51,7 @@ class IbmMqCheck(AgentCheck):
         except Exception as e:
             self.warning("cannot connect to queue manager: %s", e)
             self.service_check(self.SERVICE_CHECK, AgentCheck.CRITICAL, self.config.tags)
-            return
+            raise
 
         self._collect_metadata(queue_manager)
 

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -181,13 +181,19 @@ def test_ssl_connection_creation(instance):
 
     TODO: We should test SSL in e2e
     """
+    # Late import to not require it for e2e
+    import pymqi
+
     instance['ssl_auth'] = 'yes'
     instance['ssl_cipher_spec'] = 'TLS_RSA_WITH_AES_256_CBC_SHA256'
     instance['ssl_key_repository_location'] = '/dummy'
 
     check = IbmMqCheck('ibm_mq', {}, [instance])
 
-    check.check(instance)
+    with pytest.raises(pymqi.MQMIError) as excinfo:
+        check.check(instance)
+
+    assert excinfo.value.reason == pymqi.CMQC.MQRC_KEY_REPOSITORY_ERROR
 
     assert len(check.warnings) == 1
     warning = check.warnings[0]


### PR DESCRIPTION
### What does this PR do?

Raise exception on connection error

### Motivation

By raising an exception, the issue will be visible when using `agent status` command.

Currently, user only see warning logs.