### PR TITLE
Add support for named groups in regular expressions

### DIFF
--- a/rabbitmq/assets/configuration/spec.yaml
+++ b/rabbitmq/assets/configuration/spec.yaml
@@ -59,7 +59,10 @@ files:
         the metrics are collected on all the queues by default.
         If you have set up vhosts, set the queue names as `vhost_name/queue_name`.
         If you have `tag_families` enabled, the first captured group in the regex
-        is used as the queue_family tag.
+        is used as the queue_family tag if no named group is specified.
+        If you have named groups the tag names will be the named groups in regex.
+        If you use multiplies groups and not all are named, the tags are going to be
+        used only on the groups that contains names.
       value:
         type: array
         items:
@@ -75,6 +78,9 @@ files:
         the metrics are collected on all the queues by default.
         If you have `tag_families` enabled, the first captured group in the regex
         is used as the queue_family tag.
+        If you have named groups the tag names will be the named groups in regex.
+        If you use multiplies groups and not all have are named, the tags are going to be
+        used only on the groups that contains names.
       value:
         type: array
         items:

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -87,7 +87,10 @@ instances:
     ## the metrics are collected on all the queues by default.
     ## If you have set up vhosts, set the queue names as `vhost_name/queue_name`.
     ## If you have `tag_families` enabled, the first captured group in the regex
-    ## is used as the queue_family tag.
+    ## is used as the queue_family tag if no named group is specified.
+    ## If you have named groups the tag names will be the named groups in regex.
+    ## If you use multiplies groups and not all are named, the tags are going to be
+    ## used only on the groups that contains names.
     #
     # queues:
     #   - <QUEUE_NAME_1>
@@ -100,6 +103,9 @@ instances:
     ## the metrics are collected on all the queues by default.
     ## If you have `tag_families` enabled, the first captured group in the regex
     ## is used as the queue_family tag.
+    ## If you have named groups the tag names will be the named groups in regex.
+    ## If you use multiplies groups and not all have are named, the tags are going to be
+    ## used only on the groups that contains names.
     #
     # queues_regexes:
     #   - <REGEX>

--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -325,8 +325,9 @@ class RabbitMQ(AgentCheck):
                     explicit_filters.remove(name)
                     continue
 
-                match_found = self._append_match_lines(regex_filters, name,
-                    tag_families, data_line, object_type, matching_lines)
+                match_found = self._append_match_lines(
+                    regex_filters, name, tag_families, data_line, object_type, matching_lines
+                )
 
                 if match_found:
                     continue
@@ -339,16 +340,17 @@ class RabbitMQ(AgentCheck):
                     matching_lines.append(data_line)
                     explicit_filters.remove(absolute_name)
                     continue
-                
-                match_found = self._append_match_lines(regex_filters, absolute_name,
-                    tag_families, data_line, object_type, matching_lines)
+
+                match_found = self._append_match_lines(
+                    regex_filters, absolute_name, tag_families, data_line, object_type, matching_lines
+                )
                 if match_found:
                     continue
             return matching_lines
         return data
 
     def _append_match_lines(self, regex_filters, name, tag_families, data_line, object_type, matching_lines):
-        result = False        
+        result = False
         object_tag_name = "queue_family"
         if object_type == EXCHANGE_TYPE:
             object_tag_name = "exchange_family"
@@ -362,8 +364,8 @@ class RabbitMQ(AgentCheck):
                             key_name = object_tag_name + "_" + key
                             data_line[key] = named_groups_dict[key]
                             TAGS_MAP[object_type][key] = key_name
-                    else:                        
-                        data_line[object_tag_name] = match.groups()[0]                        
+                    else:
+                        data_line[object_tag_name] = match.groups()[0]
                 matching_lines.append(data_line)
                 result = True
                 break
@@ -516,7 +518,7 @@ class RabbitMQ(AgentCheck):
 
         # a list of queues/nodes is specified. We process only those
         data = self._filter_list(
-            data, explicit_filters, regex_filters, object_type, instance.get("tag_families", False)                
+            data, explicit_filters, regex_filters, object_type, instance.get("tag_families", False)
         )
 
         # if no filters are specified, check everything according to the limits

--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -360,7 +360,7 @@ class RabbitMQ(AgentCheck):
                     if len(named_groups_dict) > 0:
                         for key in named_groups_dict:
                             key_name = object_tag_name + "_" + key
-                            data_line[key] = key
+                            data_line[key] = named_groups_dict[key]
                             TAGS_MAP[object_type][key] = key_name
                     else:                        
                         data_line[object_tag_name] = match.groups()[0]                        

--- a/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
+++ b/rabbitmq/datadog_checks/rabbitmq/rabbitmq.py
@@ -325,18 +325,8 @@ class RabbitMQ(AgentCheck):
                     explicit_filters.remove(name)
                     continue
 
-                match_found = False
-                for p in regex_filters:
-                    match = re.search(p, name)
-                    if match:
-                        if is_affirmative(tag_families) and match.groups():
-                            if object_type == QUEUE_TYPE:
-                                data_line["queue_family"] = match.groups()[0]
-                            if object_type == EXCHANGE_TYPE:
-                                data_line["exchange_family"] = match.groups()[0]
-                        matching_lines.append(data_line)
-                        match_found = True
-                        break
+                match_found = self._append_match_lines(regex_filters, name,
+                    tag_families, data_line, object_type, matching_lines)
 
                 if match_found:
                     continue
@@ -349,22 +339,35 @@ class RabbitMQ(AgentCheck):
                     matching_lines.append(data_line)
                     explicit_filters.remove(absolute_name)
                     continue
-
-                for p in regex_filters:
-                    match = re.search(p, absolute_name)
-                    if match:
-                        if is_affirmative(tag_families) and match.groups():
-                            if object_type == QUEUE_TYPE:
-                                data_line["queue_family"] = match.groups()[0]
-                            if object_type == EXCHANGE_TYPE:
-                                data_line["exchange_family"] = match.groups()[0]
-                        matching_lines.append(data_line)
-                        match_found = True
-                        break
+                
+                match_found = self._append_match_lines(regex_filters, absolute_name,
+                    tag_families, data_line, object_type, matching_lines)
                 if match_found:
                     continue
             return matching_lines
         return data
+
+    def _append_match_lines(self, regex_filters, name, tag_families, data_line, object_type, matching_lines):
+        result = False        
+        object_tag_name = "queue_family"
+        if object_type == EXCHANGE_TYPE:
+            object_tag_name = "exchange_family"
+        for p in regex_filters:
+            match = re.search(p, name)
+            if match:
+                if is_affirmative(tag_families) and match.groups():
+                    named_groups_dict = match.groupdict()
+                    if len(named_groups_dict) > 0:
+                        for key in named_groups_dict:
+                            key_name = object_tag_name + "_" + key
+                            data_line[key] = key
+                            TAGS_MAP[object_type][key] = key_name
+                    else:                        
+                        data_line[object_tag_name] = match.groups()[0]                        
+                matching_lines.append(data_line)
+                result = True
+                break
+        return result
 
     def _get_tags(self, data, object_type, custom_tags):
         tags = []
@@ -513,7 +516,7 @@ class RabbitMQ(AgentCheck):
 
         # a list of queues/nodes is specified. We process only those
         data = self._filter_list(
-            data, explicit_filters, regex_filters, object_type, instance.get("tag_families", False)
+            data, explicit_filters, regex_filters, object_type, instance.get("tag_families", False)                
         )
 
         # if no filters are specified, check everything according to the limits

--- a/rabbitmq/tests/common.py
+++ b/rabbitmq/tests/common.py
@@ -64,6 +64,15 @@ CONFIG_WITH_FAMILY = {
     'exchanges_regexes': [r'(test)\d+'],
 }
 
+CONFIG_WITH_FAMILY_NAMED_GROUP = {
+    'rabbitmq_api_url': URL,
+    'rabbitmq_user': 'guest',
+    'rabbitmq_pass': 'guest',
+    'tag_families': True,
+    'queues_regexes': [r'(?P<first_group>test)\d+'],
+    'exchanges_regexes': [r'(?P<first_group>test)\d+'],
+}
+
 CONFIG_DEFAULT_VHOSTS = {
     'rabbitmq_api_url': URL,
     'rabbitmq_user': 'guest',

--- a/rabbitmq/tests/test_integration_e2e.py
+++ b/rabbitmq/tests/test_integration_e2e.py
@@ -178,6 +178,7 @@ def test_family_tagging(aggregator, check):
 
     aggregator.assert_all_metrics_covered()
 
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_family_tagging_with_named_groups(aggregator, check):
@@ -210,6 +211,7 @@ def test_family_tagging_with_named_groups(aggregator, check):
     aggregator.assert_service_check('rabbitmq.status', status=RabbitMQ.OK)
 
     aggregator.assert_all_metrics_covered()
+
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')

--- a/rabbitmq/tests/test_integration_e2e.py
+++ b/rabbitmq/tests/test_integration_e2e.py
@@ -191,10 +191,10 @@ def test_family_tagging_with_named_groups(aggregator, check):
     aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:myvhost'], value=0, count=1)
     aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:myothervhost'], value=0, count=1)
     for mname in metrics.E_METRICS:
-        aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange_family_first_group:first_group', count=2)
+        aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange_family_first_group:test', count=2)
 
     for mname in metrics.Q_METRICS:
-        aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue_family_first_group:first_group', count=6)
+        aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue_family_first_group:test', count=6)
     # Overview attributes
     for mname in metrics.OVERVIEW_METRICS_TOTALS:
         aggregator.assert_metric_has_tag(mname, 'rabbitmq_cluster:rabbitmqtest', count=1)

--- a/rabbitmq/tests/test_integration_e2e.py
+++ b/rabbitmq/tests/test_integration_e2e.py
@@ -178,6 +178,38 @@ def test_family_tagging(aggregator, check):
 
     aggregator.assert_all_metrics_covered()
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_family_tagging_with_named_groups(aggregator, check):
+    check.check(common.CONFIG_WITH_FAMILY_NAMED_GROUP)
+
+    # Node attributes
+    for mname in metrics.COMMON_METRICS:
+        aggregator.assert_metric_has_tag_prefix(mname, 'rabbitmq_node', count=1)
+
+    aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:/'], value=0, count=1)
+    aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:myvhost'], value=0, count=1)
+    aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:myothervhost'], value=0, count=1)
+    for mname in metrics.E_METRICS:
+        aggregator.assert_metric_has_tag(mname, 'rabbitmq_exchange_family_first_group:first_group', count=2)
+
+    for mname in metrics.Q_METRICS:
+        aggregator.assert_metric_has_tag(mname, 'rabbitmq_queue_family_first_group:first_group', count=6)
+    # Overview attributes
+    for mname in metrics.OVERVIEW_METRICS_TOTALS:
+        aggregator.assert_metric_has_tag(mname, 'rabbitmq_cluster:rabbitmqtest', count=1)
+    for mname in metrics.OVERVIEW_METRICS_MESSAGES:
+        # All messages metrics are not always present, so we assert with at_least=0
+        aggregator.assert_metric_has_tag(mname, 'rabbitmq_cluster:rabbitmqtest', at_least=0)
+
+    aggregator.assert_metric('rabbitmq.connections', tags=['rabbitmq_vhost:/'], value=0, count=1)
+
+    aggregator.assert_service_check('rabbitmq.aliveness', tags=['vhost:/'], status=RabbitMQ.OK)
+    aggregator.assert_service_check('rabbitmq.aliveness', tags=['vhost:myvhost'], status=RabbitMQ.OK)
+    aggregator.assert_service_check('rabbitmq.aliveness', tags=['vhost:myothervhost'], status=RabbitMQ.OK)
+    aggregator.assert_service_check('rabbitmq.status', status=RabbitMQ.OK)
+
+    aggregator.assert_all_metrics_covered()
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')


### PR DESCRIPTION
### tag_families now supports named groups regex.
<!-- A brief description of the change being made with this pull request. -->
- I refactored one duplicate code that append_lines to a data structure in the _filter_list. The new method is rabbitmq._append_match_lines 
- In _append_match_lines is where is the logic to get the regex and associate to the tags values, this is where I added the support to get the regexes names and transform to TAGS. 
- The old use of tag_families was maintained and it's happens when there are no named groups specifieds in the regex, so it's the default choice.

### Motivation
When I tried to use the integration of RabbitMQ, I had the need to specify more than one "tag" in my regex group, to create
better monitors/dashboards.
So I was asking myself, why I cant use the named groups from regexes to match the tags I want to upload to DD? 

### Additional Notes
I don't know if there are some limitations for tags that should had some code check before applying the regex.

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
