### PR TITLE
Fix warning when adding 'jumbo_chunks' metrics

### DIFF
--- a/mongo/datadog_checks/mongo/metrics.py
+++ b/mongo/datadog_checks/mongo/metrics.py
@@ -348,4 +348,5 @@ AVAILABLE_METRICS = {
     'tcmalloc': TCMALLOC_METRICS,
     'top': TOP_METRICS,
     'collection': COLLECTION_METRICS,
+    'jumbo_chunks': {},
 }


### PR DESCRIPTION
A warning was raised as `jumbo_chunks` was not a recognized option