### PR TITLE
Fix building of the connection string

### DIFF
--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -99,9 +99,6 @@ class MongoDb(AgentCheck):
             if password and not username:
                 raise ConfigurationError('`username` must be set when a `password` is specified')
 
-            if username and not password:
-                raise ConfigurationError('`password` must be set when a `username` is specified')
-
             self.server = build_connection_string(
                 hosts,
                 scheme=self.instance.get('connection_scheme', 'mongodb'),

--- a/mongo/datadog_checks/mongo/utils.py
+++ b/mongo/datadog_checks/mongo/utils.py
@@ -15,16 +15,14 @@ def build_connection_string(hosts, scheme, username=None, password=None, databas
     See https://docs.mongodb.com/manual/reference/connection-string/
     """
 
-    def add_default_port(host):
-        # type: (str) -> str
-        if ':' not in host:
-            return '{}:27017'.format(host)
-        return host
-
-    host = ','.join(add_default_port(host) for host in hosts)
+    host = ','.join(hosts)
     path = '/{}'.format(database) if database else '/'
     if username and password:
         netloc = '{}:{}@{}'.format(quote_plus(username), quote_plus(password), host)
+    elif username:
+        # Only makes sense when using X509 authentication. But specifying the username
+        # is not a requirement of MongoDB anymore since v3.4
+        netloc = '{}@{}'.format(quote_plus(username), host)
     else:
         netloc = host
 

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -135,13 +135,13 @@ def test_parse_server_config(check):
         'options': {'replicaSet': 'bar!baz'},  # Special character
     }
     check = check(instance)
-    assert check.server == 'mongodb://john+doe:p%40ss%5Cword@localhost:27017,localhost:27018/test?replicaSet=bar%21baz'
+    assert check.server == 'mongodb://john+doe:p%40ss%5Cword@localhost,localhost:27018/test?replicaSet=bar%21baz'
     assert check.username == 'john doe'
     assert check.password == 'p@ss\\word'
     assert check.db_name == 'test'
     assert check.nodelist == [('localhost', 27017), ('localhost', 27018)]
     assert check.clean_server_name == (
-        'mongodb://john doe:*****@localhost:27017,localhost:27018/test?replicaSet=bar!baz'
+        'mongodb://john doe:*****@localhost,localhost:27018/test?replicaSet=bar!baz'
     )
     assert check.auth_source == 'test'
 

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -140,9 +140,25 @@ def test_parse_server_config(check):
     assert check.password == 'p@ss\\word'
     assert check.db_name == 'test'
     assert check.nodelist == [('localhost', 27017), ('localhost', 27018)]
-    assert check.clean_server_name == (
-        'mongodb://john doe:*****@localhost,localhost:27018/test?replicaSet=bar!baz'
-    )
+    assert check.clean_server_name == ('mongodb://john doe:*****@localhost,localhost:27018/test?replicaSet=bar!baz')
+    assert check.auth_source == 'test'
+
+
+def test_username_no_password(check):
+    """Configuring the check with a username and without a password should be allowed in order to support
+    x509 connection string for MongoDB < 3.4"""
+    instance = {
+        'hosts': ['localhost', 'localhost:27018'],
+        'username': 'john doe',  # Space
+        'database': 'test',
+        'options': {'replicaSet': 'bar!baz'},  # Special character
+    }
+    check = check(instance)
+    assert check.server == 'mongodb://john+doe@localhost,localhost:27018/test?replicaSet=bar%21baz'
+    assert check.username == 'john doe'
+    assert check.db_name == 'test'
+    assert check.nodelist == [('localhost', 27017), ('localhost', 27018)]
+    assert check.clean_server_name == ('mongodb://john doe@localhost,localhost:27018/test?replicaSet=bar!baz')
     assert check.auth_source == 'test'
 
 


### PR DESCRIPTION
Port 27017 is already the default no matter what in mongo so there's no harm in removing it in any use case.

This extra logic was creating an issue with the `mongo+srv://` connection scheme. This scheme takes a hostname that resolves DNS information. The port should never be included in the URI, otherwise we see

```
pymongo.errors.InvalidURI: mongodb+srv:// URIs must not include a port number
Deprecated constructor API
```

Also, a legacy (and rare) use case is reintroduced. When using x509 authentication, it is possible to login to mongo simply using certificate files. These certificate files contain a username in them.
Priori to v3.4 of MongoDB, the URI needed to contain the username in the URI like so `mongodb://username@host/db` but this is not required anymore.
Currently the building logic only allows username+password or nothing, but for older version of mongo we want to keep supporting passing the username alone.