### PR TITLE
Add normalized per-statement metrics to Postgres

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -64,6 +64,9 @@ class DatadogAgentStub(object):
     def read_persistent_cache(self, key):
         return self._cache.get(key, '')
 
+    def obfuscate_sql(self, *args, **kwargs):
+        return ''
+
 
 # Use the stub as a singleton
 datadog_agent = DatadogAgentStub()

--- a/datadog_checks_base/datadog_checks/base/utils/db/sql.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/sql.py
@@ -1,0 +1,13 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import mmh3
+
+
+def compute_sql_signature(normalized_query):
+    """
+    Given an already obfuscated & normalized SQL query, generate its 64-bit hex signature.
+    """
+    if not normalized_query:
+        return None
+    return format(mmh3.hash64(normalized_query, signed=False)[0], 'x')

--- a/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
@@ -1,0 +1,113 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+class StatementMetrics:
+    """
+    This class supports normalized statement-level metrics, which are collected from the database's
+    statistics tables, ex:
+
+        - Postgres: pg_stat_statements
+        - MySQL: performance_schema.events_statements_summary_by_digest
+        - Oracle: V$SQLAREA
+        - SQL Server: sys.dm_exec_query_stats
+        - DB2: mon_db_summary
+
+    These tables are monotonically increasing.
+    """
+    def __init__(self, log):
+        self.log = log
+        self.previous_statements = dict()
+
+    def compute_derivative_rows(self, rows, metrics, key):
+        """
+        Compute the first derivative of column-based metrics for a given set of rows. This also resets the
+        statement cache so should only be called once per check run.
+
+        - **rows** (_List[dict]_) - rows from current check run
+        - **previous** (_List[dict]_) - rows from the previous check run
+        - **metrics** (_List[str]_) - the metrics to compute for each row
+        - **key** (_callable_) - function for an ID which uniquely identifies a row across runs
+        """
+        result = []
+        new_cache = {}
+        metrics = set(metrics)
+        dropped_metrics = set()
+        for row in rows:
+            row_key = key(row)
+            if row_key in new_cache:
+                self.log.debug(
+                    'Collision in cached query metrics. Dropping existing row, row_key=%s new=%s dropped=%s',
+                    row_key,
+                    row,
+                    new_cache[row_key])
+            new_cache[row_key] = row
+            prev = self.previous_statements.get(row_key)
+            if prev is None:
+                continue
+            metric_columns = metrics & set(row.keys())
+            dropped_metrics.update(metrics - metric_columns)
+            if any([row[k] - prev[k] < 0 for k in metric_columns]):
+                # The table was truncated or stats reset; begin tracking again from this point
+                continue
+            if all([row[k] - prev[k] == 0 for k in metric_columns]):
+                # No metrics to report; query did not run
+                continue
+            derived = {k: row[k] - prev[k] if k in metric_columns else row[k] for k in row.keys()}
+            # Add the original monotonic counts for debugging
+            derived.update({'monotonic_' + k: row[k] for k in row.keys()})
+            result.append(derived)
+
+        self.previous_statements = new_cache
+        if dropped_metrics:
+            self.log.warning('Some metrics not available from table: %s', ','.join(m for m in dropped_metrics))
+        return result
+
+
+def apply_row_limits(rows, metric_limits, tiebreaker_metric, tiebreaker_reverse, key):
+    """
+    Given a list of query rows, apply limits ensuring that the top k and bottom k of each metric (columns)
+    are present. To increase the overlap of rows across metics with the same values (such as 0), the tiebreaker metric
+    is used as a second sort dimension.
+
+    - **rows** (_List[dict]_) - rows with columns as metrics
+    - **metric_limits** (_Dict[str,Tuple[int,int]]_) - dict of the top k and bottom k limits for each metric
+            ex:
+            >>> metrics = {
+            >>>     'count': (200, 50),
+            >>>     'time': (200, 100),
+            >>>     'lock_time': (50, 50),
+            >>>     ...
+            >>>     'rows_sent': (100, 0),
+            >>> }
+    - **tiebreaker_metric** (_str_) - metric used to resolve ties, intended to increase row overlap in different metrics
+    - **tiebreaker_reverse** (_bool_) - whether the tiebreaker metric should in reverse order (descending)
+    - **key** (_callable_) - function for an ID which uniquely identifies a row
+    """
+    if len(rows) == 0:
+        return rows
+
+    limited = dict()
+    available_cols = set(rows[0].keys())
+
+    for metric, (top_k, bottom_k) in metric_limits.items():
+        if metric not in available_cols:
+            continue
+        # sort_key uses a secondary sort dimension so that if there are a lot of
+        # the same values (like 0), then there will be more overlap in selected rows
+        # over time
+        if tiebreaker_reverse:
+            sort_key = lambda row: (row[metric], -row[tiebreaker_metric])
+        else:
+            sort_key = lambda row: (row[metric], row[tiebreaker_metric])
+        sorted_rows = sorted(rows, key=sort_key)
+
+        top = sorted_rows[len(sorted_rows)-top_k:]
+        bottom = sorted_rows[:bottom_k]
+        for row in top:
+            limited[key(row)] = row
+        for row in bottom:
+            limited[key(row)] = row
+
+    return list(limited.values())

--- a/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
@@ -16,6 +16,7 @@ class StatementMetrics:
 
     These tables are monotonically increasing.
     """
+
     def __init__(self, log):
         self.log = log
         self.previous_statements = dict()
@@ -41,7 +42,8 @@ class StatementMetrics:
                     'Collision in cached query metrics. Dropping existing row, row_key=%s new=%s dropped=%s',
                     row_key,
                     row,
-                    new_cache[row_key])
+                    new_cache[row_key],
+                )
             new_cache[row_key] = row
             prev = self.previous_statements.get(row_key)
             if prev is None:
@@ -103,7 +105,7 @@ def apply_row_limits(rows, metric_limits, tiebreaker_metric, tiebreaker_reverse,
             sort_key = lambda row: (row[metric], row[tiebreaker_metric])
         sorted_rows = sorted(rows, key=sort_key)
 
-        top = sorted_rows[len(sorted_rows)-top_k:]
+        top = sorted_rows[len(sorted_rows) - top_k :]
         bottom = sorted_rows[:bottom_k]
         for row in top:
             limited[key(row)] = row

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -7,6 +7,7 @@ ddtrace==0.32.2
 enum34==1.1.6; python_version < '3.0'
 ipaddress==1.0.22; python_version < '3.0'
 kubernetes==8.0.1
+mmh3==2.5.1
 orjson==2.6.1; python_version > '3.0'
 prometheus-client==0.7.1
 protobuf==3.7.0

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -45,6 +45,7 @@ class PostgresConfig:
         else:
             self.ssl_mode = 'require' if is_affirmative(ssl) else 'disable'
 
+        # Support a custom view when datadog user has insufficient privilege to see queries
         self.table_count_limit = instance.get('table_count_limit', TABLE_COUNT_LIMIT)
         self.collect_function_metrics = is_affirmative(instance.get('collect_function_metrics', False))
         # Default value for `count_metrics` is True for backward compatibility
@@ -57,6 +58,12 @@ class PostgresConfig:
         self.service_check_tags = self._get_service_check_tags()
         self.custom_metrics = self._get_custom_metrics(instance.get('custom_metrics', []))
         self.max_relations = int(instance.get('max_relations', 300))
+
+        # Deep Database monitoring adds additional telemetry for statement metrics
+        self.deep_database_monitoring = is_affirmative(instance.get('deep_database_monitoring', False))
+        self.pg_stat_statements_view = instance.get('pg_stat_statements_view', 'pg_stat_statements')
+        self.escape_query_commas_hack = is_affirmative(instance.get('escape_query_commas_hack', True))
+        self.statement_metric_limits = instance.get('statement_metric_limits', None)
 
     def _build_tags(self, custom_tags):
         # Clean up tags in case there was a None entry in the instance

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -45,7 +45,6 @@ class PostgresConfig:
         else:
             self.ssl_mode = 'require' if is_affirmative(ssl) else 'disable'
 
-        # Support a custom view when datadog user has insufficient privilege to see queries
         self.table_count_limit = instance.get('table_count_limit', TABLE_COUNT_LIMIT)
         self.collect_function_metrics = is_affirmative(instance.get('collect_function_metrics', False))
         # Default value for `count_metrics` is True for backward compatibility
@@ -61,6 +60,7 @@ class PostgresConfig:
 
         # Deep Database monitoring adds additional telemetry for statement metrics
         self.deep_database_monitoring = is_affirmative(instance.get('deep_database_monitoring', False))
+        # Support a custom view when datadog user has insufficient privilege to see queries
         self.pg_stat_statements_view = instance.get('pg_stat_statements_view', 'pg_stat_statements')
         self.escape_query_commas_hack = is_affirmative(instance.get('escape_query_commas_hack', True))
         self.statement_metric_limits = instance.get('statement_metric_limits', None)

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -5,6 +5,7 @@
 from six import PY2, PY3, iteritems
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
+from datadog_checks.base.utils.aws import rds_parse_tags_from_endpoint
 
 SSL_MODES = {'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full'}
 TABLE_COUNT_LIMIT = 200
@@ -82,6 +83,13 @@ class PostgresConfig:
 
         # preset tags to the database name
         tags.extend(["db:%s" % self.dbname])
+
+        rds_tags = rds_parse_tags_from_endpoint(self.host)
+        if rds_tags:
+            tags.extend(rds_tags)
+            # For RDS/off-host installations, override the `host` tag to be the server
+            # being monitored, not the agent host
+            tags.append('host:{}'.format(self.host))
         return tags
 
     def _get_service_check_tags(self):

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -9,6 +9,7 @@ from six import iteritems
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.postgres.metrics_cache import PostgresMetricsCache
+from datadog_checks.postgres.statements import PostgresStatementMetrics
 
 from .config import PostgresConfig
 from .util import (
@@ -50,6 +51,7 @@ class PostgreSql(AgentCheck):
             )
         self.config = PostgresConfig(self.instance)
         self.metrics_cache = PostgresMetricsCache(self.config)
+        self.statement_metrics = PostgresStatementMetrics(self.config)
         self._clean_state()
 
     def _clean_state(self):
@@ -423,6 +425,7 @@ class PostgreSql(AgentCheck):
             self.log.debug("Running check against version %s", str(self.version))
             self._collect_stats(tags)
             self._collect_custom_queries(tags)
+            self.statement_metrics.collect_per_statement_metrics(self, self.db, tags)
         except Exception as e:
             self.log.error("Unable to collect postgres metrics.")
             self._clean_state()

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -8,11 +8,9 @@ import logging
 
 import psycopg2
 import psycopg2.extras
-from datadog import statsd
 
-from datadog_checks.base.utils.db.sql import compute_exec_plan_signature, compute_sql_signature, submit_exec_plan_events
+from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.statement_metrics import StatementMetrics, apply_row_limits
-from datadog_checks.base.utils.db.utils import ConstantRateLimiter
 
 try:
     import datadog_agent

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+import json
+import time
+import logging
+
+import psycopg2
+import psycopg2.extras
+from datadog import statsd
+
+from datadog_checks.base.utils.db.sql import compute_exec_plan_signature, compute_sql_signature, submit_exec_plan_events
+from datadog_checks.base.utils.db.statement_metrics import StatementMetrics, apply_row_limits
+from datadog_checks.base.utils.db.utils import ConstantRateLimiter
+
+try:
+    import datadog_agent
+except ImportError:
+    from ..stubs import datadog_agent
+
+
+logger = logging.getLogger(__name__)
+
+
+STATEMENTS_QUERY = """
+SELECT {cols}
+  FROM {pg_stat_statements_view} as pg_stat_statements
+  LEFT JOIN pg_roles
+         ON pg_stat_statements.userid = pg_roles.oid
+  LEFT JOIN pg_database
+         ON pg_stat_statements.dbid = pg_database.oid
+  WHERE pg_database.datname = %s
+  AND query != '<insufficient privilege>'
+"""
+
+# Required columns for the check to run
+PG_STAT_STATEMENTS_REQUIRED_COLUMNS = frozenset({'calls', 'query', 'total_time', 'rows'})
+
+PG_STAT_STATEMENTS_OPTIONAL_COLUMNS = frozenset({'queryid'})
+
+# Monotonically increasing count columns to be converted to metrics
+PG_STAT_STATEMENTS_METRIC_COLUMNS = {
+    'calls': 'postgresql.queries.count',
+    'total_time': 'postgresql.queries.time',
+    'rows': 'postgresql.queries.rows',
+    'shared_blks_hit': 'postgresql.queries.shared_blks_hit',
+    'shared_blks_read': 'postgresql.queries.shared_blks_read',
+    'shared_blks_dirtied': 'postgresql.queries.shared_blks_dirtied',
+    'shared_blks_written': 'postgresql.queries.shared_blks_written',
+    'local_blks_hit': 'postgresql.queries.local_blks_hit',
+    'local_blks_read': 'postgresql.queries.local_blks_read',
+    'local_blks_dirtied': 'postgresql.queries.local_blks_dirtied',
+    'local_blks_written': 'postgresql.queries.local_blks_written',
+    'temp_blks_read': 'postgresql.queries.temp_blks_read',
+    'temp_blks_written': 'postgresql.queries.temp_blks_written',
+}
+
+# Columns to apply as tags
+PG_STAT_STATEMENTS_TAG_COLUMNS = {
+    'datname': 'db',
+    'rolname': 'user',
+    'query': 'query',
+}
+
+DEFAULT_METRIC_LIMITS = {k: (100000, 100000) for k in PG_STAT_STATEMENTS_METRIC_COLUMNS.keys()}
+
+
+class PostgresStatementMetrics(object):
+    """Collects telemetry for SQL statements"""
+
+    def __init__(self, config):
+        self.config = config
+        # Cache results of monotonic pg_stat_statements to compare to previous collection
+        self._state = StatementMetrics(logger)
+
+        # Available columns will be queried once and cached as the source of truth.
+        self._pg_stat_statements_columns = None
+        self._pg_stat_statements_query_columns = None
+
+    def _execute_query(self, cursor, query):
+        try:
+            cursor.execute(query)
+            return cursor.fetchall()
+        except (psycopg2.ProgrammingError, psycopg2.errors.QueryCanceled) as e:
+            logger.warning('Statement-level metrics are unavailable: {}'.format(e))
+            return []
+
+    def init_pg_stat_statements_columns(self, db):
+        """
+        Load and cache the list of the columns available under the `pg_stat_statements` table. This must be
+        queried because version is not a reliable way to determine the available columns on `pg_stat_statements`.
+        The database can be upgraded without upgrading extensions, even when the extension is included by default.
+        """
+        if self._pg_stat_statements_columns is not None and self._pg_stat_statements_query_columns is not None:
+            return
+
+        query = """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+            AND table_name = 'pg_stat_statements';
+            """
+        cursor = db.cursor()
+        columns = self._execute_query(cursor, query)
+        self._pg_stat_statements_columns = frozenset(column[0] for column in columns)
+
+        # Given all of the available columns, determine the columns that will actually be used to query
+        desired_columns = (
+            list(PG_STAT_STATEMENTS_METRIC_COLUMNS.keys())
+            + list(PG_STAT_STATEMENTS_OPTIONAL_COLUMNS)
+            + list(PG_STAT_STATEMENTS_TAG_COLUMNS.keys())
+        )
+        self._pg_stat_statements_query_columns = sorted(list(set(desired_columns) & self._pg_stat_statements_columns))
+
+    def _collect_per_statement_metrics(self, instance, db, instance_tags):
+        if not self.config.deep_database_monitoring:
+            return
+
+        try:
+            self.__collect_per_statement_metrics(db, instance_tags)
+        except:
+            self.log.exception('Unable to collect statement metrics due to an error')
+
+    def __collect_per_statement_metrics(self, instance, db, instance_tags):
+        self.init_pg_stat_statements_columns(db)
+        missing_columns = PG_STAT_STATEMENTS_REQUIRED_COLUMNS - self._pg_stat_statements_columns
+        if len(missing_columns) > 0:
+            logger.warning(
+                'Unable to collect statement metrics because required fields are unavailable: {}'.format(
+                    ', '.join(list(missing_columns))
+                )
+            )
+            return
+
+        cursor = db.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+        rows = self._execute_query(
+            cursor,
+            STATEMENTS_QUERY.format(
+                cols=', '.join(self._pg_stat_statements_query_columns),
+                pg_stat_statements_view=self.config.pg_stat_statements_view,
+            ),
+        )
+        if not rows:
+            return
+
+        def row_keyfunc(row):
+            # old versions of pg_stat_statements don't have a query ID so fall back to the query string itself
+            queryid = row['queryid'] if 'queryid' in row else row['query']
+            return (queryid, row['datname'], row['rolname'])
+
+        rows = self._state.compute_derivative_rows(rows, PG_STAT_STATEMENTS_METRIC_COLUMNS.keys(), key=row_keyfunc)
+        metric_limits = (
+            self.config.statement_metric_limits if self.config.statement_metric_limits else DEFAULT_METRIC_LIMITS
+        )
+        rows = apply_row_limits(rows, metric_limits, 'calls', True, key=row_keyfunc)
+
+        for row in rows:
+            try:
+                normalized_query = datadog_agent.obfuscate_sql(row['query'])
+            except Exception as e:
+                logger.warn("Failed to obfuscate query '%s': %s", row['query'], e)
+                continue
+
+            # The APM resource hash will use the same query signature because the grouped query is close
+            # enough to the raw query that they will intersect frequently.
+            query_signature = compute_sql_signature(normalized_query)
+            apm_resource_hash = query_signature
+            tags = ['query_signature:' + query_signature, 'resource_hash:' + apm_resource_hash] + instance_tags
+            for column, tag_name in PG_STAT_STATEMENTS_TAG_COLUMNS.items():
+                if column not in row:
+                    continue
+                value = row[column]
+                if column == 'query':
+                    value = self._normalize_query_tag(value)
+                tags.append('{tag_name}:{value}'.format(tag_name=tag_name, value=value))
+
+            for column, metric_name in PG_STAT_STATEMENTS_METRIC_COLUMNS.items():
+                if column not in row:
+                    continue
+                value = row[column]
+                if column == 'total_time':
+                    # convert milliseconds to nanoseconds
+                    value = value * 1000000
+                instance.count(metric_name, value, tags=tags)
+
+    def _normalize_query_tag(self, query):
+        """Normalize the query value to be used as a tag"""
+        # Truncate to metrics tag limit
+        query = query.strip()[:200]
+        if self.config.escape_query_commas_hack:
+            # Substitute commas in the query with unicode commas. Temp hack to
+            # work around the bugs in arbitrary tag values on the backend.
+            query = query.replace(', ', '，').replace(',', '，')
+        return query

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -111,7 +111,7 @@ class PostgresStatementMetrics(object):
         )
         self._pg_stat_statements_query_columns = sorted(list(set(desired_columns) & self._pg_stat_statements_columns))
 
-    def _collect_per_statement_metrics(self, instance, db, instance_tags):
+    def collect_per_statement_metrics(self, instance, db, instance_tags):
         if not self.config.deep_database_monitoring:
             return
 


### PR DESCRIPTION
### What does this PR do?

This PR adds per-statement metrics from the `pg_stat_statements` table. A follow-up PR will do the same for MySQL using the same shared logic in `datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py`.

All relational database integrations will work the same way by polling aggregate monotonic stat tables which track metrics per-normalized query family.

Tests are in progress, but I want to put this up for review now to leave more time to address feedback before code freeze goes into effect.

### Motivation

Query-level metrics is one of the features of Deep Database Monitoring. This change will give customers metrics like `postgresql.queries.time` to report the time spent executing a particular normalized query.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
