### PR TITLE
Use `git diff` instead of GitHub's API to detect if manifest fields changed during validation

### DIFF
--- a/.azure-pipelines/templates/run-validations.yml
+++ b/.azure-pipelines/templates/run-validations.yml
@@ -24,7 +24,7 @@ steps:
   - script: ddev validate dep
     displayName: 'Validate dependencies'
 
-- script: ddev validate manifest -i
+- script: ddev validate manifest
   displayName: 'Validate manifest files'
 
 - script: ddev validate metadata

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -7,10 +7,10 @@ import uuid
 
 import click
 import jsonschema
-import requests
 
 from ....utils import file_exists, read_file, write_file
 from ...constants import get_root
+from ...git import content_changed
 from ...utils import get_metadata_file, parse_version_parts, read_metadata_rows
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning
 
@@ -257,43 +257,19 @@ def is_metric_in_metadata_file(metric, check):
     return False
 
 
-def get_original_manifest_field(check_name, field_to_check, repo_url, manifests_from_master):
-    repo_url = f'{repo_url}/{check_name}/manifest.json'
-    if manifests_from_master.get(check_name):
-        data = manifests_from_master.get(check_name)
-    else:
-        data = requests.get(repo_url.format(check_name))
-        manifests_from_master[check_name] = data
-
-    if data.status_code == 404:
-        # This integration isn't on the provided repo yet, so it's field can change
-        return None
-
-    data.raise_for_status()
-    decoded_master = data.json()
-    return decoded_master.get(field_to_check)
-
-
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate `manifest.json` files')
 @click.option('--fix', is_flag=True, help='Attempt to fix errors')
-@click.option('--include-extras', '-i', is_flag=True, help='Include optional fields, and extra validations')
-@click.option(
-    '--repo_url', '-r', help='The raw github URL to the base of the repository to compare manifest fields against'
-)
 @click.pass_context
-def manifest(ctx, fix, include_extras, repo_url):
+def manifest(ctx, fix):
     """Validate `manifest.json` files."""
     all_guids = {}
-    raw_gh_url = 'https://raw.githubusercontent.com/DataDog/{}/master/'
 
     root = get_root()
     is_extras = ctx.obj['repo_choice'] == 'extras'
     is_marketplace = ctx.obj['repo_choice'] == 'marketplace'
-    formatted_repo_url = repo_url or raw_gh_url.format(os.path.basename(root))
     ok_checks = 0
     failed_checks = 0
     fixed_checks = 0
-    manifests_from_master = {}
 
     echo_info("Validating all manifest.json files...")
     for check_name in sorted(os.listdir(root)):
@@ -498,45 +474,31 @@ def manifest(ctx, fix, include_extras, repo_url):
                 else:
                     display_queue.append((echo_failure, output))
 
-            if include_extras:
-                # Ensure attributes haven't changed
-                for field in FIELDS_NOT_ALLOWED_TO_CHANGE:
-                    original_value = get_original_manifest_field(
-                        check_name, field, formatted_repo_url, manifests_from_master
-                    )
-                    output = f'Attribute `{field}` is not allowed to be modified.'
-                    if original_value and original_value != decoded.get(field):
-                        file_failures += 1
-                        if fix:
-                            decoded[field] = original_value
-                            file_failures -= 1
-                            file_fixed = True
-                            display_queue.append((echo_warning, output))
-                            display_queue.append((echo_success, f'  original {field}: {original_value}'))
-                        else:
-                            output += f" Please use the existing value: {original_value}"
-                            display_queue.append((echo_failure, output))
-                    elif not original_value:
-                        output = f"  No existing field on default branch: {field}"
-                        display_queue.append((echo_warning, output))
+            # is_public
+            correct_is_public = True
+            is_public = decoded.get('is_public')
+            if not isinstance(is_public, bool):
+                file_failures += 1
+                output = '  required boolean: is_public'
 
-                # is_public
-                correct_is_public = True
-                is_public = decoded.get('is_public')
-                if not isinstance(is_public, bool):
+                if fix:
+                    decoded['is_public'] = correct_is_public
+
+                    display_queue.append((echo_warning, output))
+                    display_queue.append((echo_success, f'  new `is_public`: {correct_is_public}'))
+
+                    file_failures -= 1
+                    file_fixed = True
+                else:
+                    display_queue.append((echo_failure, output))
+
+            # Ensure attributes haven't changed
+            manifest_fields_changed = content_changed(file_glob=f"{check_name}/manifest.json")
+            for field in FIELDS_NOT_ALLOWED_TO_CHANGE:
+                if field in manifest_fields_changed:
+                    output = f'Attribute `{field}` is not allowed to be modified. Please revert to original value'
                     file_failures += 1
-                    output = '  required boolean: is_public'
-
-                    if fix:
-                        decoded['is_public'] = correct_is_public
-
-                        display_queue.append((echo_warning, output))
-                        display_queue.append((echo_success, f'  new `is_public`: {correct_is_public}'))
-
-                        file_failures -= 1
-                        file_fixed = True
-                    else:
-                        display_queue.append((echo_failure, output))
+                    display_queue.append((echo_failure, output))
 
             if file_failures > 0:
                 failed_checks += 1

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -34,6 +34,15 @@ def get_current_branch():
         return run_command(command, capture='out').stdout.strip()
 
 
+def content_changed(file_glob="*"):
+    """
+    Return the content changed in the current branch compared to `master`
+    """
+    with chdir(get_root()):
+        output = run_command(f'git diff master -U0 -- "{file_glob}"', capture='out')
+    return output.stdout
+
+
 def files_changed(include_uncommitted=True):
     """
     Return the list of file changed in the current branch compared to `master`

--- a/docs/developer/meta/ci.md
+++ b/docs/developer/meta/ci.md
@@ -126,7 +126,7 @@ This validation only applies if your work introduces new external dependencies.
 ### Manifest files
 
 ```
-ddev validate manifest -i
+ddev validate manifest
 ```
 
 This validates that the manifest files contain required fields, are formatted correctly, and don't contain common errors. See the [Datadog docs](https://docs.datadoghq.com/developers/integrations/check_references/#manifest-file) for more detailed constraints. 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the `ddev validate manifest` command to:
    * remove the `-i` option
    * remove the `repo_url` option

and switch the method used to detect if a manifest file changed to use a local git diff instead of the github api.

### Motivation
<!-- What inspired you to submit this pull request? -->
Using local git is much faster (and less error prone) than reaching out to the github API for each integration's manifest content. Locally the runtime of the command went from ~45 seconds down to ~3 seconds. 

Additionally this lets us work with private integration repos since the detection is all done locally. 

This comes with the drawback of no longer supporting the `fix` flag for this specific part of the validation. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
