### PR TITLE
Add lighttpd logs

### DIFF
--- a/lighttpd/README.md
+++ b/lighttpd/README.md
@@ -53,6 +53,29 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
 
+#### Log collection
+
+1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+
+   ```yaml
+   logs_enabled: true
+   ```
+
+2. Add this configuration block to your `lighttpd.d/conf.yaml` file to start collecting your lighttpd Logs:
+
+   ```yaml
+   logs:
+     - type: file
+       path: /path/to/my/directory/file.log
+       source: lighttpd
+   ```
+
+   Change the `path` parameter value and configure it for your environment.
+   See the [sample lighttpd.d/conf.yaml][4] for all available configuration options.
+
+3. [Restart the Agent][5].
+
+
 ### Validation
 
 [Run the Agent's `status` subcommand][7] and look for `lighttpd` under the Checks section.

--- a/lighttpd/README.md
+++ b/lighttpd/README.md
@@ -66,6 +66,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
    ```yaml
    logs:
      - type: file
+       encoding: utf-16-le
        path: /path/to/my/directory/file.log
        source: lighttpd
    ```

--- a/lighttpd/assets/configuration/spec.yaml
+++ b/lighttpd/assets/configuration/spec.yaml
@@ -16,3 +16,13 @@ files:
         type: string
     - template: instances/http
     - template: instances/default
+  - template: logs
+    example:
+      - type: file
+        path: /var/log/lighttpd/access.log
+        source: lighttpd
+        service: lighttpd
+      - type: file
+        path: /var/log/lighttpd/error.log
+        source: lighttpd
+        service: lighttpd

--- a/lighttpd/assets/configuration/spec.yaml
+++ b/lighttpd/assets/configuration/spec.yaml
@@ -19,6 +19,7 @@ files:
   - template: logs
     example:
       - type: file
+        encoding: utf-16-le
         path: /var/log/lighttpd/access.log
         source: lighttpd
         service: lighttpd

--- a/lighttpd/assets/configuration/spec.yaml
+++ b/lighttpd/assets/configuration/spec.yaml
@@ -23,6 +23,7 @@ files:
         source: lighttpd
         service: lighttpd
       - type: file
+        encoding: utf-16-le
         path: /var/log/lighttpd/error.log
         source: lighttpd
         service: lighttpd

--- a/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
+++ b/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
@@ -328,3 +328,26 @@ instances:
     ## This is useful for cluster-level checks.
     #
     # empty_default_hostname: false
+
+## Log Section
+##
+## type - required - Type of log input source (tcp / udp / file / windows_event)
+## port / path / channel_path - required - Set port if type is tcp or udp.
+##                                         Set path if type is file.
+##                                         Set channel_path if type is windows_event.
+## source  - required - Attribute that defines which Integration sent the logs.
+## service - optional - The name of the service that generates the log.
+##                      Overrides any `service` defined in the `init_config` section.
+## tags - optional - Add tags to the collected logs.
+##
+## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
+#
+# logs:
+#   - type: file
+#     path: /var/log/lighttpd/access.log
+#     source: lighttpd
+#     service: lighttpd
+#   - type: file
+#     path: /var/log/lighttpd/error.log
+#     source: lighttpd
+#     service: lighttpd

--- a/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
+++ b/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
@@ -346,6 +346,7 @@ instances:
 #
 # logs:
 #   - type: file
+#     encoding: utf-16-le
 #     path: /var/log/lighttpd/access.log
 #     source: lighttpd
 #     service: lighttpd

--- a/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
+++ b/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
@@ -336,6 +336,8 @@ instances:
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
 ## source  - required - Attribute that defines which Integration sent the logs.
+## encoding - optional - For file specifies the file encoding, default is utf-8, other
+##                       possible values are utf-16-le and utf-16-be.
 ## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
 ## tags - optional - Add tags to the collected logs.
@@ -348,6 +350,7 @@ instances:
 #     source: lighttpd
 #     service: lighttpd
 #   - type: file
+#     encoding: utf-16-le
 #     path: /var/log/lighttpd/error.log
 #     source: lighttpd
 #     service: lighttpd

--- a/lighttpd/manifest.json
+++ b/lighttpd/manifest.json
@@ -1,7 +1,8 @@
 {
   "categories": [
     "web",
-    "autodiscovery"
+    "autodiscovery",
+    "log collection"
   ],
   "creates_events": false,
   "display_name": "Lighttpd",
@@ -32,7 +33,9 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {},
+    "logs": {
+      "source": "lighttpd"
+    },
     "metrics_metadata": "metadata.csv"
   }
 }

--- a/lighttpd/setup.py
+++ b/lighttpd/setup.py
@@ -1,4 +1,5 @@
 # (C) Datadog, Inc. 2018-present
+# (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from codecs import open
@@ -27,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-lighttpd',

--- a/lighttpd/tests/conftest.py
+++ b/lighttpd/tests/conftest.py
@@ -23,7 +23,7 @@ def wait_for_lighttpd():
 
 @pytest.fixture(scope="session")
 def dd_environment():
-    with docker_run(common.COMPOSE_FILE, conditions=[WaitFor(wait_for_lighttpd)]):
+    with docker_run(common.COMPOSE_FILE, conditions=[WaitFor(wait_for_lighttpd)], mount_logs=True):
         instance = deepcopy(common.INSTANCE)
         yield instance
 

--- a/lighttpd/tests/docker/noauth/docker-compose.yaml
+++ b/lighttpd/tests/docker/noauth/docker-compose.yaml
@@ -7,3 +7,5 @@ services:
       - "9449:9449"
     volumes:
       - ./lighttpd.conf:/etc/lighttpd/lighttpd.conf
+      - ${DD_LOG_1}:/var/log/lighttpd/access.log
+      - ${DD_LOG_2}:/var/log/lighttpd/error.log

--- a/lighttpd/tests/docker/noauth/lighttpd.conf
+++ b/lighttpd/tests/docker/noauth/lighttpd.conf
@@ -5,7 +5,8 @@ server.modules = (
     "mod_compress",
     "mod_redirect",
     "mod_rewrite",
-    "mod_status"
+    "mod_status",
+    "mod_accesslog"
 )
 
 server.document-root           = "/var/www"
@@ -23,3 +24,6 @@ static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
 #include_shell "/usr/share/lighttpd/use-ipv6.pl"
 dir-listing.encoding           = "utf-8"
 server.dir-listing             = "enable"
+
+server.errorlog   = "/var/log/lighttpd/error.log"
+accesslog.filename = "/var/log/lighttpd/access.log"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add support for lighttpd log integration
- [JIRA](https://datadoghq.atlassian.net/browse/AI-743?atlOrigin=eyJpIjoiOTcwNTRlMGZiMjE4NGY3NWI5YTk0Njk4OTViZDI2NzQiLCJwIjoiaiJ9)
- [logs-backend PR](https://github.com/DataDog/logs-backend/pull/12575)
- [web-ui](https://github.com/DataDog/web-ui/pull/21116)
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
