### PR TITLE
Check types inside untyped functions by default

### DIFF
--- a/azure_iot_edge/tox.ini
+++ b/azure_iot_edge/tox.ini
@@ -13,7 +13,7 @@ envdir =
     py38: {toxworkdir}/py38
 dd_check_style = true
 dd_check_types = true
-dd_mypy_args = --check-untyped-defs --py2 datadog_checks/ tests/
+dd_mypy_args = --py2 datadog_checks/ tests/
 description =
     py{27,38}: e2e ready if IOT_EDGE_CONNSTR
 usedevelop = true

--- a/datadog_checks_base/tox.ini
+++ b/datadog_checks_base/tox.ini
@@ -14,7 +14,6 @@ dd_check_style = true
 dd_check_types = true
 dd_mypy_args =
     --py2
-    --check-untyped-defs
     --follow-imports silent
     datadog_checks/base/checks/base.py
     datadog_checks/base/checks/win/wmi/__init__.py

--- a/docs/developer/guidelines/style.md
+++ b/docs/developer/guidelines/style.md
@@ -57,8 +57,7 @@ dd_mypy_args = <FLAGS> --py2 datadog_checks/ tests/
 
 The `dd_mypy_args` defines the [mypy command line option][mypy-command-line] for this specific integration. `--py2` is here to make sure the integration is Python2.7 compatible. Here are some useful flags you can add:
 
-- `--check-untyped-defs`: Type-checks the interior of functions without type annotations.
-- `--disallow-untyped-defs`: Disallows defining functions without type annotations or with incomplete type annotations.
+- `--disallow-untyped-defs`: Disallows defining functions without type annotations or with incomplete type annotations. (By default this is allowed for maximum flexibility.)
 
 Note that there is a default configuration in the [`mypy.ini`][mypy-ini] file.
 

--- a/docs/developer/guidelines/style.md
+++ b/docs/developer/guidelines/style.md
@@ -58,6 +58,7 @@ dd_mypy_args = <FLAGS> --py2 datadog_checks/ tests/
 The `dd_mypy_args` defines the [mypy command line option][mypy-command-line] for this specific integration. `--py2` is here to make sure the integration is Python2.7 compatible. Here are some useful flags you can add:
 
 - `--disallow-untyped-defs`: Disallows defining functions without type annotations or with incomplete type annotations. (By default this is allowed for maximum flexibility.)
+- `--follow-imports=silent`: Prevent `mypy` from erroring when importing modules that aren't annotated. Useful when doing partial type checking (i.e. only annotating some modules instead of the entire package).
 
 Note that there is a default configuration in the [`mypy.ini`][mypy-ini] file.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,10 +7,15 @@ follow_imports = normal
 ; Ignore errors about imported packages that don't provide type hints.
 ignore_missing_imports = true
 
-; Don't require that all functions be annotated, as it would create
-; a lot of noise for imported modules that aren't annotated yet.
-; Note that this is the default behavior, but we're making our choice explicit here.
-disallow_untyped_defs = false
+; Don't require that functions be annotated, as it would create a lot of noise for
+; imported modules that aren't annotated yet.
+; (Default behavior, set for the sake of explicitness.)
+allow_untyped_defs = true
+
+; Check the interior of functions by default, even when they are not annotated.
+; We do this so that developers can implement type checking and skip annotating functions when it
+; does not bring value (for example, allow skipping annotations on the `.check()` method of a check).
+check_untyped_defs = true
 
 ; Include column numbers in errors.
 show_column_numbers = true


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Drop [`--disable-untyped-defs`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-disallow_untyped_defs) and add [`--check-untyped-defs`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-check_untyped_defs) in our default `mypy.ini`.
* Drop `--check-untyped-defs` from `tox.ini` files that were using it, since it's now enabled by default.
* Update [docs](https://datadoghq.dev/integrations-core/guidelines/style/#mypy).

### Motivation
<!-- What inspired you to submit this pull request? -->
Consider a check with the following `tox.ini`:

```ini
; ...

[testenv]
dd_check_types = true
dd_mypy_args = --py2 datadog_checks/ tests/
```

And the following `check.py` snippet:

```python
from typing import Iterator

from datadog_checks.base import AgentCheck
from .config import Config
from .types import Metric


class ExampleCheck(AgentCheck):
    def __init__(self, *args, **kwargs):
        super(ExampleCheck, self).__init__(*args, **kwargs)
        self._config = Config(self.instance)
        reveal_type(self._config)  # Is this recognized as a `Config` instance?

    def scrape_metrics(self):
        # type: () -> Iterator[Metric]
        pass

    def submit_metric(self, metric):
        # type: (Metric) -> None
        pass

    def check(self, _):
        reveal_type(self._config)  # Is this recognized as a  `Config` instance?
        for metric in self.scrape_metrics():
            reveal_type(metric)  # Is this recognized as a `Metric` instance?
            self.submit_metric(metric + 1)  # Obvious type error! Will this be caught?
```

Although `.scrape_metrics()` and `.submit_metric()` are properly annotated `mypy` is unable to use the type of `self._config` and of `metric` (everything is treated as `Any`), because `.check()` and `__init__()` are not annotated:

```console
style run-test: commands[0] | mypy --config-file=../mypy.ini --py2 datadog_checks/
datadog_checks/example/check.py:15:21: note: Revealed type is 'Any'
datadog_checks/example/check.py:15:21: note: 'reveal_type' always outputs 'Any' in unchecked functions
datadog_checks/example/check.py:26:21: note: Revealed type is 'Any'
datadog_checks/example/check.py:26:21: note: 'reveal_type' always outputs 'Any' in unchecked functions
datadog_checks/example/check.py:28:25: note: Revealed type is 'Any'
datadog_checks/example/check.py:28:25: note: 'reveal_type' always outputs 'Any' in unchecked functions
```

The fix would be to add `# type: (*Any, **Any) -> None` to `__init__()`, and `# type: (dict) -> None` to `.check()`, but this is a pain, because those annotations are pretty much _useless_ by themselves, and just bring noise. (I personally don't care, but I know some people on the team are sensitive to mypy not taking too much space, and being able to use it with minimum boilerplate.)

Instead, if we turn on `--check-untyped-defs`, we're allowing mypy to type-check the interatior of these un-annotated functions, and the output is now what we'd expect, _without having to riddle the code with useless annotations_:

```console
style run-test: commands[0] | mypy --config-file=../mypy.ini --py2 datadog_checks/
datadog_checks/example/check.py:15:21: note: Revealed type is 'datadog_checks.example.config.Config'
datadog_checks/example/check.py:26:21: note: Revealed type is 'datadog_checks.example.config.Config'
datadog_checks/example/check.py:28:25: note: Revealed type is 'TypedDict('datadog_checks.example.types.Metric', {'name': builtins.str})'
datadog_checks/example/check.py:29:32: error: Unsupported operand types for + ("Metric" and "int")
datadog_checks/example/check.py:29:32: error: Argument 1 to "submit_metric" of "ExampleCheck" has incompatible type "int"; expected "Metric"
```

(And this is reflected in IDEs which show the `reveal_type()` hints, and highlight the error on `metric + 1`.)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
