### PR TITLE
New replication lag metric collected from the primary

### DIFF
--- a/mongo/datadog_checks/mongo/collectors/replica.py
+++ b/mongo/datadog_checks/mongo/collectors/replica.py
@@ -131,4 +131,15 @@ class ReplicaCollector(MongoCollector):
             replset_name = status['set']
             self._report_replica_set_states(status['members'], replset_name)
 
+            # Compute a lag time
+            for member in status.get('members', []):
+                if 'optimeDate' in primary and 'optimeDate' in member:
+                    lag = primary['optimeDate'] - member['optimeDate']
+                    tags = self.check.base_tags + [
+                        'member:{}'.format(member.get('name', 'unknown')),
+                        'replset_name:{}'.format(replset_name),
+                        'replset_state:{}'.format(get_state_name(member.get('state')).lower()),
+                    ]
+                    self.gauge('mongodb.replset.lag_from_primary', lag.total_seconds(), tags)
+
         self.check.last_states_by_server = {member['_id']: member['state'] for member in status['members']}

--- a/mongo/datadog_checks/mongo/collectors/replica.py
+++ b/mongo/datadog_checks/mongo/collectors/replica.py
@@ -140,6 +140,6 @@ class ReplicaCollector(MongoCollector):
                         'replset_name:{}'.format(replset_name),
                         'replset_state:{}'.format(get_state_name(member.get('state')).lower()),
                     ]
-                    self.gauge('mongodb.replset.lag_from_primary', lag.total_seconds(), tags)
+                    self.gauge('mongodb.replset.optime_lag', lag.total_seconds(), tags)
 
         self.check.last_states_by_server = {member['_id']: member['state'] for member in status['members']}

--- a/mongo/metadata.csv
+++ b/mongo/metadata.csv
@@ -161,7 +161,8 @@ mongodb.oplog.logsizemb,gauge,,mebibyte,,Total size of the oplog.,0,mongodb,oplo
 mongodb.oplog.timediff,gauge,,second,,Oplog window: difference between the first and last operation in the oplog.,1,mongodb,oplog timediff
 mongodb.oplog.usedsizemb,gauge,,mebibyte,,Total amount of space used by the oplog.,0,mongodb,oplog used size mb
 mongodb.replset.health,gauge,,,,Member health value of the replica set: conveys if the member is up (i.e. 1) or down (i.e. 0).,1,mongodb,replset health
-mongodb.replset.replicationlag,gauge,,second,,Delay between a write operation on the primary and its copy to a secondary.,-1,mongodb,replication lag
+mongodb.replset.replicationlag,gauge,,second,,[Deprecated] Use mongodb.replset.lag_from_primary instead. Delay between a write operation on the primary and its copy to a secondary. Computed on each node and tagged by 'host'.,-1,mongodb,replication lag
+mongodb.replset.lag_from_primary,gauge,,second,,Delay between a write operation on the primary and its copy to a secondary. Computed only on primary and tagged by 'member'.,-1,mongodb,replication lag
 mongodb.replset.state,gauge,,,,State of a replica that reflects its disposition within the set.,0,mongodb,replset state
 mongodb.replset.votefraction,gauge,,fraction,,Fraction of votes a server will cast in a replica set election.,0,mongodb,votes fraction
 mongodb.replset.votes,gauge,,item,,The number of votes a server will cast in a replica set election.,0,mongodb,replset votes

--- a/mongo/metadata.csv
+++ b/mongo/metadata.csv
@@ -161,7 +161,7 @@ mongodb.oplog.logsizemb,gauge,,mebibyte,,Total size of the oplog.,0,mongodb,oplo
 mongodb.oplog.timediff,gauge,,second,,Oplog window: difference between the first and last operation in the oplog.,1,mongodb,oplog timediff
 mongodb.oplog.usedsizemb,gauge,,mebibyte,,Total amount of space used by the oplog.,0,mongodb,oplog used size mb
 mongodb.replset.health,gauge,,,,Member health value of the replica set: conveys if the member is up (i.e. 1) or down (i.e. 0).,1,mongodb,replset health
-mongodb.replset.replicationlag,gauge,,second,,[Deprecated] Use mongodb.replset.optime_lag instead. Delay between a write operation on the primary and its copy to a secondary. Computed on each node and tagged by 'host'.,-1,mongodb,replication lag
+mongodb.replset.replicationlag,gauge,,second,,"Delay between a write operation on the primary and its copy to a secondary. Computed on each node and tagged by 'host', but may not be representative of cluster health. Negative values do not indicate that the secondary is ahead of the primary. To use a more up-to-date metric, use mongodb.replset.optime_lag instead.",-1,mongodb,replication lag
 mongodb.replset.optime_lag,gauge,,second,,Delay between a write operation on the primary and its copy to a secondary. Computed only on primary and tagged by 'member'.,-1,mongodb,replication lag
 mongodb.replset.state,gauge,,,,State of a replica that reflects its disposition within the set.,0,mongodb,replset state
 mongodb.replset.votefraction,gauge,,fraction,,Fraction of votes a server will cast in a replica set election.,0,mongodb,votes fraction

--- a/mongo/metadata.csv
+++ b/mongo/metadata.csv
@@ -161,8 +161,8 @@ mongodb.oplog.logsizemb,gauge,,mebibyte,,Total size of the oplog.,0,mongodb,oplo
 mongodb.oplog.timediff,gauge,,second,,Oplog window: difference between the first and last operation in the oplog.,1,mongodb,oplog timediff
 mongodb.oplog.usedsizemb,gauge,,mebibyte,,Total amount of space used by the oplog.,0,mongodb,oplog used size mb
 mongodb.replset.health,gauge,,,,Member health value of the replica set: conveys if the member is up (i.e. 1) or down (i.e. 0).,1,mongodb,replset health
-mongodb.replset.replicationlag,gauge,,second,,[Deprecated] Use mongodb.replset.lag_from_primary instead. Delay between a write operation on the primary and its copy to a secondary. Computed on each node and tagged by 'host'.,-1,mongodb,replication lag
-mongodb.replset.lag_from_primary,gauge,,second,,Delay between a write operation on the primary and its copy to a secondary. Computed only on primary and tagged by 'member'.,-1,mongodb,replication lag
+mongodb.replset.replicationlag,gauge,,second,,[Deprecated] Use mongodb.replset.optime_lag instead. Delay between a write operation on the primary and its copy to a secondary. Computed on each node and tagged by 'host'.,-1,mongodb,replication lag
+mongodb.replset.optime_lag,gauge,,second,,Delay between a write operation on the primary and its copy to a secondary. Computed only on primary and tagged by 'member'.,-1,mongodb,replication lag
 mongodb.replset.state,gauge,,,,State of a replica that reflects its disposition within the set.,0,mongodb,replset state
 mongodb.replset.votefraction,gauge,,fraction,,Fraction of votes a server will cast in a replica set election.,0,mongodb,votes fraction
 mongodb.replset.votes,gauge,,item,,The number of votes a server will cast in a replica set election.,0,mongodb,replset votes

--- a/mongo/tests/fixtures/replSetGetStatus-replica-primary
+++ b/mongo/tests/fixtures/replSetGetStatus-replica-primary
@@ -193,7 +193,7 @@
                 "t": 24
             },
             "optimeDate": {
-                "$date": 1601384207000
+                "$date": 1601384107000
             },
             "optimeDurableDate": {
                 "$date": 1601384207000
@@ -238,7 +238,7 @@
                 "t": 24
             },
             "optimeDate": {
-                "$date": 1601384207000
+                "$date": 1601384202000
             },
             "optimeDurableDate": {
                 "$date": 1601384207000

--- a/mongo/tests/fixtures/replSetGetStatus-replica-primary-in-shard
+++ b/mongo/tests/fixtures/replSetGetStatus-replica-primary-in-shard
@@ -193,7 +193,7 @@
                 "t": 24
             },
             "optimeDate": {
-                "$date": 1601384207000
+                "$date": 1601374207000
             },
             "optimeDurableDate": {
                 "$date": 1601384207000
@@ -238,7 +238,7 @@
                 "t": 24
             },
             "optimeDate": {
-                "$date": 1601384207000
+                "$date": 1601384007000
             },
             "optimeDurableDate": {
                 "$date": 1601384207000

--- a/mongo/tests/results/metrics-replset-lag-from-primary-in-shard.json
+++ b/mongo/tests/results/metrics-replset-lag-from-primary-in-shard.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "mongodb.replset.lag_from_primary",
+        "name": "mongodb.replset.optime_lag",
         "type": 0,
         "value": 0.0,
         "tags": [
@@ -11,7 +11,7 @@
         ]
     },
     {
-        "name": "mongodb.replset.lag_from_primary",
+        "name": "mongodb.replset.optime_lag",
         "type": 0,
         "value": 10000.0,
         "tags": [
@@ -22,7 +22,7 @@
         ]
     },
     {
-        "name": "mongodb.replset.lag_from_primary",
+        "name": "mongodb.replset.optime_lag",
         "type": 0,
         "value": 200.0,
         "tags": [

--- a/mongo/tests/results/metrics-replset-lag-from-primary-in-shard.json
+++ b/mongo/tests/results/metrics-replset-lag-from-primary-in-shard.json
@@ -1,0 +1,35 @@
+[
+    {
+        "name": "mongodb.replset.lag_from_primary",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "member:mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "replset_name:mongo-mongodb-sharded-shard-0",
+            "replset_state:primary"
+        ]
+    },
+    {
+        "name": "mongodb.replset.lag_from_primary",
+        "type": 0,
+        "value": 10000.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "member:mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "replset_name:mongo-mongodb-sharded-shard-0",
+            "replset_state:secondary"
+        ]
+    },
+    {
+        "name": "mongodb.replset.lag_from_primary",
+        "type": 0,
+        "value": 200.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "member:mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "replset_name:mongo-mongodb-sharded-shard-0",
+            "replset_state:secondary"
+        ]
+    }
+]

--- a/mongo/tests/results/metrics-replset-lag-from-primary.json
+++ b/mongo/tests/results/metrics-replset-lag-from-primary.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "mongodb.replset.lag_from_primary",
+        "name": "mongodb.replset.optime_lag",
         "type": 0,
         "value": 0.0,
         "tags": [
@@ -11,7 +11,7 @@
         ]
     },
     {
-        "name": "mongodb.replset.lag_from_primary",
+        "name": "mongodb.replset.optime_lag",
         "type": 0,
         "value": 100.0,
         "tags": [
@@ -22,7 +22,7 @@
         ]
     },
     {
-        "name": "mongodb.replset.lag_from_primary",
+        "name": "mongodb.replset.optime_lag",
         "type": 0,
         "value": 5.0,
         "tags": [

--- a/mongo/tests/results/metrics-replset-lag-from-primary.json
+++ b/mongo/tests/results/metrics-replset-lag-from-primary.json
@@ -1,0 +1,35 @@
+[
+    {
+        "name": "mongodb.replset.lag_from_primary",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "member:replset-data-0.mongo.default.svc.cluster.local:27017",
+            "replset_name:replset",
+            "replset_state:primary"
+        ]
+    },
+    {
+        "name": "mongodb.replset.lag_from_primary",
+        "type": 0,
+        "value": 100.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "member:replset-data-1.mongo.default.svc.cluster.local:27017",
+            "replset_name:replset",
+            "replset_state:secondary"
+        ]
+    },
+    {
+        "name": "mongodb.replset.lag_from_primary",
+        "type": 0,
+        "value": 5.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "member:replset-data-2.mongo.default.svc.cluster.local:27017",
+            "replset_name:replset",
+            "replset_state:secondary"
+        ]
+    }
+]

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -69,7 +69,8 @@ def test_integration_replicaset_primary_in_shard(instance_integration, aggregato
         'fsynclock',
     ]
     _assert_metrics(aggregator, metrics_categories, replica_tags)
-
+    # Lag metrics are tagged with the state of the member and not with the current one.
+    _assert_metrics(aggregator, ['replset-lag-from-primary-in-shard'])
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(),
@@ -174,6 +175,8 @@ def test_integration_replicaset_primary(instance_integration, aggregator, check)
         'collection',
     ]
     _assert_metrics(aggregator, metrics_categories, replica_tags)
+    # Lag metrics are tagged with the state of the member and not with the current one.
+    _assert_metrics(aggregator, ['replset-lag-from-primary'])
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(


### PR DESCRIPTION
### What does this PR do?
Adds a new metric called `mongodb.replset.optime_lag` (open to better naming suggestions).
This metric is a replacement for `mongodb.replset.replicationlag` currently submitted by the mongo integration but both continue to be collected.

In mongo, all writes go to the primary. The operations are stored in an "oplog" and each secondary reads from this oplog and applies the same operations. Each member also stores where it's at in the oplog and stores the timestamp of the latest operation applied. This timestamp is the 'optime'

When fetching the optime from the secondaries, it is possible to find the secondary optime ahead of the primary optime. This does not mean that the secondary is ahead of the primary, rather than the secondary hasn't recently received an update from the primary with its current optime. That method of collection leads negative values and unreliability of the data. As [MongoDB docs](https://docs.mongodb.com/manual/reference/method/rs.printSlaveReplicationInfo/) mention:
> The lag reported by secondaries may not be representative of cluster health. Negative values do not indicate that the secondary is ahead of the primary.
For the most up-to-date information on your replica set, it is generally advisable to run rs.printSlaveReplicationInfo() on the primary.

For this reason collecting that lag from the primary is more reliable.

Yet we're keeping the old metric as well for a few reasons:

1. There is no way to keep backwards compatibility by replacing the metric. Currently a common usage for this metric is to alert when any of `avg:mongodb.replset.replicationlag{*} by {host}` deviates too much. We can't reliably determine the host tag from the mongo integration the same way as it is applied until now. Also mongo can run as containers, meaning there is no hope to match the host tag.
Also custom tags applied to different check instances can't be reflected because this changes which agent collects the metric. The new metric is collected from all nodes with a single agent, where the old metric is one agent for each node.
2. The metric is usable as is, its value will be negative from time to time but a member starts lagging the current metric  reflects that correctly.
3. Having visibility on the estimated lag from the secondary could provide some other kind of visibility. i.e if the lag starts to be really negative, this could mean that the primary is not able to send heartbeats to that node.

Lastly we could have replaced the value of the current metric with the max between it and zero (in order to have positive numbers only), but that would prevent `3.` even if it's probably an uncommon use case.

### Motivation
https://github.com/DataDog/integrations-core/issues/7076

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
