### PR TITLE
fix which prometheus metric is used for reload.success to properly monitor nginx config reload errors

### DIFF
--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
@@ -17,7 +17,7 @@ DEFAULT_METRICS = [
     {'nginx_ingress_controller_nginx_process_resident_memory_bytes': 'nginx.mem.resident'},
     {'nginx_ingress_controller_nginx_process_virtual_memory_bytes': 'nginx.mem.virtual'},
     # controller metrics
-    {'nginx_ingress_controller_success': 'controller.reload.success'},
+    {'nginx_ingress_controller_config_last_reload_successful': 'controller.reload.success'},
     {'nginx_ingress_controller_ingress_upstream_latency_seconds': 'controller.upstream.latency'},
     {'nginx_ingress_controller_requests': 'controller.requests'},
     {'process_cpu_seconds_total': 'controller.cpu.time'},

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/nginx_ingress_controller.py
@@ -17,7 +17,8 @@ DEFAULT_METRICS = [
     {'nginx_ingress_controller_nginx_process_resident_memory_bytes': 'nginx.mem.resident'},
     {'nginx_ingress_controller_nginx_process_virtual_memory_bytes': 'nginx.mem.virtual'},
     # controller metrics
-    {'nginx_ingress_controller_config_last_reload_successful': 'controller.reload.success'},
+    {'nginx_ingress_controller_success': 'controller.reload.success'},
+    {'nginx_ingress_controller_config_last_reload_successful': 'controller.last.reload.success'},
     {'nginx_ingress_controller_ingress_upstream_latency_seconds': 'controller.upstream.latency'},
     {'nginx_ingress_controller_requests': 'controller.requests'},
     {'process_cpu_seconds_total': 'controller.cpu.time'},

--- a/nginx_ingress_controller/metadata.csv
+++ b/nginx_ingress_controller/metadata.csv
@@ -8,7 +8,8 @@ nginx_ingress.nginx.bytes.write,count,,byte,,Number of bytes written,0,nginx-ing
 nginx_ingress.nginx.cpu.time,count,,second,,Cpu usage in seconds,0,nginx-ingress-controller,cpu
 nginx_ingress.nginx.mem.resident,gauge,,byte,,Resident memory size in bytes,0,nginx-ingress-controller,mem rss
 nginx_ingress.nginx.mem.virtual,gauge,,byte,,Virtual memory size in bytes,0,nginx-ingress-controller,mem virt
-nginx_ingress.controller.reload.success,gauge,,,,Whether the last configuration reload attempt was successful,0,nginx-ingress-controller,nb reload
+nginx_ingress.controller.reload.success,count,,,,Cumulative number of Ingress controller reload operations,0,nginx-ingress-controller,nb reload
+nginx_ingress.controller.last.reload.success,gauge,,,,Whether the last configuration reload attempt was successful,0,nginx-ingress-controller,nb reload
 nginx_ingress.controller.upstream.latency.count,gauge,,,,Count of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency count
 nginx_ingress.controller.upstream.latency.sum,gauge,,second,,Sum of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency sum
 nginx_ingress.controller.upstream.latency.quantile,gauge,,second,,Quantiles of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency quant

--- a/nginx_ingress_controller/metadata.csv
+++ b/nginx_ingress_controller/metadata.csv
@@ -8,7 +8,7 @@ nginx_ingress.nginx.bytes.write,count,,byte,,Number of bytes written,0,nginx-ing
 nginx_ingress.nginx.cpu.time,count,,second,,Cpu usage in seconds,0,nginx-ingress-controller,cpu
 nginx_ingress.nginx.mem.resident,gauge,,byte,,Resident memory size in bytes,0,nginx-ingress-controller,mem rss
 nginx_ingress.nginx.mem.virtual,gauge,,byte,,Virtual memory size in bytes,0,nginx-ingress-controller,mem virt
-nginx_ingress.controller.reload.success,count,,,,Cumulative number of Ingress controller reload operations,0,nginx-ingress-controller,nb reload
+nginx_ingress.controller.reload.success,gauge,,,,Whether the last configuration reload attempt was successful,0,nginx-ingress-controller,nb reload
 nginx_ingress.controller.upstream.latency.count,gauge,,,,Count of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency count
 nginx_ingress.controller.upstream.latency.sum,gauge,,second,,Sum of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency sum
 nginx_ingress.controller.upstream.latency.quantile,gauge,,second,,Quantiles of upstream service latency per Ingress,0,nginx-ingress-controller,upstream latency quant

--- a/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
+++ b/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
@@ -44,6 +44,7 @@ EXPECTED_METRICS = [
     '.nginx.mem.virtual',
     # controller metrics
     '.controller.reload.success',
+    '.controller.last.reload.success',
     '.controller.upstream.latency.count',
     '.controller.upstream.latency.sum',
     '.controller.upstream.latency.quantile',


### PR DESCRIPTION
### What does this PR do?
Currently the metric being collected `nginx_ingress_controller_success` is described as `Cumulative number of Ingress controller reload operations`
https://github.com/kubernetes/ingress-nginx/blob/master/internal/ingress/metric/collectors/controller.go#L98

Changing the metric to use `nginx_ingress_controller_config_last_reload_successful` is described as `Whether the last configuration reload attempt was successful`
https://github.com/kubernetes/ingress-nginx/blob/master/internal/ingress/metric/collectors/controller.go#L84

### Motivation
The reason for this is because measuring and alerting on `Cumulative number of Ingress controller reload operations` is useless and not helpful to the end user monitoring ingress controller.  What is helpful is the gauge metric `nginx_ingress_controll_config_last_reload_successful` which can be watched and monitored properly such that if the value falls below 1 then something with the nginx configuration is broken and someone needs to look at it.  In the current state monitoring `nginx_ingress_controller_success` there is no way to detect this and using the metric as gathered now leads to a false sense of security in monitoring for failed reloads.

### Additional Notes
This changes the metric type collection from a `counter` to a `gauge` as well because of the change to the underlying prometheus metric type.
