### PR TITLE
Better error message when config example not in sync

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -106,7 +106,7 @@ def config(ctx, check, sync, verbose):
                             files_failed[example_file_path] = True
                             check_display_queue.append(
                                 lambda example_file=example_file, **kwargs: echo_failure(
-                                    f'File `{example_file}` needs to be synced, please run "ddev validate config --sync"', **kwargs
+                                    f'File `{example_file}` is not in sync, run "ddev validate config -s"', **kwargs
                                 )
                             )
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -106,7 +106,7 @@ def config(ctx, check, sync, verbose):
                             files_failed[example_file_path] = True
                             check_display_queue.append(
                                 lambda example_file=example_file, **kwargs: echo_failure(
-                                    f'File `{example_file}` needs to be synced', **kwargs
+                                    f'File `{example_file}` needs to be synced, please run "ddev validate config --sync"', **kwargs
                                 )
                             )
 


### PR DESCRIPTION
### What does this PR do?
Add an actionable hint to the 'needs to be synced' error message.

### Motivation
I did't know what to do when I got this error.

