### PR TITLE
Add support for hashing sequences containing None on Python 3

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/containers.py
+++ b/datadog_checks_base/datadog_checks/base/utils/containers.py
@@ -4,19 +4,59 @@
 from six import iteritems
 
 
+class _FreezeKey(object):
+    # "Why does this class exist?"
+    # To freeze and compute hashes or mutable structures, we use sorting as an intermediary step so that the
+    # order of items in the container doesn't change the final hash (a property we could call "commutativity").
+    # When items in the container are all the same type (eg a list of strings), there is no problem to this.
+    # But when the container has items of mixed types, we'd get a `TypeError` on Python 3. (Not on Python 2 though,
+    # since comparisons there default to returning `False`.)
+    # So this class was introduced to support specific comparison cases that we need to support to fulfill the needs
+    # of integrations that use these freeze/hash helpers.
+
+    def __init__(self, value):
+        self.value = value
+
+    def __lt__(self, other):
+        # type: (_FreezeKey) -> bool
+        try:
+            lt = self.value < other.value
+        except TypeError:
+            # We're on Python 3, and values are of differing types.
+            # Some integrations may using freezing on structures that contain `None`, so we want to support it and
+            # use the same behavior than on Python 2, i.e. `None < <anything>` must return `False`...
+            if self.value is None:
+                # `None < x` -> `False`
+                return False
+            if other.value is None:
+                # `x < None` -> `True`
+                return True
+            # ...But we let other cases bubble through.
+            raise
+        else:
+            # We're on Python 2, where `a < b` never fails (returns `False` by default).
+            return lt
+
+
+def _item_freeze_key(item):
+    # type: (tuple) -> tuple
+    key, value = item
+    return (_FreezeKey(key), _FreezeKey(value))
+
+
 def freeze(o):
     """
     Freezes any mutable object including dictionaries and lists for hashing.
     Accepts nested dictionaries.
     """
     if isinstance(o, (tuple, list)):
-        return tuple(sorted(freeze(e) for e in o))
+        return tuple(sorted((freeze(e) for e in o), key=_FreezeKey))
 
     if isinstance(o, dict):
-        return tuple(sorted((k, freeze(v)) for k, v in iteritems(o)))
+        return tuple(sorted(((k, freeze(v)) for k, v in iteritems(o)), key=_item_freeze_key))
 
     if isinstance(o, (set, frozenset)):
-        return tuple(sorted(freeze(e) for e in o))
+        return tuple(sorted((freeze(e) for e in o), key=_FreezeKey))
 
     return o
 

--- a/datadog_checks_base/datadog_checks/base/utils/containers.py
+++ b/datadog_checks_base/datadog_checks/base/utils/containers.py
@@ -26,15 +26,16 @@ class _FreezeKey(object):
             # Some integrations may using freezing on structures that contain `None`, so we want to support it and
             # use the same behavior than on Python 2, i.e. `None < <anything>` must return `False`...
             if self.value is None:
-                # `None < x` -> `False`
-                return False
-            if other.value is None:
-                # `x < None` -> `True`
+                # `None < x` -> `True`
                 return True
+            if other.value is None:
+                # `x < None` -> `False`
+                return False
             # ...But we let other cases bubble through.
             raise
         else:
-            # We're on Python 2, where `a < b` never fails (returns `False` by default).
+            # We're on Python 2, where `a < b` never fails (returns `False` by default), or
+            # we're on Python 3 and values have the same type.
             return lt
 
 

--- a/datadog_checks_base/tests/test_utils.py
+++ b/datadog_checks_base/tests/test_utils.py
@@ -8,10 +8,10 @@ from decimal import ROUND_HALF_DOWN
 
 import mock
 import pytest
-from six import PY3
+from six import PY2, PY3
 
 from datadog_checks.base.utils.common import ensure_bytes, ensure_unicode, pattern_filter, round_value, to_native_string
-from datadog_checks.base.utils.containers import iter_unique
+from datadog_checks.base.utils.containers import hash_mutable, iter_unique
 from datadog_checks.base.utils.limiter import Limiter
 from datadog_checks.base.utils.secrets import SecretsSanitizer
 
@@ -149,6 +149,58 @@ class TestContainers:
         ]
 
         assert len(list(iter_unique(custom_queries))) == 1
+
+    @pytest.mark.parametrize(
+        'value',
+        [
+            pytest.param({'x': 'y'}, id='dict'),
+            pytest.param({'x': 'y', 'z': None}, id='dict-with-none-value'),
+            pytest.param({'x': 'y', None: 't'}, id='dict-with-none-key'),
+            pytest.param({'x': ['y', 'z'], 't': 'u'}, id='dict-nest-list'),
+            pytest.param(['x', 'y'], id='list'),
+            pytest.param(['x', None], id='list-with-none'),
+            pytest.param(('x', None), id='tuple-with-none'),
+            pytest.param({'x', None}, id='set-with-none'),
+        ],
+    )
+    def test_hash_mutable(self, value):
+        h = hash_mutable(value)
+        assert isinstance(h, int)
+
+    @pytest.mark.skipif(
+        PY2,
+        reason="In Python 2, a < b when a and b are of different types returns `False` (does not raise `TypeError`)",
+    )
+    @pytest.mark.parametrize(
+        'value',
+        [
+            pytest.param(['x', 1], id='mixed-list'),
+            pytest.param(['x', [1, 2, 3]], id='mixed-list-nested-1'),
+            pytest.param(['x', {'y': 'z'}], id='mixed-list-nested-2'),
+            pytest.param(('x', 1), id='mixed-tuple'),
+            pytest.param({'x', 1}, id='mixed-set'),
+            pytest.param({'x': 1, 2: 'y'}, id='mixed-dict-keys'),
+        ],
+    )
+    def test_hash_mutable_unsupported_mixed_type(self, value):
+        """
+        Hashing mixed type containers is not supported, mostly because we haven't needed to add support for it yet.
+        """
+        with pytest.raises(TypeError):
+            hash_mutable(value)
+
+    @pytest.mark.parametrize(
+        'left, right',
+        [
+            pytest.param([1, 2], [2, 1], id='top-level'),
+            pytest.param({'x': [1, 2]}, {'x': [2, 1]}, id='nested'),
+        ],
+    )
+    def test_hash_mutable_commutative(self, left, right):
+        """
+        hash_mutable() is expected to return the same hash regardless of the order of items in the container.
+        """
+        assert hash_mutable(left) == hash_mutable(right)
 
 
 class TestBytesUnicode:


### PR DESCRIPTION
### What does this PR do?
Alternative to #7763, refs https://github.com/DataDog/integrations-core/pull/7752#issuecomment-706207004

Update `hash_mutable` to allow `hash_mutable(['test', None])`, whereas right now it fails with a `TypeError` on Python 3:

```console
>>> from datadog_checks.base.utils.containers import hash_mutable
>>> hash_mutable(['test', None])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/utils/containers.py", line 25, in hash_mutable
    return hash(freeze(m))
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/utils/containers.py", line 13, in freeze
    return tuple(sorted(freeze(e) for e in o))
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```

### Motivation
<!-- What inspired you to submit this pull request? -->
We need this in the PDH check for accepting `additional_metrics` that contain `None` as the `inst_name`, see: https://github.com/DataDog/integrations-core/pull/7752#issuecomment-706207004

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
