### PR TITLE
[dcos-auth] Fix bug with exp timestamp being non-int

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -6,7 +6,6 @@ import os
 import re
 from contextlib import contextmanager
 from copy import deepcopy
-from datetime import timedelta
 from io import open
 from ipaddress import ip_address, ip_network
 
@@ -21,7 +20,7 @@ from ..config import is_affirmative
 from ..errors import ConfigurationError
 from .common import ensure_bytes, ensure_unicode
 from .headers import get_default_headers, update_headers
-from .time import get_current_datetime
+from .time import get_timestamp
 
 try:
     from contextlib import ExitStack
@@ -684,7 +683,7 @@ class DCOSAuthTokenReader(object):
                     encryption_algorithm=serialization.NoEncryption(),
                 )
 
-                exp = get_current_datetime() + timedelta(seconds=self._expiration)
+                exp = int(get_timestamp() + self._expiration)
 
                 encoded = jwt.encode({'uid': self._service_account, 'exp': exp}, serialized_private, algorithm='RS256')
 


### PR DESCRIPTION
### What does this PR do?

After refactoring I missed the fact that the type for the exp timestamp is no longer int.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
