### PR TITLE
Send bytes.in/out.total metrics with legacy check

### DIFF
--- a/haproxy/datadog_checks/haproxy/legacy/const.py
+++ b/haproxy/datadog_checks/haproxy/legacy/const.py
@@ -48,8 +48,8 @@ METRICS = {
     "slim": ("gauge", "session.limit"),
     "spct": ("gauge", "session.pct"),  # Calculated as: (scur/slim)*100
     "stot": ("rate", "session.rate"),
-    "bin": ("rate", "bytes.in_rate"),
-    "bout": ("rate", "bytes.out_rate"),
+    "bin": [("rate", "bytes.in_rate"), ("gauge", "bytes.in.total")],
+    "bout": [("rate", "bytes.out_rate"), ("gauge", "bytes.out.total")],
     "dreq": ("rate", "denied.req_rate"),
     "dresp": ("rate", "denied.resp_rate"),
     "ereq": ("rate", "errors.req_rate"),

--- a/haproxy/tests/legacy/common.py
+++ b/haproxy/tests/legacy/common.py
@@ -118,6 +118,8 @@ FRONTEND_CHECK = [
     ('haproxy.frontend.session.pct', ['1', '0']),
     ('haproxy.frontend.requests.rate', ['1', '4']),
     ('haproxy.frontend.connections.rate', ['1', '7']),
+    ('haproxy.frontend.bytes.in.total', ['1', '0']),
+    ('haproxy.frontend.bytes.out.total', ['1', '0']),
     # rates
     ('haproxy.frontend.bytes.in_rate', ['1', '0']),
     ('haproxy.frontend.bytes.out_rate', ['1', '0']),
@@ -145,6 +147,8 @@ BACKEND_CHECK = [
     ('haproxy.backend.response.time', ['1', '5']),
     ('haproxy.backend.session.time', ['1', '5']),
     ('haproxy.backend.uptime', ['1', '7']),
+    ('haproxy.backend.bytes.in.total', ['1', '0']),
+    ('haproxy.backend.bytes.out.total', ['1', '0']),
     # rates
     ('haproxy.backend.bytes.in_rate', ['1', '0']),
     ('haproxy.backend.bytes.out_rate', ['1', '0']),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Submit `bin` and `bout` information as gauge in addition to submitting those as rate for the legacy haproxy check.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/integrations-core/issues/7691

### Additional Notes
<!-- Anything else we should know when reviewing? -->
These metrics are already sent by the prometheus version of the haproxy check

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
