### PR TITLE
Add support for hashing sequences that contain None in `hash_mutable` on Python 3

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/containers.py
+++ b/datadog_checks_base/datadog_checks/base/utils/containers.py
@@ -10,21 +10,23 @@ def freeze(o):
     Accepts nested dictionaries.
     """
 
-    def key_none_safe(x):
-        # On Python 2, comparing `None < <anything>` always returns `False`,
-        # but on Python 3, it always fails with a `TypeError`.
-        if x is None:
-            return ''
-        return x
+    # NOTE: we sort items in containers so that the resulting frozen structure (and its hash) don't depend
+    # on the order of those items. In other words: `hash_mutable([1, 2]) == hash_mutable([2, 1])`.
+    # So, the sort `key` can be any function that uniquely maps a value to another.
+    # We used to use the identify function, i.e. no `key` (or `key=lambda x: x`), but this prevented freezing
+    # containers that contain `None` values, since on Python 3 those can't be compared with anything else.
+    # The `hash` built-in is a function that uniquely maps values, while being also applicable to all immutable objects.
+    # See: https://github.com/DataDog/integrations-core/pull/7763
+    key = hash
 
     if isinstance(o, (tuple, list)):
-        return tuple(sorted((freeze(e) for e in o), key=key_none_safe))
+        return tuple(sorted((freeze(e) for e in o), key=key))
 
     if isinstance(o, dict):
-        return tuple(sorted(((k, freeze(v)) for k, v in iteritems(o)), key=key_none_safe))
+        return tuple(sorted(((k, freeze(v)) for k, v in iteritems(o)), key=key))
 
     if isinstance(o, (set, frozenset)):
-        return tuple(sorted((freeze(e) for e in o), key=key_none_safe))
+        return tuple(sorted((freeze(e) for e in o), key=key))
 
     return o
 

--- a/datadog_checks_base/datadog_checks/base/utils/containers.py
+++ b/datadog_checks_base/datadog_checks/base/utils/containers.py
@@ -9,14 +9,22 @@ def freeze(o):
     Freezes any mutable object including dictionaries and lists for hashing.
     Accepts nested dictionaries.
     """
+
+    def key_none_safe(x):
+        # On Python 2, comparing `None < <anything>` always returns `False`,
+        # but on Python 3, it always fails with a `TypeError`.
+        if x is None:
+            return ''
+        return x
+
     if isinstance(o, (tuple, list)):
-        return tuple(sorted(freeze(e) for e in o))
+        return tuple(sorted((freeze(e) for e in o), key=key_none_safe))
 
     if isinstance(o, dict):
-        return tuple(sorted((k, freeze(v)) for k, v in iteritems(o)))
+        return tuple(sorted(((k, freeze(v)) for k, v in iteritems(o)), key=key_none_safe))
 
     if isinstance(o, (set, frozenset)):
-        return tuple(sorted(freeze(e) for e in o))
+        return tuple(sorted((freeze(e) for e in o), key=key_none_safe))
 
     return o
 

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -170,6 +170,23 @@ class TestContainers:
         h = hash_mutable(value)  # Must not fail.
         assert isinstance(h, int)
 
+    @pytest.mark.parametrize(
+        'left, right',
+        [
+            pytest.param([1, 2], [2, 1], id='top-level'),
+            pytest.param({'x': [1, 2]}, {'x': [2, 1]}, id='nested'),
+        ],
+    )
+    def test_hash_mutable_order_irrelevant(self, left, right):
+        assert hash_mutable(left) == hash_mutable(right)
+
+    @pytest.mark.parametrize('value', ['', 0, ()])
+    def test_hash_mutable_none_is_not_just_falsy(self, value):
+        """
+        None shouldn't be treated as any other false-y value when computing hashes.
+        """
+        assert hash_mutable(['test', None]) != hash_mutable(['test', value])
+
 
 class TestBytesUnicode:
     @pytest.mark.skipif(PY3, reason="Python 3 does not support explicit bytestring with special characters")

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -155,23 +155,15 @@ class TestContainers:
         [
             pytest.param({'x': 'y'}, id='dict'),
             pytest.param({'x': 'y', 'z': None}, id='dict-with-none-value'),
-            pytest.param(
-                {'x': 'y', None: 't'},
-                id='dict-with-none-key',
-                marks=pytest.mark.xfail(PY3, raises=TypeError, reason='not implemented'),
-            ),
+            pytest.param({'x': 'y', None: 't'}, id='dict-with-none-key'),
             pytest.param(['x', 'y'], id='list'),
-            pytest.param(['x', None], id='list-containing-none'),
+            pytest.param(['x', 1, None], id='mixed-list'),
             pytest.param(('x', 'y'), id='tuple'),
-            pytest.param(('x', None), id='tuple-containing-none'),
+            pytest.param(('x', 1, None), id='mixed-tuple'),
             pytest.param({'x', 'y'}, id='set'),
-            pytest.param({'x', None}, id='set-containing-none'),
+            pytest.param({'x', 1, None}, id='mixed-set'),
             pytest.param({'x': ['y', 'z']}, id='dict-nest-list'),
-            pytest.param(
-                ['x', {'y': 'z'}],
-                id='list-nest-dict',
-                marks=pytest.mark.xfail(PY3, raises=TypeError, reason='not implemented'),
-            ),
+            pytest.param(['x', {'y': 'z'}], id='list-nest-dict'),
         ],
     )
     def test_hash_mutable(self, value):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Update `hash_mutable` to allow `hash_mutable(['test', None])` to succeed, whereas right now it fails with a `TypeError` on Python 3:

```console
>>> from datadog_checks.base.utils.containers import hash_mutable
>>> hash_mutable(['test', None])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/utils/containers.py", line 25, in hash_mutable
    return hash(freeze(m))
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/utils/containers.py", line 13, in freeze
    return tuple(sorted(freeze(e) for e in o))
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```

* Add unit tests for this function.

### Motivation
<!-- What inspired you to submit this pull request? -->
We need this in the PDH check for accepting `additional_metrics` that contain `None` as the `inst_name`, see: https://github.com/DataDog/integrations-core/pull/7752#issuecomment-706207004

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
