### PR TITLE
Clarify password percent-encoding expectations

### DIFF
--- a/pgbouncer/assets/configuration/spec.yaml
+++ b/pgbouncer/assets/configuration/spec.yaml
@@ -8,7 +8,11 @@ files:
   - template: instances
     options:
       - name: database_url
-        description: "`database_url` parameter should point to PgBouncer stats database url"
+        description: |
+          The PgBouncer stats database URL.
+
+          If the password contains special characters, be sure to escape them using
+          URL encoding (also known as percent-encoding).
         required: true
         value:
           example: postgresql://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>/<DATABASE_URL>?sslmode=require
@@ -26,7 +30,11 @@ files:
         value:
           type: string
       - name: password
-        description: If `database_url` is not used, set up the password to use with the `password` parameter.
+        description: |
+          If `database_url` is not used, set up the password to use with the `password` parameter.
+
+          If the password contains special characters, be sure to escape them using
+          URL encoding (also known as percent-encoding).
         value:
           type: string
       - name: use_cached

--- a/pgbouncer/assets/configuration/spec.yaml
+++ b/pgbouncer/assets/configuration/spec.yaml
@@ -11,8 +11,8 @@ files:
         description: |
           The PgBouncer stats database URL.
 
-          If the password contains special characters, be sure to escape them using
-          URL encoding (also known as percent-encoding).
+          If the password contains special characters, be sure to escape them using percent encoding.
+          See: https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding
         required: true
         value:
           example: postgresql://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>/<DATABASE_URL>?sslmode=require
@@ -33,8 +33,8 @@ files:
         description: |
           If `database_url` is not used, set up the password to use with the `password` parameter.
 
-          If the password contains special characters, be sure to escape them using
-          URL encoding (also known as percent-encoding).
+          If the password contains special characters, be sure to escape them using percent encoding.
+          See: https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding
         value:
           type: string
       - name: use_cached

--- a/pgbouncer/assets/configuration/spec.yaml
+++ b/pgbouncer/assets/configuration/spec.yaml
@@ -12,7 +12,8 @@ files:
           The PgBouncer stats database URL.
 
           If the password contains special characters, be sure to escape them using percent encoding.
-          See: https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding
+
+          See: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
         required: true
         value:
           example: postgresql://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>/<DATABASE_URL>?sslmode=require
@@ -34,7 +35,8 @@ files:
           If `database_url` is not used, set up the password to use with the `password` parameter.
 
           If the password contains special characters, be sure to escape them using percent encoding.
-          See: https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding
+
+          See: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
         value:
           type: string
       - name: use_cached

--- a/pgbouncer/datadog_checks/pgbouncer/data/conf.yaml.example
+++ b/pgbouncer/datadog_checks/pgbouncer/data/conf.yaml.example
@@ -14,7 +14,10 @@ init_config:
 instances:
 
     ## @param database_url - string - required
-    ## `database_url` parameter should point to PgBouncer stats database url
+    ## The PgBouncer stats database URL.
+    ##
+    ## If the password contains special characters, be sure to escape them using
+    ## URL encoding (also known as percent-encoding).
     #
   - database_url: postgresql://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>/<DATABASE_URL>?sslmode=require
 
@@ -35,6 +38,9 @@ instances:
 
     ## @param password - string - optional
     ## If `database_url` is not used, set up the password to use with the `password` parameter.
+    ##
+    ## If the password contains special characters, be sure to escape them using
+    ## URL encoding (also known as percent-encoding).
     #
     # password: <PASSWORD>
 

--- a/pgbouncer/datadog_checks/pgbouncer/data/conf.yaml.example
+++ b/pgbouncer/datadog_checks/pgbouncer/data/conf.yaml.example
@@ -16,8 +16,8 @@ instances:
     ## @param database_url - string - required
     ## The PgBouncer stats database URL.
     ##
-    ## If the password contains special characters, be sure to escape them using
-    ## URL encoding (also known as percent-encoding).
+    ## If the password contains special characters, be sure to escape them using percent encoding.
+    ## See: https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding
     #
   - database_url: postgresql://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>/<DATABASE_URL>?sslmode=require
 
@@ -39,8 +39,8 @@ instances:
     ## @param password - string - optional
     ## If `database_url` is not used, set up the password to use with the `password` parameter.
     ##
-    ## If the password contains special characters, be sure to escape them using
-    ## URL encoding (also known as percent-encoding).
+    ## If the password contains special characters, be sure to escape them using percent encoding.
+    ## See: https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding
     #
     # password: <PASSWORD>
 

--- a/pgbouncer/datadog_checks/pgbouncer/data/conf.yaml.example
+++ b/pgbouncer/datadog_checks/pgbouncer/data/conf.yaml.example
@@ -17,7 +17,8 @@ instances:
     ## The PgBouncer stats database URL.
     ##
     ## If the password contains special characters, be sure to escape them using percent encoding.
-    ## See: https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding
+    ##
+    ## See: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
     #
   - database_url: postgresql://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>/<DATABASE_URL>?sslmode=require
 
@@ -40,7 +41,8 @@ instances:
     ## If `database_url` is not used, set up the password to use with the `password` parameter.
     ##
     ## If the password contains special characters, be sure to escape them using percent encoding.
-    ## See: https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding
+    ##
+    ## See: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
     #
     # password: <PASSWORD>
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
In reaction to a support case.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Will log a ticket in our backlog to review and add support for automatically quoting passwords in `password` option, and possibly `database_url` too.

Goal of this PR is solely to clarify _current_ expectations and abilities of the check.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
