### PR TITLE
Cleanup mock_dns library calls

### DIFF
--- a/.azure-pipelines/scripts/mapreduce/linux/50_increase_docker_memory.sh
+++ b/.azure-pipelines/scripts/mapreduce/linux/50_increase_docker_memory.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+
+# Allocate 3GB for activemq
+# The default number of memory addresses is 65536, i.e. 512MB (Linux 64-bit).
+# => To get 3GB, we multiply that amount by 6.
+sudo sysctl -w vm.max_map_count=$(expr 6 \* 65536)
+
+set +ex

--- a/datadog_checks_tests_helper/datadog_test_libs/utils/mock_dns.py
+++ b/datadog_checks_tests_helper/datadog_test_libs/utils/mock_dns.py
@@ -9,20 +9,22 @@ def mock_local(src_to_dest_mapping):
     """
     Mock 'socket' to resolve hostname based on a provided mapping.
     This method has no effect for e2e tests.
-    :param src_to_dest_mapping: Mapping from source hostname to a tuple of destination hostname and port
+    :param src_to_dest_mapping: Mapping from source hostname to a tuple of destination hostname and port.
+        If port is None or evaluates to False, then only the host will be overridden and not the port.
     """
     import socket
     _orig_getaddrinfo = socket.getaddrinfo
     _orig_connect = socket.socket.connect
 
-    def patched_getaddrinfo(host, *args, **kwargs):
+    def patched_getaddrinfo(host, port, *args, **kwargs):
         if host in src_to_dest_mapping:
             # See socket.getaddrinfo, just updating the hostname here.
             # https://docs.python.org/3/library/socket.html#socket.getaddrinfo
             dest_addr, dest_port = src_to_dest_mapping[host]
-            return [(2, 1, 6, '', (dest_addr, dest_port))]
+            new_port = dest_port or port
+            return [(2, 1, 6, '', (dest_addr, new_port))]
 
-        return _orig_getaddrinfo(host, *args, **kwargs)
+        return _orig_getaddrinfo(host, port, *args, **kwargs)
 
     def patched_connect(self, address):
         host, port = address[0], address[1]

--- a/mapreduce/tests/common.py
+++ b/mapreduce/tests/common.py
@@ -72,7 +72,7 @@ def setup_mapreduce():
 
 @contextmanager
 def mock_local_mapreduce_dns():
-    mapping = {x: ('127.0.0.1', 443) for x in MOCKED_E2E_HOSTS}
+    mapping = {x: ('127.0.0.1', None) for x in MOCKED_E2E_HOSTS}
     with mock_local(mapping):
         yield
 

--- a/mapreduce/tests/common.py
+++ b/mapreduce/tests/common.py
@@ -3,9 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import random
 import time
-from contextlib import contextmanager
 
 import requests
+from datadog_test_libs.utils.mock_dns import mock_local
 
 from datadog_checks.dev import get_docker_hostname, get_here, run_command
 from datadog_checks.mapreduce import MapReduceCheck
@@ -69,46 +69,10 @@ def setup_mapreduce():
     return False
 
 
-@contextmanager
-def mock_local():
-    """
-    Mock 'socket' to resolve hostname based on a provided mapping.
-    Only used for integration tests, this method has no effect for e2e tests.
-    """
-    # TODO - replace with helper function when #7106 gets merged
-    mapping = {x: '127.0.0.1' for x in MOCKED_E2E_HOSTS}
-
-    import socket
-
-    _orig_getaddrinfo = socket.getaddrinfo
-    _orig_connect = socket.socket.connect
-
-    def patched_getaddrinfo(host, port, *args, **kwargs):
-        if host in mapping:
-            # See socket.getaddrinfo, just updating the hostname here.
-            # https://docs.python.org/3/library/socket.html#socket.getaddrinfo
-            dest_addr = mapping[host]
-            return [(2, 1, 6, '', (dest_addr, port))]
-
-        return _orig_getaddrinfo(host, port, *args, **kwargs)
-
-    def patched_connect(self, address):
-        host, port = address[0], address[1]
-        if host in mapping:
-            dest_addr = mapping[host]
-            host = dest_addr
-
-        return _orig_connect(self, (host, port))
-
-    socket.getaddrinfo = patched_getaddrinfo
-    socket.socket.connect = patched_connect
-    try:
+def mock_local_mapreduce_dns():
+    mapping = {x: ('127.0.0.1', 443) for x in MOCKED_E2E_HOSTS}
+    with mock_local(mapping):
         yield
-    except Exception:
-        raise
-    finally:
-        socket.getaddrinfo = _orig_getaddrinfo
-        socket.socket.connect = _orig_connect
 
 
 CLUSTER_TAG = ['cluster_name:{}'.format(CLUSTER_NAME)]

--- a/mapreduce/tests/common.py
+++ b/mapreduce/tests/common.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import random
 import time
+from contextlib import contextmanager
 
 import requests
 from datadog_test_libs.utils.mock_dns import mock_local
@@ -69,6 +70,7 @@ def setup_mapreduce():
     return False
 
 
+@contextmanager
 def mock_local_mapreduce_dns():
     mapping = {x: ('127.0.0.1', 443) for x in MOCKED_E2E_HOSTS}
     with mock_local(mapping):

--- a/mapreduce/tests/conftest.py
+++ b/mapreduce/tests/conftest.py
@@ -6,7 +6,6 @@ import os
 from copy import deepcopy
 
 import pytest
-from datadog_test_libs.utils.mock_dns import mock_local
 from mock import patch
 
 from datadog_checks.dev import docker_run
@@ -28,11 +27,9 @@ from .common import (
     setup_mapreduce,
 )
 
-MOCKED_HOSTS = ('namenode', 'datanode', 'resourcemanager', 'nodemanager', 'historyserver')
-
 
 @pytest.fixture(scope="session")
-def dd_environment(mock_local_mapreduce_dns):
+def dd_environment():
     env = {'HOSTNAME': HOST}
     with docker_run(
         compose_file=os.path.join(HERE, "compose", "docker-compose.yaml"),
@@ -62,13 +59,6 @@ def mocked_request():
 @pytest.fixture
 def mocked_auth_request():
     with patch("requests.get", new=requests_auth_mock):
-        yield
-
-
-@pytest.fixture(scope='session')
-def mock_local_mapreduce_dns():
-    mapping = {x: ('127.0.0.1', 443) for x in MOCKED_HOSTS}
-    with mock_local(mapping):
         yield
 
 

--- a/mapreduce/tests/test_mapreduce_integration_e2e.py
+++ b/mapreduce/tests/test_mapreduce_integration_e2e.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
 def test_integration_metrics(aggregator, check, instance, datadog_agent):
     check = check(instance)
-    with common.mock_local():
+    with common.mock_local_mapreduce_dns():
         check.check(instance)
 
     for metric in common.ELAPSED_TIME_METRICS:
@@ -25,7 +25,7 @@ def test_integration_metrics(aggregator, check, instance, datadog_agent):
 def test_metadata(aggregator, check, instance, datadog_agent):
     check = check(instance)
     check.check_id = 'test:123'
-    with common.mock_local():
+    with common.mock_local_mapreduce_dns():
         check.check(instance)
 
     version_metadata = {


### PR DESCRIPTION
### What does this PR do?
Two previous PRs added functionality to mock hostname references for E2E testing: #7106 and #7343 .

The latter PR was merged first and included code borrowed from #7106.  When #7106 was merged it also made some changes to #7343 functionality which duplicated code.

This PR cleans up the duplicate code, references the library function from #7106, and removes a now unused function call `mock_e2e_agent` to avoid future confusion.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
