### PR TITLE
Fix procfs_path retrieval in network check

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -20,6 +20,11 @@ from datadog_checks.base.utils.common import pattern_filter
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.base.utils.subprocess_output import SubprocessOutputEmptyError, get_subprocess_output
 
+try:
+    import datadog_agent
+except ImportError:
+    from datadog_checks.base.stubs import datadog_agent
+
 if PY3:
     long = int
 
@@ -290,7 +295,10 @@ class Network(AgentCheck):
         For that procfs_path can be set to something like "/host/proc"
         When a custom procfs_path is set, the collect_connection_state option is ignored
         """
-        proc_location = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
+        proc_location = datadog_agent.get_config('procfs_path')
+        if not proc_location:
+            proc_location = '/proc'
+        proc_location = proc_location.rstrip('/')
         custom_tags = instance.get('tags', [])
 
         net_proc_base_location = self._get_net_proc_base_location(proc_location)


### PR DESCRIPTION
### What does this PR do?
Running the network check in a container (https://github.com/DataDog/integrations-core/pull/7095) does not work as the `procfs_path` value is not retrieved correctly, always defaulting to `/proc`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
