### PR TITLE
add labels from `self.SAMPLE_LABELS` to container status metrics

### DIFF
--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -183,6 +183,11 @@ JOINED_METRICS = {
         'label_addonmanager_kubernetes_io_mode:reconcile',
         'deployment:kube-dns',
     ],
+    NAMESPACE
+    + '.container.status_report.count.waiting': [
+        'label_addonmanager_kubernetes_io_mode:reconcile',
+        'pod:registry-creds-hq249',
+    ],
 }
 
 HOSTNAMES = {
@@ -552,9 +557,10 @@ def test_join_standard_tags_labels(aggregator, instance, check_with_join_standar
 def test_join_custom_labels(aggregator, instance, check):
     instance['label_joins'] = {
         'kube_deployment_labels': {
-            'label_to_match': 'deployment',
+            'labels_to_match': ['deployment'],
             'labels_to_get': ['label_addonmanager_kubernetes_io_mode'],
-        }
+        },
+        'kube_pod_labels': {'labels_to_match': ['pod'], 'labels_to_get': ['label_addonmanager_kubernetes_io_mode']},
     }
 
     endpoint = instance['kube_state_url']


### PR DESCRIPTION
### What does this PR do?

This change respects the pod_labels from label_joins when emitting the container status metrics.

This is similar to how `SAMPLE_LABELS` are processes for other resources in the check.

### Motivation

Users rely on label_join to associate labels from the `kube_pod_labels` with other `kube_pod_*` metrics. For example, we rely on various labels to help us route alerts to the correct team for metrics within monitors.

### Additional Notes

Nope.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
