### PR TITLE
[ddev] Trello update RC link in MacOS card as well

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/__init__.py
@@ -7,8 +7,9 @@ import click
 from ...console import CONTEXT_SETTINGS
 from .status import status
 from .testable import testable
+from .update_rc_links import update_rc_links
 
-ALL_COMMANDS = [status, testable]
+ALL_COMMANDS = [status, testable, update_rc_links]
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Tools for interacting with Trello')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/rc_build_cards_updater.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/rc_build_cards_updater.py
@@ -35,8 +35,9 @@ class RCBuildCardsUpdater:
             'DyjjKkZD',  # [A6] Windows
             'BOvSs9Le',  # [IOT] Linux
             'hu1JXJ18',  # [A7] Linux + Docker
-            'E7bHwa14',
-        ]  # [A6] Linux + Docker
+            'E7bHwa14',  # [A6] Linux + Docker
+            'dYrSpOLW',  # MacOS
+        ]
 
         for card_id in rc_build_cards:
             card = self.__trello.get_card(card_id)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/update_rc_links.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/update_rc_links.py
@@ -5,8 +5,8 @@
 import click
 
 from ....trello import TrelloClient
-from .rc_build_cards_updater import RCBuildCardsUpdater
 from ...console import CONTEXT_SETTINGS, echo_success
+from .rc_build_cards_updater import RCBuildCardsUpdater
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Update links to RCs in the QA board Trello cards')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/update_rc_links.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/update_rc_links.py
@@ -1,0 +1,20 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import click
+
+from ....trello import TrelloClient
+from .rc_build_cards_updater import RCBuildCardsUpdater
+from ...console import CONTEXT_SETTINGS, echo_success
+
+
+@click.command(context_settings=CONTEXT_SETTINGS, short_help='Update links to RCs in the QA board Trello cards')
+@click.argument('target_ref')
+@click.pass_context
+def update_rc_links(ctx: click.Context, target_ref: str) -> None:
+    user_config = ctx.obj
+    trello = TrelloClient(user_config)
+    rc_build_cards_updater = RCBuildCardsUpdater(trello, target_ref)
+    rc_build_cards_updater.update_cards()
+    echo_success('Done')


### PR DESCRIPTION
### What does this PR do?
- Adds the MacOS card to the list of cards to update when there's a new RC.
- Adds a separate command to call `update_cards` directly.

### Motivation
- New MacOS card.