### PR TITLE
Collect connection state metrics on BSD/OSX

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -346,7 +346,7 @@ class Network(AgentCheck):
                 for metric, value in iteritems(metrics):
                     self.gauge(metric, value, tags=custom_tags)
             except SubprocessOutputEmptyError:
-                self.log.exception("Error collecting connection stats.")
+                self.log.exception("Error collecting connection states.")
 
         proc_dev_path = "{}/net/dev".format(net_proc_base_location)
         try:
@@ -668,6 +668,7 @@ class Network(AgentCheck):
                 for metric, value in iteritems(metrics):
                     self.gauge(metric, value, tags=custom_tags)
             except SubprocessOutputEmptyError:
+                self.log.exception("Error collecting connection states.")
 
     def _check_solaris(self, instance):
         # Can't get bytes sent and received via netstat


### PR DESCRIPTION
### What does this PR do?
Collect cx state metrics on BSD platform (OSX)

### Motivation
AGENT-4978

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
