### PR TITLE
Add config specs

### DIFF
--- a/etcd/assets/configuration/spec.yaml
+++ b/etcd/assets/configuration/spec.yaml
@@ -1,0 +1,55 @@
+name: Couchbase
+files:
+- name: couchbase.yaml
+  options:
+  - template: init_config
+    options:
+    - template: init_config/openmetrics
+  - template: instances
+    options:
+      - name: use_preview
+        description: Whether or not the preview the new version of the check supporting only ETCD 3+
+        value:
+          type: string
+          example: true
+      - template: instances/openmetrics
+        overrides:
+          prometheus_url.example: http://localhost:2379/metrics
+      - name: leader_tag
+        description: Enable to tag metrics with `is_leader:true` or `is_leader:false`.
+        value:
+          type: boolean
+          example: true
+      - name: url
+        description: |
+          Note: the following configuration option is only available when `use_preview` option is set to `false`.
+          The API endpoint of your etcd instance.
+        value:
+          type: string
+          example: https://server:port
+
+  - template: logs
+    example:
+    - type: file
+      path: <LOG_FILE_PATH>
+      source: etcd
+
+- name: auto_conf.yaml
+  options:
+  - template: ad_identifiers
+    overrides:
+      value.example:
+        - etcd
+  - template: init_config
+    options: []
+  - template: instances
+    options:
+    - name: prometheus_url
+      description: |
+      Prometheus endpoint of your etcd instance.
+
+      Note: To monitor ETCD versions pre-3.x.x, set `use_preview` to `false` and use the `url` configuration option.
+      required: true
+      value:
+        example: http://%%host%%:2379/metrics
+        type: string

--- a/etcd/assets/configuration/spec.yaml
+++ b/etcd/assets/configuration/spec.yaml
@@ -1,6 +1,6 @@
-name: Couchbase
+name: etcd
 files:
-- name: couchbase.yaml
+- name: etcd.yaml
   options:
   - template: init_config
     options:
@@ -10,7 +10,7 @@ files:
       - name: use_preview
         description: Whether or not the preview the new version of the check supporting only ETCD 3+
         value:
-          type: string
+          type: boolean
           example: true
       - template: instances/openmetrics
         overrides:
@@ -46,9 +46,9 @@ files:
     options:
     - name: prometheus_url
       description: |
-      Prometheus endpoint of your etcd instance.
+        Prometheus endpoint of your etcd instance.
 
-      Note: To monitor ETCD versions pre-3.x.x, set `use_preview` to `false` and use the `url` configuration option.
+        Note: To monitor ETCD versions pre-3.x.x, set `use_preview` to `false` and use the `url` configuration option.
       required: true
       value:
         example: http://%%host%%:2379/metrics

--- a/etcd/assets/configuration/spec.yaml
+++ b/etcd/assets/configuration/spec.yaml
@@ -14,7 +14,7 @@ files:
           example: true
       - template: instances/openmetrics
         overrides:
-          prometheus_url.example: http://localhost:2379/metrics
+          prometheus_url.value.example: http://localhost:2379/metrics
       - name: leader_tag
         description: Enable to tag metrics with `is_leader:true` or `is_leader:false`.
         value:

--- a/etcd/assets/configuration/spec.yaml
+++ b/etcd/assets/configuration/spec.yaml
@@ -8,7 +8,7 @@ files:
   - template: instances
     options:
       - name: use_preview
-        description: Whether or not the preview the new version of the check supporting only ETCD 3+
+        description: Whether or not to preview the new version of the check supporting only ETCD 3+
         value:
           type: boolean
           example: true

--- a/etcd/datadog_checks/etcd/data/auto_conf.yaml
+++ b/etcd/datadog_checks/etcd/data/auto_conf.yaml
@@ -1,14 +1,22 @@
+## @param ad_identifiers - list of strings - required
+## A list of container identifiers that are used by Autodiscovery to identify
+## which container the check should be run against. For more information, see:
+## https://docs.datadoghq.com/agent/guide/ad_identifiers/
+#
 ad_identifiers:
   - etcd
 
+## All options defined here are available to all instances.
+#
 init_config:
 
+## Every instance is scheduled independent of the others.
+#
 instances:
 
     ## @param prometheus_url - string - required
     ## Prometheus endpoint of your etcd instance.
     ##
-    ## Note: To monitor ETCD versions pre-3.x.x set 
-    ##`use_preview` param to 'false' and use the `url` param
+    ## Note: To monitor ETCD versions pre-3.x.x, set `use_preview` to `false` and use the `url` configuration option.
     #
-  - prometheus_url: "http://%%host%%:2379/metrics"
+  - prometheus_url: http://%%host%%:2379/metrics

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -47,7 +47,7 @@ instances:
 
   -
     ## @param use_preview - boolean - optional - default: true
-    ## Whether or not the preview to new version of the check supporting only ETCD 3+
+    ## Whether or not to preview the new version of the check supporting only ETCD 3+
     #
     # use_preview: true
 

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -1,11 +1,14 @@
+## All options defined here are available to all instances.
+#
 init_config:
-    ## @param proxy - object - optional
+
+    ## @param proxy - mapping - optional
     ## Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
     ## to specify hosts that must bypass proxies.
     ##
-    ## The SOCKS protocol is also supported:
+    ## The SOCKS protocol is also supported like so:
     ##
-    ## socks5://user:pass@host:port
+    ##   socks5://user:pass@host:port
     ##
     ## Using the scheme `socks5` causes the DNS resolution to happen on the
     ## client, rather than on the proxy server. This is in line with `curl`,
@@ -17,128 +20,147 @@ init_config:
     #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
     #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
     #   no_proxy:
-    #     - <HOSTNAME_1>
-    #     - <HOSTNAME_2>
+    #   - <HOSTNAME_1>
+    #   - <HOSTNAME_2>
 
+    ## @param skip_proxy - boolean - optional - default: false
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
+
+    ## @param timeout - number - optional - default: 10
+    ## The timeout for connecting to services.
+    #
+    # timeout: 10
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Additionally, this sets the default `service` for every log source.
+    #
+    # service: <SERVICE>
+
+## Every instance is scheduled independent of the others.
+#
 instances:
 
-  -  
+  -
     ## @param use_preview - boolean - optional - default: true
-    ## Whether or not to preview the new version of the check supporting only ETCD 3+
+    ## Whether or not the preview the new version of the check supporting only ETCD 3+
     #
     # use_preview: true
 
     ## @param prometheus_url - string - required
     ## The URL where your application metrics are exposed by Prometheus.
     #
-    # prometheus_url: http://localhost:2379/metrics
+    prometheus_url: <PROMETHEUS_URL>
 
-    ## @param ssl_cert - string - optional
-    ## The certificate to use when connecting to the `prometheus_url`.
-    ## It may also contain an unencrypted private key to use.
-    ##
-    ## NOTE: Use only if `use_preview` is set to `true`.
-    ##       This option is used in place of `tls_cert`
+    ## @param prometheus_metrics_prefix - string - optional
+    ## <PREFIX> for exposed Prometheus metrics.
     #
-    # ssl_cert: <CERT_PATH>
+    # prometheus_metrics_prefix: <PREFIX>_
 
-    ## @param ssl_private_key - string - optional
-    ## The unencrypted private key to use when connecting to the `prometheus_url`.
-    ## This is required if `ssl_cert` is set and it does not already contain a private key.
-    ##
-    ## NOTE: Use only if `use_preview` is set to `true`.
-    ##       This option is used in place of `tls_private_key`.
+    ## @param health_service_check - boolean - optional - default: true
+    ## Send a service check reporting about the health of the Prometheus endpoint.
+    ## The service check is named <NAMESPACE>.prometheus.health
     #
-    # ssl_private_key: <PRIVATE_KEY_PATH>
+    # health_service_check: true
 
-    ## @param ssl_ca_cert - string - optional
-    ## The path to a CA_BUNDLE file or a directory with certificates of trusted CAs.
-    ##
-    ## NOTE: Use only if `use_preview` is set to `true`.
-    ##       This option is used in place of `tls_ca_cert`.
+    ## @param label_to_hostname - string - optional
+    ## Override the hostname with the value of one label.
     #
-    # ssl_ca_cert: <CA_CERT_PATH>
+    # label_to_hostname: <LABEL>
 
-    ## @param ssl_verify - boolean - optional - default: true
-    ## Instruct the check to validate SSL certificates when connecting to `prometheus_url` and GPRC gateway.
-    ##
-    ## NOTE: Use only if `use_preview` is set to `true`.
-    ##       This option is used in place of `tls_verify`.
+    ## @param label_joins - mapping - optional
+    ## Allows targeting a metric to retrieve its label with a 1:1 mapping.
     #
-    # ssl_verify: true
+    # label_joins:
+    #   target_metric:
+    #     label_to_match: <MATCHED_LABEL>
+    #     labels_to_get:
+    #     - <EXTRA_LABEL_1>
+    #     - <EXTRA_LABEL_2>
 
-    ## @param leader_tag - boolean - optional - default: true
-    ## Whether or not to tag with `is_leader:true` or `is_leader:false`.
+    ## @param labels_mapper - mapping - optional
+    ## The label mapper allows you to rename labels.
+    ## Format is <LABEL_TO_RENAME>: <NEW_LABEL_NAME>
     #
-    # leader_tag: true
+    # labels_mapper:
+    #   flavor: origin
+
+    ## @param type_overrides - mapping - optional
+    ## Override a type in the Prometheus payload or type an untyped metric (ignored by default).
+    ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, and `summary`.
+    ## The "*" wildcard can be used to match multiple metric names.
+    #
+    # type_overrides:
+    #   <METRIC_NAME>: <METRIC_TYPE>
 
     ## @param send_histograms_buckets - boolean - optional - default: true
-    ## Histogram buckets can be noisy and generate many tags.
-    ## Set send_histograms_buckets to true to pull them.
+    ## Set send_histograms_buckets to true to send the histograms bucket.
     #
     # send_histograms_buckets: true
 
-    ## @param tags - list of key:value string - optional
-    ## List of tags to attach to every metric and service check emitted by this integration.
+    ## @param send_distribution_buckets - boolean - optional - default: false
+    ## Set `send_distribution_buckets` to `true` to send histograms as Datadog distribution metrics.
     ##
-    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    ## Learn more about distribution metrics: https://docs.datadoghq.com/developers/metrics/distributions/
     #
-    # tags:
-    #   - <KEY_1>:<VALUE_1>
-    #   - <KEY_2>:<VALUE_2>
+    # send_distribution_buckets: false
 
-    ## @param url - string - optional
-    ## Note: the following configuration param is only available when the `use_preview` param is set to 'false'.
-    ## API endpoint of your etcd instance.
+    ## @param send_monotonic_counter - boolean - optional - default: true
+    ## Set send_monotonic_counter to true to send counters as monotonic counter.
     #
-    # url: "https://server:port"
+    # send_monotonic_counter: true
 
-    ## @param auth_type - string - optional
-    ## The type of authentication to use.
-    ## The available values are "basic" and "digest".
+    ## @param send_distribution_counts_as_monotonic - boolean - optional - default: false
+    ## If set to true, sends histograms and summary counters as monotonic counters (instead of gauges).
     #
-    # auth_type: <AUTH_TYPE>
+    # send_distribution_counts_as_monotonic: false
 
-    ## @param username - string - optional
-    ## The username to use if services are behind basic auth.
+    ## @param send_distribution_sums_as_monotonic - boolean - optional - default: false
+    ## If set to true, sends histograms and summary sums as monotonic counters (instead of gauges).
     #
-    # username: <USERNAME>
+    # send_distribution_sums_as_monotonic: false
 
-    ## @param ntlm_domain - string - optional
-    ## If your services uses NTLM authentication, you can
-    ## specify a domain that is used in the check. For NTLM auth,
-    ## append the username to domain, not as the `username` parameter.
-    ## Example: <NTLM_DOMAIN>\<USERNAME>
+    ## @param exclude_labels - list of strings - optional
+    ## A list of labels to be excluded
     #
-    # ntlm_domain: <DOMAIN>
+    # exclude_labels:
+    #   - timestamp
 
-    ## @param password - string - optional
-    ## The password to use if services are behind basic or NTLM auth.
+    ## @param bearer_token_auth - boolean - optional - default: false
+    ## If set to true, adds a bearer token authentication header.
+    ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
-    # password: <PASSWORD>
+    # bearer_token_auth: false
 
-    ## @param connect_timeout - integer - optional
-    ## Overrides the default connection timeout value,
-    ## and fails the check if the time to establish the (TCP) connection
-    ## exceeds the connect_timeout value (in seconds)
+    ## @param bearer_token_path - string - optional
+    ## The path to a Kubernetes service account bearer token file. Make sure the file exists and is mounted correctly.
+    ## Note: bearer_token_auth should be set to true to enable adding the token to HTTP headers for authentication.
     #
-    # connect_timeout: <VALUE_IN_SECOND>
+    # bearer_token_path: <TOKEN_PATH>
 
-    ## @param read_timeout - integer - optional
-    ## Overrides the default received timeout value, and fails the check if the time to receive
-    ## the server status from the server exceeds the read_timeout value (in seconds)
+    ## @param ignore_metrics - list of strings - optional
+    ## A list of metrics to ignore, use the "*" wildcard can be used to match multiple metric names.
     #
-    # read_timeout: <VALUE_IN_SECOND>
+    # ignore_metrics:
+    #   - <IGNORED_METRIC_NAME>
+    #   - <PREFIX_*>
+    #   - <*_SUFFIX>
+    #   - <PREFIX_*_SUFFIX>
+    #   - <*_SUBSTRING_*>
 
-    ## @param proxy - object - optional
+    ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##
-    ## Set HTTP or HTTPS proxies. Use the `no_proxy` list
+    ## Set HTTP or HTTPS proxies for this instance. Use the `no_proxy` list
     ## to specify hosts that must bypass proxies.
     ##
-    ## The SOCKS protocol is also supported:
+    ## The SOCKS protocol is also supported, for example:
     ##
-    ## socks5://user:pass@host:port
+    ##   socks5://user:pass@host:port
     ##
     ## Using the scheme `socks5` causes the DNS resolution to happen on the
     ## client, rather than on the proxy server. This is in line with `curl`,
@@ -150,8 +172,8 @@ instances:
     #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
     #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
     #   no_proxy:
-    #     - <HOSTNAME_1>
-    #     - <HOSTNAME_2>
+    #   - <HOSTNAME_1>
+    #   - <HOSTNAME_2>
 
     ## @param skip_proxy - boolean - optional - default: false
     ## This overrides the `skip_proxy` setting in `init_config`.
@@ -161,64 +183,182 @@ instances:
     #
     # skip_proxy: false
 
+    ## @param auth_type - string - optional - default: basic
+    ## The type of authentication to use. The available types (and related options) are:
+    ##
+    ##   - basic
+    ##     |__ username
+    ##     |__ password
+    ##     |__ use_legacy_auth_encoding
+    ##   - digest
+    ##     |__ username
+    ##     |__ password
+    ##   - ntlm
+    ##     |__ ntlm_domain
+    ##     |__ password
+    ##   - kerberos
+    ##     |__ kerberos_auth
+    ##     |__ kerberos_cache
+    ##     |__ kerberos_delegate
+    ##     |__ kerberos_force_initiate
+    ##     |__ kerberos_hostname
+    ##     |__ kerberos_keytab
+    ##     |__ kerberos_principal
+    ##   - aws
+    ##     |__ aws_region
+    ##     |__ aws_host
+    ##     |__ aws_service
+    ##
+    ## The `aws` auth type relies on boto3 to automatically gather AWS credentials, for example: from `.aws/credentials`.
+    ## Details: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials
+    #
+    # auth_type: basic
+
+    ## @param use_legacy_auth_encoding - boolean - optional - default: true
+    ## When `auth_type` is set to `basic`, this determines whether to encode as `latin1` rather than `utf-8`.
+    #
+    # use_legacy_auth_encoding: true
+
+    ## @param username - string - optional
+    ## The username to use if services are behind basic or digest auth.
+    #
+    # username: <USERNAME>
+
+    ## @param password - string - optional
+    ## The password to use if services are behind basic or NTLM auth.
+    #
+    # password: <PASSWORD>
+
+    ## @param ntlm_domain - string - optional
+    ## If your services use NTLM authentication, specify
+    ## the domain used in the check. For NTLM Auth, append
+    ## the username to domain, not as the `username` parameter.
+    #
+    # ntlm_domain: <NTLM_DOMAIN>\<USERNAME>
+
     ## @param kerberos_auth - string - optional - default: disabled
-    ## If your service uses Kerberos authentication, you can specify the Kerberos
+    ## If your services use Kerberos authentication, you can specify the Kerberos
     ## strategy to use between:
-    ##  * required
-    ##  * optional
-    ##  * disabled
+    ##
+    ##   - required
+    ##   - optional
+    ##   - disabled
     ##
     ## See https://github.com/requests/requests-kerberos#mutual-authentication
     #
     # kerberos_auth: disabled
 
+    ## @param kerberos_cache - string - optional
+    ## Sets the KRB5CCNAME environment variable.
+    ## It should point to a credential cache with a valid TGT.
+    #
+    # kerberos_cache: <KERBEROS_CACHE>
+
     ## @param kerberos_delegate - boolean - optional - default: false
     ## Set to `true` to enable Kerberos delegation of credentials to a server that requests delegation.
+    ##
     ## See https://github.com/requests/requests-kerberos#delegation
     #
     # kerberos_delegate: false
 
     ## @param kerberos_force_initiate - boolean - optional - default: false
-    ## Set to `true` to preemptively initiate the Kerberos GSS exchange and present a Kerberos ticket on the initial
-    ## request (and all subsequent requests).
+    ## Set to `true` to preemptively initiate the Kerberos GSS exchange and
+    ## present a Kerberos ticket on the initial request (and all subsequent).
+    ##
     ## See https://github.com/requests/requests-kerberos#preemptive-authentication
     #
     # kerberos_force_initiate: false
 
     ## @param kerberos_hostname - string - optional
-    ## Override the hostname used for the Kerberos GSS exchange if its DNS name doesn't match its Kerberos
-    ## hostname (e.g., behind a content switch or load balancer).
+    ## Override the hostname used for the Kerberos GSS exchange if its DNS name doesn't
+    ## match its Kerberos hostname, for example: behind a content switch or load balancer.
+    ##
     ## See https://github.com/requests/requests-kerberos#hostname-override
     #
-    # kerberos_hostname: null
+    # kerberos_hostname: <KERBEROS_HOSTNAME>
 
     ## @param kerberos_principal - string - optional
-    ## Set an explicit principal, to force Kerberos to look for a matching credential cache for the named user.
+    ## Set an explicit principal, to force Kerberos to look for a
+    ## matching credential cache for the named user.
+    ##
     ## See https://github.com/requests/requests-kerberos#explicit-principal
     #
-    # kerberos_principal: null
+    # kerberos_principal: <KERBEROS_PRINCIPAL>
 
     ## @param kerberos_keytab - string - optional
     ## Set the path to your Kerberos key tab file.
     #
     # kerberos_keytab: <KEYTAB_FILE_PATH>
 
-    ## @param kerberos_cache - string - optional
-    ## Sets the KRB5CCNAME environment variable.
-    ## It should point to a credential cache with a valid TGT.
+    ## @param auth_token - mapping - optional
+    ## This allows for the use of authentication information from dynamic sources.
+    ## Both a reader and writer must be configured.
+    ##
+    ## The available readers are:
+    ##
+    ##   - type: file
+    ##     path (required): The absolute path for the file to read from.
+    ##     pattern: A regular expression pattern with a single capture group used to find the
+    ##              token rather than using the entire file, for example: Your secret is (.+)
+    ##
+    ## The available writers are:
+    ##
+    ##   - type: header
+    ##     name (required): The name of the field, for example: Authorization
+    ##     value: The template value, for example `Bearer <TOKEN>`. The default is: <TOKEN>
+    ##     placeholder: The substring in `value` to replace by the token, defaults to: <TOKEN>
     #
-    # kerberos_cache: <KRB5CCNAME>
+    # auth_token:
+    #   reader:
+    #     type: <READER_TYPE>
+    #     <OPTION_1>: <VALUE_1>
+    #     <OPTION_2>: <VALUE_2>
+    #   writer:
+    #     type: <WRITER_TYPE>
+    #     <OPTION_1>: <VALUE_1>
+    #     <OPTION_2>: <VALUE_2>
+
+    ## @param aws_region - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the region.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_region: <AWS_REGION>
+
+    ## @param aws_host - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the host.
+    ##
+    ## Note: This setting is not necessary for official integrations.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_host: <AWS_HOST>
+
+    ## @param aws_service - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the service code. For a list
+    ## of available service codes, see https://docs.aws.amazon.com/general/latest/gr/rande.html
+    ##
+    ## Note: This setting is not necessary for official integrations.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_service: <AWS_SERVICE>
 
     ## @param tls_verify - boolean - optional - default: true
     ## Instructs the check to validate the TLS certificate of services.
     #
     # tls_verify: true
 
+    ## @param tls_use_host_header - boolean - optional - default: false
+    ## If a `Host` header is set, this enables its use for SNI (matching against the TLS certificate CN or SAN).
+    #
+    # tls_use_host_header: false
+
     ## @param tls_ignore_warning - boolean - optional - default: false
     ## If `tls_verify` is disabled, security warnings are logged by the check.
-    ## Disable these by setting `tls_ignore_warning` to true.
+    ## Disable those by setting `tls_ignore_warning` to true.
     ##
-    ## Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration. 
+    ## Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration.
     ## If enabled for multiple instances, spurious warnings might still appear even if `tls_ignore_warning` is set
     ## to true.
     #
@@ -226,7 +366,7 @@ instances:
 
     ## @param tls_cert - string - optional
     ## The path to a single file in PEM format containing a certificate as well as any
-    ## number of CA certificates needed to establish the certificate’s authenticity for
+    ## number of CA certificates needed to establish the certificate's authenticity for
     ## use when connecting to services. It may also contain an unencrypted private key to use.
     #
     # tls_cert: <CERT_PATH>
@@ -245,7 +385,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param headers - list of key:value elements - optional
+    ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for
     ## authorization purposes.
@@ -256,10 +396,29 @@ instances:
     #   Host: <ALTERNATIVE_HOSTNAME>
     #   X-Auth-Token: <AUTH_TOKEN>
 
-    ## @param timeout - integer - optional - default: 10
-    ## The timeout for connecting to services.
+    ## @param extra_headers - mapping - optional
+    ## Additional headers to send with every request.
+    #
+    # extra_headers:
+    #   Host: <ALTERNATIVE_HOSTNAME>
+    #   X-Auth-Token: <AUTH_TOKEN>
+
+    ## @param timeout - number - optional - default: 10
+    ## The timeout for accessing services.
+    ##
+    ## This overrides the `timeout` setting in `init_config`.
     #
     # timeout: 10
+
+    ## @param connect_timeout - number - optional
+    ## The connect timeout for accessing services. Defaults to `timeout`.
+    #
+    # connect_timeout: <CONNECT_TIMEOUT>
+
+    ## @param read_timeout - number - optional
+    ## The read timeout for accessing services. Defaults to `timeout`.
+    #
+    # read_timeout: <READ_TIMEOUT>
 
     ## @param log_requests - boolean - optional - default: false
     ## Whether or not to debug log the HTTP(S) requests made, including the method and URL.
@@ -271,16 +430,58 @@ instances:
     #
     # persist_connections: false
 
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Overrides any `service` defined in the `init_config` section.
+    #
+    # service: <SERVICE>
+
+    ## @param min_collection_interval - number - optional - default: 15
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    # min_collection_interval: 15
+
+    ## @param empty_default_hostname - boolean - optional - default: false
+    ## This forces the check to send metrics with no hostname.
+    ##
+    ## This is useful for cluster-level checks.
+    #
+    # empty_default_hostname: false
+
+    ## @param leader_tag - boolean - optional - default: true
+    ## Enable to tag metrics with `is_leader:true` or `is_leader:false`.
+    #
+    # leader_tag: true
+
+    ## @param url - string - optional - default: https://server:port
+    ## Note: the following configuration option is only available when `use_preview` option is set to `false`.
+    ## The API endpoint of your etcd instance.
+    #
+    # url: https://server:port
+
 ## Log Section
 ##
 ## type - required - Type of log input source (tcp / udp / file / windows_event)
 ## port / path / channel_path - required - Set port if type is tcp or udp.
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
-## source  - required - Attribute that defines which Integration sent the logs
-## service - required - The name of the service that generates the log.
+## source  - required - Attribute that defines which Integration sent the logs.
+## encoding - optional - For file specifies the file encoding, default is utf-8, other
+##                       possible values are utf-16-le and utf-16-be.
+## service - optional - The name of the service that generates the log.
 ##                      Overrides any `service` defined in the `init_config` section.
-## tags - optional - Add tags to the collected logs
+## tags - optional - Add tags to the collected logs.
 ##
 ## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
 #
@@ -288,4 +489,3 @@ instances:
 #   - type: file
 #     path: <LOG_FILE_PATH>
 #     source: etcd
-#     service: <SERVICE_NAME>

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -47,7 +47,7 @@ instances:
 
   -
     ## @param use_preview - boolean - optional - default: true
-    ## Whether or not the preview the new version of the check supporting only ETCD 3+
+    ## Whether or not the preview to new version of the check supporting only ETCD 3+
     #
     # use_preview: true
 

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -54,7 +54,7 @@ instances:
     ## @param prometheus_url - string - required
     ## The URL where your application metrics are exposed by Prometheus.
     #
-    prometheus_url: <PROMETHEUS_URL>
+    prometheus_url: http://localhost:2379/metrics
 
     ## @param prometheus_metrics_prefix - string - optional
     ## <PREFIX> for exposed Prometheus metrics.

--- a/etcd/manifest.json
+++ b/etcd/manifest.json
@@ -32,6 +32,9 @@
   "type": "check",
   "integration_id": "etcd",
   "assets": {
+    "configuration": {
+      "spec": "assets/configuration/spec.yaml"
+    },
     "monitors": {},
     "dashboards": {
       "Etcd Overview": "assets/dashboards/etcd_overview.json"

--- a/etcd/setup.py
+++ b/etcd/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base'
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
 
 setup(
     name='datadog-etcd',


### PR DESCRIPTION
### What does this PR do?
Add config specs for conf.yaml.example + auto_conf.yaml

Both integration versions is using the http wrapper, and remapped: https://github.com/DataDog/integrations-core/blob/master/etcd/datadog_checks/etcd/etcd.py#L67-L84

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes

The previous configuration were using ssl, but prometheus based integrations now use tls options.
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
