### PR TITLE
Incorrect syntax of host in INSTANCE_CONFIG

### DIFF
--- a/mongo/README.md
+++ b/mongo/README.md
@@ -145,7 +145,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][8]
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `mongo`                                                                                                                                   |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                                                                             |
-| `<INSTANCE_CONFIG>`  | `{"hosts": ["%%hosts%%:%%port%%], "username": "datadog", "password : "<UNIQUEPASSWORD>", "database": "<DATABASE>", "replica_check": true}` |
+| `<INSTANCE_CONFIG>`  | `{"host": ["%%hosts%%:%%port%%"], "username": "datadog", "password : "<UNIQUEPASSWORD>", "database": "<DATABASE>", "replica_check": true}` |
 
 ##### Trace collection
 


### PR DESCRIPTION
Fixing the syntax according to the sample in this link : https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixing the incorrect syntax of host in INSTANCE_CONFIG

### Motivation
<!-- What inspired you to submit this pull request? -->
The customer reported this issue

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
