### PR TITLE
Add an official Datadog Cluster Agent integration

### DIFF
--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -97,6 +97,9 @@ jobs:
     - checkName: crio
       displayName: CRI-O
       os: linux
+    - checkName: datadog_cluster_agent
+      displayName: Datadog Cluster Agent
+      os: linux
     - checkName: directory
       displayName: Directory
       os: linux

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -123,6 +123,10 @@ coverage:
         target: 75
         flags:
         - datadog_checks_downloader
+      Datadog Cluster Agent:
+        target: 75
+        flags:
+        - datadog_cluster_agent
       Directory:
         target: 75
         flags:
@@ -650,6 +654,11 @@ flags:
     paths:
     - datadog_checks_downloader/datadog_checks/downloader
     - datadog_checks_downloader/tests
+  datadog_cluster_agent:
+    carryforward: true
+    paths:
+    - datadog_cluster_agent/datadog_checks/datadog_cluster_agent
+    - datadog_cluster_agent/tests
   directory:
     carryforward: true
     paths:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,8 @@ assets/               @DataDog/agent-integrations
 /crio/                                    @DataDog/container-integrations @DataDog/agent-integrations
 /crio/*.md                                @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /crio/manifest.json                       @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/datadog_cluster_agent/                   @DataDog/container-integrations @DataDog/agent-integrations
+/datadog_cluster_agent/*.md               @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /ecs_fargate/                             @DataDog/container-integrations @DataDog/agent-integrations
 /ecs_fargate/*.md                         @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /ecs_fargate/manifest.json                @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation

--- a/datadog_cluster_agent/CHANGELOG.md
+++ b/datadog_cluster_agent/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG - datadog_cluster_agent
+
+## 1.0.0 / 2020-07-15
+
+* [FEATURE] Add new datadog_cluster_agent integration for collecting metrics from the Datadog Cluster Agent.

--- a/datadog_cluster_agent/MANIFEST.in
+++ b/datadog_cluster_agent/MANIFEST.in
@@ -1,0 +1,10 @@
+graft datadog_checks
+graft tests
+
+include MANIFEST.in
+include README.md
+include requirements.in
+include requirements-dev.txt
+include manifest.json
+
+global-exclude *.py[cod] __pycache__

--- a/datadog_cluster_agent/README.md
+++ b/datadog_cluster_agent/README.md
@@ -1,0 +1,59 @@
+# Datadog Cluster Agent Integration
+
+## Overview
+
+This check monitors the [Datadog Cluster Agent][1].
+
+## Setup
+
+Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying these instructions.
+
+### Installation
+
+The `datadog_cluster_agent` check is included in the [Datadog Agent][2] package.
+No additional installation is needed on your server.
+
+### Configuration
+
+1. Edit the `datadog_cluster_agent.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your `datadog_cluster_agent` performance data. See the [sample datadog_cluster_agent.d/conf.yaml][3] for all available configuration options.
+
+Only the following parameter is required:
+
+| Parameter        | Description                                                                                                                                                                                                                                                              |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `prometheus_url` | The URL where the Datadog Cluster Agent metrics are exposed by Prometheus (must be unique).                                                                                                                                                                              |
+
+This integration is based on OpenMetrics. For more configurations, see [Prometheus and OpenMetrics Metrics Collection][8].
+
+2. [Restart the Agent][4].
+
+### Validation
+
+[Run the Agent's status subcommand][5] and look for `datadog_cluster_agent` under the Checks section.
+
+## Data Collected
+
+### Metrics
+
+See [metadata.csv][6] for a list of metrics provided by this check.
+
+### Service Checks
+
+`datadog.cluster_agent.prometheus.health`: Returns CRITICAL if the Agent cannot reach the metrics endpoints, OK otherwise.
+
+### Events
+
+datadog_cluster_agent does not include any events.
+
+## Troubleshooting
+
+Need help? Contact [Datadog support][7].
+
+[1]: https://docs.datadoghq.com/agent/cluster_agent/
+[2]: https://docs.datadoghq.com/agent/kubernetes/integrations/
+[3]: https://github.com/DataDog/integrations-core/blob/master/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
+[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
+[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[6]: https://github.com/DataDog/integrations-core/blob/master/datadog_cluster_agent/metadata.csv
+[7]: https://docs.datadoghq.com/help/
+[8]: https://docs.datadoghq.com/getting_started/integrations/prometheus/

--- a/datadog_cluster_agent/assets/configuration/spec.yaml
+++ b/datadog_cluster_agent/assets/configuration/spec.yaml
@@ -1,0 +1,13 @@
+name: Datadog Cluster Agent
+files:
+- name: datadog_cluster_agent.yaml
+  options:
+  - template: init_config
+    options:
+    - template: init_config/openmetrics
+  - template: instances
+    options:
+    - template: instances/openmetrics
+      overrides:
+        prometheus_url.value.example: http://%%host%%:5000/metrics
+        label_joins.hidden: true

--- a/datadog_cluster_agent/assets/service_checks.json
+++ b/datadog_cluster_agent/assets/service_checks.json
@@ -1,0 +1,17 @@
+[
+    {
+        "agent_version": "6.16.0",
+        "integration": "Datadog Cluster Agent",
+        "check": "datadog.cluster_agent.prometheus.health",
+        "statuses": [
+            "ok",
+            "critical"
+        ],
+        "groups": [
+            "host",
+            "endpoint"
+        ],
+        "name": "Datadog Cluster Agent prometheus health",
+        "description": "Returns `CRITICAL` if the check cannot access the metrics endpoint. Returns `OK` otherwise."
+    }
+]

--- a/datadog_cluster_agent/datadog_checks/__init__.py
+++ b/datadog_cluster_agent/datadog_checks/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/__about__.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/__about__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+__version__ = '1.0.0'

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/__init__.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/__init__.py
@@ -1,0 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from .__about__ import __version__
+from .check import DatadogClusterAgentCheck
+
+__all__ = ['__version__', 'DatadogClusterAgentCheck']

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -1,0 +1,47 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.base import OpenMetricsBaseCheck
+
+DEFAULT_METRICS = {
+    'admission_webhooks_certificate_expiry': 'admission_webhooks.certificate_expiry',
+    'admission_webhooks_mutation_attempts': 'admission_webhooks.mutation_attempts',
+    'admission_webhooks_reconcile_success': 'admission_webhooks.reconcile_success',
+    'admission_webhooks_webhooks_received': 'admission_webhooks.webhooks_received',
+    'cluster_checks_busyness': 'cluster_checks.busyness',
+    'cluster_checks_configs_dangling': 'cluster_checks.configs_dangling',
+    'cluster_checks_configs_dispatched': 'cluster_checks.configs_dispatched',
+    'cluster_checks_nodes_reporting': 'cluster_checks.nodes_reporting',
+    'cluster_checks_rebalancing_decisions': 'cluster_checks.rebalancing_decisions',
+    'cluster_checks_rebalancing_duration_seconds': 'cluster_checks.rebalancing_duration_seconds',
+    'cluster_checks_successful_rebalancing_moves': 'cluster_checks.successful_rebalancing_moves',
+    'cluster_checks_updating_stats_duration_seconds': 'cluster_checks.updating_stats_duration_seconds',
+    'external_metrics_delay_seconds': 'external_metrics.delay_seconds',
+    'external_metrics_processed_value': 'external_metrics.processed_value',
+    'rate_limit_queries_limit': 'datadog.rate_limit_queries.limit',
+    'rate_limit_queries_period': 'datadog.rate_limit_queries.period',
+    'rate_limit_queries_remaining': 'datadog.rate_limit_queries.remaining',
+    'rate_limit_queries_reset': 'datadog.rate_limit_queries.reset',
+}
+
+
+class DatadogClusterAgentCheck(OpenMetricsBaseCheck):
+    """
+    Collect Cluster Agent metrics from its Prometheus endpoint
+    """
+
+    def __init__(self, name, init_config, instances):
+        default_namespace = 'datadog.cluster_agent'
+        default_instances = {
+            'datadog.cluster_agent': {
+                'namespace': default_namespace,
+                'metrics': [DEFAULT_METRICS],
+                'label_joins': {
+                    'leader_election_is_leader': {'labels_to_match': ['join_leader'], 'labels_to_get': ['is_leader']}
+                },
+            },
+        }
+
+        super(DatadogClusterAgentCheck, self).__init__(
+            name, init_config, instances, default_namespace=default_namespace, default_instances=default_instances
+        )

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
@@ -1,0 +1,444 @@
+## All options defined here are available to all instances.
+#
+init_config:
+
+    ## @param proxy - mapping - optional
+    ## Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
+    ## to specify hosts that must bypass proxies.
+    ##
+    ## The SOCKS protocol is also supported like so:
+    ##
+    ##   socks5://user:pass@host:port
+    ##
+    ## Using the scheme `socks5` causes the DNS resolution to happen on the
+    ## client, rather than on the proxy server. This is in line with `curl`,
+    ## which uses the scheme to decide whether to do the DNS resolution on
+    ## the client or proxy. If you want to resolve the domains on the proxy
+    ## server, use `socks5h` as the scheme.
+    #
+    # proxy:
+    #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+    #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+    #   no_proxy:
+    #   - <HOSTNAME_1>
+    #   - <HOSTNAME_2>
+
+    ## @param skip_proxy - boolean - optional - default: false
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
+
+    ## @param timeout - number - optional - default: 10
+    ## The timeout for connecting to services.
+    #
+    # timeout: 10
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Additionally, this sets the default `service` for every log source.
+    #
+    # service: <SERVICE>
+
+## Every instance is scheduled independent of the others.
+#
+instances:
+
+    ## @param prometheus_url - string - required
+    ## The URL where your application metrics are exposed by Prometheus.
+    #
+  - prometheus_url: http://%%host%%:5000/metrics
+
+    ## @param prometheus_metrics_prefix - string - optional
+    ## <PREFIX> for exposed Prometheus metrics.
+    #
+    # prometheus_metrics_prefix: <PREFIX>_
+
+    ## @param health_service_check - boolean - optional - default: true
+    ## Send a service check reporting about the health of the Prometheus endpoint.
+    ## The service check is named <NAMESPACE>.prometheus.health
+    #
+    # health_service_check: true
+
+    ## @param label_to_hostname - string - optional
+    ## Override the hostname with the value of one label.
+    #
+    # label_to_hostname: <LABEL>
+
+    ## @param labels_mapper - mapping - optional
+    ## The label mapper allows you to rename labels.
+    ## Format is <LABEL_TO_RENAME>: <NEW_LABEL_NAME>
+    #
+    # labels_mapper:
+    #   flavor: origin
+
+    ## @param type_overrides - mapping - optional
+    ## Override a type in the Prometheus payload or type an untyped metric (ignored by default).
+    ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, and `summary`.
+    ## The "*" wildcard can be used to match multiple metric names.
+    #
+    # type_overrides:
+    #   <METRIC_NAME>: <METRIC_TYPE>
+
+    ## @param send_histograms_buckets - boolean - optional - default: true
+    ## Set send_histograms_buckets to true to send the histograms bucket.
+    #
+    # send_histograms_buckets: true
+
+    ## @param send_distribution_buckets - boolean - optional - default: false
+    ## Set `send_distribution_buckets` to `true` to send histograms as Datadog distribution metrics.
+    ##
+    ## Learn more about distribution metrics: https://docs.datadoghq.com/developers/metrics/distributions/
+    #
+    # send_distribution_buckets: false
+
+    ## @param send_monotonic_counter - boolean - optional - default: true
+    ## Set send_monotonic_counter to true to send counters as monotonic counter.
+    #
+    # send_monotonic_counter: true
+
+    ## @param send_distribution_counts_as_monotonic - boolean - optional - default: false
+    ## If set to true, sends histograms and summary counters as monotonic counters (instead of gauges).
+    #
+    # send_distribution_counts_as_monotonic: false
+
+    ## @param send_distribution_sums_as_monotonic - boolean - optional - default: false
+    ## If set to true, sends histograms and summary sums as monotonic counters (instead of gauges).
+    #
+    # send_distribution_sums_as_monotonic: false
+
+    ## @param exclude_labels - list of strings - optional
+    ## A list of labels to be excluded
+    #
+    # exclude_labels:
+    #   - timestamp
+
+    ## @param bearer_token_auth - boolean - optional - default: false
+    ## If set to true, adds a bearer token authentication header.
+    ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
+    #
+    # bearer_token_auth: false
+
+    ## @param bearer_token_path - string - optional
+    ## The path to a Kubernetes service account bearer token file. Make sure the file exists and is mounted correctly.
+    ## Note: bearer_token_auth should be set to true to enable adding the token to HTTP headers for authentication.
+    #
+    # bearer_token_path: <TOKEN_PATH>
+
+    ## @param ignore_metrics - list of strings - optional
+    ## A list of metrics to ignore, use the "*" wildcard can be used to match multiple metric names.
+    #
+    # ignore_metrics:
+    #   - <IGNORED_METRIC_NAME>
+    #   - <PREFIX_*>
+    #   - <*_SUFFIX>
+    #   - <PREFIX_*_SUFFIX>
+    #   - <*_SUBSTRING_*>
+
+    ## @param proxy - mapping - optional
+    ## This overrides the `proxy` setting in `init_config`.
+    ##
+    ## Set HTTP or HTTPS proxies for this instance. Use the `no_proxy` list
+    ## to specify hosts that must bypass proxies.
+    ##
+    ## The SOCKS protocol is also supported, for example:
+    ##
+    ##   socks5://user:pass@host:port
+    ##
+    ## Using the scheme `socks5` causes the DNS resolution to happen on the
+    ## client, rather than on the proxy server. This is in line with `curl`,
+    ## which uses the scheme to decide whether to do the DNS resolution on
+    ## the client or proxy. If you want to resolve the domains on the proxy
+    ## server, use `socks5h` as the scheme.
+    #
+    # proxy:
+    #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+    #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+    #   no_proxy:
+    #   - <HOSTNAME_1>
+    #   - <HOSTNAME_2>
+
+    ## @param skip_proxy - boolean - optional - default: false
+    ## This overrides the `skip_proxy` setting in `init_config`.
+    ##
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
+
+    ## @param auth_type - string - optional - default: basic
+    ## The type of authentication to use. The available types (and related options) are:
+    ##
+    ##   - basic
+    ##     |__ username
+    ##     |__ password
+    ##     |__ use_legacy_auth_encoding
+    ##   - digest
+    ##     |__ username
+    ##     |__ password
+    ##   - ntlm
+    ##     |__ ntlm_domain
+    ##     |__ password
+    ##   - kerberos
+    ##     |__ kerberos_auth
+    ##     |__ kerberos_cache
+    ##     |__ kerberos_delegate
+    ##     |__ kerberos_force_initiate
+    ##     |__ kerberos_hostname
+    ##     |__ kerberos_keytab
+    ##     |__ kerberos_principal
+    ##   - aws
+    ##     |__ aws_region
+    ##     |__ aws_host
+    ##     |__ aws_service
+    ##
+    ## The `aws` auth type relies on boto3 to automatically gather AWS credentials, for example: from `.aws/credentials`.
+    ## Details: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials
+    #
+    # auth_type: basic
+
+    ## @param use_legacy_auth_encoding - boolean - optional - default: true
+    ## When `auth_type` is set to `basic`, this determines whether to encode as `latin1` rather than `utf-8`.
+    #
+    # use_legacy_auth_encoding: true
+
+    ## @param username - string - optional
+    ## The username to use if services are behind basic or digest auth.
+    #
+    # username: <USERNAME>
+
+    ## @param password - string - optional
+    ## The password to use if services are behind basic or NTLM auth.
+    #
+    # password: <PASSWORD>
+
+    ## @param ntlm_domain - string - optional
+    ## If your services use NTLM authentication, specify
+    ## the domain used in the check. For NTLM Auth, append
+    ## the username to domain, not as the `username` parameter.
+    #
+    # ntlm_domain: <NTLM_DOMAIN>\<USERNAME>
+
+    ## @param kerberos_auth - string - optional - default: disabled
+    ## If your services use Kerberos authentication, you can specify the Kerberos
+    ## strategy to use between:
+    ##
+    ##   - required
+    ##   - optional
+    ##   - disabled
+    ##
+    ## See https://github.com/requests/requests-kerberos#mutual-authentication
+    #
+    # kerberos_auth: disabled
+
+    ## @param kerberos_cache - string - optional
+    ## Sets the KRB5CCNAME environment variable.
+    ## It should point to a credential cache with a valid TGT.
+    #
+    # kerberos_cache: <KERBEROS_CACHE>
+
+    ## @param kerberos_delegate - boolean - optional - default: false
+    ## Set to `true` to enable Kerberos delegation of credentials to a server that requests delegation.
+    ##
+    ## See https://github.com/requests/requests-kerberos#delegation
+    #
+    # kerberos_delegate: false
+
+    ## @param kerberos_force_initiate - boolean - optional - default: false
+    ## Set to `true` to preemptively initiate the Kerberos GSS exchange and
+    ## present a Kerberos ticket on the initial request (and all subsequent).
+    ##
+    ## See https://github.com/requests/requests-kerberos#preemptive-authentication
+    #
+    # kerberos_force_initiate: false
+
+    ## @param kerberos_hostname - string - optional
+    ## Override the hostname used for the Kerberos GSS exchange if its DNS name doesn't
+    ## match its Kerberos hostname, for example: behind a content switch or load balancer.
+    ##
+    ## See https://github.com/requests/requests-kerberos#hostname-override
+    #
+    # kerberos_hostname: <KERBEROS_HOSTNAME>
+
+    ## @param kerberos_principal - string - optional
+    ## Set an explicit principal, to force Kerberos to look for a
+    ## matching credential cache for the named user.
+    ##
+    ## See https://github.com/requests/requests-kerberos#explicit-principal
+    #
+    # kerberos_principal: <KERBEROS_PRINCIPAL>
+
+    ## @param kerberos_keytab - string - optional
+    ## Set the path to your Kerberos key tab file.
+    #
+    # kerberos_keytab: <KEYTAB_FILE_PATH>
+
+    ## @param auth_token - mapping - optional
+    ## This allows for the use of authentication information from dynamic sources.
+    ## Both a reader and writer must be configured.
+    ##
+    ## The available readers are:
+    ##
+    ##   - type: file
+    ##     path (required): The absolute path for the file to read from.
+    ##     pattern: A regular expression pattern with a single capture group used to find the
+    ##              token rather than using the entire file, for example: Your secret is (.+)
+    ##
+    ## The available writers are:
+    ##
+    ##   - type: header
+    ##     name (required): The name of the field, for example: Authorization
+    ##     value: The template value, for example `Bearer <TOKEN>`. The default is: <TOKEN>
+    ##     placeholder: The substring in `value` to replace by the token, defaults to: <TOKEN>
+    #
+    # auth_token:
+    #   reader:
+    #     type: <READER_TYPE>
+    #     <OPTION_1>: <VALUE_1>
+    #     <OPTION_2>: <VALUE_2>
+    #   writer:
+    #     type: <WRITER_TYPE>
+    #     <OPTION_1>: <VALUE_1>
+    #     <OPTION_2>: <VALUE_2>
+
+    ## @param aws_region - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the region.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_region: <AWS_REGION>
+
+    ## @param aws_host - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the host.
+    ##
+    ## Note: This setting is not necessary for official integrations.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_host: <AWS_HOST>
+
+    ## @param aws_service - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the service code. For a list
+    ## of available service codes, see https://docs.aws.amazon.com/general/latest/gr/rande.html
+    ##
+    ## Note: This setting is not necessary for official integrations.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_service: <AWS_SERVICE>
+
+    ## @param tls_verify - boolean - optional - default: true
+    ## Instructs the check to validate the TLS certificate of services.
+    #
+    # tls_verify: true
+
+    ## @param tls_use_host_header - boolean - optional - default: false
+    ## If a `Host` header is set, this enables its use for SNI (matching against the TLS certificate CN or SAN).
+    #
+    # tls_use_host_header: false
+
+    ## @param tls_ignore_warning - boolean - optional - default: false
+    ## If `tls_verify` is disabled, security warnings are logged by the check.
+    ## Disable those by setting `tls_ignore_warning` to true.
+    ##
+    ## Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration.
+    ## If enabled for multiple instances, spurious warnings might still appear even if `tls_ignore_warning` is set
+    ## to true.
+    #
+    # tls_ignore_warning: false
+
+    ## @param tls_cert - string - optional
+    ## The path to a single file in PEM format containing a certificate as well as any
+    ## number of CA certificates needed to establish the certificate's authenticity for
+    ## use when connecting to services. It may also contain an unencrypted private key to use.
+    #
+    # tls_cert: <CERT_PATH>
+
+    ## @param tls_private_key - string - optional
+    ## The unencrypted private key to use for `tls_cert` when connecting to services. This is
+    ## required if `tls_cert` is set and it does not already contain a private key.
+    #
+    # tls_private_key: <PRIVATE_KEY_PATH>
+
+    ## @param tls_ca_cert - string - optional
+    ## The path to a file of concatenated CA certificates in PEM format or a directory
+    ## containing several CA certificates in PEM format. If a directory, the directory
+    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
+    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    #
+    # tls_ca_cert: <CA_CERT_PATH>
+
+    ## @param headers - mapping - optional
+    ## The headers parameter allows you to send specific headers with every request.
+    ## You can use it for explicitly specifying the host header or adding headers for
+    ## authorization purposes.
+    ##
+    ## This overrides any default headers.
+    #
+    # headers:
+    #   Host: <ALTERNATIVE_HOSTNAME>
+    #   X-Auth-Token: <AUTH_TOKEN>
+
+    ## @param extra_headers - mapping - optional
+    ## Additional headers to send with every request.
+    #
+    # extra_headers:
+    #   Host: <ALTERNATIVE_HOSTNAME>
+    #   X-Auth-Token: <AUTH_TOKEN>
+
+    ## @param timeout - number - optional - default: 10
+    ## The timeout for accessing services.
+    ##
+    ## This overrides the `timeout` setting in `init_config`.
+    #
+    # timeout: 10
+
+    ## @param connect_timeout - number - optional
+    ## The connect timeout for accessing services. Defaults to `timeout`.
+    #
+    # connect_timeout: <CONNECT_TIMEOUT>
+
+    ## @param read_timeout - number - optional
+    ## The read timeout for accessing services. Defaults to `timeout`.
+    #
+    # read_timeout: <READ_TIMEOUT>
+
+    ## @param log_requests - boolean - optional - default: false
+    ## Whether or not to debug log the HTTP(S) requests made, including the method and URL.
+    #
+    # log_requests: false
+
+    ## @param persist_connections - boolean - optional - default: false
+    ## Whether or not to persist cookies and use connection pooling for increased performance.
+    #
+    # persist_connections: false
+
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Overrides any `service` defined in the `init_config` section.
+    #
+    # service: <SERVICE>
+
+    ## @param min_collection_interval - number - optional - default: 15
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    # min_collection_interval: 15
+
+    ## @param empty_default_hostname - boolean - optional - default: false
+    ## This forces the check to send metrics with no hostname.
+    ##
+    ## This is useful for cluster-level checks.
+    #
+    # empty_default_hostname: false

--- a/datadog_cluster_agent/manifest.json
+++ b/datadog_cluster_agent/manifest.json
@@ -1,0 +1,34 @@
+{
+  "display_name": "Datadog Cluster Agent",
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "1.0.0",
+  "name": "datadog_cluster_agent",
+  "metric_prefix": "datadog.cluster_agent.",
+  "metric_to_check": "",
+  "creates_events": false,
+  "short_description": "Track Datadog Cluster Agent's metrics",
+  "guid": "2b116278-fa9c-4efd-a250-fa6baf209607",
+  "support": "core",
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "public_title": "Datadog Cluster Agent Integration",
+  "categories": [
+    "containers"
+  ],
+  "type": "check",
+  "is_public": true,
+  "integration_id": "datadog-cluster-agent",
+  "assets": {
+    "configuration": {
+      "spec": "assets/configuration/spec.yaml"
+    },
+    "dashboards": {},
+    "monitors": {},
+    "saved_views": {},
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
+  }
+}

--- a/datadog_cluster_agent/metadata.csv
+++ b/datadog_cluster_agent/metadata.csv
@@ -1,0 +1,19 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+datadog.cluster_agent.admission_webhooks.certificate_expiry,gauge,,hour,,Time left before the certificate expires in hours.,0,datadog_cluster_agent,admission webhooks certificate expiry
+datadog.cluster_agent.admission_webhooks.mutation_attempts,gauge,,,,"Number of pod mutation attempts by mutation type (agent config, standard tags).",0,datadog_cluster_agent,admission webhooks mutation attempts
+datadog.cluster_agent.admission_webhooks.reconcile_success,gauge,,,,Number of reconcile success per controller.,0,datadog_cluster_agent,admission webhooks reconcile success
+datadog.cluster_agent.admission_webhooks.webhooks_received,gauge,,request,,Number of mutation webhook requests received.,0,datadog_cluster_agent,admission webhooks received
+datadog.cluster_agent.cluster_checks.busyness,gauge,,,,Busyness of a node per the number of metrics submitted and average duration of all checks run,-1,datadog_cluster_agent,cluster check node busyness
+datadog.cluster_agent.cluster_checks.configs_dangling,gauge,,,,Number of check configurations not dispatched.,-1,datadog_cluster_agent,cluster check configs dangling
+datadog.cluster_agent.cluster_checks.configs_dispatched,gauge,,,,"Number of check configurations dispatched, by node.",0,datadog_cluster_agent,cluster check configs dispatched
+datadog.cluster_agent.cluster_checks.nodes_reporting,gauge,,node,,Number of node agents reporting.,0,datadog_cluster_agent,cluster check nodes reporting
+datadog.cluster_agent.cluster_checks.rebalancing_decisions,count,,,,Total number of check rebalancing decisions,0,datadog_cluster_agent,cluster check rebalancing decisions
+datadog.cluster_agent.cluster_checks.rebalancing_duration_seconds,gauge,,second,,Duration of the check rebalancing algorithm last execution,0,datadog_cluster_agent,cluster check rebalancing duration
+datadog.cluster_agent.cluster_checks.successful_rebalancing_moves,count,,,,Total number of successful check rebalancing decisions,0,datadog_cluster_agent,cluster check rebalancing moves
+datadog.cluster_agent.cluster_checks.updating_stats_duration_seconds,gauge,,second,,Duration of collecting stats from check runners and updating cache,0,datadog_cluster_agent,cluster check updating stats duration
+datadog.cluster_agent.external_metrics.delay_seconds,gauge,,second,,Freshness of the metric evaluated from querying Datadog,0,datadog_cluster_agent,external metrics delay
+datadog.cluster_agent.external_metrics.processed_value,gauge,,,,Value processed from querying Datadog,0,datadog_cluster_agent,external metrics processed value
+datadog.cluster_agent.datadog.rate_limit_queries.limit,gauge,,query,,Maximum number of queries to the Datadog API allowed in the period,0,datadog_cluster_agent,rate limit queries limit
+datadog.cluster_agent.datadog.rate_limit_queries.period,gauge,,,,Period of rate limiting to the Datadog API,0,datadog_cluster_agent,rate limit queries period
+datadog.cluster_agent.datadog.rate_limit_queries.remaining,gauge,,query,,Number of queries to the Datadog API remaining before next reset,0,datadog_cluster_agent,rate limit queries remaining
+datadog.cluster_agent.datadog.rate_limit_queries.reset,gauge,,second,,Number of seconds before next reset of the rate limiting to the Datadog API,0,datadog_cluster_agent,rate limit queries reset

--- a/datadog_cluster_agent/requirements-dev.txt
+++ b/datadog_cluster_agent/requirements-dev.txt
@@ -1,0 +1,1 @@
+-e ../datadog_checks_dev

--- a/datadog_cluster_agent/setup.py
+++ b/datadog_cluster_agent/setup.py
@@ -1,0 +1,64 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from codecs import open  # To use a consistent encoding
+from os import path
+
+from setuptools import setup
+
+HERE = path.dirname(path.abspath(__file__))
+
+# Get version info
+ABOUT = {}
+with open(path.join(HERE, 'datadog_checks', 'datadog_cluster_agent', '__about__.py')) as f:
+    exec(f.read(), ABOUT)
+
+# Get the long description from the README file
+with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+
+
+setup(
+    name='datadog-datadog_cluster_agent',
+    version=ABOUT['__version__'],
+    description='The datadog_cluster_agent check',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    keywords='datadog agent datadog_cluster_agent check',
+    # The project's main homepage.
+    url='https://github.com/DataDog/integrations-core',
+    # Author details
+    author='Datadog',
+    author_email='packages@datadoghq.com',
+    # License
+    license='BSD-3-Clause',
+    # See https://pypi.org/classifiers
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: System Administrators',
+        'Topic :: System :: Monitoring',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.8',
+    ],
+    # The package we're going to ship
+    packages=['datadog_checks.datadog_cluster_agent'],
+    # Run-time dependencies
+    install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
+    # Extra files to ship with the wheel package
+    include_package_data=True,
+)

--- a/datadog_cluster_agent/tests/__init__.py
+++ b/datadog_cluster_agent/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/datadog_cluster_agent/tests/conftest.py
+++ b/datadog_cluster_agent/tests/conftest.py
@@ -1,0 +1,26 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+
+import mock
+import pytest
+
+
+@pytest.fixture
+def instance():
+    return {'prometheus_url': 'http://localhost:10055/metrics'}
+
+
+@pytest.fixture()
+def mock_get():
+    f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics.txt')
+    with open(f_name, 'r') as f:
+        text_data = f.read()
+    with mock.patch(
+        'requests.get',
+        return_value=mock.MagicMock(
+            status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
+        ),
+    ):
+        yield

--- a/datadog_cluster_agent/tests/fixtures/metrics.txt
+++ b/datadog_cluster_agent/tests/fixtures/metrics.txt
@@ -1,0 +1,249 @@
+# HELP admission_webhooks_certificate_expiry Time left before the certificate expires in hours.
+# TYPE admission_webhooks_certificate_expiry gauge
+admission_webhooks_certificate_expiry 9.416617185589166
+# HELP admission_webhooks_mutation_attempts Number of pod mutation attempts by mutation type (agent config, standard tags).
+# TYPE admission_webhooks_mutation_attempts gauge
+admission_webhooks_mutation_attempts{injected="false",mutation_type="agent_config"} 180806
+# HELP admission_webhooks_reconcile_success Number of reconcile success per controller.
+# TYPE admission_webhooks_reconcile_success gauge
+admission_webhooks_reconcile_success{controller="secrets"} 1753
+admission_webhooks_reconcile_success{controller="webhooks"} 49
+# HELP admission_webhooks_webhooks_received Number of mutation webhook requests received.
+# TYPE admission_webhooks_webhooks_received gauge
+admission_webhooks_webhooks_received 180806
+# HELP aggregator__flush Count of flush
+# TYPE aggregator__flush counter
+aggregator__flush{data_type="events",state="ok"} 5.683227e+06
+aggregator__flush{data_type="series",state="ok"} 69055
+aggregator__flush{data_type="service_checks",state="ok"} 310686
+# HELP aggregator__processed Amount of metrics/services_checks/events processed by the aggregator
+# TYPE aggregator__processed counter
+aggregator__processed{data_type="dogstatsd_metrics"} 1
+aggregator__processed{data_type="events"} 5.683353e+06
+aggregator__processed{data_type="metrics"} 69054
+aggregator__processed{data_type="service_checks"} 276167
+# HELP api_requests Counter of requests made to the cluster agent API.
+# TYPE api_requests counter
+api_requests{handler="GetEndpointsConfigs",status="200"} 1.46070512e+08
+api_requests{handler="getCheckConfigs",status="200"} 6302
+api_requests{handler="getCheckConfigs",status="302"} 1
+api_requests{handler="getCheckConfigs",status="500"} 494
+api_requests{handler="getEndpointsCheckConfigs",status="302"} 4542
+api_requests{handler="getNodeMetadata",status="200"} 423935
+api_requests{handler="getPodMetadata",status="200"} 3.06863254e+08
+api_requests{handler="getPodMetadataForNode",status="200"} 2.3567363e+08
+api_requests{handler="postCheckStatus",status="200"} 417129
+api_requests{handler="postCheckStatus",status="302"} 17
+# HELP checks__events Events count
+# TYPE checks__events counter
+checks__events{check_name="kubernetes_apiserver"} 5.683352e+06
+# HELP checks__execution_time Check execution time
+# TYPE checks__execution_time gauge
+checks__execution_time{check_name="kubernetes_apiserver"} 2050
+# HELP checks__metrics_samples Metrics count
+# TYPE checks__metrics_samples counter
+checks__metrics_samples{check_name="kubernetes_apiserver"} 0
+# HELP checks__runs Check runs
+# TYPE checks__runs counter
+checks__runs{check_name="kubernetes_apiserver",state="fail"} 3
+checks__runs{check_name="kubernetes_apiserver",state="ok"} 34524
+# HELP checks__services_checks Service checks count
+# TYPE checks__services_checks counter
+checks__services_checks{check_name="kubernetes_apiserver"} 241640
+# HELP checks__warnings Check warnings
+# TYPE checks__warnings counter
+checks__warnings{check_name="kubernetes_apiserver"} 3
+# HELP cluster_checks_busyness Busyness of a node per the number of metrics submitted and average duration of all checks run
+# TYPE cluster_checks_busyness gauge
+cluster_checks_busyness{join_leader="true",node="foo"} 3657
+# HELP cluster_checks_configs_dangling Number of check configurations not dispatched.
+# TYPE cluster_checks_configs_dangling gauge
+cluster_checks_configs_dangling{join_leader="true"} 0
+# HELP cluster_checks_configs_dispatched Number of check configurations dispatched, by node.
+# TYPE cluster_checks_configs_dispatched gauge
+cluster_checks_configs_dispatched{join_leader="true",node="foo"} 31
+# HELP cluster_checks_nodes_reporting Number of node agents reporting.
+# TYPE cluster_checks_nodes_reporting gauge
+cluster_checks_nodes_reporting{join_leader="true"} 9
+# HELP cluster_checks_rebalancing_decisions Total number of check rebalancing decisions
+# TYPE cluster_checks_rebalancing_decisions counter
+cluster_checks_rebalancing_decisions{join_leader="true"} 4589
+# HELP cluster_checks_rebalancing_duration_seconds Duration of the check rebalancing algorithm last execution
+# TYPE cluster_checks_rebalancing_duration_seconds gauge
+cluster_checks_rebalancing_duration_seconds{join_leader="true"} 0.002682512
+# HELP cluster_checks_successful_rebalancing_moves Total number of successful check rebalancing decisions
+# TYPE cluster_checks_successful_rebalancing_moves counter
+cluster_checks_successful_rebalancing_moves{join_leader="true"} 4589
+# HELP cluster_checks_updating_stats_duration_seconds Duration of collecting stats from check runners and updating cache
+# TYPE cluster_checks_updating_stats_duration_seconds gauge
+cluster_checks_updating_stats_duration_seconds{join_leader="true"} 0.050987865
+# HELP datadog_requests Counter of requests made to Datadog
+# TYPE datadog_requests counter
+datadog_requests{join_leader="true",status="error"} 1
+datadog_requests{join_leader="true",status="success"} 69043
+# HELP external_metrics_delay_seconds freshness of the metric evaluated from querying Datadog
+# TYPE external_metrics_delay_seconds gauge
+external_metrics_delay_seconds{join_leader="true",metric="kubernetes.cpu.usage.total"} 41
+# HELP external_metrics_processed_value value processed from querying Datadog
+# TYPE external_metrics_processed_value gauge
+external_metrics_processed_value{join_leader="true",metric="kubernetes.cpu.usage.total"} 8.0226661796875e+07
+# HELP forwarder__connection_events Count of new connection events grouped by type of event
+# TYPE forwarder__connection_events counter
+forwarder__connection_events{connection_event_type="connection_success"} 52
+forwarder__connection_events{connection_event_type="dns_lookup_success"} 52
+# HELP forwarder__transactions Forwarder telemetry
+# TYPE forwarder__transactions counter
+forwarder__transactions{endpoint="https://app.datadoghq.com.",route="intake"} 33680
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 1.5071e-05
+go_gc_duration_seconds{quantile="0.25"} 1.8595e-05
+go_gc_duration_seconds{quantile="0.5"} 2.2509e-05
+go_gc_duration_seconds{quantile="0.75"} 4.9669e-05
+go_gc_duration_seconds{quantile="1"} 0.015402036
+go_gc_duration_seconds_sum 15.142729159
+go_gc_duration_seconds_count 101006
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 6262
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{version="go1.13.11"} 1
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 2.92362008e+08
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 2.44702991116e+13
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.1354836e+07
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 2.15513650785e+11
+# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
+# TYPE go_memstats_gc_cpu_fraction gauge
+go_memstats_gc_cpu_fraction 0.013457194517537085
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 3.5446784e+07
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 2.92362008e+08
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 3.98508032e+08
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 4.70925312e+08
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 2.516598e+06
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes 2.65183232e+08
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 8.69433344e+08
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.595334421612011e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 0
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 2.15516167383e+11
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 6944
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 8.654632e+06
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 1.056768e+07
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 4.70397072e+08
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 5.253668e+06
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 7.0090752e+07
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 7.0090752e+07
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 1.002163448e+09
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 19
+# HELP jsonstream__bytes_in Count of bytes entering the jsonstream serializer
+# TYPE jsonstream__bytes_in counter
+jsonstream__bytes_in 5.238238034e+09
+# HELP jsonstream__bytes_out Count of bytes out the jsonstream serializer
+# TYPE jsonstream__bytes_out counter
+jsonstream__bytes_out 5.58380477e+08
+# HELP jsonstream__total_calls Total calls to the jsontream serializer
+# TYPE jsonstream__total_calls counter
+jsonstream__total_calls 102734
+# HELP jsonstream__total_items Total items in the jsonstream serializer
+# TYPE jsonstream__total_items counter
+jsonstream__total_items 413421
+# HELP jsonstream__total_payloads Total payloads in the jsonstream serializer
+# TYPE jsonstream__total_payloads counter
+jsonstream__total_payloads 102734
+# HELP leader_election_is_leader The label is_leader is true if the reporting pod is leader, equals false otherwise.
+# TYPE leader_election_is_leader gauge
+leader_election_is_leader{is_leader="true",join_leader="true"} 1
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 286059.44
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 5933
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 9.99665664e+08
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.59481650612e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 2.38245888e+09
+# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
+# TYPE process_virtual_memory_max_bytes gauge
+process_virtual_memory_max_bytes -1
+# HELP rate_limit_queries_limit maximum number of queries allowed in the period
+# TYPE rate_limit_queries_limit gauge
+rate_limit_queries_limit{endpoint="/api/v1/query",join_leader="true"} 10000
+# HELP rate_limit_queries_period period of rate limiting
+# TYPE rate_limit_queries_period gauge
+rate_limit_queries_period{endpoint="/api/v1/query",join_leader="true"} 3600
+# HELP rate_limit_queries_remaining number of queries remaining before next reset
+# TYPE rate_limit_queries_remaining gauge
+rate_limit_queries_remaining{endpoint="/api/v1/query",join_leader="true"} 8296
+# HELP rate_limit_queries_reset number of seconds before next reset
+# TYPE rate_limit_queries_reset gauge
+rate_limit_queries_reset{endpoint="/api/v1/query",join_leader="true"} 2000
+# HELP scheduler__checks_entered How many checks entered the scheduler
+# TYPE scheduler__checks_entered gauge
+scheduler__checks_entered{check_name="kubernetes_apiserver"} 1
+# HELP scheduler__queues_count How many queues were opened
+# TYPE scheduler__queues_count counter
+scheduler__queues_count{check_name="kubernetes_apiserver"} 1
+# HELP transactions__retry_queue_size Retry queue size
+# TYPE transactions__retry_queue_size gauge
+transactions__retry_queue_size{domain="https://app.datadoghq.com."} 0
+# HELP transactions__success Count of successful transactions
+# TYPE transactions__success counter
+transactions__success{domain="https://app.datadoghq.com."} 102734

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -1,0 +1,50 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from datadog_checks.datadog_cluster_agent import DatadogClusterAgentCheck
+from datadog_checks.dev.utils import get_metadata_metrics
+
+NAMESPACE = 'datadog.cluster_agent'
+METRICS_WITH_LABEL_JOINS = [
+    'cluster_checks.busyness',
+    'cluster_checks.configs_dangling',
+    'cluster_checks.configs_dispatched',
+    'cluster_checks.nodes_reporting',
+    'cluster_checks.rebalancing_decisions',
+    'cluster_checks.rebalancing_duration_seconds',
+    'cluster_checks.successful_rebalancing_moves',
+    'cluster_checks.updating_stats_duration_seconds',
+    'external_metrics.delay_seconds',
+    'external_metrics.processed_value',
+    'datadog.rate_limit_queries.limit',
+    'datadog.rate_limit_queries.period',
+    'datadog.rate_limit_queries.remaining',
+    'datadog.rate_limit_queries.reset',
+]
+
+METRICS = [
+    'admission_webhooks.certificate_expiry',
+    'admission_webhooks.mutation_attempts',
+    'admission_webhooks.reconcile_success',
+    'admission_webhooks.webhooks_received',
+]
+
+
+def test_check(aggregator, instance, mock_get):
+    check = DatadogClusterAgentCheck('datadog_cluster_agent', {}, [instance])
+
+    # dry run to build mapping for label joins
+    check.check(instance)
+
+    # actual run that submits metrics
+    check.check(instance)
+
+    for metric in METRICS + METRICS_WITH_LABEL_JOINS:
+        aggregator.assert_metric(NAMESPACE + '.' + metric)
+
+    for metric in METRICS_WITH_LABEL_JOINS:
+        aggregator.assert_metric_has_tag(NAMESPACE + '.' + metric, 'is_leader:true')
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_metric_type=False)

--- a/datadog_cluster_agent/tox.ini
+++ b/datadog_cluster_agent/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+minversion = 2.0
+skip_missing_interpreters = true
+basepython = py38
+envlist =
+    py{27,38}
+
+[testenv]
+ensure_default_envdir = true
+envdir =
+    py27: {toxworkdir}/py27
+    py38: {toxworkdir}/py38
+dd_check_style = true
+usedevelop = true
+platform = linux|darwin|win32
+deps =
+    -e../datadog_checks_base[deps]
+    -rrequirements-dev.txt
+passenv =
+    DOCKER*
+    COMPOSE*
+commands =
+    pip install -r requirements.in
+    pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?

This is a rework of #7136 that contains the same code, but does not contain a dashboard, as we currently don't want to expose an OOTB dashboard for the Cluster Agent without having one for the Agent itself as well.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
