### PR TITLE
Fix vsphere dash query value widgets

### DIFF
--- a/vsphere/assets/dashboards/vsphere_overview.json
+++ b/vsphere/assets/dashboards/vsphere_overview.json
@@ -248,7 +248,7 @@
         "type": "query_value",
         "requests": [
           {
-            "q": "sum:vsphere.host.count{$vcenter_server,$vcenter_datacenter,$host}",
+            "q": "sum:vsphere.host.count{$vcenter_server,$vcenter_datacenter,$host}.rollup(avg)",
             "aggregator": "last"
           }
         ],
@@ -267,7 +267,7 @@
         "type": "query_value",
         "requests": [
           {
-            "q": "sum:vsphere.vm.count{$vcenter_server,$vcenter_datacenter,$host}",
+            "q": "sum:vsphere.vm.count{$vcenter_server,$vcenter_datacenter,$host}.rollup(avg)",
             "aggregator": "last"
           }
         ],
@@ -300,7 +300,7 @@
         "type": "query_value",
         "requests": [
           {
-            "q": "sum:vsphere.datastore.count{$vcenter_server,$vcenter_datacenter,$host}",
+            "q": "sum:vsphere.datastore.count{$vcenter_server,$vcenter_datacenter,$host}.rollup(avg)",
             "aggregator": "last"
           }
         ],
@@ -318,7 +318,7 @@
         "type": "query_value",
         "requests": [
           {
-            "q": "sum:vsphere.cluster.count{$vcenter_server,$vcenter_datacenter,$host}",
+            "q": "sum:vsphere.cluster.count{$vcenter_server,$vcenter_datacenter,$host}.rollup(avg)",
             "aggregator": "last"
           }
         ],
@@ -337,7 +337,7 @@
         "type": "query_value",
         "requests": [
           {
-            "q": "sum:vsphere.datacenter.count{$vcenter_server,$vcenter_datacenter,$host}",
+            "q": "sum:vsphere.datacenter.count{$vcenter_server,$vcenter_datacenter,$host}.rollup(avg)",
             "aggregator": "last"
           }
         ],


### PR DESCRIPTION
The `vsphere.*.count` metrics are count type metrics which defaults to time aggregation. That means that when zooming out, the value of the graph will increase as a summation rollup will be performed.
Such a metric has to be a count because of how it's incremented on the agent, but the query value widgets used in the dash should make the correct query. Otherwise, we see the value bumping every now and then and the wrong value being displayed when looking at a more than 4hours timewindow.