### PR TITLE
adding instances/openmetrics and init_config/openmetrics for http template check

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -21,8 +21,6 @@ REQUEST_LIBRARY_FUNCTIONS = {
     'requests.delete',
 }
 
-SPEC_CONFIG_HTTP = {'instances/http', 'init_config/http'}
-
 
 def validate_config_http(file, check):
     """Determines if integration with http wrapper class
@@ -40,9 +38,9 @@ def validate_config_http(file, check):
     has_failed = False
     with open(file, 'r', encoding='utf-8') as f:
         for _, line in enumerate(f):
-            if 'instances/http' in line:
+            if 'instances/http' or 'instances/openmetrics' in line:
                 has_instance_http = True
-            if 'init_config/http' in line:
+            if 'init_config/http' or 'init_config/openmetrics' in line:
                 has_init_config_http = True
 
     if not has_instance_http:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Including instances/openmetrics and init_config/openmetrics to check for when checking for http template in spec.yaml files.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
Not sure if I should try for a more optimized way of checking for the http template if new templates with http are added?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
