### PR TITLE
Mark Unix Socket support as Unix-only

### DIFF
--- a/datadog_checks_base/tests/conftest.py
+++ b/datadog_checks_base/tests/conftest.py
@@ -62,9 +62,6 @@ def uds_path():
         # See: https://github.com/docker/for-mac/issues/483
         pytest.skip('Sharing Unix sockets is not supported by Docker for Mac.')
 
-    if Platform.is_windows():
-        pytest.skip('Nginx does not run on Windows.')
-
     with TempDir() as tmp_dir:
         compose_file = os.path.join(HERE, 'compose', 'uds.yaml')
         uds_filename = 'tmp.sock'

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -19,7 +19,7 @@ from six import iteritems
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.utils.http import STANDARD_FIELDS, RequestsWrapper, is_uds_url, quote_uds_url
 from datadog_checks.dev import EnvVars
-from datadog_checks.dev.utils import running_on_windows_ci, ON_WINDOWS
+from datadog_checks.dev.utils import ON_WINDOWS, running_on_windows_ci
 
 pytestmark = pytest.mark.http
 

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -19,7 +19,7 @@ from six import iteritems
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.utils.http import STANDARD_FIELDS, RequestsWrapper, is_uds_url, quote_uds_url
 from datadog_checks.dev import EnvVars
-from datadog_checks.dev.utils import running_on_windows_ci
+from datadog_checks.dev.utils import running_on_windows_ci, ON_WINDOWS
 
 pytestmark = pytest.mark.http
 
@@ -976,6 +976,7 @@ class TestUnixDomainSocket:
         assert adapter is not None
         assert isinstance(adapter, requests_unixsocket.UnixAdapter)
 
+    @pytest.mark.skipif(ON_WINDOWS, reason='AF_UNIX not supported by Python on Windows yet')
     def test_uds_request(self, uds_path):
         # type: (str) -> None
         http = RequestsWrapper({}, {})

--- a/docs/developer/.snippets/links.txt
+++ b/docs/developer/.snippets/links.txt
@@ -104,12 +104,14 @@
 [pytest-markers]: http://doc.pytest.org/en/latest/example/markers.html
 [pytest-mock-github]: https://github.com/pytest-dev/pytest-mock
 [pytest-usage]: https://docs.pytest.org/en/latest/usage.html
+[python-bpo-af-unix-win]: https://bugs.python.org/issue33408
 [python-cprofile]: https://docs.python.org/3/library/profile.html#module-cProfile
 [python-downloads-windows]: https://www.python.org/downloads/windows
 [python-home]: https://www.python.org
 [python-markdown-extensions]: https://github.com/Python-Markdown/markdown/wiki/Third-Party-Extensions
 [python-pdb]: https://docs.python.org/3/library/pdb.html
 [requests-github]: https://github.com/psf/requests
+[requests-unixsocket-pypi]: https://pypi.org/project/requests-unixsocket/
 [root-tox-config]: https://github.com/DataDog/integrations-core/blob/master/tox.ini
 [rtloader]: https://github.com/DataDog/datadog-agent/tree/master/rtloader
 [semver-home]: https://semver.org

--- a/docs/developer/base/http.md
+++ b/docs/developer/base/http.md
@@ -35,7 +35,7 @@ class MyCheck(AgentCheck):
     ...
 ```
 
-Support for Unix socket (provided by [requests-unixsocket][requests-unixsocket-pypi]) allows making UDS requests on the `unix://` scheme:
+Support for Unix socket is provided via [requests-unixsocket][requests-unixsocket-pypi] and allows making UDS requests on the `unix://` scheme (not supported on Windows until Python adds support for `AF_UNIX`, see [ticket][python-bpo-af-unix-win]):
 
 ```python
 url = 'unix:///var/run/docker.sock'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Cleanup for #7585 

A few changes to mark Unix Socket support in `RequestsWrapper` as Unix-only (or rather, not supported on Windows).

- Explicitly skip integration test for this reason.
- Update docs.

Also fixed the missing link to `requests-unixsocket`.

Note that we don't need to change anything to our usage of `requests-unixsocket`, since importing that library and mounting the adapter works on Windows (a user would only see a syscall failure when effectively trying to make a `unix://` request). This means when Python adds support we should automatically support UDS on Windows.

### Motivation
<!-- What inspired you to submit this pull request? -->
Even though Windows added `AF_UNIX` support in Windows 10, Python doesn't have support yet, and this won't be in 3.9 either, see https://bugs.python.org/issue33408

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Will log a ticket to track adding support on Windows, though we're currently blocked on Python adding support for it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
