### PR TITLE
Add note that check is not available for MacOS in Agent 6 using Python 2

### DIFF
--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -16,7 +16,7 @@ Follow the instructions below to install and configure this check for an Agent r
 The Snowflake check is included in the [Datadog Agent][2] package.
 No additional installation is needed on your server.
 
-Note: Snowflake check is currently not available for MacOS in Datadog Agent 6 using Python 2.
+**Note**: Snowflake check is currently not available for MacOS in Datadog Agent 6 using Python 2.
 
 ### Configuration
 

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -16,6 +16,8 @@ Follow the instructions below to install and configure this check for an Agent r
 The Snowflake check is included in the [Datadog Agent][2] package.
 No additional installation is needed on your server.
 
+Note: Snowflake check is currently not available for MacOS in Datadog Agent 6 using Python 2.
+
 ### Configuration
 
 1. Edit the `snowflake.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your snowflake performance data. See the [sample snowflake.d/conf.yaml][3] for all available configuration options.


### PR DESCRIPTION
### What does this PR do?

Add note check not available for MacOS in Agent 6 using Python 2

### Motivation

Motivation and details: https://github.com/DataDog/datadog-agent/pull/6391