### PR TITLE
Revert "Check types inside untyped functions by default (#7839)"

### DIFF
--- a/azure_iot_edge/tox.ini
+++ b/azure_iot_edge/tox.ini
@@ -13,7 +13,7 @@ envdir =
     py38: {toxworkdir}/py38
 dd_check_style = true
 dd_check_types = true
-dd_mypy_args = --py2 datadog_checks/ tests/
+dd_mypy_args = --check-untyped-defs --py2 datadog_checks/ tests/
 description =
     py{27,38}: e2e ready if IOT_EDGE_CONNSTR
 usedevelop = true

--- a/datadog_checks_base/tox.ini
+++ b/datadog_checks_base/tox.ini
@@ -14,6 +14,7 @@ dd_check_style = true
 dd_check_types = true
 dd_mypy_args =
     --py2
+    --check-untyped-defs
     --follow-imports silent
     datadog_checks/base/checks/base.py
     datadog_checks/base/checks/win/wmi/__init__.py

--- a/docs/developer/guidelines/style.md
+++ b/docs/developer/guidelines/style.md
@@ -57,8 +57,8 @@ dd_mypy_args = <FLAGS> --py2 datadog_checks/ tests/
 
 The `dd_mypy_args` defines the [mypy command line option][mypy-command-line] for this specific integration. `--py2` is here to make sure the integration is Python2.7 compatible. Here are some useful flags you can add:
 
-- `--disallow-untyped-defs`: Disallows defining functions without type annotations or with incomplete type annotations. (By default this is allowed for maximum flexibility.)
-- `--follow-imports=silent`: Prevent `mypy` from erroring when importing modules that aren't annotated. Useful when doing partial type checking (i.e. only annotating some modules instead of the entire package).
+- `--check-untyped-defs`: Type-checks the interior of functions without type annotations.
+- `--disallow-untyped-defs`: Disallows defining functions without type annotations or with incomplete type annotations.
 
 The `datadog_checks/ tests/` arguments represent the list of files that `mypy` should type check. Feel free to edit them as desired, including removing `tests/` (if you'd prefer to not type-check the test suite), or targeting specific files (when doing partial type checking).
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,15 +7,10 @@ follow_imports = normal
 ; Ignore errors about imported packages that don't provide type hints.
 ignore_missing_imports = true
 
-; Don't require that functions be annotated, as it would create a lot of noise for
-; imported modules that aren't annotated yet.
-; (Default behavior, set for the sake of explicitness.)
-allow_untyped_defs = true
-
-; Check the interior of functions by default, even when they are not annotated.
-; We do this so that developers can implement type checking and skip annotating functions when it
-; does not bring value (for example, allow skipping annotations on the `.check()` method of a check).
-check_untyped_defs = true
+; Don't require that all functions be annotated, as it would create
+; a lot of noise for imported modules that aren't annotated yet.
+; Note that this is the default behavior, but we're making our choice explicit here.
+disallow_untyped_defs = false
 
 ; Include column numbers in errors.
 show_column_numbers = true


### PR DESCRIPTION
This reverts commit 2aba166904fdea971c2438bc7a51a749c612aaa0.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
CI is breaking because enabling this flag creates mypy error in some checks, like `cloud_foundry_api`, `datadog_checks_dev`, and some others. After revert is merged, we can create a sandbox PR to see all issues, and secure them separately.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
