### PR TITLE
Fix init_config/db config spec template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/db.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/db.yaml
@@ -10,7 +10,6 @@
       type: object
     default: null
     example:
-      - metric_prefix: <INTEGRATION>
-        query: <QUERY>
+      - query: <QUERY>
         columns: <COLUMNS>
         tags: <TAGS>


### PR DESCRIPTION
### Motivation

There is no standard `metric_prefix` option, only in older custom query logic (deprecated)