### PR TITLE
Store english and localized counter classes for reusability

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
@@ -75,7 +75,7 @@ class WinPDHCounter(object):
 
     @property
     def localized_class_name(self):
-        return self._counter_name
+        return self._class_name
 
     @property
     def english_class_name(self):
@@ -83,7 +83,7 @@ class WinPDHCounter(object):
 
     def get_single_value(self):
         if not self.is_single_instance():
-            raise ValueError('counter is not single instance %s %s' % (self._class_name, self._counter_name))
+            raise ValueError('counter is not single instance %s %s' % (self.localized_class_name, self._counter_name))
 
         vals = self.get_all_values()
         return vals[SINGLE_INSTANCE_KEY]
@@ -161,7 +161,7 @@ class WinPDHCounter(object):
             """
             try:
                 path = win32pdh.MakeCounterPath(
-                    (machine_name, self._class_name, instance_name, None, 0, en_counter_name)
+                    (machine_name, self.localized_class_name, instance_name, None, 0, en_counter_name)
                 )
                 self.logger.debug("Successfully created English-only path")
             except Exception as e:  # noqa: E722
@@ -190,7 +190,7 @@ class WinPDHCounter(object):
 
             # see if we can create a counter
             try:
-                path = win32pdh.MakeCounterPath((machine_name, self._class_name, instance_name, None, 0, c))
+                path = win32pdh.MakeCounterPath((machine_name, self.localized_class_name, instance_name, None, 0, c))
                 break
             except:  # noqa: E722
                 try:
@@ -201,7 +201,7 @@ class WinPDHCounter(object):
 
     def collect_counters(self):
         counters, instances = win32pdh.EnumObjectItems(
-            None, self._machine_name, self._class_name, win32pdh.PERF_DETAIL_WIZARD
+            None, self._machine_name, self.localized_class_name, win32pdh.PERF_DETAIL_WIZARD
         )
         if self._instance_name is None and len(instances) > 0:
             all_instances = set()
@@ -217,7 +217,7 @@ class WinPDHCounter(object):
                         self.counterdict[inst] = win32pdh.AddCounter(self.hq, path)
                 except:  # noqa: E722
                     self.logger.fatal(
-                        "Failed to create counter.  No instances of %s\\%s" % (self._class_name, self._counter_name)
+                        "Failed to create counter.  No instances of %s\\%s" % (self.localized_class_name, self._counter_name)
                     )
 
             expired_instances = set(self.counterdict) - all_instances
@@ -230,13 +230,13 @@ class WinPDHCounter(object):
                 if len(instances) <= 0:
                     self.logger.error(
                         "%s doesn't seem to be a multi-instance counter, but asked for specific instance %s",
-                        self._class_name,
+                        self.localized_class_name,
                         self._instance_name,
                     )
-                    raise AttributeError("%s is not a multi-instance counter" % self._class_name)
+                    raise AttributeError("%s is not a multi-instance counter" % self.localized_class_name)
                 if self._instance_name not in instances:
-                    self.logger.error("%s is not a counter instance in %s", self._instance_name, self._class_name)
-                    raise AttributeError("%s is not an instance of %s" % (self._instance_name, self._class_name))
+                    self.logger.error("%s is not a counter instance in %s", self._instance_name, self.localized_class_name)
+                    raise AttributeError("%s is not an instance of %s" % (self._instance_name, self.localized_class_name))
 
             path = self._make_counter_path(self._machine_name, self._counter_name, self._instance_name, counters)
             if not path:
@@ -251,7 +251,7 @@ class WinPDHCounter(object):
                         self.counterdict[SINGLE_INSTANCE_KEY] = win32pdh.AddCounter(self.hq, path)
                 except:  # noqa: E722
                     self.logger.fatal(
-                        "Failed to create counter.  No instances of %s\\%s" % (self._class_name, self._counter_name)
+                        "Failed to create counter.  No instances of %s\\%s" % (self.localized_class_name, self._counter_name)
                     )
                     raise
                 self._is_single_instance = True

--- a/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
@@ -217,7 +217,8 @@ class WinPDHCounter(object):
                         self.counterdict[inst] = win32pdh.AddCounter(self.hq, path)
                 except:  # noqa: E722
                     self.logger.fatal(
-                        "Failed to create counter.  No instances of %s\\%s" % (self.localized_class_name, self._counter_name)
+                        "Failed to create counter.  No instances of %s\\%s"
+                        % (self.localized_class_name, self._counter_name)
                     )
 
             expired_instances = set(self.counterdict) - all_instances
@@ -235,8 +236,12 @@ class WinPDHCounter(object):
                     )
                     raise AttributeError("%s is not a multi-instance counter" % self.localized_class_name)
                 if self._instance_name not in instances:
-                    self.logger.error("%s is not a counter instance in %s", self._instance_name, self.localized_class_name)
-                    raise AttributeError("%s is not an instance of %s" % (self._instance_name, self.localized_class_name))
+                    self.logger.error(
+                        "%s is not a counter instance in %s", self._instance_name, self.localized_class_name
+                    )
+                    raise AttributeError(
+                        "%s is not an instance of %s" % (self._instance_name, self.localized_class_name)
+                    )
 
             path = self._make_counter_path(self._machine_name, self._counter_name, self._instance_name, counters)
             if not path:
@@ -251,7 +256,8 @@ class WinPDHCounter(object):
                         self.counterdict[SINGLE_INSTANCE_KEY] = win32pdh.AddCounter(self.hq, path)
                 except:  # noqa: E722
                     self.logger.fatal(
-                        "Failed to create counter.  No instances of %s\\%s" % (self.localized_class_name, self._counter_name)
+                        "Failed to create counter.  No instances of %s\\%s"
+                        % (self.localized_class_name, self._counter_name)
                     )
                     raise
                 self._is_single_instance = True

--- a/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
+++ b/datadog_checks_base/datadog_checks/base/checks/win/winpdh.py
@@ -74,16 +74,19 @@ class WinPDHCounter(object):
         return self._is_single_instance
 
     @property
-    def localized_class_name(self):
+    def class_name(self):
+        """Returns the counter class name. The value is localized to the system but falls back to the english
+        class name if the counter translations can't be fetched."""
         return self._class_name
 
     @property
     def english_class_name(self):
+        """Always return the english version of the counter class name."""
         return self._en_class_name
 
     def get_single_value(self):
         if not self.is_single_instance():
-            raise ValueError('counter is not single instance %s %s' % (self.localized_class_name, self._counter_name))
+            raise ValueError('counter is not single instance %s %s' % (self.class_name, self._counter_name))
 
         vals = self.get_all_values()
         return vals[SINGLE_INSTANCE_KEY]
@@ -161,7 +164,7 @@ class WinPDHCounter(object):
             """
             try:
                 path = win32pdh.MakeCounterPath(
-                    (machine_name, self.localized_class_name, instance_name, None, 0, en_counter_name)
+                    (machine_name, self.class_name, instance_name, None, 0, en_counter_name)
                 )
                 self.logger.debug("Successfully created English-only path")
             except Exception as e:  # noqa: E722
@@ -190,7 +193,7 @@ class WinPDHCounter(object):
 
             # see if we can create a counter
             try:
-                path = win32pdh.MakeCounterPath((machine_name, self.localized_class_name, instance_name, None, 0, c))
+                path = win32pdh.MakeCounterPath((machine_name, self.class_name, instance_name, None, 0, c))
                 break
             except:  # noqa: E722
                 try:
@@ -201,7 +204,7 @@ class WinPDHCounter(object):
 
     def collect_counters(self):
         counters, instances = win32pdh.EnumObjectItems(
-            None, self._machine_name, self.localized_class_name, win32pdh.PERF_DETAIL_WIZARD
+            None, self._machine_name, self.class_name, win32pdh.PERF_DETAIL_WIZARD
         )
         if self._instance_name is None and len(instances) > 0:
             all_instances = set()
@@ -217,8 +220,7 @@ class WinPDHCounter(object):
                         self.counterdict[inst] = win32pdh.AddCounter(self.hq, path)
                 except:  # noqa: E722
                     self.logger.fatal(
-                        "Failed to create counter.  No instances of %s\\%s"
-                        % (self.localized_class_name, self._counter_name)
+                        "Failed to create counter.  No instances of %s\\%s" % (self.class_name, self._counter_name)
                     )
 
             expired_instances = set(self.counterdict) - all_instances
@@ -231,17 +233,13 @@ class WinPDHCounter(object):
                 if len(instances) <= 0:
                     self.logger.error(
                         "%s doesn't seem to be a multi-instance counter, but asked for specific instance %s",
-                        self.localized_class_name,
+                        self.class_name,
                         self._instance_name,
                     )
-                    raise AttributeError("%s is not a multi-instance counter" % self.localized_class_name)
+                    raise AttributeError("%s is not a multi-instance counter" % self.class_name)
                 if self._instance_name not in instances:
-                    self.logger.error(
-                        "%s is not a counter instance in %s", self._instance_name, self.localized_class_name
-                    )
-                    raise AttributeError(
-                        "%s is not an instance of %s" % (self._instance_name, self.localized_class_name)
-                    )
+                    self.logger.error("%s is not a counter instance in %s", self._instance_name, self.class_name)
+                    raise AttributeError("%s is not an instance of %s" % (self._instance_name, self.class_name))
 
             path = self._make_counter_path(self._machine_name, self._counter_name, self._instance_name, counters)
             if not path:
@@ -256,8 +254,7 @@ class WinPDHCounter(object):
                         self.counterdict[SINGLE_INSTANCE_KEY] = win32pdh.AddCounter(self.hq, path)
                 except:  # noqa: E722
                     self.logger.fatal(
-                        "Failed to create counter.  No instances of %s\\%s"
-                        % (self.localized_class_name, self._counter_name)
+                        "Failed to create counter.  No instances of %s\\%s" % (self.class_name, self._counter_name)
                     )
                     raise
                 self._is_single_instance = True


### PR DESCRIPTION
First step to address: https://github.com/DataDog/integrations-core/pull/7853
IIS checks relies on the counter "class name" which can be localized and has different logic based on it. Currently the check compares the class name to the english class names of the counters ("Web Service" and "APP_POOL_WAS") which can be localized.
Currently the IIS check has no other option as the english class name is discarded once the localized name is found.

This PRs adds two new public properties to WinPDHCounter `localized_class_name` and `english_class_name` which, as they name suggest, return the name of the counter class either in english or localized.