### PR TITLE
Re-add empty_default_hostname to configuration by default

### DIFF
--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -9,12 +9,14 @@ files:
     options:
       - name: host
         required: true
+        display_priority: 1
         description: The host used to resolve the vCenter IP. It is either a FQDN or an IP.
         value:
           type: string
           example: <HOSTNAME>
       - name: username
         required: true
+        display_priority: 1
         description: | 
           The username of the read-only credentials to connect to vCenter
           see https://app.datadoghq.com/account/settings#integrations/vsphere
@@ -23,6 +25,7 @@ files:
           example: <USERNAME>
       - name: password 
         required: true
+        display_priority: 1
         description: | 
           The password of the read-only credentials to connect to vCenter.
           see https://app.datadoghq.com/account/settings#integrations/vsphere
@@ -31,6 +34,7 @@ files:
           example: <PASSWORD>
       - name: use_legacy_check_version
         required: true
+        display_priority: 1
         description: | 
           For backward compatibility reasons, it is possible to use a deprecated version of the vSphere 
           integration by setting this field to "true".
@@ -411,4 +415,13 @@ files:
         value:
           type: boolean
           example: true
-      - template: instances/default  
+      - template: instances/default
+        overrides:
+          empty_default_hostname.display_priority: 1
+          empty_default_hostname.required: true
+          empty_default_hostname.value.example: true
+          empty_default_hostname.description: |
+            The vSphere integration is a cluster-level check where metrics are usually unrelated to the host
+            on which the Agent runs. Setting this parameter to true, prevents the Agent from attaching the hostname
+            (and the host tags) to the metrics. It is especially important to leave this parameter to "true" when you are
+            running the agent inside a vSphere VM as the VM tags are going to be unrelated to other metrics.

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -36,6 +36,14 @@ instances:
     #
     use_legacy_check_version: false
 
+    ## @param empty_default_hostname - boolean - required
+    ## The vSphere integration is a cluster-level check where metrics are usually unrelated to the host
+    ## on which the Agent runs. Setting this parameter to true, prevents the Agent from attaching the hostname
+    ## (and the host tags) to the metrics. It is especially important to leave this parameter to "true" when you are
+    ## running the agent inside a vSphere VM as the VM tags are going to be unrelated to other metrics.
+    #
+    empty_default_hostname: true
+
     ## @param collection_level - integer - optional - default: 1
     ## A number between 1 and 4 to specify how many metrics will be sent
     ## 1: Only basic metrics - 4: every metric available.
@@ -348,10 +356,3 @@ instances:
     ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
     #
     # min_collection_interval: 15
-
-    ## @param empty_default_hostname - boolean - optional - default: false
-    ## This forces the check to send metrics with no hostname.
-    ##
-    ## This is useful for cluster-level checks.
-    #
-    # empty_default_hostname: false


### PR DESCRIPTION
The `empty_default_hostname` default config was removed in https://github.com/DataDog/integrations-core/pull/7537

This PR re-adds it at the top of the config file.