### PR TITLE
Add mypy typing to datadog_checks_base for db utils

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/sql.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/sql.py
@@ -4,6 +4,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import unicode_literals
 
+from typing import Optional
+
 import mmh3
 
 from datadog_checks.base.utils.serialization import json, sort_keys_kwargs
@@ -15,6 +17,7 @@ ARABIC_DECIMAL_SEPARATOR = '，'
 
 
 def compute_sql_signature(normalized_query):
+    # type: (str) -> Optional[str]
     """
     Given an already obfuscated & normalized SQL query, generate its 64-bit hex signature.
     """
@@ -22,10 +25,11 @@ def compute_sql_signature(normalized_query):
         return None
     # Note: please be cautious when changing this function as some features rely on this
     # hash matching the APM resource hash generated on our backend.
-    return format(mmh3.hash64(normalized_query, signed=False)[0], 'x')
+    return format(mmh3.hash64(normalized_query, signed=False)[0], str('x'))
 
 
 def normalize_query_tag(query):
+    # type: (str) -> str
     """
     Normalize the SQL query value to be used as a tag on metrics.
 
@@ -40,7 +44,9 @@ def normalize_query_tag(query):
     For Datadog employees, more background on "Arbitrary Tag Values":
     https://docs.google.com/document/d/1LQWw6ZiQZW18lknsBAZFMrba8BQ5yOmaWoEC7J1nLxU
     """
-    query = query.replace(', ', '{} '.format(ARABIC_DECIMAL_SEPARATOR)).replace(',', ARABIC_DECIMAL_SEPARATOR)
+    query = query.replace(', ', '{} '.format(ARABIC_DECIMAL_SEPARATOR)).replace(  # type: ignore
+        ',', ARABIC_DECIMAL_SEPARATOR
+    )
     return query
 
 

--- a/datadog_checks_base/tox.ini
+++ b/datadog_checks_base/tox.ini
@@ -17,6 +17,8 @@ dd_mypy_args =
     --check-untyped-defs
     --follow-imports silent
     datadog_checks/base/checks/base.py
+    datadog_checks/base/utils/db/sql.py
+    datadog_checks/base/utils/db/statement_metrics.py
     datadog_checks/base/checks/win/wmi/__init__.py
     datadog_checks/base/checks/win/winpdh_base.py
 usedevelop = true


### PR DESCRIPTION
### What does this PR do?

As a follow-up to https://github.com/DataDog/integrations-core/pull/7837, add the mypy typing to the added functions.

### Motivation

This was requested as part of the PR, but I decided to make it a fast follow-on to reduce risk.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
