### PR TITLE
Add the shard cluster role as a tag

### DIFF
--- a/mongo/datadog_checks/mongo/common.py
+++ b/mongo/datadog_checks/mongo/common.py
@@ -71,12 +71,13 @@ class MongosDeployment(Deployment):
 
 
 class ReplicaSetDeployment(Deployment):
-    def __init__(self, replset_name, replset_state, in_shard=False):
+    def __init__(self, replset_name, replset_state, cluster_role=None):
         super(ReplicaSetDeployment, self).__init__()
         self.replset_name = replset_name
         self.replset_state = replset_state
         self.replset_state_name = get_state_name(replset_state).lower()
-        self.use_shards = in_shard
+        self.use_shards = cluster_role is not None
+        self.cluster_role = cluster_role
         self.is_primary = replset_state == 1
         self.is_secondary = replset_state == 2
 

--- a/mongo/tests/fixtures/getCmdLineOpts-configsvr-primary
+++ b/mongo/tests/fixtures/getCmdLineOpts-configsvr-primary
@@ -1,0 +1,90 @@
+{
+    "argv": [
+        "/opt/bitnami/mongodb/bin/mongod",
+        "--config=/opt/bitnami/mongodb/conf/mongodb.conf"
+    ],
+    "parsed": {
+        "config": "/opt/bitnami/mongodb/conf/mongodb.conf",
+        "net": {
+            "bindIp": "*",
+            "ipv6": false,
+            "port": 27017,
+            "unixDomainSocket": {
+                "enabled": true,
+                "pathPrefix": "/opt/bitnami/mongodb/tmp"
+            }
+        },
+        "processManagement": {
+            "fork": false,
+            "pidFilePath": "/opt/bitnami/mongodb/tmp/mongodb.pid"
+        },
+        "replication": {
+            "enableMajorityReadConcern": true,
+            "replSetName": "mongo-mongodb-sharded-configsvr"
+        },
+        "security": {
+            "authorization": "enabled",
+            "keyFile": "/opt/bitnami/mongodb/conf/keyfile"
+        },
+        "setParameter": {
+            "enableLocalhostAuthBypass": "false"
+        },
+        "sharding": {
+            "clusterRole": "configsvr"
+        },
+        "storage": {
+            "dbPath": "/bitnami/mongodb/data/db",
+            "directoryPerDB": false,
+            "journal": {
+                "enabled": true
+            }
+        },
+        "systemLog": {
+            "destination": "file",
+            "logAppend": true,
+            "logRotate": "reopen",
+            "path": "/opt/bitnami/mongodb/logs/mongodb.log",
+            "quiet": false,
+            "verbosity": 0
+        }
+    },
+    "ok": 1.0,
+    "$gleStats": {
+        "lastOpTime": {
+            "$timestamp": {
+                "t": 0,
+                "i": 0
+            }
+        },
+        "electionId": {
+            "$oid": "7fffffff000000000000002a"
+        }
+    },
+    "lastCommittedOpTime": {
+        "$timestamp": {
+            "t": 1603376638,
+            "i": 3
+        }
+    },
+    "$clusterTime": {
+        "clusterTime": {
+            "$timestamp": {
+                "t": 1603376638,
+                "i": 3
+            }
+        },
+        "signature": {
+            "hash": {
+                "$binary": "0Bq0aou04TFps0PPSJuVBK98ym0=",
+                "$type": "00"
+            },
+            "keyId": 6857852638906548233
+        }
+    },
+    "operationTime": {
+        "$timestamp": {
+            "t": 1603376638,
+            "i": 3
+        }
+    }
+}

--- a/mongo/tests/fixtures/getCmdLineOpts-configsvr-secondary
+++ b/mongo/tests/fixtures/getCmdLineOpts-configsvr-secondary
@@ -1,0 +1,90 @@
+{
+    "argv": [
+        "/opt/bitnami/mongodb/bin/mongod",
+        "--config=/opt/bitnami/mongodb/conf/mongodb.conf"
+    ],
+    "parsed": {
+        "config": "/opt/bitnami/mongodb/conf/mongodb.conf",
+        "net": {
+            "bindIp": "*",
+            "ipv6": false,
+            "port": 27017,
+            "unixDomainSocket": {
+                "enabled": true,
+                "pathPrefix": "/opt/bitnami/mongodb/tmp"
+            }
+        },
+        "processManagement": {
+            "fork": false,
+            "pidFilePath": "/opt/bitnami/mongodb/tmp/mongodb.pid"
+        },
+        "replication": {
+            "enableMajorityReadConcern": true,
+            "replSetName": "mongo-mongodb-sharded-configsvr"
+        },
+        "security": {
+            "authorization": "disabled",
+            "keyFile": "/opt/bitnami/mongodb/conf/keyfile"
+        },
+        "setParameter": {
+            "enableLocalhostAuthBypass": "true"
+        },
+        "sharding": {
+            "clusterRole": "configsvr"
+        },
+        "storage": {
+            "dbPath": "/bitnami/mongodb/data/db",
+            "directoryPerDB": false,
+            "journal": {
+                "enabled": true
+            }
+        },
+        "systemLog": {
+            "destination": "file",
+            "logAppend": true,
+            "logRotate": "reopen",
+            "path": "/opt/bitnami/mongodb/logs/mongodb.log",
+            "quiet": false,
+            "verbosity": 0
+        }
+    },
+    "ok": 1.0,
+    "$gleStats": {
+        "lastOpTime": {
+            "$timestamp": {
+                "t": 0,
+                "i": 0
+            }
+        },
+        "electionId": {
+            "$oid": "7fffffff0000000000000027"
+        }
+    },
+    "lastCommittedOpTime": {
+        "$timestamp": {
+            "t": 1603377015,
+            "i": 1
+        }
+    },
+    "$clusterTime": {
+        "clusterTime": {
+            "$timestamp": {
+                "t": 1603377016,
+                "i": 25
+            }
+        },
+        "signature": {
+            "hash": {
+                "$binary": "nm5rJMKtA96bAdvD1MYxSousluk=",
+                "$type": "00"
+            },
+            "keyId": 6857852638906548233
+        }
+    },
+    "operationTime": {
+        "$timestamp": {
+            "t": 1603377015,
+            "i": 1
+        }
+    }
+}

--- a/mongo/tests/fixtures/replSetGetStatus-configsvr-primary
+++ b/mongo/tests/fixtures/replSetGetStatus-configsvr-primary
@@ -1,0 +1,280 @@
+{
+    "set": "mongo-mongodb-sharded-configsvr",
+    "date": {
+        "$date": 1603376670611
+    },
+    "myState": 1,
+    "term": 42,
+    "syncingTo": "",
+    "syncSourceHost": "",
+    "syncSourceId": -1,
+    "configsvr": true,
+    "heartbeatIntervalMillis": 2000,
+    "majorityVoteCount": 2,
+    "writeMajorityCount": 2,
+    "optimes": {
+        "lastCommittedOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1603376668,
+                    "i": 3
+                }
+            },
+            "t": 42
+        },
+        "lastCommittedWallTime": {
+            "$date": 1603376668294
+        },
+        "readConcernMajorityOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1603376668,
+                    "i": 3
+                }
+            },
+            "t": 42
+        },
+        "readConcernMajorityWallTime": {
+            "$date": 1603376668294
+        },
+        "appliedOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1603376668,
+                    "i": 3
+                }
+            },
+            "t": 42
+        },
+        "durableOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1603376668,
+                    "i": 3
+                }
+            },
+            "t": 42
+        },
+        "lastAppliedWallTime": {
+            "$date": 1603376668294
+        },
+        "lastDurableWallTime": {
+            "$date": 1603376668294
+        }
+    },
+    "lastStableRecoveryTimestamp": {
+        "$timestamp": {
+            "t": 1603376655,
+            "i": 1
+        }
+    },
+    "lastStableCheckpointTimestamp": {
+        "$timestamp": {
+            "t": 1603376655,
+            "i": 1
+        }
+    },
+    "electionCandidateMetrics": {
+        "lastElectionReason": "priorityTakeover",
+        "lastElectionDate": {
+            "$date": 1603358777803
+        },
+        "electionTerm": 42,
+        "lastCommittedOpTimeAtElection": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1603358776,
+                    "i": 1
+                }
+            },
+            "t": 41
+        },
+        "lastSeenOpTimeAtElection": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1603358776,
+                    "i": 1
+                }
+            },
+            "t": 41
+        },
+        "numVotesNeeded": 2,
+        "priorityAtElection": 5.0,
+        "electionTimeoutMillis": 10000,
+        "priorPrimaryMemberId": 1,
+        "numCatchUpOps": 0,
+        "newTermStartDate": {
+            "$date": 1603358777836
+        },
+        "wMajorityWriteAvailabilityDate": {
+            "$date": 1603358786696
+        }
+    },
+    "members": [
+        {
+            "_id": 0,
+            "name": "mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 1,
+            "stateStr": "PRIMARY",
+            "uptime": 17942,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1603376668,
+                        "i": 3
+                    }
+                },
+                "t": 42
+            },
+            "optimeDate": {
+                "$date": 1603376668000
+            },
+            "syncingTo": "",
+            "syncSourceHost": "",
+            "syncSourceId": -1,
+            "infoMessage": "",
+            "electionTime": {
+                "$timestamp": {
+                    "t": 1603358777,
+                    "i": 1
+                }
+            },
+            "electionDate": {
+                "$date": 1603358777000
+            },
+            "configVersion": 3,
+            "self": true,
+            "lastHeartbeatMessage": ""
+        },
+        {
+            "_id": 1,
+            "name": "mongo-mongodb-sharded-configsvr-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 2,
+            "stateStr": "SECONDARY",
+            "uptime": 17928,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1603376668,
+                        "i": 3
+                    }
+                },
+                "t": 42
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1603376668,
+                        "i": 3
+                    }
+                },
+                "t": 42
+            },
+            "optimeDate": {
+                "$date": 1603376668000
+            },
+            "optimeDurableDate": {
+                "$date": 1603376668000
+            },
+            "lastHeartbeat": {
+                "$date": 1603376669736
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1603376670102
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceHost": "mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceId": 0,
+            "infoMessage": "",
+            "configVersion": 3
+        },
+        {
+            "_id": 2,
+            "name": "mongo-mongodb-sharded-configsvr-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 2,
+            "stateStr": "SECONDARY",
+            "uptime": 17928,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1603376668,
+                        "i": 3
+                    }
+                },
+                "t": 42
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1603376668,
+                        "i": 3
+                    }
+                },
+                "t": 42
+            },
+            "optimeDate": {
+                "$date": 1603376668000
+            },
+            "optimeDurableDate": {
+                "$date": 1603376668000
+            },
+            "lastHeartbeat": {
+                "$date": 1603376669565
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1603376669564
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceHost": "mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceId": 0,
+            "infoMessage": "",
+            "configVersion": 3
+        }
+    ],
+    "ok": 1.0,
+    "$gleStats": {
+        "lastOpTime": {
+            "$timestamp": {
+                "t": 0,
+                "i": 0
+            }
+        },
+        "electionId": {
+            "$oid": "7fffffff000000000000002a"
+        }
+    },
+    "lastCommittedOpTime": {
+        "$timestamp": {
+            "t": 1603376668,
+            "i": 3
+        }
+    },
+    "$clusterTime": {
+        "clusterTime": {
+            "$timestamp": {
+                "t": 1603376668,
+                "i": 3
+            }
+        },
+        "signature": {
+            "hash": {
+                "$binary": "0ViML72aWSh27riNUdXRJ1Z7PqY=",
+                "$type": "00"
+            },
+            "keyId": 6857852638906548233
+        }
+    },
+    "operationTime": {
+        "$timestamp": {
+            "t": 1603376668,
+            "i": 3
+        }
+    }
+}

--- a/mongo/tests/fixtures/replSetGetStatus-configsvr-secondary
+++ b/mongo/tests/fixtures/replSetGetStatus-configsvr-secondary
@@ -1,0 +1,278 @@
+{
+    "set": "mongo-mongodb-sharded-configsvr",
+    "date": {
+        "$date": 1603377113096
+    },
+    "myState": 2,
+    "term": 42,
+    "syncingTo": "mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+    "syncSourceHost": "mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+    "syncSourceId": 0,
+    "configsvr": true,
+    "heartbeatIntervalMillis": 2000,
+    "majorityVoteCount": 2,
+    "writeMajorityCount": 2,
+    "optimes": {
+        "lastCommittedOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1603377109,
+                    "i": 2
+                }
+            },
+            "t": 42
+        },
+        "lastCommittedWallTime": {
+            "$date": 1603377109889
+        },
+        "readConcernMajorityOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1603377109,
+                    "i": 2
+                }
+            },
+            "t": 42
+        },
+        "readConcernMajorityWallTime": {
+            "$date": 1603377109889
+        },
+        "appliedOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1603377109,
+                    "i": 2
+                }
+            },
+            "t": 42
+        },
+        "durableOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1603377109,
+                    "i": 2
+                }
+            },
+            "t": 42
+        },
+        "lastAppliedWallTime": {
+            "$date": 1603377109889
+        },
+        "lastDurableWallTime": {
+            "$date": 1603377109889
+        }
+    },
+    "lastStableRecoveryTimestamp": {
+        "$timestamp": {
+            "t": 1603377109,
+            "i": 2
+        }
+    },
+    "lastStableCheckpointTimestamp": {
+        "$timestamp": {
+            "t": 1603377109,
+            "i": 2
+        }
+    },
+    "electionParticipantMetrics": {
+        "votedForCandidate": true,
+        "electionTerm": 41,
+        "lastVoteDate": {
+            "$date": 1603358762849
+        },
+        "electionCandidateMemberId": 1,
+        "voteReason": "",
+        "lastAppliedOpTimeAtElection": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1603358752,
+                    "i": 1
+                }
+            },
+            "t": 39
+        },
+        "maxAppliedOpTimeInSet": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1603358752,
+                    "i": 1
+                }
+            },
+            "t": 39
+        },
+        "priorityAtElection": 1.0,
+        "newTermStartDate": {
+            "$date": 1603358777836
+        },
+        "newTermAppliedDate": {
+            "$date": 1603358786681
+        }
+    },
+    "members": [
+        {
+            "_id": 0,
+            "name": "mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 1,
+            "stateStr": "PRIMARY",
+            "uptime": 18326,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1603377109,
+                        "i": 2
+                    }
+                },
+                "t": 42
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1603377109,
+                        "i": 2
+                    }
+                },
+                "t": 42
+            },
+            "optimeDate": {
+                "$date": 1603377109000
+            },
+            "optimeDurableDate": {
+                "$date": 1603377109000
+            },
+            "lastHeartbeat": {
+                "$date": 1603377111637
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1603377111636
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "",
+            "syncSourceHost": "",
+            "syncSourceId": -1,
+            "infoMessage": "",
+            "electionTime": {
+                "$timestamp": {
+                    "t": 1603358777,
+                    "i": 1
+                }
+            },
+            "electionDate": {
+                "$date": 1603358777000
+            },
+            "configVersion": 3
+        },
+        {
+            "_id": 1,
+            "name": "mongo-mongodb-sharded-configsvr-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 2,
+            "stateStr": "SECONDARY",
+            "uptime": 18410,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1603377109,
+                        "i": 2
+                    }
+                },
+                "t": 42
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1603377109,
+                        "i": 2
+                    }
+                },
+                "t": 42
+            },
+            "optimeDate": {
+                "$date": 1603377109000
+            },
+            "optimeDurableDate": {
+                "$date": 1603377109000
+            },
+            "lastHeartbeat": {
+                "$date": 1603377112045
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1603377112198
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceHost": "mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceId": 0,
+            "infoMessage": "",
+            "configVersion": 3
+        },
+        {
+            "_id": 2,
+            "name": "mongo-mongodb-sharded-configsvr-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 2,
+            "stateStr": "SECONDARY",
+            "uptime": 18558,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1603377109,
+                        "i": 2
+                    }
+                },
+                "t": 42
+            },
+            "optimeDate": {
+                "$date": 1603377109000
+            },
+            "syncingTo": "mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceHost": "mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceId": 0,
+            "infoMessage": "",
+            "configVersion": 3,
+            "self": true,
+            "lastHeartbeatMessage": ""
+        }
+    ],
+    "ok": 1.0,
+    "$gleStats": {
+        "lastOpTime": {
+            "$timestamp": {
+                "t": 0,
+                "i": 0
+            }
+        },
+        "electionId": {
+            "$oid": "7fffffff0000000000000027"
+        }
+    },
+    "lastCommittedOpTime": {
+        "$timestamp": {
+            "t": 1603377109,
+            "i": 2
+        }
+    },
+    "$clusterTime": {
+        "clusterTime": {
+            "$timestamp": {
+                "t": 1603377109,
+                "i": 2
+            }
+        },
+        "signature": {
+            "hash": {
+                "$binary": "lSGGX4kaBhWIBlkyJqlmU3mgDfo=",
+                "$type": "00"
+            },
+            "keyId": 6857852638906548233
+        }
+    },
+    "operationTime": {
+        "$timestamp": {
+            "t": 1603377109,
+            "i": 2
+        }
+    }
+}

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -34,6 +34,7 @@ def test_integration_mongos(instance_integration, aggregator, check):
     _assert_metrics(
         aggregator,
         ['default', 'custom-queries', 'dbstats', 'indexes-stats', 'collection', 'connection-pool', 'jumbo', 'sessions'],
+        ['sharding_cluster_role:mongos'],
     )
 
     aggregator.assert_all_metrics_covered()
@@ -57,7 +58,11 @@ def test_integration_replicaset_primary_in_shard(instance_integration, aggregato
     with mock_pymongo("replica-primary-in-shard"):
         mongo_check.check(None)
 
-    replica_tags = ['replset_name:mongo-mongodb-sharded-shard-0', 'replset_state:primary']
+    replica_tags = [
+        'replset_name:mongo-mongodb-sharded-shard-0',
+        'replset_state:primary',
+        'sharding_cluster_role:shardsvr',
+    ]
     metrics_categories = [
         'default',
         'custom-queries',
@@ -127,7 +132,122 @@ def test_integration_replicaset_secondary_in_shard(instance_integration, aggrega
     with mock_pymongo("replica-secondary-in-shard"):
         mongo_check.check(None)
 
-    replica_tags = ['replset_name:mongo-mongodb-sharded-shard-0', 'replset_state:secondary']
+    replica_tags = [
+        'replset_name:mongo-mongodb-sharded-shard-0',
+        'replset_state:secondary',
+        'sharding_cluster_role:shardsvr',
+    ]
+    metrics_categories = [
+        'default',
+        'oplog',
+        'replset-secondary',
+        'top',
+        'dbstats-local',
+        'fsynclock',
+        'connection-pool',
+    ]
+    _assert_metrics(aggregator, metrics_categories, replica_tags)
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(
+        get_metadata_metrics(),
+        exclude=[
+            'dd.custom.mongo.aggregate.total',
+            'dd.custom.mongo.count',
+            'dd.custom.mongo.query_a.amount',
+            'dd.custom.mongo.query_a.el',
+        ],
+        check_metric_type=False,
+    )
+    assert len(aggregator._events) == 0
+
+
+def test_integration_configsvr_primary(instance_integration, aggregator, check):
+    mongo_check = check(instance_integration)
+    mongo_check.last_states_by_server = {0: 2, 1: 1, 2: 7, 3: 2}
+
+    with mock_pymongo("configsvr-primary"):
+        mongo_check.check(None)
+
+    replica_tags = [
+        'replset_name:mongo-mongodb-sharded-configsvr',
+        'replset_state:primary',
+        'sharding_cluster_role:configsvr',
+    ]
+    metrics_categories = [
+        'default',
+        'custom-queries',
+        'oplog',
+        'replset-primary',
+        'top',
+        'connection-pool',
+        'dbstats-local',
+        'fsynclock',
+    ]
+    _assert_metrics(aggregator, metrics_categories, replica_tags)
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(
+        get_metadata_metrics(),
+        exclude=[
+            'dd.custom.mongo.aggregate.total',
+            'dd.custom.mongo.count',
+            'dd.custom.mongo.query_a.amount',
+            'dd.custom.mongo.query_a.el',
+        ],
+        check_metric_type=False,
+    )
+    assert len(aggregator._events) == 3
+    aggregator.assert_event(
+        "MongoDB mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017 "
+        "(_id: 0, mongodb://testUser2:*****@localhost:27017/test) just reported as Primary (PRIMARY) for "
+        "mongo-mongodb-sharded-configsvr; it was SECONDARY before.",
+        tags=[
+            'action:mongo_replset_member_status_change',
+            'member_status:PRIMARY',
+            'previous_member_status:SECONDARY',
+            'replset:mongo-mongodb-sharded-configsvr',
+        ],
+        count=1,
+    )
+    aggregator.assert_event(
+        "MongoDB mongo-mongodb-sharded-configsvr-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017 "
+        "(_id: 1, mongodb://testUser2:*****@localhost:27017/test) just reported as Secondary (SECONDARY) for "
+        "mongo-mongodb-sharded-configsvr; it was PRIMARY before.",
+        tags=[
+            'action:mongo_replset_member_status_change',
+            'member_status:SECONDARY',
+            'previous_member_status:PRIMARY',
+            'replset:mongo-mongodb-sharded-configsvr',
+        ],
+        count=1,
+    )
+    aggregator.assert_event(
+        "MongoDB mongo-mongodb-sharded-configsvr-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017 "
+        "(_id: 2, mongodb://testUser2:*****@localhost:27017/test) just reported as Secondary (SECONDARY) for "
+        "mongo-mongodb-sharded-configsvr; it was ARBITER before.",
+        tags=[
+            'action:mongo_replset_member_status_change',
+            'member_status:SECONDARY',
+            'previous_member_status:ARBITER',
+            'replset:mongo-mongodb-sharded-configsvr',
+        ],
+        count=1,
+    )
+
+
+def test_integration_configsvr_secondary(instance_integration, aggregator, check):
+    mongo_check = check(instance_integration)
+    mongo_check.last_states_by_server = {0: 2, 1: 1, 2: 7, 3: 2}
+
+    with mock_pymongo("configsvr-secondary"):
+        mongo_check.check(None)
+
+    replica_tags = [
+        'replset_name:mongo-mongodb-sharded-configsvr',
+        'replset_state:secondary',
+        'sharding_cluster_role:configsvr',
+    ]
     metrics_categories = [
         'default',
         'oplog',


### PR DESCRIPTION
Useful to differentiate a `shardSvr` (ie a member of a shard containing data), from a `configSvr` (i.e storing the cluster configuration) from a `mongos`