### PR TITLE
Update documentation about service check message limit

### DIFF
--- a/http_check/assets/configuration/spec.yaml
+++ b/http_check/assets/configuration/spec.yaml
@@ -76,7 +76,7 @@ files:
     - name: include_content
       description: |
         The include_content parameter will instruct the check
-        to include the first 200 characters of the HTTP response body
+        to include the first 500 characters of the HTTP response body
         in notifications sent by this plugin. This is best used with
         "healthcheck"-type URLs, where the body contains a brief, human-
         readable summary of failure reasons in the case of errors.

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -103,7 +103,7 @@ instances:
 
     ## @param include_content - boolean - optional - default: false
     ## The include_content parameter will instruct the check
-    ## to include the first 200 characters of the HTTP response body
+    ## to include the first 500 characters of the HTTP response body
     ## in notifications sent by this plugin. This is best used with
     ## "healthcheck"-type URLs, where the body contains a brief, human-
     ## readable summary of failure reasons in the case of errors.


### PR DESCRIPTION
In https://github.com/DataDog/integrations-core/pull/7008/files#diff-d1d3b592cf2ef4b7512bec5a80f322f0ce4391a524574c9e67693d840adc26bdR31 we updated the limit on the check side. Since, the backend has updated the intake limit to 500 so let's update the documentation to reflect that https://docs.datadoghq.com/api/v1/service-checks/