### PR TITLE
Add a TLSContextWrapper to the base class

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+
 import copy
 import functools
 import importlib
@@ -12,7 +14,7 @@ import traceback
 import unicodedata
 from collections import defaultdict, deque
 from os.path import basename
-from typing import Any, Callable, DefaultDict, Deque, Dict, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, DefaultDict, Deque, Dict, List, Optional, Sequence, Tuple, Union
 
 import yaml
 from six import binary_type, iteritems, text_type
@@ -34,6 +36,7 @@ from ..utils.http import RequestsWrapper
 from ..utils.limiter import Limiter
 from ..utils.metadata import MetadataManager
 from ..utils.secrets import SecretsSanitizer
+from ..utils.tls import TlsContextWrapper
 
 try:
     import datadog_agent
@@ -62,6 +65,8 @@ if datadog_agent.get_config('disable_unsafe_yaml'):
 
     monkey_patch_pyyaml()
 
+if TYPE_CHECKING:
+    import ssl
 
 # Metric types for which it's only useful to submit once per set of tags
 ONE_PER_CONTEXT_METRIC_TYPES = [aggregator.GAUGE, aggregator.RATE, aggregator.MONOTONIC_COUNT]
@@ -102,6 +107,9 @@ class AgentCheck(object):
 
     # Used by `self.http` for an instance of RequestsWrapper
     HTTP_CONFIG_REMAPPER = None
+
+    # Used by `create_tls_context` for an instance of RequestsWrapper
+    TLS_CONFIG_REMAPPER = None
 
     # Used by `self.set_metadata` for an instance of MetadataManager
     #
@@ -302,6 +310,21 @@ class AgentCheck(object):
             self._http = RequestsWrapper(self.instance or {}, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log)
 
         return self._http
+
+    def get_tls_context(self, refresh=False):
+        # type: (bool) -> ssl.SSLContext
+        """
+        Provides logic to yield consistent network behavior based on user configuration.
+
+        Only new checks or checks on Agent 6.13+ can and should use this for HTTP requests.
+        """
+        if not hasattr(self, '_tls_context_wrapper'):
+            self._tls_context_wrapper = TlsContextWrapper(self.instance or {}, self.TLS_CONFIG_REMAPPER)
+
+        if refresh:
+            self._tls_context_wrapper.refresh_tls_context()
+
+        return self._tls_context_wrapper.tls_context
 
     @property
     def metadata_manager(self):

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
-
 import copy
 import functools
 import importlib

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -312,9 +312,9 @@ class AgentCheck(object):
     def get_tls_context(self, refresh=False):
         # type: (bool) -> ssl.SSLContext
         """
-        Provides logic to yield consistent network behavior based on user configuration.
+        Creates and cache an SSLContext instance based on user configuration.
 
-        Only new checks or checks on Agent 6.13+ can and should use this for HTTP requests.
+        Since: Agent 7.24
         """
         if not hasattr(self, '_tls_context_wrapper'):
             self._tls_context_wrapper = TlsContextWrapper(self.instance or {}, self.TLS_CONFIG_REMAPPER)

--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -1,0 +1,139 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
+import os
+import ssl
+from typing import TYPE_CHECKING, Any, AnyStr, Dict
+
+from six import iteritems
+
+from ..config import is_affirmative
+
+if TYPE_CHECKING:
+    from ..types import InstanceType
+
+LOGGER = logging.getLogger(__file__)
+
+
+# The TLSContextWrapper shares configuration options with the HTTP Request wrapper for simplicity of user configuration.
+# To allow for a specific use case where an integraiton needs both a TLSContextWrapper plus the RequestsWrapper but with
+# different option, there is the ability to have configuration option with higher priority by using the following
+# prefix.
+UNIQUE_FIELD_PREFIX = '_tls_context_'
+
+STANDARD_FIELDS = {
+    'tls_verify': True,
+    'tls_ca_cert': None,
+    'tls_cert': None,
+    'tls_private_key': None,
+    'tls_private_key_password': None,
+    'tls_validate_hostname': True,
+    'tls_load_default_certs': True
+}
+
+
+class TlsContextWrapper(object):
+    __slots__ = ('logger', 'config', 'tls_context')
+
+    def __init__(self, instance, remapper=None):
+        # type: (InstanceType, Dict[AnyStr, Dict[AnyStr, Any]]) -> None
+        default_fields = dict(STANDARD_FIELDS)
+
+        # Populate with the default values
+        config = {field: instance.get(field, value) for field, value in iteritems(default_fields)}
+        for field in STANDARD_FIELDS:
+            unique_name = UNIQUE_FIELD_PREFIX + field
+            if unique_name in instance:
+                config[unique_name] = instance[unique_name]
+
+        if remapper is None:
+            remapper = {}
+
+        for remapped_field, data in iteritems(remapper):
+            field = data.get('name')
+
+            if field.startswith(UNIQUE_FIELD_PREFIX):
+                standard_field_name = field[len(UNIQUE_FIELD_PREFIX):]
+            else:
+                standard_field_name = field
+
+            # Ignore fields we don't recognize
+            if standard_field_name not in STANDARD_FIELDS:
+                continue
+
+            # Ignore remapped fields if the standard one is already used
+            if field in instance:
+                continue
+
+            # Invert default booleans if need be
+            default = default_fields[standard_field_name]
+            if data.get('invert'):
+                default = not default
+
+            # Get value, with a possible default
+            value = instance.get(remapped_field, data.get('default', default))
+
+            # Invert booleans if need be
+            if data.get('invert'):
+                value = not is_affirmative(value)
+
+            config[field] = value
+
+        if any(
+            (config['tls_ca_cert'], config['tls_cert'], config['tls_private_key'], config['tls_private_key_password'])
+        ):
+            config['tls_verify'] = True
+
+        # Populate with the higher-priority configuration options if set
+        for field in default_fields:
+            unique_name = UNIQUE_FIELD_PREFIX + field
+            if unique_name in config:
+                config[field] = config[unique_name]
+                del config[unique_name]
+
+        self.config = config
+        self.tls_context = self._create_tls_context()
+
+    def _create_tls_context(self):
+        # type: () -> ssl.SSLContext
+
+        # https://docs.python.org/3/library/ssl.html#ssl.SSLContext
+        # https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS
+        context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS)
+
+        # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.verify_mode
+        if not self.config['tls_verify']:
+            context.verify_mode = ssl.CERT_NONE
+            return context
+        context.verify_mode = ssl.CERT_REQUIRED
+
+        # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname
+        context.check_hostname = self.config['tls_validate_hostname']
+
+        # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_verify_locations
+        # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_default_certs
+        ca_cert = self.config['tls_ca_cert']
+        if ca_cert:
+            ca_cert = os.path.expanduser(ca_cert)
+            if os.path.isdir(ca_cert):
+                context.load_verify_locations(cafile=None, capath=ca_cert, cadata=None)
+            else:
+                context.load_verify_locations(cafile=ca_cert, capath=None, cadata=None)
+        elif self.config['tls_load_default_certs']:
+            context.load_default_certs(ssl.Purpose.SERVER_AUTH)
+
+        # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain
+        client_cert, client_key = self.config['tls_cert'], self.config['tls_private_key']
+        client_key_pass = self.config['tls_private_key_password']
+        if client_key:
+            client_key = os.path.expanduser(client_key)
+        if client_cert:
+            client_cert = os.path.expanduser(client_cert)
+            context.load_cert_chain(client_cert, keyfile=client_key, password=client_key_pass)
+
+        return context
+
+    def refresh_tls_context(self):
+        # type: () -> None
+        self.tls_context = self._create_tls_context()

--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -29,7 +29,7 @@ STANDARD_FIELDS = {
     'tls_private_key': None,
     'tls_private_key_password': None,
     'tls_validate_hostname': True,
-    'tls_load_default_certs': True
+    'tls_load_default_certs': True,
 }
 
 
@@ -54,7 +54,7 @@ class TlsContextWrapper(object):
             field = data.get('name')
 
             if field.startswith(UNIQUE_FIELD_PREFIX):
-                standard_field_name = field[len(UNIQUE_FIELD_PREFIX):]
+                standard_field_name = field[len(UNIQUE_FIELD_PREFIX) :]
             else:
                 standard_field_name = field
 

--- a/datadog_checks_base/tests/test_tls.py
+++ b/datadog_checks_base/tests/test_tls.py
@@ -1,0 +1,218 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+import ssl
+from ssl import SSLContext
+
+import pytest
+from datadog_checks.dev import TempDir
+from mock import patch, MagicMock
+
+from datadog_checks.base import AgentCheck
+from datadog_checks.base.utils.tls import TlsContextWrapper
+
+
+class TestCheckAttribute:
+    def test_default(self):
+        check = AgentCheck('test', {}, [{}])
+
+        assert not hasattr(check, '_tls_context_wrapper')
+
+    def test_activate(self):
+        check = AgentCheck('test', {}, [{}])
+
+        context = check.get_tls_context()
+        assert context == check._tls_context_wrapper.tls_context
+        assert isinstance(context, SSLContext)
+
+    def test_refresh(self):
+        check = AgentCheck('test', {}, [{}])
+
+        context = check.get_tls_context()
+        assert context == check.get_tls_context()
+        assert context != check.get_tls_context(refresh=True)
+
+
+class TestVerify:
+    def test_default(self):
+        tls = TlsContextWrapper({})
+        assert tls.config['tls_verify'] is True
+
+    def test_config(self):
+        tls = TlsContextWrapper({'tls_verify': False})
+        assert tls.config['tls_verify'] is False
+
+    @pytest.mark.parametrize('param', ('tls_ca_cert', 'tls_cert', 'tls_private_key', 'tls_private_key_password'))
+    def test_config_overwrite(self, param):
+        config = {'tls_verify': False, param: 'foo'}
+        with patch('ssl.SSLContext'):
+            tls = TlsContextWrapper(config)
+        assert tls.config['tls_verify'] is True
+
+
+@pytest.mark.parametrize(
+    'param', ('tls_ca_cert', 'tls_cert', 'tls_private_key', 'tls_private_key_password', 'tls_validate_hostname')
+)
+def test_attributes(param):
+    config = {param: 'foo'}
+    with patch('ssl.SSLContext'):
+        tls = TlsContextWrapper(config)
+    assert tls.config[param] == 'foo'
+
+
+class TestRemapper:
+    def test_no_default(self):
+        remapper = {'verify': {'name': 'tls_verify'}}
+        tls = TlsContextWrapper({}, remapper)
+        assert tls.config['tls_verify'] is True
+
+    def test_default(self):
+        remapper = {'verify': {'name': 'tls_verify', 'default': False}}
+        tls = TlsContextWrapper({}, remapper)
+        assert tls.config['tls_verify'] is False
+
+    def test_invert(self):
+        instance = {'disable_tls_validation': True}
+        remapper = {'disable_tls_validation': {'name': 'tls_verify', 'default': True, 'invert': True}}
+        tls = TlsContextWrapper(instance, remapper)
+
+        assert tls.config['tls_verify'] is False
+
+    def test_invert_with_explicit_default(self):
+        instance = {}
+        remapper = {'disable_tls_validation': {'name': 'tls_verify', 'invert': True, 'default': True}}
+        tls = TlsContextWrapper(instance, remapper)
+        assert tls.config['tls_verify'] is False
+
+    def test_invert_without_explicit_default(self):
+        instance = {}
+        remapper = {'disable_tls_validation': {'name': 'tls_verify', 'invert': True}}
+        tls = TlsContextWrapper(instance, remapper)
+        assert tls.config['tls_verify'] is True
+
+
+class TestHigherPriorityRemapper:
+    def test_verify_no_remapper(self):
+        instance = {
+            'tls_verify': False,
+            '_tls_context_tls_verify': True
+        }
+        tls = TlsContextWrapper(instance)
+        assert tls.config['tls_verify'] is True
+
+    def test_verify_remapper(self):
+        instance = {
+            'disable_tls_validation': True,
+            '_tls_context_tls_verify': True
+        }
+        remapper = {'disable_tls_validation': {'name': 'tls_verify', 'invert': True}}
+        tls = TlsContextWrapper(instance, remapper)
+        assert tls.config['tls_verify'] is True
+
+    def test_verify_remapper_to_higher_priority(self):
+        instance = {
+            'disable_tls_validation': True,
+            'tls_verify': True
+        }
+        remapper = {'disable_tls_validation': {'name': '_tls_context_tls_verify', 'invert': True}}
+        tls = TlsContextWrapper(instance, remapper)
+        assert tls.config['tls_verify'] is False
+
+
+class TestTLSContext:
+    def test_unverified_tls(self):
+        instance = {'tls_verify': False}
+        check = AgentCheck('test', {}, [instance])
+        assert check.get_tls_context().verify_mode == ssl.CERT_NONE
+
+    def test_verify_ssl(self):
+        instance = {'tls_verify': True, 'tls_validate_hostname': False}
+        check = AgentCheck('test', {}, [instance])
+        context = check.get_tls_context()
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is False
+
+    def test_verify_ssl_with_hostname_by_default(self):
+        instance = {'tls_verify': True}
+        check = AgentCheck('test', {}, [instance])
+        context = check.get_tls_context()
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+
+    def test_verify_ssl_with_hostname(self):
+        instance = {'tls_verify': True, 'tls_validate_hostname': True}
+        check = AgentCheck('test', {}, [instance])
+        context = check.get_tls_context()
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+
+    def test_no_ca_certs_default(self):
+        check = AgentCheck('test', {}, [{}])
+        context = check.get_tls_context()
+        # Loads agent default ca certs from /opt/datadog-agent/embedded/ssl/cert.pem
+        assert len(context.get_ca_certs()) > 100
+
+    def test_no_ca_certs_no_default(self):
+        instance = {'tls_load_default_certs': False}
+        check = AgentCheck('test', {}, [instance])
+        context = check.get_tls_context()
+        assert len(context.get_ca_certs()) == 0
+
+    def test_ca_cert_file(self):
+        with patch('ssl.SSLContext'), TempDir("test_ca_cert_file") as tmp_dir:
+            filename = os.path.join(tmp_dir, 'foo')
+            open(filename, 'w').close()
+            instance = {'tls_ca_cert': filename}
+            check = AgentCheck('test', {}, [instance])
+            context = check.get_tls_context()  # type: MagicMock
+            context.load_verify_locations.assert_called_with(cafile=filename, capath=None, cadata=None)
+
+    def test_ca_cert_dir(self):
+        with patch('ssl.SSLContext'), TempDir("test_ca_cert_file") as tmp_dir:
+            instance = {'tls_ca_cert': tmp_dir}
+            check = AgentCheck('test', {}, [instance])
+            context = check.get_tls_context()  # type: MagicMock
+            context.load_verify_locations.assert_called_with(cafile=None, capath=tmp_dir, cadata=None)
+
+    def test_ca_cert_expand_user(self):
+        instance = {'tls_ca_cert': '~/foo'}
+        check = AgentCheck('test', {}, [instance])
+        with patch('ssl.SSLContext'), patch('os.path.expanduser') as mock_expand:
+            check.get_tls_context()
+            mock_expand.assert_called_with('~/foo')
+
+    def test_client_cert_no_key_no_pass(self):
+        instance = {'tls_cert': 'foo'}
+        check = AgentCheck('test', {}, [instance])
+        with patch('ssl.SSLContext'):
+            context = check.get_tls_context()  # type: MagicMock
+            context.load_cert_chain.assert_called_with('foo', keyfile=None, password=None)
+
+    def test_client_cert_key_no_pass(self):
+        instance = {'tls_cert': 'foo', 'tls_private_key': 'bar'}
+        check = AgentCheck('test', {}, [instance])
+        with patch('ssl.SSLContext'):
+            context = check.get_tls_context()  # type: MagicMock
+            context.load_cert_chain.assert_called_with('foo', keyfile='bar', password=None)
+
+    def test_client_cert_key_and_pass(self):
+        instance = {'tls_cert': 'foo', 'tls_private_key': 'bar', 'tls_private_key_password': 'pass'}
+        check = AgentCheck('test', {}, [instance])
+        with patch('ssl.SSLContext'):
+            context = check.get_tls_context()  # type: MagicMock
+            context.load_cert_chain.assert_called_with('foo', keyfile='bar', password='pass')
+
+    def test_client_cert_expanded(self):
+        instance = {'tls_cert': '~/foo'}
+        check = AgentCheck('test', {}, [instance])
+        with patch('ssl.SSLContext'), patch('os.path.expanduser') as mock_expand:
+            check.get_tls_context()
+            mock_expand.assert_called_with('~/foo')
+
+    def test_client_key_expanded(self):
+        instance = {'tls_private_key': '~/foo'}
+        check = AgentCheck('test', {}, [instance])
+        with patch('ssl.SSLContext'), patch('os.path.expanduser') as mock_expand:
+            check.get_tls_context()
+            mock_expand.assert_called_with('~/foo')

--- a/datadog_checks_base/tests/test_tls.py
+++ b/datadog_checks_base/tests/test_tls.py
@@ -140,9 +140,9 @@ class TestTLSContext:
 
     def test_no_ca_certs_default(self):
         check = AgentCheck('test', {}, [{}])
-        context = check.get_tls_context()
-        # Loads agent default ca certs from /opt/datadog-agent/embedded/ssl/cert.pem
-        assert len(context.get_ca_certs()) > 100
+        with patch('ssl.SSLContext'):
+            context = check.get_tls_context()  # type: MagicMock
+            context.load_default_certs.assert_called_with(ssl.Purpose.SERVER_AUTH)
 
     def test_no_ca_certs_no_default(self):
         instance = {'tls_load_default_certs': False}

--- a/datadog_checks_base/tests/test_tls.py
+++ b/datadog_checks_base/tests/test_tls.py
@@ -169,9 +169,9 @@ class TestTLSContext:
     def test_ca_cert_expand_user(self):
         instance = {'tls_ca_cert': '~/foo'}
         check = AgentCheck('test', {}, [instance])
-        with patch('ssl.SSLContext'), patch('os.path.expanduser') as mock_expand:
+        with patch('ssl.SSLContext'), patch('os.path') as mock_path:
             check.get_tls_context()
-            mock_expand.assert_called_with('~/foo')
+            mock_path.expanduser.assert_called_with('~/foo')
 
     def test_client_cert_no_key_no_pass(self):
         instance = {'tls_cert': 'foo'}

--- a/datadog_checks_base/tests/test_tls.py
+++ b/datadog_checks_base/tests/test_tls.py
@@ -6,11 +6,11 @@ import ssl
 from ssl import SSLContext
 
 import pytest
-from datadog_checks.dev import TempDir
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.tls import TlsContextWrapper
+from datadog_checks.dev import TempDir
 
 
 class TestCheckAttribute:
@@ -94,27 +94,18 @@ class TestRemapper:
 
 class TestHigherPriorityRemapper:
     def test_verify_no_remapper(self):
-        instance = {
-            'tls_verify': False,
-            '_tls_context_tls_verify': True
-        }
+        instance = {'tls_verify': False, '_tls_context_tls_verify': True}
         tls = TlsContextWrapper(instance)
         assert tls.config['tls_verify'] is True
 
     def test_verify_remapper(self):
-        instance = {
-            'disable_tls_validation': True,
-            '_tls_context_tls_verify': True
-        }
+        instance = {'disable_tls_validation': True, '_tls_context_tls_verify': True}
         remapper = {'disable_tls_validation': {'name': 'tls_verify', 'invert': True}}
         tls = TlsContextWrapper(instance, remapper)
         assert tls.config['tls_verify'] is True
 
     def test_verify_remapper_to_higher_priority(self):
-        instance = {
-            'disable_tls_validation': True,
-            'tls_verify': True
-        }
+        instance = {'disable_tls_validation': True, 'tls_verify': True}
         remapper = {'disable_tls_validation': {'name': '_tls_context_tls_verify', 'invert': True}}
         tls = TlsContextWrapper(instance, remapper)
         assert tls.config['tls_verify'] is False


### PR DESCRIPTION
Adds a new method to the base class `AgentCheck.get_tls_context(self, refresh=False)`

This helper method can be used by checks to create an `SSLContext` instance in a reliable way using generic configuration.
The default fields in the configuration are the following ones:

configuration | defaults | description
------------ | ------------- | -----
tls_verify | True | Whether or not the SSLContext instance will verify the validity of the certificates. If false, the context will still be used to establish a SSL/TLS connection but in an insecure way.
tls_ca_cert | None | Path to a file or a directory of certificate files in PEM format
tls_cert | None | Path to a certificate file
tls_private_key | None | Optional key for the certificate file. If missing, the key is expected to be in the same file as `tls_cert`
tls_private_key_password | None | Optional password to read the tls_private_key
tls_validate_hostname | True | Whether or not to verify that the hostname of the certificate is the same as the one requested.
tls_load_default_certs | True | If enabled, the SSL context will load the default system certificates shipped with the agent (usually from `/opt/datadog-agent/embedded/ssl/cert.pem`)

As you can see most options overlap the options from the http requests wrapper. This is for simplicity of use.
In some very specific case, an integration might need both the http requests wrapper and the tls context wrapper but with different options. Such an example is vSphere, where a SOAP API using an explicit ssl context is required but the integration also needs to make REST calls to a different API. Those APIs being different, they might require different settings.

To give more control to integrations, the TLS wrapper supports prefixing all configs with `_tls_context_` for higher priority. That means that if an integration uses the following config:
```
tls_verify: True
soap_tls_verify: False
```
and uses the following remapper:
```
{
    'soap_tls_verify': {'name': '_tls_context_tls_verify'}
}
```
the HTTP wrapper will use `tls_verify: True` but the TLSContextWrapper will use `tls_verify: False`.

Note that this extended logic will only be used for:
- Integrations that need different configs for the http wrapper and an SSL context
- Integrations that already supports overlapping configuration (like `tls_verify`).

Future integrations won't have this problem, for vSphere we could design the config to be
```
http_tls_verify: True
soap_tls_verify: True
```
 and have http remapper that maps `http_tls_verify` to `tls_verify` and one tls remapper that maps `soap_tls_verify` to `tls_verify`.


TODO: In another PR, adds a spec.yaml for those new configuration options.
TODO2: For each integraiton using an SSLContext, use the TLSContextWrapper instead