### PR TITLE
Add logs support

### DIFF
--- a/kyototycoon/README.md
+++ b/kyototycoon/README.md
@@ -28,7 +28,6 @@ The KyotoTycoon check is included in the [Datadog Agent][1] package, so you don'
 
 ##### Log collection
 
-_Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
@@ -43,10 +42,9 @@ _Available for Agent versions >6.0_
       - type: file
         path: /var/data/ktserver.log
         source: kyototycoon
-        service: "<SERVICE_NAME>"
     ```
 
-    Change the `path` and `service` parameter values based on your environment. See the [sample kyototycoon.d/conf.yaml][3] for all available configuration options.
+    Change the `path` parameter value based on your environment. See the [sample kyototycoon.d/conf.yaml][3] for all available configuration options.
 
 3. [Restart the Agent][4].
 

--- a/kyototycoon/README.md
+++ b/kyototycoon/README.md
@@ -28,7 +28,6 @@ The KyotoTycoon check is included in the [Datadog Agent][1] package, so you don'
 
 ##### Log collection
 
-
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
     ```yaml

--- a/kyototycoon/README.md
+++ b/kyototycoon/README.md
@@ -26,6 +26,30 @@ The KyotoTycoon check is included in the [Datadog Agent][1] package, so you don'
 
 2. [Restart the Agent][4].
 
+##### Log collection
+
+_Available for Agent versions >6.0_
+
+1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
+
+    ```yaml
+    logs_enabled: true
+    ```
+
+2. Add this configuration block to your `kyototycoon.d/conf.yaml` file to start collecting Kyoto Tycoon logs:
+
+    ```yaml
+    logs:
+      - type: file
+        path: /var/data/ktserver.log
+        source: kyototycoon
+        service: "<SERVICE_NAME>"
+    ```
+
+    Change the `path` and `service` parameter values based on your environment. See the [sample kyototycoon.d/conf.yaml][3] for all available configuration options.
+
+3. [Restart the Agent][4].
+
 ### Validation
 
 [Run the Agent's `status` subcommand][5] and look for `kyototycoon` under the Checks section.

--- a/kyototycoon/assets/configuration/spec.yaml
+++ b/kyototycoon/assets/configuration/spec.yaml
@@ -26,6 +26,13 @@ files:
           - template: instances/http
           - template: instances/default
 
+      - template: logs
+        example:
+        - type: file
+          path: /var/data/ktserver.log
+          source: kyototycoon
+          service: kyototycoon
+
   - name: auto_conf.yaml
     options:
       - template: ad_identifiers

--- a/kyototycoon/assets/configuration/spec.yaml
+++ b/kyototycoon/assets/configuration/spec.yaml
@@ -31,7 +31,6 @@ files:
         - type: file
           path: /var/data/ktserver.log
           source: kyototycoon
-          service: kyototycoon
 
   - name: auto_conf.yaml
     options:

--- a/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
+++ b/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
@@ -361,3 +361,24 @@ instances:
     ## This is useful for cluster-level checks.
     #
     # empty_default_hostname: false
+
+## Log Section
+##
+## type - required - Type of log input source (tcp / udp / file / windows_event)
+## port / path / channel_path - required - Set port if type is tcp or udp.
+##                                         Set path if type is file.
+##                                         Set channel_path if type is windows_event.
+## source  - required - Attribute that defines which Integration sent the logs.
+## encoding - optional - For file specifies the file encoding, default is utf-8, other
+##                       possible values are utf-16-le and utf-16-be.
+## service - optional - The name of the service that generates the log.
+##                      Overrides any `service` defined in the `init_config` section.
+## tags - optional - Add tags to the collected logs.
+##
+## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
+#
+# logs:
+#   - type: file
+#     path: /var/data/ktserver.log
+#     source: kyototycoon
+#     service: kyototycoon

--- a/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
+++ b/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
@@ -381,4 +381,3 @@ instances:
 #   - type: file
 #     path: /var/data/ktserver.log
 #     source: kyototycoon
-#     service: kyototycoon

--- a/kyototycoon/manifest.json
+++ b/kyototycoon/manifest.json
@@ -1,6 +1,7 @@
 {
   "categories": [
-    "data store"
+    "data store",
+    "log collection"
   ],
   "creates_events": false,
   "display_name": "Kyoto Tycoon",
@@ -31,7 +32,9 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {},
+    "logs": {
+      "source": "kyototycoon"
+    },
     "metrics_metadata": "metadata.csv"
   }
 }

--- a/kyototycoon/tests/compose/compose_kyototycoon.yaml
+++ b/kyototycoon/tests/compose/compose_kyototycoon.yaml
@@ -3,5 +3,8 @@ version: '3.5'
 services:
   kyototycoon-standalone:
     image: "datadog/docker-library:kyototycoon_0_9_56"
+    command: ["-log", "/var/log/ktserver.log"]
+    volumes:
+      - ${DD_LOG_1}:/var/log/ktserver.log
     ports:
       - 1978:1978

--- a/kyototycoon/tests/conftest.py
+++ b/kyototycoon/tests/conftest.py
@@ -19,7 +19,9 @@ def dd_environment():
     """
 
     with docker_run(
-        compose_file=os.path.join(HERE, 'compose', 'compose_kyototycoon.yaml'), endpoints='{}/rpc/report'.format(URL)
+        compose_file=os.path.join(HERE, 'compose', 'compose_kyototycoon.yaml'),
+        endpoints='{}/rpc/report'.format(URL),
+        mount_logs=True,
     ):
 
         # Generate a test database


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add logs support for the `kyototycoon` integration.

### Motivation
<!-- What inspired you to submit this pull request? -->
1. Let users know how to configure the integration to collect logs.
2. Allow sending logs from a `ddev` env, eg for testing.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Follow-ups (that this PR doesn't require nor block, but just for reference):
- Add log parser in `logs-backend`.
- Link metrics and logs `web-ui` (similar to https://github.com/DataDog/web-ui/pull/20394).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
