### PR TITLE
Fix token permissions documentation

### DIFF
--- a/docs/developer/ddev/configuration.md
+++ b/docs/developer/ddev/configuration.md
@@ -83,7 +83,7 @@ Run `ddev config show` to see if your GitHub user and token is set.
 If not:
 
 1. Run `ddev config set github.user <YOUR_GITHUB_USERNAME>`
-1. Create a [personal access token][github-personal-access-token] with `public_repo` permissions
+1. Create a [personal access token][github-personal-access-token] with `public_repo` and `read:org` permissions
 1. Run `ddev config set github.token` then paste the token
 1. [Enable single sign-on][github-saml-single-sign-on] for the token
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`ddev release trello testable` also needs `read:org` permission to get the team composition

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
