### PR TITLE
Handle missing "eula" key in EULA validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -274,7 +274,7 @@ def get_metadata_file(check_name):
 
 
 def get_eula_from_manifest(check_name):
-    path = load_manifest(check_name).get('terms', {}).get('eula')
+    path = load_manifest(check_name).get('terms', {}).get('eula', '')
     path = os.path.join(get_root(), check_name, *path.split('/'))
     return path, file_exists(path)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Cleanup for https://github.com/DataDog/integrations-core/pull/7473

### Motivation
<!-- What inspired you to submit this pull request? -->
When the `terms.eula` key is missing, `<None>.split()` was called resulting in an `AttributeError`:

```console
$ ddev -m validate eula
Validating all EULA files...
Traceback (most recent call last):
  File "/Users/florimond.manca/go/src/github.com/DataDog/marketplace/venv/bin/ddev", line 11, in <module>
    load_entry_point('datadog-checks-dev', 'console_scripts', 'ddev')()
  File "/Users/florimond.manca/go/src/github.com/DataDog/marketplace/venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/florimond.manca/go/src/github.com/DataDog/marketplace/venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/florimond.manca/go/src/github.com/DataDog/marketplace/venv/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/florimond.manca/go/src/github.com/DataDog/marketplace/venv/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/florimond.manca/go/src/github.com/DataDog/marketplace/venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/florimond.manca/go/src/github.com/DataDog/marketplace/venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/eula.py", line 18, in eula
    eula_relative_location, eula_exists = get_eula_from_manifest(check_name)
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/utils.py", line 278, in get_eula_from_manifest
    path = os.path.join(get_root(), check_name, *path.split('/'))
AttributeError: 'NoneType' object has no attribute 'split'
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
