### PR TITLE
Support MySQL statement-level metrics for deep database monitoring

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -235,6 +235,18 @@ files:
                   type: boolean
                   example: false
 
+          - name: deep_database_monitoring
+            description: |
+              Set to `true` to enable the BETA features for Deep Database Monitoring.
+
+              If you would like to hear more about Deep Database Monitoring, please reach out to your customer
+              success manager or Datadog support.
+            enabled: false
+            value:
+              type: boolean
+              example: true
+              default: false
+
           - template: instances/default
 
       - template: logs

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -1,8 +1,9 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from datadog_checks.base import ConfigurationError
+from datadog_checks.base import ConfigurationError, is_affirmative
 from datadog_checks.base.log import get_check_logger
+from datadog_checks.base.utils.aws import rds_parse_tags_from_endpoint
 
 DEFAULT_MAX_CUSTOM_QUERIES = 20
 
@@ -17,14 +18,23 @@ class MySQLConfig(object):
         self.defaults_file = instance.get('defaults_file', '')
         self.user = instance.get('user', '')
         self.password = str(instance.get('pass', ''))
-        self.tags = instance.get('tags', [])
+        self.tags = self._build_tags(instance.get('tags', []))
         self.options = instance.get('options', {}) or {}  # options could be None if empty in the YAML
         self.queries = instance.get('queries', [])
         self.ssl = instance.get('ssl', {})
         self.connect_timeout = instance.get('connect_timeout', 10)
         self.max_custom_queries = instance.get('max_custom_queries', DEFAULT_MAX_CUSTOM_QUERIES)
         self.charset = instance.get('charset')
+        self.deep_database_monitoring = is_affirmative(instance.get('deep_database_monitoring', False))
         self.configuration_checks()
+
+    def _build_tags(self, custom_tags):
+        tags = list(set(custom_tags)) or []
+
+        rds_tags = rds_parse_tags_from_endpoint(self.host)
+        if rds_tags:
+            tags.extend(rds_tags)
+        return tags
 
     def configuration_checks(self):
         if self.queries or self.max_custom_queries != DEFAULT_MAX_CUSTOM_QUERIES:

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -224,6 +224,14 @@ instances:
         #
         # extra_performance_metrics: false
 
+    ## @param deep_database_monitoring - boolean - optional - default: false
+    ## Set to `true` to enable the BETA features for Deep Database Monitoring.
+    ##
+    ## If you would like to hear more about Deep Database Monitoring, please reach out to your customer
+    ## success manager or Datadog support.
+    #
+    # deep_database_monitoring: true
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -352,7 +352,7 @@ class MySql(AgentCheck):
 
     def _collect_statement_metrics(self, db, tags):
         tags = self.service_check_tags + tags
-        metrics = self._statement_metrics.collect_per_statement_metrics(self, db)
+        metrics = self._statement_metrics.collect_per_statement_metrics(db)
         for metric_name, metric_value, metric_tags in metrics:
             self.count(metric_name, metric_value, tags=list(set(tags + metric_tags)))
 

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -63,8 +63,8 @@ class MySQLStatementMetrics(object):
         rows = apply_row_limits(
             rows,
             DEFAULT_STATEMENT_METRIC_LIMITS,
-            'count',
-            True,
+            tiebreaker_metric='count',
+            tiebreaker_reverse=True,
             key=keyfunc,
         )
 

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -61,7 +61,7 @@ class MySQLStatementMetrics(object):
         rows = self._state.compute_derivative_rows(monotonic_rows, STATEMENT_METRICS.keys(), key=keyfunc)
         rows = apply_row_limits(
             rows,
-            self.config.options.get('query_metric_limits', DEFAULT_STATEMENT_METRIC_LIMITS),
+            DEFAULT_STATEMENT_METRIC_LIMITS,
             'count',
             True,
             key=keyfunc,

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -79,7 +79,7 @@ class MySQLStatementMetrics(object):
                 self.log.warning("Failed to obfuscate query '%s': %s", row['query'], e)
                 continue
             tags.append('query_signature:' + compute_sql_signature(obfuscated_statement))
-            tags.append('query:' + normalize_query_tag(obfuscated_statement))
+            tags.append('query:' + normalize_query_tag(obfuscated_statement).strip())
 
             for col, name in STATEMENT_METRICS.items():
                 value = row[col]

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+import copy
+import logging
+from contextlib import closing
+
+import pymysql
+
+from datadog_checks.base.utils.db.sql import compute_sql_signature
+from datadog_checks.base.utils.db.statement_metrics import StatementMetrics, apply_row_limits
+
+try:
+    import datadog_agent
+except ImportError:
+    from ..stubs import datadog_agent
+
+
+logger = logging.getLogger(__name__)
+
+
+METRICS = {
+    'count': 'mysql.queries.count',
+    'errors': 'mysql.queries.errors',
+    'time': 'mysql.queries.time',
+    'select_scan': 'mysql.queries.select_scan',
+    'select_full_join': 'mysql.queries.select_full_join',
+    'no_index_used': 'mysql.queries.no_index_used',
+    'no_good_index_used': 'mysql.queries.no_good_index_used',
+    'lock_time': 'mysql.queries.lock_time',
+    'rows_affected': 'mysql.queries.rows_affected',
+    'rows_sent': 'mysql.queries.rows_sent',
+    'rows_examined': 'mysql.queries.rows_examined',
+}
+
+DEFAULT_METRIC_LIMITS = {k: (10000, 10000) for k in METRICS.keys()}
+
+
+class MySQLStatementMetrics(object):
+    """
+    MySQLStatementMetrics collects database metrics per normalized MySQL statement
+    """
+
+    def __init__(self, config):
+        self.config = config
+        self._state = StatementMetrics()
+
+    def collect_per_statement_metrics(self, instance, db, instance_tags):
+        try:
+            self.__collect_per_statement_metrics(instance, db, instance_tags)
+        except Exception:
+            logger.exception('Unable to collect statement metrics due to an error')
+
+    def __collect_per_statement_metrics(self, instance, db, instance_tags):
+        def keyfunc(row):
+            return (row['schema'], row['digest'])
+
+        monotonic_rows = self._query_summary_per_statement(db)
+        monotonic_rows = self._merge_duplicate_rows(monotonic_rows, key=keyfunc)
+        rows = self._state.compute_derivative_rows(monotonic_rows, METRICS.keys(), key=keyfunc)
+        rows = apply_row_limits(
+            rows, self.config.options.get('query_metric_limits', DEFAULT_METRIC_LIMITS), 'count', True, key=keyfunc
+        )
+
+        for row in rows:
+            tags = list(instance_tags)
+            tags.append('digest:' + row['digest'])
+            if row['schema'] is not None:
+                tags.append('schema:' + row['schema'])
+
+            # Remove backticks from identifiers as they will be replaced by spaces in obfuscation
+            row['query'] = self._normalize_digest_text(row['query'])
+            try:
+                obfuscated_statement = datadog_agent.obfuscate_sql(row['query'])
+            except Exception as e:
+                logger.warning("Failed to obfuscate query '%s': %s", row['query'], e)
+                continue
+            tags.append('query_signature:' + compute_sql_signature(obfuscated_statement))
+            tags.append('query:' + self._normalize_query_tag(obfuscated_statement))
+
+            for col, name in METRICS.items():
+                value = row[col]
+                instance.count(name, value, tags=tags)
+
+    @staticmethod
+    def _merge_duplicate_rows(rows, key):
+        """
+        Merges the metrics from duplicate rows because the (schema, digest) identifier may not be
+        unique, see: https://bugs.mysql.com/bug.php?id=79533
+        """
+        merged = {}
+
+        for row in rows:
+            k = key(row)
+            if k in merged:
+                for m in METRICS:
+                    merged[k][m] += row[m]
+            else:
+                merged[k] = copy.copy(row)
+
+        return list(merged.values())
+
+    def _query_summary_per_statement(self, db):
+        """
+        Collects per-statement metrics from performance schema. Because the statement sums are
+        cumulative, the results of the previous run are stored and subtracted from the current
+        values to get the counts for the elapsed period. This is similar to monotonic_count, but
+        several fields must be further processed from the delta values.
+        """
+
+        sql_statement_summary = """\
+            SELECT `schema_name` as `schema`,
+                `digest` as `digest`,
+                `digest_text` as `query`,
+                `count_star` as `count`,
+                `sum_timer_wait` / 1000 as `time`,
+                `sum_lock_time` / 1000 as `lock_time`,
+                `sum_errors` as `errors`,
+                `sum_rows_affected` as `rows_affected`,
+                `sum_rows_sent` as `rows_sent`,
+                `sum_rows_examined` as `rows_examined`,
+                `sum_select_scan` as `select_scan`,
+                `sum_select_full_join` as `select_full_join`,
+                `sum_no_index_used` as `no_index_used`,
+                `sum_no_good_index_used` as `no_good_index_used`
+            FROM performance_schema.events_statements_summary_by_digest
+            WHERE `digest_text` NOT LIKE 'EXPLAIN %'
+            ORDER BY `count_star` DESC
+            LIMIT 10000"""
+
+        try:
+            with closing(db.cursor(pymysql.cursors.DictCursor)) as cursor:
+                cursor.execute(sql_statement_summary)
+
+                rows = cursor.fetchall()
+        except (pymysql.err.InternalError, pymysql.err.OperationalError) as e:
+            logger.warning("Statement summary metrics are unavailable at this time: %s", e)
+            return []
+
+        return rows
+
+    @staticmethod
+    def _normalize_digest_text(query):
+        """
+        Cleans the digest query for obfuscation by stripping the backticks from identifiers.
+        Digest text like "`schema` . `table`" are normalized to "schema.table" as well.
+        """
+        return query.replace('` . `', '.').replace('`', '')
+
+    def _normalize_query_tag(self, query):
+        """Normalize the query value to be used as a tag"""
+        # Truncate to metrics tag limit
+        query = query.strip()[:200]
+        # Substitute commas in the query with unicode commas. Temp hack to
+        # work around the bugs in arbitrary tag values on the backend.
+        query = query.replace(', ', '，').replace(',', '，')
+        return query

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -48,11 +48,11 @@ class MySQLStatementMetrics(object):
 
     def collect_per_statement_metrics(self, instance, db, instance_tags):
         try:
-            self.__collect_per_statement_metrics(instance, db, instance_tags)
+            self._collect_per_statement_metrics(instance, db, instance_tags)
         except Exception:
             logger.exception('Unable to collect statement metrics due to an error')
 
-    def __collect_per_statement_metrics(self, instance, db, instance_tags):
+    def _collect_per_statement_metrics(self, instance, db, instance_tags):
         def keyfunc(row):
             return (row['schema'], row['digest'])
 

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -179,3 +179,14 @@ mysql.performance.qcache.utilization,gauge,,fraction,,Fraction of the query cach
 mysql.performance.digest_95th_percentile.avg_us,gauge,,microsecond,,Query response time 95th percentile per schema.,0,mysql,mysql response time 95th
 mysql.performance.query_run_time.avg,gauge,,microsecond,,Avg query response time per schema.,0,mysql,mysql response time avg
 mysql.binlog.disk_use,gauge,,byte,,Total binary log file size.,0,mysql,mysql binlog disk
+mysql.queries.count,count,,query,,The total count of executed queries per query per schema.,0,mysql,mysql queries count
+mysql.queries.errors,count,,error,,The total count of queries run with an error per query per schema.,0,mysql,mysql query errors
+mysql.queries.time,count,,nanosecond,,The total query execution time per query per schema.,0,mysql,mysql queries total time
+mysql.queries.select_scan,count,,join,,The total count of full table scans on the first table per query per schema.,0,mysql,mysql queries select scan
+mysql.queries.select_full_join,count,,join,,The total count of full table scans on a joined table per query per schema.,0,mysql,mysql queries select full join
+mysql.queries.no_index_used,count,,query,,The total count of queries which do not use an index per query per schema.,0,mysql,mysql queries no index used
+mysql.queries.no_good_index_used,count,,query,,The total count of queries which used a sub-optimal index per query per schema.,0,mysql,mysql queries no good index used
+mysql.queries.lock_time,count,,nanosecond,,The total time spent waiting on locks per query per schema.,0,mysql,mysql queries lock time
+mysql.queries.rows_affected,count,,row,,The number of rows mutated per query per schema.,0,mysql,mysql queries rows affected
+mysql.queries.rows_sent,count,,row,,The number of rows sent per query per schema.,0,mysql,mysql queries rows sent
+mysql.queries.rows_examined,count,,row,,The number of rows examined per query per schema.,0,mysql,mysql queries rows examined

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -182,8 +182,8 @@ mysql.binlog.disk_use,gauge,,byte,,Total binary log file size.,0,mysql,mysql bin
 mysql.queries.count,count,,query,,The total count of executed queries per query per schema.,0,mysql,mysql queries count
 mysql.queries.errors,count,,error,,The total count of queries run with an error per query per schema.,0,mysql,mysql query errors
 mysql.queries.time,count,,nanosecond,,The total query execution time per query per schema.,0,mysql,mysql queries total time
-mysql.queries.select_scan,count,,join,,The total count of full table scans on the first table per query per schema.,0,mysql,mysql queries select scan
-mysql.queries.select_full_join,count,,join,,The total count of full table scans on a joined table per query per schema.,0,mysql,mysql queries select full join
+mysql.queries.select_scan,count,,,,The total count of full table scans on the first table per query per schema.,0,mysql,mysql queries select scan
+mysql.queries.select_full_join,count,,,,The total count of full table scans on a joined table per query per schema.,0,mysql,mysql queries select full join
 mysql.queries.no_index_used,count,,query,,The total count of queries which do not use an index per query per schema.,0,mysql,mysql queries no index used
 mysql.queries.no_good_index_used,count,,query,,The total count of queries which used a sub-optimal index per query per schema.,0,mysql,mysql queries no good index used
 mysql.queries.lock_time,count,,nanosecond,,The total time spent waiting on locks per query per schema.,0,mysql,mysql queries lock time

--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.2.0'
 
 setup(
     name='datadog-mysql',

--- a/mysql/tests/compose/mariadb.conf
+++ b/mysql/tests/compose/mariadb.conf
@@ -7,3 +7,8 @@ slow_query_log = on
 slow_query_log_file = /opt/bitnami/mariadb/logs/mysql_slow.log
 long_query_time = 0.1  # Facilitates local slow query log testing.
 # log_short_format=ON  # Uncomment to simulate short log format.
+performance_schema = ON
+performance-schema-instrument='stage/%=ON'
+performance-schema-consumer-events-stages-current=ON
+performance-schema-consumer-events-stages-history=ON
+performance-schema-consumer-events-stages-history-long=ON

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -101,6 +101,7 @@ def instance_complex():
                 'field': 'age',
             },
         ],
+        'deep_database_monitoring': True,
     }
 
 

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -208,11 +208,11 @@ def test_complex_config_replica(aggregator, instance_complex):
 @pytest.mark.usefixtures('dd_environment')
 def test_statement_metrics(aggregator, instance_complex):
     QUERY = 'select * from information_schema.processlist'
-    QUERY_DIGEST_TEXT = 'SELECT * FROM information_schema.processlist'
+    QUERY_DIGEST_TEXT = 'SELECT * FROM `information_schema` . `processlist`'
     # The query signature should match the query and consistency of this tag has product impact. Do not change
     # the query signature for this test unless you know what you're doing. The query digest is determined by
     # mysql and varies across versions.
-    QUERY_SIGNATURE = 'daad54371910af37'
+    QUERY_SIGNATURE = '8cd0f2b4343decc'
     if environ.get('MYSQL_FLAVOR') == 'mariadb':
         QUERY_DIGEST = '5d343195f2d7adf4388d42755311c3e3'
     elif environ.get('MYSQL_VERSION') == '5.6':
@@ -222,7 +222,7 @@ def test_statement_metrics(aggregator, instance_complex):
     else:
         # 8.0+
         QUERY_DIGEST = '6817a67871eb7edddad5b7836c93330aa3c98801ac759eed1bea6db1a34579c4'
-        QUERY_SIGNATURE = '4a086f63b2b0fa2a'
+        QUERY_SIGNATURE = '9d73cb71644af0a2'
 
     config = copy.deepcopy(instance_complex)
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[config])

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import copy
 import subprocess
+from contextlib import closing
 from os import environ
 
 import mock
@@ -13,6 +14,7 @@ from pkg_resources import parse_version
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.mysql import MySql
+from datadog_checks.mysql import statements
 from datadog_checks.mysql.version_utils import get_version
 
 from . import common, tags, variables
@@ -73,7 +75,7 @@ def _assert_complex_config(aggregator):
         + variables.SYNTHETIC_VARS
     )
 
-    if MYSQL_VERSION_PARSED >= parse_version('5.6') and environ.get('MYSQL_FLAVOR') != 'mariadb':
+    if MYSQL_VERSION_PARSED >= parse_version('5.6'):
         testable_metrics.extend(variables.PERFORMANCE_VARS)
 
     # Test metrics
@@ -201,6 +203,54 @@ def test_complex_config_replica(aggregator, instance_complex):
 
     # Raises when coverage < 100%
     aggregator.assert_all_metrics_covered()
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_statement_metrics(aggregator, instance_complex):
+    QUERY = 'select * from information_schema.processlist'
+    QUERY_DIGEST_TEXT = 'SELECT * FROM information_schema.processlist'
+    # The query signature should match the query and consistency of this tag has product impact. Do not change
+    # the query signature for this test unless you know what you're doing. The query digest is determined by
+    # mysql and varies across versions.
+    QUERY_SIGNATURE = 'daad54371910af37'
+    if environ.get('MYSQL_FLAVOR') == 'mariadb':
+        QUERY_DIGEST = '5d343195f2d7adf4388d42755311c3e3'
+    elif environ.get('MYSQL_VERSION') == '5.6':
+        QUERY_DIGEST = 'acfa199773950cd8cf912f3a19219492'
+    elif environ.get('MYSQL_VERSION') == '5.7':
+        QUERY_DIGEST = '0737e429dc883ba8c86c15ae76e59dda'
+    else:
+        # 8.0+
+        QUERY_DIGEST = '6817a67871eb7edddad5b7836c93330aa3c98801ac759eed1bea6db1a34579c4'
+        QUERY_SIGNATURE = '4a086f63b2b0fa2a'
+
+    config = copy.deepcopy(instance_complex)
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[config])
+
+    def run_query(q):
+        with mysql_check._connect() as db:
+            with closing(db.cursor()) as cursor:
+                cursor.execute(q)
+
+    # Run a query
+    run_query(QUERY)
+    mysql_check.check(config)
+
+    # Run the query and check a second time so statement metrics are computed from the previous run
+    run_query(QUERY)
+    mysql_check.check(config)
+    for name in statements.METRICS.values():
+        aggregator.assert_metric(
+            name,
+            tags=tags.SC_TAGS
+            + [
+                'query:{}'.format(QUERY_DIGEST_TEXT),
+                'query_signature:{}'.format(QUERY_SIGNATURE),
+                'digest:{}'.format(QUERY_DIGEST),
+            ],
+            count=1,
+        )
 
 
 def _test_optional_metrics(aggregator, optional_metrics, at_least):

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -239,7 +239,7 @@ def test_statement_metrics(aggregator, instance_complex):
     # Run the query and check a second time so statement metrics are computed from the previous run
     run_query(QUERY)
     mysql_check.check(config)
-    for name in statements.METRICS.values():
+    for name in statements.STATEMENT_METRICS.values():
         aggregator.assert_metric(
             name,
             tags=tags.SC_TAGS

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -13,8 +13,7 @@ from pkg_resources import parse_version
 
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.dev.utils import get_metadata_metrics
-from datadog_checks.mysql import MySql
-from datadog_checks.mysql import statements
+from datadog_checks.mysql import MySql, statements
 from datadog_checks.mysql.version_utils import get_version
 
 from . import common, tags, variables

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -12,6 +12,12 @@ envdir =
 description =
     py{27,38}: e2e ready
 dd_check_style = true
+dd_check_types = true
+dd_mypy_args =
+    --py2
+    --check-untyped-defs
+    --follow-imports silent
+    datadog_checks/mysql/statements.py
 usedevelop = true
 platform = linux|darwin|win32
 passenv =

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -18,7 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    -e../datadog_checks_base[deps]
+    -e../datadog_checks_base[deps,db]
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in


### PR DESCRIPTION
### What does this PR do?

This PR adds MySQL statement-level metrics from performance_schema. 

Please also refer to the code in the datadog_checks_base PR which is used here: https://github.com/DataDog/integrations-core/pull/7837

* MySQL Integration PR: https://github.com/DataDog/integrations-core/pull/7851
* Postgres Integration PR: https://github.com/DataDog/integrations-core/pull/7852

### Motivation

Query-level metrics is one of the features of Deep Database Monitoring. This change will give customers metrics like `mysql.queries.time` tagged by `query` and `query_signature` to report the time spent executing a particular normalized statement.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
