### PR TITLE
Update conf.yaml.example - wrong file name

### DIFF
--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -144,7 +144,7 @@ init_config:
   #   isilon:
   #     definition_file: isilon.yaml
   #   apc-ups:
-  #     definition_file: apc-ups.yaml
+  #     definition_file: apc_ups.yaml
   #   fortinet-fortigate:
   #     definition_file: fortinet-fortigate.yaml
   #   netapp:

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -143,7 +143,7 @@ init_config:
   #     definition_file: checkpoint-firewall.yaml
   #   isilon:
   #     definition_file: isilon.yaml
-  #   apc-ups:
+  #   apc_ups:
   #     definition_file: apc_ups.yaml
   #   fortinet-fortigate:
   #     definition_file: fortinet-fortigate.yaml


### PR DESCRIPTION
APC-UPS was referencing the wrong definition file under the profiles dir.
This should be apc_ups.yaml
as per:
https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/profiles/apc_ups.yaml

### What does this PR do?
Changes conf.yaml.example file with correct apcups file definition.

### Motivation
Picked up whilst investigating other snmp config issues for a customer.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
