### PR TITLE
Mark Azure IoT Edge integration as macOS-compatible

### DIFF
--- a/azure_iot_edge/manifest.json
+++ b/azure_iot_edge/manifest.json
@@ -11,6 +11,7 @@
   "support": "core",
   "supported_os": [
     "linux",
+    "mac_os",
     "windows"
   ],
   "public_title": "Datadog-Azure IoT Edge Integration",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Cleanup for #7465, pre-requisite to #7841

Add `mac_os` to `supported_os` in `manifest.json`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Although Azure IoT Edge as a technology isn't intended to run on macOS systems (it only supports Linux and Windows), there's no reason to not ship the integration on macOS. Indeed, there's nothing in the integration code that's incompatible with macOS. And we could imagine a weird (but valid) scenario where a macOS native Agent would be used to monitor a distant device — no need to artificially disallow it.

So let's just ship the integration everywhere.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
