### PR TITLE
Fix network metric collection failure on CentOS

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
@@ -59,6 +59,8 @@ def get_subprocess_output(command, log, raise_on_empty_output=True, log_debug=Tr
         'get_subprocess_output returned (len(out): %s ; len(err): %s ; returncode: %s)', len(out), len(err), returncode
     )
 
+    log.debug('out: %s ; err: %s', out, err)
+
     out = ensure_unicode(out) if out is not None else None
     err = ensure_unicode(err) if err is not None else None
 

--- a/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
@@ -59,7 +59,6 @@ def get_subprocess_output(command, log, raise_on_empty_output=True, log_debug=Tr
         'get_subprocess_output returned (len(out): %s ; len(err): %s ; returncode: %s)', len(out), len(err), returncode
     )
 
-    log.debug('out: %s ; err: %s', out, err)
 
     out = ensure_unicode(out) if out is not None else None
     err = ensure_unicode(err) if err is not None else None

--- a/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
+++ b/datadog_checks_base/datadog_checks/base/utils/subprocess_output.py
@@ -59,7 +59,6 @@ def get_subprocess_output(command, log, raise_on_empty_output=True, log_debug=Tr
         'get_subprocess_output returned (len(out): %s ; len(err): %s ; returncode: %s)', len(out), len(err), returncode
     )
 
-
     out = ensure_unicode(out) if out is not None else None
     err = ensure_unicode(err) if err is not None else None
 

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -309,6 +309,15 @@ class Network(AgentCheck):
                 # Try using `ss` for increased performance over `netstat`
                 ss_env = {"PROC_ROOT": net_proc_base_location}
 
+                # By providing the environment variables in ss_env, the PATH will be overriden. In CentOS,
+                # datadog-agent PATH is "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin", while sh PATH
+                # will be '/usr/local/bin:/usr/bin'. In CentOS, ss is located in /sbin and /usr/sbin, not
+                # in the sh PATH, which will result in network metric collection failure.
+                #
+                # The line below will set sh PATH explicitly as the datadog-agent PATH to fix that issue.
+                if "PATH" in os.environ:
+                    ss_env["PATH"] = os.environ["PATH"]
+
                 metrics = self._get_metrics()
                 for ip_version in ['4', '6']:
                     # Call `ss` for each IP version because there's no built-in way of distinguishing

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -370,5 +370,7 @@ def test_ss_with_custom_procfs(is_linux, is_bsd, is_solaris, is_windows, aggrega
         check._get_net_proc_base_location = lambda x: "/something/proc"
         check.check(instance)
         get_subprocess_output.assert_called_with(
-            ["sh", "-c", "ss --numeric --tcp --all --ipv6"], check.log, env={'PROC_ROOT': "/something/proc"}
+            ["sh", "-c", "ss --numeric --tcp --all --ipv6"],
+            check.log,
+            env={'PROC_ROOT': "/something/proc", 'PATH': os.environ["PATH"]},
         )


### PR DESCRIPTION
### What does this PR do?
Set PATH env to ensure "sh" command receive the same PATH as the caller process.

### Motivation
Customers find network metric collection failure in CentOS, it's a regression from 7.22.1.

### Additional Notes
None

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
