### PR TITLE
[Recommended Monitors] Fix renotify_interval 

### DIFF
--- a/nginx/assets/monitors/4xx.json
+++ b/nginx/assets/monitors/4xx.json
@@ -13,7 +13,7 @@
 		"new_host_delay": 300,
 		"require_full_window": false,
 		"notify_no_data": false,
-		"renotify_interval": "0",
+		"renotify_interval": 0,
 		"escalation_message": "",
 		"no_data_timeframe": null,
 		"include_tags": true,

--- a/nginx/assets/monitors/5xx.json
+++ b/nginx/assets/monitors/5xx.json
@@ -13,7 +13,7 @@
 		"new_host_delay": 300,
 		"require_full_window": false,
 		"notify_no_data": false,
-		"renotify_interval": "0",
+		"renotify_interval": 0,
 		"escalation_message": "",
 		"no_data_timeframe": null,
 		"include_tags": true,

--- a/nginx/assets/monitors/upstream_peer_fails.json
+++ b/nginx/assets/monitors/upstream_peer_fails.json
@@ -13,7 +13,7 @@
 		"new_host_delay": 300,
 		"require_full_window": false,
 		"notify_no_data": false,
-		"renotify_interval": "0",
+		"renotify_interval": 0,
 		"escalation_message": "",
 		"no_data_timeframe": null,
 		"include_tags": true,

--- a/scylla/assets/monitors/instance_down.json
+++ b/scylla/assets/monitors/instance_down.json
@@ -13,7 +13,7 @@
 		"new_host_delay": 300,
 		"require_full_window": true,
 		"notify_no_data": false,
-		"renotify_interval": "0",
+		"renotify_interval": 0,
 		"escalation_message": "",
 		"no_data_timeframe": null,
 		"include_tags": true,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`renotify_interval` should be int and not a string. This is causing ES 7 migration to fail on staging

### Motivation
<!-- What inspired you to submit this pull request? -->
ES 7 migration for gov cloud for recommended monitors 
https://datadoghq.atlassian.net/browse/MA-1641

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
