### PR TITLE
Add hostname to vsphere debug metrics

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -174,7 +174,10 @@ class VSphereCheck(AgentCheck):
             self.log.error("Failed to collect tags: %s", e)
             return {}
 
-        self.gauge('datadog.vsphere.query_tags.time', t0.total(), tags=self.config.base_tags, raw=True)
+        self.gauge(
+            'datadog.vsphere.query_tags.time', t0.total(), tags=self.config.base_tags, raw=True, hostname=self._hostname
+        )
+
         return mor_tags
 
     def refresh_infrastructure_cache(self):
@@ -371,7 +374,13 @@ class VSphereCheck(AgentCheck):
         """
         t0 = Timer()
         metrics_values = self.api.query_metrics(query_specs)
-        self.histogram('datadog.vsphere.query_metrics.time', t0.total(), tags=self.config.base_tags, raw=True)
+        self.histogram(
+            'datadog.vsphere.query_metrics.time',
+            t0.total(),
+            tags=self.config.base_tags,
+            raw=True,
+            hostname=self._hostname,
+        )
         return metrics_values
 
     def make_query_specs(self):


### PR DESCRIPTION
### What does this PR do?
Adding hostname to vsphere debug metrics

### Motivation
From @FlorianVeaux 
```
Some vSphere debug metrics do not explicitly define an hostname. For regular check this is not an issue as an unset hostname means "use the local agent hostname".
But for vsphere we explicitly set "empty_default_hostname: true" in the config. 
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
