### PR TITLE
Skip auto-setting Python version suffix if using an RC build

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -60,8 +60,8 @@ class DockerInterface(object):
         self.config_file = locate_config_file(check, env)
         self.config_file_name = config_file_name(self.check)
 
-        # If we use a default build, and it's missing the py suffix, adds it
-        if default_agent and self.agent_build and 'py' not in self.agent_build:
+        # If we use a default non-RC build, and it's missing the py suffix, adds it
+        if default_agent and self.agent_build and 'rc' not in self.agent_build and 'py' not in self.agent_build:
             # Agent 6 image no longer supports -pyX
             if self.agent_build != 'datadog/agent:6':
                 self.agent_build = f'{self.agent_build}-py{self.python_version}'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Skip adding the `-py2` or `-py3` suffix if we're using an RC Agent build, such as `datadog/agent:7.23.0-rc.2`.

### Motivation
<!-- What inspired you to submit this pull request? -->
RC builds aren't published with a `-py2` or `-py3` suffix, and I got tired of commenting out this auto-set code when doing QA. :-)

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Might need an additional tweak and thinking, because even public tags don't have `-py2` or `-py3` suffixes either, but only internal dev versions such as `datadog/agent-dev:master-py3`. But for now I'm just scratching my own itch!

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
