### PR TITLE
[DOC] Remove sidekiq integration under agent status validation section

### DIFF
--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -72,10 +72,6 @@ No additional installation is needed on your server.
 
 4. [Restart the Agent][8].
 
-### Validation
-
-[Run the Agent's `status` subcommand][10] and look for `sidekiq` under the Checks section.
-
 ## Data Collected
 
 ### Metrics


### PR DESCRIPTION

### What does this PR do?

It removes the sidekiq validation section since sidekiq integration doesn't show up on agent status page because it is not the sort of integration where the Agent runs a Python check every <n> seconds. It is merely Dogstatsd waiting for metrics to be sent to it.

### Motivation
[Motivation](https://datadoghq.atlassian.net/browse/AGENT-5012?focusedCommentId=290152&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-290152)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
