### PR TITLE
Do not emit insecure warning log for HTTP requests

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -528,7 +528,7 @@ class PrometheusScraperMixin(object):
             disable_insecure_warnings = True
             verify = False
 
-        if not disable_insecure_warnings and not verify:
+        if endpoint.startswith('https') and not disable_insecure_warnings and not verify:
             self.log.warning(u'An unverified HTTPS request is being made to %s', endpoint)
 
         try:

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -310,7 +310,7 @@ class RequestsWrapper(object):
 
         new_options = self.populate_options(options)
 
-        if not self.ignore_tls_warning and not new_options['verify']:
+        if url.startswith('https') and not self.ignore_tls_warning and not new_options['verify']:
             self.logger.warning(u'An unverified HTTPS request is being made to %s', url)
 
         extra_headers = options.pop('extra_headers', None)

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -846,6 +846,16 @@ class TestIgnoreTLSWarning:
         else:
             raise AssertionError('Expected WARNING log with message `{}`'.format(expected_message))
 
+    def test_default_no_ignore_http(self, caplog):
+        instance = {}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        with caplog.at_level(logging.DEBUG), mock.patch('requests.get'):
+            http.get('http://www.google.com', verify=False)
+
+        assert sum(1 for _, level, _ in caplog.record_tuples if level == logging.WARNING) == 0
+
     def test_ignore(self, caplog):
         instance = {'tls_ignore_warning': True}
         init_config = {}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Cleanup #7512

Inspect URL schemes so we don't emit a warning if using `verify: false` but an `http://` request is being made.

### Motivation
<!-- What inspired you to submit this pull request? -->
When requesting an `http://` (plaintext) endpoint, whether TLS verification is disabled is irrelevant. Besides the warning we're logging is explicitly for "an HTTPS request", so I assume this was an oversight.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
