### PR TITLE
[HOLD] Skip already processed OIDs

### DIFF
--- a/snmp/datadog_checks/snmp/commands.py
+++ b/snmp/datadog_checks/snmp/commands.py
@@ -109,7 +109,7 @@ def snmp_getnext(config, oids, lookup_mib, ignore_nonincreasing_oid):
         for col, var_bind in enumerate(ctx['var_bind_table']):
             name, val = var_bind
             if name in already_processed_oids:
-                logger.warn("Skipping already processing OID: %s", name)
+                logger.debug("Skipping already processed OID: %s", name)
                 continue
             if not isinstance(val, Null) and initial_vars[col].isPrefixOf(name):
                 var_binds.append(var_bind)
@@ -171,7 +171,7 @@ def snmp_bulk(config, oid, non_repeaters, max_repetitions, lookup_mib, ignore_no
             if endOfMibView.isSameTypeWith(value):
                 return
             if name in already_processed_oids:
-                logger.warn("Skipping already processing OID: %s", name)
+                logger.debug("Skipping already processed OID: %s", name)
                 continue
             if initial_var.isPrefixOf(name):
                 already_processed_oids.add(name)

--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -79,7 +79,7 @@ class InstanceConfig:
             if value in (None, ""):
                 instance.pop(key)
 
-        self.logger = weakref.ref(local_logger) if logger is None else weakref.ref(logger)
+        self.get_logger = weakref.ref(local_logger) if logger is None else weakref.ref(logger)
 
         self.instance = instance
         self.tags = instance.get('tags', [])
@@ -285,7 +285,7 @@ class InstanceConfig:
         """Parse configuration and returns data to be used for SNMP queries."""
         # Use bulk for SNMP version > 1 only.
         bulk_threshold = self.bulk_threshold if self._auth_data.mpModel else 0
-        result = parse_metrics(metrics, resolver=self._resolver, logger=self.logger(), bulk_threshold=bulk_threshold)
+        result = parse_metrics(metrics, resolver=self._resolver, logger=self.get_logger(), bulk_threshold=bulk_threshold)
         return result['oids'], result['next_oids'], result['bulk_oids'], result['parsed_metrics']
 
     def parse_metric_tags(self, metric_tags):


### PR DESCRIPTION
### What does this PR do?

Skip already processed OIDs

### Motivation

Makes `ignore_nonincreasing_oid` safer. Currently, if `ignore_nonincreasing_oid` is true, this might lead to infinite loop.

Example, getnext on `1.1.3` returns `1.1.2` and getnext on `1.2.2` returns `1.1.3`.