### PR TITLE
DOCS-1268 fluentd link update

### DIFF
--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -195,7 +195,7 @@ Need help? Contact [Datadog support][16].
 [4]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [5]: https://github.com/DataDog/integrations-core/blob/master/fluentd/datadog_checks/fluentd/data/conf.yaml.example
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[7]: http://www.rubydoc.info/gems/fluent-plugin-datadog
+[7]: https://github.com/DataDog/fluent-plugin-datadog
 [8]: https://docs.datadoghq.com/logs/processing/#edit-reserved-attributes
 [9]: https://docs.datadoghq.com/integrations/#cat-log-collection
 [10]: https://docs.datadoghq.com/logs/processing/#integration-pipelines


### PR DESCRIPTION
### What does this PR do?
Changes the plugin link from rubydoc to a datadog github repo, so customers aren't mislead into thinking we don't own it

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
