### PR TITLE
Add metrics_metadata to manifest

### DIFF
--- a/active_directory/manifest.json
+++ b/active_directory/manifest.json
@@ -30,6 +30,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "ruby"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -36,6 +36,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "activemq"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/activemq_xml/manifest.json
+++ b/activemq_xml/manifest.json
@@ -30,6 +30,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/aerospike/manifest.json
+++ b/aerospike/manifest.json
@@ -30,6 +30,7 @@
       "Aerospike Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/agent_metrics/manifest.json
+++ b/agent_metrics/manifest.json
@@ -25,6 +25,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/airflow/manifest.json
+++ b/airflow/manifest.json
@@ -34,6 +34,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "airflow"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/amazon_msk/manifest.json
+++ b/amazon_msk/manifest.json
@@ -33,6 +33,7 @@
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/ambari/manifest.json
+++ b/ambari/manifest.json
@@ -33,6 +33,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "ambari"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -47,6 +47,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "apache"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/aspdotnet/manifest.json
+++ b/aspdotnet/manifest.json
@@ -21,12 +21,13 @@
   "type": "check",
   "integration_id": "aspdotnet",
   "assets": {
-     "configuration": {
+    "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/azure_active_directory/manifest.json
+++ b/azure_active_directory/manifest.json
@@ -30,6 +30,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "azure.active_directory"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/btrfs/manifest.json
+++ b/btrfs/manifest.json
@@ -27,6 +27,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/cacti/manifest.json
+++ b/cacti/manifest.json
@@ -26,6 +26,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -35,6 +35,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "cassandra"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/cassandra_nodetool/manifest.json
+++ b/cassandra_nodetool/manifest.json
@@ -28,6 +28,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -36,6 +36,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "ceph"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/cilium/manifest.json
+++ b/cilium/manifest.json
@@ -32,6 +32,7 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -29,6 +29,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/clickhouse/manifest.json
+++ b/clickhouse/manifest.json
@@ -33,6 +33,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "clickhouse"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/cloud_foundry_api/manifest.json
+++ b/cloud_foundry_api/manifest.json
@@ -30,6 +30,7 @@
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/cockroachdb/manifest.json
+++ b/cockroachdb/manifest.json
@@ -32,6 +32,7 @@
       "CockroachDB Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/confluent_platform/manifest.json
+++ b/confluent_platform/manifest.json
@@ -36,6 +36,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "confluent_platform"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -40,6 +40,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "consul"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/containerd/manifest.json
+++ b/containerd/manifest.json
@@ -23,6 +23,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/coredns/manifest.json
+++ b/coredns/manifest.json
@@ -29,6 +29,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "coredns"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -15,7 +15,10 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "couch.",
-  "metric_to_check": ["couchdb.couchdb.request_time.n", "couchdb.couchdb.request_time"],
+  "metric_to_check": [
+    "couchdb.couchdb.request_time.n",
+    "couchdb.couchdb.request_time"
+  ],
   "name": "couch",
   "process_signatures": [
     "couchjs"
@@ -39,6 +42,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "couchdb"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/couchbase/manifest.json
+++ b/couchbase/manifest.json
@@ -32,6 +32,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/cri/manifest.json
+++ b/cri/manifest.json
@@ -23,6 +23,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/crio/manifest.json
+++ b/crio/manifest.json
@@ -25,6 +25,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/directory/manifest.json
+++ b/directory/manifest.json
@@ -25,6 +25,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -28,6 +28,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/dns_check/manifest.json
+++ b/dns_check/manifest.json
@@ -32,6 +32,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/dotnetclr/manifest.json
+++ b/dotnetclr/manifest.json
@@ -26,6 +26,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/druid/manifest.json
+++ b/druid/manifest.json
@@ -34,6 +34,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "druid"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/ecs_fargate/manifest.json
+++ b/ecs_fargate/manifest.json
@@ -29,6 +29,7 @@
       "Amazon Fargate": "assets/dashboards/amazon_fargate_overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/eks_fargate/manifest.json
+++ b/eks_fargate/manifest.json
@@ -31,6 +31,7 @@
     "dashboards": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -38,6 +38,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "elasticsearch"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/envoy/manifest.json
+++ b/envoy/manifest.json
@@ -35,6 +35,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "envoy"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/etcd/manifest.json
+++ b/etcd/manifest.json
@@ -42,6 +42,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "etcd"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/exchange_server/manifest.json
+++ b/exchange_server/manifest.json
@@ -25,6 +25,7 @@
       "Exchange Server Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/external_dns/manifest.json
+++ b/external_dns/manifest.json
@@ -26,6 +26,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/flink/manifest.json
+++ b/flink/manifest.json
@@ -34,6 +34,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "flink"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/fluentd/manifest.json
+++ b/fluentd/manifest.json
@@ -37,6 +37,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/gearmand/manifest.json
+++ b/gearmand/manifest.json
@@ -35,6 +35,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/gitlab/manifest.json
+++ b/gitlab/manifest.json
@@ -39,6 +39,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "gitlab"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/gitlab_runner/manifest.json
+++ b/gitlab_runner/manifest.json
@@ -33,6 +33,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "gitlab-runner"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/go-metro/manifest.json
+++ b/go-metro/manifest.json
@@ -23,6 +23,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/go_expvar/manifest.json
+++ b/go_expvar/manifest.json
@@ -29,6 +29,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/gunicorn/manifest.json
+++ b/gunicorn/manifest.json
@@ -25,7 +25,7 @@
   "type": "check",
   "integration_id": "gunicorn",
   "assets": {
-     "configuration": {
+    "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {},
@@ -39,6 +39,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "gunicorn"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -42,6 +42,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "haproxy"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/harbor/manifest.json
+++ b/harbor/manifest.json
@@ -31,6 +31,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "harbor"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/hazelcast/manifest.json
+++ b/hazelcast/manifest.json
@@ -38,6 +38,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "hazelcast"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/hdfs_datanode/manifest.json
+++ b/hdfs_datanode/manifest.json
@@ -32,6 +32,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "hdfs_datanode"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/hdfs_namenode/manifest.json
+++ b/hdfs_namenode/manifest.json
@@ -32,6 +32,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "hdfs_namenode"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/hive/manifest.json
+++ b/hive/manifest.json
@@ -34,6 +34,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "hive"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/hivemq/manifest.json
+++ b/hivemq/manifest.json
@@ -35,6 +35,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "hivemq"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -32,6 +32,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/hyperv/manifest.json
+++ b/hyperv/manifest.json
@@ -29,6 +29,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/ibm_db2/manifest.json
+++ b/ibm_db2/manifest.json
@@ -31,6 +31,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "ibm_db2"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/ibm_mq/manifest.json
+++ b/ibm_mq/manifest.json
@@ -32,6 +32,7 @@
     },
     "logs": {
       "source": "ibm_mq"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/ibm_was/manifest.json
+++ b/ibm_was/manifest.json
@@ -30,6 +30,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "ibm_was"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/ignite/manifest.json
+++ b/ignite/manifest.json
@@ -35,6 +35,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "ignite"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -34,6 +34,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "iis"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/istio/manifest.json
+++ b/istio/manifest.json
@@ -39,6 +39,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "istio"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/jboss_wildfly/manifest.json
+++ b/jboss_wildfly/manifest.json
@@ -32,6 +32,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "jboss_wildfly"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -41,6 +41,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "kafka"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -26,6 +26,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -43,6 +43,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "kong"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/kube_apiserver_metrics/manifest.json
+++ b/kube_apiserver_metrics/manifest.json
@@ -27,7 +27,8 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   },
   "is_public": true
 }

--- a/kube_controller_manager/manifest.json
+++ b/kube_controller_manager/manifest.json
@@ -26,6 +26,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/kube_dns/manifest.json
+++ b/kube_dns/manifest.json
@@ -26,6 +26,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/kube_metrics_server/manifest.json
+++ b/kube_metrics_server/manifest.json
@@ -28,6 +28,7 @@
       "Kubernetes Metrics Server - Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/kube_proxy/manifest.json
+++ b/kube_proxy/manifest.json
@@ -26,6 +26,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/kube_scheduler/manifest.json
+++ b/kube_scheduler/manifest.json
@@ -29,6 +29,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "kube_scheduler"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/kubelet/manifest.json
+++ b/kubelet/manifest.json
@@ -25,6 +25,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -38,6 +38,7 @@
       "Kubernetes Deployments Overview": "assets/dashboards/kubernetes_deployments.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/kubernetes_state/manifest.json
+++ b/kubernetes_state/manifest.json
@@ -26,6 +26,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/kyototycoon/manifest.json
+++ b/kyototycoon/manifest.json
@@ -28,6 +28,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/lighttpd/manifest.json
+++ b/lighttpd/manifest.json
@@ -32,6 +32,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/linkerd/manifest.json
+++ b/linkerd/manifest.json
@@ -29,6 +29,7 @@
       "Linkerd - Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/linux_proc_extras/manifest.json
+++ b/linux_proc_extras/manifest.json
@@ -23,6 +23,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/mapr/manifest.json
+++ b/mapr/manifest.json
@@ -30,6 +30,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "mapr"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/mapreduce/manifest.json
+++ b/mapreduce/manifest.json
@@ -32,6 +32,7 @@
     "logs": {
       "source": "mapreduce"
     },
-    "monitors": {}
+    "monitors": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/marathon/manifest.json
+++ b/marathon/manifest.json
@@ -35,6 +35,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "marathon"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/marklogic/manifest.json
+++ b/marklogic/manifest.json
@@ -32,6 +32,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "marklogic"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/mcache/manifest.json
+++ b/mcache/manifest.json
@@ -35,6 +35,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "memcached"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -37,6 +37,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/mesos_slave/manifest.json
+++ b/mesos_slave/manifest.json
@@ -29,6 +29,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -46,6 +46,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "mongodb"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -40,6 +40,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "mysql"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/nagios/manifest.json
+++ b/nagios/manifest.json
@@ -28,6 +28,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/network/manifest.json
+++ b/network/manifest.json
@@ -29,6 +29,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/nfsstat/manifest.json
+++ b/nfsstat/manifest.json
@@ -26,6 +26,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -46,6 +46,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "nginx"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/nginx_ingress_controller/manifest.json
+++ b/nginx_ingress_controller/manifest.json
@@ -40,6 +40,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "nginx-ingress-controller"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/ntp/manifest.json
+++ b/ntp/manifest.json
@@ -26,6 +26,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/oom_kill/manifest.json
+++ b/oom_kill/manifest.json
@@ -24,6 +24,7 @@
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/openldap/manifest.json
+++ b/openldap/manifest.json
@@ -30,6 +30,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "openldap"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/openmetrics/manifest.json
+++ b/openmetrics/manifest.json
@@ -27,6 +27,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/openshift/manifest.json
+++ b/openshift/manifest.json
@@ -24,6 +24,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/openstack/manifest.json
+++ b/openstack/manifest.json
@@ -30,6 +30,7 @@
       "OpenStack Controller Overview": "assets/dashboards/openstack-controller.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/openstack_controller/manifest.json
+++ b/openstack_controller/manifest.json
@@ -25,6 +25,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/oracle/manifest.json
+++ b/oracle/manifest.json
@@ -28,6 +28,7 @@
       "oracle": "assets/dashboards/oracle_overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/pdh_check/manifest.json
+++ b/pdh_check/manifest.json
@@ -25,6 +25,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/pgbouncer/manifest.json
+++ b/pgbouncer/manifest.json
@@ -39,6 +39,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "pgbouncer"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/php_fpm/manifest.json
+++ b/php_fpm/manifest.json
@@ -39,6 +39,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -31,6 +31,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "postfix"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -49,6 +49,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "postgresql"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/powerdns_recursor/manifest.json
+++ b/powerdns_recursor/manifest.json
@@ -34,6 +34,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/presto/manifest.json
+++ b/presto/manifest.json
@@ -37,6 +37,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "presto"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/process/manifest.json
+++ b/process/manifest.json
@@ -28,6 +28,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/prometheus/manifest.json
+++ b/prometheus/manifest.json
@@ -23,6 +23,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/proxysql/manifest.json
+++ b/proxysql/manifest.json
@@ -35,6 +35,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "proxysql"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -39,6 +39,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "rabbitmq"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -43,6 +43,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "redis"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/rethinkdb/manifest.json
+++ b/rethinkdb/manifest.json
@@ -37,6 +37,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "rethinkdb"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/riak/manifest.json
+++ b/riak/manifest.json
@@ -32,6 +32,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "riak"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/riakcs/manifest.json
+++ b/riakcs/manifest.json
@@ -28,6 +28,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/sap_hana/manifest.json
+++ b/sap_hana/manifest.json
@@ -27,6 +27,7 @@
     },
     "monitors": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/scylla/manifest.json
+++ b/scylla/manifest.json
@@ -33,6 +33,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "scylla"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/sidekiq/manifest.json
+++ b/sidekiq/manifest.json
@@ -33,6 +33,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "sidekiq"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -30,6 +30,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/snowflake/manifest.json
+++ b/snowflake/manifest.json
@@ -32,6 +32,7 @@
       "Snowflake failed logins": "assets/recommended_monitors/snowflake_failed_logins.json"
     },
     "saved_views": {},
-    "service_checks": "assets/service_checks.json"
+    "service_checks": "assets/service_checks.json",
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -35,6 +35,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "solr"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/spark/manifest.json
+++ b/spark/manifest.json
@@ -32,6 +32,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "spark"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -31,6 +31,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "sqlserver"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/squid/manifest.json
+++ b/squid/manifest.json
@@ -33,6 +33,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "squid"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/ssh_check/manifest.json
+++ b/ssh_check/manifest.json
@@ -38,6 +38,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/statsd/manifest.json
+++ b/statsd/manifest.json
@@ -29,6 +29,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/supervisord/manifest.json
+++ b/supervisord/manifest.json
@@ -33,6 +33,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/system_core/manifest.json
+++ b/system_core/manifest.json
@@ -28,6 +28,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/system_swap/manifest.json
+++ b/system_swap/manifest.json
@@ -25,6 +25,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/systemd/manifest.json
+++ b/systemd/manifest.json
@@ -25,6 +25,7 @@
       "Systemd Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/tcp_check/manifest.json
+++ b/tcp_check/manifest.json
@@ -33,6 +33,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/tcp_queue_length/manifest.json
+++ b/tcp_queue_length/manifest.json
@@ -23,6 +23,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/teamcity/manifest.json
+++ b/teamcity/manifest.json
@@ -32,6 +32,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/tenable/manifest.json
+++ b/tenable/manifest.json
@@ -31,6 +31,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "tenable"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/tls/manifest.json
+++ b/tls/manifest.json
@@ -32,6 +32,7 @@
       "TLS Overview": "assets/dashboards/overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/tokumx/manifest.json
+++ b/tokumx/manifest.json
@@ -32,6 +32,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -35,6 +35,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "tomcat"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/twemproxy/manifest.json
+++ b/twemproxy/manifest.json
@@ -26,6 +26,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/twistlock/manifest.json
+++ b/twistlock/manifest.json
@@ -32,6 +32,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "twistlock"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -42,6 +42,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "varnish"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/vault/manifest.json
+++ b/vault/manifest.json
@@ -40,6 +40,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "vault"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/vertica/manifest.json
+++ b/vertica/manifest.json
@@ -33,6 +33,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "vertica"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/vsphere/manifest.json
+++ b/vsphere/manifest.json
@@ -33,6 +33,7 @@
       "vsphere-overview": "assets/dashboards/vsphere_overview.json"
     },
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/win32_event_log/manifest.json
+++ b/win32_event_log/manifest.json
@@ -27,6 +27,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/windows_service/manifest.json
+++ b/windows_service/manifest.json
@@ -25,6 +25,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/wmi_check/manifest.json
+++ b/wmi_check/manifest.json
@@ -28,6 +28,7 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {}
+    "logs": {},
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/yarn/manifest.json
+++ b/yarn/manifest.json
@@ -32,6 +32,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "yarn"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -39,6 +39,7 @@
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "zookeeper"
-    }
+    },
+    "metrics_metadata": "metadata.csv"
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds the path to the metadata.csv file to the integration's manifest.json file
This is to further standardize how we look for integration assets (and is currently what we do for service_checks.json files)

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Mostly a re-use of the script I used for this PR - https://github.com/DataDog/integrations-core/pull/3768

``` python3
from datadog_checks.dev.tooling.utils import get_valid_integrations, load_manifest, get_manifest_file
from datadog_checks.dev.tooling.constants import set_root

import json
import os

ROOT = '/Users/nicholasmuesch/git/integrations-core/'


def get_updated_manifest(manifest_data):
    manifest_data['assets']['metrics_metadata'] = 'metadata.csv'
    return manifest_data


if __name__ == "__main__":
    set_root(ROOT)
    checks = get_valid_integrations()
    for check in checks:
        print(f'Modifying {check}')
        current_dir = f'{ROOT}{check}'
        manifest_file = get_manifest_file(check)
        manifest = load_manifest(check)

        # Update the manifest file to include this new locations
        if os.path.exists(os.path.join(ROOT, check, 'metadata.csv')):
            manifest = get_updated_manifest(manifest)

            with open(manifest_file, 'w+') as f:
                f.write(f'{json.dumps(manifest, indent=2)}\n')

```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
