### PR TITLE
Updated docs to reflect cloud provider detection for NTP check

### DIFF
--- a/ntp/README.md
+++ b/ntp/README.md
@@ -8,7 +8,9 @@ The Network Time Protocol (NTP) integration is enabled by default and reports th
 - Metric delays
 - Gaps in graphs of metrics
 
-Default NTP servers reached:
+By default, the check will detect which cloud provider the agent is running on and use the private
+NTP server of that cloud provider if available. If no cloud provider is detected, the agent will
+default to the NTP servers below:
 
 - `0.datadog.pool.ntp.org`
 - `1.datadog.pool.ntp.org`


### PR DESCRIPTION
### What does this PR do?
Updates the docs to reflect that the default cloud provider is now based on the one that is detected. Related change in agent-core: https://github.com/DataDog/datadog-agent/pull/6279
