### PR TITLE
Add missing custom_jar_paths option

### DIFF
--- a/jboss_wildfly/assets/configuration/spec.yaml
+++ b/jboss_wildfly/assets/configuration/spec.yaml
@@ -9,6 +9,16 @@ files:
         service_check_prefix.required: true
         service_check_prefix.value.example: jboss
         service_check_prefix.description: Service check prefix to use.
+    - name: custom_jar_paths
+      description: |
+        When using JBoss default JMX implementation, the client JAR which allows connecting to it.
+        See documentation: https://docs.datadoghq.com/integrations/java/#monitoring-jboss-wildfly-applications
+      value:
+        type: array
+        items:
+          type: string
+        example:
+        - /path/to/jboss-cli-client.jar
   - template: instances
     options:
     - template: instances/jmx
@@ -23,6 +33,7 @@ files:
         jmx_url.display_priority: 10
         host.required: false
         port.required: false
+
   - template: logs
     example:
     - type: file

--- a/jboss_wildfly/assets/configuration/spec.yaml
+++ b/jboss_wildfly/assets/configuration/spec.yaml
@@ -11,7 +11,7 @@ files:
         service_check_prefix.description: Service check prefix to use.
     - name: custom_jar_paths
       description: |
-        When using JBoss default JMX implementation, the client JAR which allows connecting to it.
+        These are the client JARs which allow connecting to the JBoss default JMX implementation.
         See documentation: https://docs.datadoghq.com/integrations/java/#monitoring-jboss-wildfly-applications
       value:
         type: array

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -49,7 +49,7 @@ init_config:
     # service: <SERVICE>
 
     ## @param custom_jar_paths - list of strings - optional
-    ## When using JBoss default JMX implementation, the client JAR which allows connecting to it.
+    ## These are the client JARs which allow connecting to the JBoss default JMX implementation.
     ## See documentation: https://docs.datadoghq.com/integrations/java/#monitoring-jboss-wildfly-applications
     #
     # custom_jar_paths:

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -48,6 +48,13 @@ init_config:
     #
     # service: <SERVICE>
 
+    ## @param custom_jar_paths - list of strings - optional
+    ## When using JBoss default JMX implementation, the client JAR which allows connecting to it.
+    ## See documentation: https://docs.datadoghq.com/integrations/java/#monitoring-jboss-wildfly-applications
+    #
+    # custom_jar_paths:
+    #   - /path/to/jboss-cli-client.jar
+
 ## Every instance is scheduled independent of the others.
 #
 instances:


### PR DESCRIPTION
### What does this PR do?
During addition of config specs in this PR https://github.com/DataDog/integrations-core/pull/6225 the `custom_jar_paths` option was omitted by accident

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
