### PR TITLE
Validate metrics_metadata in manifest.json

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -270,7 +270,8 @@ def get_tox_file(check_name):
 
 
 def get_metadata_file(check_name):
-    return os.path.join(get_root(), check_name, 'metadata.csv')
+    path = load_manifest(check_name).get('assets', {}).get("metrics_metadata", "metadata.csv")
+    return os.path.join(get_root(), check_name, path)
 
 
 def get_eula_from_manifest(check_name):


### PR DESCRIPTION
Adds validation for the `assets/metrics_metadata` field in the manifest.json.
This field is still **optional** to allow integration without a metadata.csv file. 

The new validation checks two things:
- If a metadata file is specified, it needs to exist on the filesystem.
- If a metadata file is found at the root called "metadata.csv", it needs to be defined in the manifest.json file

Note: No test as we don't have any testing setup for validation. This is a task on its own.