### PR TITLE
Initial draft of doc spec with examples

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/default.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/default.yaml
@@ -6,8 +6,9 @@
   description: |
     TODO: General comments
   parameters:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
+  processor:
   hidden: false
   sections:
 
@@ -21,8 +22,9 @@
 
     [1]: https://docs.datadoghq.com/agent/kubernetes/integrations/
   parameters:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
+  processor:
   hidden: false
   sections:
 
@@ -34,8 +36,9 @@
 
     [1]: https://docs.datadoghq.com/agent/
   parameters:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
+  processor:
   hidden: false
   sections:
 
@@ -44,8 +47,9 @@
   header_level: 3
   description:
   parameters:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
+  processor:
   hidden: false
   sections:
 
@@ -55,8 +59,9 @@
   header_level: 4
   description:
   parameters:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
+  processor:
   hidden: false
   sections:
 
@@ -66,8 +71,9 @@
   header_level: 4
   description:
   parameters:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
+  processor:
   hidden: false
   sections:
 
@@ -99,8 +105,9 @@
   parameters:
     check_log_conf_snippet:
     check_conf_link:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
+  processor:
   hidden: false
   sections:
 
@@ -112,8 +119,9 @@
 
     [1]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
   parameters:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
+  processor:
   hidden: false
   sections:
 
@@ -121,8 +129,9 @@
   name: Data Collected
   header_level: 2
   description:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
+  processor:
   hidden: false
   sections:
 
@@ -134,8 +143,9 @@
 
     [1]: https://github.com/DataDog/integrations-core/blob/master/rethinkdb/metadata.csv
   parameters:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
+  processor:
   hidden: false
   sections:
 
@@ -145,20 +155,20 @@
   description: |
     {display_name} does not include any events.
   parameters:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
+  processor:
   hidden: false
   sections:
 
-# TODO - how to override this automagically with values from `service_checks.json`
 - template: data_collected/service_checks
   name: Service Checks
   header_level: 3
   description: |
     The {display_name} does not include any service checks.
   parameters:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
   processor: datadog_checks.dev.tooling.specs.docs.service_check_processor
   hidden: false
   sections:
@@ -171,8 +181,9 @@
 
     [1]: https://docs.datadoghq.com/help/
   parameters:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
+  processor:
   hidden: false
   sections:
 
@@ -181,7 +192,8 @@
   header_level: 2
   description:
   parameters:
-  prepend_text: null
-  append_text: null
+  prepend_text:
+  append_text:
+  processor:
   hidden: false
   sections:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/default.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/default.yaml
@@ -1,7 +1,7 @@
 # TODO: To be split into separate files
 
-- template: overview
-  name: Overview
+# filename: overview.yaml
+- name: Overview
   header_level: 2
   description: |
     TODO: General comments
@@ -12,8 +12,8 @@
   hidden: false
   sections:
 
-- template: setup
-  name: Setup
+# filename: setup.yaml
+- name: Setup
   header_level: 2
   description: |
     Follow the instructions below to install and configure this check for an Agent running on a host. For
@@ -28,8 +28,8 @@
   hidden: false
   sections:
 
-- template: setup/installation
-  name: Installation
+# filename: setup/installation.yaml
+- name: Installation
   header_level: 3
   description: |
     The {check_name} check is included in the [Datadog Agent][1] package. No additional installation is needed on your server.
@@ -42,8 +42,8 @@
   hidden: false
   sections:
 
-- template: setup/configuration
-  name: Configuration
+# filename: setup/configuration.yaml
+- name: Configuration
   header_level: 3
   description:
   parameters:
@@ -53,8 +53,8 @@
   hidden: false
   sections:
 
-- template: setup/configuration/host
-  name: Host
+# filename: setup/configuration/host.yaml
+- name: Host
   tab: Host
   header_level: 4
   description:
@@ -65,8 +65,8 @@
   hidden: false
   sections:
 
-- template: setup/configuration/containerized
-  name: Containerized
+# filename: setup/configuration/containerized.yaml
+- name: Containerized
   tab: Containerized
   header_level: 4
   description:
@@ -77,8 +77,8 @@
   hidden: false
   sections:
 
-- template: setup/configuration/log_collection
-  name: Log Collection
+# filename: setup/configuration/log_collection.yaml
+- name: Log Collection
   header_level: 4
   description: |
     _Available for Agent versions >6.0_
@@ -111,8 +111,8 @@
   hidden: false
   sections:
 
-- template: setup/validation
-  name: Validation
+# filename: setup/validation.yaml
+- name: Validation
   header_level: 3
   description: |
     [Run the Agent's status subcommand][1] and look for `{check_name}` under the Checks section.
@@ -125,8 +125,8 @@
   hidden: false
   sections:
 
-- template: data_collected
-  name: Data Collected
+# filename: data_collected.yaml
+- name: Data Collected
   header_level: 2
   description:
   prepend_text:
@@ -135,8 +135,8 @@
   hidden: false
   sections:
 
-- template: data_collected/metrics
-  name: Metrics
+# filename: data_collected/metrics.yaml
+- name: Metrics
   header_level: 3
   description: |
     See [metadata.csv][1] for a list of metrics provided by this check.
@@ -149,8 +149,8 @@
   hidden: false
   sections:
 
-- template: data_collected/events
-  name: Events
+# filename: data_collected/events.yaml
+- name: Events
   header_level: 3
   description: |
     {display_name} does not include any events.
@@ -161,8 +161,8 @@
   hidden: false
   sections:
 
-- template: data_collected/service_checks
-  name: Service Checks
+# filename: data_collected/service_checks.yaml
+- name: Service Checks
   header_level: 3
   description: |
     The {display_name} does not include any service checks.
@@ -173,8 +173,8 @@
   hidden: false
   sections:
 
-- template: troubleshooting
-  name: Overview
+# filename: troubleshooting.yaml
+- name: Overview
   header_level: 2
   description: |
     Need help? Contact [Datadog support][1].
@@ -187,8 +187,8 @@
   hidden: false
   sections:
 
-- template: further_reading
-  name: Further Reading
+# filename: further_reading.yaml
+- name: Further Reading
   header_level: 2
   description:
   parameters:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/default.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/default.yaml
@@ -1,0 +1,187 @@
+# TODO: To be split into separate files
+
+- template: overview
+  name: Overview
+  header_level: 2
+  description: |
+    TODO: General comments
+  parameters:
+  prepend_text: null
+  append_text: null
+  hidden: false
+  sections:
+
+- template: setup
+  name: Setup
+  header_level: 2
+  description: |
+    Follow the instructions below to install and configure this check for an Agent running on a host. For
+    containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying these
+    instructions.
+
+    [1]: https://docs.datadoghq.com/agent/kubernetes/integrations/
+  parameters:
+  prepend_text: null
+  append_text: null
+  hidden: false
+  sections:
+
+- template: setup/installation
+  name: Installation
+  header_level: 3
+  description: |
+    The {check_name} check is included in the [Datadog Agent][1] package. No additional installation is needed on your server.
+
+    [1]: https://docs.datadoghq.com/agent/
+  parameters:
+  prepend_text: null
+  append_text: null
+  hidden: false
+  sections:
+
+- template: setup/configuration
+  name: Configuration
+  header_level: 3
+  description:
+  parameters:
+  prepend_text: null
+  append_text: null
+  hidden: false
+  sections:
+
+- template: setup/configuration/host
+  name: Host
+  tab: Host
+  header_level: 4
+  description:
+  parameters:
+  prepend_text: null
+  append_text: null
+  hidden: false
+  sections:
+
+- template: setup/configuration/containerized
+  name: Containerized
+  tab: Containerized
+  header_level: 4
+  description:
+  parameters:
+  prepend_text: null
+  append_text: null
+  hidden: false
+  sections:
+
+- template: setup/configuration/log_collection
+  name: Log Collection
+  header_level: 4
+  description: |
+    _Available for Agent versions >6.0_
+
+    1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
+
+      ```yaml
+      logs_enabled: true
+      ```
+
+    2. Add this configuration block to your `{check_conf_path}` file to start collecting your {display_name} logs:
+
+      {check_log_conf_snippet}
+
+      Change the `path` and `service` parameter values based on your environment. See the {check_conf_link} for all available configuration options.
+
+      3. [Restart the Agent][1].
+
+      See [Datadog's documentation][2] for additional information on how to configure the Agent for log collection in Kubernetes environments.
+
+    [1]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
+    [2]: https://docs.datadoghq.com/agent/kubernetes/log/
+
+  parameters:
+    check_log_conf_snippet:
+    check_conf_link:
+  prepend_text: null
+  append_text: null
+  hidden: false
+  sections:
+
+- template: setup/validation
+  name: Validation
+  header_level: 3
+  description: |
+    [Run the Agent's status subcommand][1] and look for `{check_name}` under the Checks section.
+
+    [1]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+  parameters:
+  prepend_text: null
+  append_text: null
+  hidden: false
+  sections:
+
+- template: data_collected
+  name: Data Collected
+  header_level: 2
+  description:
+  prepend_text: null
+  append_text: null
+  hidden: false
+  sections:
+
+- template: data_collected/metrics
+  name: Metrics
+  header_level: 3
+  description: |
+    See [metadata.csv][1] for a list of metrics provided by this check.
+
+    [1]: https://github.com/DataDog/integrations-core/blob/master/rethinkdb/metadata.csv
+  parameters:
+  prepend_text: null
+  append_text: null
+  hidden: false
+  sections:
+
+- template: data_collected/events
+  name: Events
+  header_level: 3
+  description: |
+    {display_name} does not include any events.
+  parameters:
+  prepend_text: null
+  append_text: null
+  hidden: false
+  sections:
+
+# TODO - how to override this automagically with values from `service_checks.json`
+- template: data_collected/service_checks
+  name: Service Checks
+  header_level: 3
+  description: |
+    The {display_name} does not include any service checks.
+  parameters:
+  prepend_text: null
+  append_text: null
+  processor: datadog_checks.dev.tooling.specs.docs.service_check_processor
+  hidden: false
+  sections:
+
+- template: troubleshooting
+  name: Overview
+  header_level: 2
+  description: |
+    Need help? Contact [Datadog support][1].
+
+    [1]: https://docs.datadoghq.com/help/
+  parameters:
+  prepend_text: null
+  append_text: null
+  hidden: false
+  sections:
+
+- template: further_reading
+  name: Further Reading
+  header_level: 2
+  description:
+  parameters:
+  prepend_text: null
+  append_text: null
+  hidden: false
+  sections:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/example_nagios.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/example_nagios.yaml
@@ -1,0 +1,84 @@
+name: Nagios
+options:
+  autodiscovery: true
+
+files:
+  - name: README.md
+    sections:
+      - template: overview
+        overrides:
+          description: |
+            Send events from your Nagios-monitored infrastructure to Datadog for richer alerting and to help correlate Nagios events with metrics from your Datadog-monitored infrastructure.
+
+            This check watches your Nagios server's logs and sends events to your Datadog event stream: track service flaps, host state changes, passive service checks, host and service downtimes, and more. This check can also send Nagios performance data as metrics to Datadog.
+      - template: setup
+        overrides:
+          description: |
+            Follow the instructions below to install and configure this check for an Agent running on a host. For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying these instructions.
+      - template: setup/installation
+      - template: setup/configuration
+      - template: setup/configuration/host
+        overrides:
+          description: |
+            To configure this check for an Agent running on a host:
+
+            1. Edit the `nagios.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][1]. See the [sample nagios.d/conf.yaml][2] for all available configuration options.
+
+            2. [Restart the Agent][3] to start sending Nagios events and (optionally) performance data metrics to Datadog.
+
+            **Note**: The Nagios check can potentially emit [custom metrics][4], which may impact your [billing][5].
+
+            [1]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
+            [2]: https://github.com/DataDog/integrations-core/blob/master/nagios/datadog_checks/nagios/data/conf.yaml.example
+            [3]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
+            [4]: https://docs.datadoghq.com/developers/metrics/custom_metrics/
+            [5]: https://docs.datadoghq.com/account_management/billing/custom_metrics/
+      - template: setup/configuration/containerized
+        overrides:
+          description: |
+            For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying the parameters below.
+
+            | Parameter            | Value                                        |
+            | -------------------- | -------------------------------------------- |
+            | `<INTEGRATION_NAME>` | `nagios`                                     |
+            | `<INIT_CONFIG>`      | blank or `{}`                                |
+            | `<INSTANCE_CONFIG>`  | `{"nagios_conf": "/etc/nagios3/nagios.cfg"}` |
+
+            **Note**: The containerized Agent should be able to access the `/etc/nagios3/nagios.cfg` file to enable the Datadog-Nagios integration.
+
+            [1]: https://docs.datadoghq.com/agent/kubernetes/integrations/
+
+      - template: setup/configuration/log_collection
+        # could also just omit the section
+        overrides:
+          hidden: true
+      - template: setup/validation
+      - template: data_collected
+      - template: data_collected/metrics
+        overrides:
+          description: |
+            With the default configuration, the Nagios check doesn't collect any metrics. But if you set `collect_host_performance_data` and/or `collect_service_performance_data` to `True`, the check watches for Nagios performance data and submits it as gauge metrics to Datadog.
+
+      - template: data_collected/events
+        overrides:
+          description: |
+            The check watches the Nagios events log for log lines containing these strings, emitting an event for each line:
+
+            - SERVICE FLAPPING ALERT
+            - ACKNOWLEDGE_SVC_PROBLEM
+            - SERVICE ALERT
+            - HOST ALERT
+            - ACKNOWLEDGE_HOST_PROBLEM
+            - SERVICE NOTIFICATION
+            - HOST DOWNTIME ALERT
+            - PROCESS_SERVICE_CHECK_RESULT
+            - SERVICE DOWNTIME ALERT
+
+      - template: data_collected/service_checks
+      - template: troubleshooting
+      - template: further_reading
+        overrides:
+          description: |
+            - [Understand your Nagios alerts with Datadog][1]
+
+            [1]: https://www.datadoghq.com/blog/nagios-monitoring

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/example_rethinkdb.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/example_rethinkdb.yaml
@@ -1,0 +1,68 @@
+name: RethinkDB
+files:
+  - name: README.md
+    options:
+      - template: overview
+        overrides:
+          description: |
+            [RethinkDB][1] is a distributed documented-oriented NoSQL database, with first class support for realtime
+            change feeds.
+
+            This check monitors a RethinkDB cluster through the Datadog Agent and collects metrics about performance,
+            data availability, cluster configuration, and more.
+
+            **Note**: this integration is compatible with RethinkDB **version 2.3.6 and above**.
+
+            [1]: https://rethinkdb.com
+      - template: setup
+      - template: setup/installation
+      - template: setup/configuration
+        overrides:
+          tab: false
+          description: |
+            1. If using RethinkDB 2.4+, add a `datadog-agent` user with read-only permissions on the `rethinkdb`
+            database. You can use the following ReQL commands, and refer to [Permissions and user accounts][4] for
+            details:
+
+                ```python
+                r.db('rethinkdb').table('users').insert({'id': 'datadog-agent', 'password': '<PASSWORD>'})
+                r.db('rethinkdb').grant('datadog-agent', {'read': True})
+                ```
+
+                **Note**: on RethinkDB 2.3.x, granting permissions on the `rethinkdb` database is not supported. Skip
+                *this step and use your [admin account][5] below instead.
+
+            2. Edit the `rethinkdb.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration
+            directory][6]. See the [sample rethinkdb.d/conf.yaml][7] for all available configuration options.
+
+                ```yaml
+                init_config:
+
+                instances:
+                  - host: localhost
+                    port: 28015
+                    user: "<USER>"
+                    password: "<PASSWORD>"
+                ```
+
+            3. [Restart the Agent][8].
+
+            **Note**: this integration collects metrics from all servers in the cluster, so you only need a single
+            *Agent.
+      - template: setup/configuration/log_collection
+        overrides:
+          parameters:
+            check_log_conf_snippet: |
+              ```yaml
+              logs:
+                - type: file
+                  path: "<LOG_FILE_PATH>"
+                  source: rethinkdb
+                  service: "<SERVICE_NAME>"
+              ```
+      - template: setup/validation
+      - template: data_collected/metrics
+      - template: data_collected/events
+      # override for service checks unnecessary, `processor` function will parse `service_checks.json`
+      - template: data_collected/service_checks
+      - template: troubleshooting

--- a/docs/developer/meta/docs-specs.md
+++ b/docs/developer/meta/docs-specs.md
@@ -14,9 +14,10 @@ The [producer][doc-spec-producer]'s job is to read a specification and:
 1. Populate all unset default fields
 1. Gather and prioritize other schema for inclusion
 1. Resolve any defined templates
+1. Normalize links to embedded style
 1. Output the complete specification as JSON for arbitrary consumers
 
-This spec is dependent on other config files within an integration, the order of precedence:
+This spec is dependent on other config files within an integration check, in order of precedence:
 
 - `manifest.json`
 - `assets/service_checks.json`
@@ -35,7 +36,7 @@ Consumers may utilize specs in a number of scenarios, such as:
 
 The root of every spec is a map with 3 keys:
 
-- `name` - The display name of what the spec refers to e.g. `Postgres`, `Datadog Agent`, etc.
+- `name` - The display name of what the spec refers to e.g. `Postgres`, `Nagios`, etc.
 - `options` - Top-level [spec options](#spec-options) related to the check overall (optional)
 - `files` - A list of all [files](#files) that influence behavior
 
@@ -66,7 +67,7 @@ Every section has these possible attributes:
 - `parameters` - Mapping of extra parameters for string formatting in the `description`.
 - `prepend_text` - Text to insert in front of the description field. Useful for overrides.
 - `append_text` - Text to append after the description field. Useful for overrides.
-- `processor` - Reference to a Python function which should be invoked.  If the function returns None, the default description carries forward, otherwise the results of the function will be used for the `description`.  Used by the `data_collected/service_checks` template, for example.
+- `processor` - Reference to a Python function which should be invoked.  If the function returns `None`, the default description carries forward, otherwise the results of the function will be used for the `description`.  Used by the `data_collected/service_checks` template, for example.
 - `hidden` - Whether or not the section should be publicly exposed. It defaults to `false`.
 - `sections` - Nested sections, this will increase the `header_level` of embedded sections accordingly.
 - `template` - See [templates](#templates) below for more.
@@ -74,9 +75,9 @@ Every section has these possible attributes:
 
 #### Parameters
 
-When constructing each text section, the description field will first prepend and append values from `prepend_text` and `append_text`, respectively.  Next string formatting operations will take place by using a default set of parameters joined with amy parameters explicitly defined in the `parameter` option.
+When constructing each text section, the description field will first prepend and append values from `prepend_text` and `append_text`, respectively.  Next string formatting operations will take place by using a default set of parameters joined with any parameters explicitly defined in the `parameter` attribute.
 
-Default parameters which will be present for all sections include:
+Default parameters which will be present for all sections and passed as keyword args during string formatting include:
 
 - `name` - the formal name of the check
 - all fields from `manifest.json`
@@ -111,9 +112,9 @@ attributes via a ++period++ (dot) accessor.
 
 ```yaml
 options:
-- template: instances/http
+- template: setup/configuration
   overrides:
-    timeout.value.example: 42
+    templates.log_collection.hidden: true
 ```
 
 ## README file consumer

--- a/docs/developer/meta/docs-specs.md
+++ b/docs/developer/meta/docs-specs.md
@@ -1,0 +1,131 @@
+# Documentation specification
+
+-----
+
+Building on top of the [configuration spec](config-specs.md) implementation, we also incorporate a documentation spec.
+
+Similar to configuration specs, these YAML files are located at `<INTEGRATION>/assets/documentation/spec.yaml`, and referenced in the check's `manifest.json` file.
+
+## Producer
+
+The [producer][doc-spec-producer]'s job is to read a specification and:
+
+1. Validate for correctness
+1. Populate all unset default fields
+1. Gather and prioritize other schema for inclusion
+1. Resolve any defined templates
+1. Output the complete specification as JSON for arbitrary consumers
+
+This spec is dependent on other config files within an integration, the order of precedence:
+
+- `manifest.json`
+- `assets/service_checks.json`
+- `assets/configuration/spec.yaml` (included for reference, but unused for now)
+
+## Consumers
+
+Consumers may utilize specs in a number of scenarios, such as:
+
+- rendering [README.md](#readme-file-consumer) files for git and user documentation
+- rendering HTML files for user documentation on our datadoghq.com site
+- easily updating common components via base template changes
+- creating single-source-of-truth for data such as `short_description`
+
+## Schema
+
+The root of every spec is a map with 3 keys:
+
+- `name` - The display name of what the spec refers to e.g. `Postgres`, `Datadog Agent`, etc.
+- `options` - Top-level [spec options](#spec-options) related to the check overall (optional)
+- `files` - A list of all [files](#files) that influence behavior
+
+### Spec Options
+
+Every spec has a set of optional options:
+
+- `autodiscovery` - Indicates if this check supports autodiscovery.  Default: false
+
+### Files
+
+Every file has 3 possible attributes:
+
+- `name` - This is the name of the file the Agent will look for (**REQUIRED**)
+- `render_name` - This is the name of the rendered file, and defaults to `README.md`.
+  Consumers may choose their own output name, or may read from this value.
+- `sections` - A list of [sections](#sections) (**REQUIRED**)
+
+### Sections
+
+Every section has these possible attributes:
+
+- `name` - The title of the section.
+- `header_level` - Level of indentation.  
+- `tab` - If not null, then the name of the tab, and all sections of the same indent must specify.
+- `description` - Actual text content for the section.  May be parameterized using keyword argument formatter
+  strings, see [parameterization](#parameters) for more info. Hyperlinks may be embedded or reference-style.
+- `parameters` - Mapping of extra parameters for string formatting in the `description`.
+- `prepend_text` - Text to insert in front of the description field. Useful for overrides.
+- `append_text` - Text to append after the description field. Useful for overrides.
+- `processor` - Reference to a Python function which should be invoked.  If the function returns None, the default description carries forward, otherwise the results of the function will be used for the `description`.  Used by the `data_collected/service_checks` template, for example.
+- `hidden` - Whether or not the section should be publicly exposed. It defaults to `false`.
+- `sections` - Nested sections, this will increase the `header_level` of embedded sections accordingly.
+- `template` - See [templates](#templates) below for more.
+- `overrides` - Override specific attributes within a given template.  See [overrides](#overrides) for more.
+
+#### Parameters
+
+When constructing each text section, the description field will first prepend and append values from `prepend_text` and `append_text`, respectively.  Next string formatting operations will take place by using a default set of parameters joined with amy parameters explicitly defined in the `parameter` option.
+
+Default parameters which will be present for all sections include:
+
+- `name` - the formal name of the check
+- all fields from `manifest.json`
+- objects from `service_checks.json`
+
+## Templates
+
+Every [section](#section) may reference [pre-defined doc templates][doc-spec-templates] using a key called `template`.
+The template format looks like `path/to/template_file` where `path/to` must point an existing directory relative
+to a template directory and `template_file` must have the file extension `.yaml` or `.yml`.
+
+You can use custom templates that will take precedence over the pre-defined templates by using the `template_paths`
+parameter of the [ConfigSpec](#datadog_checks.dev.tooling.configuration.core.ConfigSpec) class.
+
+### Overrides
+
+Commonly used to update a description of a given template, or to inject specific parameters:
+
+```yaml
+sections:
+- template: setup/installation
+  overrides:
+    description: |
+      The Nagios check is included in the [Datadog Agent][1] package, 
+      so you don't need to install anything else on your Nagios servers.
+
+      [1]: https://docs.datadoghq.com/agent/
+```
+
+For occasions when deeply nested default template values need to be overridden, there is the ability to redefine
+attributes via a ++period++ (dot) accessor.
+
+```yaml
+options:
+- template: instances/http
+  overrides:
+    timeout.value.example: 42
+```
+
+## README file consumer
+
+The [README example consumer][] uses the documentation spec to render the README files that are included with
+every Integration package.
+
+### Links
+
+As a custom with our README.md files, we use [reference style links](https://www.markdownguide.org/basic-syntax/#reference-style-links). Each section description may have embedded or reference style links, and as part of the [Producer](#producer) step, these will be all normalized to embedded links.  This ensures that any consumers can handle them as needed.  For the README consumer, it will translate everything to reference style as part of its output stage.
+
+### Usage
+
+Use the `--sync` flag of the [config validation command](../ddev/cli.md#config_1) to render the README files.
+


### PR DESCRIPTION
### What does this PR do?
Includes a draft of the specification for a new documentation spec format.  

Spec [rendered view](https://github.com/DataDog/integrations-core/blob/0abca820b02d6104cdc8cbf99eda47097bae06c4/docs/developer/meta/docs-specs.md).

Also includes notional templates consolidated into a single file for easier viewing, and two notional spec files for Nagios and RethinkDB.


### Motivation
Inspiration: Config specs - https://github.com/DataDog/integrations-core/pull/5072

### Additional Notes
- Link handling needs some more thought, but could be addressed incrementally.  Initially, the spec defines all links to be described within either the template or the spec file, but for often used links we should be able to abstract these to common patterns, like we use for our [docs pages](https://github.com/DataDog/integrations-core/blob/master/docs/developer/.snippets/links.txt).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
