### PR TITLE
Stop collecting custom queries from secondaries by default

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -143,6 +143,8 @@ files:
     - name: custom_queries
       description: |
         Define custom queries to collect custom metrics on your Mongo
+        Note: Custom queries are ignored by default when the mongo node is a secondary of a replica set.
+        You can add `run_on_secondary: true` for each query that you want to run on both primaries and secondaries.
         See https://docs.datadoghq.com/integrations/guide/mongo-custom-query-collection to learn more.
       value:
         type: array

--- a/mongo/datadog_checks/mongo/common.py
+++ b/mongo/datadog_checks/mongo/common.py
@@ -70,6 +70,7 @@ class ReplicaSetDeployment(Deployment):
         self.replset_state_name = get_state_name(replset_state).lower()
         self.in_shard = in_shard
         self.is_primary = replset_state == 1
+        self.is_secondary = replset_state == 2
 
     def is_principal(self):
         # There is only ever one primary node in a replica set.

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -138,6 +138,8 @@ instances:
 
     ## @param custom_queries - list of mappings - optional
     ## Define custom queries to collect custom metrics on your Mongo
+    ## Note: Custom queries are ignored by default when the mongo node is a secondary of a replica set.
+    ## You can add `run_on_secondary: true` for each query that you want to run on both primaries and secondaries.
     ## See https://docs.datadoghq.com/integrations/guide/mongo-custom-query-collection to learn more.
     #
     # custom_queries:


### PR DESCRIPTION
### What does this PR do?
Prevents custom queries from being run on secondaries by default. To enable them, users now have to set `run_on_secondary: true` in each query.

### Motivation
1. In most cases it doesn't make sense to run queries on something else than a `mongos` if using shards or the `primary` if using a single replica set (or on a standalone). But there are rare cases where it make senses (like collecting stats from the 'local' database, different on each node) so the user is responsible for configuring the check correctly. For example, when using shards, check instances connected to the primary of a shard will still execute the queries as instructed by the configuration.
2. In replica set, custom queries should only be run once and preferably on the primary. But because a mongod node can change state, the user doesn't have the ability to specify which queries run on the primary and which run on secondary at the moment so the only option is to define the queries on each node configuration and deal with the duplicates in the UI. Leading to many custom metrics that are billed.

With this PR, custom queries are now ignored when the mongod node is a secondary by default. This is a small breaking change (only affected users are the one explicitly looking for running a query on a secondary node, maybe for the 'local' database) but a breaking change nonetheless for some users. For queries that make sense to run on all secondaries and on the primary, a new configuration 'run_on_secondary' is introduced in the `custom_queries` section to tell whether or not a specified query should also be run on secondaries.

This change is especially important in containerized environment where there is no distinction between one mongod node and another in the replica set. Setting the same configuration using annotations for each node is an important added value.

### Additional Notes
Will need to update this documentation as well: https://docs.datadoghq.com/integrations/guide/mongo-custom-query-collection to learn more.
But the integration part should be merged first until we release the agent.
