### PR TITLE
Fix missing tags from tag_by

### DIFF
--- a/wmi_check/datadog_checks/wmi_check/wmi_check.py
+++ b/wmi_check/datadog_checks/wmi_check/wmi_check.py
@@ -37,7 +37,7 @@ class WMICheck(WinWMICheck):
         # Create or retrieve an existing WMISampler
         metric_name_and_type_by_property, properties = self.get_wmi_properties()
 
-        wmi_sampler = self.get_running_wmi_sampler(properties, self.filters)
+        wmi_sampler = self.get_running_wmi_sampler(properties, self.filters, tag_by=self.tag_by)
 
         # Sample, extract & submit metrics
         try:

--- a/wmi_check/tests/test_wmi_check.py
+++ b/wmi_check/tests/test_wmi_check.py
@@ -67,3 +67,11 @@ def test_check(mock_disk_sampler, aggregator, check):
         aggregator.assert_metric(mname, tags=["foobar"], count=1)
 
     aggregator.assert_all_metrics_covered()
+
+def test_tag_by_is_correctly_requested(mock_proc_sampler, aggregator, check):
+    instance = copy.deepcopy(common.INSTANCE)
+    instance['tag_by'] = 'Name'
+    c = check(instance)
+    c.check(instance)
+    get_running_wmi_sampler = datadog_checks.wmi_check.WMICheck._get_running_wmi_sampler
+    assert get_running_wmi_sampler.call_args.kwargs['tag_by'] == 'Name'

--- a/wmi_check/tests/test_wmi_check.py
+++ b/wmi_check/tests/test_wmi_check.py
@@ -73,5 +73,5 @@ def test_tag_by_is_correctly_requested(mock_proc_sampler, aggregator, check):
     instance['tag_by'] = 'Name'
     c = check(instance)
     c.check(instance)
-    get_running_wmi_sampler = datadog_checks.wmi_check.WMICheck._get_running_wmi_sampler
+    get_running_wmi_sampler = c._get_running_wmi_sampler
     assert get_running_wmi_sampler.call_args.kwargs['tag_by'] == 'Name'

--- a/wmi_check/tests/test_wmi_check.py
+++ b/wmi_check/tests/test_wmi_check.py
@@ -68,6 +68,7 @@ def test_check(mock_disk_sampler, aggregator, check):
 
     aggregator.assert_all_metrics_covered()
 
+
 def test_tag_by_is_correctly_requested(mock_proc_sampler, aggregator, check):
     instance = copy.deepcopy(common.INSTANCE)
     instance['tag_by'] = 'Name'


### PR DESCRIPTION
### What does this PR do?
Fix missing tags from `tag_by`

Used to be passed to `self._get_running_wmi_sampler` but has changed in 
https://github.com/DataDog/integrations-core/pull/6325/files#diff-5616a77c5830301f9247aa423b0158edL59

### Motivation
AGENT-5007
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
