### PR TITLE
Use snmp mibs copy while mibs.snmplabs.com is down

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
@@ -19,7 +19,9 @@ def fetch_mib(mib):
 
     target_directory = os.path.dirname(pysnmp_mibs.__file__)
 
-    reader = HttpReader('mibs.snmplabs.com', 80, '/asn1/@mib@')
+    # As mibs.snmplabs.com is down, use a copy
+    # https://github.com/etingof/pysnmp/issues/376
+    reader = HttpReader('raw.githubusercontent.com', 80, '/projx/snmp-mibs/master/@mib@')
     mibCompiler = MibCompiler(SmiStarParser(), PySnmpCodeGen(), PyFileWriter(target_directory))
 
     mibCompiler.addSources(reader)


### PR DESCRIPTION
### What does this PR do?
mibs.snmplabs.com has been down since late August, as reported in https://github.com/etingof/pysnmp/issues/376. In the meantime a copy has been provided at https://github.com/projx/snmp-mibs. This PR changes the target mibs source url 

We might also create our copy and point to our mibs - not sure there could be security concerns 

### Motivation
Fix ddev mibs resolution

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
