### PR TITLE
[network] Collect receive and send queue metrics

### DIFF
--- a/network/metadata.csv
+++ b/network/metadata.csv
@@ -58,6 +58,16 @@ system.net.tcp.listen_drops.count,count,,,,Total number of times connections hav
 system.net.tcp.backlog_drops,gauge,,packet,,The number of packets dropped because there wasn't room in the TCP backlog (Linux only). Available since Agent v5.14.0.,-1,system,tcp backlog drops
 system.net.tcp.backlog_drops.count,count,,packet,,Total number of packets dropped because there wasn't room in the TCP backlog (Linux only).,-1,system,tcp backlog drops
 system.net.tcp.failed_retransmits.count,count,,packet,,Total number of packets that failed to be retransmitted (Linux only).,-1,system,tcp failed retrans
+system.net.tcp.recv_q.95percentile,gauge,,byte,,The 95th percentile of the size of the TCP receive queue.,0,system,recv-q 95th
+system.net.tcp.recv_q.avg,gauge,,byte,,The average TCP receive queue size.,0,system,recv-q avg
+system.net.tcp.recv_q.count,rate,,connection,second,The rate of connections.,0,system,recv-q count
+system.net.tcp.recv_q.max,gauge,,byte,,The maximum TCP receive queue size.,0,system,recv-q max
+system.net.tcp.recv_q.median,gauge,,byte,,The median TCP receive queue size.,0,system,recv-q median
+system.net.tcp.send_q.95percentile,gauge,,byte,,The 95th percentile of the size of the TCP send queue.,0,system,send-q 95th
+system.net.tcp.send_q.avg,gauge,,byte,,The average TCP send queue size.,0,system,send-q avg
+system.net.tcp.send_q.count,rate,,connection,second,The rate of connections.,0,system,send-q count
+system.net.tcp.send_q.max,gauge,,byte,,The maximum TCP send queue size.,0,system,send-q max
+system.net.tcp.send_q.median,gauge,,byte,,The median TCP send queue size.,0,system,send-q median
 system.net.tcp4.closing,gauge,,connection,second,The number of TCP IPv4 closing connections. ,0,system,tcp4 closing
 system.net.tcp4.established,gauge,,connection,second,The number of TCP IPv4 established connections. ,0,system,tcp4 established
 system.net.tcp4.listening,gauge,,connection,second,The number of TCP IPv4 listening connections. ,0,system,tcp4 listening

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -370,5 +370,5 @@ def test_ss_with_custom_procfs(is_linux, is_bsd, is_solaris, is_windows, aggrega
         check._get_net_proc_base_location = lambda x: "/something/proc"
         check.check(instance)
         get_subprocess_output.assert_called_with(
-            ["sh", "-c", "ss --numeric --udp --all --ipv6 | wc -l"], check.log, env={'PROC_ROOT': "/something/proc"}
+            ["sh", "-c", "ss --numeric --tcp --all --ipv6"], check.log, env={'PROC_ROOT': "/something/proc"}
         )


### PR DESCRIPTION
### What does this PR do?

Collect the send and receive queues metrics in the output of `ss` or `netstat`.

### Motivation

The TCP queues length metrics are already gathered by the [eBPF-based `tcp-queue-length` core check](https://github.com/DataDog/integrations-core/tree/master/tcp_queue_length), but being able to collect those data from the `network` python check has the advantage of simplicity. There’s no need for running `system-probe`, installing the kernel headers, etc.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
