### PR TITLE
Standardize HTTP mocks

### DIFF
--- a/amazon_msk/tests/conftest.py
+++ b/amazon_msk/tests/conftest.py
@@ -9,7 +9,7 @@ from six.moves.urllib.parse import urlparse
 
 from .common import read_fixture, stream_fixture
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 def mock_requests_get(url, *args, **kwargs):

--- a/amazon_msk/tests/conftest.py
+++ b/amazon_msk/tests/conftest.py
@@ -9,6 +9,8 @@ from six.moves.urllib.parse import urlparse
 
 from .common import read_fixture, stream_fixture
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 def mock_requests_get(url, *args, **kwargs):
     fixture = 'jmx_metrics.txt' if urlparse(url).port == 11001 else 'node_metrics.txt'
@@ -17,7 +19,7 @@ def mock_requests_get(url, *args, **kwargs):
 
 @pytest.fixture
 def mock_data():
-    with mock.patch('requests.get', side_effect=mock_requests_get, autospec=True):
+    with mock.patch(MOCK_HTTP_GET, side_effect=mock_requests_get, autospec=True):
         yield
 
 

--- a/apache/tests/conftest.py
+++ b/apache/tests/conftest.py
@@ -14,7 +14,7 @@ from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
 
 from .common import AUTO_STATUS_URL, BASE_URL, CHECK_NAME, HERE, STATUS_CONFIG, STATUS_URL
 
-MOCK_HTTP_SESSION = 'datadog_checks.base.utils.http.SessionMockTarget'
+MOCK_HTTP_SESSION = 'datadog_checks.base.utils.http.requests'
 
 
 @pytest.fixture(scope="session")

--- a/apache/tests/conftest.py
+++ b/apache/tests/conftest.py
@@ -14,6 +14,8 @@ from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
 
 from .common import AUTO_STATUS_URL, BASE_URL, CHECK_NAME, HERE, STATUS_CONFIG, STATUS_URL
 
+MOCK_HTTP_SESSION = 'datadog_checks.base.utils.http.SessionMockTarget'
+
 
 @pytest.fixture(scope="session")
 def dd_environment():
@@ -49,7 +51,7 @@ def check_status_page_ready():
 
 @pytest.fixture
 def mock_hide_server_version():
-    with mock.patch('datadog_checks.base.utils.http.requests') as req:
+    with mock.patch(MOCK_HTTP_SESSION) as req:
 
         def mock_requests_get_headers(*args, **kwargs):
             r = requests.get(*args, **kwargs)

--- a/cilium/tests/conftest.py
+++ b/cilium/tests/conftest.py
@@ -26,7 +26,7 @@ OPERATOR_URL = "http://{}:{}/metrics".format(HOST, OPERATOR_PORT)
 
 PORTS = [AGENT_PORT, OPERATOR_PORT]
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 def setup_cilium():

--- a/cilium/tests/conftest.py
+++ b/cilium/tests/conftest.py
@@ -26,6 +26,8 @@ OPERATOR_URL = "http://{}:{}/metrics".format(HOST, OPERATOR_PORT)
 
 PORTS = [AGENT_PORT, OPERATOR_PORT]
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 def setup_cilium():
     config = os.path.join(HERE, 'kind', 'cilium.yaml')
@@ -82,7 +84,7 @@ def mock_agent_data():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
         ),
@@ -96,7 +98,7 @@ def mock_operator_data():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
         ),

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.unit
 
 log = logging.getLogger(__file__)
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 def test_get_nodes_with_service(aggregator):

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -15,6 +15,8 @@ pytestmark = pytest.mark.unit
 
 log = logging.getLogger(__file__)
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 def test_get_nodes_with_service(aggregator):
     consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])
@@ -157,7 +159,7 @@ def test_get_nodes_with_service_critical(aggregator):
 
 def test_consul_request(aggregator, instance):
     consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])
-    with mock.patch("datadog_checks.consul.consul.requests.get") as mock_requests_get:
+    with mock.patch(MOCK_HTTP_GET) as mock_requests_get:
         consul_check.consul_request("foo")
         url = "{}/{}".format(instance["url"], "foo")
         aggregator.assert_service_check("consul.can_connect", ConsulCheck.OK, tags=["url:{}".format(url)], count=1)

--- a/coredns/tests/conftest.py
+++ b/coredns/tests/conftest.py
@@ -16,6 +16,8 @@ from .common import ATHOST, CONFIG_FILE, HERE, URL
 # One lookup each for the forward and proxy plugins
 DIG_ARGS = ["dig", "google.com", ATHOST, "example.com", ATHOST, "-p", "54"]
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 def init_coredns():
     res = requests.get(URL)
@@ -49,7 +51,7 @@ def mock_get():
     mesh_file_path = os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics.txt')
     with open(mesh_file_path, 'r') as f:
         text_data = f.read()
-    with mock.patch('requests.get', return_value=MockResponse(text_data, 'text/plain; version=0.0.4'), __name__='get'):
+    with mock.patch(MOCK_HTTP_GET, return_value=MockResponse(text_data, 'text/plain; version=0.0.4'), __name__='get'):
         yield
 
 

--- a/coredns/tests/conftest.py
+++ b/coredns/tests/conftest.py
@@ -16,7 +16,7 @@ from .common import ATHOST, CONFIG_FILE, HERE, URL
 # One lookup each for the forward and proxy plugins
 DIG_ARGS = ["dig", "google.com", ATHOST, "example.com", ATHOST, "-p", "54"]
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 def init_coredns():

--- a/crio/tests/test_crio.py
+++ b/crio/tests/test_crio.py
@@ -12,6 +12,7 @@ instance = {'prometheus_url': 'http://localhost:10249/metrics'}
 
 CHECK_NAME = 'crio'
 NAMESPACE = 'crio'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
 
 
 @pytest.fixture()
@@ -20,7 +21,7 @@ def mock_data():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
         ),

--- a/crio/tests/test_crio.py
+++ b/crio/tests/test_crio.py
@@ -12,7 +12,7 @@ instance = {'prometheus_url': 'http://localhost:10249/metrics'}
 
 CHECK_NAME = 'crio'
 NAMESPACE = 'crio'
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture()

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -89,11 +89,6 @@ PROXY_SETTINGS_DISABLED = {
 KERBEROS_STRATEGIES = {}
 
 
-# Stable reference to the session-like object used by the wrapper for non-persistent requests.
-# For mocking purposes in tests only.
-SessionMockTarget = requests
-
-
 class RequestsWrapper(object):
     __slots__ = (
         '_session',

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -89,6 +89,11 @@ PROXY_SETTINGS_DISABLED = {
 KERBEROS_STRATEGIES = {}
 
 
+# Stable reference to the session-like object used by the wrapper for non-persistent requests.
+# For mocking purposes in tests only.
+SessionMockTarget = requests
+
+
 class RequestsWrapper(object):
     __slots__ = (
         '_session',

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -31,12 +31,12 @@ DEFAULT_OPTIONS = {
     'verify': True,
 }
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
-MOCK_HTTP_POST = 'datadog_checks.base.utils.http.SessionMockTarget.post'
-MOCK_HTTP_HEAD = 'datadog_checks.base.utils.http.SessionMockTarget.head'
-MOCK_HTTP_PUT = 'datadog_checks.base.utils.http.SessionMockTarget.put'
-MOCK_HTTP_PATCH = 'datadog_checks.base.utils.http.SessionMockTarget.patch'
-MOCK_HTTP_DELETE = 'datadog_checks.base.utils.http.SessionMockTarget.delete'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
+MOCK_HTTP_POST = 'datadog_checks.base.utils.http.requests.post'
+MOCK_HTTP_HEAD = 'datadog_checks.base.utils.http.requests.head'
+MOCK_HTTP_PUT = 'datadog_checks.base.utils.http.requests.put'
+MOCK_HTTP_PATCH = 'datadog_checks.base.utils.http.requests.patch'
+MOCK_HTTP_DELETE = 'datadog_checks.base.utils.http.requests.delete'
 MOCK_REQUESTS_WRAPPER_SESSION_ATTR = 'datadog_checks.base.utils.http.RequestsWrapper.session'
 
 

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -31,6 +31,14 @@ DEFAULT_OPTIONS = {
     'verify': True,
 }
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_POST = 'datadog_checks.base.utils.http.SessionMockTarget.post'
+MOCK_HTTP_HEAD = 'datadog_checks.base.utils.http.SessionMockTarget.head'
+MOCK_HTTP_PUT = 'datadog_checks.base.utils.http.SessionMockTarget.put'
+MOCK_HTTP_PATCH = 'datadog_checks.base.utils.http.SessionMockTarget.patch'
+MOCK_HTTP_DELETE = 'datadog_checks.base.utils.http.SessionMockTarget.delete'
+MOCK_REQUESTS_WRAPPER_SESSION_ATTR = 'datadog_checks.base.utils.http.RequestsWrapper.session'
+
 
 class TestAttribute:
     def test_default(self):
@@ -124,7 +132,7 @@ class TestHeaders:
         http = RequestsWrapper(instance, init_config)
 
         extra_headers = {"foo": "bar"}
-        with mock.patch("requests.get") as get:
+        with mock.patch(MOCK_HTTP_GET) as get:
             http.get("http://example.com/hello", extra_headers=extra_headers)
 
             expected_options = {'foo': 'bar', 'User-Agent': 'Datadog Agent/0.0.0', 'answer': '42'}
@@ -344,7 +352,7 @@ class TestAuth:
 
         assert os.environ.get('KRB5_CLIENT_KTNAME') is None
 
-        with mock.patch('requests.get', side_effect=lambda *args, **kwargs: os.environ.get('KRB5_CLIENT_KTNAME')):
+        with mock.patch(MOCK_HTTP_GET, side_effect=lambda *args, **kwargs: os.environ.get('KRB5_CLIENT_KTNAME')):
             assert http.get('https://www.google.com') == '/test/file'
 
         assert os.environ.get('KRB5_CLIENT_KTNAME') is None
@@ -357,7 +365,7 @@ class TestAuth:
 
         assert os.environ.get('KRB5CCNAME') is None
 
-        with mock.patch('requests.get', side_effect=lambda *args, **kwargs: os.environ.get('KRB5CCNAME')):
+        with mock.patch(MOCK_HTTP_GET, side_effect=lambda *args, **kwargs: os.environ.get('KRB5CCNAME')):
             assert http.get('https://www.google.com') == '/test/file'
 
         assert os.environ.get('KRB5CCNAME') is None
@@ -369,7 +377,7 @@ class TestAuth:
         http = RequestsWrapper(instance, init_config)
 
         with EnvVars({'KRB5CCNAME': 'old'}):
-            with mock.patch('requests.get', side_effect=lambda *args, **kwargs: os.environ.get('KRB5CCNAME')):
+            with mock.patch(MOCK_HTTP_GET, side_effect=lambda *args, **kwargs: os.environ.get('KRB5CCNAME')):
                 assert http.get('https://www.google.com') == '/test/file'
 
             assert os.environ.get('KRB5CCNAME') == 'old'
@@ -383,7 +391,7 @@ class TestAuth:
         with EnvVars({'KRB5_CLIENT_KTNAME': 'old'}):
             assert os.environ.get('KRB5_CLIENT_KTNAME') == 'old'
 
-            with mock.patch('requests.get', side_effect=lambda *args, **kwargs: os.environ.get('KRB5_CLIENT_KTNAME')):
+            with mock.patch(MOCK_HTTP_GET, side_effect=lambda *args, **kwargs: os.environ.get('KRB5_CLIENT_KTNAME')):
                 assert http.get('https://www.google.com') == '/test/file'
 
             assert os.environ.get('KRB5_CLIENT_KTNAME') == 'old'
@@ -835,7 +843,7 @@ class TestIgnoreTLSWarning:
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
-        with caplog.at_level(logging.DEBUG), mock.patch('requests.get'):
+        with caplog.at_level(logging.DEBUG), mock.patch(MOCK_HTTP_GET):
             http.get('https://www.google.com', verify=False)
 
         expected_message = 'An unverified HTTPS request is being made to https://www.google.com'
@@ -850,7 +858,7 @@ class TestIgnoreTLSWarning:
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
-        with caplog.at_level(logging.DEBUG), mock.patch('requests.get'):
+        with caplog.at_level(logging.DEBUG), mock.patch(MOCK_HTTP_GET):
             http.get('https://www.google.com', verify=False)
 
         expected_message = 'An unverified HTTPS request is being made to https://www.google.com'
@@ -862,7 +870,7 @@ class TestIgnoreTLSWarning:
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
-        with caplog.at_level(logging.DEBUG), mock.patch('requests.get'):
+        with caplog.at_level(logging.DEBUG), mock.patch(MOCK_HTTP_GET):
             http.get('https://www.google.com', verify=False)
 
         expected_message = 'An unverified HTTPS request is being made to https://www.google.com'
@@ -877,7 +885,7 @@ class TestIgnoreTLSWarning:
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
-        with caplog.at_level(logging.DEBUG), mock.patch('requests.get'):
+        with caplog.at_level(logging.DEBUG), mock.patch(MOCK_HTTP_GET):
             http.get('https://www.google.com', verify=False)
 
         expected_message = 'An unverified HTTPS request is being made to https://www.google.com'
@@ -889,7 +897,7 @@ class TestIgnoreTLSWarning:
         init_config = {'tls_ignore_warning': True}
         http = RequestsWrapper(instance, init_config)
 
-        with caplog.at_level(logging.DEBUG), mock.patch('requests.get'):
+        with caplog.at_level(logging.DEBUG), mock.patch(MOCK_HTTP_GET):
             http.get('https://www.google.com', verify=False)
 
         expected_message = 'An unverified HTTPS request is being made to https://www.google.com'
@@ -901,7 +909,7 @@ class TestIgnoreTLSWarning:
         init_config = {'tls_ignore_warning': False}
         http = RequestsWrapper(instance, init_config)
 
-        with caplog.at_level(logging.DEBUG), mock.patch('requests.get'):
+        with caplog.at_level(logging.DEBUG), mock.patch(MOCK_HTTP_GET):
             http.get('https://www.google.com', verify=False)
 
         expected_message = 'An unverified HTTPS request is being made to https://www.google.com'
@@ -916,7 +924,7 @@ class TestIgnoreTLSWarning:
         init_config = {'tls_ignore_warning': False}
         http = RequestsWrapper(instance, init_config)
 
-        with caplog.at_level(logging.DEBUG), mock.patch('requests.get'):
+        with caplog.at_level(logging.DEBUG), mock.patch(MOCK_HTTP_GET):
             http.get('https://www.google.com', verify=False)
 
         expected_message = 'An unverified HTTPS request is being made to https://www.google.com'
@@ -928,7 +936,7 @@ class TestIgnoreTLSWarning:
         init_config = {'tls_ignore_warning': True}
         http = RequestsWrapper(instance, init_config)
 
-        with caplog.at_level(logging.DEBUG), mock.patch('requests.get'):
+        with caplog.at_level(logging.DEBUG), mock.patch(MOCK_HTTP_GET):
             http.get('https://www.google.com', verify=False)
 
         expected_message = 'An unverified HTTPS request is being made to https://www.google.com'
@@ -1019,7 +1027,7 @@ class TestLogger:
     def test_default(self, caplog):
         check = AgentCheck('test', {}, [{}])
 
-        with caplog.at_level(logging.DEBUG), mock.patch('requests.get'):
+        with caplog.at_level(logging.DEBUG), mock.patch(MOCK_HTTP_GET):
             check.http.get('https://www.google.com')
 
         expected_message = 'Sending GET request to https://www.google.com'
@@ -1033,7 +1041,7 @@ class TestLogger:
 
         assert check.http.logger is check.log
 
-        with caplog.at_level(logging.DEBUG), mock.patch('requests.get'):
+        with caplog.at_level(logging.DEBUG), mock.patch(MOCK_HTTP_GET):
             check.http.get('https://www.google.com')
 
         expected_message = 'Sending GET request to https://www.google.com'
@@ -1050,7 +1058,7 @@ class TestLogger:
 
         assert check.http.logger is check.log
 
-        with caplog.at_level(logging.DEBUG), mock.patch('requests.get'):
+        with caplog.at_level(logging.DEBUG), mock.patch(MOCK_HTTP_GET):
             check.http.get('https://www.google.com')
 
         expected_message = 'Sending GET request to https://www.google.com'
@@ -1065,7 +1073,7 @@ class TestLogger:
         init_config = {'log_requests': True}
         check = AgentCheck('test', init_config, [instance])
 
-        with caplog.at_level(logging.DEBUG), mock.patch('requests.get'):
+        with caplog.at_level(logging.DEBUG), mock.patch(MOCK_HTTP_GET):
             check.http.get('https://www.google.com')
 
         expected_message = 'Sending GET request to https://www.google.com'
@@ -1077,25 +1085,25 @@ class TestAPI:
     def test_get(self):
         http = RequestsWrapper({}, {})
 
-        with mock.patch('requests.get'):
+        with mock.patch(MOCK_HTTP_GET) as m:
             http.get('https://www.google.com')
-            requests.get.assert_called_once_with('https://www.google.com', **http.options)
+            m.assert_called_once_with('https://www.google.com', **http.options)
 
     def test_get_session(self):
         http = RequestsWrapper({'persist_connections': True}, {})
 
-        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+        with mock.patch(MOCK_REQUESTS_WRAPPER_SESSION_ATTR) as m:
             http.get('https://www.google.com')
-            http.session.get.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
+            m.get.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
 
     def test_get_option_override(self):
         http = RequestsWrapper({}, {})
         options = http.options.copy()
         options['auth'] = ('user', 'pass')
 
-        with mock.patch('requests.get'):
+        with mock.patch(MOCK_HTTP_GET) as m:
             http.get('https://www.google.com', auth=options['auth'])
-            requests.get.assert_called_once_with('https://www.google.com', **options)
+            m.assert_called_once_with('https://www.google.com', **options)
 
     def test_get_session_option_override(self):
         http = RequestsWrapper({}, {})
@@ -1109,162 +1117,162 @@ class TestAPI:
     def test_post(self):
         http = RequestsWrapper({}, {})
 
-        with mock.patch('requests.post'):
+        with mock.patch(MOCK_HTTP_POST) as m:
             http.post('https://www.google.com')
-            requests.post.assert_called_once_with('https://www.google.com', **http.options)
+            m.assert_called_once_with('https://www.google.com', **http.options)
 
     def test_post_session(self):
         http = RequestsWrapper({'persist_connections': True}, {})
 
-        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+        with mock.patch(MOCK_REQUESTS_WRAPPER_SESSION_ATTR) as m:
             http.post('https://www.google.com')
-            http.session.post.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
+            m.post.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
 
     def test_post_option_override(self):
         http = RequestsWrapper({}, {})
         options = http.options.copy()
         options['auth'] = ('user', 'pass')
 
-        with mock.patch('requests.post'):
+        with mock.patch(MOCK_HTTP_POST) as m:
             http.post('https://www.google.com', auth=options['auth'])
-            requests.post.assert_called_once_with('https://www.google.com', **options)
+            m.assert_called_once_with('https://www.google.com', **options)
 
     def test_post_session_option_override(self):
         http = RequestsWrapper({}, {})
         options = DEFAULT_OPTIONS.copy()
         options.update({'auth': ('user', 'pass')})
 
-        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+        with mock.patch(MOCK_REQUESTS_WRAPPER_SESSION_ATTR) as m:
             http.post('https://www.google.com', persist=True, auth=options['auth'])
-            http.session.post.assert_called_once_with('https://www.google.com', **options)
+            m.post.assert_called_once_with('https://www.google.com', **options)
 
     def test_head(self):
         http = RequestsWrapper({}, {})
 
-        with mock.patch('requests.head'):
+        with mock.patch(MOCK_HTTP_HEAD) as m:
             http.head('https://www.google.com')
-            requests.head.assert_called_once_with('https://www.google.com', **http.options)
+            m.assert_called_once_with('https://www.google.com', **http.options)
 
     def test_head_session(self):
         http = RequestsWrapper({'persist_connections': True}, {})
 
-        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+        with mock.patch(MOCK_REQUESTS_WRAPPER_SESSION_ATTR) as m:
             http.head('https://www.google.com')
-            http.session.head.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
+            m.head.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
 
     def test_head_option_override(self):
         http = RequestsWrapper({}, {})
         options = http.options.copy()
         options['auth'] = ('user', 'pass')
 
-        with mock.patch('requests.head'):
+        with mock.patch(MOCK_HTTP_HEAD) as m:
             http.head('https://www.google.com', auth=options['auth'])
-            requests.head.assert_called_once_with('https://www.google.com', **options)
+            m.assert_called_once_with('https://www.google.com', **options)
 
     def test_head_session_option_override(self):
         http = RequestsWrapper({}, {})
         options = DEFAULT_OPTIONS.copy()
         options.update({'auth': ('user', 'pass')})
 
-        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+        with mock.patch(MOCK_REQUESTS_WRAPPER_SESSION_ATTR) as m:
             http.head('https://www.google.com', persist=True, auth=options['auth'])
-            http.session.head.assert_called_once_with('https://www.google.com', **options)
+            m.head.assert_called_once_with('https://www.google.com', **options)
 
     def test_put(self):
         http = RequestsWrapper({}, {})
 
-        with mock.patch('requests.put'):
+        with mock.patch(MOCK_HTTP_PUT) as m:
             http.put('https://www.google.com')
-            requests.put.assert_called_once_with('https://www.google.com', **http.options)
+            m.assert_called_once_with('https://www.google.com', **http.options)
 
     def test_put_session(self):
         http = RequestsWrapper({'persist_connections': True}, {})
 
-        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+        with mock.patch(MOCK_REQUESTS_WRAPPER_SESSION_ATTR) as m:
             http.put('https://www.google.com')
-            http.session.put.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
+            m.put.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
 
     def test_put_option_override(self):
         http = RequestsWrapper({}, {})
         options = http.options.copy()
         options['auth'] = ('user', 'pass')
 
-        with mock.patch('requests.put'):
+        with mock.patch(MOCK_HTTP_PUT) as m:
             http.put('https://www.google.com', auth=options['auth'])
-            requests.put.assert_called_once_with('https://www.google.com', **options)
+            m.assert_called_once_with('https://www.google.com', **options)
 
     def test_put_session_option_override(self):
         http = RequestsWrapper({}, {})
         options = DEFAULT_OPTIONS.copy()
         options.update({'auth': ('user', 'pass')})
 
-        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+        with mock.patch(MOCK_REQUESTS_WRAPPER_SESSION_ATTR) as m:
             http.put('https://www.google.com', persist=True, auth=options['auth'])
-            http.session.put.assert_called_once_with('https://www.google.com', **options)
+            m.put.assert_called_once_with('https://www.google.com', **options)
 
     def test_patch(self):
         http = RequestsWrapper({}, {})
 
-        with mock.patch('requests.patch'):
+        with mock.patch(MOCK_HTTP_PATCH) as m:
             http.patch('https://www.google.com')
-            requests.patch.assert_called_once_with('https://www.google.com', **http.options)
+            m.assert_called_once_with('https://www.google.com', **http.options)
 
     def test_patch_session(self):
         http = RequestsWrapper({'persist_connections': True}, {})
 
-        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+        with mock.patch(MOCK_REQUESTS_WRAPPER_SESSION_ATTR) as m:
             http.patch('https://www.google.com')
-            http.session.patch.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
+            m.patch.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
 
     def test_patch_option_override(self):
         http = RequestsWrapper({}, {})
         options = http.options.copy()
         options['auth'] = ('user', 'pass')
 
-        with mock.patch('requests.patch'):
+        with mock.patch(MOCK_HTTP_PATCH) as m:
             http.patch('https://www.google.com', auth=options['auth'])
-            requests.patch.assert_called_once_with('https://www.google.com', **options)
+            m.assert_called_once_with('https://www.google.com', **options)
 
     def test_patch_session_option_override(self):
         http = RequestsWrapper({}, {})
         options = DEFAULT_OPTIONS.copy()
         options.update({'auth': ('user', 'pass')})
 
-        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+        with mock.patch(MOCK_REQUESTS_WRAPPER_SESSION_ATTR) as m:
             http.patch('https://www.google.com', persist=True, auth=options['auth'])
-            http.session.patch.assert_called_once_with('https://www.google.com', **options)
+            m.patch.assert_called_once_with('https://www.google.com', **options)
 
     def test_delete(self):
         http = RequestsWrapper({}, {})
 
-        with mock.patch('requests.delete'):
+        with mock.patch(MOCK_HTTP_DELETE) as m:
             http.delete('https://www.google.com')
-            requests.delete.assert_called_once_with('https://www.google.com', **http.options)
+            m.assert_called_once_with('https://www.google.com', **http.options)
 
     def test_delete_session(self):
         http = RequestsWrapper({'persist_connections': True}, {})
 
-        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+        with mock.patch(MOCK_REQUESTS_WRAPPER_SESSION_ATTR) as m:
             http.delete('https://www.google.com')
-            http.session.delete.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
+            m.delete.assert_called_once_with('https://www.google.com', **DEFAULT_OPTIONS)
 
     def test_delete_option_override(self):
         http = RequestsWrapper({}, {})
         options = http.options.copy()
         options['auth'] = ('user', 'pass')
 
-        with mock.patch('requests.delete'):
+        with mock.patch(MOCK_HTTP_DELETE) as m:
             http.delete('https://www.google.com', auth=options['auth'])
-            requests.delete.assert_called_once_with('https://www.google.com', **options)
+            m.assert_called_once_with('https://www.google.com', **options)
 
     def test_delete_session_option_override(self):
         http = RequestsWrapper({}, {})
         options = DEFAULT_OPTIONS.copy()
         options.update({'auth': ('user', 'pass')})
 
-        with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.session'):
+        with mock.patch(MOCK_REQUESTS_WRAPPER_SESSION_ATTR) as m:
             http.delete('https://www.google.com', persist=True, auth=options['auth'])
-            http.session.delete.assert_called_once_with('https://www.google.com', **options)
+            m.delete.assert_called_once_with('https://www.google.com', **options)
 
 
 class TestIntegration:

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -22,6 +22,8 @@ from datadog_checks.dev import get_here
 
 text_content_type = 'text/plain; version=0.0.4'
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 class MockResponse:
     """
@@ -117,7 +119,7 @@ def mock_get():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
         return_value=mock.MagicMock(
             status_code=200,
             iter_lines=lambda **kwargs: text_data.split("\n"),
@@ -183,7 +185,7 @@ def test_poll_text_plain(mocked_prometheus_check, mocked_prometheus_scraper_conf
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': text_content_type}
     )
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         response = check.poll(mocked_prometheus_scraper_config)
         messages = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
         messages.sort(key=lambda x: x.name)
@@ -200,7 +202,7 @@ def test_poll_octet_stream(mocked_prometheus_check, mocked_prometheus_scraper_co
     mock_response.status_code = 200
     mock_response.headers = {'Content-Type': 'application/octet-stream'}
 
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         response = check.poll(mocked_prometheus_scraper_config)
         messages = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
         assert len(messages) == 40
@@ -1688,7 +1690,7 @@ def test_ignore_metrics_multiple_wildcards(
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': text_content_type}
     )
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         check.process(config)
 
         # Make sure metrics are ignored
@@ -1740,7 +1742,7 @@ def test_match_metrics_multiple_wildcards(
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': text_content_type}
     )
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         check.process(config)
 
         aggregator.assert_metric('prometheus.go_memstats_mcache_inuse_bytes', count=1)
@@ -2136,7 +2138,7 @@ def test_label_joins_gc(aggregator, mocked_prometheus_check, mocked_prometheus_s
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': text_content_type}
     )
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         check.process(mocked_prometheus_scraper_config)
         assert 'dd-agent-1337' in mocked_prometheus_scraper_config['_label_mapping']['pod']
         assert 'dd-agent-62bgh' not in mocked_prometheus_scraper_config['_label_mapping']['pod']
@@ -2296,7 +2298,7 @@ def test_label_join_state_change(aggregator, mocked_prometheus_check, mocked_pro
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': text_content_type}
     )
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         check.process(mocked_prometheus_scraper_config)
         assert 15 == len(mocked_prometheus_scraper_config['_label_mapping']['pod'])
         assert mocked_prometheus_scraper_config['_label_mapping']['pod']['dd-agent-62bgh']['phase'] == 'Test'
@@ -2414,7 +2416,7 @@ def mock_filter_get():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200,
             iter_lines=lambda **kwargs: text_data.split("\n"),

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -22,7 +22,7 @@ from datadog_checks.dev import get_here
 
 text_content_type = 'text/plain; version=0.0.4'
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 class MockResponse:
@@ -119,7 +119,7 @@ def mock_get():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200,
             iter_lines=lambda **kwargs: text_data.split("\n"),

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -17,6 +17,8 @@ from datadog_checks.utils.prometheus import metrics_pb2, parse_metric_family
 
 protobuf_content_type = 'application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited'
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 class MockResponse:
     """
@@ -332,7 +334,7 @@ def test_poll_protobuf(mocked_prometheus_check, bin_data):
     """ Tests poll using the protobuf format """
     check = mocked_prometheus_check
     mock_response = mock.MagicMock(status_code=200, content=bin_data, headers={'Content-Type': protobuf_content_type})
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         response = check.poll("http://fake.endpoint:10055/metrics")
         messages = list(check.parse_metric_family(response))
         assert len(messages) == 61
@@ -345,7 +347,7 @@ def test_poll_text_plain(mocked_prometheus_check, text_data):
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
     )
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         response = check.poll("http://fake.endpoint:10055/metrics")
         messages = list(check.parse_metric_family(response))
         messages.sort(key=lambda x: x.name)
@@ -1282,7 +1284,7 @@ def test_label_joins(sorted_tags_check):
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
     )
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         check = sorted_tags_check
         check.NAMESPACE = 'ksm'
         check.label_joins = {
@@ -1632,7 +1634,7 @@ def test_label_joins_gc(sorted_tags_check):
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
     )
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         check = sorted_tags_check
         check.NAMESPACE = 'ksm'
         check.label_joins = {'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node', 'pod_ip']}}
@@ -1682,7 +1684,7 @@ def test_label_joins_gc(sorted_tags_check):
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
     )
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         check.process("http://fake.endpoint:10055/metrics")
         assert 'dd-agent-1337' in check._label_mapping['pod']
         assert 'dd-agent-62bgh' not in check._label_mapping['pod']
@@ -1698,7 +1700,7 @@ def test_label_joins_missconfigured(sorted_tags_check):
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
     )
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         check = sorted_tags_check
         check.NAMESPACE = 'ksm'
         check.label_joins = {'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node', 'not_existing']}}
@@ -1751,7 +1753,7 @@ def test_label_join_not_existing(sorted_tags_check):
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
     )
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         check = sorted_tags_check
         check.NAMESPACE = 'ksm'
         check.label_joins = {'kube_pod_info': {'label_to_match': 'not_existing', 'labels_to_get': ['node', 'pod_ip']}}
@@ -1790,7 +1792,7 @@ def test_label_join_metric_not_existing(sorted_tags_check):
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
     )
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         check = sorted_tags_check
         check.NAMESPACE = 'ksm'
         check.label_joins = {'not_existing': {'label_to_match': 'pod', 'labels_to_get': ['node', 'pod_ip']}}
@@ -1829,7 +1831,7 @@ def test_label_join_with_hostname(sorted_tags_check):
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
     )
-    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=mock_response, __name__="get"):
         check = sorted_tags_check
         check.NAMESPACE = 'ksm'
         check.label_joins = {'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node']}}
@@ -1881,7 +1883,7 @@ def mock_get():
     with open(f_name, 'r') as f:
         text_data = f.read()
     mock_get = mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
         ),

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -17,7 +17,7 @@ from datadog_checks.utils.prometheus import metrics_pb2, parse_metric_family
 
 protobuf_content_type = 'application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited'
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 class MockResponse:

--- a/ecs_fargate/tests/test_unit.py
+++ b/ecs_fargate/tests/test_unit.py
@@ -52,7 +52,7 @@ EXTRA_NETWORK_METRICS = [
     'ecs.fargate.net.bytes_sent',
 ]
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 MOCK_GET_TAGS = 'datadog_checks.ecs_fargate.ecs_fargate.get_tags'
 MOCK_C_IS_EXCLUDED = 'datadog_checks.ecs_fargate.ecs_fargate.c_is_excluded'
 

--- a/ecs_fargate/tests/test_unit.py
+++ b/ecs_fargate/tests/test_unit.py
@@ -52,6 +52,10 @@ EXTRA_NETWORK_METRICS = [
     'ecs.fargate.net.bytes_sent',
 ]
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_GET_TAGS = 'datadog_checks.ecs_fargate.ecs_fargate.get_tags'
+MOCK_C_IS_EXCLUDED = 'datadog_checks.ecs_fargate.ecs_fargate.c_is_excluded'
+
 
 @pytest.fixture
 def instance():
@@ -143,7 +147,7 @@ def test_failing_check(check, instance, aggregator):
     """
     Testing fargate metadata endpoint error.
     """
-    with mock.patch('datadog_checks.ecs_fargate.ecs_fargate.requests.get', return_value=MockResponse("{}", 500)):
+    with mock.patch(MOCK_HTTP_GET, return_value=MockResponse("{}", 500)):
         check.check(instance)
 
     aggregator.assert_service_check("fargate_check", status=FargateCheck.CRITICAL, tags=INSTANCE_TAGS, count=1)
@@ -153,7 +157,7 @@ def test_invalid_response_check(check, instance, aggregator):
     """
     Testing invalid fargate metadata payload.
     """
-    with mock.patch('datadog_checks.ecs_fargate.ecs_fargate.requests.get', return_value=MockResponse("{}", 200)):
+    with mock.patch(MOCK_HTTP_GET, return_value=MockResponse("{}", 200)):
         check.check(instance)
 
     aggregator.assert_service_check("fargate_check", status=FargateCheck.WARNING, tags=INSTANCE_TAGS, count=1)
@@ -163,9 +167,9 @@ def test_successful_check(check, instance, aggregator):
     """
     Testing successful fargate check.
     """
-    with mock.patch('datadog_checks.ecs_fargate.ecs_fargate.requests.get', side_effect=mocked_requests_get):
-        with mock.patch("datadog_checks.ecs_fargate.ecs_fargate.get_tags", side_effect=mocked_get_tags):
-            with mock.patch("datadog_checks.ecs_fargate.ecs_fargate.c_is_excluded", side_effect=mocked_is_excluded):
+    with mock.patch(MOCK_HTTP_GET, side_effect=mocked_requests_get):
+        with mock.patch(MOCK_GET_TAGS, side_effect=mocked_get_tags):
+            with mock.patch(MOCK_C_IS_EXCLUDED, side_effect=mocked_is_excluded):
                 check.check(instance)
 
     aggregator.assert_service_check("fargate_check", status=FargateCheck.OK, tags=INSTANCE_TAGS, count=1)

--- a/envoy/tests/test_bench.py
+++ b/envoy/tests/test_bench.py
@@ -5,6 +5,8 @@ from datadog_checks.envoy import Envoy
 
 from .common import INSTANCES, response
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.mark.usefixtures('dd_environment')
 def test_run(benchmark):
@@ -21,7 +23,7 @@ def test_fixture(benchmark):
     instance = INSTANCES['main']
     c = Envoy('envoy', {}, [instance])
 
-    with mock.patch('requests.get', return_value=response('multiple_services')):
+    with mock.patch(MOCK_HTTP_GET, return_value=response('multiple_services')):
         # Run once to get logging of unknown metrics out of the way.
         c.check(instance)
 

--- a/envoy/tests/test_bench.py
+++ b/envoy/tests/test_bench.py
@@ -5,7 +5,7 @@ from datadog_checks.envoy import Envoy
 
 from .common import INSTANCES, response
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.mark.usefixtures('dd_environment')

--- a/envoy/tests/test_envoy.py
+++ b/envoy/tests/test_envoy.py
@@ -14,7 +14,7 @@ from .common import ENVOY_VERSION, HOST, INSTANCES, response
 
 CHECK_NAME = 'envoy'
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.mark.integration

--- a/envoy/tests/test_envoy.py
+++ b/envoy/tests/test_envoy.py
@@ -14,6 +14,8 @@ from .common import ENVOY_VERSION, HOST, INSTANCES, response
 
 CHECK_NAME = 'envoy'
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
@@ -34,7 +36,7 @@ def test_success_fixture(aggregator):
     instance = INSTANCES['main']
     c = Envoy(CHECK_NAME, {}, [instance])
 
-    with mock.patch('requests.get', return_value=response('multiple_services')):
+    with mock.patch(MOCK_HTTP_GET, return_value=response('multiple_services')):
         c.check(instance)
 
     metrics_collected = 0
@@ -63,7 +65,7 @@ def test_success_fixture_included_metrics(aggregator):
     instance = INSTANCES['included_metrics']
     c = Envoy(CHECK_NAME, {}, [instance])
 
-    with mock.patch('requests.get', return_value=response('multiple_services')):
+    with mock.patch(MOCK_HTTP_GET, return_value=response('multiple_services')):
         c.check(instance)
 
     for metric in aggregator.metric_names:
@@ -75,7 +77,7 @@ def test_success_fixture_excluded_metrics(aggregator):
     instance = INSTANCES['excluded_metrics']
     c = Envoy(CHECK_NAME, {}, [instance])
 
-    with mock.patch('requests.get', return_value=response('multiple_services')):
+    with mock.patch(MOCK_HTTP_GET, return_value=response('multiple_services')):
         c.check(instance)
 
     for metric in aggregator.metric_names:
@@ -87,7 +89,7 @@ def test_success_fixture_inclued_and_excluded_metrics(aggregator):
     instance = INSTANCES['included_excluded_metrics']
     c = Envoy(CHECK_NAME, {}, [instance])
 
-    with mock.patch('requests.get', return_value=response('multiple_services')):
+    with mock.patch(MOCK_HTTP_GET, return_value=response('multiple_services')):
         c.check(instance)
 
     for metric in aggregator.metric_names:
@@ -99,7 +101,7 @@ def test_service_check(aggregator):
     instance = INSTANCES['main']
     c = Envoy(CHECK_NAME, {}, [instance])
 
-    with mock.patch('requests.get', return_value=response('multiple_services')):
+    with mock.patch(MOCK_HTTP_GET, return_value=response('multiple_services')):
         c.check(instance)
 
     assert aggregator.service_checks(Envoy.SERVICE_CHECK_NAME)[0].status == Envoy.OK
@@ -110,7 +112,7 @@ def test_unknown():
     instance = INSTANCES['main']
     c = Envoy(CHECK_NAME, {}, [instance])
 
-    with mock.patch('requests.get', return_value=response('unknown_metrics')):
+    with mock.patch(MOCK_HTTP_GET, return_value=response('unknown_metrics')):
         c.check(instance)
 
     assert sum(c.unknown_metrics.values()) == 5
@@ -150,7 +152,7 @@ def test_metadata(datadog_agent):
     check.check_id = 'test:123'
     check.log = mock.MagicMock()
 
-    with mock.patch('requests.get', side_effect=requests.exceptions.Timeout()):
+    with mock.patch(MOCK_HTTP_GET, side_effect=requests.exceptions.Timeout()):
         check._collect_metadata(instance['stats_url'])
         datadog_agent.assert_metadata_count(0)
         check.log.warning.assert_called_with(
@@ -158,7 +160,7 @@ def test_metadata(datadog_agent):
         )
 
     datadog_agent.reset()
-    with mock.patch('requests.get', side_effect=IndexError()):
+    with mock.patch(MOCK_HTTP_GET, side_effect=IndexError()):
         check._collect_metadata(instance['stats_url'])
         datadog_agent.assert_metadata_count(0)
         check.log.warning.assert_called_with(
@@ -166,7 +168,7 @@ def test_metadata(datadog_agent):
         )
 
     datadog_agent.reset()
-    with mock.patch('requests.get', side_effect=requests.exceptions.RequestException('Req Exception')):
+    with mock.patch(MOCK_HTTP_GET, side_effect=requests.exceptions.RequestException('Req Exception')):
         check._collect_metadata(instance['stats_url'])
         datadog_agent.assert_metadata_count(0)
         check.log.warning.assert_called_with(
@@ -176,7 +178,7 @@ def test_metadata(datadog_agent):
         )
 
     datadog_agent.reset()
-    with mock.patch('requests.get', return_value=response('server_info')):
+    with mock.patch(MOCK_HTTP_GET, return_value=response('server_info')):
         check._collect_metadata(instance['stats_url'])
 
         major, minor, patch = ENVOY_VERSION.split('.')
@@ -192,7 +194,7 @@ def test_metadata(datadog_agent):
         datadog_agent.assert_metadata_count(len(version_metadata))
 
     datadog_agent.reset()
-    with mock.patch('requests.get', return_value=response('server_info_before_1_9')):
+    with mock.patch(MOCK_HTTP_GET, return_value=response('server_info_before_1_9')):
         check._collect_metadata(instance['stats_url'])
 
         expected_version = '1.8.0'
@@ -209,7 +211,7 @@ def test_metadata(datadog_agent):
         datadog_agent.assert_metadata_count(len(version_metadata))
 
     datadog_agent.reset()
-    with mock.patch('requests.get', return_value=response('server_info_invalid')):
+    with mock.patch(MOCK_HTTP_GET, return_value=response('server_info_invalid')):
         check._collect_metadata(instance['stats_url'])
 
         datadog_agent.assert_metadata('test:123', {})

--- a/external_dns/tests/conftest.py
+++ b/external_dns/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 from .common import FIXTURE_DIR
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture

--- a/external_dns/tests/conftest.py
+++ b/external_dns/tests/conftest.py
@@ -8,6 +8,8 @@ import pytest
 
 from .common import FIXTURE_DIR
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.fixture
 def mock_external_dns():
@@ -16,7 +18,7 @@ def mock_external_dns():
         text_data = f.read()
 
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split('\n'), headers={'Content-Type': 'text/plain'}
         ),

--- a/gitlab/tests/conftest.py
+++ b/gitlab/tests/conftest.py
@@ -22,6 +22,8 @@ from .common import (
     HERE,
 )
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.fixture(scope="session")
 def dd_environment():
@@ -55,7 +57,7 @@ def mock_data():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
         ),

--- a/gitlab/tests/conftest.py
+++ b/gitlab/tests/conftest.py
@@ -22,7 +22,7 @@ from .common import (
     HERE,
 )
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture(scope="session")

--- a/gitlab/tests/test_integration.py
+++ b/gitlab/tests/test_integration.py
@@ -11,6 +11,8 @@ from .common import AUTH_CONFIG, BAD_CONFIG, CONFIG, CUSTOM_TAGS, HOST, METRICS,
 
 pytestmark = [pytest.mark.usefixtures("dd_environment"), pytest.mark.integration]
 
+MOCK_HTTP_RESPONSE_JSON = 'datadog_checks.base.utils.http.requests.Response.json'
+
 
 def test_connection_failure(aggregator):
     """
@@ -59,7 +61,7 @@ def test_connection_failure(aggregator):
     ],
 )
 def test_check_submit_metadata(aggregator, datadog_agent, raw_version, version_metadata, count):
-    with mock.patch('datadog_checks.base.utils.http.requests.Response.json') as g:
+    with mock.patch(MOCK_HTTP_RESPONSE_JSON) as g:
         # mock the api call so that it returns the given version
         g.return_value = {"version": raw_version}
 

--- a/haproxy/tests/conftest.py
+++ b/haproxy/tests/conftest.py
@@ -26,7 +26,7 @@ from .common import (
 
 log = logging.getLogger('test_haproxy')
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 def wait_for_haproxy():

--- a/haproxy/tests/conftest.py
+++ b/haproxy/tests/conftest.py
@@ -26,6 +26,8 @@ from .common import (
 
 log = logging.getLogger('test_haproxy')
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 def wait_for_haproxy():
     res = requests.get(STATS_URL, auth=(USERNAME, PASSWORD))
@@ -100,7 +102,7 @@ def haproxy_mock():
     filepath = os.path.join(HERE, 'fixtures', 'mock_data')
     with open(filepath, 'rb') as f:
         data = f.read()
-    p = mock.patch('requests.get', return_value=mock.Mock(content=data))
+    p = mock.patch(MOCK_HTTP_GET, return_value=mock.Mock(content=data))
     yield p.start()
     p.stop()
 
@@ -118,7 +120,7 @@ def haproxy_mock_evil():
     filepath = os.path.join(HERE, 'fixtures', 'mock_data_evil')
     with open(filepath, 'rb') as f:
         data = f.read()
-    p = mock.patch('requests.get', return_value=mock.Mock(content=data))
+    p = mock.patch(MOCK_HTTP_GET, return_value=mock.Mock(content=data))
     yield p.start()
     p.stop()
 
@@ -128,7 +130,7 @@ def haproxy_mock_enterprise_version_info():
     filepath = os.path.join(HERE, 'fixtures', 'enterprise_version_info.html')
     with open(filepath, 'rb') as f:
         data = f.read()
-    with mock.patch('requests.get', return_value=mock.Mock(content=data)) as p:
+    with mock.patch(MOCK_HTTP_GET, return_value=mock.Mock(content=data)) as p:
         yield p
 
 

--- a/haproxy/tests/test_unit.py
+++ b/haproxy/tests/test_unit.py
@@ -7,7 +7,7 @@ import mock
 from . import common
 
 BASE_CONFIG = {'url': 'http://localhost/admin?stats', 'collect_status_metrics': True, 'enable_service_check': True}
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 def _assert_agg_statuses(

--- a/haproxy/tests/test_unit.py
+++ b/haproxy/tests/test_unit.py
@@ -7,6 +7,7 @@ import mock
 from . import common
 
 BASE_CONFIG = {'url': 'http://localhost/admin?stats', 'collect_status_metrics': True, 'enable_service_check': True}
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
 
 
 def _assert_agg_statuses(
@@ -426,7 +427,7 @@ def test_version_failure(aggregator, check, datadog_agent):
     filepath = os.path.join(common.HERE, 'fixtures', 'mock_data')
     with open(filepath, 'rb') as f:
         data = f.read()
-    with mock.patch('requests.get') as m:
+    with mock.patch(MOCK_HTTP_GET) as m:
         m.side_effect = [RuntimeError("Ooops"), mock.Mock(content=data)]
         haproxy_check.check(config)
 

--- a/harbor/tests/conftest.py
+++ b/harbor/tests/conftest.py
@@ -44,7 +44,7 @@ from .common import (
     VOLUME_INFO_FIXTURE,
 )
 
-HTTP_SESSION_REQUEST = 'datadog_checks.base.utils.http.SessionMockTarget.request'
+MOCK_HTTP_REQUEST = 'datadog_checks.base.utils.http.requests.request'
 
 
 @pytest.fixture(scope='session')
@@ -112,7 +112,7 @@ def harbor_api(harbor_check, admin_instance, patch_requests):
 
 @pytest.fixture
 def patch_requests():
-    with patch(HTTP_SESSION_REQUEST, side_effect=mocked_requests):
+    with patch(MOCK_HTTP_REQUEST, side_effect=mocked_requests):
         yield
 
 

--- a/harbor/tests/conftest.py
+++ b/harbor/tests/conftest.py
@@ -44,6 +44,8 @@ from .common import (
     VOLUME_INFO_FIXTURE,
 )
 
+HTTP_SESSION_REQUEST = 'datadog_checks.base.utils.http.SessionMockTarget.request'
+
 
 @pytest.fixture(scope='session')
 def dd_environment(e2e_instance):
@@ -110,7 +112,7 @@ def harbor_api(harbor_check, admin_instance, patch_requests):
 
 @pytest.fixture
 def patch_requests():
-    with patch("requests.api.request", side_effect=mocked_requests):
+    with patch(HTTP_SESSION_REQUEST, side_effect=mocked_requests):
         yield
 
 

--- a/hdfs_datanode/tests/conftest.py
+++ b/hdfs_datanode/tests/conftest.py
@@ -14,7 +14,7 @@ from datadog_checks.hdfs_datanode import HDFSDataNode
 
 from .common import HERE, INSTANCE_INTEGRATION, TEST_PASSWORD, TEST_USERNAME
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture(scope="session")

--- a/hdfs_datanode/tests/conftest.py
+++ b/hdfs_datanode/tests/conftest.py
@@ -14,6 +14,8 @@ from datadog_checks.hdfs_datanode import HDFSDataNode
 
 from .common import HERE, INSTANCE_INTEGRATION, TEST_PASSWORD, TEST_USERNAME
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.fixture(scope="session")
 def dd_environment():
@@ -36,19 +38,19 @@ def instance():
 
 @pytest.fixture
 def mocked_request():
-    with patch('requests.get', new=requests_get_mock):
+    with patch(MOCK_HTTP_GET, new=requests_get_mock):
         yield
 
 
 @pytest.fixture
 def mocked_metadata_request():
-    with patch('requests.get', new=requests_metadata_mock):
+    with patch(MOCK_HTTP_GET, new=requests_metadata_mock):
         yield
 
 
 @pytest.fixture
 def mocked_auth_request():
-    with patch('requests.get', new=requests_auth_mock):
+    with patch(MOCK_HTTP_GET, new=requests_auth_mock):
         yield
 
 

--- a/hdfs_namenode/tests/conftest.py
+++ b/hdfs_namenode/tests/conftest.py
@@ -20,7 +20,7 @@ from .common import (
     TEST_USERNAME,
 )
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture(scope="session")

--- a/hdfs_namenode/tests/conftest.py
+++ b/hdfs_namenode/tests/conftest.py
@@ -20,6 +20,8 @@ from .common import (
     TEST_USERNAME,
 )
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.fixture(scope="session")
 def dd_environment():
@@ -42,13 +44,13 @@ def check():
 
 @pytest.fixture
 def mocked_request():
-    with patch("requests.get", new=requests_get_mock):
+    with patch(MOCK_HTTP_GET, new=requests_get_mock):
         yield
 
 
 @pytest.fixture
 def mocked_auth_request():
-    with patch("requests.get", new=requests_auth_mock):
+    with patch(MOCK_HTTP_GET, new=requests_auth_mock):
         yield
 
 

--- a/istio/tests/conftest.py
+++ b/istio/tests/conftest.py
@@ -31,7 +31,7 @@ DEPLOYMENTS_LEGACY = [
     ('istio-ingressgateway', 80),
 ]
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture(scope='session')

--- a/istio/tests/conftest.py
+++ b/istio/tests/conftest.py
@@ -31,6 +31,8 @@ DEPLOYMENTS_LEGACY = [
     ('istio-ingressgateway', 80),
 ]
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.fixture(scope='session')
 def dd_environment():
@@ -100,7 +102,7 @@ def istio_proxy_mesh_fixture():
     with open(mesh_file_path, 'r') as f:
         responses.append(f.read())
 
-    with mock.patch('requests.get', return_value=MockResponse(responses, 'text/plain'), __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=MockResponse(responses, 'text/plain'), __name__="get"):
         yield
 
 
@@ -111,7 +113,7 @@ def istiod_mixture_fixture():
     with open(mesh_file_path, 'r') as f:
         responses.append(f.read())
 
-    with mock.patch('requests.get', return_value=MockResponse(responses, 'text/plain'), __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=MockResponse(responses, 'text/plain'), __name__="get"):
         yield
 
 
@@ -122,7 +124,7 @@ def mesh_fixture():
     with open(mesh_file_path, 'r') as f:
         responses.append(f.read())
 
-    with mock.patch('requests.get', return_value=MockResponse(responses, 'text/plain'), __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=MockResponse(responses, 'text/plain'), __name__="get"):
         yield
 
 
@@ -133,7 +135,7 @@ def mixture_fixture():
     with open(mixer_file_path, 'r') as f:
         responses.append(f.read())
 
-    with mock.patch('requests.get', return_value=MockResponse(responses, 'text/plain'), __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=MockResponse(responses, 'text/plain'), __name__="get"):
         yield
 
 
@@ -146,7 +148,7 @@ def new_mesh_mixture_fixture():
         with open(file_path, 'r') as f:
             responses.append(f.read())
 
-    with mock.patch('requests.get', return_value=MockResponse(responses, 'text/plain'), __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=MockResponse(responses, 'text/plain'), __name__="get"):
         yield
 
 
@@ -159,7 +161,7 @@ def new_pilot_fixture():
         with open(file_path, 'r') as f:
             responses.append(f.read())
 
-    with mock.patch('requests.get', return_value=MockResponse(responses, 'text/plain'), __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=MockResponse(responses, 'text/plain'), __name__="get"):
         yield
 
 
@@ -172,5 +174,5 @@ def new_galley_fixture():
         with open(file_path, 'r') as f:
             responses.append(f.read())
 
-    with mock.patch('requests.get', return_value=MockResponse(responses, 'text/plain'), __name__="get"):
+    with mock.patch(MOCK_HTTP_GET, return_value=MockResponse(responses, 'text/plain'), __name__="get"):
         yield

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -30,6 +30,8 @@ instanceSecure = {
     'tags': [customtag],
 }
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.fixture()
 def mock_get():
@@ -37,7 +39,7 @@ def mock_get():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200,
             iter_lines=lambda **kwargs: text_data.split("\n"),

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -30,7 +30,7 @@ instanceSecure = {
     'tags': [customtag],
 }
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture()

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
@@ -18,6 +18,8 @@ instance = {
     'tags': [customtag],
 }
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.fixture()
 def mock_get():
@@ -25,7 +27,7 @@ def mock_get():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200,
             iter_lines=lambda **kwargs: text_data.split("\n"),

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
@@ -18,7 +18,7 @@ instance = {
     'tags': [customtag],
 }
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture()

--- a/kube_controller_manager/tests/test_kube_controller_manager.py
+++ b/kube_controller_manager/tests/test_kube_controller_manager.py
@@ -27,6 +27,7 @@ instance2 = {
 # Constants
 CHECK_NAME = 'kube_controller_manager'
 NAMESPACE = 'kube_controller_manager'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
 
 
 @pytest.fixture()
@@ -35,7 +36,7 @@ def mock_metrics():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
         ),

--- a/kube_controller_manager/tests/test_kube_controller_manager.py
+++ b/kube_controller_manager/tests/test_kube_controller_manager.py
@@ -27,7 +27,7 @@ instance2 = {
 # Constants
 CHECK_NAME = 'kube_controller_manager'
 NAMESPACE = 'kube_controller_manager'
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture()

--- a/kube_dns/tests/test_kube_dns.py
+++ b/kube_dns/tests/test_kube_dns.py
@@ -15,6 +15,8 @@ customtag = "custom:tag"
 
 instance = {'prometheus_endpoint': 'http://localhost:10055/metrics', 'tags': [customtag]}
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.fixture()
 def mock_get():
@@ -22,7 +24,7 @@ def mock_get():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
         ),

--- a/kube_dns/tests/test_kube_dns.py
+++ b/kube_dns/tests/test_kube_dns.py
@@ -15,7 +15,7 @@ customtag = "custom:tag"
 
 instance = {'prometheus_endpoint': 'http://localhost:10055/metrics', 'tags': [customtag]}
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture()

--- a/kube_metrics_server/tests/test_kube_metrics_server.py
+++ b/kube_metrics_server/tests/test_kube_metrics_server.py
@@ -18,6 +18,7 @@ instance = {
 # Constants
 CHECK_NAME = 'kube_metrics_server'
 NAMESPACE = 'kube_metrics_server'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
 
 
 @pytest.fixture()
@@ -26,7 +27,7 @@ def mock_metrics():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
         ),

--- a/kube_metrics_server/tests/test_kube_metrics_server.py
+++ b/kube_metrics_server/tests/test_kube_metrics_server.py
@@ -18,7 +18,7 @@ instance = {
 # Constants
 CHECK_NAME = 'kube_metrics_server'
 NAMESPACE = 'kube_metrics_server'
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture()

--- a/kube_proxy/tests/test_kube_proxy.py
+++ b/kube_proxy/tests/test_kube_proxy.py
@@ -14,7 +14,7 @@ instance = {'prometheus_url': 'http://localhost:10249/metrics'}
 # Constants
 CHECK_NAME = 'kube_proxy'
 NAMESPACE = 'kubeproxy'
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture()

--- a/kube_proxy/tests/test_kube_proxy.py
+++ b/kube_proxy/tests/test_kube_proxy.py
@@ -14,6 +14,7 @@ instance = {'prometheus_url': 'http://localhost:10249/metrics'}
 # Constants
 CHECK_NAME = 'kube_proxy'
 NAMESPACE = 'kubeproxy'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
 
 
 @pytest.fixture()
@@ -22,7 +23,7 @@ def mock_iptables():
     with open(f_name, 'r') as f:
         text_data = f.read()
     mock_iptables = mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
         ),
@@ -37,7 +38,7 @@ def mock_userspace():
     with open(f_name, 'r') as f:
         text_data = f.read()
     mock_userspace = mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
         ),

--- a/kube_scheduler/tests/test_kube_scheduler_1_13.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_13.py
@@ -15,7 +15,7 @@ instance = {'prometheus_url': 'http://localhost:10251/metrics', 'send_histograms
 # Constants
 CHECK_NAME = 'kube_scheduler'
 NAMESPACE = 'kube_scheduler'
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture()

--- a/kube_scheduler/tests/test_kube_scheduler_1_13.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_13.py
@@ -15,6 +15,7 @@ instance = {'prometheus_url': 'http://localhost:10251/metrics', 'send_histograms
 # Constants
 CHECK_NAME = 'kube_scheduler'
 NAMESPACE = 'kube_scheduler'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
 
 
 @pytest.fixture()
@@ -23,7 +24,7 @@ def mock_metrics():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
         ),

--- a/kube_scheduler/tests/test_kube_scheduler_1_14.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_14.py
@@ -15,7 +15,7 @@ instance = {'prometheus_url': 'http://localhost:10251/metrics', 'send_histograms
 # Constants
 CHECK_NAME = 'kube_scheduler'
 NAMESPACE = 'kube_scheduler'
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture()

--- a/kube_scheduler/tests/test_kube_scheduler_1_14.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_14.py
@@ -15,6 +15,7 @@ instance = {'prometheus_url': 'http://localhost:10251/metrics', 'send_histograms
 # Constants
 CHECK_NAME = 'kube_scheduler'
 NAMESPACE = 'kube_scheduler'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
 
 
 @pytest.fixture()
@@ -23,7 +24,7 @@ def mock_metrics():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
         ),

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -206,7 +206,7 @@ METRICS_WITH_INTERFACE_TAG = {
     'kubernetes.network.tx_dropped': 'eth0',
 }
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 class MockStreamResponse:

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -206,6 +206,8 @@ METRICS_WITH_INTERFACE_TAG = {
     'kubernetes.network.tx_dropped': 'eth0',
 }
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 class MockStreamResponse:
     """
@@ -403,7 +405,7 @@ def test_kubelet_credentials_update(monkeypatch, aggregator):
     get = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: mock_from_file('kubelet_metrics_1_14.txt').splitlines()
     )
-    with mock.patch('requests.get', return_value=get):
+    with mock.patch(MOCK_HTTP_GET, return_value=get):
         check.check(instance)
 
     assert check._http_handlers[instance['kubelet_metrics_endpoint']].options['verify'] is True
@@ -413,7 +415,7 @@ def test_kubelet_credentials_update(monkeypatch, aggregator):
         status_code=200, iter_lines=lambda **kwargs: mock_from_file('kubelet_metrics_1_14.txt').splitlines()
     )
     kubelet_conn_info = {'url': 'http://127.0.0.1:10255', 'ca_cert': False}
-    with mock.patch('requests.get', return_value=get), mock.patch(
+    with mock.patch(MOCK_HTTP_GET, return_value=get), mock.patch(
         'datadog_checks.kubelet.kubelet.get_connection_info', return_value=kubelet_conn_info
     ):
         check.check(instance)
@@ -787,7 +789,7 @@ def test_perform_kubelet_check(monkeypatch):
 
     instance_tags = ["one:1"]
     get = MockResponse()
-    with mock.patch("requests.get", side_effect=get):
+    with mock.patch(MOCK_HTTP_GET, side_effect=get):
         check._perform_kubelet_check(instance_tags)
 
     get.assert_has_calls(
@@ -828,7 +830,7 @@ def test_report_node_metrics_kubernetes1_18(monkeypatch, aggregator):
 
     get = mock.MagicMock(status_code=404, iter_lines=lambda **kwargs: "Error Code")
     get.raise_for_status.side_effect = requests.HTTPError('error')
-    with mock.patch('requests.get', return_value=get):
+    with mock.patch(MOCK_HTTP_GET, return_value=get):
         check._report_node_metrics(['foo:bar'])
         aggregator.assert_all_metrics_covered()
 

--- a/mapreduce/tests/conftest.py
+++ b/mapreduce/tests/conftest.py
@@ -29,6 +29,7 @@ from .common import (
 )
 
 MOCKED_HOSTS = ('namenode', 'datanode', 'resourcemanager', 'nodemanager', 'historyserver')
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
 
 
 @pytest.fixture(scope="session")
@@ -55,13 +56,13 @@ def instance():
 
 @pytest.fixture
 def mocked_request():
-    with patch("requests.get", new=requests_get_mock):
+    with patch(MOCK_HTTP_GET, new=requests_get_mock):
         yield
 
 
 @pytest.fixture
 def mocked_auth_request():
-    with patch("requests.get", new=requests_auth_mock):
+    with patch(MOCK_HTTP_GET, new=requests_auth_mock):
         yield
 
 

--- a/mapreduce/tests/conftest.py
+++ b/mapreduce/tests/conftest.py
@@ -29,7 +29,7 @@ from .common import (
 )
 
 MOCKED_HOSTS = ('namenode', 'datanode', 'resourcemanager', 'nodemanager', 'historyserver')
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture(scope="session")

--- a/mesos_master/tests/test_check.py
+++ b/mesos_master/tests/test_check.py
@@ -10,6 +10,8 @@ from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException
 from datadog_checks.mesos_master import MesosMaster
 
+MOCK_HTTP_SESSION = 'datadog_checks.base.utils.http.SessionMockTarget'
+
 
 def test_check(check, instance, aggregator):
     check = check({}, instance)
@@ -133,7 +135,7 @@ def test_can_connect_service_check(
 ):
     check = MesosMaster('mesos_master', {}, [instance])
 
-    with mock.patch('datadog_checks.base.utils.http.requests') as r:
+    with mock.patch(MOCK_HTTP_SESSION) as r:
         r.get.side_effect = request_mock_side_effects
 
         try:

--- a/mesos_master/tests/test_check.py
+++ b/mesos_master/tests/test_check.py
@@ -10,7 +10,7 @@ from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException
 from datadog_checks.mesos_master import MesosMaster
 
-MOCK_HTTP_SESSION = 'datadog_checks.base.utils.http.SessionMockTarget'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 def test_check(check, instance, aggregator):
@@ -135,8 +135,8 @@ def test_can_connect_service_check(
 ):
     check = MesosMaster('mesos_master', {}, [instance])
 
-    with mock.patch(MOCK_HTTP_SESSION) as r:
-        r.get.side_effect = request_mock_side_effects
+    with mock.patch(MOCK_HTTP_GET) as m:
+        m.side_effect = request_mock_side_effects
 
         try:
             check._get_master_state('http://hello.com', ['my:tag'])

--- a/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
+++ b/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
@@ -14,6 +14,7 @@ INSTANCE_HISTO = {'prometheus_url': 'http://localhost:10249/metrics', 'collect_n
 
 CHECK_NAME = 'nginx_ingress_controller'
 NAMESPACE = 'nginx_ingress'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
 
 
 @pytest.fixture()
@@ -22,7 +23,7 @@ def mock_data():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
         ),

--- a/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
+++ b/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
@@ -14,7 +14,7 @@ INSTANCE_HISTO = {'prometheus_url': 'http://localhost:10249/metrics', 'collect_n
 
 CHECK_NAME = 'nginx_ingress_controller'
 NAMESPACE = 'nginx_ingress'
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture()

--- a/openmetrics/tests/conftest.py
+++ b/openmetrics/tests/conftest.py
@@ -13,7 +13,7 @@ from datadog_checks.dev import docker_run
 
 from .common import HERE, INSTANCE
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture(scope="session")

--- a/openmetrics/tests/conftest.py
+++ b/openmetrics/tests/conftest.py
@@ -13,6 +13,8 @@ from datadog_checks.dev import docker_run
 
 from .common import HERE, INSTANCE
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.fixture(scope="session")
 def dd_environment():
@@ -36,7 +38,7 @@ def poll_mock():
     g3.labels(matched_label="foobar", node="host2", timestamp="456").set(float('inf'))
 
     poll_mock_patch = mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200,
             iter_lines=lambda **kwargs: ensure_unicode(generate_latest(registry)).split("\n"),

--- a/openstack_controller/tests/test_simple_api.py
+++ b/openstack_controller/tests/test_simple_api.py
@@ -23,7 +23,7 @@ from . import common
 
 log = logging.getLogger('test_openstack_controller')
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 def test_get_endpoint():

--- a/openstack_controller/tests/test_simple_api.py
+++ b/openstack_controller/tests/test_simple_api.py
@@ -23,6 +23,8 @@ from . import common
 
 log = logging.getLogger('test_openstack_controller')
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 def test_get_endpoint():
     authenticator = Authenticator()
@@ -727,7 +729,7 @@ def test__make_request_failure(requests_wrapper):
         api = ApiFactory.create(log, instance, requests_wrapper)
 
     response_mock = mock.MagicMock()
-    with mock.patch("datadog_checks.openstack_controller.api.requests.get", return_value=response_mock):
+    with mock.patch(MOCK_HTTP_GET, return_value=response_mock):
         response_mock.raise_for_status.side_effect = requests.exceptions.HTTPError
         response_mock.status_code = 401
         with pytest.raises(AuthenticationNeeded):

--- a/powerdns_recursor/tests/test_metadata.py
+++ b/powerdns_recursor/tests/test_metadata.py
@@ -10,7 +10,7 @@ from datadog_checks.powerdns_recursor import PowerDNSRecursorCheck
 
 from . import common
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 def test_metadata_unit(datadog_agent):

--- a/powerdns_recursor/tests/test_metadata.py
+++ b/powerdns_recursor/tests/test_metadata.py
@@ -10,6 +10,8 @@ from datadog_checks.powerdns_recursor import PowerDNSRecursorCheck
 
 from . import common
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 def test_metadata_unit(datadog_agent):
     version = common._get_pdns_version()
@@ -23,19 +25,19 @@ def test_metadata_unit(datadog_agent):
 
     config_obj, tags = check._get_config(instance)
 
-    with mock.patch('requests.get', side_effect=requests.exceptions.Timeout()):
+    with mock.patch(MOCK_HTTP_GET, side_effect=requests.exceptions.Timeout()):
         check._collect_metadata(config_obj)
         datadog_agent.assert_metadata_count(0)
         check.log.debug.assert_called_with('Error collecting PowerDNS Recursor version: %s', '')
 
     datadog_agent.reset()
-    with mock.patch('requests.get', return_value=common.MockResponse({}, 200)):
+    with mock.patch(MOCK_HTTP_GET, return_value=common.MockResponse({}, 200)):
         check._collect_metadata(config_obj)
         datadog_agent.assert_metadata_count(0)
         check.log.debug.assert_called_with("Couldn't find the PowerDNS Recursor Server version header")
 
     datadog_agent.reset()
-    with mock.patch('requests.get', return_value=common.MockResponse({'Server': 'wrong_stuff'}, 200)):
+    with mock.patch(MOCK_HTTP_GET, return_value=common.MockResponse({'Server': 'wrong_stuff'}, 200)):
         check._collect_metadata(config_obj)
         datadog_agent.assert_metadata_count(0)
         check.log.debug.assert_called_with(

--- a/prometheus/tests/conftest.py
+++ b/prometheus/tests/conftest.py
@@ -25,6 +25,8 @@ INSTANCE_UNIT = {
     'send_monotonic_counter': True,
 }
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.fixture(scope="session")
 def instance():
@@ -59,7 +61,7 @@ def poll_mock():
     g3.labels(matched_label="foobar", node="host2", timestamp="456").set(float('inf'))
 
     poll_mock_patch = mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200,
             iter_lines=lambda **kwargs: ensure_unicode(generate_latest(registry)).split("\n"),

--- a/prometheus/tests/conftest.py
+++ b/prometheus/tests/conftest.py
@@ -25,7 +25,7 @@ INSTANCE_UNIT = {
     'send_monotonic_counter': True,
 }
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture(scope="session")

--- a/scylla/tests/conftest.py
+++ b/scylla/tests/conftest.py
@@ -12,7 +12,7 @@ HERE = get_here()
 HOST = get_docker_hostname()
 INSTANCE_PORT = 9180
 INSTANCE_URL = "http://{}:{}/metrics".format(HOST, INSTANCE_PORT)
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture(scope='session')

--- a/scylla/tests/conftest.py
+++ b/scylla/tests/conftest.py
@@ -12,6 +12,7 @@ HERE = get_here()
 HOST = get_docker_hostname()
 INSTANCE_PORT = 9180
 INSTANCE_URL = "http://{}:{}/metrics".format(HOST, INSTANCE_PORT)
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
 
 
 @pytest.fixture(scope='session')
@@ -34,7 +35,7 @@ def mock_db_data():
     with open(f_name, 'r') as f:
         text_data = f.read()
     with mock.patch(
-        'requests.get',
+        MOCK_HTTP_GET,
         return_value=mock.MagicMock(
             status_code=200,
             iter_lines=lambda **kwargs: text_data.split("\n"),

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -644,10 +644,12 @@ SPARK_STREAMING_STATISTICS_METRIC_VALUES = {
 
 SPARK_METRIC_TAGS = ['cluster_name:' + CLUSTER_NAME, 'app_name:' + APP_NAME]
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.mark.unit
 def test_yarn(aggregator):
-    with mock.patch('requests.get', yarn_requests_get_mock):
+    with mock.patch(MOCK_HTTP_GET, yarn_requests_get_mock):
         c = SparkCheck('spark', {}, [YARN_CONFIG])
         c.check(YARN_CONFIG)
 
@@ -697,7 +699,7 @@ def test_yarn(aggregator):
 
 @pytest.mark.unit
 def test_auth_yarn(aggregator):
-    with mock.patch('requests.get', yarn_requests_auth_mock):
+    with mock.patch(MOCK_HTTP_GET, yarn_requests_auth_mock):
         c = SparkCheck('spark', {}, [YARN_AUTH_CONFIG])
         c.check(YARN_AUTH_CONFIG)
 
@@ -717,7 +719,7 @@ def test_auth_yarn(aggregator):
 
 @pytest.mark.unit
 def test_mesos(aggregator):
-    with mock.patch('requests.get', mesos_requests_get_mock):
+    with mock.patch(MOCK_HTTP_GET, mesos_requests_get_mock):
         c = SparkCheck('spark', {}, [MESOS_CONFIG])
         c.check(MESOS_CONFIG)
 
@@ -774,7 +776,7 @@ def test_mesos(aggregator):
 
 @pytest.mark.unit
 def test_mesos_filter(aggregator):
-    with mock.patch('requests.get', mesos_requests_get_mock):
+    with mock.patch(MOCK_HTTP_GET, mesos_requests_get_mock):
         c = SparkCheck('spark', {}, [MESOS_FILTERED_CONFIG])
         c.check(MESOS_FILTERED_CONFIG)
 
@@ -787,7 +789,7 @@ def test_mesos_filter(aggregator):
 
 @pytest.mark.unit
 def test_driver_unit(aggregator):
-    with mock.patch('requests.get', driver_requests_get_mock):
+    with mock.patch(MOCK_HTTP_GET, driver_requests_get_mock):
         c = SparkCheck('spark', {}, [DRIVER_CONFIG])
         c.check(DRIVER_CONFIG)
 
@@ -844,7 +846,7 @@ def test_driver_unit(aggregator):
 
 @pytest.mark.unit
 def test_standalone_unit(aggregator):
-    with mock.patch('requests.get', standalone_requests_get_mock):
+    with mock.patch(MOCK_HTTP_GET, standalone_requests_get_mock):
         c = SparkCheck('spark', {}, [STANDALONE_CONFIG])
         c.check(STANDALONE_CONFIG)
 
@@ -899,7 +901,7 @@ def test_standalone_unit(aggregator):
 @pytest.mark.unit
 def test_standalone_unit_with_proxy_warning_page(aggregator):
     c = SparkCheck('spark', {}, [STANDALONE_CONFIG])
-    with mock.patch('requests.get', proxy_with_warning_page_mock):
+    with mock.patch(MOCK_HTTP_GET, proxy_with_warning_page_mock):
         c.check(STANDALONE_CONFIG)
 
         # Check the running job metrics
@@ -952,7 +954,7 @@ def test_standalone_unit_with_proxy_warning_page(aggregator):
 
 @pytest.mark.unit
 def test_standalone_pre20(aggregator):
-    with mock.patch('requests.get', standalone_requests_pre20_get_mock):
+    with mock.patch(MOCK_HTTP_GET, standalone_requests_pre20_get_mock):
         c = SparkCheck('spark', {}, [STANDALONE_CONFIG_PRE_20])
         c.check(STANDALONE_CONFIG_PRE_20)
 
@@ -1006,7 +1008,7 @@ def test_standalone_pre20(aggregator):
 
 @pytest.mark.unit
 def test_metadata(aggregator, datadog_agent):
-    with mock.patch('requests.get', standalone_requests_pre20_get_mock):
+    with mock.patch(MOCK_HTTP_GET, standalone_requests_pre20_get_mock):
         c = SparkCheck(CHECK_NAME, {}, [STANDALONE_CONFIG_PRE_20])
         c.check_id = "test:123"
         c.check(STANDALONE_CONFIG_PRE_20)

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -644,7 +644,7 @@ SPARK_STREAMING_STATISTICS_METRIC_VALUES = {
 
 SPARK_METRIC_TAGS = ['cluster_name:' + CLUSTER_NAME, 'app_name:' + APP_NAME]
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.mark.unit

--- a/squid/tests/test_squid.py
+++ b/squid/tests/test_squid.py
@@ -7,6 +7,8 @@ import pytest
 
 from . import common
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
@@ -70,7 +72,7 @@ def test_check_ok(aggregator, check, instance):
 )
 @pytest.mark.usefixtures("dd_environment")
 def test_version_metadata(check, instance, datadog_agent, raw_version, version_metadata, count):
-    with mock.patch('datadog_checks.base.utils.http.requests.get') as g:
+    with mock.patch(MOCK_HTTP_GET) as g:
         g.return_value.headers = {'Server': raw_version}
 
         check.check_id = 'test:123'

--- a/squid/tests/test_squid.py
+++ b/squid/tests/test_squid.py
@@ -7,7 +7,7 @@ import pytest
 
 from . import common
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.mark.usefixtures('dd_environment')

--- a/squid/tests/test_unit.py
+++ b/squid/tests/test_unit.py
@@ -10,6 +10,9 @@ from datadog_checks.squid import SquidCheck
 
 from . import common
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_SUBMIT_VERSION = 'datadog_checks.squid.SquidCheck.submit_version'
+
 
 def test_parse_counter(aggregator, check):
     # Good format
@@ -62,8 +65,8 @@ def test_get_counters(check):
     due to a missing = character.
     See https://github.com/DataDog/integrations-core/pull/1643
     """
-    with mock.patch('datadog_checks.squid.squid.requests.get') as g:
-        with mock.patch('datadog_checks.squid.SquidCheck.submit_version'):
+    with mock.patch(MOCK_HTTP_GET) as g:
+        with mock.patch(MOCK_SUBMIT_VERSION):
             g.return_value = mock.MagicMock(text="client_http.requests=42\n\n")
             check.parse_counter = mock.MagicMock(return_value=('foo', 'bar'))
             check.get_counters('host', 'port', [])
@@ -84,8 +87,8 @@ def test_legacy_username_password(instance, auth_config):
     instance.update(auth_config)
     check = SquidCheck(common.CHECK_NAME, {}, {}, [instance])
 
-    with mock.patch('datadog_checks.base.utils.http.requests.get') as g:
-        with mock.patch('datadog_checks.squid.SquidCheck.submit_version'):
+    with mock.patch(MOCK_HTTP_GET) as g:
+        with mock.patch(MOCK_SUBMIT_VERSION):
             check.get_counters('host', 'port', [])
 
             g.assert_called_with(

--- a/squid/tests/test_unit.py
+++ b/squid/tests/test_unit.py
@@ -10,7 +10,7 @@ from datadog_checks.squid import SquidCheck
 
 from . import common
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 MOCK_SUBMIT_VERSION = 'datadog_checks.squid.SquidCheck.submit_version'
 
 

--- a/teamcity/tests/test_teamcity.py
+++ b/teamcity/tests/test_teamcity.py
@@ -10,19 +10,21 @@ from datadog_checks.teamcity import TeamCityCheck
 
 from .common import CHECK_NAME, CONFIG
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.mark.integration
 def test_build_event(aggregator):
     teamcity = TeamCityCheck(CHECK_NAME, {}, [CONFIG])
 
-    with patch('datadog_checks.base.utils.http.requests.get', get_mock_first_build):
+    with patch(MOCK_HTTP_GET, get_mock_first_build):
         teamcity.check(CONFIG['instances'][0])
 
     assert len(aggregator.metric_names) == 0
     assert len(aggregator.events) == 0
     aggregator.reset()
 
-    with patch('datadog_checks.base.utils.http.requests.get', get_mock_one_more_build):
+    with patch(MOCK_HTTP_GET, get_mock_one_more_build):
         teamcity.check(CONFIG['instances'][0])
 
     events = aggregator.events
@@ -38,7 +40,7 @@ def test_build_event(aggregator):
     aggregator.reset()
 
     # One more check should not create any more events
-    with patch('datadog_checks.base.utils.http.requests.get', get_mock_one_more_build):
+    with patch(MOCK_HTTP_GET, get_mock_one_more_build):
         teamcity.check(CONFIG['instances'][0])
 
     assert len(aggregator.events) == 0
@@ -122,7 +124,7 @@ def test_config(test_case, extra_config, expected_http_kwargs):
     instance.update(extra_config)
     check = TeamCityCheck(CHECK_NAME, {}, [instance])
 
-    with patch('datadog_checks.base.utils.http.requests.get') as r:
+    with patch(MOCK_HTTP_GET) as r:
         check.check(instance)
 
         http_wargs = dict(auth=ANY, cert=ANY, headers=ANY, proxies=ANY, timeout=ANY, verify=ANY)

--- a/teamcity/tests/test_teamcity.py
+++ b/teamcity/tests/test_teamcity.py
@@ -10,7 +10,7 @@ from datadog_checks.teamcity import TeamCityCheck
 
 from .common import CHECK_NAME, CONFIG
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.mark.integration

--- a/twistlock/tests/test_twistlock.py
+++ b/twistlock/tests/test_twistlock.py
@@ -42,7 +42,7 @@ METRICS = [
 
 HERE = get_here()
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 class MockResponse:

--- a/twistlock/tests/test_twistlock.py
+++ b/twistlock/tests/test_twistlock.py
@@ -42,6 +42,8 @@ METRICS = [
 
 HERE = get_here()
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 class MockResponse:
     def __init__(self, j):
@@ -74,7 +76,7 @@ def test_check(aggregator, fixture_group):
 
     check = TwistlockCheck('twistlock', {}, [instance])
 
-    with mock.patch('requests.get', side_effect=mock_get_factory(fixture_group), autospec=True):
+    with mock.patch(MOCK_HTTP_GET, side_effect=mock_get_factory(fixture_group), autospec=True):
         check.check(instance)
         check.check(instance)
 
@@ -96,7 +98,7 @@ def test_config_project(aggregator, fixture_group):
     instance['project'] = project
     check = TwistlockCheck('twistlock', {}, [instance])
 
-    with mock.patch('requests.get', side_effect=mock_get_factory(fixture_group), autospec=True) as r:
+    with mock.patch(MOCK_HTTP_GET, side_effect=mock_get_factory(fixture_group), autospec=True) as r:
         check.check(instance)
 
         r.assert_called_with(
@@ -119,6 +121,6 @@ def test_err_response(aggregator):
     check = TwistlockCheck('twistlock', {}, [instance])
 
     with pytest.raises(Exception, match='^Error in response'):
-        with mock.patch('requests.get', return_value=MockResponse('{"err": "invalid credentials"}'), autospec=True):
+        with mock.patch(MOCK_HTTP_GET, return_value=MockResponse('{"err": "invalid credentials"}'), autospec=True):
 
             check.check(instance)

--- a/vault/tests/test_vault.py
+++ b/vault/tests/test_vault.py
@@ -16,7 +16,7 @@ from .utils import run_check
 
 pytestmark = pytest.mark.usefixtures('dd_environment')
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 class TestVault:

--- a/vault/tests/test_vault.py
+++ b/vault/tests/test_vault.py
@@ -16,6 +16,8 @@ from .utils import run_check
 
 pytestmark = pytest.mark.usefixtures('dd_environment')
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 class TestVault:
     def test_bad_config(self, aggregator):
@@ -72,7 +74,7 @@ class TestVault:
                 )
             return requests_get(url, *args, **kwargs)
 
-        with mock.patch('requests.get', side_effect=mock_requests_get, autospec=True):
+        with mock.patch(MOCK_HTTP_GET, side_effect=mock_requests_get, autospec=True):
             run_check(c)
 
         aggregator.assert_service_check(Vault.SERVICE_CHECK_CONNECT, status=Vault.OK, tags=global_tags, count=1)
@@ -98,7 +100,7 @@ class TestVault:
         instance = INSTANCES['main']
         c = Vault(Vault.CHECK_NAME, {}, [instance])
 
-        with mock.patch('requests.get', return_value=MockResponse('', status_code=500)):
+        with mock.patch(MOCK_HTTP_GET, return_value=MockResponse('', status_code=500)):
             with pytest.raises(
                 Exception, match=r'^The Vault endpoint `{}.+?` returned 500$'.format(re.escape(instance['api_url']))
             ):
@@ -148,7 +150,7 @@ class TestVault:
                 )
             return requests_get(url, *args, **kwargs)
 
-        with mock.patch('requests.get', side_effect=mock_requests_get, autospec=True):
+        with mock.patch(MOCK_HTTP_GET, side_effect=mock_requests_get, autospec=True):
             run_check(c)
 
         expected_tags = ['is_leader:true', 'cluster_name:vault-cluster-f5f44063', 'vault_version:0.10.2']
@@ -180,7 +182,7 @@ class TestVault:
                 )
             return requests_get(url, *args, **kwargs)
 
-        with mock.patch('requests.get', side_effect=mock_requests_get, autospec=True):
+        with mock.patch(MOCK_HTTP_GET, side_effect=mock_requests_get, autospec=True):
             run_check(c)
 
         aggregator.assert_service_check(Vault.SERVICE_CHECK_UNSEALED, status=Vault.CRITICAL, count=1)
@@ -220,7 +222,7 @@ class TestVault:
                 )
             return requests_get(url, *args, **kwargs)
 
-        with mock.patch('requests.get', side_effect=mock_requests_get, autospec=True):
+        with mock.patch(MOCK_HTTP_GET, side_effect=mock_requests_get, autospec=True):
             run_check(c)
 
         expected_tags = ['is_leader:true', 'cluster_name:vault-cluster-f5f44063', 'vault_version:0.10.2']
@@ -252,7 +254,7 @@ class TestVault:
                 )
             return requests_get(url, *args, **kwargs)
 
-        with mock.patch('requests.get', side_effect=mock_requests_get, autospec=True):
+        with mock.patch(MOCK_HTTP_GET, side_effect=mock_requests_get, autospec=True):
             run_check(c)
 
         aggregator.assert_service_check(Vault.SERVICE_CHECK_INITIALIZED, status=Vault.CRITICAL, count=1)
@@ -284,7 +286,7 @@ class TestVault:
                 )
             return requests_get(url, *args, **kwargs)
 
-        with mock.patch('requests.get', side_effect=mock_requests_get, autospec=True):
+        with mock.patch(MOCK_HTTP_GET, side_effect=mock_requests_get, autospec=True):
             run_check(c)
 
         assert len(aggregator.events) > 0
@@ -318,7 +320,7 @@ class TestVault:
                 )
             return requests_get(url, *args, **kwargs)
 
-        with mock.patch('requests.get', side_effect=mock_requests_get, autospec=True):
+        with mock.patch(MOCK_HTTP_GET, side_effect=mock_requests_get, autospec=True):
             run_check(c)
 
         assert len(aggregator.events) == 0
@@ -337,7 +339,7 @@ class TestVault:
                 )
             return requests_get(url, *args, **kwargs)
 
-        with mock.patch('requests.get', side_effect=mock_requests_get, autospec=True):
+        with mock.patch(MOCK_HTTP_GET, side_effect=mock_requests_get, autospec=True):
             run_check(c)
 
         aggregator.assert_metric('vault.is_leader', 1)
@@ -356,7 +358,7 @@ class TestVault:
                 )
             return requests_get(url, *args, **kwargs)
 
-        with mock.patch('requests.get', side_effect=mock_requests_get, autospec=True):
+        with mock.patch(MOCK_HTTP_GET, side_effect=mock_requests_get, autospec=True):
             run_check(c)
 
         aggregator.assert_metric('vault.is_leader', 0)
@@ -388,7 +390,7 @@ class TestVault:
                 )
             return requests_get(url, *args, **kwargs)
 
-        with mock.patch('requests.get', side_effect=mock_requests_get, autospec=True):
+        with mock.patch(MOCK_HTTP_GET, side_effect=mock_requests_get, autospec=True):
             run_check(c)
 
         aggregator.assert_metric('vault.is_leader', 1)
@@ -406,7 +408,7 @@ class TestVault:
                 return MockResponse({'errors': ["Vault is sealed"]}, status_code=503)
             return requests_get(url, *args, **kwargs)
 
-        with mock.patch('requests.get', side_effect=mock_requests_get, autospec=True):
+        with mock.patch(MOCK_HTTP_GET, side_effect=mock_requests_get, autospec=True):
             run_check(c)
 
         aggregator.assert_metric('vault.is_leader', count=0)

--- a/vsphere/tests/conftest.py
+++ b/vsphere/tests/conftest.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     from contextlib2 import ExitStack
 
-MOCK_HTTP_REQUEST = 'datadog_checks.base.utils.http.SessionMockTarget.request'
+MOCK_HTTP_REQUEST = 'datadog_checks.base.utils.http.requests.request'
 
 
 @pytest.fixture(scope='session')

--- a/vsphere/tests/conftest.py
+++ b/vsphere/tests/conftest.py
@@ -14,6 +14,8 @@ try:
 except ImportError:
     from contextlib2 import ExitStack
 
+MOCK_HTTP_REQUEST = 'datadog_checks.base.utils.http.SessionMockTarget.request'
+
 
 @pytest.fixture(scope='session')
 def dd_environment():
@@ -99,5 +101,5 @@ def mock_api():
 
 @pytest.fixture
 def mock_rest_api():
-    with patch('requests.api.request', mock_http_rest_api):
+    with patch(MOCK_HTTP_REQUEST, mock_http_rest_api):
         yield

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -19,7 +19,7 @@ from datadog_checks.vsphere.config import VSphereConfig
 from .common import HERE
 from .mocked_api import MockedAPI
 
-MOCK_HTTP_POST = 'datadog_checks.base.utils.http.SessionMockTarget.post'
+MOCK_HTTP_POST = 'datadog_checks.base.utils.http.requests.post'
 
 
 @pytest.mark.usefixtures("mock_type", "mock_threadpool", "mock_api")

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -19,6 +19,8 @@ from datadog_checks.vsphere.config import VSphereConfig
 from .common import HERE
 from .mocked_api import MockedAPI
 
+MOCK_HTTP_POST = 'datadog_checks.base.utils.http.SessionMockTarget.post'
+
 
 @pytest.mark.usefixtures("mock_type", "mock_threadpool", "mock_api")
 def test_realtime_metrics(aggregator, dd_run_check, realtime_instance):
@@ -251,7 +253,7 @@ def test_continue_if_tag_collection_fail(aggregator, dd_run_check, realtime_inst
     check = VSphereCheck('vsphere', {}, [realtime_instance])
     check.log = MagicMock()
 
-    with mock.patch('requests.post', side_effect=Exception, autospec=True):
+    with mock.patch(MOCK_HTTP_POST, side_effect=Exception, autospec=True):
         dd_run_check(check)
 
     aggregator.assert_metric('vsphere.cpu.usage.avg', tags=['vcenter_server:FAKE'], hostname='10.0.0.104')

--- a/yarn/tests/conftest.py
+++ b/yarn/tests/conftest.py
@@ -25,7 +25,7 @@ from .common import (
     YARN_SCHEDULER_URL,
 )
 
-MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.requests.get'
 
 
 @pytest.fixture(scope="session")

--- a/yarn/tests/conftest.py
+++ b/yarn/tests/conftest.py
@@ -25,6 +25,8 @@ from .common import (
     YARN_SCHEDULER_URL,
 )
 
+MOCK_HTTP_GET = 'datadog_checks.base.utils.http.SessionMockTarget.get'
+
 
 @pytest.fixture(scope="session")
 def dd_environment():
@@ -48,7 +50,7 @@ def instance():
 
 @pytest.fixture
 def mocked_request():
-    with patch("requests.get", new=requests_get_mock):
+    with patch(MOCK_HTTP_GET, new=requests_get_mock):
         yield
 
 
@@ -64,7 +66,7 @@ def mocked_auth_request():
         # Return mocked request.get(...)
         return requests_get_mock(*args, **kwargs)
 
-    with patch("requests.get", new=requests_auth_get):
+    with patch(MOCK_HTTP_GET, new=requests_auth_get):
         yield
 
 
@@ -84,7 +86,7 @@ def mocked_bad_cert_request():
         # Return the actual response
         return requests_get_mock(*args, **kwargs)
 
-    with patch("requests.get", new=requests_bad_cert_get):
+    with patch(MOCK_HTTP_GET, new=requests_bad_cert_get):
         yield
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Refactor mock targets in tests so that they all point to `datadog_checks.base.utils.http.requests`.

This is okay because almost no test enables `persist_connections`, so they indeed rely on the behavior in that case to be calling into `requests` top-level API, rather than a `requests.Session` instance.

Limited to our tests, there's no behavioral change in `RequestsWrapper` at all.

### Motivation
<!-- What inspired you to submit this pull request? -->

Initially, I was thinking this was a required step to prepare for Unix Socket support (or support for any plugin that requires mounting adapters, which can't be done at the top level `requests` namespace).

But I'm thinking of other options (such as only supporting UDS if `persist_connections` is turned on), so I converted this PR to a simple, no-impact refactor of our tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
