### PR TITLE
Better metric names handling when the namespace is empty

### DIFF
--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -2605,3 +2605,19 @@ def test_wildcard_type_overrides(aggregator, mocked_prometheus_check, text_data)
     assert len(check.config_map[FAKE_ENDPOINT]['_type_override_patterns']) == 1
     assert list(check.config_map[FAKE_ENDPOINT]['_type_override_patterns'].values())[0] == 'counter'
     assert len(check.config_map[FAKE_ENDPOINT]['type_overrides']) == 0
+
+
+def test_empty_namespace(aggregator, mocked_prometheus_check, text_data, ref_gauge):
+    """
+    Test that metric type is overridden correctly with wildcard.
+    """
+    check = mocked_prometheus_check
+    instance = copy.deepcopy(PROMETHEUS_CHECK_INSTANCE)
+    instance['namespace'] = ''
+
+    config = check.get_scraper_config(instance)
+    config['_dry_run'] = False
+
+    check.process_metric(ref_gauge, config)
+
+    aggregator.assert_metric('process.vm.bytes', count=1)


### PR DESCRIPTION
### What does this PR do?

- Remove the leading dot in metric names when the namespace is empty (e.g `.process.vm.bytes` -> `process.vm.bytes`)

### Motivation

- Users might want to pass an empty namespace to the `openmetrics` check to ease the migration from Prometheus (by having the same metric names in DD)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
