### PR TITLE
Fix changed manifest validation for new integrations

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -493,12 +493,18 @@ def manifest(ctx, fix):
                     display_queue.append((echo_failure, output))
 
             # Ensure attributes haven't changed
+            # Skip if the manifest is a new file (i.e. new integration)
             manifest_fields_changed = content_changed(file_glob=f"{check_name}/manifest.json")
-            for field in FIELDS_NOT_ALLOWED_TO_CHANGE:
-                if field in manifest_fields_changed:
-                    output = f'Attribute `{field}` is not allowed to be modified. Please revert to original value'
-                    file_failures += 1
-                    display_queue.append((echo_failure, output))
+            if 'new file' not in manifest_fields_changed:
+                for field in FIELDS_NOT_ALLOWED_TO_CHANGE:
+                    if field in manifest_fields_changed:
+                        output = f'Attribute `{field}` is not allowed to be modified. Please revert to original value'
+                        file_failures += 1
+                        display_queue.append((echo_failure, output))
+            else:
+                display_queue.append(
+                    (echo_info, "  skipping check for changed fields: integration not on default branch")
+                )
 
             if file_failures > 0:
                 failed_checks += 1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This recent PR - https://github.com/DataDog/integrations-core/pull/7599/files changed the way the detection of manifest changes occur, from using the github api to using a git diff local command. 

This change didn't take into account new integrations, as once they're `git add`-ed, they'll have a changed manifest against master that include the fields we're checking for, which causes the manifest validation to fail.

This PR takes into account new integrations by checking for the `new file` string in the git diff output and skips the change validation if present. It logs an info level log stating that we have detected a new integration and are skipping this piece of validation.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
