### PR TITLE
Fix test environment setup with mongo 4.1

### DIFF
--- a/mongo/tests/compose/scripts/init-shard01.js
+++ b/mongo/tests/compose/scripts/init-shard01.js
@@ -3,8 +3,8 @@ rs.initiate(
       _id: "shard01",
       version: 1,
       members: [
-         { _id: 0, host : "shard01a:27018" },
-         { _id: 1, host : "shard01b:27018" },
+         { _id: 0, host : "shard01a:27018", priority: 1},
+         { _id: 1, host : "shard01b:27018", priority: 0.5 },
       ]
    }
 )

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -23,7 +23,12 @@ def dd_environment():
     compose_file = os.path.join(common.HERE, 'compose', 'docker-compose.yml')
 
     with docker_run(
-        compose_file, conditions=[WaitFor(setup_sharding, args=(compose_file,), attempts=5, wait=5), InitializeDB()]
+        compose_file,
+        conditions=[
+            WaitFor(setup_sharding, args=(compose_file,), attempts=5, wait=5),
+            InitializeDB(),
+            WaitFor(create_shard_user, attempts=60, wait=5),
+        ],
     ):
         yield common.INSTANCE_BASIC
 
@@ -142,7 +147,7 @@ def setup_sharding(compose_file):
     for i, (service, command) in enumerate(service_commands, 1):
         # Wait before router init
         if i == len(service_commands):
-            time.sleep(30)
+            time.sleep(10)
 
         run_command(['docker-compose', '-f', compose_file, 'exec', '-T', service, 'sh', '-c', command], check=True)
 
@@ -183,7 +188,10 @@ class InitializeDB(LazyFunction):
         auth_db.command("createUser", 'special test user', pwd='s3\\kr@t', roles=[{'role': 'read', 'db': 'test'}])
 
         db.command("createUser", 'testUser2', pwd='testPass2', roles=[{'role': 'read', 'db': 'test'}])
-        cli_shard = pymongo.mongo_client.MongoClient(
-            common.SHARD_SERVER, socketTimeoutMS=30000, read_preference=pymongo.ReadPreference.PRIMARY_PREFERRED
-        )
-        cli_shard['admin'].command("createUser", "testUser", pwd="testPass", roles=["root"])
+
+
+def create_shard_user():
+    cli_shard = pymongo.mongo_client.MongoClient(
+        common.SHARD_SERVER, socketTimeoutMS=30000, read_preference=pymongo.ReadPreference.PRIMARY_PREFERRED
+    )
+    cli_shard['admin'].command("createUser", "testUser", pwd="testPass", roles=["root"])

--- a/mongo/tox.ini
+++ b/mongo/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{3.2.10,3.4,3.5,4.1}
+    py{27,38}-{4.1}
 
 [testenv]
 ensure_default_envdir = true

--- a/mongo/tox.ini
+++ b/mongo/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{4.1}
+    py{27,38}-{3.2.10,3.4,3.5,4.1}
 
 [testenv]
 ensure_default_envdir = true


### PR DESCRIPTION
Make sure that the container `shard01a` will be the pirmary node. It seems like priori to v4.1 of mongo, the node on which the replica set is initialized is always the primary.
Since v4.1 (or before), the primary seems to be picked on another criteria. This PR sets a higher priority to `shard01a` so that we're sure that this one will become the primary eventually.

The `create_shard_user` method is also moved in a `WaitFor` so that it is retried until `shard01a` gets elected as primary.