### PR TITLE
Fix tests by installing libpython2-dev instead of libpython-dev

### DIFF
--- a/cacti/tests/common.py
+++ b/cacti/tests/common.py
@@ -29,7 +29,7 @@ INSTANCE_INTEGRATION = {
 E2E_METADATA = {
     'start_commands': [
         'apt-get update',
-        'apt-get install rrdtool librrd-dev libpython-dev  build-essential -y',
+        'apt-get install rrdtool librrd-dev libpython2-dev build-essential -y',
         'pip install rrdtool',
     ]
 }

--- a/cacti/tests/common.py
+++ b/cacti/tests/common.py
@@ -29,7 +29,7 @@ INSTANCE_INTEGRATION = {
 E2E_METADATA = {
     'start_commands': [
         'apt-get update',
-        'apt-get install rrdtool librrd-dev libpython-dev build-essential -y',
+        'apt-get install rrdtool librrd-dev libpython-dev  build-essential -y',
         'pip install rrdtool',
     ]
 }


### PR DESCRIPTION
### What does this PR do?

Fix cacti test

### Motivation

Failing due to:

```
2020-09-16T22:10:44.7465383Z Package libpython-dev is not available, but is referred to by another package.
2020-09-16T22:10:44.7466054Z This may mean that the package is missing, has been obsoleted, or
2020-09-16T22:10:44.7466542Z is only available from another source
2020-09-16T22:10:44.7466973Z However the following packages replace it:
2020-09-16T22:10:44.7467604Z   libpython2-dev
2020-09-16T22:10:44.7467971Z 
2020-09-16T22:10:44.7468608Z E: Package 'libpython-dev' has no installation candidate
```
https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=24299&view=logs&jobId=9f1de384-230b-528c-4a39-e126e25236ca&j=9f1de384-230b-528c-4a39-e126e25236ca&t=715013fb-940a-5df6-f53e-cd98dc790235