### PR TITLE
QueryManager - Prevent queries leaking between check instances

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -46,9 +46,10 @@ class QueryManager(object):
         """
         self.check = check
         self.executor = executor
-        self.queries = queries or []
         self.tags = tags or []
         self.error_handler = error_handler
+        queries = queries or []
+        self.queries = [q.copy() for q in queries]
 
         custom_queries = list(self.check.instance.get('custom_queries', []))
         use_global_custom_queries = self.check.instance.get('use_global_custom_queries', True)

--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -26,6 +26,12 @@ class Query(object):
         self.extras = None
         self.tags = None
 
+    def copy(self):
+        if self.name:
+            # Already compiled, can't be copied
+            raise ValueError("Query is already compiled and can't be copied anymore.")
+        return Query(self.query_data)
+
     def compile(self, column_transformers, extra_transformers):
         """
         This idempotent method will be called by `QueryManager.compile_queries` so you

--- a/oracle/tests/test_metrics.py
+++ b/oracle/tests/test_metrics.py
@@ -17,7 +17,7 @@ def test_sys_metrics(aggregator, check):
     cur.fetchall.return_value = zip([0] * len(metrics.keys()), metrics.keys())
 
     check._connection = con
-    check._query_manager.queries = [queries.SystemMetrics]
+    check._query_manager.queries = [queries.SystemMetrics.copy()]
     check._query_manager.tags = ['custom_tag']
     check._query_manager.compile_queries()
     check._query_manager.execute()
@@ -40,7 +40,7 @@ def test_process_metrics(aggregator, check):
     cur.fetchall.return_value = [[program] + ([0] * len(metrics)) for program in programs]
 
     check._connection = con
-    check._query_manager.queries = [queries.ProcessMetrics]
+    check._query_manager.queries = [queries.ProcessMetrics.copy()]
     check._query_manager.tags = ['custom_tag']
     check._query_manager.compile_queries()
     check._query_manager.execute()
@@ -67,7 +67,7 @@ def test_tablespace_metrics(aggregator, check):
     con.cursor.return_value = cur
 
     check._connection = con
-    check._query_manager.queries = [queries.TableSpaceMetrics]
+    check._query_manager.queries = [queries.TableSpaceMetrics.copy()]
     check._query_manager.tags = ['custom_tag']
     check._query_manager.compile_queries()
     check._query_manager.execute()

--- a/proxysql.yml
+++ b/proxysql.yml
@@ -1,0 +1,12 @@
+init_config:
+instances:
+  - host: "proxysql"
+    port: 6032
+    username: proxy
+    password: proxy
+  - host: "proxysql"
+    port: 6032
+    username: proxy
+    password: proxy
+    tags:
+      - florian:test

--- a/snowflake/tests/test_snowflake.py
+++ b/snowflake/tests/test_snowflake.py
@@ -21,7 +21,7 @@ def test_storage_metrics(dd_run_check, aggregator, instance):
     with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_storage):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.StorageUsageMetrics]
+        check._query_manager.queries = [queries.StorageUsageMetrics.copy()]
         dd_run_check(check)
 
     aggregator.assert_metric('snowflake.storage.storage_bytes.total', value=0.0, tags=EXPECTED_TAGS)
@@ -31,7 +31,6 @@ def test_storage_metrics(dd_run_check, aggregator, instance):
 
 def test_db_storage_metrics(dd_run_check, aggregator, instance):
     # type: (AggregatorStub, Dict[str, Any]) -> None
-
     expected_db_storage_usage = [('SNOWFLAKE_DB', Decimal('133.000000'), Decimal('9.100000'))]
     expected_tags = EXPECTED_TAGS + ['database:SNOWFLAKE_DB']
     with mock.patch(
@@ -39,7 +38,7 @@ def test_db_storage_metrics(dd_run_check, aggregator, instance):
     ):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.DatabaseStorageMetrics]
+        check._query_manager.queries = [queries.DatabaseStorageMetrics.copy()]
         dd_run_check(check)
     aggregator.assert_metric('snowflake.storage.database.storage_bytes', value=133.0, tags=expected_tags)
     aggregator.assert_metric('snowflake.storage.database.failsafe_bytes', value=9.1, tags=expected_tags)
@@ -64,7 +63,7 @@ def test_credit_usage_metrics(dd_run_check, aggregator, instance):
     with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_credit_usage):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.CreditUsage]
+        check._query_manager.queries = [queries.CreditUsage.copy()]
         dd_run_check(check)
 
     aggregator.assert_metric('snowflake.billing.cloud_service.sum', count=1, tags=expected_tags)
@@ -93,7 +92,7 @@ def test_warehouse_usage_metrics(dd_run_check, aggregator, instance):
     with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_wh_usage):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.WarehouseCreditUsage]
+        check._query_manager.queries = [queries.WarehouseCreditUsage.copy()]
         dd_run_check(check)
 
     aggregator.assert_metric('snowflake.billing.warehouse.cloud_service.avg', count=1, tags=expected_tags)
@@ -111,7 +110,7 @@ def test_login_metrics(dd_run_check, aggregator, instance):
     with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_login_metrics):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.LoginMetrics]
+        check._query_manager.queries = [queries.LoginMetrics.copy()]
         dd_run_check(check)
     snowflake_tags = EXPECTED_TAGS + ['client_type:SNOWFLAKE_UI']
     aggregator.assert_metric('snowflake.logins.fail.count', value=2, tags=snowflake_tags)
@@ -134,7 +133,7 @@ def test_warehouse_load(dd_run_check, aggregator, instance):
     with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_wl_metrics):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.WarehouseLoad]
+        check._query_manager.queries = [queries.WarehouseLoad.copy()]
         dd_run_check(check)
     aggregator.assert_metric('snowflake.query.executed', value=0.000446667, tags=expected_tags)
     aggregator.assert_metric('snowflake.query.queued_overload', value=0, count=1, tags=expected_tags)
@@ -163,7 +162,7 @@ def test_query_metrics(dd_run_check, aggregator, instance):
     with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_query_metrics):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.QueryHistory]
+        check._query_manager.queries = [queries.QueryHistory.copy()]
         dd_run_check(check)
 
     aggregator.assert_metric('snowflake.query.execution_time', value=4.333333, tags=expected_tags)


### PR DESCRIPTION
Database checks pass instances of 'Query' directly to the QueryManager for them to be 'compiled' and used.
The QueryManager modifies those 'Query' instances in-place which means that multiple instances of a same check will share the same references to those 'Query' objects.
It wouldn't be a problem if those Query did not contain references to bounded methods of the check.

Note for reviewers:
We want to keep the same interface for checks as custom/extras/internal check may use it. So checks should continue to create instances of 'Query' that they pass to the Query Manager

Impact:
- Any check currently using the QueryManager with multiple configuration instances will see metrics that should be submitted with one instance being submitted with another one. This is transparent to users, metrics will be sent to Datadog app anyway.
- If the check is using autodiscovery, configuration instances are generated dynamically. Instances can be unscheduled and that leads to integrations trying to report metrics through another un-existing check instance which the agent refuses to send.