### PR TITLE
Make refresh_oids_cache_interval available as init_config

### DIFF
--- a/snmp/datadog_checks/snmp/config.py
+++ b/snmp/datadog_checks/snmp/config.py
@@ -63,6 +63,7 @@ class InstanceConfig:
         instance,  # type: dict
         global_metrics=None,  # type: List[dict]
         mibs_path=None,  # type: str
+        refresh_oids_cache_interval=DEFAULT_REFRESH_OIDS_CACHE_INTERVAL,  # type: int
         profiles=None,  # type: Dict[str, dict]
         profiles_by_oid=None,  # type: Dict[str, str]
         loader=None,  # type: MIBLoader
@@ -158,7 +159,7 @@ class InstanceConfig:
         if tag_oids:
             scalar_oids.extend(tag_oids)
 
-        refresh_interval_sec = instance.get('refresh_oids_cache_interval', self.DEFAULT_REFRESH_OIDS_CACHE_INTERVAL)
+        refresh_interval_sec = instance.get('refresh_oids_cache_interval', refresh_oids_cache_interval)
         self.oid_config = OIDConfig(refresh_interval_sec)
         self.oid_config.add_parsed_oids(scalar_oids=scalar_oids, next_oids=next_oids, bulk_oids=bulk_oids)
 

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -32,6 +32,7 @@ init_config:
   ## @param refresh_oids_cache_interval - integer - optional - default: 0
   ## (beta feature) Set this option to enable caching of OIDs. The value is the number of seconds before the
   ## the cache is refreshed.
+  ## This option works best when `oid_batch_size` is set to 128 or 256.
   ## This is useful to improve performance when fetching metrics from large tables.
   ## When OID caching is enabled, table row OIDs are reused. This means that the table can be fetched
   ## using batched GET queries, as opposed to one GETNEXT query per row in the table.
@@ -393,6 +394,7 @@ instances:
     ## @param refresh_oids_cache_interval - integer - optional - default: 0
     ## (beta feature) Set this option to enable caching of OIDs. The value is the number of seconds before the
     ## the cache is refreshed.
+    ## This option works best when `oid_batch_size` is set to 128 or 256.
     ## This is useful to improve performance when fetching metrics from large tables.
     ## When OID caching is enabled, table row OIDs are reused. This means that the table can be fetched
     ## using batched GET queries, as opposed to one GETNEXT query per row in the table.

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -29,6 +29,21 @@ init_config:
   #
   # optimize_mib_memory_usage: false
 
+  ## @param refresh_oids_cache_interval - integer - optional - default: 0
+  ## (beta feature) Set this option to enable caching of OIDs. The value is the number of seconds before the
+  ## the cache is refreshed.
+  ## This is useful to improve performance when fetching metrics from large tables.
+  ## When OID caching is enabled, table row OIDs are reused. This means that the table can be fetched
+  ## using batched GET queries, as opposed to one GETNEXT query per row in the table.
+  ## The caching is disabled if the interval is set to `0` (default).
+  ##
+  ## Caveat: If some tables rows are dynamic, new rows will only be fetched at every refresh interval.
+  ##         - This means new OIDs will only be picked up when OIDs are refreshed according to the refresh interval.
+  ##         - With auto discovery, if the same IP is assigned to a different device with different OIDs,
+  ##         the OIDs will be refreshed only according to the refresh interval.
+  #
+  # refresh_oids_cache_interval: 3600
+
   ## @param global_metrics - list of elements - optional
   ## Specify global_metrics you want to monitor by using MIBS for Counter and Gauge.
   ## global_metrics are applied to all instances where use_global_metrics is set to true at the instance level.

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -69,6 +69,9 @@ class SnmpCheck(AgentCheck):
         self.optimize_mib_memory_usage = is_affirmative(self.init_config.get('optimize_mib_memory_usage', False))
 
         self.ignore_nonincreasing_oid = is_affirmative(self.init_config.get('ignore_nonincreasing_oid', False))
+        self.refresh_oids_cache_interval = int(
+            self.init_config.get('refresh_oids_cache_interval', InstanceConfig.DEFAULT_REFRESH_OIDS_CACHE_INTERVAL)
+        )
 
         self.profiles = self._load_profiles()
         self.profiles_by_oid = self._get_profiles_mapping()
@@ -132,6 +135,7 @@ class SnmpCheck(AgentCheck):
             instance,
             global_metrics=self.init_config.get('global_metrics', []),
             mibs_path=self.mibs_path,
+            refresh_oids_cache_interval=self.refresh_oids_cache_interval,
             profiles=self.profiles,
             profiles_by_oid=self.profiles_by_oid,
             loader=loader,

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -1122,6 +1122,23 @@ def test_oids_cache_metrics_collected_using_scalar_oids(aggregator):
 
 
 @pytest.mark.parametrize(
+    'init_config, instance_extra, expected_interval',
+    [
+        pytest.param({}, {}, 0, id='none'),
+        pytest.param({}, {'refresh_oids_cache_interval': 3600}, 3600, id='instance_config'),
+        pytest.param({'refresh_oids_cache_interval': 3600}, {}, 3600, id='init_config'),
+        pytest.param({'refresh_oids_cache_interval': 0}, {'refresh_oids_cache_interval': 3600}, 3600, id='both'),
+    ],
+)
+def test_oids_cache_configs(init_config, instance_extra, expected_interval):
+    instance = common.generate_instance_config(common.TABULAR_OBJECTS)
+    instance.update(instance_extra)
+    check = SnmpCheck('snmp', init_config, [instance])
+
+    assert check._config.oid_config._refresh_interval_sec == expected_interval
+
+
+@pytest.mark.parametrize(
     "config, has_next_bulk_oids",
     [
         pytest.param({}, True, id='disabled_config_default'),


### PR DESCRIPTION
### What does this PR do?

Make `refresh_oids_cache_interval` available as init_config

### Motivation

User request.