### PR TITLE
Fix release-hash-check

### DIFF
--- a/.github/workflows/release-hash-check.yml
+++ b/.github/workflows/release-hash-check.yml
@@ -25,5 +25,15 @@ jobs:
         FILES=$(git --no-pager diff --name-only origin/master -- .in-toto | xargs echo)
         echo "::set-output name=all::$FILES"
 
-    - run: git merge --commit --no-edit origin/master
+    - id: merge
+      name: Merge branch into latest master
+      env:
+        HEAD_BRANCH: ${{ github.head_ref }}
+      run: |
+        git fetch origin $HEAD_BRANCH
+        git checkout origin/master
+        git config user.name "release-hash-check"
+        git config user.email "<>"
+        git merge --no-commit --no-edit origin/$HEAD_BRANCH
+
     - run: python .github/workflows/release-hash-check.py ${{ steps.files.outputs.all }}


### PR DESCRIPTION
The release-hash-check jobs checks out the PR git reference, which is the result of the merging of that PR into master.
But that reference may not be up to date with the latest master.

To run the release-hash-check job always on the latest master, the job now manually fetches the latest master and merges the PR manually into it.