### PR TITLE
Add note on configuring mypy `files`

### DIFF
--- a/docs/developer/.snippets/links.txt
+++ b/docs/developer/.snippets/links.txt
@@ -27,6 +27,7 @@
 [datadog-agent-logs]: https://docs.datadoghq.com/agent/logs/?tab=tailfiles
 [datadog-agent-status-page]: https://docs.datadoghq.com/agent/guide/agent-status-page/
 [datadog-checks-base]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_base
+[datadog-checks-base-tox-ini]: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/tox.ini
 [datadog-distribution-metrics]: https://docs.datadoghq.com/metrics/distributions/
 [datadog-checks-dev]: https://github.com/DataDog/integrations-core/tree/master/datadog_checks_dev
 [datadog-checks-dev-plugin-pytest]: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py

--- a/docs/developer/guidelines/style.md
+++ b/docs/developer/guidelines/style.md
@@ -60,6 +60,10 @@ The `dd_mypy_args` defines the [mypy command line option][mypy-command-line] for
 - `--check-untyped-defs`: Type-checks the interior of functions without type annotations.
 - `--disallow-untyped-defs`: Disallows defining functions without type annotations or with incomplete type annotations.
 
+The `datadog_checks/ tests/` arguments represent the list of files that `mypy` should type check. Feel free to edit them as desired, including removing `tests/` (if you'd prefer to not type-check the test suite), or targeting specific files (when doing partial type checking).
+
+For a complete example, see the [`datadog_checks_base` tox configuration][datadog-checks-base-tox-ini].
+
 Note that there is a default configuration in the [`mypy.ini`][mypy-ini] file.
 
 ### Example


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add some more hints on configuring `mypy` for partial type checking, in this case configuring `mypy` so that it only type checks a few select files instead of the entire `datadog_checks/` directory.

### Motivation
<!-- What inspired you to submit this pull request? -->
More helpful developer docs

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
