### PR TITLE
Normalize count metric type in `assert_metrics_using_metadata()`

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -348,6 +348,9 @@ class AggregatorStub(object):
                     expected_metric_type = metadata_metrics[metric_stub_name]['metric_type']
                     actual_metric_type = AggregatorStub.METRIC_ENUM_MAP_REV[metric_stub.type]
 
+                    if actual_metric_type == 'monotonic_count' and expected_metric_type == 'count':
+                        actual_metric_type = 'count'
+
                     if expected_metric_type != actual_metric_type:
                         errors.add(
                             "Expect `{}` to have type `{}` but got `{}`.".format(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Allow `monotonic_count` metrics to match expected type of `count` when comparing collected metrics with `metadata.csv`.

### Motivation
<!-- What inspired you to submit this pull request? -->
`metadata.csv` cannot contain `monotonic_count` (only `count` is allowed AFAIK), so when a `monotonic_count` metric is submitted and is defined in `metadata.csv`, `assert_metrics_using_metadata()` fails.

Example for Azure IoT Edge (currently making #7465 fail):

```console
tests/test_check.py:58: in test_check
    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:358: in assert_metrics_using_metadata
    assert not errors, "Metadata assertion errors using metadata.csv:" + "\n\t- ".join([''] + sorted(errors))
E   AssertionError: Metadata assertion errors using metadata.csv:
E       - Expect `azure.iot_edge.edge_agent.iothub_syncs_total` to have type `count` but got `monotonic_count`.
E       - Expect `azure.iot_edge.edge_agent.module_start_total` to have type `count` but got `monotonic_count`.
E       - Expect `azure.iot_edge.edge_agent.module_stop_total` to have type `count` but got `monotonic_count`.
E       - Expect `azure.iot_edge.edge_agent.unsuccessful_iothub_syncs_total` to have type `count` but got `monotonic_count`.
E       - Expect `azure.iot_edge.edge_hub.client_connect_failed_total` to have type `count` but got `monotonic_count`.
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
