### PR TITLE
Add source logs in statsd manifest

### DIFF
--- a/statsd/manifest.json
+++ b/statsd/manifest.json
@@ -29,7 +29,9 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {},
+    "logs": {
+      "source": "statsd"
+    },
     "metrics_metadata": "metadata.csv"
   }
 }


### PR DESCRIPTION
### What does this PR do?
I forgot to add the logs source in https://github.com/DataDog/integrations-core/pull/7773, this PR integrates the missing change.

### Motivation
Add log support for statsd


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
