### PR TITLE
Filter metrics by label keys and values

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -640,7 +640,7 @@ class OpenMetricsScraperMixin(object):
         sample_labels = sample[self.SAMPLE_LABELS]
         for label_key, label_values in ignore_metrics_by_label.items():
             # Wildcard * means all metrics with label_key will be ignored
-            if '*' in label_values:
+            if label_values is not None and '*' in label_values:
                 self.log.debug("Detected wildcard for label %s", label_key)
                 label_values = None
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -181,6 +181,10 @@ class OpenMetricsScraperMixin(object):
         if ignored_patterns:
             config['_ignored_re'] = compile('|'.join(ignored_patterns))
 
+        # Ignore metrics based on tags
+        config['ignore_metrics_by_label'] = instance.get('ignore_metrics_by_label',
+                                                         default_instance.get('ignore_metrics_by_label', []))
+
         # If you want to send the buckets as tagged values when dealing with histograms,
         # set send_histograms_buckets to True, set to False otherwise.
         config['send_histograms_buckets'] = is_affirmative(

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -182,8 +182,9 @@ class OpenMetricsScraperMixin(object):
             config['_ignored_re'] = compile('|'.join(ignored_patterns))
 
         # Ignore metrics based on tags
-        config['ignore_metrics_by_label'] = instance.get('ignore_metrics_by_label',
-                                                         default_instance.get('ignore_metrics_by_label', {}))
+        config['ignore_metrics_by_label'] = instance.get(
+            'ignore_metrics_by_label', default_instance.get('ignore_metrics_by_label', {})
+        )
 
         # If you want to send the buckets as tagged values when dealing with histograms,
         # set send_histograms_buckets to True, set to False otherwise.
@@ -645,7 +646,9 @@ class OpenMetricsScraperMixin(object):
             else:
                 for val in label_values:
                     if label_key in sample_labels and sample_labels[label_key] == val:
-                        self.log.debug("Skipping metric %s due to label %s value matching: %s", metric_name, label_key, val)
+                        self.log.debug(
+                            "Skipping metric %s due to label %s value matching: %s", metric_name, label_key, val
+                        )
                         return True
         return False
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -639,6 +639,11 @@ class OpenMetricsScraperMixin(object):
         ignore_metrics_by_label = scraper_config['ignore_metrics_by_labels']
         sample_labels = sample[self.SAMPLE_LABELS]
         for label_key, label_values in ignore_metrics_by_label.items():
+            # Wildcard * means all metrics with label_key will be ignored
+            if '*' in label_values:
+                self.log.debug("Detected wildcard for label %s", label_key)
+                label_values = None
+
             if label_values is None:
                 if label_key in sample_labels:
                     self.log.debug("Skipping metric %s due to label key matching: %s", metric_name, label_key)

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -181,9 +181,9 @@ class OpenMetricsScraperMixin(object):
         if ignored_patterns:
             config['_ignored_re'] = compile('|'.join(ignored_patterns))
 
-        # Ignore metrics based on tags
-        config['ignore_metrics_by_label'] = instance.get(
-            'ignore_metrics_by_label', default_instance.get('ignore_metrics_by_label', {})
+        # Ignore metrics based on label keys or specific label values
+        config['ignore_metrics_by_labels'] = instance.get(
+            'ignore_metrics_by_labels', default_instance.get('ignore_metrics_by_labels', {})
         )
 
         # If you want to send the buckets as tagged values when dealing with histograms,
@@ -636,7 +636,7 @@ class OpenMetricsScraperMixin(object):
                         sample_labels.update(label_mapping[mapping_key][mapping_value])
 
     def _ignore_metrics_by_label(self, scraper_config, metric_name, sample):
-        ignore_metrics_by_label = scraper_config['ignore_metrics_by_label']
+        ignore_metrics_by_label = scraper_config['ignore_metrics_by_labels']
         sample_labels = sample[self.SAMPLE_LABELS]
         for label_key, label_values in ignore_metrics_by_label.items():
             if label_values is None:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -648,6 +648,8 @@ class OpenMetricsScraperMixin(object):
                 if label_key in sample_labels:
                     self.log.debug("Skipping metric %s due to label key matching: %s", metric_name, label_key)
                     return True
+            elif len(label_values) == 0:
+                self.log.debug("Skipping filter label %s with an empty values list, did you mean to use '*' wildcard?", label_key)
             else:
                 for val in label_values:
                     if label_key in sample_labels and sample_labels[label_key] == val:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -653,7 +653,7 @@ class OpenMetricsScraperMixin(object):
                 for val in label_values:
                     if label_key in sample_labels and sample_labels[label_key] == val:
                         self.log.debug(
-                            "Skipping metric `%s` due to label %s value matching: %s", metric_name, label_key, val
+                            "Skipping metric `%s` due to label `%s` value matching: %s", metric_name, label_key, val
                         )
                         return True
         return False

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -640,7 +640,7 @@ class OpenMetricsScraperMixin(object):
         sample_labels = sample[self.SAMPLE_LABELS]
         for label_key, label_values in ignore_metrics_by_label.items():
             if not label_values:
-                self.log.warning(
+                self.log.debug(
                     "Skipping filter label `%s` with an empty values list, did you mean to use '*' wildcard?", label_key
                 )
             elif '*' in label_values:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -639,19 +639,16 @@ class OpenMetricsScraperMixin(object):
         ignore_metrics_by_label = scraper_config['ignore_metrics_by_labels']
         sample_labels = sample[self.SAMPLE_LABELS]
         for label_key, label_values in ignore_metrics_by_label.items():
-            # Wildcard * means all metrics with label_key will be ignored
-            if label_values is not None and '*' in label_values:
-                self.log.debug("Detected wildcard for label `%s`", label_key)
-                label_values = None
-
-            if label_values is None:
-                if label_key in sample_labels:
-                    self.log.debug("Skipping metric `%s` due to label key matching: %s", metric_name, label_key)
-                    return True
-            elif len(label_values) == 0:
+            if not label_values:
                 self.log.warning(
                     "Skipping filter label `%s` with an empty values list, did you mean to use '*' wildcard?", label_key
                 )
+            elif '*' in label_values:
+                # Wildcard '*' means all metrics with label_key will be ignored
+                self.log.debug("Detected wildcard for label `%s`", label_key)
+                if label_key in sample_labels.keys():
+                    self.log.debug("Skipping metric `%s` due to label key matching: %s", metric_name, label_key)
+                    return True
             else:
                 for val in label_values:
                     if label_key in sample_labels and sample_labels[label_key] == val:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -638,9 +638,10 @@ class OpenMetricsScraperMixin(object):
         ignore_metrics_by_label = scraper_config['ignore_metrics_by_label']
         sample_labels = sample[self.SAMPLE_LABELS]
         for label_key, label_values in ignore_metrics_by_label.items():
-            if label_values is None and label_key in sample_labels:
-                self.log.debug("Skipping metric %s due to label key matching: %s", metric_name, label_key)
-                return True
+            if label_values is None:
+                if label_key in sample_labels:
+                    self.log.debug("Skipping metric %s due to label key matching: %s", metric_name, label_key)
+                    return True
             else:
                 for val in label_values:
                     if label_key in sample_labels and sample_labels[label_key] == val:

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -641,20 +641,22 @@ class OpenMetricsScraperMixin(object):
         for label_key, label_values in ignore_metrics_by_label.items():
             # Wildcard * means all metrics with label_key will be ignored
             if label_values is not None and '*' in label_values:
-                self.log.debug("Detected wildcard for label %s", label_key)
+                self.log.debug("Detected wildcard for label `%s`", label_key)
                 label_values = None
 
             if label_values is None:
                 if label_key in sample_labels:
-                    self.log.debug("Skipping metric %s due to label key matching: %s", metric_name, label_key)
+                    self.log.debug("Skipping metric `%s` due to label key matching: %s", metric_name, label_key)
                     return True
             elif len(label_values) == 0:
-                self.log.debug("Skipping filter label %s with an empty values list, did you mean to use '*' wildcard?", label_key)
+                self.log.warning(
+                    "Skipping filter label `%s` with an empty values list, did you mean to use '*' wildcard?", label_key
+                )
             else:
                 for val in label_values:
                     if label_key in sample_labels and sample_labels[label_key] == val:
                         self.log.debug(
-                            "Skipping metric %s due to label %s value matching: %s", metric_name, label_key, val
+                            "Skipping metric `%s` due to label %s value matching: %s", metric_name, label_key, val
                         )
                         return True
         return False

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -66,7 +66,6 @@ def mocked_prometheus_check():
     check = OpenMetricsBaseCheck('prometheus_check', {}, {})
     check.log = logging.getLogger('datadog-prometheus.test')
     check.log.debug = mock.MagicMock()
-    check.log.warning = mock.MagicMock()
     return check
 
 
@@ -1768,7 +1767,7 @@ def test_gauge_with_invalid_ignore_label_value(aggregator, mocked_prometheus_che
     mocked_prometheus_scraper_config['ignore_metrics_by_labels'] = {'worker': []}
     metric_name = mocked_prometheus_scraper_config['metrics_mapper'][ref_gauge.name]
     check.submit_openmetric(metric_name, ref_gauge, mocked_prometheus_scraper_config)
-    check.log.warning.assert_called_with(
+    check.log.debug.assert_called_with(
         "Skipping filter label `%s` with an empty values list, did you mean to use '*' wildcard?", 'worker'
     )
 

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -1705,9 +1705,7 @@ def test_ignore_metrics_multiple_wildcards(
         aggregator.assert_all_metrics_covered()
 
 
-def test_gauge_with_ignore_label_key(
-    aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config
-):
+def test_gauge_with_ignore_label_key(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
     """ submitting metrics that contain labels should result in tags on the gauge call """
     ref_gauge = GaugeMetricFamily(
         'process_virtual_memory_bytes', 'Virtual memory size in bytes.', labels=['worker', 'node']
@@ -1720,6 +1718,29 @@ def test_gauge_with_ignore_label_key(
     check.submit_openmetric(metric_name, ref_gauge, mocked_prometheus_scraper_config)
     check.log.debug.assert_called_with('Skipping metric %s due to label key matching: %s', 'process.vm.bytes', 'worker')
     aggregator.assert_metric('prometheus.process.vm.bytes', count=0)
+
+
+def test_gauge_with_ignore_label_value(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+    """ submitting metrics that contain labels should result in tags on the gauge call """
+    ref_gauge = GaugeMetricFamily(
+        'process_virtual_memory_bytes', 'Virtual memory size in bytes.', labels=['worker', 'node']
+    )
+    ref_gauge.add_metric(['worker_1', 'foo'], 54927360.0)
+    ref_gauge.add_metric(['worker_2', 'bar'], 1009345.0)
+
+    check = mocked_prometheus_check
+    mocked_prometheus_scraper_config['ignore_metrics_by_label'] = {'worker': ['worker_1']}
+    metric_name = mocked_prometheus_scraper_config['metrics_mapper'][ref_gauge.name]
+    check.submit_openmetric(metric_name, ref_gauge, mocked_prometheus_scraper_config)
+
+    check.log.debug.assert_called_with(
+        'Skipping metric %s due to label %s value matching: %s', 'process.vm.bytes', 'worker', 'worker_1'
+    )
+    # Ignored metric
+    aggregator.assert_metric('prometheus.process.vm.bytes', count=0, tags=['worker:worker_1', 'node:foo'])
+
+    # Not ignored metric
+    aggregator.assert_metric('prometheus.process.vm.bytes', count=1, tags=['worker:worker_2', 'node:bar'])
 
 
 def test_metrics_with_ignore_label_value(
@@ -1751,7 +1772,9 @@ def test_metrics_with_ignore_label_value(
 
         # Make sure metrics are ignored
         aggregator.assert_metric('prometheus.skydns.dns.error.count', count=0, tags=expected_tags + ['system:auth'])
-        aggregator.assert_metric('prometheus.skydns.dns.error.count', count=0, tags=expected_tags + ['system:recursive'])
+        aggregator.assert_metric(
+            'prometheus.skydns.dns.error.count', count=0, tags=expected_tags + ['system:recursive']
+        )
         aggregator.assert_metric('prometheus.skydns.dns.cache_missed', count=0)
         # Make sure we don't ignore other metrics
         aggregator.assert_metric('prometheus.skydns.dns.error.count', count=1, tags=expected_tags + ['system:reverse'])

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -1741,7 +1741,7 @@ def test_gauge_with_ignore_label_value(aggregator, mocked_prometheus_check, mock
     check.submit_openmetric(metric_name, ref_gauge, mocked_prometheus_scraper_config)
 
     check.log.debug.assert_called_with(
-        'Skipping metric `%s` due to label %s value matching: %s', 'process.vm.bytes', 'worker', 'worker_1'
+        'Skipping metric `%s` due to label `%s` value matching: %s', 'process.vm.bytes', 'worker', 'worker_1'
     )
     # Ignored metric
     aggregator.assert_metric(

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -1720,6 +1720,24 @@ def test_gauge_with_ignore_label_key(aggregator, mocked_prometheus_check, mocked
     aggregator.assert_metric('prometheus.process.vm.bytes', count=0)
 
 
+def test_gauge_with_ignore_label_wildcard(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+    """ submitting metrics that contain labels should result in tags on the gauge call """
+    ref_gauge = GaugeMetricFamily(
+        'process_virtual_memory_bytes', 'Virtual memory size in bytes.', labels=['worker', 'node']
+    )
+    ref_gauge.add_metric(['worker_1', 'foo'], 54927360.0)
+    ref_gauge.add_metric(['worker_2', 'bar'], 1009345.0)
+
+    check = mocked_prometheus_check
+    mocked_prometheus_scraper_config['ignore_metrics_by_labels'] = {'worker': '*'}
+    metric_name = mocked_prometheus_scraper_config['metrics_mapper'][ref_gauge.name]
+    check.submit_openmetric(metric_name, ref_gauge, mocked_prometheus_scraper_config)
+    check.log.debug.assert_called_with('Skipping metric %s due to label key matching: %s', 'process.vm.bytes', 'worker')
+    # Ignored metric
+    aggregator.assert_metric('prometheus.process.vm.bytes', count=0, tags=['worker:worker_1', 'node:foo'])
+    aggregator.assert_metric('prometheus.process.vm.bytes', count=0, tags=['worker:worker_2', 'node:bar'])
+
+
 def test_gauge_with_ignore_label_value(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
     """ submitting metrics that contain labels should result in tags on the gauge call """
     ref_gauge = GaugeMetricFamily(

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -1713,7 +1713,7 @@ def test_gauge_with_ignore_label_key(aggregator, mocked_prometheus_check, mocked
     ref_gauge.add_metric(['worker_1', 'foo'], 54927360.0)
 
     check = mocked_prometheus_check
-    mocked_prometheus_scraper_config['ignore_metrics_by_label'] = {'worker': None}
+    mocked_prometheus_scraper_config['ignore_metrics_by_labels'] = {'worker': None}
     metric_name = mocked_prometheus_scraper_config['metrics_mapper'][ref_gauge.name]
     check.submit_openmetric(metric_name, ref_gauge, mocked_prometheus_scraper_config)
     check.log.debug.assert_called_with('Skipping metric %s due to label key matching: %s', 'process.vm.bytes', 'worker')
@@ -1729,7 +1729,7 @@ def test_gauge_with_ignore_label_value(aggregator, mocked_prometheus_check, mock
     ref_gauge.add_metric(['worker_2', 'bar'], 1009345.0)
 
     check = mocked_prometheus_check
-    mocked_prometheus_scraper_config['ignore_metrics_by_label'] = {'worker': ['worker_1']}
+    mocked_prometheus_scraper_config['ignore_metrics_by_labels'] = {'worker': ['worker_1']}
     metric_name = mocked_prometheus_scraper_config['metrics_mapper'][ref_gauge.name]
     check.submit_openmetric(metric_name, ref_gauge, mocked_prometheus_scraper_config)
 
@@ -1761,7 +1761,7 @@ def test_metrics_with_ignore_label_value(
             'go_memstats_mspan_inuse_bytes': 'go_memstats.mspan.inuse_bytes',
         }
     ]
-    instance['ignore_metrics_by_label'] = {'system': ['auth', 'recursive'], 'cache': None}
+    instance['ignore_metrics_by_labels'] = {'system': ['auth', 'recursive'], 'cache': None}
     config = check.create_scraper_configuration(instance)
     expected_tags = ['cause:nxdomain']
     mock_response = mock.MagicMock(

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -1705,6 +1705,61 @@ def test_ignore_metrics_multiple_wildcards(
         aggregator.assert_all_metrics_covered()
 
 
+def test_gauge_with_ignore_label_key(
+    aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config
+):
+    """ submitting metrics that contain labels should result in tags on the gauge call """
+    ref_gauge = GaugeMetricFamily(
+        'process_virtual_memory_bytes', 'Virtual memory size in bytes.', labels=['worker', 'node']
+    )
+    ref_gauge.add_metric(['worker_1', 'foo'], 54927360.0)
+
+    check = mocked_prometheus_check
+    mocked_prometheus_scraper_config['ignore_metrics_by_label'] = {'worker': None}
+    metric_name = mocked_prometheus_scraper_config['metrics_mapper'][ref_gauge.name]
+    check.submit_openmetric(metric_name, ref_gauge, mocked_prometheus_scraper_config)
+    check.log.debug.assert_called_with('Skipping metric %s due to label key matching: %s', 'process.vm.bytes', 'worker')
+    aggregator.assert_metric('prometheus.process.vm.bytes', count=0)
+
+
+def test_metrics_with_ignore_label_value(
+    aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config, text_data
+):
+    """
+    Test that metrics that matched an ignored label values is properly discarded.
+    """
+    check = mocked_prometheus_check
+    instance = copy.deepcopy(PROMETHEUS_CHECK_INSTANCE)
+    instance['metrics'] = [
+        {
+            # Ignore counter by label values 'system': ['auth', 'recursive']
+            'skydns_skydns_dns_error_count_total': 'skydns.dns.error.count',
+            # Ignore counter by label key 'cache'
+            'skydns_skydns_dns_cachemiss_count_total': 'skydns.dns.cache_missed',
+            # Expected metric
+            'go_memstats_mspan_inuse_bytes': 'go_memstats.mspan.inuse_bytes',
+        }
+    ]
+    instance['ignore_metrics_by_label'] = {'system': ['auth', 'recursive'], 'cache': None}
+    config = check.create_scraper_configuration(instance)
+    expected_tags = ['cause:nxdomain']
+    mock_response = mock.MagicMock(
+        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': text_content_type}
+    )
+    with mock.patch('requests.get', return_value=mock_response, __name__="get"):
+        check.process(config)
+
+        # Make sure metrics are ignored
+        aggregator.assert_metric('prometheus.skydns.dns.error.count', count=0, tags=expected_tags + ['system:auth'])
+        aggregator.assert_metric('prometheus.skydns.dns.error.count', count=0, tags=expected_tags + ['system:recursive'])
+        aggregator.assert_metric('prometheus.skydns.dns.cache_missed', count=0)
+        # Make sure we don't ignore other metrics
+        aggregator.assert_metric('prometheus.skydns.dns.error.count', count=1, tags=expected_tags + ['system:reverse'])
+        aggregator.assert_metric('prometheus.go_memstats.mspan.inuse_bytes', count=1)
+
+        aggregator.assert_all_metrics_covered()
+
+
 def test_match_metric_wildcard(aggregator, mocked_prometheus_check, ref_gauge):
     """
     Test that a matched metric is properly collected.

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -1732,7 +1732,7 @@ def test_gauge_with_ignore_label_wildcard(aggregator, mocked_prometheus_check, m
     ref_gauge.add_metric(['worker_2', 'bar'], 1009345.0)
 
     check = mocked_prometheus_check
-    mocked_prometheus_scraper_config['ignore_metrics_by_labels'] = {'worker': '*'}
+    mocked_prometheus_scraper_config['ignore_metrics_by_labels'] = {'worker': ['*']}
     metric_name = mocked_prometheus_scraper_config['metrics_mapper'][ref_gauge.name]
     check.submit_openmetric(metric_name, ref_gauge, mocked_prometheus_scraper_config)
     check.log.debug.assert_called_with(


### PR DESCRIPTION
### What does this PR do?
This PR introduces a config option that allows users to ignore metrics with certain labels or label values.

in conf.yaml
```
init_config: {}
instances:
  prometheus_endpoint: http://localhost:8086/-/metrics
  ignore_metrics_by_labels:
  pid:
  - puma_master
  worker: *
```
The above will ignore metrics with labels `pid:puma_master` or any metric with label `worker:<ANY>`
### Motivation
FR
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
