### PR TITLE
Sync openmetrics config specs with new option ignore_metrics_by_labels

### DIFF
--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -176,7 +176,8 @@ instances:
     #   <KEY_1>:
     #   - <LABEL_1>
     #   - <LABEL_2>
-    #   <KEY_2>: '*'
+    #   <KEY_2>:
+    #   - '*'
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -168,6 +168,16 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>: '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/amazon_msk/setup.py
+++ b/amazon_msk/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 
 setup(

--- a/cilium/datadog_checks/cilium/data/conf.yaml.example
+++ b/cilium/datadog_checks/cilium/data/conf.yaml.example
@@ -130,7 +130,8 @@ instances:
     #   <KEY_1>:
     #   - <LABEL_1>
     #   - <LABEL_2>
-    #   <KEY_2>: '*'
+    #   <KEY_2>:
+    #   - '*'
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/cilium/datadog_checks/cilium/data/conf.yaml.example
+++ b/cilium/datadog_checks/cilium/data/conf.yaml.example
@@ -122,6 +122,16 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>: '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/cilium/setup.py
+++ b/cilium/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 
 setup(

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -146,6 +146,16 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>: '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -154,7 +154,8 @@ instances:
     #   <KEY_1>:
     #   - <LABEL_1>
     #   - <LABEL_2>
-    #   <KEY_2>: '*'
+    #   <KEY_2>:
+    #   - '*'
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/cockroachdb/setup.py
+++ b/cockroachdb/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 
 setup(

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -173,7 +173,8 @@ instances:
     #   <KEY_1>:
     #   - <LABEL_1>
     #   - <LABEL_2>
-    #   <KEY_2>: '*'
+    #   <KEY_2>:
+    #   - '*'
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -165,6 +165,16 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>: '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/coredns/setup.py
+++ b/coredns/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 
 setup(

--- a/crio/datadog_checks/crio/data/conf.yaml.example
+++ b/crio/datadog_checks/crio/data/conf.yaml.example
@@ -146,6 +146,17 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>:
+    #   - '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/crio/setup.py
+++ b/crio/setup.py
@@ -24,7 +24,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 
 setup(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -149,6 +149,22 @@
       - <*_SUFFIX>
       - <PREFIX_*_SUFFIX>
       - <*_SUBSTRING_*>
+- name: ignore_metrics_by_labels
+  description: A mapping of labels where metrics with matching labels are ignored.
 
+  value:
+    type: array
+    items:
+      type: object
+      properties:
+        - name: key
+          type: string
+        - name: label
+          type: array
+          items:
+            type: string
+      example:
+        <KEY_1>: [<LABEL_1>, <LABEL_2>]
+        <KEY_2>: *
 - template: instances/http
 - template: instances/default

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -162,8 +162,6 @@
         type: array
         items:
           type: string
-      - name: target_label_value_wildcard
-        type: string
     example:
       <KEY_1>: [<LABEL_1>, <LABEL_2>]
       <KEY_2>: ['*']

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -150,21 +150,22 @@
       - <PREFIX_*_SUFFIX>
       - <*_SUBSTRING_*>
 - name: ignore_metrics_by_labels
-  description: A mapping of labels where metrics with matching labels are ignored.
-
+  description: |
+    A mapping of labels where metrics with matching label key and values are ignored.
+    Use the "*" wildcard to match all label values.
   value:
-    type: array
-    items:
-      type: object
-      properties:
-        - name: key
+    type: object
+    properties:
+      - name: target_label_key
+        type: string
+      - name: target_label_value_list
+        type: array
+        items:
           type: string
-        - name: label
-          type: array
-          items:
-            type: string
-      example:
-        <KEY_1>: [<LABEL_1>, <LABEL_2>]
-        <KEY_2>: *
+      - name: target_label_value_wildcard
+        type: string
+    example:
+      <KEY_1>: [<LABEL_1>, <LABEL_2>]
+      <KEY_2>: '*'
 - template: instances/http
 - template: instances/default

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -166,6 +166,6 @@
         type: string
     example:
       <KEY_1>: [<LABEL_1>, <LABEL_2>]
-      <KEY_2>: '*'
+      <KEY_2>: ['*']
 - template: instances/http
 - template: instances/default

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -152,6 +152,17 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>:
+    #   - '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/etcd/setup.py
+++ b/etcd/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 setup(
     name='datadog-etcd',

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -124,7 +124,8 @@ instances:
     #   <KEY_1>:
     #   - <LABEL_1>
     #   - <LABEL_2>
-    #   <KEY_2>: '*'
+    #   <KEY_2>:
+    #   - '*'
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -116,6 +116,16 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>: '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/gitlab/setup.py
+++ b/gitlab/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 setup(
     name='datadog-gitlab',

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -200,6 +200,16 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>: '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -208,7 +208,8 @@ instances:
     #   <KEY_1>:
     #   - <LABEL_1>
     #   - <LABEL_2>
-    #   <KEY_2>: '*'
+    #   <KEY_2>:
+    #   - '*'
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/gitlab_runner/setup.py
+++ b/gitlab_runner/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 setup(
     name='datadog-gitlab_runner',

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -292,6 +292,16 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>: '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -300,7 +300,8 @@ instances:
     #   <KEY_1>:
     #   - <LABEL_1>
     #   - <LABEL_2>
-    #   <KEY_2>: '*'
+    #   <KEY_2>:
+    #   - '*'
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/haproxy/setup.py
+++ b/haproxy/setup.py
@@ -25,7 +25,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 setup(
     name='datadog-haproxy',

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -185,6 +185,16 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>: '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -193,7 +193,8 @@ instances:
     #   <KEY_1>:
     #   - <LABEL_1>
     #   - <LABEL_2>
-    #   <KEY_2>: '*'
+    #   <KEY_2>:
+    #   - '*'
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/istio/setup.py
+++ b/istio/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 setup(
     name='datadog-istio',

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -153,6 +153,16 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>: '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -161,7 +161,8 @@ instances:
     #   <KEY_1>:
     #   - <LABEL_1>
     #   - <LABEL_2>
-    #   <KEY_2>: '*'
+    #   <KEY_2>:
+    #   - '*'
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/kube_apiserver_metrics/setup.py
+++ b/kube_apiserver_metrics/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 
 setup(

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -151,6 +151,16 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>: '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -159,7 +159,8 @@ instances:
     #   <KEY_1>:
     #   - <LABEL_1>
     #   - <LABEL_2>
-    #   <KEY_2>: '*'
+    #   <KEY_2>:
+    #   - '*'
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/kube_scheduler/setup.py
+++ b/kube_scheduler/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 
 setup(

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -154,6 +154,16 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>: '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -162,7 +162,8 @@ instances:
     #   <KEY_1>:
     #   - <LABEL_1>
     #   - <LABEL_2>
-    #   <KEY_2>: '*'
+    #   <KEY_2>:
+    #   - '*'
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/nginx_ingress_controller/setup.py
+++ b/nginx_ingress_controller/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 
 setup(

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -160,6 +160,16 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>: '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -168,7 +168,8 @@ instances:
     #   <KEY_1>:
     #   - <LABEL_1>
     #   - <LABEL_2>
-    #   <KEY_2>: '*'
+    #   <KEY_2>:
+    #   - '*'
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/openmetrics/setup.py
+++ b/openmetrics/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 setup(
     name='datadog-openmetrics',

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -163,6 +163,16 @@ instances:
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
 
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>: '*'
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -171,7 +171,8 @@ instances:
     #   <KEY_1>:
     #   - <LABEL_1>
     #   - <LABEL_2>
-    #   <KEY_2>: '*'
+    #   <KEY_2>:
+    #   - '*'
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/scylla/setup.py
+++ b/scylla/setup.py
@@ -32,7 +32,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.4.0'
 
 
 setup(


### PR DESCRIPTION
### What does this PR do?
Adds config option introduced in this PR: https://github.com/DataDog/integrations-core/pull/7822/s

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
