### PR TITLE
varnish: fix parsing of varnishstat 6.5 JSON output

### DIFF
--- a/varnish/datadog_checks/varnish/varnish.py
+++ b/varnish/datadog_checks/varnish/varnish.py
@@ -225,6 +225,8 @@ class Varnish(AgentCheck):
             p.Parse(output, True)
         elif varnishstat_format == "json":
             json_output = json.loads(output)
+            if "counters" in json_output:
+                json_output = json_output["counters"]
             for name, metric in iteritems(json_output):
                 if not isinstance(metric, dict):  # skip 'timestamp' field
                     continue

--- a/varnish/tests/fixtures/stats_output_json_6.5
+++ b/varnish/tests/fixtures/stats_output_json_6.5
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "timestamp": "2020-10-06T20:43:18",
+  "counters": {
+    "MGT.uptime": {
+      "description": "Management process uptime",
+      "flag": "c",
+      "format": "d",
+      "value": 2544
+    },
+    "MGT.child_start": {
+      "description": "Child process started",
+      "flag": "c",
+      "format": "i",
+      "value": 1
+    },
+    "MGT.child_exit": {
+      "description": "Child process normal exit",
+      "flag": "c",
+      "format": "i",
+      "value": 0
+    }
+  }
+}
+


### PR DESCRIPTION
### What does this PR do?

Fixes parsing of the varnishstat 6.5 JSON output.

### Motivation

The JSON structure returned by `varnishstat -j` changed in version 6.5.
Notably, all counters have been moved under the "counters" key.

https://github.com/varnishcache/varnish-cache/blob/6.5/doc/changes.rst#varnish-cache-650-2020-09-15

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
