### PR TITLE
Use creation, update and closed date to detect user inactivity.

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_users.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_users.py
@@ -52,8 +52,25 @@ class GithubUsers:
     def get_last_pr_date(self, login: str) -> Optional[str]:
         last_prs = self.__github.get_last_prs(login)
         last_prs_items = last_prs['items']
-        if len(last_prs_items) == 0:
-            return None
-        last_pr = last_prs_items[0]
-        created_at = last_pr['created_at']
-        return created_at
+        latest_date = None
+        for pr in last_prs_items:
+            latest_date = self.__get_max_date(pr['created_at'], latest_date)
+            latest_date = self.__get_max_date(pr['closed_at'], latest_date)
+            latest_date = self.__get_max_date(pr['updated_at'], latest_date)
+        if latest_date:
+            return datetime.strftime(latest_date, PR_DATE_FORMAT)
+        return None
+
+    def __get_max_date(self, date_str: Optional[str], latest_date: Optional[datetime]) -> Optional[datetime]:
+        if date_str is not None:
+            date = pr_date_str_to_date(date_str)
+            if latest_date is None or date > latest_date:
+                return date
+        return latest_date
+
+
+PR_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def pr_date_str_to_date(date_str: str) -> datetime:
+    return datetime.strptime(date_str, PR_DATE_FORMAT)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_users.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_users.py
@@ -10,6 +10,8 @@ from .....github import Github
 from ....console import echo_info
 from .cache import Cache
 
+PR_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
 
 class GithubUser:
     def __init__(self, data: Dict[str, object]):
@@ -67,9 +69,6 @@ class GithubUsers:
             if latest_date is None or date > latest_date:
                 return date
         return latest_date
-
-
-PR_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 def pr_date_str_to_date(date_str: str) -> datetime:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector.py
@@ -9,7 +9,7 @@ from .....github import Github
 from .....trello import TrelloClient
 from ....console import echo_info, echo_warning
 from .github_trello_user_matcher import GithubTrelloUserMatcher
-from .github_users import GithubUser, GithubUsers
+from .github_users import GithubUser, GithubUsers, pr_date_str_to_date
 from .tester_selector_team import TesterSelectorTeam
 from .trello_users import TrelloUser, TrelloUsers
 
@@ -90,5 +90,5 @@ class TesterSelector:
     def __get_last_user_activity(self, user: GithubUser) -> Optional[datetime]:
         last_pr_date = user.last_pr_date_str
         if last_pr_date:
-            return datetime.strptime(last_pr_date, "%Y-%m-%dT%H:%M:%SZ")
+            return pr_date_str_to_date(last_pr_date)
         return None


### PR DESCRIPTION
### What does this PR do?

This PR uses creation, update and closed date to detect user inactivity.

### Motivation

If a user open a pull request and merge it several weeks later, the last activity date must be the close date of the PR.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
