### PR TITLE
Add OAuth authentication option and use new connection on check run

### DIFF
--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -82,6 +82,15 @@ files:
         description: Token used for OAuth connection to Snowflake.
         value:
           type: string
+      - name: client_session_keep_alive
+        description: |
+          If set to true, Snowflake keeps the session active indefinitely as long as the connection is active,
+          even if there is no activity from the user.
+
+          By default, the connection will need to be renewed after four hours of inactivity.
+        value:
+          type: boolean
+          example: false
       - name: metric_groups
         description: |
           List Snowflake metric groups to collect. Metric groups are determined by the metric prefixes.

--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -71,6 +71,17 @@ files:
         value:
           type: string
           example: <OCSP_RESPONSE_CACHE_FILENAME>
+      - name: authenticator
+        description: |
+          Authenticator for Snowflake. The default `snowflake` uses the internal Snowflake authenticator.
+          Use `oauth` to authenticate with OAuth, be sure to set the `token` option as well.
+        value:
+          type: string
+          default: snowflake
+      - name: token
+        description: Token used for OAuth connection to Snowflake.
+        value:
+          type: string
       - name: metric_groups
         description: |
           List Snowflake metric groups to collect. Metric groups are determined by the metric prefixes.

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -116,6 +116,7 @@ class SnowflakeCheck(AgentCheck):
                 ocsp_response_cache_filename=self.config.ocsp_response_cache_filename,
                 authenticator=self.config.authenticator,
                 token=self.config.token,
+                client_session_keep_alive=self.config.client_keep_alive,
             )
         except Exception as e:
             msg = "Unable to connect to Snowflake: {}".format(e)

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -86,7 +86,19 @@ class SnowflakeCheck(AgentCheck):
             return cursor.fetchall()
 
     def connect(self):
-        self.log.debug("Establishing a new connection to Snowflake.")
+        self.log.debug(
+            "Establishing a new connection to Snowflake: account=%s, user=%s, database=%s, schema=%s, warehouse=%s, "
+            "role=%s, login_timeout=%s, authenticator=%s, ocsp_response_cache_filename=%s",
+            self.config.account,
+            self.config.user,
+            self.config.database,
+            self.config.schema,
+            self.config.warehouse,
+            self.config.role,
+            self.config.login_timeout,
+            self.config.authenticator,
+            self.config.ocsp_response_cache_filename,
+        )
 
         try:
             conn = sf.connect(
@@ -104,7 +116,6 @@ class SnowflakeCheck(AgentCheck):
                 ocsp_response_cache_filename=self.config.ocsp_response_cache_filename,
                 authenticator=self.config.authenticator,
                 token=self.config.token,
-                client_session_keep_alive=True,
             )
         except Exception as e:
             msg = "Unable to connect to Snowflake: {}".format(e)
@@ -113,7 +124,6 @@ class SnowflakeCheck(AgentCheck):
         else:
             self.service_check(self.SERVICE_CHECK_CONNECT, self.OK, tags=self._tags)
             self._conn = conn
-
 
     @AgentCheck.metadata_entrypoint
     def _collect_version(self):

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -103,6 +103,8 @@ class SnowflakeCheck(AgentCheck):
                 client_prefetch_threads=self.config.client_prefetch_threads,
                 login_timeout=self.config.login_timeout,
                 ocsp_response_cache_filename=self.config.ocsp_response_cache_filename,
+                authenticator=self.config.authenticator,
+                token=self.config.token,
             )
         except Exception as e:
             msg = "Unable to connect to Snowflake: {}".format(e)

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -64,13 +64,14 @@ class SnowflakeCheck(AgentCheck):
     def check(self, _):
         self.connect()
 
-        # Execute queries
-        self._query_manager.execute()
+        if self._conn is not None:
+            # Execute queries
+            self._query_manager.execute()
 
-        self._collect_version()
+            self._collect_version()
 
-        self.log.debug("Closing connection to Snowflake...")
-        self._conn.close()
+            self.log.debug("Closing connection to Snowflake...")
+            self._conn.close()
 
     def execute_query_raw(self, query):
         """
@@ -85,7 +86,6 @@ class SnowflakeCheck(AgentCheck):
             return cursor.fetchall()
 
     def connect(self):
-
         self.log.debug("Establishing a new connection to Snowflake.")
 
         try:
@@ -109,6 +109,7 @@ class SnowflakeCheck(AgentCheck):
         except Exception as e:
             msg = "Unable to connect to Snowflake: {}".format(e)
             self.service_check(self.SERVICE_CHECK_CONNECT, self.CRITICAL, message=msg, tags=self._tags)
+            self.warning(msg)
         else:
             self.service_check(self.SERVICE_CHECK_CONNECT, self.OK, tags=self._tags)
             self._conn = conn

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -59,7 +59,7 @@ class Config(object):
             raise ConfigurationError('MFA enabled, please specify a passcode')
 
         if authenticator not in self.AUTHENTICATION_MODES:
-            raise ConfigurationError('The Authenticator method set is invalid: %s'.format(authenticator))
+            raise ConfigurationError('The Authenticator method set is invalid: {}'.format(authenticator))
 
         if authenticator == 'oauth' and token is None:
             raise ConfigurationError('If using OAuth, you must specify a token')

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -40,6 +40,7 @@ class Config(object):
         tags = instance.get('tags', [])
         authenticator = instance.get('authenticator', 'snowflake')
         token = instance.get('token', None)
+        client_keep_alive = instance.get('client_session_keep_alive', False)
 
         # min_collection_interval defaults to 60 minutes
         min_collection = instance.get('min_collection_interval', 3600)
@@ -81,3 +82,4 @@ class Config(object):
         self.metric_groups = metric_groups
         self.authenticator = authenticator
         self.token = token
+        self.client_keep_alive = client_keep_alive

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -19,6 +19,8 @@ class Config(object):
         'snowflake.logins',
     ]
 
+    AUTHENTICATION_MODES = ['snowflake', 'oauth']
+
     def __init__(self, instance=None):
         if instance is None:
             instance = {}
@@ -36,6 +38,8 @@ class Config(object):
         login_timeout = instance.get('login_timeout', 60)
         ocsp_response_cache_filename = instance.get('ocsp_response_cache_filename')
         tags = instance.get('tags', [])
+        authenticator = instance.get('authenticator', 'snowflake')
+        token = instance.get('token', None)
 
         # min_collection_interval defaults to 60 minutes
         min_collection = instance.get('min_collection_interval', 3600)
@@ -54,6 +58,12 @@ class Config(object):
         if is_affirmative(passcode_in_password) and passcode is None:
             raise ConfigurationError('MFA enabled, please specify a passcode')
 
+        if authenticator not in self.AUTHENTICATION_MODES:
+            raise ConfigurationError('The Authenticator method set is invalid: %s'.format(authenticator))
+
+        if authenticator == 'oauth' and token is None:
+            raise ConfigurationError('If using OAuth, you must specify a token')
+
         self.account = account  # type: str
         self.user = user  # type: str
         self.password = password  # type: str
@@ -69,3 +79,5 @@ class Config(object):
         self.tags = tags  # type: List[str]
         self.min_collection = min_collection
         self.metric_groups = metric_groups
+        self.authenticator = authenticator
+        self.token = token

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -91,6 +91,14 @@ instances:
     #
     # token: <TOKEN>
 
+    ## @param client_session_keep_alive - boolean - optional - default: false
+    ## If set to true, Snowflake keeps the session active indefinitely as long as the connection is active,
+    ## even if there is no activity from the user.
+    ##
+    ## By default, the connection will need to be renewed after four hours of inactivity.
+    #
+    # client_session_keep_alive: false
+
     ## @param metric_groups - list of strings - optional
     ## List Snowflake metric groups to collect. Metric groups are determined by the metric prefixes.
     ##

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -80,6 +80,17 @@ instances:
     #
     # ocsp_response_cache_filename: <OCSP_RESPONSE_CACHE_FILENAME>
 
+    ## @param authenticator - string - optional - default: snowflake
+    ## Authenticator for Snowflake. The default `snowflake` uses the internal Snowflake authenticator.
+    ## Use `oauth` to authenticate with OAuth, be sure to set the `token` option as well.
+    #
+    # authenticator: <AUTHENTICATOR>
+
+    ## @param token - string - optional
+    ## Token used for OAuth connection to Snowflake.
+    #
+    # token: <TOKEN>
+
     ## @param metric_groups - list of strings - optional
     ## List Snowflake metric groups to collect. Metric groups are determined by the metric prefixes.
     ##

--- a/snowflake/tests/test_unit.py
+++ b/snowflake/tests/test_unit.py
@@ -32,7 +32,7 @@ def test_default_authentication(instance):
     assert check.config.authenticator == 'snowflake'
 
 
-def test_oauth_authentication(instance):
+def test_invalid_auth(instance):
     # Test oauth
     oauth_inst = copy.deepcopy(instance)
     oauth_inst['authenticator'] = 'oauth'
@@ -42,6 +42,62 @@ def test_oauth_authentication(instance):
     oauth_inst['authenticator'] = 'testauth'
     with pytest.raises(Exception, match='The Authenticator method set is invalid: testauth'):
         SnowflakeCheck(CHECK_NAME, {}, [oauth_inst])
+
+
+def test_default_auth(instance):
+    check = SnowflakeCheck(CHECK_NAME, {}, [instance])
+    check._conn = mock.MagicMock()
+    check._query_manager = mock.MagicMock()
+
+    with mock.patch('datadog_checks.snowflake.check.sf') as sf:
+        check.check(instance)
+        sf.connect.assert_called_with(
+            user='testuser',
+            password='pass',
+            account='test_acct.us-central1.gcp',
+            database='SNOWFLAKE',
+            schema='ACCOUNT_USAGE',
+            warehouse=None,
+            role='ACCOUNTADMIN',
+            passcode_in_password=False,
+            passcode=None,
+            client_prefetch_threads=4,
+            login_timeout=60,
+            ocsp_response_cache_filename=None,
+            authenticator='snowflake',
+            token=None,
+            client_session_keep_alive=False,
+        )
+
+
+def test_oauth_auth(instance):
+    # Test oauth
+    oauth_inst = copy.deepcopy(instance)
+    oauth_inst['authenticator'] = 'oauth'
+    oauth_inst['token'] = 'testtoken'
+
+    with mock.patch('datadog_checks.snowflake.check.sf') as sf:
+        check = SnowflakeCheck(CHECK_NAME, {}, [oauth_inst])
+        check._conn = mock.MagicMock()
+        check._query_manager = mock.MagicMock()
+        check.check(oauth_inst)
+        sf.connect.assert_called_with(
+            user='testuser',
+            password='pass',
+            account='test_acct.us-central1.gcp',
+            database='SNOWFLAKE',
+            schema='ACCOUNT_USAGE',
+            warehouse=None,
+            role='ACCOUNTADMIN',
+            passcode_in_password=False,
+            passcode=None,
+            client_prefetch_threads=4,
+            login_timeout=60,
+            ocsp_response_cache_filename=None,
+            authenticator='oauth',
+            token='testtoken',
+            client_session_keep_alive=False,
+        )
 
 
 def test_default_metric_groups(instance):

--- a/snowflake/tests/test_unit.py
+++ b/snowflake/tests/test_unit.py
@@ -26,6 +26,24 @@ def test_config():
         SnowflakeCheck(CHECK_NAME, {}, [account_config])
 
 
+def test_default_authentication(instance):
+    # Test default auth
+    check = SnowflakeCheck(CHECK_NAME, {}, [instance])
+    assert check.config.authenticator == 'snowflake'
+
+
+def test_oauth_authentication(instance):
+    # Test oauth
+    oauth_inst = copy.deepcopy(instance)
+    oauth_inst['authenticator'] = 'oauth'
+    with pytest.raises(Exception, match='If using OAuth, you must specify a token'):
+        SnowflakeCheck(CHECK_NAME, {}, [oauth_inst])
+
+    oauth_inst['authenticator'] = 'testauth'
+    with pytest.raises(Exception, match='The Authenticator method set is invalid: testauth'):
+        SnowflakeCheck(CHECK_NAME, {}, [oauth_inst])
+
+
 def test_default_metric_groups(instance):
     check = SnowflakeCheck(CHECK_NAME, {}, [instance])
     assert check.config.metric_groups == [


### PR DESCRIPTION
### What does this PR do?
This PR adds OAuth as per beta user feedback.

This PR also fixes connection issue because the snowflake python connector's connection must be explicitly closed. see `snowflakedb/snowflake-connector-python/issues/42`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
