### PR TITLE
QueryManager - Prevent queries leaking between check instances

### DIFF
--- a/clickhouse/datadog_checks/clickhouse/queries.py
+++ b/clickhouse/datadog_checks/clickhouse/queries.py
@@ -1,311 +1,302 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.base.utils.db import Query
-
 from .utils import compact_query
 
 # https://clickhouse.yandex/docs/en/operations/system_tables/#system_tables-metrics
-SystemMetrics = Query(
-    {
-        'name': 'system.metrics',
-        'query': 'SELECT value, metric FROM system.metrics',
-        'columns': [
-            {'name': 'value', 'type': 'source'},
-            {
-                'name': 'metric',
-                'type': 'match',
-                'source': 'value',
-                'items': {
-                    'BackgroundMovePoolTask': {'name': 'background_pool.move.task.active', 'type': 'gauge'},
-                    'BackgroundPoolTask': {'name': 'background_pool.processing.task.active', 'type': 'gauge'},
-                    'BackgroundSchedulePoolTask': {'name': 'background_pool.schedule.task.active', 'type': 'gauge'},
-                    'CacheDictionaryUpdateQueueBatches': {
-                        'name': 'cache_dictionary.update_queue.batches',
-                        'type': 'gauge',
-                    },
-                    'CacheDictionaryUpdateQueueKeys': {'name': 'cache_dictionary.update_queue.keys', 'type': 'gauge'},
-                    'ContextLockWait': {'name': 'thread.lock.context.waiting', 'type': 'gauge'},
-                    'DelayedInserts': {'name': 'query.insert.delayed', 'type': 'gauge'},
-                    'DictCacheRequests': {'name': 'dictionary.request.cache', 'type': 'gauge'},
-                    'DiskSpaceReservedForMerge': {'name': 'merge.disk.reserved', 'type': 'gauge'},
-                    'DistributedFilesToInsert': {'name': 'table.distributed.file.insert.pending', 'type': 'gauge'},
-                    'DistributedSend': {'name': 'table.distributed.connection.inserted', 'type': 'gauge'},
-                    'EphemeralNode': {'name': 'zk.node.ephemeral', 'type': 'gauge'},
-                    'GlobalThread': {'name': 'thread.global.total', 'type': 'gauge'},
-                    'GlobalThreadActive': {'name': 'thread.global.active', 'type': 'gauge'},
-                    'HTTPConnection': {'name': 'connection.http', 'type': 'gauge'},
-                    'InterserverConnection': {'name': 'connection.interserver', 'type': 'gauge'},
-                    'LeaderElection': {'name': 'replica.leader.election', 'type': 'gauge'},
-                    'LeaderReplica': {'name': 'table.replicated.leader', 'type': 'gauge'},
-                    'LocalThread': {'name': 'thread.local.total', 'type': 'gauge'},
-                    'LocalThreadActive': {'name': 'thread.local.active', 'type': 'gauge'},
-                    'MemoryTracking': {'name': 'query.memory', 'type': 'gauge'},
-                    'MemoryTrackingForMerges': {'name': 'merge.memory', 'type': 'gauge'},
-                    'MemoryTrackingInBackgroundMoveProcessingPool': {
-                        'name': 'background_pool.move.memory',
-                        'type': 'gauge',
-                    },
-                    'MemoryTrackingInBackgroundProcessingPool': {
-                        'name': 'background_pool.processing.memory',
-                        'type': 'gauge',
-                    },
-                    'MemoryTrackingInBackgroundSchedulePool': {
-                        'name': 'background_pool.schedule.memory',
-                        'type': 'gauge',
-                    },
-                    'Merge': {'name': 'merge.active', 'type': 'gauge'},
-                    'MySQLConnection': {'name': 'connection.mysql', 'type': 'gauge'},
-                    'OpenFileForRead': {'name': 'file.open.read', 'type': 'gauge'},
-                    'OpenFileForWrite': {'name': 'file.open.write', 'type': 'gauge'},
-                    'PartMutation': {'name': 'query.mutation', 'type': 'gauge'},
-                    'Query': {'name': 'query.active', 'type': 'gauge'},
-                    'QueryPreempted': {'name': 'query.waiting', 'type': 'gauge'},
-                    'QueryThread': {'name': 'thread.query', 'type': 'gauge'},
-                    'RWLockActiveReaders': {'name': 'thread.lock.rw.active.read', 'type': 'gauge'},
-                    'RWLockActiveWriters': {'name': 'thread.lock.rw.active.write', 'type': 'gauge'},
-                    'RWLockWaitingReaders': {'name': 'thread.lock.rw.waiting.read', 'type': 'gauge'},
-                    'RWLockWaitingWriters': {'name': 'thread.lock.rw.waiting.write', 'type': 'gauge'},
-                    'Read': {'name': 'syscall.read', 'type': 'gauge'},
-                    'ReadonlyReplica': {'name': 'table.replicated.readonly', 'type': 'gauge'},
-                    'ReplicatedChecks': {'name': 'table.replicated.part.check', 'type': 'gauge'},
-                    'ReplicatedFetch': {'name': 'table.replicated.part.fetch', 'type': 'gauge'},
-                    'ReplicatedSend': {'name': 'table.replicated.part.send', 'type': 'gauge'},
-                    'SendExternalTables': {'name': 'connection.send.external', 'type': 'gauge'},
-                    'SendScalars': {'name': 'connection.send.scalar', 'type': 'gauge'},
-                    'StorageBufferBytes': {'name': 'table.buffer.size', 'type': 'gauge'},
-                    'StorageBufferRows': {'name': 'table.buffer.row', 'type': 'gauge'},
-                    'TCPConnection': {'name': 'connection.tcp', 'type': 'gauge'},
-                    'Write': {'name': 'syscall.write', 'type': 'gauge'},
-                    'ZooKeeperRequest': {'name': 'zk.request', 'type': 'gauge'},
-                    'ZooKeeperSession': {'name': 'zk.connection', 'type': 'gauge'},
-                    'ZooKeeperWatch': {'name': 'zk.watch', 'type': 'gauge'},
+SystemMetrics = {
+    'name': 'system.metrics',
+    'query': 'SELECT value, metric FROM system.metrics',
+    'columns': [
+        {'name': 'value', 'type': 'source'},
+        {
+            'name': 'metric',
+            'type': 'match',
+            'source': 'value',
+            'items': {
+                'BackgroundMovePoolTask': {'name': 'background_pool.move.task.active', 'type': 'gauge'},
+                'BackgroundPoolTask': {'name': 'background_pool.processing.task.active', 'type': 'gauge'},
+                'BackgroundSchedulePoolTask': {'name': 'background_pool.schedule.task.active', 'type': 'gauge'},
+                'CacheDictionaryUpdateQueueBatches': {
+                    'name': 'cache_dictionary.update_queue.batches',
+                    'type': 'gauge',
                 },
+                'CacheDictionaryUpdateQueueKeys': {'name': 'cache_dictionary.update_queue.keys', 'type': 'gauge'},
+                'ContextLockWait': {'name': 'thread.lock.context.waiting', 'type': 'gauge'},
+                'DelayedInserts': {'name': 'query.insert.delayed', 'type': 'gauge'},
+                'DictCacheRequests': {'name': 'dictionary.request.cache', 'type': 'gauge'},
+                'DiskSpaceReservedForMerge': {'name': 'merge.disk.reserved', 'type': 'gauge'},
+                'DistributedFilesToInsert': {'name': 'table.distributed.file.insert.pending', 'type': 'gauge'},
+                'DistributedSend': {'name': 'table.distributed.connection.inserted', 'type': 'gauge'},
+                'EphemeralNode': {'name': 'zk.node.ephemeral', 'type': 'gauge'},
+                'GlobalThread': {'name': 'thread.global.total', 'type': 'gauge'},
+                'GlobalThreadActive': {'name': 'thread.global.active', 'type': 'gauge'},
+                'HTTPConnection': {'name': 'connection.http', 'type': 'gauge'},
+                'InterserverConnection': {'name': 'connection.interserver', 'type': 'gauge'},
+                'LeaderElection': {'name': 'replica.leader.election', 'type': 'gauge'},
+                'LeaderReplica': {'name': 'table.replicated.leader', 'type': 'gauge'},
+                'LocalThread': {'name': 'thread.local.total', 'type': 'gauge'},
+                'LocalThreadActive': {'name': 'thread.local.active', 'type': 'gauge'},
+                'MemoryTracking': {'name': 'query.memory', 'type': 'gauge'},
+                'MemoryTrackingForMerges': {'name': 'merge.memory', 'type': 'gauge'},
+                'MemoryTrackingInBackgroundMoveProcessingPool': {
+                    'name': 'background_pool.move.memory',
+                    'type': 'gauge',
+                },
+                'MemoryTrackingInBackgroundProcessingPool': {
+                    'name': 'background_pool.processing.memory',
+                    'type': 'gauge',
+                },
+                'MemoryTrackingInBackgroundSchedulePool': {
+                    'name': 'background_pool.schedule.memory',
+                    'type': 'gauge',
+                },
+                'Merge': {'name': 'merge.active', 'type': 'gauge'},
+                'MySQLConnection': {'name': 'connection.mysql', 'type': 'gauge'},
+                'OpenFileForRead': {'name': 'file.open.read', 'type': 'gauge'},
+                'OpenFileForWrite': {'name': 'file.open.write', 'type': 'gauge'},
+                'PartMutation': {'name': 'query.mutation', 'type': 'gauge'},
+                'Query': {'name': 'query.active', 'type': 'gauge'},
+                'QueryPreempted': {'name': 'query.waiting', 'type': 'gauge'},
+                'QueryThread': {'name': 'thread.query', 'type': 'gauge'},
+                'RWLockActiveReaders': {'name': 'thread.lock.rw.active.read', 'type': 'gauge'},
+                'RWLockActiveWriters': {'name': 'thread.lock.rw.active.write', 'type': 'gauge'},
+                'RWLockWaitingReaders': {'name': 'thread.lock.rw.waiting.read', 'type': 'gauge'},
+                'RWLockWaitingWriters': {'name': 'thread.lock.rw.waiting.write', 'type': 'gauge'},
+                'Read': {'name': 'syscall.read', 'type': 'gauge'},
+                'ReadonlyReplica': {'name': 'table.replicated.readonly', 'type': 'gauge'},
+                'ReplicatedChecks': {'name': 'table.replicated.part.check', 'type': 'gauge'},
+                'ReplicatedFetch': {'name': 'table.replicated.part.fetch', 'type': 'gauge'},
+                'ReplicatedSend': {'name': 'table.replicated.part.send', 'type': 'gauge'},
+                'SendExternalTables': {'name': 'connection.send.external', 'type': 'gauge'},
+                'SendScalars': {'name': 'connection.send.scalar', 'type': 'gauge'},
+                'StorageBufferBytes': {'name': 'table.buffer.size', 'type': 'gauge'},
+                'StorageBufferRows': {'name': 'table.buffer.row', 'type': 'gauge'},
+                'TCPConnection': {'name': 'connection.tcp', 'type': 'gauge'},
+                'Write': {'name': 'syscall.write', 'type': 'gauge'},
+                'ZooKeeperRequest': {'name': 'zk.request', 'type': 'gauge'},
+                'ZooKeeperSession': {'name': 'zk.connection', 'type': 'gauge'},
+                'ZooKeeperWatch': {'name': 'zk.watch', 'type': 'gauge'},
             },
-        ],
-    }
-)
+        },
+    ],
+}
 
 
 # https://clickhouse.yandex/docs/en/operations/system_tables/#system_tables-events
-SystemEvents = Query(
-    {
-        'name': 'system.events',
-        'query': 'SELECT value, event FROM system.events',
-        'columns': [
-            {'name': 'value', 'type': 'source'},
-            {
-                'name': 'event',
-                'type': 'match',
-                'source': 'value',
-                'items': {
-                    'CannotRemoveEphemeralNode': {'name': 'node.remove', 'type': 'monotonic_gauge'},
-                    'CannotWriteToWriteBufferDiscard': {'name': 'buffer.write.discard', 'type': 'monotonic_gauge'},
-                    'CompileAttempt': {'name': 'compilation.attempt', 'type': 'monotonic_gauge'},
-                    'CompileExpressionsBytes': {'name': 'compilation.size', 'type': 'monotonic_gauge'},
-                    'CompileExpressionsMicroseconds': {
-                        'name': 'compilation.time',
-                        'type': 'temporal_percent',
-                        'scale': 'microsecond',
-                    },
-                    'CompileFunction': {'name': 'compilation.llvm.attempt', 'type': 'monotonic_gauge'},
-                    'CompileSuccess': {'name': 'compilation.success', 'type': 'monotonic_gauge'},
-                    'CompiledFunctionExecute': {'name': 'compilation.function.execute', 'type': 'monotonic_gauge'},
-                    'CompressedReadBufferBlocks': {'name': 'read.compressed.block', 'type': 'monotonic_gauge'},
-                    'CompressedReadBufferBytes': {'name': 'read.compressed.raw.size', 'type': 'monotonic_gauge'},
-                    'ContextLock': {'name': 'lock.context.acquisition', 'type': 'monotonic_gauge'},
-                    'CreatedHTTPConnections': {'name': 'connection.http.create', 'type': 'monotonic_gauge'},
-                    'DelayedInserts': {'name': 'table.mergetree.insert.delayed', 'type': 'monotonic_gauge'},
-                    'DelayedInsertsMilliseconds': {
-                        'name': 'table.mergetree.insert.delayed.time',
-                        'type': 'temporal_percent',
-                        'scale': 'millisecond',
-                    },
-                    'DiskReadElapsedMicroseconds': {
-                        'name': 'syscall.read.wait',
-                        'type': 'temporal_percent',
-                        'scale': 'microsecond',
-                    },
-                    'DiskWriteElapsedMicroseconds': {
-                        'name': 'syscall.write.wait',
-                        'type': 'temporal_percent',
-                        'scale': 'microsecond',
-                    },
-                    'DuplicatedInsertedBlocks': {
-                        'name': 'table.mergetree.replicated.insert.deduplicate',
-                        'type': 'monotonic_gauge',
-                    },
-                    'FileOpen': {'name': 'file.open', 'type': 'monotonic_gauge'},
-                    'InsertQuery': {'name': 'query.insert', 'type': 'monotonic_gauge'},
-                    'InsertedBytes': {'name': 'table.insert.size', 'type': 'monotonic_gauge'},
-                    'InsertedRows': {'name': 'table.insert.row', 'type': 'monotonic_gauge'},
-                    'LeaderElectionAcquiredLeadership': {
-                        'name': 'table.mergetree.replicated.leader.elected',
-                        'type': 'monotonic_gauge',
-                    },
-                    'Merge': {'name': 'merge', 'type': 'monotonic_gauge'},
-                    'MergeTreeDataWriterBlocks': {'name': 'table.mergetree.insert.block', 'type': 'monotonic_gauge'},
-                    'MergeTreeDataWriterBlocksAlreadySorted': {
-                        'name': 'table.mergetree.insert.block.already_sorted',
-                        'type': 'monotonic_gauge',
-                    },
-                    'MergeTreeDataWriterCompressedBytes': {
-                        'name': 'table.mergetree.insert.write.size.compressed',
-                        'type': 'monotonic_gauge',
-                    },
-                    'MergeTreeDataWriterRows': {'name': 'table.mergetree.insert.row', 'type': 'monotonic_gauge'},
-                    'MergeTreeDataWriterUncompressedBytes': {
-                        'name': 'table.mergetree.insert.write.size.uncompressed',
-                        'type': 'monotonic_gauge',
-                    },
-                    'MergedRows': {'name': 'merge.row.read', 'type': 'monotonic_gauge'},
-                    'MergedUncompressedBytes': {'name': 'merge.read.size.uncompressed', 'type': 'monotonic_gauge'},
-                    'MergesTimeMilliseconds': {
-                        'name': 'merge.time',
-                        'type': 'temporal_percent',
-                        'scale': 'millisecond',
-                    },
-                    'OSCPUVirtualTimeMicroseconds': {
-                        'name': 'cpu.time',
-                        'type': 'temporal_percent',
-                        'scale': 'microsecond',
-                    },
-                    'OSCPUWaitMicroseconds': {
-                        'name': 'thread.cpu.wait',
-                        'type': 'temporal_percent',
-                        'scale': 'microsecond',
-                    },
-                    'OSIOWaitMicroseconds': {
-                        'name': 'thread.io.wait',
-                        'type': 'temporal_percent',
-                        'scale': 'microsecond',
-                    },
-                    'OSReadBytes': {'name': 'disk.read.size', 'type': 'monotonic_gauge'},
-                    'OSReadChars': {'name': 'fs.read.size', 'type': 'monotonic_gauge'},
-                    'OSWriteBytes': {'name': 'disk.write.size', 'type': 'monotonic_gauge'},
-                    'OSWriteChars': {'name': 'fs.write.size', 'type': 'monotonic_gauge'},
-                    'Query': {'name': 'query', 'type': 'monotonic_gauge'},
-                    'QueryMaskingRulesMatch': {'name': 'query.mask.match', 'type': 'monotonic_gauge'},
-                    'QueryProfilerSignalOverruns': {'name': 'query.signal.dropped', 'type': 'monotonic_gauge'},
-                    'ReadBackoff': {'name': 'query.read.backoff', 'type': 'monotonic_gauge'},
-                    'ReadBufferFromFileDescriptorRead': {'name': 'file.read', 'type': 'monotonic_gauge'},
-                    'ReadBufferFromFileDescriptorReadBytes': {'name': 'file.read.size', 'type': 'monotonic_gauge'},
-                    'ReadBufferFromFileDescriptorReadFailed': {'name': 'file.read.fail', 'type': 'monotonic_gauge'},
-                    'ReadCompressedBytes': {'name': 'read.compressed.size', 'type': 'monotonic_gauge'},
-                    'RealTimeMicroseconds': {
-                        'name': 'thread.process_time',
-                        'type': 'temporal_percent',
-                        'scale': 'microsecond',
-                    },
-                    'RegexpCreated': {'name': 'compilation.regex', 'type': 'monotonic_gauge'},
-                    'RejectedInserts': {'name': 'table.mergetree.insert.block.rejected', 'type': 'monotonic_gauge'},
-                    'ReplicaYieldLeadership': {'name': 'table.replicated.leader.yield', 'type': 'monotonic_gauge'},
-                    'ReplicatedDataLoss': {'name': 'table.replicated.part.loss', 'type': 'monotonic_gauge'},
-                    'ReplicatedPartFailedFetches': {
-                        'name': 'table.mergetree.replicated.fetch.replica.fail',
-                        'type': 'monotonic_gauge',
-                    },
-                    'ReplicatedPartFetches': {
-                        'name': 'table.mergetree.replicated.fetch.replica',
-                        'type': 'monotonic_gauge',
-                    },
-                    'ReplicatedPartFetchesOfMerged': {
-                        'name': 'table.mergetree.replicated.fetch.merged',
-                        'type': 'monotonic_gauge',
-                    },
-                    'ReplicatedPartMerges': {'name': 'table.mergetree.replicated.merge', 'type': 'monotonic_gauge'},
-                    'Seek': {'name': 'file.seek', 'type': 'monotonic_gauge'},
-                    'SelectQuery': {'name': 'query.select', 'type': 'monotonic_gauge'},
-                    'SelectedMarks': {'name': 'table.mergetree.mark.selected', 'type': 'monotonic_gauge'},
-                    'SelectedParts': {'name': 'table.mergetree.part.selected', 'type': 'monotonic_gauge'},
-                    'SelectedRanges': {'name': 'table.mergetree.range.selected', 'type': 'monotonic_gauge'},
-                    'SlowRead': {'name': 'file.read.slow', 'type': 'monotonic_gauge'},
-                    'SystemTimeMicroseconds': {
-                        'name': 'thread.system.process_time',
-                        'type': 'temporal_percent',
-                        'scale': 'microsecond',
-                    },
-                    'ThrottlerSleepMicroseconds': {
-                        'name': 'query.sleep.time',
-                        'type': 'temporal_percent',
-                        'scale': 'microsecond',
-                    },
-                    'UserTimeMicroseconds': {
-                        'name': 'thread.user.process_time',
-                        'type': 'temporal_percent',
-                        'scale': 'microsecond',
-                    },
-                    'WriteBufferFromFileDescriptorWrite': {'name': 'file.write', 'type': 'monotonic_gauge'},
-                    'WriteBufferFromFileDescriptorWriteBytes': {'name': 'file.write.size', 'type': 'monotonic_gauge'},
-                    'WriteBufferFromFileDescriptorWriteFailed': {'name': 'file.write.fail', 'type': 'monotonic_gauge'},
+SystemEvents = {
+    'name': 'system.events',
+    'query': 'SELECT value, event FROM system.events',
+    'columns': [
+        {'name': 'value', 'type': 'source'},
+        {
+            'name': 'event',
+            'type': 'match',
+            'source': 'value',
+            'items': {
+                'CannotRemoveEphemeralNode': {'name': 'node.remove', 'type': 'monotonic_gauge'},
+                'CannotWriteToWriteBufferDiscard': {'name': 'buffer.write.discard', 'type': 'monotonic_gauge'},
+                'CompileAttempt': {'name': 'compilation.attempt', 'type': 'monotonic_gauge'},
+                'CompileExpressionsBytes': {'name': 'compilation.size', 'type': 'monotonic_gauge'},
+                'CompileExpressionsMicroseconds': {
+                    'name': 'compilation.time',
+                    'type': 'temporal_percent',
+                    'scale': 'microsecond',
                 },
+                'CompileFunction': {'name': 'compilation.llvm.attempt', 'type': 'monotonic_gauge'},
+                'CompileSuccess': {'name': 'compilation.success', 'type': 'monotonic_gauge'},
+                'CompiledFunctionExecute': {'name': 'compilation.function.execute', 'type': 'monotonic_gauge'},
+                'CompressedReadBufferBlocks': {'name': 'read.compressed.block', 'type': 'monotonic_gauge'},
+                'CompressedReadBufferBytes': {'name': 'read.compressed.raw.size', 'type': 'monotonic_gauge'},
+                'ContextLock': {'name': 'lock.context.acquisition', 'type': 'monotonic_gauge'},
+                'CreatedHTTPConnections': {'name': 'connection.http.create', 'type': 'monotonic_gauge'},
+                'DelayedInserts': {'name': 'table.mergetree.insert.delayed', 'type': 'monotonic_gauge'},
+                'DelayedInsertsMilliseconds': {
+                    'name': 'table.mergetree.insert.delayed.time',
+                    'type': 'temporal_percent',
+                    'scale': 'millisecond',
+                },
+                'DiskReadElapsedMicroseconds': {
+                    'name': 'syscall.read.wait',
+                    'type': 'temporal_percent',
+                    'scale': 'microsecond',
+                },
+                'DiskWriteElapsedMicroseconds': {
+                    'name': 'syscall.write.wait',
+                    'type': 'temporal_percent',
+                    'scale': 'microsecond',
+                },
+                'DuplicatedInsertedBlocks': {
+                    'name': 'table.mergetree.replicated.insert.deduplicate',
+                    'type': 'monotonic_gauge',
+                },
+                'FileOpen': {'name': 'file.open', 'type': 'monotonic_gauge'},
+                'InsertQuery': {'name': 'query.insert', 'type': 'monotonic_gauge'},
+                'InsertedBytes': {'name': 'table.insert.size', 'type': 'monotonic_gauge'},
+                'InsertedRows': {'name': 'table.insert.row', 'type': 'monotonic_gauge'},
+                'LeaderElectionAcquiredLeadership': {
+                    'name': 'table.mergetree.replicated.leader.elected',
+                    'type': 'monotonic_gauge',
+                },
+                'Merge': {'name': 'merge', 'type': 'monotonic_gauge'},
+                'MergeTreeDataWriterBlocks': {'name': 'table.mergetree.insert.block', 'type': 'monotonic_gauge'},
+                'MergeTreeDataWriterBlocksAlreadySorted': {
+                    'name': 'table.mergetree.insert.block.already_sorted',
+                    'type': 'monotonic_gauge',
+                },
+                'MergeTreeDataWriterCompressedBytes': {
+                    'name': 'table.mergetree.insert.write.size.compressed',
+                    'type': 'monotonic_gauge',
+                },
+                'MergeTreeDataWriterRows': {'name': 'table.mergetree.insert.row', 'type': 'monotonic_gauge'},
+                'MergeTreeDataWriterUncompressedBytes': {
+                    'name': 'table.mergetree.insert.write.size.uncompressed',
+                    'type': 'monotonic_gauge',
+                },
+                'MergedRows': {'name': 'merge.row.read', 'type': 'monotonic_gauge'},
+                'MergedUncompressedBytes': {'name': 'merge.read.size.uncompressed', 'type': 'monotonic_gauge'},
+                'MergesTimeMilliseconds': {
+                    'name': 'merge.time',
+                    'type': 'temporal_percent',
+                    'scale': 'millisecond',
+                },
+                'OSCPUVirtualTimeMicroseconds': {
+                    'name': 'cpu.time',
+                    'type': 'temporal_percent',
+                    'scale': 'microsecond',
+                },
+                'OSCPUWaitMicroseconds': {
+                    'name': 'thread.cpu.wait',
+                    'type': 'temporal_percent',
+                    'scale': 'microsecond',
+                },
+                'OSIOWaitMicroseconds': {
+                    'name': 'thread.io.wait',
+                    'type': 'temporal_percent',
+                    'scale': 'microsecond',
+                },
+                'OSReadBytes': {'name': 'disk.read.size', 'type': 'monotonic_gauge'},
+                'OSReadChars': {'name': 'fs.read.size', 'type': 'monotonic_gauge'},
+                'OSWriteBytes': {'name': 'disk.write.size', 'type': 'monotonic_gauge'},
+                'OSWriteChars': {'name': 'fs.write.size', 'type': 'monotonic_gauge'},
+                'Query': {'name': 'query', 'type': 'monotonic_gauge'},
+                'QueryMaskingRulesMatch': {'name': 'query.mask.match', 'type': 'monotonic_gauge'},
+                'QueryProfilerSignalOverruns': {'name': 'query.signal.dropped', 'type': 'monotonic_gauge'},
+                'ReadBackoff': {'name': 'query.read.backoff', 'type': 'monotonic_gauge'},
+                'ReadBufferFromFileDescriptorRead': {'name': 'file.read', 'type': 'monotonic_gauge'},
+                'ReadBufferFromFileDescriptorReadBytes': {'name': 'file.read.size', 'type': 'monotonic_gauge'},
+                'ReadBufferFromFileDescriptorReadFailed': {'name': 'file.read.fail', 'type': 'monotonic_gauge'},
+                'ReadCompressedBytes': {'name': 'read.compressed.size', 'type': 'monotonic_gauge'},
+                'RealTimeMicroseconds': {
+                    'name': 'thread.process_time',
+                    'type': 'temporal_percent',
+                    'scale': 'microsecond',
+                },
+                'RegexpCreated': {'name': 'compilation.regex', 'type': 'monotonic_gauge'},
+                'RejectedInserts': {'name': 'table.mergetree.insert.block.rejected', 'type': 'monotonic_gauge'},
+                'ReplicaYieldLeadership': {'name': 'table.replicated.leader.yield', 'type': 'monotonic_gauge'},
+                'ReplicatedDataLoss': {'name': 'table.replicated.part.loss', 'type': 'monotonic_gauge'},
+                'ReplicatedPartFailedFetches': {
+                    'name': 'table.mergetree.replicated.fetch.replica.fail',
+                    'type': 'monotonic_gauge',
+                },
+                'ReplicatedPartFetches': {
+                    'name': 'table.mergetree.replicated.fetch.replica',
+                    'type': 'monotonic_gauge',
+                },
+                'ReplicatedPartFetchesOfMerged': {
+                    'name': 'table.mergetree.replicated.fetch.merged',
+                    'type': 'monotonic_gauge',
+                },
+                'ReplicatedPartMerges': {'name': 'table.mergetree.replicated.merge', 'type': 'monotonic_gauge'},
+                'Seek': {'name': 'file.seek', 'type': 'monotonic_gauge'},
+                'SelectQuery': {'name': 'query.select', 'type': 'monotonic_gauge'},
+                'SelectedMarks': {'name': 'table.mergetree.mark.selected', 'type': 'monotonic_gauge'},
+                'SelectedParts': {'name': 'table.mergetree.part.selected', 'type': 'monotonic_gauge'},
+                'SelectedRanges': {'name': 'table.mergetree.range.selected', 'type': 'monotonic_gauge'},
+                'SlowRead': {'name': 'file.read.slow', 'type': 'monotonic_gauge'},
+                'SystemTimeMicroseconds': {
+                    'name': 'thread.system.process_time',
+                    'type': 'temporal_percent',
+                    'scale': 'microsecond',
+                },
+                'ThrottlerSleepMicroseconds': {
+                    'name': 'query.sleep.time',
+                    'type': 'temporal_percent',
+                    'scale': 'microsecond',
+                },
+                'UserTimeMicroseconds': {
+                    'name': 'thread.user.process_time',
+                    'type': 'temporal_percent',
+                    'scale': 'microsecond',
+                },
+                'WriteBufferFromFileDescriptorWrite': {'name': 'file.write', 'type': 'monotonic_gauge'},
+                'WriteBufferFromFileDescriptorWriteBytes': {'name': 'file.write.size', 'type': 'monotonic_gauge'},
+                'WriteBufferFromFileDescriptorWriteFailed': {'name': 'file.write.fail', 'type': 'monotonic_gauge'},
             },
-        ],
-    }
-)
+        },
+    ],
+}
 
 
 # https://clickhouse.yandex/docs/en/operations/system_tables/#system_tables-asynchronous_metrics
-SystemAsynchronousMetrics = Query(
-    {
-        'name': 'system.asynchronous_metrics',
-        'query': 'SELECT value, metric FROM system.asynchronous_metrics',
-        'columns': [
-            {'name': 'value', 'type': 'source'},
-            {
-                'name': 'metric',
-                'type': 'match',
-                'source': 'value',
-                'items': {
-                    'CompiledExpressionCacheCount': {'name': 'CompiledExpressionCacheCount', 'type': 'gauge'},
-                    'MarkCacheBytes': {'name': 'table.mergetree.storage.mark.cache', 'type': 'gauge'},
-                    'MarkCacheFiles': {'name': 'MarkCacheFiles', 'type': 'gauge'},
-                    'MaxPartCountForPartition': {'name': 'part.max', 'type': 'gauge'},
-                    'NumberOfDatabases': {'name': 'database.total', 'type': 'gauge'},
-                    'NumberOfTables': {'name': 'table.total', 'type': 'gauge'},
-                    'ReplicasMaxAbsoluteDelay': {'name': 'replica.delay.absolute', 'type': 'gauge'},
-                    'ReplicasMaxInsertsInQueue': {'name': 'ReplicasMaxInsertsInQueue', 'type': 'gauge'},
-                    'ReplicasMaxMergesInQueue': {'name': 'ReplicasMaxMergesInQueue', 'type': 'gauge'},
-                    'ReplicasMaxQueueSize': {'name': 'ReplicasMaxQueueSize', 'type': 'gauge'},
-                    'ReplicasMaxRelativeDelay': {'name': 'replica.delay.relative', 'type': 'gauge'},
-                    'ReplicasSumInsertsInQueue': {'name': 'ReplicasSumInsertsInQueue', 'type': 'gauge'},
-                    'ReplicasSumMergesInQueue': {'name': 'ReplicasSumMergesInQueue', 'type': 'gauge'},
-                    'ReplicasSumQueueSize': {'name': 'replica.queue.size', 'type': 'gauge'},
-                    'UncompressedCacheBytes': {'name': 'UncompressedCacheBytes', 'type': 'gauge'},
-                    'UncompressedCacheCells': {'name': 'UncompressedCacheCells', 'type': 'gauge'},
-                    'Uptime': {'name': 'uptime', 'type': 'gauge'},
-                    'jemalloc.active': {'name': 'jemalloc.active', 'type': 'gauge'},
-                    'jemalloc.allocated': {'name': 'jemalloc.allocated', 'type': 'gauge'},
-                    'jemalloc.background_thread.num_runs': {
-                        'name': 'jemalloc.background_thread.num_runs',
-                        'type': 'gauge',
-                    },
-                    'jemalloc.background_thread.num_threads': {
-                        'name': 'jemalloc.background_thread.num_threads',
-                        'type': 'gauge',
-                    },
-                    'jemalloc.background_thread.run_interval': {
-                        'name': 'jemalloc.background_thread.run_interval',
-                        'type': 'gauge',
-                    },
-                    'jemalloc.mapped': {'name': 'jemalloc.mapped', 'type': 'gauge'},
-                    'jemalloc.metadata': {'name': 'jemalloc.metadata', 'type': 'gauge'},
-                    'jemalloc.metadata_thp': {'name': 'jemalloc.metadata_thp', 'type': 'gauge'},
-                    'jemalloc.resident': {'name': 'jemalloc.resident', 'type': 'gauge'},
-                    'jemalloc.retained': {'name': 'jemalloc.retained', 'type': 'gauge'},
+SystemAsynchronousMetrics = {
+    'name': 'system.asynchronous_metrics',
+    'query': 'SELECT value, metric FROM system.asynchronous_metrics',
+    'columns': [
+        {'name': 'value', 'type': 'source'},
+        {
+            'name': 'metric',
+            'type': 'match',
+            'source': 'value',
+            'items': {
+                'CompiledExpressionCacheCount': {'name': 'CompiledExpressionCacheCount', 'type': 'gauge'},
+                'MarkCacheBytes': {'name': 'table.mergetree.storage.mark.cache', 'type': 'gauge'},
+                'MarkCacheFiles': {'name': 'MarkCacheFiles', 'type': 'gauge'},
+                'MaxPartCountForPartition': {'name': 'part.max', 'type': 'gauge'},
+                'NumberOfDatabases': {'name': 'database.total', 'type': 'gauge'},
+                'NumberOfTables': {'name': 'table.total', 'type': 'gauge'},
+                'ReplicasMaxAbsoluteDelay': {'name': 'replica.delay.absolute', 'type': 'gauge'},
+                'ReplicasMaxInsertsInQueue': {'name': 'ReplicasMaxInsertsInQueue', 'type': 'gauge'},
+                'ReplicasMaxMergesInQueue': {'name': 'ReplicasMaxMergesInQueue', 'type': 'gauge'},
+                'ReplicasMaxQueueSize': {'name': 'ReplicasMaxQueueSize', 'type': 'gauge'},
+                'ReplicasMaxRelativeDelay': {'name': 'replica.delay.relative', 'type': 'gauge'},
+                'ReplicasSumInsertsInQueue': {'name': 'ReplicasSumInsertsInQueue', 'type': 'gauge'},
+                'ReplicasSumMergesInQueue': {'name': 'ReplicasSumMergesInQueue', 'type': 'gauge'},
+                'ReplicasSumQueueSize': {'name': 'replica.queue.size', 'type': 'gauge'},
+                'UncompressedCacheBytes': {'name': 'UncompressedCacheBytes', 'type': 'gauge'},
+                'UncompressedCacheCells': {'name': 'UncompressedCacheCells', 'type': 'gauge'},
+                'Uptime': {'name': 'uptime', 'type': 'gauge'},
+                'jemalloc.active': {'name': 'jemalloc.active', 'type': 'gauge'},
+                'jemalloc.allocated': {'name': 'jemalloc.allocated', 'type': 'gauge'},
+                'jemalloc.background_thread.num_runs': {
+                    'name': 'jemalloc.background_thread.num_runs',
+                    'type': 'gauge',
                 },
+                'jemalloc.background_thread.num_threads': {
+                    'name': 'jemalloc.background_thread.num_threads',
+                    'type': 'gauge',
+                },
+                'jemalloc.background_thread.run_interval': {
+                    'name': 'jemalloc.background_thread.run_interval',
+                    'type': 'gauge',
+                },
+                'jemalloc.mapped': {'name': 'jemalloc.mapped', 'type': 'gauge'},
+                'jemalloc.metadata': {'name': 'jemalloc.metadata', 'type': 'gauge'},
+                'jemalloc.metadata_thp': {'name': 'jemalloc.metadata_thp', 'type': 'gauge'},
+                'jemalloc.resident': {'name': 'jemalloc.resident', 'type': 'gauge'},
+                'jemalloc.retained': {'name': 'jemalloc.retained', 'type': 'gauge'},
             },
-        ],
-    }
-)
+        },
+    ],
+}
 
 
 # https://clickhouse.yandex/docs/en/operations/system_tables/#system_tables-parts
-SystemParts = Query(
-    {
-        'name': 'system.parts',
-        'query': compact_query(
-            """
+SystemParts = {
+    'name': 'system.parts',
+    'query': compact_query(
+        """
             SELECT
               database,
               table,
@@ -318,24 +309,22 @@ SystemParts = Query(
               database,
               table
             """
-        ),
-        'columns': [
-            {'name': 'database', 'type': 'tag'},
-            {'name': 'table', 'type': 'tag'},
-            {'name': 'table.mergetree.size', 'type': 'gauge'},
-            {'name': 'table.mergetree.part.current', 'type': 'gauge'},
-            {'name': 'table.mergetree.row.current', 'type': 'gauge'},
-        ],
-    }
-)
+    ),
+    'columns': [
+        {'name': 'database', 'type': 'tag'},
+        {'name': 'table', 'type': 'tag'},
+        {'name': 'table.mergetree.size', 'type': 'gauge'},
+        {'name': 'table.mergetree.part.current', 'type': 'gauge'},
+        {'name': 'table.mergetree.row.current', 'type': 'gauge'},
+    ],
+}
 
 
 # https://clickhouse.yandex/docs/en/operations/system_tables/#system_tables-replicas
-SystemReplicas = Query(
-    {
-        'name': 'system.replicas',
-        'query': compact_query(
-            """
+SystemReplicas = {
+    'name': 'system.replicas',
+    'query': compact_query(
+        """
             SELECT
               database,
               table,
@@ -354,34 +343,32 @@ SystemReplicas = Query(
               active_replicas
             FROM system.replicas
             """
-        ),
-        'columns': [
-            {'name': 'database', 'type': 'tag'},
-            {'name': 'table', 'type': 'tag'},
-            {'name': 'is_leader', 'type': 'tag', 'boolean': True},
-            {'name': 'is_readonly', 'type': 'tag', 'boolean': True},
-            {'name': 'is_session_expired', 'type': 'tag', 'boolean': True},
-            {'name': 'table.replicated.part.future', 'type': 'gauge'},
-            {'name': 'table.replicated.part.suspect', 'type': 'gauge'},
-            {'name': 'table.replicated.version', 'type': 'gauge'},
-            {'name': 'table.replicated.queue.size', 'type': 'gauge'},
-            {'name': 'table.replicated.queue.insert', 'type': 'gauge'},
-            {'name': 'table.replicated.queue.merge', 'type': 'gauge'},
-            {'name': 'table.replicated.log.max', 'type': 'gauge'},
-            {'name': 'table.replicated.log.pointer', 'type': 'gauge'},
-            {'name': 'table.replicated.total', 'type': 'gauge'},
-            {'name': 'table.replicated.active', 'type': 'gauge'},
-        ],
-    }
-)
+    ),
+    'columns': [
+        {'name': 'database', 'type': 'tag'},
+        {'name': 'table', 'type': 'tag'},
+        {'name': 'is_leader', 'type': 'tag', 'boolean': True},
+        {'name': 'is_readonly', 'type': 'tag', 'boolean': True},
+        {'name': 'is_session_expired', 'type': 'tag', 'boolean': True},
+        {'name': 'table.replicated.part.future', 'type': 'gauge'},
+        {'name': 'table.replicated.part.suspect', 'type': 'gauge'},
+        {'name': 'table.replicated.version', 'type': 'gauge'},
+        {'name': 'table.replicated.queue.size', 'type': 'gauge'},
+        {'name': 'table.replicated.queue.insert', 'type': 'gauge'},
+        {'name': 'table.replicated.queue.merge', 'type': 'gauge'},
+        {'name': 'table.replicated.log.max', 'type': 'gauge'},
+        {'name': 'table.replicated.log.pointer', 'type': 'gauge'},
+        {'name': 'table.replicated.total', 'type': 'gauge'},
+        {'name': 'table.replicated.active', 'type': 'gauge'},
+    ],
+}
 
 
 # https://clickhouse.yandex/docs/en/operations/system_tables/#system-dictionaries
-SystemDictionaries = Query(
-    {
-        'name': 'system.dictionaries',
-        'query': compact_query(
-            """
+SystemDictionaries = {
+    'name': 'system.dictionaries',
+    'query': compact_query(
+        """
             SELECT
               name,
               bytes_allocated,
@@ -389,12 +376,11 @@ SystemDictionaries = Query(
               load_factor
             FROM system.dictionaries
             """
-        ),
-        'columns': [
-            {'name': 'dictionary', 'type': 'tag'},
-            {'name': 'dictionary.memory.used', 'type': 'gauge'},
-            {'name': 'dictionary.item.current', 'type': 'gauge'},
-            {'name': 'dictionary.load', 'type': 'gauge'},
-        ],
-    }
-)
+    ),
+    'columns': [
+        {'name': 'dictionary', 'type': 'tag'},
+        {'name': 'dictionary.memory.used', 'type': 'gauge'},
+        {'name': 'dictionary.item.current', 'type': 'gauge'},
+        {'name': 'dictionary.load', 'type': 'gauge'},
+    ],
+}

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -61,12 +61,12 @@ def test_error_query(instance):
     'metrics, ignored_columns, metric_source_url',
     [
         (
-            queries.SystemMetrics.query_data['columns'][1]['items'],
+            queries.SystemMetrics['columns'][1]['items'],
             {'Revision', 'VersionInteger'},
             'https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/src/Common/CurrentMetrics.cpp',
         ),
         (
-            queries.SystemEvents.query_data['columns'][1]['items'],
+            queries.SystemEvents['columns'][1]['items'],
             set(),
             'https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/src/Common/ProfileEvents.cpp',
         ),

--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -46,10 +46,9 @@ class QueryManager(object):
         """
         self.check = check
         self.executor = executor
-        self.queries = queries or []
         self.tags = tags or []
         self.error_handler = error_handler
-
+        self.queries = [Query(payload) for payload in queries or []]
         custom_queries = list(self.check.instance.get('custom_queries', []))
         use_global_custom_queries = self.check.instance.get('use_global_custom_queries', True)
 

--- a/datadog_checks_base/tests/test_db.py
+++ b/datadog_checks_base/tests/test_db.py
@@ -9,7 +9,7 @@ import pytz
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.stubs.aggregator import AggregatorStub
-from datadog_checks.base.utils.db import Query, QueryManager
+from datadog_checks.base.utils.db import QueryManager
 
 pytestmark = pytest.mark.db
 
@@ -29,7 +29,7 @@ def create_query_manager(*args, **kwargs):
     check = kwargs.pop('check', None) or AgentCheck('test', {}, [{}])
     check.check_id = 'test:instance'
 
-    return QueryManager(check, executor, [Query(arg) for arg in args], **kwargs)
+    return QueryManager(check, executor, args, **kwargs)
 
 
 class TestQueryResultIteration:
@@ -1019,6 +1019,29 @@ class TestSubmission:
         aggregator.assert_metric('test_check.test.foo', 1, metric_type=aggregator.GAUGE, tags=['override:ok'])
         aggregator.assert_metric('test.baz', 2, metric_type=aggregator.GAUGE, tags=['test:foo', 'test:bar'])
         aggregator.assert_all_metrics_covered()
+
+    def test_queries_are_copied(self):
+        class MyCheck(AgentCheck):
+            pass
+
+        check1 = MyCheck('test', {}, [{}])
+        check2 = MyCheck('test', {}, [{}])
+        dummy_query = {
+            'name': 'test query',
+            'query': 'foo',
+            'columns': [
+                {'name': 'test.foo', 'type': 'gauge', 'tags': ['override:ok']},
+                {'name': 'test.baz', 'type': 'gauge', 'raw': True},
+            ],
+            'tags': ['test:bar'],
+        }
+        query_manager1 = QueryManager(check1, mock_executor(), [dummy_query])
+        query_manager2 = QueryManager(check2, mock_executor(), [dummy_query])
+        query_manager1.compile_queries()
+        query_manager2.compile_queries()
+        assert not id(query_manager1.queries[0]) == id(
+            query_manager2.queries[0]
+        ), "QueryManager does not copy the queries"
 
     def test_query_execution_error(self, caplog, aggregator):
         class Result(object):

--- a/oracle/datadog_checks/oracle/queries.py
+++ b/oracle/datadog_checks/oracle/queries.py
@@ -2,65 +2,60 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from datadog_checks.base.utils.db import Query
 
-ProcessMetrics = Query(
-    {
-        'name': 'process',
-        'query': 'SELECT PROGRAM, PGA_USED_MEM, PGA_ALLOC_MEM, PGA_FREEABLE_MEM, PGA_MAX_MEM FROM GV$PROCESS',
-        'columns': [
-            {'name': 'program', 'type': 'tag'},
-            {'name': 'process.pga_used_memory', 'type': 'gauge'},
-            {'name': 'process.pga_allocated_memory', 'type': 'gauge'},
-            {'name': 'process.pga_freeable_memory', 'type': 'gauge'},
-            {'name': 'process.pga_maximum_memory', 'type': 'gauge'},
-        ],
-    }
-)
+ProcessMetrics = {
+    'name': 'process',
+    'query': 'SELECT PROGRAM, PGA_USED_MEM, PGA_ALLOC_MEM, PGA_FREEABLE_MEM, PGA_MAX_MEM FROM GV$PROCESS',
+    'columns': [
+        {'name': 'program', 'type': 'tag'},
+        {'name': 'process.pga_used_memory', 'type': 'gauge'},
+        {'name': 'process.pga_allocated_memory', 'type': 'gauge'},
+        {'name': 'process.pga_freeable_memory', 'type': 'gauge'},
+        {'name': 'process.pga_maximum_memory', 'type': 'gauge'},
+    ],
+}
 
-SystemMetrics = Query(
-    {
-        'name': 'system',
-        'query': 'SELECT VALUE, METRIC_NAME FROM GV$SYSMETRIC ORDER BY BEGIN_TIME',
-        'columns': [
-            {'name': 'value', 'type': 'source'},
-            {
-                'name': 'metric_name',
-                'type': 'match',
-                'source': 'value',
-                'items': {
-                    'Buffer Cache Hit Ratio': {'name': 'buffer_cachehit_ratio', 'type': 'gauge'},
-                    'Cursor Cache Hit Ratio': {'name': 'cursor_cachehit_ratio', 'type': 'gauge'},
-                    'Library Cache Hit Ratio': {'name': 'library_cachehit_ratio', 'type': 'gauge'},
-                    'Shared Pool Free %': {'name': 'shared_pool_free', 'type': 'gauge'},
-                    'Physical Reads Per Sec': {'name': 'physical_reads', 'type': 'gauge'},
-                    'Physical Writes Per Sec': {'name': 'physical_writes', 'type': 'gauge'},
-                    'Enqueue Timeouts Per Sec': {'name': 'enqueue_timeouts', 'type': 'gauge'},
-                    'GC CR Block Received Per Second': {'name': 'gc_cr_block_received', 'type': 'gauge'},
-                    'Global Cache Blocks Corrupted': {'name': 'cache_blocks_corrupt', 'type': 'gauge'},
-                    'Global Cache Blocks Lost': {'name': 'cache_blocks_lost', 'type': 'gauge'},
-                    'Logons Per Sec': {'name': 'logons', 'type': 'gauge'},
-                    'Average Active Sessions': {'name': 'active_sessions', 'type': 'gauge'},
-                    'Long Table Scans Per Sec': {'name': 'long_table_scans', 'type': 'gauge'},
-                    'SQL Service Response Time': {'name': 'service_response_time', 'type': 'gauge'},
-                    'User Rollbacks Per Sec': {'name': 'user_rollbacks', 'type': 'gauge'},
-                    'Total Sorts Per User Call': {'name': 'sorts_per_user_call', 'type': 'gauge'},
-                    'Rows Per Sort': {'name': 'rows_per_sort', 'type': 'gauge'},
-                    'Disk Sort Per Sec': {'name': 'disk_sorts', 'type': 'gauge'},
-                    'Memory Sorts Ratio': {'name': 'memory_sorts_ratio', 'type': 'gauge'},
-                    'Database Wait Time Ratio': {'name': 'database_wait_time_ratio', 'type': 'gauge'},
-                    'Session Limit %': {'name': 'session_limit_usage', 'type': 'gauge'},
-                    'Session Count': {'name': 'session_count', 'type': 'gauge'},
-                    'Temp Space Used': {'name': 'temp_space_used', 'type': 'gauge'},
-                },
+SystemMetrics = {
+    'name': 'system',
+    'query': 'SELECT VALUE, METRIC_NAME FROM GV$SYSMETRIC ORDER BY BEGIN_TIME',
+    'columns': [
+        {'name': 'value', 'type': 'source'},
+        {
+            'name': 'metric_name',
+            'type': 'match',
+            'source': 'value',
+            'items': {
+                'Buffer Cache Hit Ratio': {'name': 'buffer_cachehit_ratio', 'type': 'gauge'},
+                'Cursor Cache Hit Ratio': {'name': 'cursor_cachehit_ratio', 'type': 'gauge'},
+                'Library Cache Hit Ratio': {'name': 'library_cachehit_ratio', 'type': 'gauge'},
+                'Shared Pool Free %': {'name': 'shared_pool_free', 'type': 'gauge'},
+                'Physical Reads Per Sec': {'name': 'physical_reads', 'type': 'gauge'},
+                'Physical Writes Per Sec': {'name': 'physical_writes', 'type': 'gauge'},
+                'Enqueue Timeouts Per Sec': {'name': 'enqueue_timeouts', 'type': 'gauge'},
+                'GC CR Block Received Per Second': {'name': 'gc_cr_block_received', 'type': 'gauge'},
+                'Global Cache Blocks Corrupted': {'name': 'cache_blocks_corrupt', 'type': 'gauge'},
+                'Global Cache Blocks Lost': {'name': 'cache_blocks_lost', 'type': 'gauge'},
+                'Logons Per Sec': {'name': 'logons', 'type': 'gauge'},
+                'Average Active Sessions': {'name': 'active_sessions', 'type': 'gauge'},
+                'Long Table Scans Per Sec': {'name': 'long_table_scans', 'type': 'gauge'},
+                'SQL Service Response Time': {'name': 'service_response_time', 'type': 'gauge'},
+                'User Rollbacks Per Sec': {'name': 'user_rollbacks', 'type': 'gauge'},
+                'Total Sorts Per User Call': {'name': 'sorts_per_user_call', 'type': 'gauge'},
+                'Rows Per Sort': {'name': 'rows_per_sort', 'type': 'gauge'},
+                'Disk Sort Per Sec': {'name': 'disk_sorts', 'type': 'gauge'},
+                'Memory Sorts Ratio': {'name': 'memory_sorts_ratio', 'type': 'gauge'},
+                'Database Wait Time Ratio': {'name': 'database_wait_time_ratio', 'type': 'gauge'},
+                'Session Limit %': {'name': 'session_limit_usage', 'type': 'gauge'},
+                'Session Count': {'name': 'session_count', 'type': 'gauge'},
+                'Temp Space Used': {'name': 'temp_space_used', 'type': 'gauge'},
             },
-        ],
-    }
-)
-TableSpaceMetrics = Query(
-    {
-        'name': 'process',
-        'query': """\
+        },
+    ],
+}
+
+TableSpaceMetrics = {
+    'name': 'process',
+    'query': """\
 SELECT
   m.tablespace_name,
   NVL(m.used_space * t.block_size, 0),
@@ -71,12 +66,11 @@ FROM
   dba_tablespace_usage_metrics m
   join dba_tablespaces t on m.tablespace_name = t.tablespace_name
   """,
-        'columns': [
-            {'name': 'tablespace', 'type': 'tag'},
-            {'name': 'tablespace.used', 'type': 'gauge'},
-            {'name': 'tablespace.size', 'type': 'gauge'},
-            {'name': 'tablespace.in_use', 'type': 'gauge'},
-            {'name': 'tablespace.offline', 'type': 'gauge'},
-        ],
-    }
-)
+    'columns': [
+        {'name': 'tablespace', 'type': 'tag'},
+        {'name': 'tablespace.used', 'type': 'gauge'},
+        {'name': 'tablespace.size', 'type': 'gauge'},
+        {'name': 'tablespace.in_use', 'type': 'gauge'},
+        {'name': 'tablespace.offline', 'type': 'gauge'},
+    ],
+}

--- a/oracle/tests/test_metrics.py
+++ b/oracle/tests/test_metrics.py
@@ -5,7 +5,7 @@ import copy
 
 import mock
 
-from datadog_checks.base.utils.db import QueryManager
+from datadog_checks.base.utils.db import Query, QueryManager
 from datadog_checks.oracle import queries
 
 
@@ -13,11 +13,11 @@ def test_sys_metrics(aggregator, check):
     con = mock.MagicMock()
     cur = mock.MagicMock()
     con.cursor.return_value = cur
-    metrics = copy.deepcopy(queries.SystemMetrics.query_data['columns'][1]['items'])
+    metrics = copy.deepcopy(queries.SystemMetrics['columns'][1]['items'])
     cur.fetchall.return_value = zip([0] * len(metrics.keys()), metrics.keys())
 
     check._connection = con
-    check._query_manager.queries = [queries.SystemMetrics]
+    check._query_manager.queries = [Query(queries.SystemMetrics)]
     check._query_manager.tags = ['custom_tag']
     check._query_manager.compile_queries()
     check._query_manager.execute()
@@ -30,7 +30,7 @@ def test_process_metrics(aggregator, check):
     con = mock.MagicMock()
     cur = mock.MagicMock()
     con.cursor.return_value = cur
-    metrics = copy.deepcopy(queries.ProcessMetrics.query_data['columns'][1:])
+    metrics = copy.deepcopy(queries.ProcessMetrics['columns'][1:])
     programs = [
         "PSEUDO",
         "oracle@localhost.localdomain (PMON)",
@@ -40,7 +40,7 @@ def test_process_metrics(aggregator, check):
     cur.fetchall.return_value = [[program] + ([0] * len(metrics)) for program in programs]
 
     check._connection = con
-    check._query_manager.queries = [queries.ProcessMetrics]
+    check._query_manager.queries = [Query(queries.ProcessMetrics)]
     check._query_manager.tags = ['custom_tag']
     check._query_manager.compile_queries()
     check._query_manager.execute()
@@ -67,7 +67,7 @@ def test_tablespace_metrics(aggregator, check):
     con.cursor.return_value = cur
 
     check._connection = con
-    check._query_manager.queries = [queries.TableSpaceMetrics]
+    check._query_manager.queries = [Query(queries.TableSpaceMetrics)]
     check._query_manager.tags = ['custom_tag']
     check._query_manager.compile_queries()
     check._query_manager.execute()

--- a/proxysql/datadog_checks/proxysql/queries.py
+++ b/proxysql/datadog_checks/proxysql/queries.py
@@ -1,267 +1,253 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.base.utils.db import Query
 
-STATS_MYSQL_GLOBAL = Query(
-    {
-        'name': 'stats_mysql_global',
-        'query': 'SELECT * FROM stats_mysql_global',
-        'columns': [
-            {
-                'name': 'Variable_Name',
-                'type': 'match',
-                'source': 'Variable_Value',
-                'items': {
-                    # the total uptime of ProxySQL in seconds
-                    'ProxySQL_Uptime': {'name': 'uptime', 'type': 'gauge'},
-                    # memory used by the embedded SQLite
-                    'SQLite3_memory_bytes': {'name': 'memory.sqlite3_memory_bytes', 'type': 'gauge'},
-                    # provides a count of how many client connection are currently processing a transaction
-                    'Active_Transactions': {'name': 'active_transactions', 'type': 'gauge'},
-                    # client failed connections (or closed improperly)
-                    'Client_Connections_aborted': {'name': 'client.connections_aborted', 'type': 'rate'},
-                    # client connections that are currently connected
-                    'Client_Connections_connected': {'name': 'client.connections_connected', 'type': 'gauge'},
-                    # total number of client connections created
-                    'Client_Connections_created': {'name': 'client.connections_created', 'type': 'rate'},
-                    # backend failed connections (or closed improperly)
-                    'Server_Connections_aborted': {'name': 'server.connections_aborted', 'type': 'rate'},
-                    # backend connections that are currently connected
-                    'Server_Connections_connected': {'name': 'server.connections_connected', 'type': 'gauge'},
-                    # total number of backend connections created
-                    'Server_Connections_created': {'name': 'server.connections_created', 'type': 'rate'},
-                    # number of client connections that are currently handled by the main worker threads. If ProxySQL
-                    # isn't running with "--idle-threads", Client_Connections_non_idle is always equal to
-                    # "Client_Connections_connected"
-                    'Client_Connections_non_idle': {'name': 'client.connections_non_idle', 'type': 'gauge'},
-                    # time spent making network calls to communicate with the backends
-                    'Backend_query_time_nsec': {
-                        'name': 'backend.query_time_pct',
-                        'type': 'temporal_percent',
-                        'scale': 'nanosecond',
-                    },
-                    # buffers related to backend connections if "fast_forward" is used, 0 means fast_forward is not used
-                    'mysql_backend_buffers_bytes': {'name': 'mysql.backend_buffers_bytes', 'type': 'gauge'},
-                    # buffers related to frontend connections (read/write buffers and other queues)
-                    'mysql_frontend_buffers_bytes': {'name': 'mysql.frontend_buffers_bytes', 'type': 'gauge'},
-                    # other memory used by ProxySQL to handle MySQL Sessions
-                    'mysql_session_internal_bytes': {'name': 'mysql.session_internal_bytes', 'type': 'gauge'},
-                    # number of MySQL Thread workers i.e. "mysql-threads"
-                    'MySQL_Thread_Workers': {'name': 'mysql.thread_workers', 'type': 'gauge'},
-                    # The number of monitor threads. By default it is twice the number of worker threads, initially
-                    # capped to 16 yet more threads will be created checks are being queued. Monitor threads perform
-                    # blocking network operations and do not consume much CPU
-                    'MySQL_Monitor_Workers': {'name': 'mysql.monitor_workers', 'type': 'gauge'},
-                    # number of requests where a connection was already available in the connection pool
-                    'ConnPool_get_conn_success': {'name': 'pool.conn_success', 'type': 'rate'},
-                    # number of requests where a connection was not available in the connection pool and either: a new
-                    # connection had to be created or no backend was available
-                    'ConnPool_get_conn_failure': {'name': 'pool.conn_failure', 'type': 'rate'},
-                    # number of connections that a MySQL Thread obtained from its own local connection pool cache.
-                    # This value tends to be large only when there is high concurrency.
-                    'ConnPool_get_conn_immediate': {'name': 'pool.conn_immediate', 'type': 'rate'},
-                    # the total number of client requests / statements executed
-                    'Questions': {'name': 'questions', 'type': 'rate'},
-                    # the total number of queries with an execution time greater than mysql-long_query_time milliseconds
-                    'Slow_queries': {'name': 'slow_queries', 'type': 'rate'},
-                    # memory used by the connection pool to store connections metadata
-                    'ConnPool_memory_bytes': {'name': 'pool.memory_bytes', 'type': 'gauge'},
-                    # the total number of prepared statements that are in use by clients
-                    'Stmt_Client_Active_Total': {'name': 'client.statements.active_total', 'type': 'gauge'},
-                    # this variable tracks the number of unique prepared statements currently in use by clients
-                    'Stmt_Client_Active_Unique': {'name': 'client.statements.active_unique', 'type': 'gauge'},
-                    # the total number of prepared statements currently available across all backend connections
-                    'Stmt_Server_Active_Total': {'name': 'server.statements.active_total', 'type': 'gauge'},
-                    # the number of unique prepared statements currently available across all backend connections
-                    'Stmt_Server_Active_Unique': {'name': 'server.statements.active_unique', 'type': 'gauge'},
-                    # this is the number of global prepared statements for which proxysql has metadata
-                    'Stmt_Cached': {'name': 'statements.cached', 'type': 'gauge'},
-                    # memory currently used by the query cache
-                    'Query_Cache_Memory_bytes': {'name': 'query_cache.memory_bytes', 'type': 'gauge'},
-                    # number of entries currently stored in the query cache
-                    'Query_Cache_Entries': {'name': 'query_cache.entries', 'type': 'gauge'},
-                    # number of entries purged by the Query Cache due to TTL expiration
-                    'Query_Cache_Purged': {'name': 'query_cache.purged', 'type': 'rate'},
-                    # number of bytes sent into the Query Cache
-                    'Query_Cache_bytes_IN': {'name': 'query_cache.bytes_in', 'type': 'rate'},
-                    # number of bytes read from the Query Cache
-                    'Query_Cache_bytes_OUT': {'name': 'query_cache.bytes_out', 'type': 'rate'},
-                    # number of read requests
-                    'Query_Cache_count_GET': {'name': 'query_cache.get.count', 'type': 'rate'},
-                    # number of successful read requests
-                    'Query_Cache_count_GET_OK': {'name': 'query_cache.get_ok.count', 'type': 'rate'},
-                    # number of write requests
-                    'Query_Cache_count_SET': {'name': 'query_cache.set.count', 'type': 'rate'},
-                    # the time spent inside the Query Processor to determine what action needs to be taken with the
-                    # query (internal module)
-                    'Query_Processor_time_nsec': {
-                        'name': 'query_processor_time_pct',
-                        'type': 'temporal_percent',
-                        'scale': 'nanosecond',
-                    },
+STATS_MYSQL_GLOBAL = {
+    'name': 'stats_mysql_global',
+    'query': 'SELECT * FROM stats_mysql_global',
+    'columns': [
+        {
+            'name': 'Variable_Name',
+            'type': 'match',
+            'source': 'Variable_Value',
+            'items': {
+                # the total uptime of ProxySQL in seconds
+                'ProxySQL_Uptime': {'name': 'uptime', 'type': 'gauge'},
+                # memory used by the embedded SQLite
+                'SQLite3_memory_bytes': {'name': 'memory.sqlite3_memory_bytes', 'type': 'gauge'},
+                # provides a count of how many client connection are currently processing a transaction
+                'Active_Transactions': {'name': 'active_transactions', 'type': 'gauge'},
+                # client failed connections (or closed improperly)
+                'Client_Connections_aborted': {'name': 'client.connections_aborted', 'type': 'rate'},
+                # client connections that are currently connected
+                'Client_Connections_connected': {'name': 'client.connections_connected', 'type': 'gauge'},
+                # total number of client connections created
+                'Client_Connections_created': {'name': 'client.connections_created', 'type': 'rate'},
+                # backend failed connections (or closed improperly)
+                'Server_Connections_aborted': {'name': 'server.connections_aborted', 'type': 'rate'},
+                # backend connections that are currently connected
+                'Server_Connections_connected': {'name': 'server.connections_connected', 'type': 'gauge'},
+                # total number of backend connections created
+                'Server_Connections_created': {'name': 'server.connections_created', 'type': 'rate'},
+                # number of client connections that are currently handled by the main worker threads. If ProxySQL
+                # isn't running with "--idle-threads", Client_Connections_non_idle is always equal to
+                # "Client_Connections_connected"
+                'Client_Connections_non_idle': {'name': 'client.connections_non_idle', 'type': 'gauge'},
+                # time spent making network calls to communicate with the backends
+                'Backend_query_time_nsec': {
+                    'name': 'backend.query_time_pct',
+                    'type': 'temporal_percent',
+                    'scale': 'nanosecond',
+                },
+                # buffers related to backend connections if "fast_forward" is used, 0 means fast_forward is not used
+                'mysql_backend_buffers_bytes': {'name': 'mysql.backend_buffers_bytes', 'type': 'gauge'},
+                # buffers related to frontend connections (read/write buffers and other queues)
+                'mysql_frontend_buffers_bytes': {'name': 'mysql.frontend_buffers_bytes', 'type': 'gauge'},
+                # other memory used by ProxySQL to handle MySQL Sessions
+                'mysql_session_internal_bytes': {'name': 'mysql.session_internal_bytes', 'type': 'gauge'},
+                # number of MySQL Thread workers i.e. "mysql-threads"
+                'MySQL_Thread_Workers': {'name': 'mysql.thread_workers', 'type': 'gauge'},
+                # The number of monitor threads. By default it is twice the number of worker threads, initially
+                # capped to 16 yet more threads will be created checks are being queued. Monitor threads perform
+                # blocking network operations and do not consume much CPU
+                'MySQL_Monitor_Workers': {'name': 'mysql.monitor_workers', 'type': 'gauge'},
+                # number of requests where a connection was already available in the connection pool
+                'ConnPool_get_conn_success': {'name': 'pool.conn_success', 'type': 'rate'},
+                # number of requests where a connection was not available in the connection pool and either: a new
+                # connection had to be created or no backend was available
+                'ConnPool_get_conn_failure': {'name': 'pool.conn_failure', 'type': 'rate'},
+                # number of connections that a MySQL Thread obtained from its own local connection pool cache.
+                # This value tends to be large only when there is high concurrency.
+                'ConnPool_get_conn_immediate': {'name': 'pool.conn_immediate', 'type': 'rate'},
+                # the total number of client requests / statements executed
+                'Questions': {'name': 'questions', 'type': 'rate'},
+                # the total number of queries with an execution time greater than mysql-long_query_time milliseconds
+                'Slow_queries': {'name': 'slow_queries', 'type': 'rate'},
+                # memory used by the connection pool to store connections metadata
+                'ConnPool_memory_bytes': {'name': 'pool.memory_bytes', 'type': 'gauge'},
+                # the total number of prepared statements that are in use by clients
+                'Stmt_Client_Active_Total': {'name': 'client.statements.active_total', 'type': 'gauge'},
+                # this variable tracks the number of unique prepared statements currently in use by clients
+                'Stmt_Client_Active_Unique': {'name': 'client.statements.active_unique', 'type': 'gauge'},
+                # the total number of prepared statements currently available across all backend connections
+                'Stmt_Server_Active_Total': {'name': 'server.statements.active_total', 'type': 'gauge'},
+                # the number of unique prepared statements currently available across all backend connections
+                'Stmt_Server_Active_Unique': {'name': 'server.statements.active_unique', 'type': 'gauge'},
+                # this is the number of global prepared statements for which proxysql has metadata
+                'Stmt_Cached': {'name': 'statements.cached', 'type': 'gauge'},
+                # memory currently used by the query cache
+                'Query_Cache_Memory_bytes': {'name': 'query_cache.memory_bytes', 'type': 'gauge'},
+                # number of entries currently stored in the query cache
+                'Query_Cache_Entries': {'name': 'query_cache.entries', 'type': 'gauge'},
+                # number of entries purged by the Query Cache due to TTL expiration
+                'Query_Cache_Purged': {'name': 'query_cache.purged', 'type': 'rate'},
+                # number of bytes sent into the Query Cache
+                'Query_Cache_bytes_IN': {'name': 'query_cache.bytes_in', 'type': 'rate'},
+                # number of bytes read from the Query Cache
+                'Query_Cache_bytes_OUT': {'name': 'query_cache.bytes_out', 'type': 'rate'},
+                # number of read requests
+                'Query_Cache_count_GET': {'name': 'query_cache.get.count', 'type': 'rate'},
+                # number of successful read requests
+                'Query_Cache_count_GET_OK': {'name': 'query_cache.get_ok.count', 'type': 'rate'},
+                # number of write requests
+                'Query_Cache_count_SET': {'name': 'query_cache.set.count', 'type': 'rate'},
+                # the time spent inside the Query Processor to determine what action needs to be taken with the
+                # query (internal module)
+                'Query_Processor_time_nsec': {
+                    'name': 'query_processor_time_pct',
+                    'type': 'temporal_percent',
+                    'scale': 'nanosecond',
                 },
             },
-            {'name': 'Variable_Value', 'type': 'source'},
-        ],
-    }
-)
+        },
+        {'name': 'Variable_Value', 'type': 'source'},
+    ],
+}
 
-STATS_COMMAND_COUNTERS = Query(
-    {
-        'name': 'stats_mysql_commands_counters',
-        'query': 'SELECT Command, Total_time_us, Total_cnt, cnt_100us, cnt_500us, cnt_1ms, cnt_5ms, cnt_10ms, '
-        'cnt_50ms, cnt_100ms, cnt_500ms, cnt_1s, cnt_5s, cnt_10s, cnt_INFs FROM '
-        'stats_mysql_commands_counters',
-        'columns': [
-            # the type of SQL command that has been executed. Examples: FLUSH, INSERT, KILL, SELECT FOR UPDATE, etc.
-            {'name': 'sql_command', 'type': 'tag'},
-            # the total time spent executing commands of that type, in microseconds
-            {'name': 'performance.command.total_time_pct', 'type': 'temporal_percent', 'scale': 'microsecond'},
-            # the total number of commands of that type executed
-            {'name': 'performance.command.total_count', 'type': 'monotonic_count'},
-            # the total number of commands of the given type which executed within the specified time limit and the
-            # previous one. For example, cnt_500us is the number of commands which executed within 500 microseconds,
-            # but more than 100 microseconds (because there's also a cnt_100us field). cnt_INFs is the number of
-            # commands whose execution exceeded 10 seconds.
-            {'name': 'performance.command.cnt_100us', 'type': 'monotonic_count'},
-            {'name': 'performance.command.cnt_500us', 'type': 'monotonic_count'},
-            {'name': 'performance.command.cnt_1ms', 'type': 'monotonic_count'},
-            {'name': 'performance.command.cnt_5ms', 'type': 'monotonic_count'},
-            {'name': 'performance.command.cnt_10ms', 'type': 'monotonic_count'},
-            {'name': 'performance.command.cnt_50ms', 'type': 'monotonic_count'},
-            {'name': 'performance.command.cnt_100ms', 'type': 'monotonic_count'},
-            {'name': 'performance.command.cnt_500ms', 'type': 'monotonic_count'},
-            {'name': 'performance.command.cnt_1s', 'type': 'monotonic_count'},
-            {'name': 'performance.command.cnt_5s', 'type': 'monotonic_count'},
-            {'name': 'performance.command.cnt_10s', 'type': 'monotonic_count'},
-            {'name': 'performance.command.cnt_infs', 'type': 'monotonic_count'},
-        ],
-    }
-)
+STATS_COMMAND_COUNTERS = {
+    'name': 'stats_mysql_commands_counters',
+    'query': 'SELECT Command, Total_time_us, Total_cnt, cnt_100us, cnt_500us, cnt_1ms, cnt_5ms, cnt_10ms, '
+    'cnt_50ms, cnt_100ms, cnt_500ms, cnt_1s, cnt_5s, cnt_10s, cnt_INFs FROM '
+    'stats_mysql_commands_counters',
+    'columns': [
+        # the type of SQL command that has been executed. Examples: FLUSH, INSERT, KILL, SELECT FOR UPDATE, etc.
+        {'name': 'sql_command', 'type': 'tag'},
+        # the total time spent executing commands of that type, in microseconds
+        {'name': 'performance.command.total_time_pct', 'type': 'temporal_percent', 'scale': 'microsecond'},
+        # the total number of commands of that type executed
+        {'name': 'performance.command.total_count', 'type': 'monotonic_count'},
+        # the total number of commands of the given type which executed within the specified time limit and the
+        # previous one. For example, cnt_500us is the number of commands which executed within 500 microseconds,
+        # but more than 100 microseconds (because there's also a cnt_100us field). cnt_INFs is the number of
+        # commands whose execution exceeded 10 seconds.
+        {'name': 'performance.command.cnt_100us', 'type': 'monotonic_count'},
+        {'name': 'performance.command.cnt_500us', 'type': 'monotonic_count'},
+        {'name': 'performance.command.cnt_1ms', 'type': 'monotonic_count'},
+        {'name': 'performance.command.cnt_5ms', 'type': 'monotonic_count'},
+        {'name': 'performance.command.cnt_10ms', 'type': 'monotonic_count'},
+        {'name': 'performance.command.cnt_50ms', 'type': 'monotonic_count'},
+        {'name': 'performance.command.cnt_100ms', 'type': 'monotonic_count'},
+        {'name': 'performance.command.cnt_500ms', 'type': 'monotonic_count'},
+        {'name': 'performance.command.cnt_1s', 'type': 'monotonic_count'},
+        {'name': 'performance.command.cnt_5s', 'type': 'monotonic_count'},
+        {'name': 'performance.command.cnt_10s', 'type': 'monotonic_count'},
+        {'name': 'performance.command.cnt_infs', 'type': 'monotonic_count'},
+    ],
+}
 
-STATS_MYSQL_CONNECTION_POOL = Query(
-    {
-        'name': 'stats_mysql_connection_pool',
-        # Need explicit selections as some columns are unusable.
-        'query': 'SELECT hostgroup, srv_host, srv_port, status, ConnUsed, ConnFree, ConnOK, ConnERR, Queries, '
-        'Bytes_data_sent, Bytes_data_recv, Latency_us FROM stats_mysql_connection_pool',
-        'columns': [
-            # the hostgroup in which the backend server belongs. Note that a single backend server can belong to more
-            # than one hostgroup
-            {'name': 'hostgroup', 'type': 'tag'},
-            # the TCP endpoint on which the mysqld backend server is listening for connections
-            {'name': 'srv_host', 'type': 'tag'},
-            {'name': 'srv_port', 'type': 'tag'},
-            # the status of the backend server. Can be ONLINE, SHUNNED, OFFLINE_SOFT, OFFLINE_HARD
-            # see https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers
-            {
-                'name': 'backend.status',
-                'type': 'service_check',
-                'status_map': {
-                    'ONLINE': 'OK',
-                    'SHUNNED': 'CRITICAL',
-                    'OFFLINE_SOFT': 'WARNING',
-                    'OFFLINE_HARD': 'CRITICAL',
-                },
+STATS_MYSQL_CONNECTION_POOL = {
+    'name': 'stats_mysql_connection_pool',
+    # Need explicit selections as some columns are unusable.
+    'query': 'SELECT hostgroup, srv_host, srv_port, status, ConnUsed, ConnFree, ConnOK, ConnERR, Queries, '
+    'Bytes_data_sent, Bytes_data_recv, Latency_us FROM stats_mysql_connection_pool',
+    'columns': [
+        # the hostgroup in which the backend server belongs. Note that a single backend server can belong to more
+        # than one hostgroup
+        {'name': 'hostgroup', 'type': 'tag'},
+        # the TCP endpoint on which the mysqld backend server is listening for connections
+        {'name': 'srv_host', 'type': 'tag'},
+        {'name': 'srv_port', 'type': 'tag'},
+        # the status of the backend server. Can be ONLINE, SHUNNED, OFFLINE_SOFT, OFFLINE_HARD
+        # see https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers
+        {
+            'name': 'backend.status',
+            'type': 'service_check',
+            'status_map': {
+                'ONLINE': 'OK',
+                'SHUNNED': 'CRITICAL',
+                'OFFLINE_SOFT': 'WARNING',
+                'OFFLINE_HARD': 'CRITICAL',
             },
-            # how many connections are currently used by ProxySQL for sending queries to the backend server
-            {'name': 'pool.connections_used', 'type': 'gauge'},
-            # how many connections are currently free. They are kept open in order to minimize the time cost of sending
-            # a query to the backend server
-            {'name': 'pool.connections_free', 'type': 'gauge'},
-            # how many connections were established successfully.
-            {'name': 'pool.connections_ok', 'type': 'rate'},
-            # how many connections weren't established successfully.
-            {'name': 'pool.connections_error', 'type': 'rate'},
-            # the number of queries routed towards this particular backend server
-            {'name': 'pool.queries', 'type': 'rate'},
-            # the amount of data sent to the backend. This does not include metadata (packets' headers)
-            {'name': 'pool.bytes_data_sent', 'type': 'rate'},
-            # the amount of data received from the backend. This does not include metadata (packets' headers,
-            # OK/ERR packets, fields' description, etc)
-            {'name': 'pool.bytes_data_recv', 'type': 'rate'},
-            # the currently ping time in microseconds, as reported from Monitor
-            {'name': 'pool.latency_ms', 'type': 'gauge'},
-        ],
-    }
-)
+        },
+        # how many connections are currently used by ProxySQL for sending queries to the backend server
+        {'name': 'pool.connections_used', 'type': 'gauge'},
+        # how many connections are currently free. They are kept open in order to minimize the time cost of sending
+        # a query to the backend server
+        {'name': 'pool.connections_free', 'type': 'gauge'},
+        # how many connections were established successfully.
+        {'name': 'pool.connections_ok', 'type': 'rate'},
+        # how many connections weren't established successfully.
+        {'name': 'pool.connections_error', 'type': 'rate'},
+        # the number of queries routed towards this particular backend server
+        {'name': 'pool.queries', 'type': 'rate'},
+        # the amount of data sent to the backend. This does not include metadata (packets' headers)
+        {'name': 'pool.bytes_data_sent', 'type': 'rate'},
+        # the amount of data received from the backend. This does not include metadata (packets' headers,
+        # OK/ERR packets, fields' description, etc)
+        {'name': 'pool.bytes_data_recv', 'type': 'rate'},
+        # the currently ping time in microseconds, as reported from Monitor
+        {'name': 'pool.latency_ms', 'type': 'gauge'},
+    ],
+}
 
-STATS_MYSQL_USERS = Query(
-    {
-        'name': 'stats_mysql_users',
-        'query': 'SELECT username, frontend_connections, frontend_max_connections FROM stats_mysql_users',
-        'columns': [
-            {'name': 'username', 'type': 'tag'},
-            {'name': 'frontend.user_connections', 'type': 'gauge'},
-            {'name': 'frontend.user_max_connections', 'type': 'gauge'},
-        ],
-    }
-)
+STATS_MYSQL_USERS = {
+    'name': 'stats_mysql_users',
+    'query': 'SELECT username, frontend_connections, frontend_max_connections FROM stats_mysql_users',
+    'columns': [
+        {'name': 'username', 'type': 'tag'},
+        {'name': 'frontend.user_connections', 'type': 'gauge'},
+        {'name': 'frontend.user_max_connections', 'type': 'gauge'},
+    ],
+}
 
-STATS_MEMORY_METRICS = Query(
-    {
-        'name': 'stats_memory_metrics',
-        'query': 'SELECT * FROM stats_memory_metrics',
-        'columns': [
-            {
-                'name': 'Variable_Name',
-                'type': 'match',
-                'source': 'Variable_Value',
-                'items': {
-                    # bytes in physically resident data pages mapped by the allocator
-                    'jemalloc_resident': {'name': 'memory.jemalloc_resident', 'type': 'gauge'},
-                    # bytes in pages allocated by the application
-                    'jemalloc_active': {'name': 'memory.jemalloc_active', 'type': 'gauge'},
-                    # bytes allocated by the application
-                    'jemalloc_allocated': {'name': 'memory.jemalloc_allocated', 'type': 'gauge'},
-                    # bytes in extents mapped by the allocator
-                    'jemalloc_mapped': {'name': 'memory.jemalloc_mapped', 'type': 'gauge'},
-                    # bytes dedicated to metadata
-                    'jemalloc_metadata': {'name': 'memory.jemalloc_metadata', 'type': 'gauge'},
-                    # bytes in virtual memory mappings that were retained rather than being returned to the OS
-                    # http://jemalloc.net/jemalloc.3.html
-                    'jemalloc_retained': {'name': 'memory.jemalloc_retained', 'type': 'gauge'},
-                    # memory used by the authentication module to store user credentials and attributes
-                    'Auth_memory': {'name': 'memory.auth_memory', 'type': 'gauge'},
-                    # memory used to store data related to `stats_mysql_query_digest`
-                    'query_digest_memory': {'name': 'memory.query_digest_memory', 'type': 'gauge'},
-                    # Memory used by the stack of the MySQL threads
-                    'stack_memory_mysql_threads': {'name': 'memory.stack_memory_mysql_threads', 'type': 'gauge'},
-                    # Memory used by the stack of the admin threads
-                    'stack_memory_admin_threads': {'name': 'memory.stack_memory_admin_threads', 'type': 'gauge'},
-                    # Memory used by the stack of the cluster threads
-                    'stack_memory_cluster_threads': {'name': 'memory.stack_memory_cluster_threads', 'type': 'gauge'},
-                },
+STATS_MEMORY_METRICS = {
+    'name': 'stats_memory_metrics',
+    'query': 'SELECT * FROM stats_memory_metrics',
+    'columns': [
+        {
+            'name': 'Variable_Name',
+            'type': 'match',
+            'source': 'Variable_Value',
+            'items': {
+                # bytes in physically resident data pages mapped by the allocator
+                'jemalloc_resident': {'name': 'memory.jemalloc_resident', 'type': 'gauge'},
+                # bytes in pages allocated by the application
+                'jemalloc_active': {'name': 'memory.jemalloc_active', 'type': 'gauge'},
+                # bytes allocated by the application
+                'jemalloc_allocated': {'name': 'memory.jemalloc_allocated', 'type': 'gauge'},
+                # bytes in extents mapped by the allocator
+                'jemalloc_mapped': {'name': 'memory.jemalloc_mapped', 'type': 'gauge'},
+                # bytes dedicated to metadata
+                'jemalloc_metadata': {'name': 'memory.jemalloc_metadata', 'type': 'gauge'},
+                # bytes in virtual memory mappings that were retained rather than being returned to the OS
+                # http://jemalloc.net/jemalloc.3.html
+                'jemalloc_retained': {'name': 'memory.jemalloc_retained', 'type': 'gauge'},
+                # memory used by the authentication module to store user credentials and attributes
+                'Auth_memory': {'name': 'memory.auth_memory', 'type': 'gauge'},
+                # memory used to store data related to `stats_mysql_query_digest`
+                'query_digest_memory': {'name': 'memory.query_digest_memory', 'type': 'gauge'},
+                # Memory used by the stack of the MySQL threads
+                'stack_memory_mysql_threads': {'name': 'memory.stack_memory_mysql_threads', 'type': 'gauge'},
+                # Memory used by the stack of the admin threads
+                'stack_memory_admin_threads': {'name': 'memory.stack_memory_admin_threads', 'type': 'gauge'},
+                # Memory used by the stack of the cluster threads
+                'stack_memory_cluster_threads': {'name': 'memory.stack_memory_cluster_threads', 'type': 'gauge'},
             },
-            {'name': 'Variable_Value', 'type': 'source'},
-        ],
-    }
-)
+        },
+        {'name': 'Variable_Value', 'type': 'source'},
+    ],
+}
 
-STATS_MYSQL_QUERY_RULES = Query(
-    {
-        'name': 'stats_mysql_query_rules',
-        'query': 'SELECT rule_id, hits FROM stats_mysql_query_rules',
-        'columns': [{'name': 'rule_id', 'type': 'tag'}, {'name': 'query_rules.rule_hits', 'type': 'rate'}],
-    }
-)
+STATS_MYSQL_QUERY_RULES = {
+    'name': 'stats_mysql_query_rules',
+    'query': 'SELECT rule_id, hits FROM stats_mysql_query_rules',
+    'columns': [{'name': 'rule_id', 'type': 'tag'}, {'name': 'query_rules.rule_hits', 'type': 'rate'}],
+}
 
-VERSION_METADATA = Query(
-    {
-        'name': 'version_metadata',
-        'query': "SELECT variable_value FROM main.global_variables WHERE variable_name='admin-version'",
-        'columns': [{'name': 'bad_version', 'type': 'source'}],
-        'extras': [
-            {
-                'name': 'version',
-                'source': 'bad_version',
-                # Evaluated as python code, the raw version looks like `2.0.8-67-g877cab1e` which is almost semver,
-                # that we parse automatically. To submit a semver formatted version, we transform the last hyphen into
-                # a plus sign: 2.0.8-67+g877cab1e.
-                'expression': "bad_version.replace('-', '+').replace('+', '-', 1)",
-                'submit_type': 'metadata',
-            }
-        ],
-    }
-)
+
+VERSION_METADATA = {
+    'name': 'version_metadata',
+    'query': "SELECT variable_value FROM main.global_variables WHERE variable_name='admin-version'",
+    'columns': [{'name': 'bad_version', 'type': 'source'}],
+    'extras': [
+        {
+            'name': 'version',
+            'source': 'bad_version',
+            # Evaluated as python code, the raw version looks like `2.0.8-67-g877cab1e` which is almost semver,
+            # that we parse automatically. To submit a semver formatted version, we transform the last hyphen into
+            # a plus sign: 2.0.8-67+g877cab1e.
+            'expression': "bad_version.replace('-', '+').replace('+', '-', 1)",
+            'submit_type': 'metadata',
+        }
+    ],
+}

--- a/snowflake/datadog_checks/snowflake/queries.py
+++ b/snowflake/datadog_checks/snowflake/queries.py
@@ -2,244 +2,219 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from datadog_checks.base.utils.db import Query
-
 # https://docs.snowflak e.com/en/sql-reference/account-usage/storage_usage.html
-StorageUsageMetrics = Query(
-    {
-        'name': 'storage.metrics',
-        'query': (
-            'SELECT STORAGE_BYTES, STAGE_BYTES, FAILSAFE_BYTES from STORAGE_USAGE ORDER BY USAGE_DATE DESC LIMIT 1;'
-        ),
-        'columns': [
-            {'name': 'storage.storage_bytes.total', 'type': 'gauge'},
-            {'name': 'storage.stage_bytes.total', 'type': 'gauge'},
-            {'name': 'storage.failsafe_bytes.total', 'type': 'gauge'},
-        ],
-    }
-)
+StorageUsageMetrics = {
+    'name': 'storage.metrics',
+    'query': ('SELECT STORAGE_BYTES, STAGE_BYTES, FAILSAFE_BYTES from STORAGE_USAGE ORDER BY USAGE_DATE DESC LIMIT 1;'),
+    'columns': [
+        {'name': 'storage.storage_bytes.total', 'type': 'gauge'},
+        {'name': 'storage.stage_bytes.total', 'type': 'gauge'},
+        {'name': 'storage.failsafe_bytes.total', 'type': 'gauge'},
+    ],
+}
 
 # https://docs.snowflake.com/en/sql-reference/account-usage/database_storage_usage_history.html
-DatabaseStorageMetrics = Query(
-    {
-        'name': 'database_storage.metrics',
-        'query': (
-            'SELECT DATABASE_NAME, AVERAGE_DATABASE_BYTES, AVERAGE_FAILSAFE_BYTES '
-            'from DATABASE_STORAGE_USAGE_HISTORY ORDER BY USAGE_DATE DESC LIMIT 1;'
-        ),
-        'columns': [
-            {'name': 'database', 'type': 'tag'},
-            {'name': 'storage.database.storage_bytes', 'type': 'gauge'},
-            {'name': 'storage.database.failsafe_bytes', 'type': 'gauge'},
-        ],
-    }
-)
+DatabaseStorageMetrics = {
+    'name': 'database_storage.metrics',
+    'query': (
+        'SELECT DATABASE_NAME, AVERAGE_DATABASE_BYTES, AVERAGE_FAILSAFE_BYTES '
+        'from DATABASE_STORAGE_USAGE_HISTORY ORDER BY USAGE_DATE DESC LIMIT 1;'
+    ),
+    'columns': [
+        {'name': 'database', 'type': 'tag'},
+        {'name': 'storage.database.storage_bytes', 'type': 'gauge'},
+        {'name': 'storage.database.failsafe_bytes', 'type': 'gauge'},
+    ],
+}
+
 
 # https://docs.snowflake.com/en/sql-reference/account-usage/metering_history.html
-CreditUsage = Query(
-    {
-        'name': 'billing.metrics',
-        'query': (
-            'select SERVICE_TYPE, NAME, sum(CREDITS_USED_COMPUTE), avg(CREDITS_USED_COMPUTE), '
-            'sum(CREDITS_USED_CLOUD_SERVICES), avg(CREDITS_USED_CLOUD_SERVICES), '
-            'sum(CREDITS_USED), avg(CREDITS_USED) from METERING_HISTORY '
-            'where start_time >= date_trunc(day, current_date) group by 1, 2;'
-        ),
-        'columns': [
-            {'name': 'service_type', 'type': 'tag'},
-            {'name': 'service', 'type': 'tag'},
-            {'name': 'billing.virtual_warehouse.sum', 'type': 'gauge'},
-            {'name': 'billing.virtual_warehouse.avg', 'type': 'gauge'},
-            {'name': 'billing.cloud_service.sum', 'type': 'gauge'},
-            {'name': 'billing.cloud_service.avg', 'type': 'gauge'},
-            {'name': 'billing.total_credit.sum', 'type': 'gauge'},
-            {'name': 'billing.total_credit.avg', 'type': 'gauge'},
-        ],
-    }
-)
+CreditUsage = {
+    'name': 'billing.metrics',
+    'query': (
+        'select SERVICE_TYPE, NAME, sum(CREDITS_USED_COMPUTE), avg(CREDITS_USED_COMPUTE), '
+        'sum(CREDITS_USED_CLOUD_SERVICES), avg(CREDITS_USED_CLOUD_SERVICES), '
+        'sum(CREDITS_USED), avg(CREDITS_USED) from METERING_HISTORY '
+        'where start_time >= date_trunc(day, current_date) group by 1, 2;'
+    ),
+    'columns': [
+        {'name': 'service_type', 'type': 'tag'},
+        {'name': 'service', 'type': 'tag'},
+        {'name': 'billing.virtual_warehouse.sum', 'type': 'gauge'},
+        {'name': 'billing.virtual_warehouse.avg', 'type': 'gauge'},
+        {'name': 'billing.cloud_service.sum', 'type': 'gauge'},
+        {'name': 'billing.cloud_service.avg', 'type': 'gauge'},
+        {'name': 'billing.total_credit.sum', 'type': 'gauge'},
+        {'name': 'billing.total_credit.avg', 'type': 'gauge'},
+    ],
+}
+
 
 # https://docs.snowflake.com/en/sql-reference/account-usage/warehouse_metering_history.html
-WarehouseCreditUsage = Query(
-    {
-        'name': 'billings.warehouse.metrics',
-        'query': (
-            'select WAREHOUSE_NAME, sum(CREDITS_USED_COMPUTE), avg(CREDITS_USED_COMPUTE), '
-            'sum(CREDITS_USED_CLOUD_SERVICES), avg(CREDITS_USED_CLOUD_SERVICES), '
-            'sum(CREDITS_USED), avg(CREDITS_USED) from WAREHOUSE_METERING_HISTORY '
-            'where start_time >= date_trunc(day, current_date) group by 1;'
-        ),
-        'columns': [
-            {'name': 'warehouse', 'type': 'tag'},
-            {'name': 'billing.warehouse.virtual_warehouse.sum', 'type': 'gauge'},
-            {'name': 'billing.warehouse.virtual_warehouse.avg', 'type': 'gauge'},
-            {'name': 'billing.warehouse.cloud_service.sum', 'type': 'gauge'},
-            {'name': 'billing.warehouse.cloud_service.avg', 'type': 'gauge'},
-            {'name': 'billing.warehouse.total_credit.sum', 'type': 'gauge'},
-            {'name': 'billing.warehouse.total_credit.avg', 'type': 'gauge'},
-        ],
-    }
-)
+WarehouseCreditUsage = {
+    'name': 'billings.warehouse.metrics',
+    'query': (
+        'select WAREHOUSE_NAME, sum(CREDITS_USED_COMPUTE), avg(CREDITS_USED_COMPUTE), '
+        'sum(CREDITS_USED_CLOUD_SERVICES), avg(CREDITS_USED_CLOUD_SERVICES), '
+        'sum(CREDITS_USED), avg(CREDITS_USED) from WAREHOUSE_METERING_HISTORY '
+        'where start_time >= date_trunc(day, current_date) group by 1;'
+    ),
+    'columns': [
+        {'name': 'warehouse', 'type': 'tag'},
+        {'name': 'billing.warehouse.virtual_warehouse.sum', 'type': 'gauge'},
+        {'name': 'billing.warehouse.virtual_warehouse.avg', 'type': 'gauge'},
+        {'name': 'billing.warehouse.cloud_service.sum', 'type': 'gauge'},
+        {'name': 'billing.warehouse.cloud_service.avg', 'type': 'gauge'},
+        {'name': 'billing.warehouse.total_credit.sum', 'type': 'gauge'},
+        {'name': 'billing.warehouse.total_credit.avg', 'type': 'gauge'},
+    ],
+}
+
 
 # https://docs.snowflake.com/en/sql-reference/account-usage/login_history.html
-LoginMetrics = Query(
-    {
-        'name': 'login.metrics',
-        'query': (
-            "select REPORTED_CLIENT_TYPE, sum(iff(IS_SUCCESS = 'NO', 1, 0)), sum(iff(IS_SUCCESS = 'YES', 1, 0)), "
-            "count(*) from LOGIN_HISTORY group by REPORTED_CLIENT_TYPE;"
-        ),
-        'columns': [
-            {'name': 'client_type', 'type': 'tag'},
-            {'name': 'logins.fail.count', 'type': 'monotonic_count'},
-            {'name': 'logins.success.count', 'type': 'monotonic_count'},
-            {'name': 'logins.total', 'type': 'monotonic_count'},
-        ],
-    }
-)
+LoginMetrics = {
+    'name': 'login.metrics',
+    'query': (
+        "select REPORTED_CLIENT_TYPE, sum(iff(IS_SUCCESS = 'NO', 1, 0)), sum(iff(IS_SUCCESS = 'YES', 1, 0)), "
+        "count(*) from LOGIN_HISTORY group by REPORTED_CLIENT_TYPE;"
+    ),
+    'columns': [
+        {'name': 'client_type', 'type': 'tag'},
+        {'name': 'logins.fail.count', 'type': 'monotonic_count'},
+        {'name': 'logins.success.count', 'type': 'monotonic_count'},
+        {'name': 'logins.total', 'type': 'monotonic_count'},
+    ],
+}
 
 # https://docs.snowflake.com/en/sql-reference/account-usage/warehouse_load_history.html
-WarehouseLoad = Query(
-    {
-        'name': 'warehouse_load.metrics',
-        'query': (
-            'select WAREHOUSE_NAME, AVG(AVG_RUNNING), AVG(AVG_QUEUED_LOAD), AVG(AVG_QUEUED_PROVISIONING), '
-            'AVG(AVG_BLOCKED) from WAREHOUSE_LOAD_HISTORY '
-            'where start_time >= date_trunc(day, current_date) group by 1;'
-        ),
-        'columns': [
-            {'name': 'warehouse', 'type': 'tag'},
-            {'name': 'query.executed', 'type': 'gauge'},
-            {'name': 'query.queued_overload', 'type': 'gauge'},
-            {'name': 'query.queued_provision', 'type': 'gauge'},
-            {'name': 'query.blocked', 'type': 'gauge'},
-        ],
-    }
-)
+WarehouseLoad = {
+    'name': 'warehouse_load.metrics',
+    'query': (
+        'select WAREHOUSE_NAME, AVG(AVG_RUNNING), AVG(AVG_QUEUED_LOAD), AVG(AVG_QUEUED_PROVISIONING), '
+        'AVG(AVG_BLOCKED) from WAREHOUSE_LOAD_HISTORY '
+        'where start_time >= date_trunc(day, current_date) group by 1;'
+    ),
+    'columns': [
+        {'name': 'warehouse', 'type': 'tag'},
+        {'name': 'query.executed', 'type': 'gauge'},
+        {'name': 'query.queued_overload', 'type': 'gauge'},
+        {'name': 'query.queued_provision', 'type': 'gauge'},
+        {'name': 'query.blocked', 'type': 'gauge'},
+    ],
+}
 
 # https://docs.snowflake.com/en/sql-reference/account-usage/query_history.html
-QueryHistory = Query(
-    {
-        'name': 'warehouse_load.metrics',
-        'query': (
-            'select QUERY_TYPE, WAREHOUSE_NAME, DATABASE_NAME, SCHEMA_NAME, AVG(EXECUTION_TIME), '
-            'AVG(COMPILATION_TIME), AVG(BYTES_SCANNED), AVG(BYTES_WRITTEN), AVG(BYTES_DELETED) '
-            'from QUERY_HISTORY where start_time >= date_trunc(day, current_date) '
-            'group by 1, 2, 3, 4;'
-        ),
-        'columns': [
-            {'name': 'query_type', 'type': 'tag'},
-            {'name': 'warehouse', 'type': 'tag'},
-            {'name': 'database', 'type': 'tag'},
-            {'name': 'schema', 'type': 'tag'},
-            {'name': 'query.execution_time', 'type': 'gauge'},
-            {'name': 'query.compilation_time', 'type': 'gauge'},
-            {'name': 'query.bytes_scanned', 'type': 'gauge'},
-            {'name': 'query.bytes_written', 'type': 'gauge'},
-            {'name': 'query.bytes_deleted', 'type': 'gauge'},
-        ],
-    }
-)
+QueryHistory = {
+    'name': 'warehouse_load.metrics',
+    'query': (
+        'select QUERY_TYPE, WAREHOUSE_NAME, DATABASE_NAME, SCHEMA_NAME, AVG(EXECUTION_TIME), '
+        'AVG(COMPILATION_TIME), AVG(BYTES_SCANNED), AVG(BYTES_WRITTEN), AVG(BYTES_DELETED) '
+        'from QUERY_HISTORY where start_time >= date_trunc(day, current_date) '
+        'group by 1, 2, 3, 4;'
+    ),
+    'columns': [
+        {'name': 'query_type', 'type': 'tag'},
+        {'name': 'warehouse', 'type': 'tag'},
+        {'name': 'database', 'type': 'tag'},
+        {'name': 'schema', 'type': 'tag'},
+        {'name': 'query.execution_time', 'type': 'gauge'},
+        {'name': 'query.compilation_time', 'type': 'gauge'},
+        {'name': 'query.bytes_scanned', 'type': 'gauge'},
+        {'name': 'query.bytes_written', 'type': 'gauge'},
+        {'name': 'query.bytes_deleted', 'type': 'gauge'},
+    ],
+}
 
 # https://docs.snowflake.com/en/sql-reference/account-usage/data_transfer_history.html
-DataTransferHistory = Query(
-    {
-        'name': 'data_transfer.metrics',
-        'query': (
-            'select source_cloud, source_region, target_cloud, target_region, transfer_type, '
-            'avg(bytes_transferred), sum(bytes_transferred) from DATA_TRANSFER_HISTORY '
-            'where start_time >= date_trunc(day, current_date) group by 1, 2, 3, 4, 5;'
-        ),
-        'columns': [
-            {'name': 'source_cloud', 'type': 'tag'},
-            {'name': 'source_region', 'type': 'tag'},
-            {'name': 'target_cloud', 'type': 'tag'},
-            {'name': 'target_region', 'type': 'tag'},
-            {'name': 'transfer_type', 'type': 'tag'},
-            {'name': 'data_transfer.bytes.avg', 'type': 'gauge'},
-            {'name': 'data_transfer.bytes.sum', 'type': 'gauge'},
-        ],
-    }
-)
+DataTransferHistory = {
+    'name': 'data_transfer.metrics',
+    'query': (
+        'select source_cloud, source_region, target_cloud, target_region, transfer_type, '
+        'avg(bytes_transferred), sum(bytes_transferred) from DATA_TRANSFER_HISTORY '
+        'where start_time >= date_trunc(day, current_date) group by 1, 2, 3, 4, 5;'
+    ),
+    'columns': [
+        {'name': 'source_cloud', 'type': 'tag'},
+        {'name': 'source_region', 'type': 'tag'},
+        {'name': 'target_cloud', 'type': 'tag'},
+        {'name': 'target_region', 'type': 'tag'},
+        {'name': 'transfer_type', 'type': 'tag'},
+        {'name': 'data_transfer.bytes.avg', 'type': 'gauge'},
+        {'name': 'data_transfer.bytes.sum', 'type': 'gauge'},
+    ],
+}
 
 # https://docs.snowflake.com/en/sql-reference/account-usage/automatic_clustering_history.html
-AutoReclusterHistory = Query(
-    {
-        'name': 'auto_recluster.metrics',
-        'query': (
-            'select table_name, database_name, schema_name, avg(credits_used), sum(credits_used), '
-            'avg(num_bytes_reclustered), sum(num_bytes_reclustered), '
-            'avg(num_rows_reclustered), sum(num_rows_reclustered) '
-            'from automatic_clustering_history where start_time >= date_trunc(day, current_date) group by 1, 2, 3;'
-        ),
-        'columns': [
-            {'name': 'table', 'type': 'tag'},
-            {'name': 'database', 'type': 'tag'},
-            {'name': 'schema', 'type': 'tag'},
-            {'name': 'auto_recluster.credits_used.avg', 'type': 'gauge'},
-            {'name': 'auto_recluster.credits_used.sum', 'type': 'gauge'},
-            {'name': 'auto_recluster.bytes_reclustered.avg', 'type': 'gauge'},
-            {'name': 'auto_recluster.bytes_reclustered.sum', 'type': 'gauge'},
-            {'name': 'auto_recluster.rows_reclustered.avg', 'type': 'gauge'},
-            {'name': 'auto_recluster.rows_reclustered.sum', 'type': 'gauge'},
-        ],
-    }
-)
+AutoReclusterHistory = {
+    'name': 'auto_recluster.metrics',
+    'query': (
+        'select table_name, database_name, schema_name, avg(credits_used), sum(credits_used), '
+        'avg(num_bytes_reclustered), sum(num_bytes_reclustered), '
+        'avg(num_rows_reclustered), sum(num_rows_reclustered) '
+        'from automatic_clustering_history where start_time >= date_trunc(day, current_date) group by 1, 2, 3;'
+    ),
+    'columns': [
+        {'name': 'table', 'type': 'tag'},
+        {'name': 'database', 'type': 'tag'},
+        {'name': 'schema', 'type': 'tag'},
+        {'name': 'auto_recluster.credits_used.avg', 'type': 'gauge'},
+        {'name': 'auto_recluster.credits_used.sum', 'type': 'gauge'},
+        {'name': 'auto_recluster.bytes_reclustered.avg', 'type': 'gauge'},
+        {'name': 'auto_recluster.bytes_reclustered.sum', 'type': 'gauge'},
+        {'name': 'auto_recluster.rows_reclustered.avg', 'type': 'gauge'},
+        {'name': 'auto_recluster.rows_reclustered.sum', 'type': 'gauge'},
+    ],
+}
 
 # https://docs.snowflake.com/en/sql-reference/account-usage/table_storage_metrics.html
-TableStorage = Query(
-    {
-        'name': 'table_storage.metrics',
-        'query': (
-            'select table_name, table_schema, avg(ACTIVE_BYTES), avg(TIME_TRAVEL_BYTES), avg(FAILSAFE_BYTES), '
-            'avg(RETAINED_FOR_CLONE_BYTES) from table_storage_metrics group by 1, 2'
-        ),
-        'columns': [
-            {'name': 'table', 'type': 'tag'},
-            {'name': 'schema', 'type': 'tag'},
-            {'name': 'storage.table.active_bytes.avg', 'type': 'gauge'},
-            {'name': 'storage.table.time_travel_bytes.avg', 'type': 'gauge'},
-            {'name': 'storage.table.failsafe_bytes.avg', 'type': 'gauge'},
-            {'name': 'storage.table.retained_bytes.avg', 'type': 'gauge'},
-        ],
-    }
-)
+TableStorage = {
+    'name': 'table_storage.metrics',
+    'query': (
+        'select table_name, table_schema, avg(ACTIVE_BYTES), avg(TIME_TRAVEL_BYTES), avg(FAILSAFE_BYTES), '
+        'avg(RETAINED_FOR_CLONE_BYTES) from table_storage_metrics group by 1, 2'
+    ),
+    'columns': [
+        {'name': 'table', 'type': 'tag'},
+        {'name': 'schema', 'type': 'tag'},
+        {'name': 'storage.table.active_bytes.avg', 'type': 'gauge'},
+        {'name': 'storage.table.time_travel_bytes.avg', 'type': 'gauge'},
+        {'name': 'storage.table.failsafe_bytes.avg', 'type': 'gauge'},
+        {'name': 'storage.table.retained_bytes.avg', 'type': 'gauge'},
+    ],
+}
 
 # https://docs.snowflake.com/en/sql-reference/account-usage/pipe_usage_history.html
-PipeHistory = Query(
-    {
-        'name': 'pipe.metrics',
-        'query': (
-            'select pipe_name, avg(credits_used), sum(credits_used), avg(bytes_inserted), sum(bytes_inserted), '
-            'avg(files_inserted), sum(files_inserted) from pipe_usage_history '
-            'where start_time >= date_trunc(day, current_date) group by 1;'
-        ),
-        'columns': [
-            {'name': 'pipe', 'type': 'tag'},
-            {'name': 'pipe.credits_used.avg', 'type': 'gauge'},
-            {'name': 'pipe.credits_used.sum', 'type': 'gauge'},
-            {'name': 'pipe.bytes_inserted.avg', 'type': 'gauge'},
-            {'name': 'pipe.bytes_inserted.sum', 'type': 'gauge'},
-            {'name': 'pipe.files_inserted.avg', 'type': 'gauge'},
-            {'name': 'pipe.files_inserted.sum', 'type': 'gauge'},
-        ],
-    }
-)
+PipeHistory = {
+    'name': 'pipe.metrics',
+    'query': (
+        'select pipe_name, avg(credits_used), sum(credits_used), avg(bytes_inserted), sum(bytes_inserted), '
+        'avg(files_inserted), sum(files_inserted) from pipe_usage_history '
+        'where start_time >= date_trunc(day, current_date) group by 1;'
+    ),
+    'columns': [
+        {'name': 'pipe', 'type': 'tag'},
+        {'name': 'pipe.credits_used.avg', 'type': 'gauge'},
+        {'name': 'pipe.credits_used.sum', 'type': 'gauge'},
+        {'name': 'pipe.bytes_inserted.avg', 'type': 'gauge'},
+        {'name': 'pipe.bytes_inserted.sum', 'type': 'gauge'},
+        {'name': 'pipe.files_inserted.avg', 'type': 'gauge'},
+        {'name': 'pipe.files_inserted.sum', 'type': 'gauge'},
+    ],
+}
 
 # https://docs.snowflake.com/en/sql-reference/account-usage/replication_usage_history.html
-ReplicationUsage = Query(
-    {
-        'name': 'replication.metrics',
-        'query': (
-            'select database_name, avg(credits_used), sum(credits_used), '
-            'avg(bytes_transferred), sum(bytes_transferred) from replication_usage_history '
-            'where start_time >= date_trunc(day, current_date) group by 1;'
-        ),
-        'columns': [
-            {'name': 'database', 'type': 'tag'},
-            {'name': 'replication.credits_used.avg', 'type': 'gauge'},
-            {'name': 'replication.credits_used.sum', 'type': 'gauge'},
-            {'name': 'replication.bytes_transferred.avg', 'type': 'gauge'},
-            {'name': 'replication.bytes_transferred.sum', 'type': 'gauge'},
-        ],
-    }
-)
+ReplicationUsage = {
+    'name': 'replication.metrics',
+    'query': (
+        'select database_name, avg(credits_used), sum(credits_used), '
+        'avg(bytes_transferred), sum(bytes_transferred) from replication_usage_history '
+        'where start_time >= date_trunc(day, current_date) group by 1;'
+    ),
+    'columns': [
+        {'name': 'database', 'type': 'tag'},
+        {'name': 'replication.credits_used.avg', 'type': 'gauge'},
+        {'name': 'replication.credits_used.sum', 'type': 'gauge'},
+        {'name': 'replication.bytes_transferred.avg', 'type': 'gauge'},
+        {'name': 'replication.bytes_transferred.sum', 'type': 'gauge'},
+    ],
+}

--- a/snowflake/tests/test_snowflake.py
+++ b/snowflake/tests/test_snowflake.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 import mock
 
 from datadog_checks.base.stubs.aggregator import AggregatorStub
+from datadog_checks.base.utils.db import Query
 from datadog_checks.snowflake import SnowflakeCheck, queries
 
 from .conftest import CHECK_NAME
@@ -21,7 +22,7 @@ def test_storage_metrics(dd_run_check, aggregator, instance):
     with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_storage):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.StorageUsageMetrics]
+        check._query_manager.queries = [Query(queries.StorageUsageMetrics)]
         dd_run_check(check)
 
     aggregator.assert_metric('snowflake.storage.storage_bytes.total', value=0.0, tags=EXPECTED_TAGS)
@@ -39,7 +40,7 @@ def test_db_storage_metrics(dd_run_check, aggregator, instance):
     ):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.DatabaseStorageMetrics]
+        check._query_manager.queries = [Query(queries.DatabaseStorageMetrics)]
         dd_run_check(check)
     aggregator.assert_metric('snowflake.storage.database.storage_bytes', value=133.0, tags=expected_tags)
     aggregator.assert_metric('snowflake.storage.database.failsafe_bytes', value=9.1, tags=expected_tags)
@@ -64,7 +65,7 @@ def test_credit_usage_metrics(dd_run_check, aggregator, instance):
     with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_credit_usage):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.CreditUsage]
+        check._query_manager.queries = [Query(queries.CreditUsage)]
         dd_run_check(check)
 
     aggregator.assert_metric('snowflake.billing.cloud_service.sum', count=1, tags=expected_tags)
@@ -93,7 +94,7 @@ def test_warehouse_usage_metrics(dd_run_check, aggregator, instance):
     with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_wh_usage):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.WarehouseCreditUsage]
+        check._query_manager.queries = [Query(queries.WarehouseCreditUsage)]
         dd_run_check(check)
 
     aggregator.assert_metric('snowflake.billing.warehouse.cloud_service.avg', count=1, tags=expected_tags)
@@ -111,7 +112,7 @@ def test_login_metrics(dd_run_check, aggregator, instance):
     with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_login_metrics):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.LoginMetrics]
+        check._query_manager.queries = [Query(queries.LoginMetrics)]
         dd_run_check(check)
     snowflake_tags = EXPECTED_TAGS + ['client_type:SNOWFLAKE_UI']
     aggregator.assert_metric('snowflake.logins.fail.count', value=2, tags=snowflake_tags)
@@ -134,7 +135,7 @@ def test_warehouse_load(dd_run_check, aggregator, instance):
     with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_wl_metrics):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.WarehouseLoad]
+        check._query_manager.queries = [Query(queries.WarehouseLoad)]
         dd_run_check(check)
     aggregator.assert_metric('snowflake.query.executed', value=0.000446667, tags=expected_tags)
     aggregator.assert_metric('snowflake.query.queued_overload', value=0, count=1, tags=expected_tags)
@@ -163,7 +164,7 @@ def test_query_metrics(dd_run_check, aggregator, instance):
     with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_query_metrics):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check._conn = mock.MagicMock()
-        check._query_manager.queries = [queries.QueryHistory]
+        check._query_manager.queries = [Query(queries.QueryHistory)]
         dd_run_check(check)
 
     aggregator.assert_metric('snowflake.query.execution_time', value=4.333333, tags=expected_tags)


### PR DESCRIPTION
Database checks pass instances of 'Query' directly to the QueryManager for them to be 'compiled' and used.
The QueryManager modifies those 'Query' instances in-place which means that multiple instances of a same check will share the same references to those 'Query' objects.
It wouldn't be a problem if those Query did not contain references to bounded methods of the check.

Impact:

Any check currently using the QueryManager with multiple configuration instances will see metrics that should be submitted with one instance being submitted with another one. This is transparent to users, metrics will be sent to Datadog app anyway.
If the check is using autodiscovery, configuration instances are generated dynamically. Instances can be unscheduled and that leads to integrations trying to report metrics through another un-existing check instance which the agent refuses to send.