### PR TITLE
Adding HTTP wrapper class validator

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
@@ -12,6 +12,7 @@ from .config import config
 from .dashboards import dashboards
 from .dep import dep
 from .eula import eula
+from .http import http
 from .imports import imports
 from .manifest import manifest
 from .metadata import metadata
@@ -29,6 +30,7 @@ ALL_COMMANDS = (
     dashboards,
     dep,
     eula,
+    http,
     legacy_signature,
     imports,
     manifest,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -11,7 +11,7 @@ from ..console import CONTEXT_SETTINGS, echo_info, echo_failure
 # Integrations that are not fully updated to http wrapper class but is owned partially by a different organization
 EXCLUDED_INTEGRATIONS = {
     'kubelet',
-    'openstack'
+    # 'openstack'
 }
 
 REQUEST_LIBRARY_FUNCTIONS = {
@@ -71,8 +71,8 @@ def validate_use_http_wrapper(file, check):
 
             for http_func in REQUEST_LIBRARY_FUNCTIONS:
                 if http_func in line:
-                    echo_failure(f'Check `{http_func}` uses {http_func} on line {num} in {os.path.basename(file)}, '
-                                 f'please use the HTTP wrapper instead')
+                    echo_failure(f'Check \'{check}\' uses \'{http_func}\' on line {num} in \'{os.path.basename(file)}\''
+                                 f', please use the HTTP wrapper instead')
 
     #                 Check hazelcast uses legacy agent signature in check.py on line 14
     return False

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -1,0 +1,23 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import click
+from datadog_checks.dev.tooling.utils import get_valid_integrations, get_check_file
+
+from ..console import echo_failure, echo_success, abort, CONTEXT_SETTINGS, echo_info, echo_debug
+
+
+def validate_import(filepath, check):
+    echo_info(f'filepath: {filepath}')
+    echo_info(f'check name: {check}')
+
+
+@click.command('http', context_settings=CONTEXT_SETTINGS, short_help='Validate usage of http wrapper')
+def http():
+    """Validate all integrations for usage of http wrapper."""
+    echo_info("Validating all integrations for usage of http wrapper...")
+
+    for check_name in sorted(get_valid_integrations()):
+        validate_import(get_check_file(check_name), check_name)
+
+    echo_success(f"ur smart")

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -74,7 +74,6 @@ def validate_use_http_wrapper(file, check):
                     echo_failure(f'Check \'{check}\' uses \'{http_func}\' on line {num} in \'{os.path.basename(file)}\''
                                  f', please use the HTTP wrapper instead')
 
-    #                 Check hazelcast uses legacy agent signature in check.py on line 14
     return False
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -41,7 +41,7 @@ def validate_config_http(file, check):
         has_instance_http = False
         has_init_config_http = False
         with open(file, "r") as f:
-            for num, line in enumerate(f):
+            for _, line in enumerate(f):
                 if 'instances/http' in line:
                     has_instance_http = True
                 if 'init_config/http' in line:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -4,8 +4,7 @@
 import os
 
 import click
-from datadog_checks.dev.tooling.utils import get_valid_integrations, get_check_files, get_config_spec, \
-    get_default_config_spec
+from datadog_checks.dev.tooling.utils import get_valid_integrations, get_check_files, get_default_config_spec
 
 from ..console import CONTEXT_SETTINGS, echo_info, echo_failure
 
@@ -72,8 +71,10 @@ def validate_use_http_wrapper(file, check):
 
             for http_func in REQUEST_LIBRARY_FUNCTIONS:
                 if http_func in line:
-                    echo_failure(f'Detected `{http_func}` on line {num} in {check}\'s {file}, '
-                                 f'please make sure to use http wrapper class instead of request library')
+                    echo_failure(f'Check `{http_func}` uses {http_func} on line {num} in {os.path.basename(file)}, '
+                                 f'please use the HTTP wrapper instead')
+
+    #                 Check hazelcast uses legacy agent signature in check.py on line 14
     return False
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -23,7 +23,7 @@ def validate_config_http(file, check):
     if os.path.isfile(file):
         with open(file, "r") as f:
             if 'instances/http' not in f.read():
-                echo_warning(f'{check}\'s spec.yaml file does not contain `instances/http` '
+                echo_warning(f'Detected {check}\'s spec.yaml file does not contain `instances/http` '
                              f'but {check} uses http wrapper')
 
     return config_valid

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -4,15 +4,13 @@
 import os
 
 import click
-from datadog_checks.dev.tooling.utils import get_valid_integrations, get_check_files, get_default_config_spec
 
-from ..console import CONTEXT_SETTINGS, echo_info, echo_failure, abort, echo_success
+from datadog_checks.dev.tooling.utils import get_check_files, get_default_config_spec, get_valid_integrations
+
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
 
 # Integrations that are not fully updated to http wrapper class but is owned partially by a different organization
-EXCLUDED_INTEGRATIONS = {
-    'kubelet',
-    'openstack'
-}
+EXCLUDED_INTEGRATIONS = {'kubelet', 'openstack'}
 
 REQUEST_LIBRARY_FUNCTIONS = {
     'requests.get',
@@ -20,13 +18,10 @@ REQUEST_LIBRARY_FUNCTIONS = {
     'requests.head',
     'requests.put',
     'requests.patch',
-    'requests.delete'
+    'requests.delete',
 }
 
-SPEC_CONFIG_HTTP = {
-    'instances/http',
-    'init_config/http'
-}
+SPEC_CONFIG_HTTP = {'instances/http', 'init_config/http'}
 
 
 def validate_config_http(file, check):
@@ -52,15 +47,13 @@ def validate_config_http(file, check):
 
     if not has_instance_http:
         echo_failure(
-            f"Detected {check}'s spec.yaml file does not contain `instances/http` "
-            f"but {check} uses http wrapper"
+            f"Detected {check}'s spec.yaml file does not contain `instances/http` " f"but {check} uses http wrapper"
         )
         has_failed = True
 
     if not has_init_config_http:
         echo_failure(
-            f"Detected {check}'s spec.yaml file does not contain `init_config/http` "
-            f"but {check} uses http wrapper"
+            f"Detected {check}'s spec.yaml file does not contain `init_config/http` " f"but {check} uses http wrapper"
         )
         has_failed = True
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -2,14 +2,26 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import click
-from datadog_checks.dev.tooling.utils import get_valid_integrations, get_check_file
+from datadog_checks.dev.tooling.utils import get_valid_integrations, get_check_files
 
-from ..console import echo_failure, echo_success, abort, CONTEXT_SETTINGS, echo_info, echo_debug
+from ..console import echo_success, abort, CONTEXT_SETTINGS, echo_info, echo_debug, echo_warning, echo_failure
+
+REQUEST_LIBRARY_FUNCTIONS = {
+    'request.get',
+    'request.post',
+    'request.head',
+    'request.put',
+    'request.patch',
+    'request.delete'
+}
 
 
-def validate_import(filepath, check):
-    echo_info(f'filepath: {filepath}')
-    echo_info(f'check name: {check}')
+def validate_use_http_wrapper(file, check):
+    for http_func in REQUEST_LIBRARY_FUNCTIONS:
+        with open(file, "r") as f:
+            if http_func in f.read():
+                echo_warning(f'Detected {http_func} in {check}\' {file}, '
+                             f'please make sure to use http wrapper class instead of request library')
 
 
 @click.command('http', context_settings=CONTEXT_SETTINGS, short_help='Validate usage of http wrapper')
@@ -17,7 +29,12 @@ def http():
     """Validate all integrations for usage of http wrapper."""
     echo_info("Validating all integrations for usage of http wrapper...")
 
-    for check_name in sorted(get_valid_integrations()):
-        validate_import(get_check_file(check_name), check_name)
+    validate_use_http_wrapper('/Users/andrew.zhang/integrations-core/aerospike/datadog_checks/aerospike/aerospike.py',
+                              'aerospike')
+
+    # for check_name in sorted(get_valid_integrations()):
+        # for file in get_check_files(check_name, include_tests=False):
+        #     validate_use_http_wrapper(file, check_name)
+        # also validate if config has http
 
     echo_success(f"ur smart")

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -11,7 +11,7 @@ from ..console import CONTEXT_SETTINGS, echo_info, echo_failure, abort, echo_suc
 # Integrations that are not fully updated to http wrapper class but is owned partially by a different organization
 EXCLUDED_INTEGRATIONS = {
     'kubelet',
-    # 'openstack'
+    'openstack'
 }
 
 REQUEST_LIBRARY_FUNCTIONS = {
@@ -114,6 +114,7 @@ def validate_use_http_wrapper(check):
 def http():
     """Validate all integrations for usage of http wrapper."""
 
+    has_failed = False
     echo_info("Validating all integrations for usage of http wrapper...")
     for check in sorted(get_valid_integrations()):
         check_uses_http_wrapper = False
@@ -124,6 +125,9 @@ def http():
 
         # Validate use of http template in check's spec.yaml (if exists)
         if check_uses_http_wrapper:
-            validate_config_http(get_default_config_spec(check), check)
+            has_failed = validate_config_http(get_default_config_spec(check), check) or has_failed
+
+    if has_failed:
+        abort()
 
     echo_success('Completed http validation!')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -1,27 +1,47 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import click
-from datadog_checks.dev.tooling.utils import get_valid_integrations, get_check_files
+import os
 
-from ..console import echo_success, abort, CONTEXT_SETTINGS, echo_info, echo_debug, echo_warning, echo_failure
+import click
+from datadog_checks.dev.tooling.utils import get_valid_integrations, get_check_files, get_config_spec
+
+from ..console import CONTEXT_SETTINGS, echo_info, echo_warning
 
 REQUEST_LIBRARY_FUNCTIONS = {
-    'request.get',
-    'request.post',
-    'request.head',
-    'request.put',
-    'request.patch',
-    'request.delete'
+    'requests.get',
+    'requests.post',
+    'requests.head',
+    'requests.put',
+    'requests.patch',
+    'requests.delete'
 }
 
 
-def validate_use_http_wrapper(file, check):
-    for http_func in REQUEST_LIBRARY_FUNCTIONS:
+def validate_config_http(file, check):
+    config_valid = True
+    if os.path.isfile(file):
         with open(file, "r") as f:
-            if http_func in f.read():
-                echo_warning(f'Detected {http_func} in {check}\' {file}, '
-                             f'please make sure to use http wrapper class instead of request library')
+            if 'instances/http' not in f.read():
+                echo_warning(f'{check}\'s spec.yaml file does not contain `instances/http` '
+                             f'but {check} uses http wrapper')
+
+    return config_valid
+
+
+def validate_use_http_wrapper(file, check):
+    uses_http_wrapper = False
+
+    with open(file, "r") as f:
+        for num, line in enumerate(f):
+            if 'self.http' in line:
+                uses_http_wrapper = True
+
+            for http_func in REQUEST_LIBRARY_FUNCTIONS:
+                if http_func in line:
+                    echo_warning(f'Detected `{http_func}` on line {num} in {check}\'s {file}, '
+                                 f'please make sure to use http wrapper class instead of request library')
+    return uses_http_wrapper
 
 
 @click.command('http', context_settings=CONTEXT_SETTINGS, short_help='Validate usage of http wrapper')
@@ -29,12 +49,14 @@ def http():
     """Validate all integrations for usage of http wrapper."""
     echo_info("Validating all integrations for usage of http wrapper...")
 
-    validate_use_http_wrapper('/Users/andrew.zhang/integrations-core/aerospike/datadog_checks/aerospike/aerospike.py',
-                              'aerospike')
+    for check in sorted(get_valid_integrations()):
+        uses_http_wrapper = False
+        # validate use of http wrapper (self.http.[...]) in check's .py files
+        for file in get_check_files(check, include_tests=False):
+            uses_http_wrapper = validate_use_http_wrapper(file, check)
 
-    # for check_name in sorted(get_valid_integrations()):
-        # for file in get_check_files(check_name, include_tests=False):
-        #     validate_use_http_wrapper(file, check_name)
-        # also validate if config has http
+        # validate use of `instances/http` in check's config files
+        if uses_http_wrapper:
+            validate_config_http(get_config_spec(check), check)
 
-    echo_success(f"ur smart")
+    echo_info('Completed http validation!')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -4,9 +4,16 @@
 import os
 
 import click
-from datadog_checks.dev.tooling.utils import get_valid_integrations, get_check_files, get_config_spec
+from datadog_checks.dev.tooling.utils import get_valid_integrations, get_check_files, get_config_spec, \
+    get_default_config_spec
 
-from ..console import CONTEXT_SETTINGS, echo_info, echo_warning
+from ..console import CONTEXT_SETTINGS, echo_info, echo_failure
+
+# Integrations that are not fully updated to http wrapper class but is owned partially by a different organization
+EXCLUDED_INTEGRATIONS = {
+    'kubelet',
+    'openstack'
+}
 
 REQUEST_LIBRARY_FUNCTIONS = {
     'requests.get',
@@ -17,31 +24,57 @@ REQUEST_LIBRARY_FUNCTIONS = {
     'requests.delete'
 }
 
+SPEC_CONFIG_HTTP = {
+    'instances/http',
+    'init_config/http'
+}
+
 
 def validate_config_http(file, check):
-    config_valid = True
-    if os.path.isfile(file):
-        with open(file, "r") as f:
-            if 'instances/http' not in f.read():
-                echo_warning(f'Detected {check}\'s spec.yaml file does not contain `instances/http` '
-                             f'but {check} uses http wrapper')
+    """Determines if integration with http wrapper class
+    uses the http template in its spec.yaml file.
 
-    return config_valid
+    file -- filepath of file to validate
+    check -- name of the check that file belongs to
+    """
+
+    if os.path.exists(file):
+        has_instance_http = False
+        has_init_config_http = False
+        with open(file, "r") as f:
+            for num, line in enumerate(f):
+                if 'instances/http' in line:
+                    has_instance_http = True
+                if 'init_config/http' in line:
+                    has_init_config_http = True
+
+        if not has_instance_http:
+            echo_failure(f'Detected {check}\'s spec.yaml file does not contain `instances/http` '
+                         f'but {check} uses http wrapper')
+
+        if not has_init_config_http:
+            echo_failure(f'Detected {check}\'s spec.yaml file does not contain `init_config/http` '
+                         f'but {check} uses http wrapper')
 
 
 def validate_use_http_wrapper(file, check):
-    uses_http_wrapper = False
+    """Return true if the file uses the http wrapper class.
+    Otherwise outputs every instance of request library function use
+
+    file -- filepath of file to validate
+    check -- name of the check that file belongs to
+    """
 
     with open(file, "r") as f:
         for num, line in enumerate(f):
             if 'self.http' in line:
-                uses_http_wrapper = True
+                return True
 
             for http_func in REQUEST_LIBRARY_FUNCTIONS:
                 if http_func in line:
-                    echo_warning(f'Detected `{http_func}` on line {num} in {check}\'s {file}, '
+                    echo_failure(f'Detected `{http_func}` on line {num} in {check}\'s {file}, '
                                  f'please make sure to use http wrapper class instead of request library')
-    return uses_http_wrapper
+    return False
 
 
 @click.command('http', context_settings=CONTEXT_SETTINGS, short_help='Validate usage of http wrapper')
@@ -51,12 +84,13 @@ def http():
 
     for check in sorted(get_valid_integrations()):
         uses_http_wrapper = False
-        # validate use of http wrapper (self.http.[...]) in check's .py files
-        for file in get_check_files(check, include_tests=False):
-            uses_http_wrapper = validate_use_http_wrapper(file, check)
+        # Validate use of http wrapper (self.http.[...]) in check's .py files
+        if check not in EXCLUDED_INTEGRATIONS:
+            for file in get_check_files(check, include_tests=False):
+                uses_http_wrapper = validate_use_http_wrapper(file, check)
 
-        # validate use of `instances/http` in check's config files
+        # Validate use of http template in check's spec.yaml (if exists)
         if uses_http_wrapper:
-            validate_config_http(get_config_spec(check), check)
+            validate_config_http(get_default_config_spec(check), check)
 
     echo_info('Completed http validation!')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -11,7 +11,7 @@ from ..console import CONTEXT_SETTINGS, echo_info, echo_failure
 # Integrations that are not fully updated to http wrapper class but is owned partially by a different organization
 EXCLUDED_INTEGRATIONS = {
     'kubelet',
-    # 'openstack'
+    'openstack'
 }
 
 REQUEST_LIBRARY_FUNCTIONS = {

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -47,13 +47,13 @@ def validate_config_http(file, check):
 
     if not has_instance_http:
         echo_failure(
-            f"Detected {check}'s spec.yaml file does not contain `instances/http` " f"but {check} uses http wrapper"
+            f"Detected {check}'s spec.yaml file does not contain `instances/http` but {check} uses http wrapper"
         )
         has_failed = True
 
     if not has_init_config_http:
         echo_failure(
-            f"Detected {check}'s spec.yaml file does not contain `init_config/http` " f"but {check} uses http wrapper"
+            f"Detected {check}'s spec.yaml file does not contain `init_config/http` but {check} uses http wrapper"
         )
         has_failed = True
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -370,7 +370,7 @@ def get_check_files(check_name, file_suffix='.py', abs_file_path=True, include_t
     """
     base_dirs = ['datadog_checks']
     if include_tests:
-        base_dirs += 'tests'
+        base_dirs.append('tests')
     if include_dirs is not None:
         base_dirs += include_dirs
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -362,13 +362,15 @@ def get_config_files(check_name):
     return sorted(files)
 
 
-def get_check_files(check_name, file_suffix='.py', abs_file_path=True, include_dirs=None):
+def get_check_files(check_name, file_suffix='.py', abs_file_path=True, include_tests=True, include_dirs=None):
     """Return generator of filenames from within a given check.
 
     By default, only includes files within 'datadog_checks' and 'tests' directories, this
-    can be expanded by adding to the `include_dirs` arg.
+    can be expanded by adding to the `include_dirs` arg. 'tests' can also be removed.
     """
-    base_dirs = ['datadog_checks', 'tests']
+    base_dirs = ['datadog_checks']
+    if include_tests:
+        base_dirs += 'tests'
     if include_dirs is not None:
         base_dirs += include_dirs
 


### PR DESCRIPTION
### What does this PR do?
Adding a validator that checks the following:
- if using the requests library instead of HTTP wrapper library. 
- if using HTTP wrapper library for the integration, then the config spec uses the `instances/http` template. 

The validator outputs a warning if any of the two cases above fail.

Can be executed using `ddev validate http`
Example output: 
![image](https://user-images.githubusercontent.com/31313038/94483437-dc794280-01a8-11eb-9263-172dd258efb3.png)


### Motivation
The team has updated to use http wrapper instead of requests library, and future integrations should adhere to the standard.
### Additional Notes
In the original ticket, the second case should be "if using http wrapper, http specs are included in the config spec", however I felt that it would be more efficient to just check for the http template in the `spec.yaml` file. 

Also, I added an optional parameter to `get_check_files()` in `util.py` to skip test files from being included in the generator instead of creating a new function to just get the non-test check files.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
