### PR TITLE
Add note for snowflake-connector-python version cap

### DIFF
--- a/snowflake/requirements.in
+++ b/snowflake/requirements.in
@@ -1,1 +1,3 @@
+# snowflake-connector-python capped at 2.1.3 due to 2.2.0 dropping support for Python 2.7
+# Release note: https://pypi.org/project/snowflake-connector-python/2.2.0/
 snowflake-connector-python==2.1.3


### PR DESCRIPTION
### What does this PR do?

Add note about snowflake-connector-python version cap

### Motivation

For future reference.