### PR TITLE
[http] Support wildcard subdomain and single wildcard in proxies

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -441,6 +441,11 @@ def should_bypass_proxy(url, no_proxy_uris):
     # Returns True if URL should bypass the proxy.
     parsed_uri = urlparse(url).hostname
 
+    if '*' in no_proxy_uris:
+        # The only wildcard available is a single * character, which matches all hosts, and effectively disables the proxy.
+        # See: https://curl.haxx.se/libcurl/c/CURLOPT_NOPROXY.html
+        return True
+
     for no_proxy_uri in no_proxy_uris:
         try:
             # If no_proxy_uri is an IP or IP CIDR.
@@ -455,7 +460,13 @@ def should_bypass_proxy(url, no_proxy_uris):
             #   e.g. "foo.com" matches "foo.com" and "bar.foo.com"
             # A domain name with a leading "." matches subdomains only.
             #   e.g. ".y.com" matches "x.y.com" but not "y.com".
-            dot_no_proxy_uri = no_proxy_uri if no_proxy_uri.startswith(".") else ".{}".format(no_proxy_uri)
+            if no_proxy_uri.startswith((".", "*.")):
+                # Support wildcard subdomain; treat as leading dot "."
+                # e.g. "*.example.domain" as ".example.domain"
+                dot_no_proxy_uri = no_proxy_uri.strip("*")
+            else:
+                # Used for matching subdomains.
+                dot_no_proxy_uri = ".{}".format(no_proxy_uri)
             if no_proxy_uri == parsed_uri or parsed_uri.endswith(dot_no_proxy_uri):
                 return True
     return False

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -463,7 +463,7 @@ def should_bypass_proxy(url, no_proxy_uris):
             if no_proxy_uri.startswith((".", "*.")):
                 # Support wildcard subdomain; treat as leading dot "."
                 # e.g. "*.example.domain" as ".example.domain"
-                dot_no_proxy_uri = no_proxy_uri.strip("*")
+                dot_no_proxy_uri = no_proxy_uri.lstrip("*")
             else:
                 # Used for matching subdomains.
                 dot_no_proxy_uri = ".{}".format(no_proxy_uri)

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -442,7 +442,7 @@ def should_bypass_proxy(url, no_proxy_uris):
     parsed_uri = urlparse(url).hostname
 
     if '*' in no_proxy_uris:
-        # The only wildcard available is a single * character, which matches all hosts, and effectively disables the proxy.
+        # A single * character is supported, which matches all hosts, and effectively disables the proxy.
         # See: https://curl.haxx.se/libcurl/c/CURLOPT_NOPROXY.html
         return True
 

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -1100,13 +1100,26 @@ class TestProxies:
         http.get('http://nginx')
 
     @pytest.mark.skipif(running_on_windows_ci(), reason='Test cannot be run on Windows CI')
+    def test_no_proxy_single_wildcard(self, socks5_proxy):
+        instance = {'proxy': {'http': 'http://1.2.3.4:567', 'no_proxy': '.foo,bar,*'}}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        http.get('http://www.example.org')
+        http.get('http://www.example.com')
+        http.get('http://127.0.0.9')
+
+    @pytest.mark.skipif(running_on_windows_ci(), reason='Test cannot be run on Windows CI')
     def test_no_proxy_domain(self, socks5_proxy):
-        instance = {'proxy': {'http': 'http://1.2.3.4:567', 'no_proxy': '.google.com,example.com,9'}}
+        instance = {'proxy': {'http': 'http://1.2.3.4:567', 'no_proxy': '.google.com,*.example.org,example.com,9'}}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
         # no_proxy match: .google.com
         http.get('http://www.google.com')
+
+        # no_proxy match: *.example.org
+        http.get('http://www.example.org')
 
         # no_proxy match: example.com
         http.get('http://www.example.com')


### PR DESCRIPTION
### What does this PR do?

- Support wildcard subdomain. e.g. `*.example.com`
- Support single wildcard effectively disabling proxy.

### Motivation
- wildcard subdomain widely used in Windows environment and some linux systems

### Additional Notes
- Only subdomain can be used with wildcard. e.g. `*.example.com` OK, `*example.com` NOT supported
- Wildcards in middle or at the end are not supported. e.g. `foo.*.bar` or `127.*.*.*`
- Public doc update to follow after

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
