### PR TITLE
Support additional performance metrics 

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -50,7 +50,7 @@ files:
         type: boolean
         example: true
     - name: include_task_scheduler_metrics
-      description: Include additional Task and Scheduler metrics
+      description: Include additional Task and Scheduler metrics.
       value:
         type: boolean
         example: false

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -42,6 +42,18 @@ files:
       value:
         type: string
         example: master
+    - name: include_instance_metrics
+      description: |
+        Include server-level instance metrics.  When setting up multiple instances for
+        different databases on the same host these metrics will be duplicated unless this option is turned off.
+      value:
+        type: boolean
+        example: true
+    - name: include_task_scheduler_metrics
+      description: Include additional Task and Scheduler metrics
+      value:
+        type: boolean
+        example: false
     - name: adoprovider
       description: |
         Choose the ADO provider.  Note that the (default) provider
@@ -102,11 +114,6 @@ files:
         example: master
     - name: ignore_missing_database
       description: If the DB specified doesn't exist on the server then don't do the check
-      value:
-        type: boolean
-        example: false
-    - name: include_task_scheduler_metrics
-      description: Include additional Task and Scheduler metrics
       value:
         type: boolean
         example: false

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -69,6 +69,8 @@ class Connection(object):
             )
             self.adoprovider = self.default_adoprovider
 
+        self.log.debug('Connection initialized.')
+
     @contextmanager
     def get_managed_cursor(self):
         cursor = self.get_cursor(self.DEFAULT_DB_KEY)
@@ -292,6 +294,7 @@ class Connection(object):
 
         if username:
             conn_str += 'User ID={};'.format(username)
+        self.log.debug("Connection string (before password) %s", conn_str)
         if password:
             conn_str += 'Password={};'.format(password)
         if not username and not password:

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -45,7 +45,7 @@ instances:
     # include_instance_metrics: true
 
     ## @param include_task_scheduler_metrics - boolean - optional - default: false
-    ## Include additional Task and Scheduler metrics
+    ## Include additional Task and Scheduler metrics.
     #
     # include_task_scheduler_metrics: false
 

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -38,6 +38,17 @@ instances:
     #
     # database: master
 
+    ## @param include_instance_metrics - boolean - optional - default: true
+    ## Include server-level instance metrics.  When setting up multiple instances for
+    ## different databases on the same host these metrics will be duplicated unless this option is turned off.
+    #
+    # include_instance_metrics: true
+
+    ## @param include_task_scheduler_metrics - boolean - optional - default: false
+    ## Include additional Task and Scheduler metrics
+    #
+    # include_task_scheduler_metrics: false
+
     ## @param adoprovider - string - optional - default: SQLOLEDB
     ## Choose the ADO provider.  Note that the (default) provider
     ## SQLOLEDB is being deprecated.  To use the newer MSOLEDBSQL
@@ -97,11 +108,6 @@ instances:
     ## If the DB specified doesn't exist on the server then don't do the check
     #
     # ignore_missing_database: false
-
-    ## @param include_task_scheduler_metrics - boolean - optional - default: false
-    ## Include additional Task and Scheduler metrics
-    #
-    # include_task_scheduler_metrics: false
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -53,11 +53,11 @@ class BaseSqlServerMetric(object):
         if counters_list:
             placeholders = ', '.join('?' for _ in counters_list)
             query = cls.QUERY_BASE.format(placeholders)
-            logger.debug("%s: fetch_all executing query: %s, %s", cls.__name__, query)
+            logger.debug("%s: fetch_all executing query: %s, %s", cls.__name__, query, counters_list)
             cursor.execute(query, counters_list)
         else:
             query = cls.QUERY_BASE
-            logger.debug("%s: fetch_all executing query: %s, %s", cls.__name__, query)
+            logger.debug("%s: fetch_all executing query: %s", cls.__name__, query)
             cursor.execute(query)
 
         rows = cursor.fetchall()

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -28,6 +28,9 @@ class BaseSqlServerMetric(object):
     DEFAULT_METRIC_TYPE = None
     QUERY_BASE = None
 
+    # Flag to indicate if this subclass/table is available for custom queries
+    CUSTOM_QUERY = True
+
     def __init__(self, cfg_instance, base_name, report_function, column, logger):
         self.cfg_instance = cfg_instance
         self.datadog_name = cfg_instance['name']
@@ -62,6 +65,7 @@ class BaseSqlServerMetric(object):
 
         rows = cursor.fetchall()
         columns = [i[0] for i in cursor.description]
+        logger.debug('cursor desc: %s', cursor.description)
         return rows, columns
 
     @classmethod
@@ -251,15 +255,24 @@ class SqlOsWaitStat(BaseSqlServerMetric):
 class SqlIoVirtualFileStat(BaseSqlServerMetric):
     TABLE = 'sys.dm_io_virtual_file_stats'
     DEFAULT_METRIC_TYPE = 'gauge'
-    QUERY_BASE = "select * from {table}(null, null)".format(table=TABLE)
+    QUERY_BASE = (
+        "select DB_NAME(database_id) as name, database_id, file_id, {{custom_cols}} from {table}(null, null)".format(
+            table=TABLE
+        )
+    )
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger):
+        # since we want the database name we need to update the SQL query at runtime with our custom columns
+        # multiple formats on a string are harmless
+        extra_cols = ', '.join(col for col in counters_list)
+        cls.QUERY_BASE = cls.QUERY_BASE.format(custom_cols=extra_cols)
         return cls._fetch_generic_values(cursor, None, logger)
 
     def __init__(self, cfg_instance, base_name, report_function, column, logger):
         super(SqlIoVirtualFileStat, self).__init__(cfg_instance, base_name, report_function, column, logger)
         self.dbid = self.cfg_instance.get('database_id', None)
+        self.dbname = self.cfg_instance.get('database', None)
         self.fid = self.cfg_instance.get('file_id', None)
         self.pvs_vals = defaultdict(lambda: None)
 
@@ -269,14 +282,18 @@ class SqlIoVirtualFileStat(BaseSqlServerMetric):
         #  but doesn't account for time differences.  This can work for some columns like `num_of_writes`, but is
         #  inaccurate for others like `io_stall_write_ms` which are not monotonically increasing.
         dbid_ndx = columns.index("database_id")
+        dbname_ndx = columns.index("name")
         fileid_ndx = columns.index("file_id")
         column_ndx = columns.index(self.column)
         for row in rows:
             dbid = row[dbid_ndx]
+            dbname = row[dbname_ndx]
             fid = row[fileid_ndx]
             value = row[column_ndx]
 
             if self.dbid and self.dbid != dbid:
+                continue
+            if self.dbname and self.dbname != dbname:
                 continue
             if self.fid and self.fid != fid:
                 continue
@@ -286,7 +303,11 @@ class SqlIoVirtualFileStat(BaseSqlServerMetric):
 
             report_value = value - self.pvs_vals[dbid, fid]
             self.pvs_vals[dbid, fid] = value
-            metric_tags = ['database_id:{}'.format(str(dbid).strip()), 'file_id:{}'.format(str(fid).strip())]
+            metric_tags = [
+                'database:{}'.format(str(dbname).strip()),
+                'database_id:{}'.format(str(dbid).strip()),
+                'file_id:{}'.format(str(fid).strip()),
+            ]
             metric_tags.extend(self.tags)
             metric_name = '{}.{}'.format(self.datadog_name, self.column)
             self.report_function(metric_name, report_value, tags=metric_tags)
@@ -348,32 +369,40 @@ class SqlOsSchedulers(BaseSqlServerMetric):
 
 # https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-tasks-transact-sql
 class SqlOsTasks(BaseSqlServerMetric):
+    CUSTOM_QUERY = False
     TABLE = 'sys.dm_os_tasks'
     DEFAULT_METRIC_TYPE = 'gauge'
-    QUERY_BASE = "select * from {table}".format(table=TABLE)
+    QUERY_BASE = """
+    select scheduler_id,
+           SUM(pending_io_count) as pending_io_count,
+           SUM(pending_io_byte_count) as pending_io_byte_count,
+           AVG(pending_io_byte_average) as pending_io_byte_average
+    from {table} group by scheduler_id;
+    """.format(
+        table=TABLE
+    )
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger):
         return cls._fetch_generic_values(cursor, None, logger)
 
     def fetch_metric(self, rows, columns):
-        session_id_column_index = columns.index("session_id")
         scheduler_id_column_index = columns.index("scheduler_id")
         value_column_index = columns.index(self.column)
 
         for row in rows:
             column_val = row[value_column_index]
-            session_id = row[session_id_column_index]
             scheduler_id = row[scheduler_id_column_index]
 
-            metric_tags = ['session_id:{}'.format(str(session_id)), 'scheduler_id:{}'.format(str(scheduler_id))]
+            metric_tags = ['scheduler_id:{}'.format(str(scheduler_id))]
             metric_tags.extend(self.tags)
             metric_name = '{}'.format(self.datadog_name)
             self.report_function(metric_name, column_val, tags=metric_tags)
 
 
 # https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-master-files-transact-sql
-class SqlDatabaseStats(BaseSqlServerMetric):
+class SqlDatabaseFileStats(BaseSqlServerMetric):
+    CUSTOM_QUERY = False
     TABLE = 'sys.database_files'
     DEFAULT_METRIC_TYPE = 'gauge'
     QUERY_BASE = "select * from {table}".format(table=TABLE)
@@ -385,9 +414,9 @@ class SqlDatabaseStats(BaseSqlServerMetric):
         return cls._fetch_generic_values(cursor, None, logger)
 
     def fetch_metric(self, rows, columns):
-        database_type = columns.index("type")
-        database_name = columns.index("name")
-        database_file_location = columns.index("physical_name")
+        file_id = columns.index("file_id")
+        file_type = columns.index("type")
+        file_location = columns.index("physical_name")
         value_column_index = columns.index(self.column)
 
         for row in rows:
@@ -395,14 +424,44 @@ class SqlDatabaseStats(BaseSqlServerMetric):
             if self.column in ('size', 'max_size'):
                 column_val *= 8  # size reported in 8 KB pages
 
-            dbtype = self.DB_TYPE_MAP[row[database_type]]
-            dbname = row[database_name]
-            location = row[database_file_location]
+            fileid = row[file_id]
+            filetype = self.DB_TYPE_MAP[row[file_type]]
+            location = row[file_location]
 
             metric_tags = [
-                'database_type:{}'.format(str(dbtype)),
-                'database_name:{}'.format(str(dbname)),
-                'database_location:{}'.format(str(location)),
+                'database:{}'.format(str(self.instance)),
+                'file_id:{}'.format(str(fileid)),
+                'file_type:{}'.format(str(filetype)),
+                'file_location:{}'.format(str(location)),
+            ]
+            metric_tags.extend(self.tags)
+            metric_name = '{}'.format(self.datadog_name)
+            self.report_function(metric_name, column_val, tags=metric_tags)
+
+
+# https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-databases-transact-sql?view=sql-server-ver15
+class SqlDatabaseStats(BaseSqlServerMetric):
+    CUSTOM_QUERY = False
+    TABLE = 'sys.databases'
+    DEFAULT_METRIC_TYPE = 'gauge'
+    QUERY_BASE = "select * from {table}".format(table=TABLE)
+
+    @classmethod
+    def fetch_all_values(cls, cursor, counters_list, logger):
+        return cls._fetch_generic_values(cursor, None, logger)
+
+    def fetch_metric(self, rows, columns):
+        database_name = columns.index("name")
+        value_column_index = columns.index(self.column)
+
+        for row in rows:
+            if row[database_name] != self.instance:
+                continue
+
+            column_val = row[value_column_index]
+
+            metric_tags = [
+                'database:{}'.format(str(self.instance)),
             ]
             metric_tags.extend(self.tags)
             metric_name = '{}'.format(self.datadog_name)
@@ -410,7 +469,7 @@ class SqlDatabaseStats(BaseSqlServerMetric):
 
 
 DEFAULT_PERFORMANCE_TABLE = "sys.dm_os_performance_counters"
-VALID_TABLES = set(cls.TABLE for cls in BaseSqlServerMetric.__subclasses__())
+VALID_TABLES = set(cls.TABLE for cls in BaseSqlServerMetric.__subclasses__() if cls.CUSTOM_QUERY)
 TABLE_MAPPING = {
     cls.TABLE: (cls.DEFAULT_METRIC_TYPE, cls)
     for cls in BaseSqlServerMetric.__subclasses__()

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -65,7 +65,6 @@ class BaseSqlServerMetric(object):
 
         rows = cursor.fetchall()
         columns = [i[0] for i in cursor.description]
-        logger.debug('cursor desc: %s', cursor.description)
         return rows, columns
 
     @classmethod

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -29,7 +29,7 @@ class BaseSqlServerMetric(object):
     QUERY_BASE = None
 
     # Flag to indicate if this subclass/table is available for custom queries
-    CUSTOM_QUERY = True
+    CUSTOM_QUERIES_AVAILABLE = True
 
     def __init__(self, cfg_instance, base_name, report_function, column, logger):
         self.cfg_instance = cfg_instance
@@ -368,7 +368,7 @@ class SqlOsSchedulers(BaseSqlServerMetric):
 
 # https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-tasks-transact-sql
 class SqlOsTasks(BaseSqlServerMetric):
-    CUSTOM_QUERY = False
+    CUSTOM_QUERIES_AVAILABLE = False
     TABLE = 'sys.dm_os_tasks'
     DEFAULT_METRIC_TYPE = 'gauge'
     QUERY_BASE = """
@@ -402,7 +402,7 @@ class SqlOsTasks(BaseSqlServerMetric):
 
 # https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-master-files-transact-sql
 class SqlDatabaseFileStats(BaseSqlServerMetric):
-    CUSTOM_QUERY = False
+    CUSTOM_QUERIES_AVAILABLE = False
     TABLE = 'sys.database_files'
     DEFAULT_METRIC_TYPE = 'gauge'
     QUERY_BASE = "select * from {table}".format(table=TABLE)
@@ -441,7 +441,7 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
 
 # https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-databases-transact-sql?view=sql-server-ver15
 class SqlDatabaseStats(BaseSqlServerMetric):
-    CUSTOM_QUERY = False
+    CUSTOM_QUERIES_AVAILABLE = False
     TABLE = 'sys.databases'
     DEFAULT_METRIC_TYPE = 'gauge'
     QUERY_BASE = "select * from {table}".format(table=TABLE)
@@ -469,7 +469,7 @@ class SqlDatabaseStats(BaseSqlServerMetric):
 
 
 DEFAULT_PERFORMANCE_TABLE = "sys.dm_os_performance_counters"
-VALID_TABLES = set(cls.TABLE for cls in BaseSqlServerMetric.__subclasses__() if cls.CUSTOM_QUERY)
+VALID_TABLES = set(cls.TABLE for cls in BaseSqlServerMetric.__subclasses__() if cls.CUSTOM_QUERIES_AVAILABLE)
 TABLE_MAPPING = {
     cls.TABLE: (cls.DEFAULT_METRIC_TYPE, cls)
     for cls in BaseSqlServerMetric.__subclasses__()

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -373,6 +373,7 @@ class SqlOsTasks(BaseSqlServerMetric):
     DEFAULT_METRIC_TYPE = 'gauge'
     QUERY_BASE = """
     select scheduler_id,
+           SUM(context_switches_count) as context_switches_count,
            SUM(pending_io_count) as pending_io_count,
            SUM(pending_io_byte_count) as pending_io_byte_count,
            AVG(pending_io_byte_average) as pending_io_byte_average

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -182,7 +182,7 @@ class SQLServer(AgentCheck):
             metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
 
         # Load metrics from scheduler and task tables, if enabled
-        if self.instance.get('include_task_scheduler_metrics', False):
+        if is_affirmative(self.instance.get('include_task_scheduler_metrics', False)):
             for name, table, column in self.TASK_SCHEDULER_METRICS:
                 cfg = {'name': name, 'table': table, 'column': column, 'tags': tags}
                 metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -240,8 +240,12 @@ class SQLServer(AgentCheck):
                 continue
 
             if cfg.get('database', None) and cfg.get('database') != self.instance.get('database'):
-                self.log.debug('Skipping custom metric %s for database %s, check instance configured for database %s',
-                               cfg['name'], cfg.get('database'), self.instance.get('database'))
+                self.log.debug(
+                    'Skipping custom metric %s for database %s, check instance configured for database %s',
+                    cfg['name'],
+                    cfg.get('database'),
+                    self.instance.get('database'),
+                )
                 continue
 
             if db_table == DEFAULT_PERFORMANCE_TABLE:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -61,20 +61,40 @@ class SQLServer(AgentCheck):
     # Default performance table metrics - Database Instance level
     # datadog metric name, counter name, instance name
     INSTANCE_METRICS = [
-        ('sqlserver.buffer.cache_hit_ratio', 'Buffer cache hit ratio', ''),  # RAW_LARGE_FRACTION
-        ('sqlserver.buffer.page_life_expectancy', 'Page life expectancy', ''),  # LARGE_RAWCOUNT
-        ('sqlserver.stats.batch_requests', 'Batch Requests/sec', ''),  # BULK_COUNT
-        ('sqlserver.stats.sql_compilations', 'SQL Compilations/sec', ''),  # BULK_COUNT
-        ('sqlserver.stats.sql_recompilations', 'SQL Re-Compilations/sec', ''),  # BULK_COUNT
+        # SQLServer:General Statistics
         ('sqlserver.stats.connections', 'User Connections', ''),  # LARGE_RAWCOUNT
-        ('sqlserver.stats.lock_waits', 'Lock Waits/sec', '_Total'),  # BULK_COUNT
-        ('sqlserver.access.page_splits', 'Page Splits/sec', ''),  # BULK_COUNT
         ('sqlserver.stats.procs_blocked', 'Processes blocked', ''),  # LARGE_RAWCOUNT
-        ('sqlserver.buffer.checkpoint_pages', 'Checkpoint pages/sec', ''),  # BULK_COUNT
-        # Transactions
+        # SQLServer:Locks
+        ('sqlserver.stats.lock_waits', 'Lock Waits/sec', '_Total'),  # BULK_COUNT
+        # SQLServer:Access Methods
+        ('sqlserver.access.page_splits', 'Page Splits/sec', ''),  # BULK_COUNT
+        # SQLServer:Plan Cache
+        ('sqlserver.cache.object_counts', 'Cache Object Counts', '_Total'),
+        ('sqlserver.cache.pages', 'Cache Pages', '_Total'),
+        # SQLServer:Databases
+        ('sqlserver.database.backup_restore_throughput', 'Backup/Restore Throughput/sec', '_Total'),
+        ('sqlserver.database.log_bytes_flushed', 'Log Bytes Flushed/sec', '_Total'),
+        ('sqlserver.database.log_flushes', 'Log Flushes/sec', '_Total'),
+        ('sqlserver.database.log_flush_wait', 'Log Flush Wait Time', '_Total'),
         ('sqlserver.database.transactions', 'Transactions/sec', '_Total'),  # BULK_COUNT
         ('sqlserver.database.write_transactions', 'Write Transactions/sec', '_Total'),  # BULK_COUNT
         ('sqlserver.database.active_transactions', 'Active Transactions', '_Total'),  # BULK_COUNT
+        # SQLServer:Memory Manager
+        ('sqlserver.memory.memory_grants_pending', 'Memory Grants Pending', ''),
+        ('sqlserver.memory.total_server_memory', 'Total Server Memory (KB)', ''),
+        # SQLServer:Buffer Manager
+        ('sqlserver.buffer.cache_hit_ratio', 'Buffer cache hit ratio', ''),  # RAW_LARGE_FRACTION
+        ('sqlserver.buffer.page_life_expectancy', 'Page life expectancy', ''),  # LARGE_RAWCOUNT
+        ('sqlserver.buffer.page_reads', 'Page reads/sec', ''),  # LARGE_RAWCOUNT
+        ('sqlserver.buffer.page_writes', 'Page writes/sec', ''),  # LARGE_RAWCOUNT
+        ('sqlserver.buffer.checkpoint_pages', 'Checkpoint pages/sec', ''),  # BULK_COUNT
+        # SQLServer:SQL Statistics
+        ('sqlserver.stats.auto_param_attempts', 'Auto-Param Attempts/sec', ''),
+        ('sqlserver.stats.failed_auto_param_attempts', 'Failed Auto-Params/sec', ''),
+        ('sqlserver.stats.safe_auto_param_attempts', 'Safe Auto-Params/sec', ''),
+        ('sqlserver.stats.batch_requests', 'Batch Requests/sec', ''),  # BULK_COUNT
+        ('sqlserver.stats.sql_compilations', 'SQL Compilations/sec', ''),  # BULK_COUNT
+        ('sqlserver.stats.sql_recompilations', 'SQL Re-Compilations/sec', ''),  # BULK_COUNT
     ]
 
     # Non-performance table metrics - can be database specific

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -207,7 +207,6 @@ class SQLServer(AgentCheck):
                 metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
 
         # Load any custom metrics from conf.d/sqlserver.yaml
-        # TODO - if dbid or database specified in custom metric pass the instance database value so it can be filtered
         for cfg in custom_metrics:
             sql_type = None
             base_name = None
@@ -218,6 +217,11 @@ class SQLServer(AgentCheck):
             db_table = cfg.get('table', DEFAULT_PERFORMANCE_TABLE)
             if db_table not in VALID_TABLES:
                 self.log.error('%s has an invalid table name: %s', cfg['name'], db_table)
+                continue
+
+            if cfg.get('database', None) and cfg.get('database') != self.instance.get('database'):
+                self.log.debug('Skipping custom metric %s for database %s, check instance configured for database %s',
+                               cfg['name'], cfg.get('database'), self.instance.get('database'))
                 continue
 
             if db_table == DEFAULT_PERFORMANCE_TABLE:

--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -1,14 +1,33 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+sqlserver.access.page_splits,gauge,,operation,second,The number of page splits per second.,-1,sql_server,page splits
 sqlserver.buffer.cache_hit_ratio,gauge,,fraction,,The ratio of data pages found and read from the buffer cache over all data page requests.,1,sql_server,buff hit ratio
+sqlserver.buffer.checkpoint_pages,gauge,,page,second,The number of pages flushed to disk per second by a checkpoint or other operation that require all dirty pages to be flushed.,-1,sql_server,checkpoint pages
 sqlserver.buffer.page_life_expectancy,gauge,,second,,Duration that a page resides in the buffer pool.,1,sql_server,buff page life expectancy
+sqlserver.buffer.page_reads,gauge,,page,,Indicates the number of physical database page reads that are issued per second. This statistic displays the total number of physical page reads across all databases.,-1,sql_server,buff page reads
+sqlserver.buffer.page_writes,gauge,,page,,Indicates the number of physical database page writes that are issued per second.,-1,sql_server,buff page writes
 sqlserver.stats.batch_requests,gauge,,request,second,The number of batch requests per second.,1,sql_server,batch requests
 sqlserver.stats.sql_compilations,gauge,,operation,second,The number of SQL compilations per second.,0,sql_server,sql compils
 sqlserver.stats.sql_recompilations,gauge,,operation,second,The number of SQL re-compilations per second.,-1,sql_server,sql recompils
 sqlserver.stats.connections,gauge,,connection,,The number of user connections.,0,sql_server,conns
 sqlserver.stats.lock_waits,gauge,,lock,second,The number of times per second that SQL Server is unable to retain a lock right away for a resource.,-1,sql_server,lock waits
-sqlserver.access.page_splits,gauge,,operation,second,The number of page splits per second.,-1,sql_server,page splits
 sqlserver.stats.procs_blocked,gauge,,process,,The number of processes blocked.,-1,sql_server,procs blocked
-sqlserver.buffer.checkpoint_pages,gauge,,page,second,The number of pages flushed to disk per second by a checkpoint or other operation that require all dirty pages to be flushed.,-1,sql_server,checkpoint pages
+sqlserver.stats.auto_param_attempts,gauge,,attempt,,Number of auto-parameterization attempts per second.,-1,sql_server,stats auto param
+sqlserver.stats.failed_auto_param_attempts,gauge,,attempt,,Number of failed auto-parameterization attempts per second.,-1,sql_server,stats failed auto param
+sqlserver.stats.safe_auto_param_attempts,gauge,,attempt,,Number of safe auto-parameterization attempts per second.,0,sql_server,stats safe auto param
+sqlserver.cache.object_counts,gauge,,object,,Number of cache objects in the cache.,0,sql_server,cache obj counts
+sqlserver.cache.pages,gauge,,object,,Number of 8-kilobyte (KB) pages used by cache objects.,0,sql_server,cache pages
+sqlserver.database.backup_restore_throughput,gauge,,XXX,,Read/write throughput for backup and restore operations of a database per second.,0,sql_server,database restore throughput
+sqlserver.database.log_bytes_flushed,gauge,,byte,,Total number of log bytes flushed.,0,sql_server,database log byte flushed
+sqlserver.database.log_flushes,gauge,,flush,,Number of log flushes per second.,0,sql_server,database log flushes
+sqlserver.database.log_flush_wait,gauge,,millisecond,,"Total wait time (in milliseconds) to flush the log. On an Always On secondary database, this value indicates the wait time for log records to be hardened to disk.",-1,sql_server,database log flush wait time
+sqlserver.database.transactions,gauge,,transaction,,Number of transactions started for the SQL Server instance per second.,0,sql_server,database trans
+sqlserver.database.write_transactions,gauge,,transaction,,"Number of transactions that wrote to all databases on the SQL Server instance and committed, in the last second.",0,sql_server,database trans write
+sqlserver.database.state,gauge,,,,"Database state: 0 = Online, 1 = Restoring, 2 = Recovering, 3 = Recovery_Pending, 4 = Suspect, 5 = Emergency, 6 = Offline, 7 = Copying, 10 = Offline_Secondary",0,sql_server,database state
+sqlserver.database.files.size,gauge,,kibibyte,,Current size of the database file,0,sql_server,database file size
+sqlserver.database.files.status,gauge,,,,"Database state: 0 = Online, 1 = Restoring, 2 = Recovering, 3 = Recovery_Pending, 4 = Suspect, 5 = Unknown, 6 = Offline, 7 = Defunct",0,sql_server,database file status
+sqlserver.database.active_transactions,gauge,,transaction,,Number of active transactions across all databases on the SQL Server instance.,0,sql_server,database trans active
+sqlserver.memory.memory_grants_pending,gauge,,,,Specifies the total number of processes waiting for a workspace memory grant,0,sql_server,memory grant pending
+sqlserver.memory.total_server_memory,gauge,,kibibyte,,Specifies the amount of memory the server has committed using the memory manager.,0,sql_server,memory total
 sqlserver.scheduler.current_tasks_count,gauge,,task,,Number of current tasks that are associated with this scheduler.,0,sql_server,task count
 sqlserver.scheduler.current_workers_count,gauge,,worker,,Number of workers that are associated with this scheduler.,0,sql_server,worker count
 sqlserver.scheduler.active_workers_count,gauge,,worker,,"Number of workers that are active. An active worker is never preemptive, must have an associated task, and is either running, runnable, or suspended.",0,sql_server,active worker

--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -16,7 +16,7 @@ sqlserver.stats.failed_auto_param_attempts,gauge,,attempt,,Number of failed auto
 sqlserver.stats.safe_auto_param_attempts,gauge,,attempt,,Number of safe auto-parameterization attempts per second.,0,sql_server,stats safe auto param
 sqlserver.cache.object_counts,gauge,,object,,Number of cache objects in the cache.,0,sql_server,cache obj counts
 sqlserver.cache.pages,gauge,,object,,Number of 8-kilobyte (KB) pages used by cache objects.,0,sql_server,cache pages
-sqlserver.database.backup_restore_throughput,gauge,,XXX,,Read/write throughput for backup and restore operations of a database per second.,0,sql_server,database restore throughput
+sqlserver.database.backup_restore_throughput,gauge,,,,Read/write throughput for backup and restore operations of a database per second.,0,sql_server,database restore throughput
 sqlserver.database.log_bytes_flushed,gauge,,byte,,Total number of log bytes flushed.,0,sql_server,database log byte flushed
 sqlserver.database.log_flushes,gauge,,flush,,Number of log flushes per second.,0,sql_server,database log flushes
 sqlserver.database.log_flush_wait,gauge,,millisecond,,"Total wait time (in milliseconds) to flush the log. On an Always On secondary database, this value indicates the wait time for log records to be hardened to disk.",-1,sql_server,database log flush wait time

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -31,7 +31,8 @@ CHECK_NAME = "sqlserver"
 
 CUSTOM_METRICS = ['sqlserver.clr.execution', 'sqlserver.exec.in_progress']
 EXPECTED_METRICS = (
-    [m[0] for m in SQLServer.PERF_METRICS] + [m[0] for m in SQLServer.TASK_SCHEDULER_METRICS] + CUSTOM_METRICS
+    [m[0] for m in SQLServer.INSTANCE_METRICS + SQLServer.TASK_SCHEDULER_METRICS + SQLServer.DATABASE_METRICS]
+    + CUSTOM_METRICS
 )
 
 INSTANCE_DOCKER = {

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -30,10 +30,9 @@ HERE = get_here()
 CHECK_NAME = "sqlserver"
 
 CUSTOM_METRICS = ['sqlserver.clr.execution', 'sqlserver.exec.in_progress']
-EXPECTED_METRICS = (
-    [m[0] for m in SQLServer.INSTANCE_METRICS + SQLServer.TASK_SCHEDULER_METRICS + SQLServer.DATABASE_METRICS]
-    + CUSTOM_METRICS
-)
+EXPECTED_METRICS = [
+    m[0] for m in SQLServer.INSTANCE_METRICS + SQLServer.TASK_SCHEDULER_METRICS + SQLServer.DATABASE_METRICS
+] + CUSTOM_METRICS
 
 INSTANCE_DOCKER = {
     'host': '{},1433'.format(HOST),

--- a/sqlserver/tests/compose/Dockerfile
+++ b/sqlserver/tests/compose/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+
+EXPOSE 1433
+
+RUN apt-get update && apt-get install -y  \
+	curl \
+	apt-transport-https
+
+RUN mkdir -p /var/opt/mssql/backup
+WORKDIR /var/opt/mssql/backup
+
+RUN curl -L -o AdventureWorks2017.bak https://github.com/Microsoft/sql-server-samples/releases/download/adventureworks/AdventureWorks2017.bak
+
+WORKDIR /
+COPY setup.* /
+COPY entrypoint.sh /
+
+RUN chmod +x setup.sh
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT /bin/bash ./entrypoint.sh

--- a/sqlserver/tests/compose/docker-compose.yaml
+++ b/sqlserver/tests/compose/docker-compose.yaml
@@ -4,7 +4,10 @@ services:
   sqlserver:
     # https://hub.docker.com/_/microsoft-mssql-server
     # https://docs.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker?view=sql-server-linux-2017
-    image: mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+    #image: mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+    build:
+      context: .
+      dockerfile: Dockerfile
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=Password123

--- a/sqlserver/tests/compose/entrypoint.sh
+++ b/sqlserver/tests/compose/entrypoint.sh
@@ -1,0 +1,2 @@
+#start import script in background, then SQL Server
+/setup.sh & /opt/mssql/bin/sqlservr

--- a/sqlserver/tests/compose/setup.sh
+++ b/sqlserver/tests/compose/setup.sh
@@ -1,0 +1,14 @@
+#run the setup script to create the DB
+#do this in a loop because the timing for when the SQL instance is ready is indeterminate
+for i in {1..120};
+do
+    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SA_PASSWORD -d master -i setup.sql
+    if [ $? -eq 0 ]
+    then
+        echo "setup.sql completed"
+        break
+    else
+        echo "not ready yet..."
+        sleep 1
+    fi
+done

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -1,0 +1,6 @@
+-- AdventureWorks databases
+--
+RESTORE DATABASE [AdventureWorks2017] FROM  DISK = N'/var/opt/mssql/backup/AdventureWorks2017.bak' WITH
+FILE = 1,  MOVE N'AdventureWorks2017' TO N'/var/opt/mssql/data/AdventureWorks2017.mdf',
+MOVE N'AdventureWorks2017_log' TO N'/var/opt/mssql/data/AdventureWorks2017_log.ldf',
+REPLACE, NOUNLOAD,  STATS = 2;

--- a/sqlserver/tests/test_sqlserver.py
+++ b/sqlserver/tests/test_sqlserver.py
@@ -177,8 +177,8 @@ def test_custom_metrics_alt_tables(aggregator, init_config_alt_tables, instance_
     # check a second time for io metrics to be processed
     sqlserver_check.check(instance_docker)
 
-    aggregator.assert_metric('sqlserver.io_file_stats.num_of_reads', count=8)
-    aggregator.assert_metric('sqlserver.io_file_stats.num_of_writes', count=8)
+    aggregator.assert_metric('sqlserver.io_file_stats.num_of_reads', count=10)
+    aggregator.assert_metric('sqlserver.io_file_stats.num_of_writes', count=10)
 
 
 @windows_ci

--- a/sqlserver/tests/test_sqlserver.py
+++ b/sqlserver/tests/test_sqlserver.py
@@ -177,8 +177,8 @@ def test_custom_metrics_alt_tables(aggregator, init_config_alt_tables, instance_
     # check a second time for io metrics to be processed
     sqlserver_check.check(instance_docker)
 
-    aggregator.assert_metric('sqlserver.io_file_stats.num_of_reads', count=10)
-    aggregator.assert_metric('sqlserver.io_file_stats.num_of_writes', count=10)
+    aggregator.assert_metric('sqlserver.io_file_stats.num_of_reads')
+    aggregator.assert_metric('sqlserver.io_file_stats.num_of_writes')
 
 
 @windows_ci


### PR DESCRIPTION
Expand support of SQL Server check to additional metrics.

- Expanded metrics from the `sys.dm_os_performance_counters` table, and clarify these are *instance* level metrics, vs *database* specific ones
- New database-specific metrics from the `sys.database_files` and `sys.databases` tables

Additionally enhances the test config to add an example database for better metrics collection. 