### PR TITLE
Pin mkdocstrings==0.13.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,8 @@ deps =
     ; plugins
     mkdocs-minify-plugin>=0.3.0
     mkdocs-git-revision-date-localized-plugin>=0.5.2
-    mkdocstrings>=0.11.0
+    ; See https://github.com/pawamoy/mkdocstrings/issues/154
+    mkdocstrings==0.13.2
     mkdocs-pdf-export-plugin>=0.5.6
     ; Extensions
     pymdown-extensions>=7.1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Pin `mkdocstrings` to version `0.13.2`

### Motivation
<!-- What inspired you to submit this pull request? -->
Latest release 0.13.3 is broken: https://github.com/pawamoy/mkdocstrings/issues/154

And makes our `docs` CI job fail, eg: https://github.com/DataDog/integrations-core/pull/7661/checks?check_run_id=1165278158

Not clear yet how exactly the `mkdocstrings` bug should be resolved (though I pushed a PR: https://github.com/pawamoy/mkdocstrings/pull/155) and how quickly, so pinning to unblock our builds in the meantime.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
