### PR TITLE
Update the metrics exposed by the tcp_queue_length check

### DIFF
--- a/tcp_queue_length/manifest.json
+++ b/tcp_queue_length/manifest.json
@@ -2,7 +2,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "tcp_queue.",
-  "metric_to_check": "tcp_queue.rqueue.size",
+  "metric_to_check": "tcp_queue.read_buffer_max_fill_rate",
   "name": "tcp_queue_length",
   "short_description": "Track the size of the TCP buffers with Datadog.",
   "guid": "0468b098-43bd-4157-8a01-14065cfdcb7b",

--- a/tcp_queue_length/metadata.csv
+++ b/tcp_queue_length/metadata.csv
@@ -1,8 +1,3 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-tcp_queue.rqueue.size,gauge,,byte,,TCP receive buffer size,0,tcp_queue_length,rqueue_size
-tcp_queue.rqueue.min,gauge,,byte,,TCP receive queue minimum size,0,tcp_queue_length,rqueue_min
-tcp_queue.rqueue.max,gauge,,byte,,TCP receive queue maximum size,0,tcp_queue_length,rqueue_max
-tcp_queue.wqueue.size,gauge,,byte,,TCP send buffer size,0,tcp_queue_length,wqueue_size
-tcp_queue.wqueue.min,gauge,,byte,,TCP send queue minimum size,0,tcp_queue_length,wqueue_min
-tcp_queue.wqueue.max,gauge,,byte,,TCP send queue maximum size,0,tcp_queue_length,wqueue_max
-tcp_queue.nb_contexts,gauge,,connection,,Total number of connections,0,tcp_queue_length,nb_contexts
+tcp_queue.read_buffer_max_fill_rate,gauge,,percent,,Maximum fill rate of the fuller read buffer,0,tcp_queue_length,rbuf_max_fill
+tcp_queue.write_buffer_max_fill_rate,gauge,,percent,,Maximum fill rate of the fuller write buffer,0,tcp_queue_length,wbuf_max_fill


### PR DESCRIPTION
### What does this PR do?

Update the `tcp_queue_length` check documentation following DataDog/datadog-agent#6625.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
