### PR TITLE
Fix tests

### DIFF
--- a/mongo/tests/results/metrics-replset-lag-from-primary-configsvr.json
+++ b/mongo/tests/results/metrics-replset-lag-from-primary-configsvr.json
@@ -1,0 +1,35 @@
+[
+    {
+        "name": "mongodb.replset.optime_lag",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "member:mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "replset_name:mongo-mongodb-sharded-configsvr",
+            "replset_state:primary"
+        ]
+    },
+    {
+        "name": "mongodb.replset.optime_lag",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "member:mongo-mongodb-sharded-configsvr-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "replset_name:mongo-mongodb-sharded-configsvr",
+            "replset_state:secondary"
+        ]
+    },
+    {
+        "name": "mongodb.replset.optime_lag",
+        "type": 0,
+        "value": 0.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test",
+            "member:mongo-mongodb-sharded-configsvr-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "replset_name:mongo-mongodb-sharded-configsvr",
+            "replset_state:secondary"
+        ]
+    }
+]

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -186,6 +186,7 @@ def test_integration_configsvr_primary(instance_integration, aggregator, check):
         'fsynclock',
     ]
     _assert_metrics(aggregator, metrics_categories, replica_tags)
+    _assert_metrics(aggregator, ['replset-lag-from-primary-configsvr'])
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(


### PR DESCRIPTION
Two mongo PRs were merged independetly and introduces a failure in tests when we added the replset.optime_lag metric.

This PR fixes test builds