### PR TITLE
Fix release-hash-check

### DIFF
--- a/.github/workflows/release-hash-check.yml
+++ b/.github/workflows/release-hash-check.yml
@@ -25,4 +25,5 @@ jobs:
         FILES=$(git --no-pager diff --name-only origin/master -- .in-toto | xargs echo)
         echo "::set-output name=all::$FILES"
 
+    - run: git merge --commit --no-edit origin/master
     - run: python .github/workflows/release-hash-check.py ${{ steps.files.outputs.all }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The release-hash-check job stopped working to detect hash mismatch. The PR reference may not be up to date.
Previous job was working here: https://github.com/FlorianVeaux/integrations-core/pull/6/checks?check_run_id=919053005 so I'm not so sure what's the reason.

Now the job explicitly merges master into the current branch so that files are guaranteed to be updated.

### Motivation
Re-running the job in this PR did not catch the signature error: https://github.com/DataDog/integrations-core/pull/7799
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
