### PR TITLE
Use server time to compute startTime

### DIFF
--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -147,7 +147,7 @@ class VSphereAPI(object):
 
     @smart_retry
     def get_current_time(self):
-        # type: () -> None
+        # type: () -> dt.datetime
         return self._conn.CurrentTime()
 
     @smart_retry

--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -146,9 +146,9 @@ class VSphereAPI(object):
         self.log.debug("Connected to %s", version_info.fullName)
 
     @smart_retry
-    def check_health(self):
+    def get_current_time(self):
         # type: () -> None
-        self._conn.CurrentTime()
+        return self._conn.CurrentTime()
 
     @smart_retry
     def get_version(self):

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -88,7 +88,6 @@ class VSphereCheck(AgentCheck):
         self._hostname = None
         self.thread_pool = ThreadPoolExecutor(max_workers=self.config.threads_count)
         self.check_initializations.append(self.initiate_api_connection)
-        self._server_current_time = None
 
     def initiate_api_connection(self):
         # type: () -> None
@@ -561,7 +560,6 @@ class VSphereCheck(AgentCheck):
     def check(self, _):
         # type: (Any) -> None
         self._hostname = datadog_agent.get_hostname()
-
         # Assert the health of the vCenter API by getting the version, and submit the service_check accordingly
         try:
             version_info = self.api.get_version()

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -564,7 +564,7 @@ class VSphereCheck(AgentCheck):
                 self.log.debug("Server current datetime: %s", self._server_current_time)
             except Exception as e:
                 self._server_current_time = dt.datetime.now()
-                self.log.debug(
+                self.log.warning(
                     "Cannot retrieve server current time (%s), using local datetime as fallback: %s",
                     e,
                     self._server_current_time,

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -573,6 +573,7 @@ class VSphereCheck(AgentCheck):
             self.service_check(SERVICE_CHECK_NAME, AgentCheck.OK, tags=self.config.base_tags, hostname=None)
 
         self._server_current_time = self.api.get_current_time()
+        self.log.debug("Server current time: %s", self._server_current_time)
 
         # Collect and submit events
         if self.config.should_collect_events:

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -560,7 +560,7 @@ class VSphereCheck(AgentCheck):
         # type: (Any) -> dt.datetime
         """
         Return server current datetime.
-        On failure, of getting server current datetime, use local datetime.
+        If the retrieval of server current datetime fails, use local current datetime.
 
         The server current datetime is cached for a check run.
         """

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -558,6 +558,12 @@ class VSphereCheck(AgentCheck):
 
     def get_server_current_time(self):
         # type: (Any) -> dt.datetime
+        """
+        Return server current datetime.
+        On failure, of getting server current datetime, use local datetime.
+
+        The server current datetime is cached for a check run.
+        """
         if self._server_current_time is None:
             try:
                 self._server_current_time = self.api.get_current_time()
@@ -574,6 +580,8 @@ class VSphereCheck(AgentCheck):
     def check(self, _):
         # type: (Any) -> None
         self._hostname = datadog_agent.get_hostname()
+        self._server_current_time = None
+
         # Assert the health of the vCenter API by getting the version, and submit the service_check accordingly
         try:
             version_info = self.api.get_version()
@@ -646,5 +654,3 @@ class VSphereCheck(AgentCheck):
         self.log.debug("Starting metric collection in %d threads.", self.config.threads_count)
         self.collect_metrics_async()
         self.log.debug("Metric collection completed.")
-
-        self._server_current_time = None

--- a/vsphere/tests/mocked_api.py
+++ b/vsphere/tests/mocked_api.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import datetime as dt
 import json
 import os
 import re
@@ -28,9 +29,10 @@ class MockedAPI(object):
         self.infrastructure_data = {}
         self.metrics_data = []
         self.mock_events = []
+        self.server_time = dt.datetime.now()
 
-    def check_health(self):
-        return True
+    def get_current_time(self):
+        return self.server_time
 
     def get_version(self):
         about = MagicMock(

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -361,28 +361,30 @@ def test_version_metadata(aggregator, dd_run_check, realtime_instance, datadog_a
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
 def test_server_current_time_cache(aggregator, dd_run_check, historical_instance):
 
-    mock_time = dt.datetime.now()
+    mock_time1 = dt.datetime.now()
 
     check = VSphereCheck('vsphere', {}, [historical_instance])
     check.initiate_api_connection()
 
-    check.api.server_time = mock_time
+    check.api.server_time = mock_time1
     time1 = check.get_server_current_time()
 
-    check.api.server_time = dt.datetime.now()
+    mock_time2 = dt.datetime.now()
+    check.api.server_time = mock_time2
 
     # verify that server time is cached
     # server time is cached so, time2 should be same as time1
     time2 = check.get_server_current_time()
 
-    assert time1 == mock_time
+    assert time1 == mock_time1
     assert time1 == time2
 
     # verify that running the check will reset the server time cache
     check.check(historical_instance)
     time3 = check.get_server_current_time()
 
-    assert time1 != time3
+    assert time3 != time1
+    assert time3 == mock_time2
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')


### PR DESCRIPTION
### What does this PR do?

Use server time

### Motivation

Local time might differ from server time.



> PerfQuerySpec.startTime* | xsd:dateTime | The server time from which to obtain counters. If not specified, defaults to the first available counter. When a startTime is specified, the returned samples do not include the sample at startTime.

https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.PerformanceManager.QuerySpec.html




### Sanity check

With this PR:

```
    vsphere (5.4.0)
    ---------------
      Instance ID: vsphere:9ee463a9fc5cb748 [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/vsphere.d/vsphere.yaml
      Total Runs: 1
      Metric Samples: Last Run: 1,649, Total: 1,649
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 15.126s
      Last Execution Date : 2020-09-16 10:59:06.000000 UTC
      Last Successful Execution Date : 2020-09-16 10:59:06.000000 UTC
      metadata:
        version.build: 14792544
        version.major: 6
        version.minor: 7
        version.patch: 0
        version.raw: 6.7.0+14792544
        version.scheme: semver
```

Same as before without this PR.