### PR TITLE
Fix custom_queries description

### DIFF
--- a/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
+++ b/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
@@ -92,7 +92,7 @@ instances:
     ## 2. columns - The list representing each column, ordered sequentially from left to right.
     ##              The number of columns must equal the number of columns returned in the query.
     ##              There are 2 required pieces of data:
-    ##                a. name - The suffix to append to `clickhouse.` to form
+    ##                a. name - The suffix to append to `<INTEGRATION>.` to form
     ##                          the full metric name. If `type` is `tag`, this column is
     ##                          considered a tag and applied to every
     ##                          metric collected by this particular query.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/db.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/db.yaml
@@ -17,7 +17,7 @@
     2. columns - The list representing each column, ordered sequentially from left to right.
                  The number of columns must equal the number of columns returned in the query.
                  There are 2 required pieces of data:
-                   a. name - The suffix to append to `clickhouse.` to form
+                   a. name - The suffix to append to `<INTEGRATION>.` to form
                              the full metric name. If `type` is `tag`, this column is
                              considered a tag and applied to every
                              metric collected by this particular query.

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -100,7 +100,7 @@ instances:
     ## 2. columns - The list representing each column, ordered sequentially from left to right.
     ##              The number of columns must equal the number of columns returned in the query.
     ##              There are 2 required pieces of data:
-    ##                a. name - The suffix to append to `clickhouse.` to form
+    ##                a. name - The suffix to append to `<INTEGRATION>.` to form
     ##                          the full metric name. If `type` is `tag`, this column is
     ##                          considered a tag and applied to every
     ##                          metric collected by this particular query.

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -138,7 +138,7 @@ instances:
     ## 2. columns - The list representing each column, ordered sequentially from left to right.
     ##              The number of columns must equal the number of columns returned in the query.
     ##              There are 2 required pieces of data:
-    ##                a. name - The suffix to append to `clickhouse.` to form
+    ##                a. name - The suffix to append to `<INTEGRATION>.` to form
     ##                          the full metric name. If `type` is `tag`, this column is
     ##                          considered a tag and applied to every
     ##                          metric collected by this particular query.

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -129,7 +129,7 @@ instances:
     ## 2. columns - The list representing each column, ordered sequentially from left to right.
     ##              The number of columns must equal the number of columns returned in the query.
     ##              There are 2 required pieces of data:
-    ##                a. name - The suffix to append to `clickhouse.` to form
+    ##                a. name - The suffix to append to `<INTEGRATION>.` to form
     ##                          the full metric name. If `type` is `tag`, this column is
     ##                          considered a tag and applied to every
     ##                          metric collected by this particular query.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix `custom_queries` description for database instances. It removes `clickhouse` reference.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
