### PR TITLE
Ignore `/proc/sys/fs/binfmt_misc` by default

### DIFF
--- a/disk/assets/configuration/spec.yaml
+++ b/disk/assets/configuration/spec.yaml
@@ -27,7 +27,7 @@ files:
               Instruct the check to always add these patterns to `mount_point_blacklist`.
             value:
               example:
-                - /proc/sys/fs/binfmt_misc$
+                - (/host)?/proc/sys/fs/binfmt_misc$
               type: array
               items:
                 type: string

--- a/disk/assets/configuration/spec.yaml
+++ b/disk/assets/configuration/spec.yaml
@@ -26,7 +26,8 @@ files:
             description: |
               Instruct the check to always add these patterns to `mount_point_blacklist`.
             value:
-              example: []
+              example:
+                - /proc/sys/fs/binfmt_misc$
               type: array
               items:
                 type: string

--- a/disk/assets/configuration/spec.yaml
+++ b/disk/assets/configuration/spec.yaml
@@ -8,6 +8,9 @@ files:
           - name: file_system_global_blacklist
             description: |
               Instruct the check to always add these patterns to `file_system_blacklist`.
+
+              WARNING: Overriding these defaults could negatively impact your system or
+              the performance of the check.
             value:
               example:
                 - iso9660$
@@ -17,6 +20,9 @@ files:
           - name: device_global_blacklist
             description: |
               Instruct the check to always add these patterns to `device_blacklist`.
+
+              WARNING: Overriding these defaults could negatively impact your system or
+              the performance of the check.
             value:
               example: []
               type: array
@@ -25,6 +31,9 @@ files:
           - name: mount_point_global_blacklist
             description: |
               Instruct the check to always add these patterns to `mount_point_blacklist`.
+
+              WARNING: Overriding these defaults could negatively impact your system or
+              the performance of the check.
             value:
               example:
                 - (/host)?/proc/sys/fs/binfmt_misc$

--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -4,17 +4,26 @@ init_config:
 
     ## @param file_system_global_blacklist - list of strings - optional
     ## Instruct the check to always add these patterns to `file_system_blacklist`.
+    ##
+    ## WARNING: Overriding these defaults could negatively impact your system or
+    ## the performance of the check.
     #
     # file_system_global_blacklist:
     #   - iso9660$
 
     ## @param device_global_blacklist - list of strings - optional
     ## Instruct the check to always add these patterns to `device_blacklist`.
+    ##
+    ## WARNING: Overriding these defaults could negatively impact your system or
+    ## the performance of the check.
     #
     # device_global_blacklist: []
 
     ## @param mount_point_global_blacklist - list of strings - optional
     ## Instruct the check to always add these patterns to `mount_point_blacklist`.
+    ##
+    ## WARNING: Overriding these defaults could negatively impact your system or
+    ## the performance of the check.
     #
     # mount_point_global_blacklist:
     #   - (/host)?/proc/sys/fs/binfmt_misc$

--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -17,7 +17,7 @@ init_config:
     ## Instruct the check to always add these patterns to `mount_point_blacklist`.
     #
     # mount_point_global_blacklist:
-    #   - /proc/sys/fs/binfmt_misc$
+    #   - (/host)?/proc/sys/fs/binfmt_misc$
 
 ## Every instance is scheduled independent of the others.
 #

--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -16,7 +16,8 @@ init_config:
     ## @param mount_point_global_blacklist - list of strings - optional
     ## Instruct the check to always add these patterns to `mount_point_blacklist`.
     #
-    # mount_point_global_blacklist: []
+    # mount_point_global_blacklist:
+    #   - /proc/sys/fs/binfmt_misc$
 
 ## Every instance is scheduled independent of the others.
 #

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -441,5 +441,5 @@ class Disk(AgentCheck):
         return [
             # https://github.com/DataDog/datadog-agent/issues/1961
             # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1049
-            '/proc/sys/fs/binfmt_misc$'
+            '(/host)?/proc/sys/fs/binfmt_misc$'
         ]

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -438,4 +438,8 @@ class Disk(AgentCheck):
 
     @staticmethod
     def get_default_mount_mount_blacklist():
-        return []
+        return [
+            # https://github.com/DataDog/datadog-agent/issues/1961
+            # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1049
+            '/proc/sys/fs/binfmt_misc$'
+        ]

--- a/disk/tests/test_filter.py
+++ b/disk/tests/test_filter.py
@@ -39,7 +39,7 @@ def test_bad_config_string_regex():
     assert_regex_equal(c._device_whitelist, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._device_blacklist, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._mount_point_whitelist, re.compile('test', IGNORE_CASE))
-    assert_regex_equal(c._mount_point_blacklist, re.compile('test|/proc/sys/fs/binfmt_misc$', IGNORE_CASE))
+    assert_regex_equal(c._mount_point_blacklist, re.compile('test|(/host)?/proc/sys/fs/binfmt_misc$', IGNORE_CASE))
 
 
 def test_ignore_empty_regex():
@@ -58,7 +58,7 @@ def test_ignore_empty_regex():
     assert_regex_equal(c._device_whitelist, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._device_blacklist, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._mount_point_whitelist, re.compile('test', IGNORE_CASE))
-    assert_regex_equal(c._mount_point_blacklist, re.compile('test|/proc/sys/fs/binfmt_misc$', IGNORE_CASE))
+    assert_regex_equal(c._mount_point_blacklist, re.compile('test|(/host)?/proc/sys/fs/binfmt_misc$', IGNORE_CASE))
 
 
 def test_exclude_bad_devices():
@@ -191,7 +191,7 @@ def test_legacy_config():
 
     assert_regex_equal(c._file_system_blacklist, re.compile('iso9660$|test$', re.I))
     assert_regex_equal(c._device_blacklist, re.compile('test1$|test2', IGNORE_CASE))
-    assert_regex_equal(c._mount_point_blacklist, re.compile('/proc/sys/fs/binfmt_misc$|test', IGNORE_CASE))
+    assert_regex_equal(c._mount_point_blacklist, re.compile('(/host)?/proc/sys/fs/binfmt_misc$|test', IGNORE_CASE))
 
 
 def test_legacy_exclude_disk():

--- a/disk/tests/test_filter.py
+++ b/disk/tests/test_filter.py
@@ -39,7 +39,7 @@ def test_bad_config_string_regex():
     assert_regex_equal(c._device_whitelist, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._device_blacklist, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._mount_point_whitelist, re.compile('test', IGNORE_CASE))
-    assert_regex_equal(c._mount_point_blacklist, re.compile('test', IGNORE_CASE))
+    assert_regex_equal(c._mount_point_blacklist, re.compile('test|/proc/sys/fs/binfmt_misc$', IGNORE_CASE))
 
 
 def test_ignore_empty_regex():
@@ -58,7 +58,7 @@ def test_ignore_empty_regex():
     assert_regex_equal(c._device_whitelist, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._device_blacklist, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._mount_point_whitelist, re.compile('test', IGNORE_CASE))
-    assert_regex_equal(c._mount_point_blacklist, re.compile('test', IGNORE_CASE))
+    assert_regex_equal(c._mount_point_blacklist, re.compile('test|/proc/sys/fs/binfmt_misc$', IGNORE_CASE))
 
 
 def test_exclude_bad_devices():
@@ -191,7 +191,7 @@ def test_legacy_config():
 
     assert_regex_equal(c._file_system_blacklist, re.compile('iso9660$|test$', re.I))
     assert_regex_equal(c._device_blacklist, re.compile('test1$|test2', IGNORE_CASE))
-    assert_regex_equal(c._mount_point_blacklist, re.compile('test', IGNORE_CASE))
+    assert_regex_equal(c._mount_point_blacklist, re.compile('/proc/sys/fs/binfmt_misc$|test', IGNORE_CASE))
 
 
 def test_legacy_exclude_disk():

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -27,7 +27,7 @@ def test_default_options():
     assert check._device_whitelist is None
     assert check._device_blacklist is None
     assert check._mount_point_whitelist is None
-    assert check._mount_point_blacklist == re.compile('/proc/sys/fs/binfmt_misc$', IGNORE_CASE)
+    assert check._mount_point_blacklist == re.compile('(/host)?/proc/sys/fs/binfmt_misc$', IGNORE_CASE)
     assert check._tag_by_filesystem is False
     assert check._device_tag_re == []
     assert check._service_check_rw is False

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -11,6 +11,7 @@ from six import iteritems
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.base.utils.timeout import TimeoutException
 from datadog_checks.disk import Disk
+from datadog_checks.disk.disk import IGNORE_CASE
 
 from .common import DEFAULT_DEVICE_BASE_NAME, DEFAULT_DEVICE_NAME, DEFAULT_FILE_SYSTEM, DEFAULT_MOUNT_POINT
 from .mocks import MockDiskMetrics, MockPart, mock_blkid_output
@@ -26,7 +27,7 @@ def test_default_options():
     assert check._device_whitelist is None
     assert check._device_blacklist is None
     assert check._mount_point_whitelist is None
-    assert check._mount_point_blacklist is None
+    assert check._mount_point_blacklist == re.compile('/proc/sys/fs/binfmt_misc$', IGNORE_CASE)
     assert check._tag_by_filesystem is False
     assert check._device_tag_re == []
     assert check._service_check_rw is False


### PR DESCRIPTION
### Motivation

- https://github.com/DataDog/datadog-agent/issues/1961
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1049
- https://github.com/DataDog/integrations-core/issues/2492