### PR TITLE
Generate SNMP profiles from MIBs

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/cisco-asa.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/cisco-asa.yaml
@@ -1,0 +1,6103 @@
+# Profile for Cisco ASA devices
+
+extends:
+  - _base.yaml
+  - _cisco-generic.yaml
+  - cisco-asa-5525.yaml
+
+
+sysobjectid:
+  - 1.3.6.1.4.1.9.1.669 # ciscoASA5510
+  - 1.3.6.1.4.1.9.1.670 # ciscoASA5520
+  - 1.3.6.1.4.1.9.1.671 # ciscoASA5520sc
+  - 1.3.6.1.4.1.9.1.672 # ciscoASA5540
+  - 1.3.6.1.4.1.9.1.673 # ciscoASA5540sc
+  - 1.3.6.1.4.1.9.1.745 # ciscoASA5505
+  - 1.3.6.1.4.1.9.1.753 # ciscoASA5550
+  - 1.3.6.1.4.1.9.1.763 # ciscoASA5550sc
+  - 1.3.6.1.4.1.9.1.764 # ciscoASA5520sy
+  - 1.3.6.1.4.1.9.1.765 # ciscoASA5540sy
+  - 1.3.6.1.4.1.9.1.766 # ciscoASA5550sy
+  - 1.3.6.1.4.1.9.1.773 # ciscoASA5510sc
+  - 1.3.6.1.4.1.9.1.774 # ciscoASA5510sy
+  - 1.3.6.1.4.1.9.1.914 # ciscoASA5580
+  - 1.3.6.1.4.1.9.1.915 # ciscoASA5580sc
+  - 1.3.6.1.4.1.9.1.916 # ciscoASA5580sy
+  - 1.3.6.1.4.1.9.1.1101 # ciscoASA5505W
+  - 1.3.6.1.4.1.9.1.1194 # ciscoASA5585Ssp10
+  - 1.3.6.1.4.1.9.1.1195 # ciscoASA5585Ssp20
+  - 1.3.6.1.4.1.9.1.1196 # ciscoASA5585Ssp40
+  - 1.3.6.1.4.1.9.1.1197 # ciscoASA5585Ssp60
+  - 1.3.6.1.4.1.9.1.1198 # ciscoASA5585Ssp10sc
+  - 1.3.6.1.4.1.9.1.1199 # ciscoASA5585Ssp20sc
+  - 1.3.6.1.4.1.9.1.1200 # ciscoASA5585Ssp40sc
+  - 1.3.6.1.4.1.9.1.1201 # ciscoASA5585Ssp60sc
+  - 1.3.6.1.4.1.9.1.1202 # ciscoASA5585Ssp10sy
+  - 1.3.6.1.4.1.9.1.1203 # ciscoASA5585Ssp20sy
+  - 1.3.6.1.4.1.9.1.1204 # ciscoASA5585Ssp40sy
+  - 1.3.6.1.4.1.9.1.1205 # ciscoASA5585Ssp60sy
+  - 1.3.6.1.4.1.9.1.1232 # ciscoASA5585SspIps10
+  - 1.3.6.1.4.1.9.1.1233 # ciscoASA5585SspIps20
+  - 1.3.6.1.4.1.9.1.1234 # ciscoASA5585SspIps40
+  - 1.3.6.1.4.1.9.1.1235 # ciscoASA5585SspIps60
+  - 1.3.6.1.4.1.9.1.1275 # ciscoASASm1sc
+  - 1.3.6.1.4.1.9.1.1276 # ciscoASASm1sy
+  - 1.3.6.1.4.1.9.1.1277 # ciscoASASm1
+  - 1.3.6.1.4.1.9.1.1302 # ciscoASA5585Ssp10K7
+  - 1.3.6.1.4.1.9.1.1303 # ciscoASA5585Ssp20K7
+  - 1.3.6.1.4.1.9.1.1304 # ciscoASA5585Ssp40K7
+  - 1.3.6.1.4.1.9.1.1305 # ciscoASA5585Ssp60K7
+  - 1.3.6.1.4.1.9.1.1306 # ciscoASA5585Ssp10K7sc
+  - 1.3.6.1.4.1.9.1.1307 # ciscoASA5585Ssp20K7sc
+  - 1.3.6.1.4.1.9.1.1308 # ciscoASA5585Ssp40K7sc
+  - 1.3.6.1.4.1.9.1.1309 # ciscoASA5585Ssp60K7sc
+  - 1.3.6.1.4.1.9.1.1310 # ciscoASA5585Ssp10K7sy
+  - 1.3.6.1.4.1.9.1.1311 # ciscoASA5585Ssp20K7sy
+  - 1.3.6.1.4.1.9.1.1312 # ciscoASA5585Ssp40K7sy
+  - 1.3.6.1.4.1.9.1.1313 # ciscoASA5585Ssp60K7sy
+  - 1.3.6.1.4.1.9.1.1323 # ciscoASA5585SspIps10K7
+  - 1.3.6.1.4.1.9.1.1324 # ciscoASA5585SspIps20K7
+  - 1.3.6.1.4.1.9.1.1325 # ciscoASA5585SspIps40K7
+  - 1.3.6.1.4.1.9.1.1326 # ciscoASA5585SspIps60K7
+  - 1.3.6.1.4.1.9.1.1334 # ciscoASASm1K7sc
+  - 1.3.6.1.4.1.9.1.1335 # ciscoASASm1K7sy
+  - 1.3.6.1.4.1.9.1.1336 # ciscoASASm1K7
+  - 1.3.6.1.4.1.9.1.1407 # ciscoASA5512
+  - 1.3.6.1.4.1.9.1.1408 # ciscoASA5525
+  - 1.3.6.1.4.1.9.1.1409 # ciscoASA5545
+  - 1.3.6.1.4.1.9.1.1410 # ciscoASA5555
+  - 1.3.6.1.4.1.9.1.1411 # ciscoASA5512sc
+  - 1.3.6.1.4.1.9.1.1412 # ciscoASA5525sc
+  - 1.3.6.1.4.1.9.1.1413 # ciscoASA5545sc
+  - 1.3.6.1.4.1.9.1.1414 # ciscoASA5555sc
+  - 1.3.6.1.4.1.9.1.1415 # ciscoASA5512sy
+  - 1.3.6.1.4.1.9.1.1416 # ciscoASA5515sy
+  - 1.3.6.1.4.1.9.1.1417 # ciscoASA5525sy
+  - 1.3.6.1.4.1.9.1.1418 # ciscoASA5545sy
+  - 1.3.6.1.4.1.9.1.1419 # ciscoASA5555sy
+  - 1.3.6.1.4.1.9.1.1420 # ciscoASA5515sc
+  - 1.3.6.1.4.1.9.1.1421 # ciscoASA5515
+  - 1.3.6.1.4.1.9.1.1437 # ciscoASA5585SspIps10Virtual
+  - 1.3.6.1.4.1.9.1.1438 # ciscoASA5585SspIps20Virtual
+  - 1.3.6.1.4.1.9.1.1439 # ciscoASA5585SspIps40Virtual
+  - 1.3.6.1.4.1.9.1.1440 # ciscoASA5585SspIps60Virtual
+  - 1.3.6.1.4.1.9.1.1442 # ciscoASA5512K7
+  - 1.3.6.1.4.1.9.1.1443 # ciscoASA5515K7
+  - 1.3.6.1.4.1.9.1.1444 # ciscoASA5525K7
+  - 1.3.6.1.4.1.9.1.1445 # ciscoASA5545K7
+  - 1.3.6.1.4.1.9.1.1446 # ciscoASA5555K7
+  - 1.3.6.1.4.1.9.1.1447 # ciscoASA5512K7sc
+  - 1.3.6.1.4.1.9.1.1448 # ciscoASA5515K7sc
+  - 1.3.6.1.4.1.9.1.1449 # ciscoASA5525K7sc
+  - 1.3.6.1.4.1.9.1.1450 # ciscoASA5545K7sc
+  - 1.3.6.1.4.1.9.1.1451 # ciscoASA5555K7sc
+  - 1.3.6.1.4.1.9.1.1452 # ciscoASA5512K7sy
+  - 1.3.6.1.4.1.9.1.1453 # ciscoASA5515K7sy
+  - 1.3.6.1.4.1.9.1.1454 # ciscoASA5525K7sy
+  - 1.3.6.1.4.1.9.1.1455 # ciscoASA5545K7sy
+  - 1.3.6.1.4.1.9.1.1456 # ciscoASA5555K7sy
+  - 1.3.6.1.4.1.9.1.1610 # ciscoASA5585Nm20x1GE
+  - 1.3.6.1.4.1.9.1.1612 # ciscoASA1000Vsy
+  - 1.3.6.1.4.1.9.1.1613 # ciscoASA1000Vsc
+  - 1.3.6.1.4.1.9.1.1614 # ciscoASA1000V
+  - 1.3.6.1.4.1.9.1.1617 # ciscoASA5585Nm8x10GE
+  - 1.3.6.1.4.1.9.1.1618 # ciscoASA5585Nm4x10GE
+  - 1.3.6.1.4.1.9.1.2114 # ciscoASA5506
+  - 1.3.6.1.4.1.9.1.2115 # ciscoASA5506sc
+  - 1.3.6.1.4.1.9.1.2116 # ciscoASA5506sy
+  - 1.3.6.1.4.1.9.1.2117 # ciscoASA5506W
+  - 1.3.6.1.4.1.9.1.2118 # ciscoASA5506Wsc
+  - 1.3.6.1.4.1.9.1.2119 # ciscoASA5506Wsy
+  - 1.3.6.1.4.1.9.1.2120 # ciscoASA5508
+  - 1.3.6.1.4.1.9.1.2121 # ciscoASA5508sc
+  - 1.3.6.1.4.1.9.1.2122 # ciscoASA5508sy
+  - 1.3.6.1.4.1.9.1.2123 # ciscoASA5506K7
+  - 1.3.6.1.4.1.9.1.2124 # ciscoASA5506K7sc
+  - 1.3.6.1.4.1.9.1.2125 # ciscoASA5506K7sy
+  - 1.3.6.1.4.1.9.1.2126 # ciscoASA5508K7
+  - 1.3.6.1.4.1.9.1.2127 # ciscoASA5508K7sc
+  - 1.3.6.1.4.1.9.1.2128 # ciscoASA5508K7sy
+  - 1.3.6.1.4.1.9.1.2241 # ciscoASA5506H
+  - 1.3.6.1.4.1.9.1.2242 # ciscoASA5516
+  - 1.3.6.1.4.1.9.1.2243 # ciscoASA5506Hsc
+  - 1.3.6.1.4.1.9.1.2244 # ciscoASA5516sc
+  - 1.3.6.1.4.1.9.1.2245 # ciscoASA5506Hsy
+  - 1.3.6.1.4.1.9.1.2246 # ciscoASA5516sy
+  - 1.3.6.1.4.1.9.1.2297 # ciscoASA5512td
+  - 1.3.6.1.4.1.9.1.2298 # ciscoASA5515td
+  - 1.3.6.1.4.1.9.1.2299 # ciscoASA5525td
+  - 1.3.6.1.4.1.9.1.2300 # ciscoASA5545td
+  - 1.3.6.1.4.1.9.1.2301 # ciscoASA5555td
+  - 1.3.6.1.4.1.9.1.2302 # ciscoASA5506td
+  - 1.3.6.1.4.1.9.1.2303 # ciscoASA5506Wtd
+  - 1.3.6.1.4.1.9.1.2304 # ciscoASA5506Htd
+  - 1.3.6.1.4.1.9.1.2305 # ciscoASA5508td
+  - 1.3.6.1.4.1.9.1.2306 # ciscoASA5516td
+
+metrics:
+- MIB: ALTIGA-LBSSF-STATS-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.3076.2.1.2.36.1.1.0
+    description: The role of this device.
+    name: alLBSSFRole
+- MIB: ALTIGA-LBSSF-STATS-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.3076.2.1.2.36.1.2.0
+    description: Device type of this device.
+    name: alLBSSFDeviceType
+- MIB: ALTIGA-LBSSF-STATS-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.3076.2.1.2.36.1.3.0
+    description: Indicates if device is active or not.
+    name: alLBSSFActive
+- MIB: ALTIGA-LBSSF-STATS-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.3076.2.1.2.36.1.4.0
+    description: The number of total current peers.
+    name: alLBSSFNumberOfPeers
+- MIB: ALTIGA-LBSSF-STATS-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.3076.2.1.2.36.1.5.0
+    description: The current calculated load of this device in percentage.
+    name: alLBSSFLoad
+- MIB: ALTIGA-LBSSF-STATS-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.3076.2.1.2.36.2.1.1
+    description: The status of this row.
+    name: alLBSSFPeerRowStatus
+  - OID: 1.3.6.1.4.1.3076.2.1.2.36.2.1.2
+    description: Private LAN Ip address of this peer entry.
+    name: alLBSSFPeerPrivIpAddress
+  - OID: 1.3.6.1.4.1.3076.2.1.2.36.2.1.3
+    description: Public LAN Ip address of this peer entry.
+    name: alLBSSFPeerPubIpAddress
+  - OID: 1.3.6.1.4.1.3076.2.1.2.36.2.1.4
+    description: The NAT'ed Public Ip address of this peer entry.
+    name: alLBSSFPeerMappedPubIpAddress
+  - OID: 1.3.6.1.4.1.3076.2.1.2.36.2.1.5
+    description: Indicates if this peer is active or not.
+    name: alLBSSFPeerActive
+  - OID: 1.3.6.1.4.1.3076.2.1.2.36.2.1.6
+    description: Indicates which fault zone this peer belongs.
+    name: alLBSSFPeerFaultZone
+  - OID: 1.3.6.1.4.1.3076.2.1.2.36.2.1.7
+    description: Role of current peer
+    name: alLBSSFPeerRole
+  - OID: 1.3.6.1.4.1.3076.2.1.2.36.2.1.8
+    description: Device type of this peer.
+    name: alLBSSFPeerDeviceType
+  - OID: 1.3.6.1.4.1.3076.2.1.2.36.2.1.9
+    description: Current load of the peer in percentage.
+    name: alLBSSFPeerLoad
+  - OID: 1.3.6.1.4.1.3076.2.1.2.36.2.1.10
+    description: Priority of the peer.
+    name: alLBSSFPeerPriority
+  - OID: 1.3.6.1.4.1.3076.2.1.2.36.2.1.11
+    description: Number of current active sessions on this peer
+    name: alLBSSFPeerActiveSessions
+  - OID: 1.3.6.1.4.1.3076.2.1.2.36.2.1.12
+    description: Time in time-ticks when this peer join the virtual cluster
+    name: alLBSSFPeerJoinTime
+  table:
+    OID: 1.3.6.1.4.1.3076.2.1.2.36.2
+    description: List of LBSSF peers within a LBSSF cluster.
+    name: alLBSSFPeerTable
+- MIB: ALTIGA-SSL-STATS-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.3076.2.1.2.26.1.1.0
+    description: The number of total sessions.
+    name: alSslStatsTotalSessions
+- MIB: ALTIGA-SSL-STATS-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.3076.2.1.2.26.1.2.0
+    description: The current number of active sessions.
+    name: alSslStatsActiveSessions
+- MIB: ALTIGA-SSL-STATS-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.3076.2.1.2.26.1.3.0
+    description: The maximum number current of active sessions at any one time.
+    name: alSslStatsMaxSessions
+- MIB: ALTIGA-SSL-STATS-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.3076.2.1.2.26.1.4.0
+    description: The number of octets sent to the decryption engine. Includes octets
+      used as part of negotiation.
+    name: alSslStatsPreDecryptOctets
+- MIB: ALTIGA-SSL-STATS-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.3076.2.1.2.26.1.5.0
+    description: The number of octets received from the decryption engine.
+    name: alSslStatsPostDecryptOctets
+- MIB: ALTIGA-SSL-STATS-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.3076.2.1.2.26.1.6.0
+    description: The number of octets send to the encryption engine.
+    name: alSslStatsPreEncryptOctets
+- MIB: ALTIGA-SSL-STATS-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.3076.2.1.2.26.1.7.0
+    description: The number of octets received from the encryption engine. Includes
+      octets used as part of negitiation.
+    name: alSslStatsPostEncryptOctets
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.1.1.0
+    description: 'This MIB object assumes the value of True if the managed device
+      is capable of including hardware crypto accelerator. '
+    name: ccaSupportsHwCrypto
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.1.2.0
+    description: 'This MIB object assumes the value of True if the managed device
+      supports field removable hardware crypto accelerators. '
+    name: ccaSupportsModularHwCrypto
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.1.3.0
+    description: 'The maximum number of hardware crypto accelerators which may be
+      simultaneously operational in this device. If the managed device can support
+      only software encryption, the value of this MIB object should be set to zero.
+      If there is not set limit on the maximum number of crypto accelerator modules
+      which the managed device can support, the agent should return a value of ''-1''
+      for this MIB variable. '
+    name: ccaMaxAccelerators
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.1.4.0
+    description: 'The maximum crypto throughput that may be supported by the managed
+      device with the current number of active crypto accelerators. If this value
+      cannot be determined, the agent should return a value of 0. '
+    name: ccaMaxCryptoThroughput
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.1.5.0
+    description: 'The maximum number of VPN flows (connections) the managed device
+      can support with the current number of active crypto accelerators. If this value
+      cannot be determined, the agent should return a value of 0. '
+    name: ccaMaxCryptoConnections
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.2.1.1.0
+    description: The number of crypto accelerators which are in state 'active'.
+    name: ccaGlobalNumActiveAccelerators
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.2.1.2.0
+    description: 'The number of crypto accelerators which are in a state other than
+      ''active''. '
+    name: ccaGlobalNumNonOperAccelerators
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.2.1.3.0
+    description: 'The total number of octets input to all the crypto accelerators
+      installed in the device. The value is cumulative from last reboot of the managed
+      entity. '
+    name: ccaGlobalInOctets
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.2.1.4.0
+    description: 'The total number of octets output by all the crypto accelerators
+      installed in the device. The value is cumulative from last reboot of the managed
+      entity. '
+    name: ccaGlobalOutOctets
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.2.1.5.0
+    description: 'The total number of packets input to all the crypto accelerators
+      installed in the device. The value is cumulative from last reboot of the managed
+      entity. '
+    name: ccaGlobalInPkts
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.2.1.6.0
+    description: 'The total number of packets output by all the crypto accelerators
+      installed in the device. The value is cumulative from last reboot of the managed
+      entity. '
+    name: ccaGlobalOutPkts
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.2.1.7.0
+    description: 'The total number of packets output by all the crypto accelerators
+      installed in the device which were found to be generated with errors (checksum
+      errors, other errors). The value is cumulative from last reboot of the managed
+      entity. '
+    name: ccaGlobalOutErrPkts
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.1
+    description: The index uniquely identifying a specific crypto accelerator.
+    name: ccaAcclIndex
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.2
+    description: The value of entPhysicalIndex of the module corresponding to this
+      conceptual row or zero, if the module is not an entity listed in 'entPhysicalTable'
+      of rfc2737.
+    name: ccaAcclEntPhysicalIndex
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.3
+    description: The state of the crypto accelerator corresponding to this row.
+    name: ccaAcclStatus
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.4
+    description: The type of the crypto accelerator corresponding to this row.
+    name: ccaAcclType
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.5
+    description: The version string of the firmware of the crypto accelerator corresponding
+      to this row.
+    name: ccaAcclVersion
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.6
+    description: The slot number of the crypto accelerator corresponding to this row.
+    name: ccaAcclSlot
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.7
+    description: The number of seconds elapsed since the crypto accelerator corresponding
+      to this row transitioned into the 'active' state.
+    name: ccaAcclActiveTime
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.8
+    description: The number of packets input to this module for processing since the
+      last reboot of the device.
+    name: ccaAcclInPkts
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.9
+    description: The number of packets output by this module after processing, since
+      last reboot of the device.
+    name: ccaAcclOutPkts
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.10
+    description: The number of packets output by this module after processing which
+      had crypto errors, since last reboot of the device.
+    name: ccaAcclOutBadPkts
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.11
+    description: The number of octets input to this module for processing since last
+      reboot of the device.
+    name: ccaAcclInOctets
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.12
+    description: The number of octets output by this module after processing since
+      last reboot of the device.
+    name: ccaAcclOutOctets
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.13
+    description: 'The number of packets output by this module which were prepared
+      for hash validation since the last reboot of the device. Hash validation is
+      a cryptographic operation used to verify the integrity of a block of data received
+      from a trusted source. '
+    name: ccaAcclHashOutboundPkts
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.14
+    description: The number of octets output by this module which were prepared for
+      hash validation since the last reboot of the device.
+    name: ccaAcclHashOutboundOctets
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.15
+    description: The number of packets input to this module which required hash validation
+      since the last reboot of the device.
+    name: ccaAcclHashInboundPkts
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.16
+    description: The number of octets input to this module which were authenticated
+      using hash validation since the last reboot of the device.
+    name: ccaAcclHashInboundOctets
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.17
+    description: The number of packets input to this module which required encryption
+      since the last reboot of the device.
+    name: ccaAcclEncryptPkts
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.18
+    description: The number of octets input to this module which required encryption
+      since the last reboot of the device.
+    name: ccaAcclEncryptOctets
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.19
+    description: The number of packets input to this module which required decryption
+      since the last reboot of the device.
+    name: ccaAcclDecryptPkts
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.20
+    description: The number of octets input to this module which required decryption
+      since the last reboot of the device.
+    name: ccaAcclDecryptOctets
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.21
+    description: The number of cryptographic transformations performed by this crypto
+      accelerator since the last reboot of the device.
+    name: ccaAcclTransformsTotal
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.22
+    description: The number of packets input to this module which were dropped prior
+      to processing since the last reboot of the device.
+    name: ccaAcclDropsPkts
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.23
+    description: The number of requests received by this crypto accelerator to generate
+      random numbers since the last reboot of the device.
+    name: ccaAcclRandRequests
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.24
+    description: The number of random number requests received by this module which
+      were not fulfilled, counted since the last reboot of the device.
+    name: ccaAcclRandReqFails
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.25
+    description: The number of Diffie Hellman key pairs generated by this module since
+      the last reboot.
+    name: ccaAcclDHKeysGenerated
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.26
+    description: The number of times this module has derived Diffie Hellman secret
+      keys since the last reboot of the device.
+    name: ccaAcclDHDerivedSecretKeys
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.27
+    description: The number of times a new RSA key pair was generated by this module,
+      counted since the last time this module assumed 'active' status.
+    name: ccaAcclRSAKeysGenerated
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.28
+    description: The number of times an RSA Digital Signature has been generated by
+      this module, counted since the last time this module assumed 'active' status.
+    name: ccaAcclRSASignings
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.29
+    description: The number of times an RSA Digital Signature has been verified by
+      this module, counted since the last time this module assumed 'active' status.
+    name: ccaAcclRSAVerifications
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.30
+    description: The number of packets input to this module which required RSA encryption,
+      counted since the last time this module assumed 'active' status.
+    name: ccaAcclRSAEncryptPkts
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.31
+    description: The number of octets input to this module which required RSA encryption,
+      counted since the last time this module assumed 'active' status.
+    name: ccaAcclRSAEncryptOctets
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.32
+    description: The number of packets input to this module which required RSA decryption,
+      counted since the last time this module assumed 'active' status.
+    name: ccaAcclRSADecryptPkts
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.33
+    description: The number of octets input to this module which required RSA decryption,
+      counted since the last time this module assumed 'active' status.
+    name: ccaAcclRSADecryptOctets
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.34
+    description: The number of times DSA key pair has been generated by this module,
+      counted since the last time this module assumed 'active' status.
+    name: ccaAcclDSAKeysGenerated
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.35
+    description: The number of times DSA signature has been generated by this module,
+      counted since the last time this module assumed 'active' status.
+    name: ccaAcclDSASignings
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.36
+    description: The number of times DSA signature has been verified by this module,
+      counted since the last time this module assumed 'active' status.
+    name: ccaAcclDSAVerifications
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.37
+    description: The number of combined outbound hash/encrypt SSL records processed
+      by this module, counted since the last time this module assumed 'active' status.
+    name: ccaAcclOutboundSSLRecords
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.2.1.38
+    description: The number of combined inbound hash/encrypt SSL records processed
+      by this module, counted since the last time this module assumed 'active' status.
+    name: ccaAcclInboundSSLRecords
+  table:
+    OID: 1.3.6.1.4.1.9.9.467.1.2.2
+    description: The crypto accelerator table. There is one entry in this table for
+      each crypto accelerator installed in the managed device.
+    name: ccaAcceleratorTable
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.3.1.1.1
+    description: The index uniquely identifies the security protocol for which this
+      row summarizes the statistics.
+    name: ccaProtId
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.3.1.1.2
+    description: The number of payload encrypt requests received by the crypto accelerators
+      from this security protocol, counted since the last reboot of the device.
+    name: ccaProtPktEncryptsReqs
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.3.1.1.3
+    description: The number of payload decrypt requests received by the crypto accelerators
+      from this security protocol, counted since the last reboot of the device.
+    name: ccaProtPktDecryptsReqs
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.3.1.1.4
+    description: The number of times keyed HMAC calculation requests were received
+      by the crypto accelerators due to the operation of this security protocol, counted
+      since the last reboot of the device.
+    name: ccaProtHmacCalcReqs
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.3.1.1.5
+    description: The number of times requests for creation of security associations
+      were received by the crypto accelerators from this security protocol, counted
+      since the last reboot of the device.
+    name: ccaProtSaCreateReqs
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.3.1.1.6
+    description: The number of times requests for rekeying of existing security associations
+      were received by the crypto accelerators from this security protocol, counted
+      since the last reboot of the device.
+    name: ccaProtSaRekeyReqs
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.3.1.1.7
+    description: The number of times requests for deletion of security associations
+      were received by the crypto accelerators from this security protocol, counted
+      since the last reboot of the device.
+    name: ccaProtSaDeleteReqs
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.3.1.1.8
+    description: The number of times requests for payload encapsulation were received
+      by the crypto accelerators from this security protocol, counted since the last
+      reboot of the device.
+    name: ccaProtPktEncapReqs
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.3.1.1.9
+    description: The number of times requests for payload decapsulation were received
+      by the crypto accelerators from this security protocol, counted since the last
+      reboot of the device.
+    name: ccaProtPktDecapReqs
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.3.1.1.10
+    description: The number of times requests for allocation of keys for the next
+      phase of the protocol operation which were received by the crypto accelerators
+      from this security protocol, counted since the last reboot of the device. As
+      an example, for IKE, this would identify the number of times key allocation
+      requests for Quick Mode were received by the crypto accelerator from the IKE
+      protocol engine.
+    name: ccaProtNextPhaseKeyAllocReqs
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.3.1.1.11
+    description: The number of times requests for generation of random number(s) were
+      received by the crypto accelerators from this security protocol, counted since
+      the last reboot of the device.
+    name: ccaProtRndGenReqs
+  - OID: 1.3.6.1.4.1.9.9.467.1.2.3.1.1.12
+    description: The number of times requests received from this security protocol
+      could not be fulfilled, counted since the last reboot of the device.
+    name: ccaProtFailedReqs
+  table:
+    OID: 1.3.6.1.4.1.9.9.467.1.2.3.1
+    description: The crypto accelerator statistics catalogued by security protocol
+      causing the activity. There is only entry in this table for each security protocol
+      listed in the textual convention 'CAProtocolType'.
+    name: ccaProtocolStatsTable
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.3.1.0
+    description: 'This variable controls the generation of ''ciscoCryAccelInserted''
+      notification. When this variable is set to ''true'', generation of the notification
+      is enabled. When this variable is set to ''false'', generation of the notification
+      is disabled. '
+    name: ccaNotifCntlAcclInserted
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.3.2.0
+    description: 'This variable controls the generation of ''ciscoCryAccelRemoved''
+      notification. When this variable is set to ''true'', generation of the notification
+      is enabled. When this variable is set to ''false'', generation of the notification
+      is disabled. '
+    name: ccaNotifCntlAcclRemoved
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.3.3.0
+    description: 'This variable controls the generation of ''ciscoCryAccelOperational''
+      notification. When this variable is set to ''true'', generation of the notification
+      is enabled. When this variable is set to ''false'', generation of the notification
+      is disabled. '
+    name: ccaNotifCntlAcclOperational
+- MIB: CISCO-CRYPTO-ACCELERATOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.467.1.3.4.0
+    description: 'This variable controls the generation of ''ciscoCryAccelDisabled''
+      notification. When this variable is set to ''true'', generation of the notification
+      is enabled. When this variable is set to ''false'', generation of the notification
+      is disabled. '
+    name: ccaNotifCntlAcclDisabled
+- MIB: CISCO-ENHANCED-MEMPOOL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.1
+    description: Within each physical entity, the unique value greater than zero,
+      used to represent each memory pool. It is recommended that values are assigned
+      contiguously starting from 1.
+    name: cempMemPoolIndex
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.2
+    description: The type of memory pool for which this entry contains information.
+    name: cempMemPoolType
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.3
+    description: A textual name assigned to the memory pool. This object is suitable
+      for output to a human operator, and may also be used to distinguish among the
+      various pool types.
+    name: cempMemPoolName
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.4
+    description: An indication of the platform-specific memory pool type. The associated
+      instance of cempMemPoolType is used to indicate the general type of memory pool.
+      If no platform specific memory hardware type identifier exists for this physical
+      entity, or the value is unknown by this agent, then the value { 0 0 } is returned.
+    name: cempMemPoolPlatformMemory
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.5
+    description: Indicates whether or not this memory pool has an alternate pool configured.
+      Alternate pools are used for fallback when the current pool runs out of memory.
+      If an instance of this object has a value of zero, then this pool does not have
+      an alternate. Otherwise the value of this object is the same as the value of
+      cempMemPoolType of the alternate pool.
+    name: cempMemPoolAlternate
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.6
+    description: Indicates whether or not cempMemPoolUsed, cempMemPoolFree, cempMemPoolLargestFree
+      and cempMemPoolLowestFree in this entry contain accurate data. If an instance
+      of this object has the value false (which in and of itself indicates an internal
+      error condition), the values of these objects in the conceptual row may contain
+      inaccurate information (specifically, the reported values may be less than the
+      actual values).
+    name: cempMemPoolValid
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.7
+    description: Indicates the number of bytes from the memory pool that are currently
+      in use by applications on the physical entity.
+    name: cempMemPoolUsed
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.8
+    description: Indicates the number of bytes from the memory pool that are currently
+      unused on the physical entity. Note that the sum of cempMemPoolUsed and cempMemPoolFree
+      is the total amount of memory in the pool
+    name: cempMemPoolFree
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.9
+    description: Indicates the largest number of contiguous bytes from the memory
+      pool that are currently unused on the physical entity.
+    name: cempMemPoolLargestFree
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.10
+    description: The lowest amount of available memory in the memory pool recorded
+      at any time during the operation of the system.
+    name: cempMemPoolLowestFree
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.11
+    description: 'Indicates the lowest number of bytes from the memory pool that have
+      been used by applications on the physical entity since sysUpTime.Similarly,the
+      Used High Watermark indicates the largest number of bytes from the memory pool
+      that have been used by applications on the physical entity since sysUpTime.This
+      can be derived as follows: Used High Watermark = cempMemPoolUsed + cempMemPoolFree
+      - cempMemPoolLowestFree.'
+    name: cempMemPoolUsedLowWaterMark
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.12
+    description: Indicates the number of successful allocations from the memory pool
+    name: cempMemPoolAllocHit
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.13
+    description: Indicates the number of unsuccessful allocations from the memory
+      pool
+    name: cempMemPoolAllocMiss
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.14
+    description: Indicates the number of successful frees/ deallocations from the
+      memory pool
+    name: cempMemPoolFreeHit
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.15
+    description: Indicates the number of unsuccessful attempts to free/deallocate
+      memory from the memory pool. For example, this could be due to ownership errors
+      where the application that did not assign the memory is trying to free it.
+    name: cempMemPoolFreeMiss
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.16
+    description: Indicates the number of bytes from the memory pool that are currently
+      shared on the physical entity.
+    name: cempMemPoolShared
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.17
+    description: This object represents the upper 32-bits of cempMemPoolUsed. This
+      object needs to be supported only if the used bytes in the memory pool exceeds
+      32-bits, otherwise this object value would be set to 0.
+    name: cempMemPoolUsedOvrflw
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.18
+    description: Indicates the number of bytes from the memory pool that are currently
+      in use by applications on the physical entity. This object is a 64-bit version
+      of cempMemPoolUsed.
+    name: cempMemPoolHCUsed
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.19
+    description: This object represents the upper 32-bits of cempMemPoolFree. This
+      object needs to be supported only if the unused bytes in the memory pool exceeds
+      32-bits, otherwise this object value would be set to 0.
+    name: cempMemPoolFreeOvrflw
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.20
+    description: Indicates the number of bytes from the memory pool that are currently
+      unused on the physical entity. This object is a 64-bit version of cempMemPoolFree.
+    name: cempMemPoolHCFree
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.21
+    description: This object represents the upper 32-bits of cempMemPoolLargestFree.
+      This object needs to be supported only if the value of cempMemPoolLargestFree
+      exceeds 32-bits, otherwise this object value would be set to 0.
+    name: cempMemPoolLargestFreeOvrflw
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.22
+    description: Indicates the largest number of contiguous bytes from the memory
+      pool that are currently unused on the physical entity. This object is a 64-bit
+      version of cempMemPoolLargestFree.
+    name: cempMemPoolHCLargestFree
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.23
+    description: This object represents the upper 32-bits of cempMemPoolLowestFree.
+      This object needs to be supported only if the value of cempMemPoolLowestFree
+      exceeds 32-bits, otherwise this object value would be set to 0.
+    name: cempMemPoolLowestFreeOvrflw
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.24
+    description: The lowest amount of available memory in the memory pool recorded
+      at any time during the operation of the system. This object is a 64-bit version
+      of cempMemPoolLowestFree.
+    name: cempMemPoolHCLowestFree
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.25
+    description: This object represents the upper 32-bits of cempMemPoolUsedLowWaterMark.
+      This object needs to be supported only if the value of cempMemPoolUsedLowWaterMark
+      exceeds 32-bits, otherwise this object value would be set to 0.
+    name: cempMemPoolUsedLowWaterMarkOvrflw
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.26
+    description: Indicates the lowest number of bytes from the memory pool that have
+      been used by applications on the physical entity since sysUpTime. This object
+      is a 64-bit version of cempMemPoolUsedLowWaterMark.
+    name: cempMemPoolHCUsedLowWaterMark
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.27
+    description: This object represents the upper 32-bits of cempMemPoolShared. This
+      object needs to be supported only if the value of cempMemPoolShared exceeds
+      32-bits, otherwise this object value would be set to 0.
+    name: cempMemPoolSharedOvrflw
+  - OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.28
+    description: Indicates the number of bytes from the memory pool that are currently
+      shared on the physical entity. This object is a 64-bit version of cempMemPoolShared.
+    name: cempMemPoolHCShared
+  table:
+    OID: 1.3.6.1.4.1.9.9.221.1.1.1
+    description: A table of memory pool monitoring entries for all physical entities
+      on a managed system.
+    name: cempMemPoolTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.1.1.1.1
+    description: The administratively desired power supply redundancy mode.
+    name: cefcPowerRedundancyMode
+  - OID: 1.3.6.1.4.1.9.9.117.1.1.1.1.2
+    description: The units of primary supply to interpret cefcTotalAvailableCurrent
+      and cefcTotalDrawnCurrent as power. For example, one 1000-watt power supply
+      could deliver 100 amperes at 10 volts DC. So the value of cefcPowerUnits would
+      be 'at 10 volts DC'. cefcPowerUnits is for display purposes only.
+    name: cefcPowerUnits
+  - OID: 1.3.6.1.4.1.9.9.117.1.1.1.1.3
+    description: Total current available for FRU usage.
+    name: cefcTotalAvailableCurrent
+  - OID: 1.3.6.1.4.1.9.9.117.1.1.1.1.4
+    description: Total current drawn by powered-on FRUs.
+    name: cefcTotalDrawnCurrent
+  - OID: 1.3.6.1.4.1.9.9.117.1.1.1.1.5
+    description: The power supply redundancy operational mode.
+    name: cefcPowerRedundancyOperMode
+  - OID: 1.3.6.1.4.1.9.9.117.1.1.1.1.6
+    description: This object has the value of notApplicable(1) when cefcPowerRedundancyOperMode
+      of the instance does not have the value of nonRedundant(4). The other values
+      explain the reason why cefcPowerRedundancyOperMode is nonRedundant(4), e.g.
+      unknown(2) the reason is not identified. singleSupply(3) There is only one power
+      supply in the group. mismatchedSupplies(4) There are more than one power supplies
+      in the groups. However they are mismatched and can not work redundantly. supplyError(5)
+      Some power supply or supplies does or do not working properly.
+    name: cefcPowerNonRedundantReason
+  - OID: 1.3.6.1.4.1.9.9.117.1.1.1.1.7
+    description: Total inline current drawn for inline operation.
+    name: cefcTotalDrawnInlineCurrent
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.1.1
+    description: This table lists the redundancy mode and the operational status of
+      the power supply groups in the system.
+    name: cefcFRUPowerSupplyGroupTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.117.1.1.3.0
+    description: The system will provide power to the device connecting to the FRU
+      if the device needs power, like an IP Phone. We call the providing power inline
+      power. This MIB object controls the maximum default inline power for the device
+      connecting to the FRU in the system. If the maximum default inline power of
+      the device is greater than the maximum value reportable by this object, then
+      this object should report its maximum reportable value (12500) and cefcMaxDefaultHighInLinePower
+      must be used to report the actual maximum default inline power.
+    name: cefcMaxDefaultInLinePower
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.1.4.1.1
+    description: Total current that could be supplied by the FRU (positive values)
+      for system operations.
+    name: cefcFRUTotalSystemCurrent
+  - OID: 1.3.6.1.4.1.9.9.117.1.1.4.1.2
+    description: Amount of current drawn by the FRU's in the system towards system
+      operations from this FRU
+    name: cefcFRUDrawnSystemCurrent
+  - OID: 1.3.6.1.4.1.9.9.117.1.1.4.1.3
+    description: Total current supplied by the FRU (positive values) for inline operations.
+    name: cefcFRUTotalInlineCurrent
+  - OID: 1.3.6.1.4.1.9.9.117.1.1.4.1.4
+    description: Amount of current that is being drawn from this FRU for inline operation.
+    name: cefcFRUDrawnInlineCurrent
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.1.4
+    description: This table lists the power capacity of a power FRU in the system
+      if it provides variable power. Power supplies usually provide either system
+      or inline power. They cannot be controlled by software to dictate how they distribute
+      power. We can also have what are known as variable power supplies. They can
+      provide both system and inline power and can be varied within hardware defined
+      ranges for system and inline limited by a total maximum combined output. They
+      could be configured by the user via CLI or SNMP or be controlled by software
+      internally. This table supplements the information in the cefcFRUPowerStatusTable
+      for power supply FRUs. The cefcFRUCurrent attribute in that table provides the
+      overall current the power supply FRU can provide while this table gives us the
+      individual contribution towards system and inline power.
+    name: cefcFRUPowerSupplyValueTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.117.1.1.5.0
+    description: The system will provide power to the device connecting to the FRU
+      if the device needs power, like an IP Phone. We call the providing power inline
+      power. This MIB object controls the maximum default inline power for the device
+      connecting to the FRU in the system.
+    name: cefcMaxDefaultHighInLinePower
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.1
+    description: This object provides administrative control of the module.
+    name: cefcModuleAdminStatus
+  - OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.2
+    description: This object shows the module's operational state.
+    name: cefcModuleOperStatus
+  - OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.3
+    description: This object identifies the reason for the last reset performed on
+      the module.
+    name: cefcModuleResetReason
+  - OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.4
+    description: The value of sysUpTime at the time the cefcModuleOperStatus is changed.
+    name: cefcModuleStatusLastChangeTime
+  - OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.5
+    description: The value of sysUpTime when the configuration was most recently cleared.
+    name: cefcModuleLastClearConfigTime
+  - OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.6
+    description: 'A description qualifying the module reset reason specified in cefcModuleResetReason.
+      Examples: command xyz missing task switch over watchdog timeout etc. cefcModuleResetReasonDescription
+      is for display purposes only. NMS applications must not parse.'
+    name: cefcModuleResetReasonDescription
+  - OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.7
+    description: 'This object displays human-readable textual string which describes
+      the cause of the last state change of the module. This object contains zero
+      length string if no meaningful reason could be provided. Examples: ''Invalid
+      software version'' ''Software download failed'' ''Software version mismatch''
+      ''Module is in standby state'' etc. This object is for display purposes only.
+      NMS applications must not parse this object and take any decision based on its
+      value.'
+    name: cefcModuleStateChangeReasonDescr
+  - OID: 1.3.6.1.4.1.9.9.117.1.2.1.1.8
+    description: This object provides the up time for the module since it was last
+      re-initialized. This object is not persistent; if a module reset, restart, power
+      off, the up time starts from zero.
+    name: cefcModuleUpTime
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.2.1
+    description: A cefcModuleTable entry lists the operational and administrative
+      status information for ENTITY-MIB entPhysicalTable entries for manageable components
+      of type PhysicalClass module(9).
+    name: cefcModuleTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.2.2.1.1
+    description: The type of Internet address by which the intelligent module is reachable.
+    name: cefcIntelliModuleIPAddrType
+  - OID: 1.3.6.1.4.1.9.9.117.1.2.2.1.2
+    description: The Internet address configured for the intelligent module. The type
+      of this address is determined by the value of the object cefcIntelliModuleIPAddrType.
+    name: cefcIntelliModuleIPAddr
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.2.2
+    description: This table sparsely augments the cefcModuleTable (i.e., every row
+      in this table corresponds to a row in the cefcModuleTable but not necessarily
+      vice-versa). A cefcIntelliModuleTable entry lists the information specific to
+      intelligent modules which cannot be provided by the cefcModuleTable.
+    name: cefcIntelliModuleTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.2.3.1.1
+    description: This object specifies the mode of local switching. enabled(1) - local
+      switching is enabled. disabled(2) - local switching is disabled.
+    name: cefcModuleLocalSwitchingMode
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.2.3
+    description: This table sparsely augments the cefcModuleTable (i.e., every row
+      in this table corresponds to a row in the cefcModuleTable but not necessarily
+      vice-versa). A cefcModuleLocalSwitchingTable entry lists the information specific
+      to local switching capable modules which cannot be provided by the cefcModuleTable.
+    name: cefcModuleLocalSwitchingTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.5.1.1.1
+    description: The status of this physical entity. other(1) - the status is not
+      any of the listed below. supported(2) - this entity is supported. unsupported(3)
+      - this entity is unsupported. incompatible(4) - this entity is incompatible.
+      It would be unsupported(3), if the ID read from Serial EPROM is not supported.
+      It would be incompatible(4), if in the present configuration this FRU is not
+      supported.
+    name: cefcPhysicalStatus
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.5.1
+    description: This table contains one row per physical entity.
+    name: cefcPhysicalTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.6.1.1.1
+    description: A unique value, greater than zero, for each input on a power supply.
+    name: cefcPowerSupplyInputIndex
+  - OID: 1.3.6.1.4.1.9.9.117.1.6.1.1.2
+    description: 'The type of an input power detected on the power supply. unknown(1):
+      No input power is detected. acLow(2): Lower rating AC input power is detected.
+      acHigh(3): Higher rating AC input power is detected. dcLow(4): Lower rating
+      DC input power is detected. dcHigh(5): Higher rating DC input power is detected.'
+    name: cefcPowerSupplyInputType
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.6.1
+    description: This table contains the power input information for all the power
+      supplies that have entPhysicalTable entries with 'powerSupply' in the entPhysicalClass.
+      The entries are created by the agent at the system power-up or power supply
+      insertion. Entries are deleted by the agent upon power supply removal. The number
+      of entries is determined by the number of power supplies and number of power
+      inputs on the power supply.
+    name: cefcPowerSupplyInputTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.6.2.1.1
+    description: A unique value, greater than zero, for each possible output mode
+      on a power supply.
+    name: cefcPSOutputModeIndex
+  - OID: 1.3.6.1.4.1.9.9.117.1.6.2.1.2
+    description: The output capacity of the power supply.
+    name: cefcPSOutputModeCurrent
+  - OID: 1.3.6.1.4.1.9.9.117.1.6.2.1.3
+    description: A value of 'true' indicates that this mode is the operational mode
+      of the power supply output capacity. A value of 'false' indicates that this
+      mode is not the operational mode of the power supply output capacity. For a
+      given power supply's entPhysicalIndex, at most one instance of this object can
+      have the value of true(1).
+    name: cefcPSOutputModeInOperation
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.6.2
+    description: This table contains a list of possible output mode for the power
+      supplies, whose ENTITY-MIB entPhysicalTable entries have an entPhysicalClass
+      of 'powerSupply'. It also indicate which mode is the operational mode within
+      the system.
+    name: cefcPowerSupplyOutputTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.7.1.1.1
+    description: The maximum cooling capacity that could be provided for any slot
+      in this chassis. The default unit of the cooling capacity is 'cfm', if cefcChassisPerSlotCoolingUnit
+      is not supported.
+    name: cefcChassisPerSlotCoolingCap
+  - OID: 1.3.6.1.4.1.9.9.117.1.7.1.1.2
+    description: The unit of the maximum cooling capacity for any slot in this chassis.
+    name: cefcChassisPerSlotCoolingUnit
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.7.1
+    description: This table contains the cooling capacity information of the chassis
+      whose ENTITY-MIB entPhysicalTable entries have an entPhysicalClass of 'chassis'.
+    name: cefcChassisCoolingTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.7.2.1.1
+    description: The cooling capacity that is provided by this fan. The default unit
+      of the fan cooling capacity is 'cfm', if cefcFanCoolingCapacityUnit is not supported.
+    name: cefcFanCoolingCapacity
+  - OID: 1.3.6.1.4.1.9.9.117.1.7.2.1.2
+    description: The unit of the fan cooling capacity.
+    name: cefcFanCoolingCapacityUnit
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.7.2
+    description: This table contains the cooling capacity information of the fans
+      whose ENTITY-MIB entPhysicalTable entries have an entPhysicalClass of 'fan'.
+    name: cefcFanCoolingTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.7.3.1.1
+    description: The cooling requirement of the module and its daughter cards. The
+      default unit of the module cooling requirement is 'cfm', if cefcModuleCoolingUnit
+      is not supported.
+    name: cefcModuleCooling
+  - OID: 1.3.6.1.4.1.9.9.117.1.7.3.1.2
+    description: The unit of the cooling requirement of the module and its daughter
+      cards.
+    name: cefcModuleCoolingUnit
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.7.3
+    description: This table contains the cooling requirement for all the manageable
+      components of type entPhysicalClass 'module'.
+    name: cefcModuleCoolingTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.7.4.1.1
+    description: An arbitrary value that uniquely identifies a cooling capacity mode
+      for a fan.
+    name: cefcFanCoolingCapIndex
+  - OID: 1.3.6.1.4.1.9.9.117.1.7.4.1.2
+    description: A textual description of the cooling capacity mode of the fan.
+    name: cefcFanCoolingCapModeDescr
+  - OID: 1.3.6.1.4.1.9.9.117.1.7.4.1.3
+    description: The cooling capacity that could be provided when the fan is operating
+      in this mode. The default unit of the cooling capacity is 'cfm', if cefcFanCoolingCapCapacityUnit
+      is not supported.
+    name: cefcFanCoolingCapCapacity
+  - OID: 1.3.6.1.4.1.9.9.117.1.7.4.1.4
+    description: The power consumption of the fan when operating in in this mode.
+    name: cefcFanCoolingCapCurrent
+  - OID: 1.3.6.1.4.1.9.9.117.1.7.4.1.5
+    description: The unit of the fan cooling capacity when operating in this mode.
+    name: cefcFanCoolingCapCapacityUnit
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.7.4
+    description: This table contains a list of the possible cooling capacity modes
+      and properties of the fans, whose ENTITY-MIB entPhysicalTable entries have an
+      entPhysicalClass of 'fan'.
+    name: cefcFanCoolingCapTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.8.1.1.1
+    description: The maximum power that the component's connector can withdraw.
+    name: cefcConnectorRating
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.8.1
+    description: This table contains the connector power ratings of FRUs. Only components
+      with power connector rating management are listed in this table.
+    name: cefcConnectorRatingTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.117.1.8.2.1.1
+    description: The combined power consumption to operate the module and its submodule(s)
+      and inline-power device(s).
+    name: cefcModulePowerConsumption
+  table:
+    OID: 1.3.6.1.4.1.9.9.117.1.8.2
+    description: This table contains the total power consumption information for modules
+      whose ENTITY-MIB entPhysicalTable entries have an entPhysicalClass of 'module'.
+    name: cefcModulePowerConsumptionTable
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.117.1.3.1.0
+    description: 'This variable indicates whether the system produces the following
+      notifications: cefcModuleStatusChange, cefcPowerStatusChange, cefcFRUInserted,
+      cefcFRURemoved, cefcUnrecognizedFRU and cefcFanTrayStatusChange. A false value
+      will prevent these notifications from being generated.'
+    name: cefcMIBEnableStatusNotification
+- MIB: CISCO-ENTITY-FRU-CONTROL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.117.1.3.2.0
+    description: This variable indicates whether the system produces the cefcPowerSupplyOutputChange
+      notifications when the output capacity of a power supply has changed. A false
+      value will prevent this notification to generated.
+    name: cefcEnablePSOutputChangeNotif
+- MIB: CISCO-ENTITY-SENSOR-EXT-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.745.1.1.1.1
+    description: An index that uniquely identifies an entry in the ceSensorExtThresholdTable.
+      This index permits the same sensor to have several different thresholds.
+    name: ceSensorExtThresholdIndex
+  - OID: 1.3.6.1.4.1.9.9.745.1.1.1.2
+    description: This object specifies the severity of this threshold.
+    name: ceSensorExtThresholdSeverity
+  - OID: 1.3.6.1.4.1.9.9.745.1.1.1.3
+    description: 'This object specifies the boolean relation between sensor value
+      (entPhySensorValue) and threshold value (ceSensorExtThresholdValue), required
+      to trigger the alarm. in pseudo-code, the evaluation-alarm mechanism is: ...
+      if (evaluate(entPhySensorValue, ceSensorExtThresholdRelation, ceSensorExtThresholdValue))
+      then if (((ceSensorExtThresholdNotifEnable == enabled) || (ceSensorExtThresholdNotifEnable
+      == transparent)) && (ceSensorExtThresholdNotifGlobalEnable == enabled)) then
+      raise_alarm(sensor''s entPhysicalIndex); endif endif ...'
+    name: ceSensorExtThresholdRelation
+  - OID: 1.3.6.1.4.1.9.9.745.1.1.1.4
+    description: This object specifies the value of the threshold. The value of objects
+      entPhySensorType, entPhysSensorScale and entPhySensorPrecision for this sensor
+      entity defines how ceSensorExtThresholdValue can be displayed or intepreted
+      by the user. entPhySensorValue can be compared with ceSensorExtThresholdValue
+      without taking care of semantics of both objects.
+    name: ceSensorExtThresholdValue
+  - OID: 1.3.6.1.4.1.9.9.745.1.1.1.5
+    description: This object indicates the result of the most recent evaluation of
+      the threshold. The agent will execute the below 'evaluate' function to generate
+      the notification. 'evaluate' function returns a boolean value. evaluate(entPhySensorValue,
+      ceSensorExtThresholdRelation, ceSensorExtThresholdValue) If evalute function
+      returns true then ceSensorExtThresholdEvaluation is set to 'true' If evaluate
+      function returns false then ceSensorExtThresholdEvaluation is set to 'false'.
+      Thresholds are evaluated at the rate indicated by entPhySensorValueUpdateRate.
+    name: ceSensorExtThresholdEvaluation
+  - OID: 1.3.6.1.4.1.9.9.745.1.1.1.6
+    description: A control object to activate/deactivate ceSensorExtThresholdNotification.
+      This object should hold any of the below values. enabled(1) - The notification
+      is enabled for this entity disabled(2) - The notification is disabled for this
+      entity transparent(3)- The notification is enabled/disabled based on ceSensorExtThresholdNotifGlobalEnable
+      object This object controls generation of ceSensorExtThresholdNotification for
+      this threshold. An exception to this is, if this object is set to 'transparent'
+      then ceSensorExtThresholdNotification for this threshold is controlled by ceSensorExtThresholdNotifGlobalEnable
+      object. This truth table explains how ceSensorExtThresholdNotifEnable is related
+      with ceSensorExtThresholdNotifGlobalEnable to control the ceSensorExtThresholdNotification
+      for this threshold E = enabled, D = Disabled, T = Transparent local_flag = ceSensorExtThresholdNotifEnable
+      global_flag = ceSensorExtThresholdNotifGlobalEnable local_flag global_flag outcome_per_interface
+      --------------------------------------------- E E E E D D D E D D D D T E E
+      T D D
+    name: ceSensorExtThresholdNotifEnable
+  table:
+    OID: 1.3.6.1.4.1.9.9.745.1.1
+    description: This table lists the threshold severity, relation, and comparison
+      value, for a sensor entity listed in entPhysicalTable.
+    name: ceSensorExtThresholdTable
+- MIB: CISCO-FIREWALL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.147.1.2.2.1.1.1
+    description: This object contains the size of the set of buffers for which this
+      row contains the statistics given by cfwBufferStatType.
+    name: cfwBufferStatSize
+  - OID: 1.3.6.1.4.1.9.9.147.1.2.2.1.1.2
+    description: This object identifies the type of statistic given by this row for
+      the particular set of buffers identified by cfwBufferStatSize.
+    name: cfwBufferStatType
+  - OID: 1.3.6.1.4.1.9.9.147.1.2.2.1.1.3
+    description: A detailed textual description of the statistic identified by cfwBufferStatType.
+    name: cfwBufferStatInformation
+  - OID: 1.3.6.1.4.1.9.9.147.1.2.2.1.1.4
+    description: The value of the buffer statistic.
+    name: cfwBufferStatValue
+  table:
+    OID: 1.3.6.1.4.1.9.9.147.1.2.2.1
+    description: A table conatining status information about a firewall's buffers.
+    name: cfwBufferStatsTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.1.1.0
+    description: The level of the IPsec MIB.
+    name: cipSecMibLevel
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.1.0
+    description: The number of currently active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalActiveTunnels
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.2.0
+    description: The total number of previously active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalPreviousTunnels
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.3.0
+    description: The total number of octets received by all currently and previously
+      active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalInOctets
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.4.0
+    description: The total number of packets received by all currently and previously
+      active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalInPkts
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.5.0
+    description: The total number of packets which were dropped during receive processing
+      by all currently and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalInDropPkts
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.6.0
+    description: The total number of notifys received by all currently and previously
+      active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalInNotifys
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.7.0
+    description: The total number of IPsec Phase-2 exchanges received by all currently
+      and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalInP2Exchgs
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.8.0
+    description: The total number of IPsec Phase-2 exchanges which were received and
+      found to be invalid by all currently and previously active IPsec Phase-1 IKE
+      Tunnels.
+    name: cikeGlobalInP2ExchgInvalids
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.9.0
+    description: The total number of IPsec Phase-2 exchanges which were received and
+      rejected by all currently and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalInP2ExchgRejects
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.10.0
+    description: The total number of IPsec Phase-2 security association delete requests
+      received by all currently and previously active and IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalInP2SaDelRequests
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.11.0
+    description: The total number of octets sent by all currently and previously active
+      and IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalOutOctets
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.12.0
+    description: The total number of packets sent by all currently and previously
+      active and IPsec Phase-1 Tunnels.
+    name: cikeGlobalOutPkts
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.13.0
+    description: The total number of packets which were dropped during send processing
+      by all currently and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalOutDropPkts
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.14.0
+    description: The total number of notifys sent by all currently and previously
+      active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalOutNotifys
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.15.0
+    description: The total number of IPsec Phase-2 exchanges which were sent by all
+      currently and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalOutP2Exchgs
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.16.0
+    description: The total number of IPsec Phase-2 exchanges which were sent and found
+      to be invalid by all currently and previously active IPsec Phase-1 Tunnels.
+    name: cikeGlobalOutP2ExchgInvalids
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.17.0
+    description: The total number of IPsec Phase-2 exchanges which were sent and rejected
+      by all currently and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalOutP2ExchgRejects
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.18.0
+    description: The total number of IPsec Phase-2 SA delete requests sent by all
+      currently and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalOutP2SaDelRequests
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.19.0
+    description: The total number of IPsec Phase-1 IKE Tunnels which were locally
+      initiated.
+    name: cikeGlobalInitTunnels
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.20.0
+    description: The total number of IPsec Phase-1 IKE Tunnels which were locally
+      initiated and failed to activate.
+    name: cikeGlobalInitTunnelFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.21.0
+    description: The total number of IPsec Phase-1 IKE Tunnels which were remotely
+      initiated and failed to activate.
+    name: cikeGlobalRespTunnelFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.22.0
+    description: The total number of system capacity failures which occurred during
+      processing of all current and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalSysCapFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.23.0
+    description: The total number of authentications which ended in failure by all
+      current and previous IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalAuthFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.24.0
+    description: The total number of decryptions which ended in failure by all current
+      and previous IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalDecryptFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.25.0
+    description: The total number of hash validations which ended in failure by all
+      current and previous IPsec Phase-1 IKE Tunnels.
+    name: cikeGlobalHashValidFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.1.26.0
+    description: The total number of non-existent Security Association in failures
+      which occurred during processing of all current and previous IPsec Phase-1 IKE
+      Tunnels.
+    name: cikeGlobalNoSaFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.2.1.1
+    description: 'The type of local peer identity. The local peer may be identified
+      by: 1. an IP address, or 2. a host name.'
+    name: cikePeerLocalType
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.2.1.2
+    description: The value of the local peer identity. If the local peer type is an
+      IP Address, then this is the IP Address used to identify the local peer. If
+      the local peer type is a host name, then this is the host name used to identify
+      the local peer.
+    name: cikePeerLocalValue
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.2.1.3
+    description: 'The type of remote peer identity. The remote peer may be identified
+      by: 1. an IP address, or 2. a host name.'
+    name: cikePeerRemoteType
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.2.1.4
+    description: The value of the remote peer identity. If the remote peer type is
+      an IP Address, then this is the IP Address used to identify the remote peer.
+      If the remote peer type is a host name, then this is the host name used to identify
+      the remote peer.
+    name: cikePeerRemoteValue
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.2.1.5
+    description: The internal index of the local-remote peer association. This internal
+      index is used to uniquely identify multiple associations between the local and
+      remote peer.
+    name: cikePeerIntIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.2.1.6
+    description: The IP address of the local peer.
+    name: cikePeerLocalAddr
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.2.1.7
+    description: The IP address of the remote peer.
+    name: cikePeerRemoteAddr
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.2.1.8
+    description: The length of time that the peer association has existed in hundredths
+      of a second.
+    name: cikePeerActiveTime
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.2.1.9
+    description: The index of the active IPsec Phase-1 IKE Tunnel (cikeTunIndex in
+      the cikeTunnelTable) for this peer association. If an IPsec Phase-1 IKE Tunnel
+      is not currently active, then the value of this object will be zero.
+    name: cikePeerActiveTunnelIndex
+  table:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.2
+    description: The IPsec Phase-1 Internet Key Exchange Peer Table. There is one
+      entry in this table for each IPsec Phase-1 IKE peer association which is currently
+      associated with an active IPsec Phase-1 Tunnel. The IPsec Phase-1 IKE Tunnel
+      associated with this IPsec Phase-1 IKE peer association may or may not be currently
+      active.
+    name: cikePeerTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.1
+    description: The index of the IPsec Phase-1 IKE Tunnel Table. The value of the
+      index is a number which begins at one and is incremented with each tunnel that
+      is created. The value of this object will wrap at 2,147,483,647.
+    name: cikeTunIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.2
+    description: 'The type of local peer identity. The local peer may be identified
+      by: 1. an IP address, or 2. a host name.'
+    name: cikeTunLocalType
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.3
+    description: The value of the local peer identity. If the local peer type is an
+      IP Address, then this is the IP Address used to identify the local peer. If
+      the local peer type is a host name, then this is the host name used to identify
+      the local peer.
+    name: cikeTunLocalValue
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.4
+    description: The IP address of the local endpoint for the IPsec Phase-1 IKE Tunnel.
+    name: cikeTunLocalAddr
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.5
+    description: The DNS name of the local IP address for the IPsec Phase-1 IKE Tunnel.
+      If the DNS name associated with the local tunnel endpoint is not known, then
+      the value of this object will be a NULL string.
+    name: cikeTunLocalName
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.6
+    description: 'The type of remote peer identity. The remote peer may be identified
+      by: 1. an IP address, or 2. a host name.'
+    name: cikeTunRemoteType
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.7
+    description: The value of the remote peer identity. If the remote peer type is
+      an IP Address, then this is the IP Address used to identify the remote peer.
+      If the remote peer type is a host name, then this is the host name used to identify
+      the remote peer.
+    name: cikeTunRemoteValue
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.8
+    description: The IP address of the remote endpoint for the IPsec Phase-1 IKE Tunnel.
+    name: cikeTunRemoteAddr
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.9
+    description: The DNS name of the remote IP address of IPsec Phase-1 IKE Tunnel.
+      If the DNS name associated with the remote tunnel endpoint is not known, then
+      the value of this object will be a NULL string.
+    name: cikeTunRemoteName
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.10
+    description: The negotiation mode of the IPsec Phase-1 IKE Tunnel.
+    name: cikeTunNegoMode
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.11
+    description: The Diffie Hellman Group used in IPsec Phase-1 IKE negotiations.
+    name: cikeTunDiffHellmanGrp
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.12
+    description: The encryption algorithm used in IPsec Phase-1 IKE negotiations.
+    name: cikeTunEncryptAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.13
+    description: The hash algorithm used in IPsec Phase-1 IKE negotiations.
+    name: cikeTunHashAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.14
+    description: The authentication method used in IPsec Phase-1 IKE negotiations.
+    name: cikeTunAuthMethod
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.15
+    description: The negotiated LifeTime of the IPsec Phase-1 IKE Tunnel in seconds.
+    name: cikeTunLifeTime
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.16
+    description: The length of time the IPsec Phase-1 IKE tunnel has been active in
+      hundredths of seconds.
+    name: cikeTunActiveTime
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.17
+    description: The security association refresh threshold in seconds.
+    name: cikeTunSaRefreshThreshold
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.18
+    description: The total number of security associations refreshes performed.
+    name: cikeTunTotalRefreshes
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.19
+    description: The total number of octets received by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunInOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.20
+    description: The total number of packets received by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunInPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.21
+    description: The total number of packets dropped by this IPsec Phase-1 IKE Tunnel
+      during receive processing.
+    name: cikeTunInDropPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.22
+    description: The total number of notifys received by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunInNotifys
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.23
+    description: The total number of IPsec Phase-2 exchanges received by this IPsec
+      Phase-1 IKE Tunnel.
+    name: cikeTunInP2Exchgs
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.24
+    description: The total number of IPsec Phase-2 exchanges received and found to
+      be invalid by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunInP2ExchgInvalids
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.25
+    description: The total number of IPsec Phase-2 exchanges received and rejected
+      by this IPsec Phase-1 Tunnel.
+    name: cikeTunInP2ExchgRejects
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.26
+    description: The total number of IPsec Phase-2 security association delete requests
+      received by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunInP2SaDelRequests
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.27
+    description: The total number of octets sent by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunOutOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.28
+    description: The total number of packets sent by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunOutPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.29
+    description: The total number of packets dropped by this IPsec Phase-1 IKE Tunnel
+      during send processing.
+    name: cikeTunOutDropPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.30
+    description: The total number of notifys sent by this IPsec Phase-1 Tunnel.
+    name: cikeTunOutNotifys
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.31
+    description: The total number of IPsec Phase-2 exchanges sent by this IPsec Phase-1
+      IKE Tunnel.
+    name: cikeTunOutP2Exchgs
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.32
+    description: The total number of IPsec Phase-2 exchanges sent and found to be
+      invalid by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunOutP2ExchgInvalids
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.33
+    description: The total number of IPsec Phase-2 exchanges sent and rejected by
+      this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunOutP2ExchgRejects
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.34
+    description: The total number of IPsec Phase-2 security association delete requests
+      sent by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunOutP2SaDelRequests
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.3.1.35
+    description: The status of the MIB table row. This object can be used to bring
+      the tunnel down by setting value of this object to destroy(2). This object cannot
+      be used to create a MIB table row.
+    name: cikeTunStatus
+  table:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.3
+    description: The IPsec Phase-1 Internet Key Exchange Tunnel Table. There is one
+      entry in this table for each active IPsec Phase-1 IKE Tunnel.
+    name: cikeTunnelTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.4.1.1
+    description: 'The type of local peer identity. The local peer may be identified
+      by: 1. an IP address, or 2. a host name.'
+    name: cikePeerCorrLocalType
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.4.1.2
+    description: The value of the local peer identity. If the local peer type is an
+      IP Address, then this is the IP Address used to identify the local peer. If
+      the local peer type is a host name, then this is the host name used to identify
+      the local peer.
+    name: cikePeerCorrLocalValue
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.4.1.3
+    description: 'The type of remote peer identity. The remote peer may be identified
+      by: 1. an IP address, or 2. a host name.'
+    name: cikePeerCorrRemoteType
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.4.1.4
+    description: The value of the remote peer identity. If the remote peer type is
+      an IP Address, then this is the IP Address used to identify the remote peer.
+      If the remote peer type is a host name, then this is the host name used to identify
+      the remote peer.
+    name: cikePeerCorrRemoteValue
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.4.1.5
+    description: The internal index of the local-remote peer association. This internal
+      index is used to uniquely identify multiple associations between the local and
+      remote peer.
+    name: cikePeerCorrIntIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.4.1.6
+    description: The sequence number of the local-remote peer association. This sequence
+      number is used to uniquely identify multiple instances of an unique association
+      between the local and remote peer.
+    name: cikePeerCorrSeqNum
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.4.1.7
+    description: The index of the active IPsec Phase-2 Tunnel (cipSecTunIndex in the
+      cipSecTunnelTable) for this IPsec Phase-1 IKE Peer Association.
+    name: cikePeerCorrIpSecTunIndex
+  table:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.4
+    description: The IPsec Phase-1 Internet Key Exchange Peer Association to IPsec
+      Phase-2 Tunnel Correlation Table. There is one entry in this table for each
+      active IPsec Phase-2 Tunnel.
+    name: cikePeerCorrTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.1
+    description: The number of currently active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWActiveTunnels
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.2
+    description: The total number of previously active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWPreviousTunnels
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.3
+    description: The total number of octets received by all currently and previously
+      active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWInOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.4
+    description: The total number of packets received by all currently and previously
+      active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWInPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.5
+    description: The total number of packets which were dropped during receive processing
+      by all currently and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWInDropPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.6
+    description: The total number of notifys received by all currently and previously
+      active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWInNotifys
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.7
+    description: The total number of IPsec Phase-2 exchanges received by all currently
+      and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWInP2Exchgs
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.8
+    description: The total number of IPsec Phase-2 exchanges which were received and
+      found to be invalid by all currently and previously active IPsec Phase-1 IKE
+      Tunnels.
+    name: cikePhase1GWInP2ExchgInvalids
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.9
+    description: The total number of IPsec Phase-2 exchanges which were received and
+      rejected by all currently and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWInP2ExchgRejects
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.10
+    description: The total number of IPsec Phase-2 'Security Association' delete requests
+      received by all currently and previously active and IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWInP2SaDelRequests
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.11
+    description: The total number of octets sent by all currently and previously active
+      and IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWOutOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.12
+    description: The total number of packets sent by all currently and previously
+      active and IPsec Phase-1 Tunnels.
+    name: cikePhase1GWOutPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.13
+    description: The total number of packets which were dropped during send processing
+      by all currently and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWOutDropPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.14
+    description: The total number of notifys sent by all currently and previously
+      active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWOutNotifys
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.15
+    description: The total number of IPsec Phase-2 exchanges which were sent by all
+      currently and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWOutP2Exchgs
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.16
+    description: The total number of IPsec Phase-2 exchanges which were sent and found
+      to be invalid by all currently and previously active IPsec Phase-1 Tunnels.
+    name: cikePhase1GWOutP2ExchgInvalids
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.17
+    description: The total number of IPsec Phase-2 exchanges which were sent and rejected
+      by all currently and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWOutP2ExchgRejects
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.18
+    description: The total number of IPsec Phase-2 SA delete requests sent by all
+      currently and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWOutP2SaDelRequests
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.19
+    description: The total number of IPsec Phase-1 IKE Tunnels which were locally
+      initiated.
+    name: cikePhase1GWInitTunnels
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.20
+    description: The total number of IPsec Phase-1 IKE Tunnels which were locally
+      initiated and failed to activate.
+    name: cikePhase1GWInitTunnelFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.21
+    description: The total number of IPsec Phase-1 IKE Tunnels which were remotely
+      initiated and failed to activate.
+    name: cikePhase1GWRespTunnelFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.22
+    description: The total number of system capacity failures which occurred during
+      processing of all current and previously active IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWSysCapFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.23
+    description: The total number of authentications which ended in failure by all
+      current and previous IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWAuthFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.24
+    description: The total number of decryptions which ended in failure by all current
+      and previous IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWDecryptFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.25
+    description: The total number of hash validations which ended in failure by all
+      current and previous IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWHashValidFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.2.5.1.26
+    description: The total number of non-existent 'Security Association' failures
+      occurred during processing of current and previous IPsec Phase-1 IKE Tunnels.
+    name: cikePhase1GWNoSaFails
+  table:
+    OID: 1.3.6.1.4.1.9.9.171.1.2.5
+    description: Phase-1 IKE stats information is included in this table. Each entry
+      is related to a specific gateway which is identified by 'cmgwIndex'.
+    name: cikePhase1GWStatsTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.1.0
+    description: The total number of currently active IPsec Phase-2 Tunnels.
+    name: cipSecGlobalActiveTunnels
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.2.0
+    description: The total number of previously active IPsec Phase-2 Tunnels.
+    name: cipSecGlobalPreviousTunnels
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.3.0
+    description: The total number of octets received by all current and previous IPsec
+      Phase-2 Tunnels. This value is accumulated BEFORE determining whether or not
+      the packet should be decompressed. See also cipSecGlobalInOctWraps for the number
+      of times this counter has wrapped.
+    name: cipSecGlobalInOctets
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.4.0
+    description: A high capacity count of the total number of octets received by all
+      current and previous IPsec Phase-2 Tunnels. This value is accumulated BEFORE
+      determining whether or not the packet should be decompressed.
+    name: cipSecGlobalHcInOctets
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.5.0
+    description: The number of times the global octets received counter (cipSecGlobalInOctets)
+      has wrapped.
+    name: cipSecGlobalInOctWraps
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.6.0
+    description: The total number of decompressed octets received by all current and
+      previous IPsec Phase-2 Tunnels. This value is accumulated AFTER the packet is
+      decompressed. If compression is not being used, this value will match the value
+      of cipSecGlobalInOctets. See also cipSecGlobalInDecompOctWraps for the number
+      of times this counter has wrapped.
+    name: cipSecGlobalInDecompOctets
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.7.0
+    description: A high capacity count of the total number of decompressed octets
+      received by all current and previous IPsec Phase-2 Tunnels. This value is accumulated
+      AFTER the packet is decompressed. If compression is not being used, this value
+      will match the value of cipSecGlobalHcInOctets.
+    name: cipSecGlobalHcInDecompOctets
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.8.0
+    description: The number of times the global decompressed octets received counter
+      (cipSecGlobalInDecompOctets) has wrapped.
+    name: cipSecGlobalInDecompOctWraps
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.9.0
+    description: The total number of packets received by all current and previous
+      IPsec Phase-2 Tunnels.
+    name: cipSecGlobalInPkts
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.10.0
+    description: The total number of packets dropped during receive processing by
+      all current and previous IPsec Phase-2 Tunnels. This count does NOT include
+      packets dropped due to Anti-Replay processing.
+    name: cipSecGlobalInDrops
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.11.0
+    description: The total number of packets dropped during receive processing due
+      to Anti-Replay processing by all current and previous IPsec Phase-2 Tunnels.
+    name: cipSecGlobalInReplayDrops
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.12.0
+    description: The total number of inbound authentication's performed by all current
+      and previous IPsec Phase-2 Tunnels.
+    name: cipSecGlobalInAuths
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.13.0
+    description: The total number of inbound authentication's which ended in failure
+      by all current and previous IPsec Phase-2 Tunnels.
+    name: cipSecGlobalInAuthFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.14.0
+    description: The total number of inbound decryption's performed by all current
+      and previous IPsec Phase-2 Tunnels.
+    name: cipSecGlobalInDecrypts
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.15.0
+    description: The total number of inbound decryption's which ended in failure by
+      all current and previous IPsec Phase-2 Tunnels.
+    name: cipSecGlobalInDecryptFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.16.0
+    description: The total number of octets sent by all current and previous IPsec
+      Phase-2 Tunnels. This value is accumulated AFTER determining whether or not
+      the packet should be compressed. See also cipSecGlobalOutOctWraps for the number
+      of times this counter has wrapped.
+    name: cipSecGlobalOutOctets
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.17.0
+    description: A high capacity count of the total number of octets sent by all current
+      and previous IPsec Phase-2 Tunnels. This value is accumulated AFTER determining
+      whether or not the packet should be compressed.
+    name: cipSecGlobalHcOutOctets
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.18.0
+    description: The number of times the global octets sent counter (cipSecGlobalOutOctets)
+      has wrapped.
+    name: cipSecGlobalOutOctWraps
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.19.0
+    description: The total number of uncompressed octets sent by all current and previous
+      IPsec Phase-2 Tunnels. This value is accumulated BEFORE the packet is compressed.
+      If compression is not being used, this value will match the value of cipSecGlobalOutOctets.
+      See also cipSecGlobalOutDecompOctWraps for the number of times this counter
+      has wrapped.
+    name: cipSecGlobalOutUncompOctets
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.20.0
+    description: A high capacity count of the total number of uncompressed octets
+      sent by all current and previous IPsec Phase-2 Tunnels. This value is accumulated
+      BEFORE the packet is compressed. If compression is not being used, this value
+      will match the value of cipSecGlobalHcOutOctets.
+    name: cipSecGlobalHcOutUncompOctets
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.21.0
+    description: The number of times the global uncompressed octets sent counter (cipSecGlobalOutUncompOctets)
+      has wrapped.
+    name: cipSecGlobalOutUncompOctWraps
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.22.0
+    description: The total number of packets sent by all current and previous IPsec
+      Phase-2 Tunnels.
+    name: cipSecGlobalOutPkts
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.23.0
+    description: The total number of packets dropped during send processing by all
+      current and previous IPsec Phase-2 Tunnels.
+    name: cipSecGlobalOutDrops
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.24.0
+    description: The total number of outbound authentication's performed by all current
+      and previous IPsec Phase-2 Tunnels.
+    name: cipSecGlobalOutAuths
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.25.0
+    description: The total number of outbound authentication's which ended in failure
+      by all current and previous IPsec Phase-2 Tunnels.
+    name: cipSecGlobalOutAuthFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.26.0
+    description: The total number of outbound encryption's performed by all current
+      and previous IPsec Phase-2 Tunnels.
+    name: cipSecGlobalOutEncrypts
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.27.0
+    description: The total number of outbound encryption's which ended in failure
+      by all current and previous IPsec Phase-2 Tunnels.
+    name: cipSecGlobalOutEncryptFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.28.0
+    description: The total number of protocol use failures which occurred during processing
+      of all current and previously active IPsec Phase-2 Tunnels.
+    name: cipSecGlobalProtocolUseFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.29.0
+    description: The total number of non-existent Security Association in failures
+      which occurred during processing of all current and previous IPsec Phase-2 Tunnels.
+    name: cipSecGlobalNoSaFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.1.30.0
+    description: The total number of system capacity failures which occurred during
+      processing of all current and previously active IPsec Phase-2 Tunnels.
+    name: cipSecGlobalSysCapFails
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.1
+    description: The index of the IPsec Phase-2 Tunnel Table. The value of the index
+      is a number which begins at one and is incremented with each tunnel that is
+      created. The value of this object will wrap at 2,147,483,647.
+    name: cipSecTunIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.2
+    description: The index of the associated IPsec Phase-1 IKE Tunnel. (cikeTunIndex
+      in the cikeTunnelTable)
+    name: cipSecTunIkeTunnelIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.3
+    description: An indicator which specifies whether or not the IPsec Phase-1 IKE
+      Tunnel currently exists.
+    name: cipSecTunIkeTunnelAlive
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.4
+    description: The IP address of the local endpoint for the IPsec Phase-2 Tunnel.
+    name: cipSecTunLocalAddr
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.5
+    description: The IP address of the remote endpoint for the IPsec Phase-2 Tunnel.
+    name: cipSecTunRemoteAddr
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.6
+    description: The type of key used by the IPsec Phase-2 Tunnel.
+    name: cipSecTunKeyType
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.7
+    description: The encapsulation mode used by the IPsec Phase-2 Tunnel.
+    name: cipSecTunEncapMode
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.8
+    description: The negotiated LifeSize of the IPsec Phase-2 Tunnel in kilobytes.
+    name: cipSecTunLifeSize
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.9
+    description: The negotiated LifeTime of the IPsec Phase-2 Tunnel in seconds.
+    name: cipSecTunLifeTime
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.10
+    description: The length of time the IPsec Phase-2 Tunnel has been active in hundredths
+      of seconds.
+    name: cipSecTunActiveTime
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.11
+    description: The security association LifeSize refresh threshold in kilobytes.
+    name: cipSecTunSaLifeSizeThreshold
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.12
+    description: The security association LifeTime refresh threshold in seconds.
+    name: cipSecTunSaLifeTimeThreshold
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.13
+    description: The total number of security association refreshes performed.
+    name: cipSecTunTotalRefreshes
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.14
+    description: The total number of security associations which have expired.
+    name: cipSecTunExpiredSaInstances
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.15
+    description: The number of security associations which are currently active or
+      expiring.
+    name: cipSecTunCurrentSaInstances
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.16
+    description: The Diffie Hellman Group used by the inbound security association
+      of the IPsec Phase-2 Tunnel.
+    name: cipSecTunInSaDiffHellmanGrp
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.17
+    description: The encryption algorithm used by the inbound security association
+      of the IPsec Phase-2 Tunnel.
+    name: cipSecTunInSaEncryptAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.18
+    description: The authentication algorithm used by the inbound authentication header
+      (AH) security association of the IPsec Phase-2 Tunnel.
+    name: cipSecTunInSaAhAuthAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.19
+    description: The authentication algorithm used by the inbound encapsulation security
+      protocol (ESP) security association of the IPsec Phase-2 Tunnel.
+    name: cipSecTunInSaEspAuthAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.20
+    description: The decompression algorithm used by the inbound security association
+      of the IPsec Phase-2 Tunnel.
+    name: cipSecTunInSaDecompAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.21
+    description: The Diffie Hellman Group used by the outbound security association
+      of the IPsec Phase-2 Tunnel.
+    name: cipSecTunOutSaDiffHellmanGrp
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.22
+    description: The encryption algorithm used by the outbound security association
+      of the IPsec Phase-2 Tunnel.
+    name: cipSecTunOutSaEncryptAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.23
+    description: The authentication algorithm used by the outbound authentication
+      header (AH) security association of the IPsec Phase-2 Tunnel.
+    name: cipSecTunOutSaAhAuthAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.24
+    description: The authentication algorithm used by the inbound encapsulation security
+      protocol (ESP) security association of the IPsec Phase-2 Tunnel.
+    name: cipSecTunOutSaEspAuthAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.25
+    description: The compression algorithm used by the inbound security association
+      of the IPsec Phase-2 Tunnel.
+    name: cipSecTunOutSaCompAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.26
+    description: The total number of octets received by this IPsec Phase-2 Tunnel.
+      This value is accumulated BEFORE determining whether or not the packet should
+      be decompressed. See also cipSecTunInOctWraps for the number of times this counter
+      has wrapped.
+    name: cipSecTunInOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.27
+    description: A high capacity count of the total number of octets received by this
+      IPsec Phase-2 Tunnel. This value is accumulated BEFORE determining whether or
+      not the packet should be decompressed.
+    name: cipSecTunHcInOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.28
+    description: The number of times the octets received counter (cipSecTunInOctets)
+      has wrapped.
+    name: cipSecTunInOctWraps
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.29
+    description: The total number of decompressed octets received by this IPsec Phase-2
+      Tunnel. This value is accumulated AFTER the packet is decompressed. If compression
+      is not being used, this value will match the value of cipSecTunInOctets. See
+      also cipSecTunInDecompOctWraps for the number of times this counter has wrapped.
+    name: cipSecTunInDecompOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.30
+    description: A high capacity count of the total number of decompressed octets
+      received by this IPsec Phase-2 Tunnel. This value is accumulated AFTER the packet
+      is decompressed. If compression is not being used, this value will match the
+      value of cipSecTunHcInOctets.
+    name: cipSecTunHcInDecompOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.31
+    description: The number of times the decompressed octets received counter (cipSecTunInDecompOctets)
+      has wrapped.
+    name: cipSecTunInDecompOctWraps
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.32
+    description: The total number of packets received by this IPsec Phase-2 Tunnel.
+    name: cipSecTunInPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.33
+    description: The total number of packets dropped during receive processing by
+      this IPsec Phase-2 Tunnel. This count does NOT include packets dropped due to
+      Anti-Replay processing.
+    name: cipSecTunInDropPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.34
+    description: The total number of packets dropped during receive processing due
+      to Anti-Replay processing by this IPsec Phase-2 Tunnel.
+    name: cipSecTunInReplayDropPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.35
+    description: The total number of inbound authentication's performed by this IPsec
+      Phase-2 Tunnel.
+    name: cipSecTunInAuths
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.36
+    description: The total number of inbound authentication's which ended in failure
+      by this IPsec Phase-2 Tunnel .
+    name: cipSecTunInAuthFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.37
+    description: The total number of inbound decryption's performed by this IPsec
+      Phase-2 Tunnel.
+    name: cipSecTunInDecrypts
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.38
+    description: The total number of inbound decryption's which ended in failure by
+      this IPsec Phase-2 Tunnel.
+    name: cipSecTunInDecryptFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.39
+    description: The total number of octets sent by this IPsec Phase-2 Tunnel. This
+      value is accumulated AFTER determining whether or not the packet should be compressed.
+      See also cipSecTunOutOctWraps for the number of times this counter has wrapped.
+    name: cipSecTunOutOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.40
+    description: A high capacity count of the total number of octets sent by this
+      IPsec Phase-2 Tunnel. This value is accumulated AFTER determining whether or
+      not the packet should be compressed.
+    name: cipSecTunHcOutOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.41
+    description: The number of times the out octets counter (cipSecTunOutOctets) has
+      wrapped.
+    name: cipSecTunOutOctWraps
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.42
+    description: The total number of uncompressed octets sent by this IPsec Phase-2
+      Tunnel. This value is accumulated BEFORE the packet is compressed. If compression
+      is not being used, this value will match the value of cipSecTunOutOctets. See
+      also cipSecTunOutDecompOctWraps for the number of times this counter has wrapped.
+    name: cipSecTunOutUncompOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.43
+    description: A high capacity count of the total number of uncompressed octets
+      sent by this IPsec Phase-2 Tunnel. This value is accumulated BEFORE the packet
+      is compressed. If compression is not being used, this value will match the value
+      of cipSecTunHcOutOctets.
+    name: cipSecTunHcOutUncompOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.44
+    description: The number of times the uncompressed octets sent counter (cipSecTunOutUncompOctets)
+      has wrapped.
+    name: cipSecTunOutUncompOctWraps
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.45
+    description: The total number of packets sent by this IPsec Phase-2 Tunnel.
+    name: cipSecTunOutPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.46
+    description: The total number of packets dropped during send processing by this
+      IPsec Phase-2 Tunnel.
+    name: cipSecTunOutDropPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.47
+    description: The total number of outbound authentication's performed by this IPsec
+      Phase-2 Tunnel.
+    name: cipSecTunOutAuths
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.48
+    description: The total number of outbound authentication's which ended in failure
+      by this IPsec Phase-2 Tunnel.
+    name: cipSecTunOutAuthFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.49
+    description: The total number of outbound encryption's performed by this IPsec
+      Phase-2 Tunnel.
+    name: cipSecTunOutEncrypts
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.50
+    description: The total number of outbound encryption's which ended in failure
+      by this IPsec Phase-2 Tunnel.
+    name: cipSecTunOutEncryptFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.2.1.51
+    description: The status of the MIB table row. This object can be used to bring
+      the tunnel down by setting value of this object to destroy(2). When the value
+      is set to destroy(2), the SA bundle is destroyed and this row is deleted from
+      this table. When this MIB value is queried, the value of active(1) is always
+      returned, if the instance exists. This object cannot be used to create a MIB
+      table row.
+    name: cipSecTunStatus
+  table:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.2
+    description: The IPsec Phase-2 Tunnel Table. There is one entry in this table
+      for each active IPsec Phase-2 Tunnel.
+    name: cipSecTunnelTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.3.1.1
+    description: The number of the Endpoint associated with the IPsec Phase-2 Tunnel
+      Table. The value of this index is a number which begins at one and is incremented
+      with each Endpoint associated with an IPsec Phase-2 Tunnel. The value of this
+      object will wrap at 2,147,483,647.
+    name: cipSecEndPtIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.3.1.2
+    description: The DNS name of the local Endpoint.
+    name: cipSecEndPtLocalName
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.3.1.3
+    description: 'The type of identity for the local Endpoint. Possible values are:
+      1) a single IP address, or 2) an IP address range, or 3) an IP subnet.'
+    name: cipSecEndPtLocalType
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.3.1.4
+    description: The local Endpoint's first IP address specification. If the local
+      Endpoint type is single IP address, then this is the value of the IP address.
+      If the local Endpoint type is IP subnet, then this is the value of the subnet.
+      If the local Endpoint type is IP address range, then this is the value of beginning
+      IP address of the range.
+    name: cipSecEndPtLocalAddr1
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.3.1.5
+    description: The local Endpoint's second IP address specification. If the local
+      Endpoint type is single IP address, then this is the value of the IP address.
+      If the local Endpoint type is IP subnet, then this is the value of the subnet
+      mask. If the local Endpoint type is IP address range, then this is the value
+      of ending IP address of the range.
+    name: cipSecEndPtLocalAddr2
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.3.1.6
+    description: The protocol number of the local Endpoint's traffic.
+    name: cipSecEndPtLocalProtocol
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.3.1.7
+    description: The port number of the local Endpoint's traffic.
+    name: cipSecEndPtLocalPort
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.3.1.8
+    description: The DNS name of the remote Endpoint.
+    name: cipSecEndPtRemoteName
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.3.1.9
+    description: 'The type of identity for the remote Endpoint. Possible values are:
+      1) a single IP address, or 2) an IP address range, or 3) an IP subnet.'
+    name: cipSecEndPtRemoteType
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.3.1.10
+    description: The remote Endpoint's first IP address specification. If the remote
+      Endpoint type is single IP address, then this is the value of the IP address.
+      If the remote Endpoint type is IP subnet, then this is the value of the subnet.
+      If the remote Endpoint type is IP address range, then this is the value of beginning
+      IP address of the range.
+    name: cipSecEndPtRemoteAddr1
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.3.1.11
+    description: The remote Endpoint's second IP address specification. If the remote
+      Endpoint type is single IP address, then this is the value of the IP address.
+      If the remote Endpoint type is IP subnet, then this is the value of the subnet
+      mask. If the remote Endpoint type is IP address range, then this is the value
+      of ending IP address of the range.
+    name: cipSecEndPtRemoteAddr2
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.3.1.12
+    description: The protocol number of the remote Endpoint's traffic.
+    name: cipSecEndPtRemoteProtocol
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.3.1.13
+    description: The port number of the remote Endpoint's traffic.
+    name: cipSecEndPtRemotePort
+  table:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.3
+    description: The IPsec Phase-2 Tunnel Endpoint Table. This table contains an entry
+      for each active endpoint associated with an IPsec Phase-2 Tunnel.
+    name: cipSecEndPtTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.4.1.1
+    description: The number of the SPI associated with the Phase-2 Tunnel Table. The
+      value of this index is a number which begins at one and is incremented with
+      each SPI associated with an IPsec Phase-2 Tunnel. The value of this object will
+      wrap at 2,147,483,647.
+    name: cipSecSpiIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.4.1.2
+    description: The direction of the SPI.
+    name: cipSecSpiDirection
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.4.1.3
+    description: The value of the SPI.
+    name: cipSecSpiValue
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.4.1.4
+    description: The protocol of the SPI.
+    name: cipSecSpiProtocol
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.4.1.5
+    description: The status of the SPI.
+    name: cipSecSpiStatus
+  table:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.4
+    description: The IPsec Phase-2 Security Protection Index Table. This table contains
+      an entry for each active and expiring security association.
+    name: cipSecSpiTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.1
+    description: The total number of currently active IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWActiveTunnels
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.2
+    description: The total number of previously active IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWPreviousTunnels
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.3
+    description: The total number of octets received by all current and previous IPsec
+      Phase-2 Tunnels. This value is accumulated BEFORE determining whether or not
+      the packet should be decompressed. See also cipSecGlobalInOctWraps for the number
+      of times this counter has wrapped.
+    name: cipSecPhase2GWInOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.4
+    description: The number of times the global octets received counter (cipSecGlobalInOctets)
+      has wrapped.
+    name: cipSecPhase2GWInOctWraps
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.5
+    description: The total number of decompressed octets received by all current and
+      previous IPsec Phase-2 Tunnels. This value is accumulated AFTER the packet is
+      decompressed. If compression is not being used, this value will match the value
+      of cipSecGlobalInOctets. See also cipSecGlobalInDecompOctWraps for the number
+      of times this counter has wrapped.
+    name: cipSecPhase2GWInDecompOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.6
+    description: The number of times the global decompressed octets received counter
+      (cipSecGlobalInDecompOctets) has wrapped.
+    name: cipSecPhase2GWInDecompOctWraps
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.7
+    description: The total number of packets received by all current and previous
+      IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWInPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.8
+    description: The total number of packets dropped during receive processing by
+      all current and previous IPsec Phase-2 Tunnels. This count does NOT include
+      packets dropped due to Anti-Replay processing.
+    name: cipSecPhase2GWInDrops
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.9
+    description: The total number of packets dropped during receive processing due
+      to Anti-Replay processing by all current and previous IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWInReplayDrops
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.10
+    description: The total number of inbound authentication's performed by all current
+      and previous IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWInAuths
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.11
+    description: The total number of inbound authentication's which ended in failure
+      by all current and previous IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWInAuthFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.12
+    description: The total number of inbound decryption's performed by all current
+      and previous IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWInDecrypts
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.13
+    description: The total number of inbound decryption's which ended in failure by
+      all current and previous IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWInDecryptFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.14
+    description: The total number of octets sent by all current and previous IPsec
+      Phase-2 Tunnels. This value is accumulated AFTER determining whether or not
+      the packet should be compressed. See also cipSecGlobalOutOctWraps for the number
+      of times this counter has wrapped.
+    name: cipSecPhase2GWOutOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.15
+    description: The number of times the global octets sent counter (cipSecGlobalOutOctets)
+      has wrapped.
+    name: cipSecPhase2GWOutOctWraps
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.16
+    description: The total number of uncompressed octets sent by all current and previous
+      IPsec Phase-2 Tunnels. This value is accumulated BEFORE the packet is compressed.
+      If compression is not being used, this value will match the value of cipSecGlobalOutOctets.
+      See also cipSecGlobalOutDecompOctWraps for the number of times this counter
+      has wrapped.
+    name: cipSecPhase2GWOutUncompOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.17
+    description: The number of times the global uncompressed octets sent counter (cipSecGlobalOutUncompOctets)
+      has wrapped.
+    name: cipSecPhase2GWOutUncompOctWraps
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.18
+    description: The total number of packets sent by all current and previous IPsec
+      Phase-2 Tunnels.
+    name: cipSecPhase2GWOutPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.19
+    description: The total number of packets dropped during send processing by all
+      current and previous IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWOutDrops
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.20
+    description: The total number of outbound authentication's performed by all current
+      and previous IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWOutAuths
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.21
+    description: The total number of outbound authentication's which ended in failure
+      by all current and previous IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWOutAuthFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.22
+    description: The total number of outbound encryption's performed by all current
+      and previous IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWOutEncrypts
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.23
+    description: The total number of outbound encryption's which ended in failure
+      by all current and previous IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWOutEncryptFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.24
+    description: The total number of protocol use failures which occurred during processing
+      of all current and previously active IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWProtocolUseFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.25
+    description: The total number of non-existent Security Association in failures
+      which occurred during processing of all current and previous IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWNoSaFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.3.5.1.26
+    description: The total number of system capacity failures which occurred during
+      processing of all current and previously active IPsec Phase-2 Tunnels.
+    name: cipSecPhase2GWSysCapFails
+  table:
+    OID: 1.3.6.1.4.1.9.9.171.1.3.5
+    description: Phase-2 IPsec stats information is included in this table. Each entry
+      is related to a specific gateway which is identified by 'cmgwIndex'
+    name: cipSecPhase2GWStatsTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.4.1.1.1.0
+    description: The window size of the IPsec Phase-1 and Phase-2 History Tables.
+      The IPsec Phase-1 and Phase-2 History Tables are implemented as a sliding window
+      in which only the last n entries are maintained. This object is used specify
+      the number of entries which will be maintained in the IPsec Phase-1 and Phase-2
+      History Tables. An implementation may choose suitable minimum and maximum values
+      for this element based on the local policy and available resources. If an SNMP
+      SET request specifies a value outside this window for this element, a BAD VALUE
+      may be returned.
+    name: cipSecHistTableSize
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.4.1.1.2.0
+    description: 'The current state of check point processing. This object will return
+      ready when the agent is ready to create on-demand history entries for active
+      IPsec Tunnels or checkPoint when the agent is currently creating on-demand history
+      entries for active IPsec Tunnels. By setting this value to checkPoint, the agent
+      will create: a) an entry in the IPsec Phase-1 Tunnel History for each active
+      IPsec Phase-1 Tunnel and b) an entry in the IPsec Phase-2 Tunnel History Table
+      and an entry in the IPsec Phase-2 Tunnel EndPoint History Table for each active
+      IPsec Phase-2 Tunnel.'
+    name: cipSecHistCheckPoint
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.1
+    description: The index of the IPsec Phase-1 IKE Tunnel History Table. The value
+      of the index is a number which begins at one and is incremented with each tunnel
+      that ends. The value of this object will wrap at 2,147,483,647.
+    name: cikeTunHistIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.2
+    description: 'The reason the IPsec Phase-1 IKE Tunnel was terminated. Possible
+      reasons include: 1 = other 2 = normal termination 3 = operator request 4 = peer
+      delete request was received 5 = contact with peer was lost 6 = local failure
+      occurred. 7 = operator initiated check point request'
+    name: cikeTunHistTermReason
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.3
+    description: The index of the previously active IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistActiveIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.4
+    description: 'The type of local peer identity. The local peer may be identified
+      by: 1. an IP address, or 2. a host name.'
+    name: cikeTunHistPeerLocalType
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.5
+    description: The value of the local peer identity. If the local peer type is an
+      IP Address, then this is the IP Address used to identify the local peer. If
+      the local peer type is a host name, then this is the host name used to identify
+      the local peer.
+    name: cikeTunHistPeerLocalValue
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.6
+    description: The internal index of the local-remote peer association. This internal
+      index is used to uniquely identify multiple associations between the local and
+      remote peer.
+    name: cikeTunHistPeerIntIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.7
+    description: 'The type of remote peer identity. The remote peer may be identified
+      by: 1. an IP address, or 2. a host name.'
+    name: cikeTunHistPeerRemoteType
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.8
+    description: The value of the remote peer identity. If the remote peer type is
+      an IP Address, then this is the IP Address used to identify the remote peer.
+      If the remote peer type is a host name, then this is the host name used to identify
+      the remote peer.
+    name: cikeTunHistPeerRemoteValue
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.9
+    description: The IP address of the local endpoint for the IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistLocalAddr
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.10
+    description: The DNS name of the local IP address for the IPsec Phase-1 IKE Tunnel.
+      If the DNS name associated with the local tunnel endpoint is not known, then
+      the value of this object will be a NULL string.
+    name: cikeTunHistLocalName
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.11
+    description: The IP address of the remote endpoint for the IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistRemoteAddr
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.12
+    description: The DNS name of the remote IP address of IPsec Phase-1 IKE Tunnel.
+      If the DNS name associated with the remote tunnel endpoint is not known, then
+      the value of this object will be a NULL string.
+    name: cikeTunHistRemoteName
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.13
+    description: The negotiation mode of the IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistNegoMode
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.14
+    description: The Diffie Hellman Group used in IPsec Phase-1 IKE negotiations.
+    name: cikeTunHistDiffHellmanGrp
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.15
+    description: The encryption algorithm used in IPsec Phase-1 IKE negotiations.
+    name: cikeTunHistEncryptAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.16
+    description: The hash algorithm used in IPsec Phase-1 IKE negotiations.
+    name: cikeTunHistHashAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.17
+    description: The authentication method used in IPsec Phase-1 IKE negotiations.
+    name: cikeTunHistAuthMethod
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.18
+    description: The negotiated LifeTime of the IPsec Phase-1 IKE Tunnel in seconds.
+    name: cikeTunHistLifeTime
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.19
+    description: The value of sysUpTime in hundredths of seconds when the IPsec Phase-1
+      IKE tunnel was started.
+    name: cikeTunHistStartTime
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.20
+    description: The length of time the IPsec Phase-1 IKE tunnel was been active in
+      hundredths of seconds.
+    name: cikeTunHistActiveTime
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.21
+    description: The total number of security associations refreshes performed.
+    name: cikeTunHistTotalRefreshes
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.22
+    description: The total number of security associations used during the life of
+      the IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistTotalSas
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.23
+    description: The total number of octets received by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistInOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.24
+    description: The total number of packets received by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistInPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.25
+    description: The total number of packets dropped by this IPsec Phase-1 IKE Tunnel
+      during receive processing.
+    name: cikeTunHistInDropPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.26
+    description: The total number of notifys received by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistInNotifys
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.27
+    description: The total number of IPsec Phase-2 exchanges received by this IPsec
+      Phase-1 IKE Tunnel.
+    name: cikeTunHistInP2Exchgs
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.28
+    description: The total number of IPsec Phase-2 exchanges received and found to
+      be invalid by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistInP2ExchgInvalids
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.29
+    description: The total number of IPsec Phase-2 exchanges received and rejected
+      by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistInP2ExchgRejects
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.30
+    description: The total number of IPsec Phase-2 security association delete requests
+      received by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistInP2SaDelRequests
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.31
+    description: The total number of octets sent by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistOutOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.32
+    description: The total number of packets sent by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistOutPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.33
+    description: The total number of packets dropped by this IPsec Phase-1 IKE Tunnel
+      during send processing.
+    name: cikeTunHistOutDropPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.34
+    description: The total number of notifys sent by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistOutNotifys
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.35
+    description: The total number of IPsec Phase-2 exchanges sent by this IPsec Phase-1
+      IKE Tunnel.
+    name: cikeTunHistOutP2Exchgs
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.36
+    description: The total number of IPsec Phase-2 exchanges sent and found to be
+      invalid by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistOutP2ExchgInvalids
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.37
+    description: The total number of IPsec Phase-2 exchanges sent and rejected by
+      this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistOutP2ExchgRejects
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.2.1.1.38
+    description: The total number of IPsec Phase-2 security association delete requests
+      sent by this IPsec Phase-1 IKE Tunnel.
+    name: cikeTunHistOutP2SaDelRequests
+  table:
+    OID: 1.3.6.1.4.1.9.9.171.1.4.2.1
+    description: The IPsec Phase-1 Internet Key Exchange Tunnel History Table. This
+      table is implemented as a sliding window in which only the last n entries are
+      maintained. The maximum number of entries is specified by the cipSecHistTableSize
+      object.
+    name: cikeTunnelHistTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.1
+    description: The index of the IPsec Phase-2 Tunnel History Table. The value of
+      the index is a number which begins at one and is incremented with each tunnel
+      that ends. The value of this object will wrap at 2,147,483,647.
+    name: cipSecTunHistIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.2
+    description: 'The reason the IPsec Phase-2 Tunnel was terminated. Possible reasons
+      include: 1 = other 2 = normal termination 3 = operator request 4 = peer delete
+      request was received 5 = contact with peer was lost 6 = local failure occurred
+      7 = operator initiated check point request'
+    name: cipSecTunHistTermReason
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.3
+    description: The index of the previously active IPsec Phase-2 Tunnel.
+    name: cipSecTunHistActiveIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.4
+    description: The index of the associated IPsec Phase-1 Tunnel (cikeTunIndex in
+      the cikeTunnelTable).
+    name: cipSecTunHistIkeTunnelIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.5
+    description: The IP address of the local endpoint for the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistLocalAddr
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.6
+    description: The IP address of the remote endpoint for the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistRemoteAddr
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.7
+    description: The type of key used by the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistKeyType
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.8
+    description: The encapsulation mode used by the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistEncapMode
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.9
+    description: The negotiated LifeSize of the IPsec Phase-2 Tunnel in kilobytes.
+    name: cipSecTunHistLifeSize
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.10
+    description: The negotiated LifeTime of the IPsec Phase-2 Tunnel in seconds.
+    name: cipSecTunHistLifeTime
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.11
+    description: The value of sysUpTime in hundredths of seconds when the IPsec Phase-2
+      Tunnel was started.
+    name: cipSecTunHistStartTime
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.12
+    description: The length of time the IPsec Phase-2 Tunnel has been active in hundredths
+      of seconds.
+    name: cipSecTunHistActiveTime
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.13
+    description: The total number of security association refreshes performed.
+    name: cipSecTunHistTotalRefreshes
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.14
+    description: The total number of security associations used during the life of
+      the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistTotalSas
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.15
+    description: The Diffie Hellman Group used by the inbound security association
+      of the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistInSaDiffHellmanGrp
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.16
+    description: The encryption algorithm used by the inbound security association
+      of the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistInSaEncryptAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.17
+    description: The authentication algorithm used by the inbound authentication header
+      (AH) security association of the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistInSaAhAuthAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.18
+    description: The authentication algorithm used by the inbound encapsulation security
+      protocol (ESP) security association of the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistInSaEspAuthAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.19
+    description: The decompression algorithm used by the inbound security association
+      of the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistInSaDecompAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.20
+    description: The Diffie Hellman Group used by the outbound security association
+      of the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistOutSaDiffHellmanGrp
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.21
+    description: The encryption algorithm used by the outbound security association
+      of the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistOutSaEncryptAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.22
+    description: The authentication algorithm used by the outbound authentication
+      header (AH) security association of the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistOutSaAhAuthAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.23
+    description: The authentication algorithm used by the inbound encapsulation security
+      protocol (ESP) security association of the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistOutSaEspAuthAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.24
+    description: The compression algorithm used by the inbound security association
+      of the IPsec Phase-2 Tunnel.
+    name: cipSecTunHistOutSaCompAlgo
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.25
+    description: The total number of octets received by this IPsec Phase-2 Tunnel.
+      This value is accumulated BEFORE determining whether or not the packet should
+      be decompressed. See also cipSecTunInOctWraps for the number of times this counter
+      has wrapped.
+    name: cipSecTunHistInOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.26
+    description: A high capacity count of the total number of octets received by this
+      IPsec Phase-2 Tunnel. This value is accumulated BEFORE determining whether or
+      not the packet should be decompressed.
+    name: cipSecTunHistHcInOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.27
+    description: The number of times the octets received counter (cipSecTunInOctets)
+      has wrapped.
+    name: cipSecTunHistInOctWraps
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.28
+    description: The total number of decompressed octets received by this IPsec Phase-2
+      Tunnel. This value is accumulated AFTER the packet is decompressed. If compression
+      is not being used, this value will match the value of cipSecTunHistInOctets.
+      See also cipSecTunInDecompOctWraps for the number of times this counter has
+      wrapped.
+    name: cipSecTunHistInDecompOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.29
+    description: A high capacity count of the total number of decompressed octets
+      received by this IPsec Phase-2 Tunnel. This value is accumulated AFTER the packet
+      is decompressed. If compression is not being used, this value will match the
+      value of cipSecTunHistHcInOctets.
+    name: cipSecTunHistHcInDecompOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.30
+    description: The number of times the decompressed octets received counter (cipSecTunInDecompOctets)
+      has wrapped.
+    name: cipSecTunHistInDecompOctWraps
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.31
+    description: The total number of packets received by this IPsec Phase-2 Tunnel.
+    name: cipSecTunHistInPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.32
+    description: The total number of packets dropped during receive processing by
+      this IPsec Phase-2 Tunnel. This count does NOT include packets dropped due to
+      Anti-Replay processing.
+    name: cipSecTunHistInDropPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.33
+    description: The total number of packets dropped during receive processing due
+      to Anti-Replay processing by this IPsec Phase-2 Tunnel.
+    name: cipSecTunHistInReplayDropPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.34
+    description: The total number of inbound authentication's performed by this IPsec
+      Phase-2 Tunnel.
+    name: cipSecTunHistInAuths
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.35
+    description: The total number of inbound authentication's which ended in failure
+      by this IPsec Phase-2 Tunnel .
+    name: cipSecTunHistInAuthFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.36
+    description: The total number of inbound decryption's performed by this IPsec
+      Phase-2 Tunnel.
+    name: cipSecTunHistInDecrypts
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.37
+    description: The total number of inbound decryption's which ended in failure by
+      this IPsec Phase-2 Tunnel.
+    name: cipSecTunHistInDecryptFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.38
+    description: The total number of octets sent by this IPsec Phase-2 Tunnel. This
+      value is accumulated AFTER determining whether or not the packet should be compressed.
+      See also cipSecTunOutOctWraps for the number of times this counter has wrapped.
+    name: cipSecTunHistOutOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.39
+    description: A high capacity count of the total number of octets sent by this
+      IPsec Phase-2 Tunnel. This value is accumulated AFTER determining whether or
+      not the packet should be compressed.
+    name: cipSecTunHistHcOutOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.40
+    description: The number of times the octets sent counter (cipSecTunOutOctets)
+      has wrapped.
+    name: cipSecTunHistOutOctWraps
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.41
+    description: The total number of uncompressed octets sent by this IPsec Phase-2
+      Tunnel. This value is accumulated BEFORE the packet is compressed. If compression
+      is not being used, this value will match the value of cipSecTunHistOutOctets.
+      See also cipSecTunOutDecompOctWraps for the number of times this counter has
+      wrapped.
+    name: cipSecTunHistOutUncompOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.42
+    description: A high capacity count of the total number of uncompressed octets
+      sent by this IPsec Phase-2 Tunnel. This value is accumulated BEFORE the packet
+      is compressed. If compression is not being used, this value will match the value
+      of cipSecTunHistHcOutOctets.
+    name: cipSecTunHistHcOutUncompOctets
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.43
+    description: The number of times the uncompressed octets sent counter (cipSecTunOutUncompOctets)
+      has wrapped.
+    name: cipSecTunHistOutUncompOctWraps
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.44
+    description: The total number of packets sent by this IPsec Phase-2 Tunnel.
+    name: cipSecTunHistOutPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.45
+    description: The total number of packets dropped during send processing by this
+      IPsec Phase-2 Tunnel.
+    name: cipSecTunHistOutDropPkts
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.46
+    description: The total number of outbound authentication's performed by this IPsec
+      Phase-2 Tunnel.
+    name: cipSecTunHistOutAuths
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.47
+    description: The total number of outbound authentication's which ended in failure
+      by this IPsec Phase-2 Tunnel.
+    name: cipSecTunHistOutAuthFails
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.48
+    description: The total number of outbound encryption's performed by this IPsec
+      Phase-2 Tunnel.
+    name: cipSecTunHistOutEncrypts
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.1.1.49
+    description: The total number of outbound encryption's which ended in failure
+      by this IPsec Phase-2 Tunnel.
+    name: cipSecTunHistOutEncryptFails
+  table:
+    OID: 1.3.6.1.4.1.9.9.171.1.4.3.1
+    description: The IPsec Phase-2 Tunnel History Table. This table is implemented
+      as a sliding window in which only the last n entries are maintained. The maximum
+      number of entries is specified by the cipSecHistTableSize object.
+    name: cipSecTunnelHistTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.1
+    description: The number of the previously active Endpoint associated with a IPsec
+      Phase-2 Tunnel Table. The value of this index is a number which begins at one
+      and is incremented with each Endpoint associated with an IPsec Phase-2 Tunnel.
+      The value of this object will wrap at 2,147,483,647.
+    name: cipSecEndPtHistIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.2
+    description: The index of the previously active IPsec Phase-2 Tunnel Table.
+    name: cipSecEndPtHistTunIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.3
+    description: The index of the previously active Endpoint.
+    name: cipSecEndPtHistActiveIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.4
+    description: The DNS name of the local Endpoint.
+    name: cipSecEndPtHistLocalName
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.5
+    description: 'The type of identity for the local Endpoint. Possible values are:
+      1) a single IP address, or 2) an IP address range, or 3) an IP subnet.'
+    name: cipSecEndPtHistLocalType
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.6
+    description: The local Endpoint's first IP address specification. If the local
+      Endpoint type is single IP address, then this is the value of the IP address.
+      If the local Endpoint type is IP subnet, then this is the value of the subnet.
+      If the local Endpoint type is IP address range, then this is the value of beginning
+      IP address of the range.
+    name: cipSecEndPtHistLocalAddr1
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.7
+    description: The local Endpoint's second IP address specification. If the local
+      Endpoint type is single IP address, then this is the value of the IP address.
+      If the local Endpoint type is IP subnet, then this is the value of the subnet
+      mask. If the local Endpoint type is IP address range, then this is the value
+      of ending IP address of the range.
+    name: cipSecEndPtHistLocalAddr2
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.8
+    description: The protocol number of the local Endpoint's traffic.
+    name: cipSecEndPtHistLocalProtocol
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.9
+    description: The port number of the local Endpoint's traffic.
+    name: cipSecEndPtHistLocalPort
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.10
+    description: The DNS name of the remote Endpoint.
+    name: cipSecEndPtHistRemoteName
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.11
+    description: 'The type of identity for the remote Endpoint. Possible values are:
+      1) a single IP address, or 2) an IP address range, or 3) an IP subnet.'
+    name: cipSecEndPtHistRemoteType
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.12
+    description: The remote Endpoint's first IP address specification. If the remote
+      Endpoint type is single IP address, then this is the value of the IP address.
+      If the remote Endpoint type is IP subnet, then this is the value of the subnet.
+      If the remote Endpoint type is IP address range, then this is the value of beginning
+      IP address of the range.
+    name: cipSecEndPtHistRemoteAddr1
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.13
+    description: The remote Endpoint's second IP address specification. If the remote
+      Endpoint type is single IP address, then this is the value of the IP address.
+      If the remote Endpoint type is IP subnet, then this is the value of the subnet
+      mask. If the remote Endpoint type is IP address range, then this is the value
+      of ending IP address of the range.
+    name: cipSecEndPtHistRemoteAddr2
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.14
+    description: The protocol number of the remote Endpoint's traffic.
+    name: cipSecEndPtHistRemoteProtocol
+  - OID: 1.3.6.1.4.1.9.9.171.1.4.3.2.1.15
+    description: The port number of the remote Endpoint's traffic.
+    name: cipSecEndPtHistRemotePort
+  table:
+    OID: 1.3.6.1.4.1.9.9.171.1.4.3.2
+    description: The IPsec Phase-2 Tunnel Endpoint History Table. This table is implemented
+      as a sliding window in which only the last n entries are maintained. The maximum
+      number of entries is specified by the cipSecHistTableSize object.
+    name: cipSecEndPtHistTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.5.1.1.1.0
+    description: The window size of the IPsec Phase-1 and Phase-2 Failure Tables.
+      The IPsec Phase-1 and Phase-2 Failure Tables are implemented as a sliding window
+      in which only the last n entries are maintained. This object is used specify
+      the number of entries which will be maintained in the IPsec Phase-1 and Phase-2
+      Failure Tables. An implementation may choose suitable minimum and maximum values
+      for this element based on the local policy and available resources. If an SNMP
+      SET request specifies a value outside this window for this element, a BAD VALUE
+      may be returned.
+    name: cipSecFailTableSize
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.2.1.1.1
+    description: The IPsec Phase-1 Failure Table index. The value of the index is
+      a number which begins at one and is incremented with each IPsec Phase-1 failure.
+      The value of this object will wrap at 2,147,483,647.
+    name: cikeFailIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.2.1.1.2
+    description: 'The reason for the failure. Possible reasons include: 1 = other
+      2 = peer delete request was received 3 = contact with peer was lost 4 = local
+      failure occurred 5 = authentication failure 6 = hash validation failure 7 =
+      encryption failure 8 = internal error occurred 9 = system capacity failure 10
+      = proposal failure 11 = peer''s certificate is unavailable 12 = peer''s certificate
+      was found invalid 13 = local certificate expired 14 = certificate revoke list
+      (crl) failure 15 = peer encoding error 16 = non-existent security association
+      17 = operator requested termination.'
+    name: cikeFailReason
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.2.1.1.3
+    description: The value of sysUpTime in hundredths of seconds at the time of the
+      failure.
+    name: cikeFailTime
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.2.1.1.4
+    description: 'The type of local peer identity. The local peer may be identified
+      by: 1. an IP address, or 2. a host name.'
+    name: cikeFailLocalType
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.2.1.1.5
+    description: The value of the local peer identity. If the local peer type is an
+      IP Address, then this is the IP Address used to identify the local peer. If
+      the local peer type is a host name, then this is the host name used to identify
+      the local peer.
+    name: cikeFailLocalValue
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.2.1.1.6
+    description: 'The type of remote peer identity. The remote peer may be identified
+      by: 1. an IP address, or 2. a host name.'
+    name: cikeFailRemoteType
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.2.1.1.7
+    description: The value of the remote peer identity. If the remote peer type is
+      an IP Address, then this is the IP Address used to identify the remote peer.
+      If the remote peer type is a host name, then this is the host name used to identify
+      the remote peer.
+    name: cikeFailRemoteValue
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.2.1.1.8
+    description: The IP address of the local peer.
+    name: cikeFailLocalAddr
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.2.1.1.9
+    description: The IP address of the remote peer.
+    name: cikeFailRemoteAddr
+  table:
+    OID: 1.3.6.1.4.1.9.9.171.1.5.2.1
+    description: The IPsec Phase-1 Failure Table. This table is implemented as a sliding
+      window in which only the last n entries are maintained. The maximum number of
+      entries is specified by the cipSecFailTableSize object.
+    name: cikeFailTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.3.1.1.1
+    description: The IPsec Phase-2 Failure Table index. The value of the index is
+      a number which begins at one and is incremented with each IPsec Phase-1 failure.
+      The value of this object will wrap at 2,147,483,647.
+    name: cipSecFailIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.3.1.1.2
+    description: 'The reason for the failure. Possible reasons include: 1 = other
+      2 = internal error occurred 3 = peer encoding error 4 = proposal failure 5 =
+      protocol use failure 6 = non-existent security association 7 = decryption failure
+      8 = encryption failure 9 = inbound authentication failure 10 = outbound authentication
+      failure 11 = compression failure 12 = system capacity failure 13 = peer delete
+      request was received 14 = contact with peer was lost 15 = sequence number rolled
+      over 16 = operator requested termination.'
+    name: cipSecFailReason
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.3.1.1.3
+    description: The value of sysUpTime in hundredths of seconds at the time of the
+      failure.
+    name: cipSecFailTime
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.3.1.1.4
+    description: The Phase-2 Tunnel index (cipSecTunIndex).
+    name: cipSecFailTunnelIndex
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.3.1.1.5
+    description: The security association SPI value.
+    name: cipSecFailSaSpi
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.3.1.1.6
+    description: The packet's source IP address.
+    name: cipSecFailPktSrcAddr
+  - OID: 1.3.6.1.4.1.9.9.171.1.5.3.1.1.7
+    description: The packet's destination IP address.
+    name: cipSecFailPktDstAddr
+  table:
+    OID: 1.3.6.1.4.1.9.9.171.1.5.3.1
+    description: The IPsec Phase-2 Failure Table. This table is implemented as a sliding
+      window in which only the last n entries are maintained. The maximum number of
+      entries is specified by the cipSecFailTableSize object.
+    name: cipSecFailTable
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.6.1.0
+    description: This object defines the administrative state of sending the IPsec
+      IKE Phase-1 Tunnel Start TRAP
+    name: cipSecTrapCntlIkeTunnelStart
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.6.2.0
+    description: This object defines the administrative state of sending the IPsec
+      IKE Phase-1 Tunnel Stop TRAP
+    name: cipSecTrapCntlIkeTunnelStop
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.6.3.0
+    description: This object defines the administrative state of sending the IPsec
+      IKE Phase-1 System Failure TRAP
+    name: cipSecTrapCntlIkeSysFailure
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.6.4.0
+    description: This object defines the administrative state of sending the IPsec
+      IKE Phase-1 Certificate/CRL Failure TRAP
+    name: cipSecTrapCntlIkeCertCrlFailure
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.6.5.0
+    description: This object defines the administrative state of sending the IPsec
+      IKE Phase-1 Protocol Failure TRAP
+    name: cipSecTrapCntlIkeProtocolFail
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.6.6.0
+    description: This object defines the administrative state of sending the IPsec
+      IKE Phase-1 No Security Association TRAP
+    name: cipSecTrapCntlIkeNoSa
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.6.7.0
+    description: This object defines the administrative state of sending the IPsec
+      Phase-2 Tunnel Start TRAP
+    name: cipSecTrapCntlIpSecTunnelStart
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.6.8.0
+    description: This object defines the administrative state of sending the IPsec
+      Phase-2 Tunnel Stop TRAP
+    name: cipSecTrapCntlIpSecTunnelStop
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.6.9.0
+    description: This object defines the administrative state of sending the IPsec
+      Phase-2 System Failure TRAP
+    name: cipSecTrapCntlIpSecSysFailure
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.6.10.0
+    description: This object defines the administrative state of sending the IPsec
+      Phase-2 Set Up Failure TRAP
+    name: cipSecTrapCntlIpSecSetUpFailure
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.6.11.0
+    description: This object defines the administrative state of sending the IPsec
+      Phase-2 Early Tunnel Termination TRAP
+    name: cipSecTrapCntlIpSecEarlyTunTerm
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.6.12.0
+    description: This object defines the administrative state of sending the IPsec
+      Phase-2 Protocol Failure TRAP
+    name: cipSecTrapCntlIpSecProtocolFail
+- MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.171.1.6.13.0
+    description: This object defines the administrative state of sending the IPsec
+      Phase-2 No Security Association TRAP
+    name: cipSecTrapCntlIpSecNoSa
+- MIB: CISCO-L4L7MODULE-RESOURCE-LIMIT-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.480.1.1.2.1.2
+    description: This object represents the type of resource in a resource class identified
+      by crlResourceClassName.
+    name: crlResourceLimitType
+  - OID: 1.3.6.1.4.1.9.9.480.1.1.2.1.3
+    description: 'This object represents the type of value specified in crlResourceLimitMax
+      and crlResourceLimitMin objects. The possible values are : absolute (1) : the
+      value represents an absolute number. percentage (2) : the value represents the
+      % of the total available for the system. In this case only crlResourceLimitMax
+      object is applicable.'
+    name: crlResourceLimitValueType
+  - OID: 1.3.6.1.4.1.9.9.480.1.1.2.1.4
+    description: This object represents the rate limit allowed for the resource identified
+      by 'ciscoResourceLimitType'. This value cannot be greater than the value specified
+      in ciscoResourceLimitMax. The value zero signifies that this object is not applicable
+      to the resource.
+    name: crlResourceLimitMin
+  - OID: 1.3.6.1.4.1.9.9.480.1.1.2.1.5
+    description: This object represents the limit allowed for the resource identified
+      by 'ciscoResourceLimitType'. The value zero specifies that this resource can
+      be used until the system limit reached.
+    name: crlResourceLimitMax
+  - OID: 1.3.6.1.4.1.9.9.480.1.1.2.1.6
+    description: The storage type for this conceptual row. Conceptual rows having
+      the value 'permanent' need not allow write-access to any columnar objects in
+      the row. This object cannot be modified when the value of crlResourceLimitRowStatus
+      is 'active'.
+    name: crlResourceLimitStorageType
+  - OID: 1.3.6.1.4.1.9.9.480.1.1.2.1.7
+    description: This object is used for adding/deleting entries in this table.
+    name: crlResourceLimitRowStatus
+  - OID: 1.3.6.1.4.1.9.9.480.1.1.2.1.8
+    description: This object indicates the number of resources identified by 'ciscoResourceLimitType',
+      that are currently being used in the system.
+    name: crlResourceLimitCurrentUsage
+  - OID: 1.3.6.1.4.1.9.9.480.1.1.2.1.9
+    description: This object represents the peak usage of the resource identified
+      by 'ciscoResourceLimitType' since the statistics were last cleared either through
+      the command line interface or bacause of the system reboot.
+    name: crlResourceLimitPeakUsage
+  - OID: 1.3.6.1.4.1.9.9.480.1.1.2.1.10
+    description: This object represents the number of resource requests that were
+      denied when the configured resource limit is exceeded for the resource identified
+      by 'ciscoResourceLimitType'. The value for resource limiting is specified in
+      'crlResourceLimitMax'.
+    name: crlResourceLimitReqsDeniedCount
+  table:
+    OID: 1.3.6.1.4.1.9.9.480.1.1.2
+    description: This table is used for adding resource limits to resources in a resource
+      class.
+    name: ciscoL4L7ResourceLimitTable
+- MIB: CISCO-MEMORY-POOL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.48.1.2.1.1
+    description: This is the memory pool utilization for 1 minute.
+    name: ciscoMemoryPoolUtilization1Min
+  - OID: 1.3.6.1.4.1.9.9.48.1.2.1.2
+    description: This is the memory pool utilization for 5 minutes.
+    name: ciscoMemoryPoolUtilization5Min
+  - OID: 1.3.6.1.4.1.9.9.48.1.2.1.3
+    description: This is the memory pool utilization for 10 minutes.
+    name: ciscoMemoryPoolUtilization10Min
+  table:
+    OID: 1.3.6.1.4.1.9.9.48.1.2
+    description: A table of memory pool utilization entries. Each of the objects provides
+      a general idea of how much of the memory pool has been used over a given period
+      of time. It is determined as a weighted decaying average.
+    name: ciscoMemoryPoolUtilizationTable
+- MIB: CISCO-MEMORY-POOL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.48.1.3.0
+    description: This object is used to enable or disable the generation of notification
+      when the available memory in the system has fallen below ciscoMemoryPoolLowMemoryNotifThreshold
+      and on recovery. Setting this object to 'true' will generate ciscoMemoryPoolLowMemoryNotif
+      and ciscoMemoryPoolLowMemoryRecoveryNotif. Setting this object to 'false' will
+      disable the generation of ciscoMemoryPoolLowMemoryNotif and ciscoMemoryPoolLowMemoryRecoveryNotif.
+    name: ciscoMemoryPoolLowMemoryNotifEnable
+- MIB: CISCO-PROCESS-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.109.1.1.2.1.1
+    description: An index that uniquely represents a Core (or group of Cores) whose
+      Core load information is reported by a row in this table. This index is assigned
+      arbitrarily by the engine and is not saved over reboots.
+    name: cpmCoreIndex
+  - OID: 1.3.6.1.4.1.9.9.109.1.1.2.1.2
+    description: The entCorePhysicalIndex of the physical entity for which the Core
+      statistics in this entry are maintained. The physical entity can be a CPU chip,
+      a group of CPUs, a CPU card etc. The exact type of this entity is described
+      by its entPhysicalVendorType value. If the Core statistics in this entry correspond
+      to more than one physical entity (or to no physical entity), or if the entPhysicalTable
+      is not supported on the SNMP agent, the value of this object must be zero.
+    name: cpmCorePhysicalIndex
+  - OID: 1.3.6.1.4.1.9.9.109.1.1.2.1.3
+    description: The overall Core busy percentage in the last 5 second period.
+    name: cpmCore5sec
+  - OID: 1.3.6.1.4.1.9.9.109.1.1.2.1.4
+    description: The overall Core busy percentage in the last 1 minute period.
+    name: cpmCore1min
+  - OID: 1.3.6.1.4.1.9.9.109.1.1.2.1.5
+    description: The overall Core busy percentage in the last 5 minute period.
+    name: cpmCore5min
+  - OID: 1.3.6.1.4.1.9.9.109.1.1.2.1.6
+    description: The overall Core load Average in the last 1 minute period
+    name: cpmCoreLoadAvg1min
+  - OID: 1.3.6.1.4.1.9.9.109.1.1.2.1.7
+    description: The overall Core load Average in the last 5 minutes period
+    name: cpmCoreLoadAvg5min
+  - OID: 1.3.6.1.4.1.9.9.109.1.1.2.1.8
+    description: The overall Core load Average in the last 15 minutes period
+    name: cpmCoreLoadAvg15min
+  table:
+    OID: 1.3.6.1.4.1.9.9.109.1.1.2
+    description: A table of per-Core statistics.
+    name: cpmCoreTable
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.1.1.0
+    description: The maximum number of remote access sessions that may be supported
+      on this device. If the device imposes no arbitrary limit on the maximum number
+      of sessions, it should return a value of 0.
+    name: crasMaxSessionsSupportable
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.1.2.0
+    description: The maximum number of remote access users for whom Remote Access
+      sessions may be supported on this device. If the device imposes no arbitrary
+      limit on the maximum number of users, it should return a value of 0.
+    name: crasMaxUsersSupportable
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.1.3.0
+    description: The maximum number of remote access groups that may be defined on
+      this device. 'Group' refers to a collection of users grouped together for administrative
+      convenience. If the device imposes no arbitrary limit on the maximum number
+      of groups, it should return a value of 0.
+    name: crasMaxGroupsSupportable
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.1.4.0
+    description: The maximum number of hardware crypto accelerators which can be installed
+      on this device to support remote access sessions. 'cryptoaccelerator' denotes
+      a hardware/software entity which the managed entity uses to offload some or
+      all computations pertaining to cryptographic operations. If the device imposes
+      no arbitrary limit on the number of crypto accelerators to support Remote Access
+      function, it should return a value of 0.
+    name: crasNumCryptoAccelerators
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.2.1.0
+    description: The average bandwidth used by all the active remote access sessions.
+    name: crasGlobalBwUsage
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.1.0
+    description: 'The number of currently active sessions. A session is a connection
+      terminating on the managed entity which has been established to provide remote
+      access connectivity to a user. A session is said to be ''active'' if it is ready
+      to carry application traffic between the user and the managed entity. A session
+      which is not active is defined to be ''dormant''. '
+    name: crasNumSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.2.0
+    description: The number of remote access sessions which were previously active
+      but which where since terminated. Measured since the last reboot of the device.
+    name: crasNumPrevSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.3.0
+    description: 'The number of users who have active sessions. '
+    name: crasNumUsers
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.4.0
+    description: The number of user groups whose members have active sessions.
+    name: crasNumGroups
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.5.0
+    description: The total number of packets received by all currently and previously
+      active remote access sessions.
+    name: crasGlobalInPkts
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.6.0
+    description: The total number of packets transmitted by all currently and previously
+      active remote access sessions.
+    name: crasGlobalOutPkts
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.7.0
+    description: 'The total number of octets received by all currently and previously
+      active remote access sessions. This value is accumulated BEFORE determining
+      whether or not the packet should be decompressed. '
+    name: crasGlobalInOctets
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.8.0
+    description: 'The total number of decompressed octets received by all current
+      and previous remote access sessions. This value is accumulated AFTER the packet
+      is decompressed. If compression is not being used, this value will match the
+      value of crasGlobalInOctets. '
+    name: crasGlobalInDecompOctets
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.9.0
+    description: 'The total number of octets transmitted by all currently and previously
+      active remote access sessions. This value is accumulated AFTER determining whether
+      or not the packet should be compressed. '
+    name: crasGlobalOutOctets
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.10.0
+    description: 'The total number of uncompressed octets sent by all current and
+      previous remote access sessions. This value is accumulated BEFORE the packet
+      is compressed. If compression is not being used, this value will match the value
+      of crasGlobalOutOctets. '
+    name: crasGlobalOutUncompOctets
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.11.0
+    description: The total number of packets which were dropped during receive processing
+      by all currently and previously active remote access sessions.
+    name: crasGlobalInDropPkts
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.12.0
+    description: The total number of packets which were dropped during receive processing
+      by all currently and previously active remote access sessions.
+    name: crasGlobalOutDropPkts
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.1
+    description: The name of the user associated with this remote access session.
+    name: crasUsername
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.2
+    description: The name of the user group to which this remote access session belongs.
+    name: crasGroup
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.3
+    description: 'Unique index to distinguish between multiple Remote Access Sessions
+      associated with the same user. The value of crasSessionIndex must increase monotonically
+      till it wraps. An implementation may choose to wrap this index before the value
+      of 2147483647. '
+    name: crasSessionIndex
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.4
+    description: The method used to authenticate the user prior to establishing the
+      session.
+    name: crasAuthenMethod
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.5
+    description: The method used to authorize the user prior to establishing the session.
+    name: crasAuthorMethod
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.6
+    description: The number of seconds elapsed since this session was established.
+    name: crasSessionDuration
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.7
+    description: 'The type of the address returned in ''crasLocalAddress''. '
+    name: crasLocalAddressType
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.8
+    description: The IP address assigned to the client of this session in the private
+      network assigned by the managed entity.
+    name: crasLocalAddress
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.9
+    description: 'The type of the address returned in ''crasISPAddress''. '
+    name: crasISPAddressType
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.10
+    description: The IP address of the peer (client) assigned by the ISP. This is
+      the address of the client device in the public network.
+    name: crasISPAddress
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.11
+    description: The protocol underlying this remote access session.
+    name: crasSessionProtocol
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.12
+    description: 'A reference to MIB definitions specific to the protocol underlying
+      corresponding to the session or tunnel used to realized the remote access session
+      corresponding to this conceptual row. For instance, if this remote access session
+      is based on IPsec, then this object must contain the complete instance identifier
+      of the IPsec tunnel corresponding to this remote access session. If no MIB definitions
+      specific to the underlying protocol are available, the value should be set to
+      the OBJECT IDENTIFIER { 0 0 }. '
+    name: crasProtocolElement
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.13
+    description: The algorithm used by this remote access session to encrypt its payload.
+    name: crasSessionEncryptionAlgo
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.14
+    description: The algorithm used by this remote access session to to validate packets.
+    name: crasSessionPktAuthenAlgo
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.15
+    description: The algorithm used by this remote access session to compress packets.
+    name: crasSessionCompressionAlgo
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.16
+    description: The interval in seconds between two successive heartbeats employed
+      by this session. Value of 0 denotes that no heartbeat is used.
+    name: crasHeartbeatInterval
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.17
+    description: The string identifying the vendor of the client application initiating
+      this Remote Access session.
+    name: crasClientVendorString
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.18
+    description: The string identifying the version of the of the client application
+      initiating the Remote Access session. This can be used by the administrator
+      to identify which users are running unsupported client versions.
+    name: crasClientVersionString
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.19
+    description: The string identifying the vendor of the operating system on which
+      the client application initiating the Remote Access Session is running.
+    name: crasClientOSVendorString
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.20
+    description: The string identifying the version of the operating system of the
+      entity which initiated this Remote Access session.
+    name: crasClientOSVersionString
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.21
+    description: 'The type of the address returned in ''crasPrimWINSServer''. '
+    name: crasPrimWINSServerAddrType
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.22
+    description: The IP address of the primary WINS server assigned managed entity
+      to this client session.
+    name: crasPrimWINSServer
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.23
+    description: 'The type of the address returned in ''crasSecWINSServer''. '
+    name: crasSecWINSServerAddrType
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.24
+    description: The IP address of the secondary WINS server assigned by the managed
+      entity to this client session.
+    name: crasSecWINSServer
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.25
+    description: 'The type of the address returned in ''crasPrimDNSServer''. '
+    name: crasPrimDNSServerAddrType
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.26
+    description: The IP address of the primary DNS server assigned by the managed
+      entity to this client session.
+    name: crasPrimDNSServer
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.27
+    description: 'The type of the address returned in ''crasSecDNSServer''. '
+    name: crasSecDNSServerAddrType
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.28
+    description: The IP address of the secondary DNS server assigned by the managed
+      entity to this client session.
+    name: crasSecDNSServer
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.29
+    description: 'The type of the address returned in ''crasDHCPServer''. '
+    name: crasDHCPServerAddrType
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.30
+    description: The IP address of the DHCP server assigned by the managed entity
+      to this client session.
+    name: crasDHCPServer
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.31
+    description: The total number of packets received by this Remote Access session.
+    name: crasSessionInPkts
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.32
+    description: The total number of packets transmitted by this Remote Access Session.
+    name: crasSessionOutPkts
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.33
+    description: The total number of packets received for processing on this session
+      which were dropped by the managed entity.
+    name: crasSessionInDropPkts
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.34
+    description: The total number of outgoing packets on this session which were dropped
+      during transmit processing by the managed entity.
+    name: crasSessionOutDropPkts
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.35
+    description: 'The total number of octets received by this Remote Access Session.
+      This value is accumulated BEFORE determining whether or not the packet should
+      be decompressed. '
+    name: crasSessionInOctets
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.36
+    description: 'The total number of octets transmitted by this Remote Access Session.
+      This value is accumulated AFTER determining whether or not the packet should
+      be compressed. '
+    name: crasSessionOutOctets
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.21.1.37
+    description: 'The state of the remote access session corresponding to this conceptual
+      row. The management entity may use this object to terminate an established session
+      by setting value of the object to ''terminating''. '
+    name: crasSessionState
+  table:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.21
+    description: This table lists all the currently active sessions. For each session,
+      it lists the attributes (user, group, protocol, security), statistics (packet
+      and octets) and status.
+    name: crasSessionTable
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.22.1.1
+    description: The name of the active user group corresponding to this entry.
+    name: crasActGrpName
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.22.1.2
+    description: The number of users in this group currently connected to the managed
+      device.
+    name: crasActGrNumUsers
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.22.1.3
+    description: The total number of packets received by this session.
+    name: crasActGrpInPkts
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.22.1.4
+    description: The total number of packets transmitted by this session.
+    name: crasActGrpOutPkts
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.22.1.5
+    description: The total number of packets dropped by this session which were received
+      for processing.
+    name: crasActGrpInDropPkts
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.22.1.6
+    description: The total number of outgoing packets which were dropped during transmit
+      processing by this session.
+    name: crasActGrpOutDropPkts
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.22.1.7
+    description: The total number of octets received by this session.
+    name: crasActGrpInOctets
+  - OID: 1.3.6.1.4.1.9.9.392.1.3.22.1.8
+    description: The total number of octets transmitted by this session.
+    name: crasActGrpOutOctets
+  table:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.22
+    description: This table lists all the currently active remote access user groups.
+      For each group, it lists the attributes (group, aggregate activity, aggregate
+      traffic), and status.
+    name: crasActGroupTable
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.23.0
+    description: The number of currently active Email proxy sessions.
+    name: crasEmailNumSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.24.0
+    description: The number of cumulative Email proxy sessions since system up.
+    name: crasEmailCumulateSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.25.0
+    description: The number of peak concurrent Email proxy sessions since system up.
+    name: crasEmailPeakConcurrentSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.26.0
+    description: The number of currently active IPSec sessions.
+    name: crasIPSecNumSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.27.0
+    description: The number of cumulative IPSec sessions since system up.
+    name: crasIPSecCumulateSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.28.0
+    description: The number of peak concurrent Email proxy sessions since system up.
+    name: crasIPSecPeakConcurrentSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.29.0
+    description: The number of currently active LAN to LAN sessions.
+    name: crasL2LNumSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.30.0
+    description: The number of cumulative LAN to LAN sessions since system up.
+    name: crasL2LCumulateSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.31.0
+    description: The number of peak concurrent LAN to LAN sessions since system up.
+    name: crasL2LPeakConcurrentSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.32.0
+    description: The number of currently active Load Balancing sessions.
+    name: crasLBNumSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.33.0
+    description: The number of cumulative Load Balancing sessions since system up.
+    name: crasLBCumulateSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.34.0
+    description: The number of peak concurrent Load Balancing sessions since system
+      up.
+    name: crasLBPeakConcurrentSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.35.0
+    description: The number of currently active SVC sessions.
+    name: crasSVCNumSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.36.0
+    description: The number of cumulative SVC sessions since system up.
+    name: crasSVCCumulateSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.37.0
+    description: The number of peak concurrent SVC sessions since system up.
+    name: crasSVCPeakConcurrentSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.38.0
+    description: The number of currently active Webvpn sessions.
+    name: crasWebvpnNumSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.39.0
+    description: The number of cumulative Webvpn sessions since system up.
+    name: crasWebvpnCumulateSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.3.40.0
+    description: The number of peak concurrent Webvpn sessions since system up.
+    name: crasWebvpnPeakConcurrentSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.4.1.1.0
+    description: The number of attempts to establish sessions which failed, since
+      the last reboot of the managed device.
+    name: crasNumTotalFailures
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.4.1.2.0
+    description: 'The number of session setup attempts, counted since the last time
+      the notification ''ciscoRasTooManyFailedAuths'' was issued, which were declined
+      due to authentication or authorization failure. '
+    name: crasNumDeclinedSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.4.1.3.0
+    description: The number of session setup attempts that failed due to insufficient
+      resources.
+    name: crasNumSetupFailInsufResources
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.4.1.4.0
+    description: The number of sessions which were successfully setup but were since
+      terminated abnormally.
+    name: crasNumAbortedSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.4.2.1.0
+    description: The window size of the Remote Access Failure tables. The failure
+      tables for session and group failures maintain only the last crasFailTableSize
+      number of failure records. A value of 0 for this MIB variable indicates that
+      archiving of the failures is disabled. An implementation may choose suitable
+      minimum and maximum values for this element based on the local policy and available
+      resources. If an SNMP SET request specifies a value outside this window for
+      this element, a BAD VALUE may be returned.
+    name: crasFailTableSize
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.3.1.1.1
+    description: The index of the session failure table. The value of the index is
+      a number which begins at one and is incremented with each session failure. The
+      value of this object will wrap at 4,294,967,295.
+    name: crasSessFailIndex
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.3.1.1.2
+    description: The name of the user associated with this failed remote access session.
+    name: crasSessFailUsername
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.3.1.1.3
+    description: The name of the user group to which this failed remote access session
+      belongs.
+    name: crasSessFailGroupname
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.3.1.1.4
+    description: 'The type of the failure: 1 = failure occurred during session setup
+      2 = failed occurred after the session was setup successfully. '
+    name: crasSessFailType
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.3.1.1.5
+    description: 'The reason for the failure. Possible reasons include: 1 = other
+      (error which cannot be classified in any of the types listed below). 2 = internal
+      error occurred 3 = failed to authenticate the peer/user 4 = failed to authorize
+      the peer/user 5 = system capacity exceeded (memory, cpu, max users etc) 6 =
+      peer requested to abort the session or the setup 7 = lost peer''s heartbeat
+      8 = local management request.'
+    name: crasSessFailReason
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.3.1.1.6
+    description: The value of the MIB element 'sysUpTime' at the time of the failure.
+    name: crasSessFailTime
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.3.1.1.7
+    description: The index of the session which failed (in case this was an operational
+      failure). In case of setup failures (where the value of 'crasSessFailType' of
+      this conceptual row is 'operationalFailure'), the value of this object is undefined
+      and should not be processed.
+    name: crasSessFailSessionIndex
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.3.1.1.8
+    description: 'The type of the address returned in ''crasSessFailISPAddr''. '
+    name: crasSessFailISPAddrType
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.3.1.1.9
+    description: The public address of the peer.
+    name: crasSessFailISPAddr
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.3.1.1.10
+    description: 'The type of the address returned in ''crasSessFailLocalAddr''. '
+    name: crasSessFailLocalAddrType
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.3.1.1.11
+    description: The address assigned to the peer by the local address management
+      mechanism. In case no address was assigned to the peer when the failure occurred,
+      this MIB variable would contain the IPv4 address value 0.0.0.0
+    name: crasSessFailLocalAddr
+  table:
+    OID: 1.3.6.1.4.1.9.9.392.1.4.3.1
+    description: ' This table records the last ''N'' session failures, where ''N''
+      is the value of the MIB element ''crasFailTableSize'' defined earlier. A failure
+      could be a failure to establish a session (''setup'' failure) or a failure of
+      a session after it was established (''operational'' failure). '
+    name: crasSessFailTable
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.4.3.2.0
+    description: 'The value of column ''crasSessFailIndex'' corresponding to the last
+      row added to the crasSessFailTable. The value of this object is undefined and
+      should not be processed by the management entity if the value of the object
+      ''crasFailTableSize'' is 0. '
+    name: crasFailLastFailIndex
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.4.1.1.1
+    description: The name of the user group to which this failure record corresponds.
+      This is the index of the group failure table.
+    name: crasGrpFailGroupname
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.4.1.1.2
+    description: The number of sessions belonging to this group which failed authentication;
+      counted since last reboot.
+    name: crasGrpFailNumFailAuths
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.4.1.1.3
+    description: The number of session setup attempts which failed due to insufficient
+      resources.
+    name: crasGrpFailNumResourceFailures
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.4.1.1.4
+    description: The number of session setup attempts which were declined by the managed
+      entity due to local policy. These would include sessions which were denied due
+      to rate control settings.
+    name: crasGrpFailNumDeclined
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.4.1.1.5
+    description: The number of established sessions which were terminated by explicit
+      management action. The termination may have been triggered locally or based
+      on a request from the peer.
+    name: crasGrpFailNumTerminatedMgmt
+  - OID: 1.3.6.1.4.1.9.9.392.1.4.4.1.1.6
+    description: The number of established sessions which were terminated due to insufficient
+      reasons, internal error or other reasons not caused by management action.
+    name: crasGrpFailNumTerminatedOther
+  table:
+    OID: 1.3.6.1.4.1.9.9.392.1.4.4.1
+    description: 'This table records the last ''N'' occurrences of failures (setup
+      or operational) per user group, where ''N'' is the value of the MIB element
+      ''crasFailTableSize'' defined earlier. When ''N'' entries have been created,
+      the failure information about a new user group must be created by deleting the
+      oldest entry in this table. '
+    name: crasGrpFailTable
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.5.1.1.0
+    description: The total number of user accounts which were disabled due to repeated
+      login failures.
+    name: crasNumDisabledAccounts
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.6.1.0
+    description: The maximum number of sessions which are successfully setup after
+      which the managed entity should alert the network management entity using the
+      notification 'ciscoRasTooManySessions', if the notification has been enabled.
+      A value of 0 indicates that the threshold has not been set.
+    name: crasThrMaxSessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.6.2.0
+    description: The value of object 'crasNumDeclinedSessions' at which the managed
+      entity should alert the network management entity using the notification 'ciscoRasTooManyFailedAuths',
+      if the notification has been enabled. A value of 0 indicates that the threshold
+      has not been set.
+    name: crasThrMaxFailedAuths
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.6.3.0
+    description: The highest throughput of the Remote Access Service at which the
+      managed entity should alert the network management entity using the notification
+      'ciscoRasTooHighThroughput', if the notification has been enabled. The notification
+      is disabled till the value of the aggregate throughput of the managed entity
+      drops below the value of this object. A value of 0 indicates that the threshold
+      has not been set.
+    name: crasThrMaxThroughput
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.7.1.0
+    description: This object defines the administrative state of sending the trap
+      to signal the violation of the Max session threshold.
+    name: crasCntlTooManySessions
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.7.2.0
+    description: This object defines the administrative state of sending the trap
+      to signal the violation of the Max authentication failure count threshold.
+    name: crasCntlTooManyFailedAuths
+- MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.392.1.7.3.0
+    description: This object defines the administrative state of sending the trap
+      to signal the violation of the Max throughput threshold.
+    name: crasCntlTooHighThroughput
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.1.1.0
+    description: ' Connection Statistics Aggregation Connection 1 +-----------+ ------------->|
+      |-------> Global Connection Summary Connection 2 | | ------------->| | Connection
+      3 | | ------------->| First |------------> ConnSummary | Level | (i.e, L-3/4
+      Protocol Connection 4 |Aggregation| Connection Summary) ------------->| | .
+      | | . | |---------------> PolicyConnSummary Connection N | | (i.e, L-3/4 Policy
+      Target based ------------->| | Protocol Connection Summary) +-----------+ +-----------+
+      L-3/4 Protocol | | Connection Summary | | ------------------>| |---------> AppConnSummary
+      | | (i.e, L-7 Protocol | Second | Connection Summary) |---Level---| L-3/4 Policy
+      Target |Aggregation| based Protocol | | Connection Summary | | ------------------>|
+      |---------------> PolicyAppConnSummary | | (i.e, L-7 Policy Target based | |
+      Protocol Connection Summary) +-----------+ Specifically, the object ''cufwConnGlobalNumAttempted''
+      models the number of connections which are attempted to be set up through the
+      firewall. This value is accumulated from the last reboot of the firewall. '
+    name: cufwConnGlobalNumAttempted
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.1.2.0
+    description: 'The number of connection setup attempts that were aborted before
+      the connection could proceed to completion. The counter includes setup attempts
+      aborted by the firewall as well as those aborted by the initiator and/or the
+      responder(s) of/to the connection setup attempt. Consequently, this value subsumes
+      the values of objects ''cufwConnGlobalNumPolicyDeclined'' and ''cufwConnGlobalNumResDeclined''.
+      This value is accumulated from the last reboot of the firewall. '
+    name: cufwConnGlobalNumSetupsAborted
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.1.3.0
+    description: 'The number of connections which were attempted to be setup but which
+      were declined due to reasons of security policy. This includes the connections
+      that failed authentication. This value is accumulated from the last reboot of
+      the firewall. '
+    name: cufwConnGlobalNumPolicyDeclined
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.1.4.0
+    description: 'The number of connections which were attempted to be setup but which
+      were declined due to non-availability of required resources. This value is accumulated
+      from the last reboot of the firewall. '
+    name: cufwConnGlobalNumResDeclined
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.1.5.0
+    description: 'The number of connections which are in the process of being setup
+      but which have not yet reached the established state in the connection table. '
+    name: cufwConnGlobalNumHalfOpen
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.1.6.0
+    description: 'The number of connections which are currently active. '
+    name: cufwConnGlobalNumActive
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.1.7.0
+    description: 'The number of connections which were active but which were since
+      normally terminated. This value is accumulated from the last reboot of the firewall. '
+    name: cufwConnGlobalNumExpired
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.1.8.0
+    description: 'The number of connections which were active but which were aborted
+      by the firewall due to reasons of policy or resource rationing. This value is
+      accumulated from the last reboot of the firewall. '
+    name: cufwConnGlobalNumAborted
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.1.9.0
+    description: 'The number of embryonic application layer connections (that is,
+      connections in which the signaling channel has been established while the data
+      channel is awaiting setup). This value is accumulated from the last reboot of
+      the firewall. '
+    name: cufwConnGlobalNumEmbryonic
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.1.10.0
+    description: 'The averaged number of connections which the firewall establishing
+      per second, averaged over the last 60 seconds. '
+    name: cufwConnGlobalConnSetupRate1
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.1.11.0
+    description: 'The averaged number of connections which the firewall establishing
+      per second, averaged over the last 300 seconds. '
+    name: cufwConnGlobalConnSetupRate5
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.1.12.0
+    description: 'The number of active connections which correspond to remote access
+      applications. Specifically, the protocol for which the connection is established
+      must be one of PPP, PPTP, L2TP or remote access IPsec (IPsec connections employing
+      extended authentication). This value is accumulated from the last reboot of
+      the firewall. '
+    name: cufwConnGlobalNumRemoteAccess
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.2.1.0
+    description: 'The amount of memory occupied by all structures required to maintain
+      the state of all connections which are either being established or are active. '
+    name: cufwConnResMemoryUsage
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.2.2.0
+    description: 'The amount of memory occupied by all structures required to maintain
+      the state of all active connections. '
+    name: cufwConnResActiveConnMemoryUsage
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.2.3.0
+    description: 'The amount of memory occupied by all structures required to maintain
+      the state of all half open connections. '
+    name: cufwConnResHOConnMemoryUsage
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.2.4.0
+    description: 'The amount of memory occupied by all structures required to maintain
+      the state of all embryonic connections. '
+    name: cufwConnResEmbrConnMemoryUsage
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.3.1.0
+    description: 'Setting this object to ''true'' enables the MIB to report connection
+      activity statistics pertaining to application protocols. If this object is set
+      to ''false'', the agent should stop updating the objects defined in this module
+      pertaining to application protocols. Application monitoring could be a resource
+      intensive operation. It is expected that the administrators would use this control
+      to disable application monitoring when the performance of the firewall is degrading. '
+    name: cufwConnReptAppStats
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.3.2.0
+    description: 'The time at which the value of cufwConnReptAppStats was last changed. '
+    name: cufwConnReptAppStatsLastChanged
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.1.1.1
+    description: 'The (L3-L4) protocol for which this conceptual row summarizes the
+      connection activity on the managed entity. '
+    name: cufwConnProtocol
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.1.1.2
+    description: 'The number of connections attempted since the last reboot of the
+      firewall, corresponding to the protocol denoted by ''cufwConnProtocol''. This
+      value is accumulated from the last reboot of the firewall. '
+    name: cufwConnNumAttempted
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.1.1.3
+    description: 'The number of connection setup attempts, corresponding to the protocol
+      denoted by ''cufwConnProtocol'', that were aborted before the connection could
+      proceed to completion. The counter includes setup attempts aborted by the firewall
+      as well as those aborted by the initiator and/or the responder(s) of/to the
+      connection setup attempt. Consequently, this value subsumes the values of objects
+      ''cufwConnNumPolicyDeclined'' and ''cufwConnNumResDeclined''. This value is
+      accumulated from the last reboot of the firewall. '
+    name: cufwConnNumSetupsAborted
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.1.1.4
+    description: 'The number of connection attempts that were declined due to security
+      policy, corresponding to the protocol denoted by ''cufwConnProtocol''. This
+      value is accumulated from the last reboot of the firewall. '
+    name: cufwConnNumPolicyDeclined
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.1.1.5
+    description: 'The number of connection attempts that were declined due to resource
+      unavailability, corresponding to the protocol denoted by ''cufwConnProtocol''.
+      This value is accumulated from the last reboot of the firewall. '
+    name: cufwConnNumResDeclined
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.1.1.6
+    description: 'The number of connections that are currently in the process of being
+      established, corresponding to the protocol denoted by ''cufwConnProtocol''. '
+    name: cufwConnNumHalfOpen
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.1.1.7
+    description: 'The number of connections that are currently active, corresponding
+      to the protocol denoted by ''cufwConnProtocol''. '
+    name: cufwConnNumActive
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.1.1.8
+    description: 'The number of connections that were abnormally terminated after
+      successful establishment, corresponding to the protocol denoted by ''cufwConnProtocol''.
+      This value is accumulated from the last reboot of the firewall. '
+    name: cufwConnNumAborted
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.1.1.9
+    description: 'The connection setup rate averaged over the last 60 seconds corresponding
+      to the protocol denoted by ''cufwConnProtocol''. '
+    name: cufwConnSetupRate1
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.1.1.10
+    description: 'The connection setup rate averaged over the last 300 seconds corresponding
+      to the protocol denoted by ''cufwConnProtocol''. '
+    name: cufwConnSetupRate5
+  table:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.4.1
+    description: 'This table summarizes the connection activity on the firewall per
+      layer3-layer 4 protocol instance. Each entry in the table lists the connection
+      summary of a distinct network protocol. For instance, the conceptual row corresponding
+      to the index cufwConnProtocol = fwpTcp yields the summary of TCP connection
+      activity on the firewall since its reboot. '
+    name: cufwConnSummaryTable
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.2.1.1
+    description: 'The layer7 protocol for which this conceptual row summarizes the
+      connection activity for this firewall. '
+    name: cufwAppConnProtocol
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.2.1.2
+    description: 'The number of connections attempted since the last reboot of the
+      firewall, corresponding to the protocol denoted by ''cufwAppConnProtocol''.
+      This value is accumulated from the last reboot of the firewall subject to the
+      control exercised by cufwConnReptAppStats. '
+    name: cufwAppConnNumAttempted
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.2.1.3
+    description: 'The number of connection setup attempts, corresponding to the protocol
+      denoted by ''cufwAppConnProtocol'', that were aborted before the connection
+      could proceed to completion. The counter includes setup attempts aborted by
+      the firewall as well as those aborted by the initiator and/or the responder(s)
+      of/to the connection setup attempt. Consequently, this value subsumes the values
+      of objects ''cufwAppConnNumPolicyDeclined'' and ''cufwAppConnNumResDeclined''.
+      This value is accumulated from the last reboot of the firewall subject to the
+      control exercised by cufwConnReptAppStats. '
+    name: cufwAppConnNumSetupsAborted
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.2.1.4
+    description: 'The number of connection attempts that were declined due to security
+      policy, corresponding to the protocol denoted by ''cufwAppConnProtocol''. This
+      value is accumulated from the last reboot of the firewall subject to the control
+      exercised by cufwConnReptAppStats. '
+    name: cufwAppConnNumPolicyDeclined
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.2.1.5
+    description: 'The number of connection attempts that were declined due to resource
+      unavailability, corresponding to the protocol denoted by ''cufwAppConnProtocol''.
+      This value is accumulated from the last reboot of the firewall subject to the
+      control exercised by cufwConnReptAppStats. '
+    name: cufwAppConnNumResDeclined
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.2.1.6
+    description: 'The number of connections that are currently in the process of being
+      established, corresponding to the protocol denoted by ''cufwAppConnProtocol''. '
+    name: cufwAppConnNumHalfOpen
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.2.1.7
+    description: 'The number of connections that are currently active, corresponding
+      to the protocol denoted by ''cufwAppConnProtocol''. '
+    name: cufwAppConnNumActive
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.2.1.8
+    description: 'The number of connections that were terminated by the firewall successful
+      establishment, corresponding to the protocol denoted by ''cufwAppConnProtocol''.
+      This value is accumulated from the last reboot of the firewall subject to the
+      control exercised by cufwConnReptAppStats. '
+    name: cufwAppConnNumAborted
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.2.1.9
+    description: 'The connection setup rate averaged over the last 60 seconds corresponding
+      to the protocol denoted by ''cufwAppConnProtocol''. '
+    name: cufwAppConnSetupRate1
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.2.1.10
+    description: 'The connection setup rate averaged over the last 300 seconds corresponding
+      to the protocol denoted by ''cufwAppConnProtocol''. '
+    name: cufwAppConnSetupRate5
+  table:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.4.2
+    description: 'This table lists the summary of firewall connections pertaining
+      to Layer 7 protocols, catalogued by distinct application protocols. Each entry
+      in the table lists the connection summary corresponding to a distinct application
+      protocol. For instance, to obtain the connection summary for SMTP on the firewall
+      since the last reboot of the device, use the conceptual row corresponding to
+      cufwAppConnProtocol = fwApSmtp '
+    name: cufwAppConnSummaryTable
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.3.1.1
+    description: 'The identity of the firewall policy for which this conceptual row
+      contains the connection activity summary. '
+    name: cufwPolConnPolicy
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.3.1.2
+    description: 'The type of the entity to which the firewall policy ''cufwPolConnPolicy''
+      has been applied. This could be an interface type (most commonly), the type
+      of another object or a group of objects defined in the firewall configuration.
+      When this object is set to ''targetALL'', the value of index object cufwConnPolicyTarget
+      is ignored. '
+    name: cufwPolConnPolicyTargetType
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.3.1.3
+    description: 'The identity of the entity to which the firewall policy ''cufwPolConnPolicy''
+      is applied. This could be an interface object (most commonly), another object
+      or group of objects defined in the firewall configuration. '
+    name: cufwPolConnPolicyTarget
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.3.1.4
+    description: 'The (L3-L4) protocol corresponding to which this conceptual row
+      summarizes the connection activity on the firewall. '
+    name: cufwPolConnProtocol
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.3.1.5
+    description: 'The number of connections attempted since the last reboot of the
+      firewall, corresponding to the protocol denoted by ''cufwPolConnProtocol'',
+      in the policy ''cufwPolConnPolicy'' applied to the entity identified by ''cufwPolConnPolicyTarget''. '
+    name: cufwPolConnNumAttempted
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.3.1.6
+    description: 'The number of connection setup attempts, corresponding to the protocol
+      denoted by ''cufwPolConnProtocol'', associated with the policy ''cufwPolConnPolicy''
+      applied to the entity identified by ''cufwPolConnPolicyTarget'', that were aborted
+      before the connection could proceed to completion. The counter includes setup
+      attempts aborted by the firewall as well as those aborted by the initiator and/or
+      the responder(s) of/to the connection setup attempt. Consequently, this value
+      subsumes the values of objects ''cufwPolConnNumPolicyDeclined'' and ''cufwPolConnNumResDeclined''. '
+    name: cufwPolConnNumSetupsAborted
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.3.1.7
+    description: 'The number of connection attempts that were declined due to security
+      policy, corresponding to the protocol denoted by ''cufwPolConnProtocol'', in
+      the policy ''cufwPolConnPolicy'' applied to the entity identified by ''cufwPolConnPolicyTarget''. '
+    name: cufwPolConnNumPolicyDeclined
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.3.1.8
+    description: 'The number of connection attempts that were declined due to resource
+      unavailability, corresponding to the protocol denoted by ''cufwPolConnProtocol'',
+      in the policy ''cufwPolConnPolicy'' applied to the entity identified by ''cufwPolConnPolicyTarget''. '
+    name: cufwPolConnNumResDeclined
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.3.1.9
+    description: 'The number of connections that are currently in the process of being
+      established, corresponding to the protocol denoted by ''cufwPolConnProtocol'',
+      in the policy ''cufwPolConnPolicy'' applied to the entity identified by ''cufwPolConnPolicyTarget''. '
+    name: cufwPolConnNumHalfOpen
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.3.1.10
+    description: 'The number of connections that are currently active, corresponding
+      to the protocol denoted by ''cufwPolConnProtocol'', in the policy ''cufwPolConnPolicy''
+      applied to the entity identified by ''cufwPolConnPolicyTarget''. '
+    name: cufwPolConnNumActive
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.3.1.11
+    description: 'The number of connections that were abnormally terminated after
+      successful establishment, corresponding to the protocol denoted by ''cufwPolConnProtocol'',
+      in the policy ''cufwPolConnPolicy'' applied to the entity identified by ''cufwPolConnPolicyTarget''. '
+    name: cufwPolConnNumAborted
+  table:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.4.3
+    description: 'This table lists the summary of firewall connections for layer3-layer
+      4 protocols catalogued on a per policy basis. Each entry in the table lists
+      the connection summary of a distinct network protocol, configured on the specified
+      policy on the firewall, and pertaining to a specified target to which the policy
+      is currently applied. If a policy is bound to a target, it would have one or
+      more entries in this table. If the policy is detached from the target, all entries
+      corresponding to the association between the policy and the target are elminated
+      from this table. Although the information is indexed by policy targets as well,
+      one may aggregate the connection summary for a specific policy across all the
+      target to which the policy is currently applied by setting cufwConnPolicyTargetType
+      = ''targetAll'' '
+    name: cufwPolicyConnSummaryTable
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.4.1.1
+    description: 'The identity of the firewall policy for which this conceptual row
+      contains the connection activity summary. '
+    name: cufwPolAppConnPolicy
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.4.1.2
+    description: 'The type of the entity to which the firewall policy ''cufwPolAppConnPolicy''
+      has been applied. This could be an interface type (most commonly), the type
+      of another object or a group of objects defined in the firewall configuration.
+      When this object is set to ''targetALL'', the value of index object cufwAppConnPolicyTarget
+      is ignored. '
+    name: cufwPolAppConnPolicyTargetType
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.4.1.3
+    description: 'The identity of the entity to which the firewall policy ''cufwPolAppProtocol''
+      refers. This could be an interface object (most commonly), another object or
+      group of objects defined in the firewall configuration. '
+    name: cufwPolAppConnPolicyTarget
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.4.1.4
+    description: 'The layer7 protocol for which this conceptual row summarizes the
+      connection activity for this firewall. '
+    name: cufwPolAppConnProtocol
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.4.1.5
+    description: 'The number of connections attempted since the last reboot of the
+      firewall, corresponding to the protocol denoted by ''cufwPolAppConnProtocol'',
+      in the policy ''cufwPolAppConnPolicy'' applied to the entity identified by ''cufwPolAppConnPolicyTarget''.
+      This value is accumulated from the last reboot of the firewall subject to the
+      control exercised by cufwConnReptAppStats. '
+    name: cufwPolAppConnNumAttempted
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.4.1.6
+    description: 'The number of connection setup attempts, corresponding to the protocol
+      denoted by ''cufwPolAppConnProtocol'', associated with the policy ''cufwPolAppConnPolicy''
+      applied to the entity identified by ''cufwPolAppConnPolicyTarget'', that were
+      aborted before the connections could proceed to completion. The counter includes
+      setup attempts aborted by the firewall as well as those aborted by the initiator
+      and/or the responder(s) of/to the connection setup attempt. Consequently, this
+      value subsumes the values of objects ''cufwPolAppConnNumPolicyDeclined'' and
+      ''cufwPolAppConnNumResDeclined''. This value is accumulated from the last reboot
+      of the firewall subject to the control exercised by cufwConnReptAppStats. '
+    name: cufwPolAppConnNumSetupsAborted
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.4.1.7
+    description: 'The number of connection attempts that were declined due to security
+      policy, corresponding to the protocol denoted by ''cufwPolAppConnProtocol'',
+      in the policy ''cufwPolAppConnPolicy'' applied to the entity identified by ''cufwPolAppConnPolicyTarget''.
+      This value is accumulated from the last reboot of the firewall subject to the
+      control exercised by cufwConnReptAppStats. '
+    name: cufwPolAppConnNumPolicyDeclined
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.4.1.8
+    description: 'The number of connection attempts that were declined due to resource
+      unavailability, corresponding to the protocol denoted by ''cufwPolAppConnProtocol'',
+      in the policy ''cufwPolAppConnPolicy'' applied to the entity identified by ''cufwPolAppConnPolicyTarget''.
+      This value is accumulated from the last reboot of the firewall subject to the
+      control exercised by cufwConnReptAppStats. '
+    name: cufwPolAppConnNumResDeclined
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.4.1.9
+    description: 'The number of connections that are currently in the process of being
+      established, corresponding to the protocol denoted by ''cufwPolAppConnProtocol'',
+      in the policy ''cufwPolAppConnPolicy'' applied to the entity identified by ''cufwPolAppConnPolicyTarget''. '
+    name: cufwPolAppConnNumHalfOpen
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.4.1.10
+    description: 'The number of connections that are currently active, corresponding
+      to the protocol denoted by ''cufwPolAppConnProtocol'', in the policy ''cufwPolAppConnPolicy''
+      applied to the entity identified by ''cufwPolAppConnPolicyTarget''. '
+    name: cufwPolAppConnNumActive
+  - OID: 1.3.6.1.4.1.9.9.491.1.1.4.4.1.11
+    description: 'The number of connections that were abnormally terminated after
+      successful establishment, corresponding to the protocol denoted by ''cufwPolAppConnProtocol'',
+      in the policy ''cufwPolAppConnPolicy'' applied to the entity identified by ''cufwPolAppConnPolicyTarget''. '
+    name: cufwPolAppConnNumAborted
+  table:
+    OID: 1.3.6.1.4.1.9.9.491.1.1.4.4
+    description: 'This table lists the summary of firewall connections pertaining
+      to Layer 7 protocols, catalogued on a per policy basis Each entry in the table
+      lists the connection summary of a distinct application protocol, configured
+      on the specified policy on the firewall, and pertaining to a specified target
+      to which the policy has been applied. If a policy is bound to a target, it would
+      have one or more entries in this table. If the policy is detached from the target,
+      all entries corresponding to the association between the policy and the target
+      are elminated from this table. Although the information is indexed by policy
+      targets as well, one may aggregate the connection summary for a specific policy
+      across all the target to which the policy is currently applied by setting cufwAppConnPolicyTargetType
+      = ''targetALL'' '
+    name: cufwPolicyAppConnSummaryTable
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.1.0
+    description: ' URL Filtering Operation _________ 2.2 Request | | |---------->|
+      Server | | | | _________ __|_ |_________| | |<--(5. Response )---| | 3. Response
+      | | | | |<-------------| | Client |---(1. Request )--->|FW | |_________| |____|<--------------|
+      | 4. URLF Resp ____|______ | | | |------------>|URLF Server| 2.1 URLF Req |___________|
+      1) Client sends a Request containing a URL to the Server 2.1) FW extracts the
+      URL from the Request and sends it to URL Filtering Server (or Verifies the URL
+      locally) 2.2) FW also forwards the original Request from the Client to the Server
+      3) Any Responses from the Server received before receiving a response from URLF
+      Server are cached by the FW 4) URLF Response indicates whether the URL access
+      should be allowed or denied 5) If the URLF Response allows the URL, FW forwards
+      the URL Access responses from the Server to the Client 6) If the URLF Response
+      indicates that the URL access should be denied, FW drops all the cached URL
+      responses and forces the connection between the Client and the Server to be
+      terminated Specifically, the object cufwUrlfFunctionEnabled indicates if the
+      URL filtering function is enabled. When this MIB object contains the value ''false'',
+      the firewall device will not perform URL filtering function, even if it contains
+      configuration pertaining to other aspects of URL filtering. '
+    name: cufwUrlfFunctionEnabled
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.2.0
+    description: 'The number of URL access requests processed by this firewall. This
+      value is accumulated from the last reboot of the firewall. '
+    name: cufwUrlfRequestsNumProcessed
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.3.0
+    description: 'The number of URL access requests processed per seconds by this
+      firewall averaged over the last 60 seconds. '
+    name: cufwUrlfRequestsProcRate1
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.4.0
+    description: 'The number of URL access requests processed per second by this firewall
+      averaged over the last 300 seconds. '
+    name: cufwUrlfRequestsProcRate5
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.5.0
+    description: 'The number of URL access requests allowed by this firewall, due
+      to a directive from a URL filtering server or a static policy configured on
+      the firewall. This value is accumulated from the last reboot of the firewall. '
+    name: cufwUrlfRequestsNumAllowed
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.6.0
+    description: 'The number of URL access requests declined by this firewall, due
+      to a directive from a URL filtering server, a static policy configured on the
+      firewall, due to resource constraints or any other reason. This value is accumulated
+      from the last reboot of the firewall. '
+    name: cufwUrlfRequestsNumDenied
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.7.0
+    description: 'The rate at which URL access requests were denied by this firewall,
+      due to a directive from a URL filtering server, a static policy configured on
+      the firewall, due to resource constraints or any other reason, averaged over
+      the last 60 seconds. '
+    name: cufwUrlfRequestsDeniedRate1
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.8.0
+    description: 'The rate at which URL access requests were denied by this firewall,
+      due to a directive from a URL filtering server, a static policy configured on
+      the firewall, due to resource constraints or any other reason, averaged over
+      the last 300 seconds. '
+    name: cufwUrlfRequestsDeniedRate5
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.9.0
+    description: 'The number of URL access requests allowed by the firewall because
+      of a cached entry holding the result from a previous URL access request that
+      was handled either by a URLF Server or exclusive domain configuration. This
+      value is accumulated from the last reboot of the firewall. '
+    name: cufwUrlfRequestsNumCacheAllowed
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.10.0
+    description: 'The number of URL access requests denied by the firewall because
+      of a cached entry holding the result from a previous URL access request that
+      was handled either by a URLF Server or exclusive domain configuration. This
+      value is accumulated from the last reboot of the firewall. '
+    name: cufwUrlfRequestsNumCacheDenied
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.11.0
+    description: 'The number of URL access requests that were allowed by the firewall
+      when the URL filtering server was not available. This value is accumulated from
+      the last reboot of the firewall. '
+    name: cufwUrlfAllowModeReqNumAllowed
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.12.0
+    description: 'The number of URL access requests that were declined by the firewall
+      when the URL filtering server was not available. This value is accumulated from
+      the last reboot of the firewall. '
+    name: cufwUrlfAllowModeReqNumDenied
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.13.0
+    description: 'The number of incoming URL access requests that were dropped by
+      the firewall because of resource constraints. This value is accumulated from
+      the last reboot of the firewall. '
+    name: cufwUrlfRequestsNumResDropped
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.14.0
+    description: 'The rate at which incoming URL access requests were dropped by the
+      firewall because of resource constraints, averaged over the last 60 seconds. '
+    name: cufwUrlfRequestsResDropRate1
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.15.0
+    description: 'The rate at which incoming URL access requests were dropped by the
+      firewall because of resource constraints, averaged over the last 300 seconds. '
+    name: cufwUrlfRequestsResDropRate5
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.16.0
+    description: 'The number of times the firewall failed to receive a response from
+      the configured URL filtering servers for a request to authorize a URL access
+      request. This is equal to the number of times a firewall removed a URL access
+      request from the queue of pending requests because no response was received
+      from the URL filtering server(s). This value is accumulated from the last reboot
+      of the firewall. '
+    name: cufwUrlfNumServerTimeouts
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.17.0
+    description: 'The number of URL access authorization requests re-sent by the firewall
+      to the URL Filtering Servers because a response was not received within the
+      configured time interval. This value is accumulated from the last reboot of
+      the firewall. '
+    name: cufwUrlfNumServerRetries
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.18.0
+    description: 'The number of responses from URL filtering servers which were received
+      after the original URL access request was removed from the queue of pending
+      requests. This value is accumulated from the last reboot of the firewall. '
+    name: cufwUrlfResponsesNumLate
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.1.19.0
+    description: 'The number of transport packets constituting responses to URL access
+      requests that were dropped by the firewall due to resource constraints waiting
+      for a response from the filtering server. This value is accumulated from the
+      last reboot of the firewall. '
+    name: cufwUrlfUrlAccRespsNumResDropped
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.2.1.0
+    description: 'The amount of memory occupied by all the caches used in the firewall
+      to cache pending URL access requests. '
+    name: cufwUrlfResTotalRequestCacheSize
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbol:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.2.2.0
+    description: 'The amount of memory occupied by all the caches used in the firewall
+      to cache responses for URL requests received from servers while awaiting a response
+      from URL filter server. '
+    name: cufwUrlfResTotalRespCacheSize
+- MIB: CISCO-UNIFIED-FIREWALL-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.1
+    description: 'The type of the IP address of the URL filtering server. '
+    name: cufwUrlfServerAddrType
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.2
+    description: 'The value of the IP address of the URL filtering server. '
+    name: cufwUrlfServerAddress
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.3
+    description: 'The value of the port at which the URL filtering server listens
+      for incoming requests. '
+    name: cufwUrlfServerPort
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.4
+    description: 'The vendor type of the URL filtering server. '
+    name: cufwUrlfServerVendor
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.5
+    description: 'The status of the URL filtering server corresponding to this conceptual
+      row. '
+    name: cufwUrlfServerStatus
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.6
+    description: 'The number of URL access requests forwarded by the managed firewall
+      device to the URL filtering server corresponding to this conceptual row. This
+      value is counted from the last reboot of the managed device. '
+    name: cufwUrlfServerReqsNumProcessed
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.7
+    description: 'The number of URL access requests allowed by the URL filtering server
+      corresponding to this conceptual row. This counter does not include late responses.
+      This value is counted from the last reboot of the managed device. '
+    name: cufwUrlfServerReqsNumAllowed
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.8
+    description: 'The number of URL access requests denied by the URL filtering server
+      corresponding to this conceptual row. This counter does not include late responses.
+      This value is counted from the last reboot of the managed device. '
+    name: cufwUrlfServerReqsNumDenied
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.9
+    description: 'The number of times the firewall failed to receive a response from
+      the URL filtering server corresponding to this conceptual row, for a request
+      to authorize a URL access request. This is equal to the number of times a firewall
+      removed a URL access request from the queue of pending requests because no response
+      was received from the URL filtering server. This value is accumulated from the
+      last reboot of the firewall. '
+    name: cufwUrlfServerNumTimeouts
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.10
+    description: 'The number of URL access authorization requests re-sent by the firewall
+      to the URL Filtering Server corresponding to this conceptual row, because a
+      response was not received within the configured time interval from the server.
+      This value is counted from the last reboot of the managed device. '
+    name: cufwUrlfServerNumRetries
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.11
+    description: 'The number of URL access responses received by the firewall from
+      the URL filtering server corresponding to this conceptual row. This counter
+      does not include late responses. This value is counted from the last reboot
+      of the managed device. '
+    name: cufwUrlfServerRespsNumReceived
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.12
+    description: 'The number of URL access responses received by the managed firewall
+      from the URL filtering server corresponding to this conceptual row after the
+      original URL access request was removed from the queue of pending requests.
+      This value is counted from the last reboot of the managed device. '
+    name: cufwUrlfServerRespsNumLate
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.13
+    description: 'The average round-trip response time of the URL filtering server
+      computed over the last 60 seconds. A value of zero indicates that there was
+      insufficient data to compute this value over the last time interval. '
+    name: cufwUrlfServerAvgRespTime1
+  - OID: 1.3.6.1.4.1.9.9.491.1.3.3.1.1.14
+    description: 'The average round-trip response time of the URL filtering server
+      computed over the last 300 seconds. A value of zero indicates that there was
+      insufficient data to compute this value over the last time interval. '
+    name: cufwUrlfServerAvgRespTime5
+  table:
+    OID: 1.3.6.1.4.1.9.9.491.1.3.3.1
+    description: 'This table lists the URL filtering servers configured on the managed
+      device and their performance statistics. This table is not meant as a device
+      to configure URL filtering servers. '
+    name: cufwUrlfServerTable
+- MIB: DISMAN-EVENT-MIB
+  symbols:
+  - OID: 1.3.6.1.2.1.88.1.3.1.1.1
+    description: A locally-unique, administratively assigned name for a group of objects.
+    name: mteObjectsName
+  - OID: 1.3.6.1.2.1.88.1.3.1.1.2
+    description: An arbitrary integer for the purpose of identifying individual objects
+      within a mteObjectsName group. Objects within a group are placed in the notification
+      in the numerical order of this index. Groups are placed in the notification
+      in the order of the selections for overall trigger, trigger test, and event.
+      Within trigger test they are in the same order as the numerical values of the
+      bits defined for mteTriggerTest. Bad object identifiers or a mismatch between
+      truncating the identifier and the value of mteDeltaDiscontinuityIDWildcard result
+      in operation as one would expect when providing the wrong identifier to a Get
+      operation. The Get will fail or get the wrong object. If the object is not available
+      it is omitted from the notification.
+    name: mteObjectsIndex
+  - OID: 1.3.6.1.2.1.88.1.3.1.1.3
+    description: The object identifier of a MIB object to add to a Notification that
+      results from the firing of a trigger. This may be wildcarded by truncating all
+      or part of the instance portion, in which case the instance portion of the OID
+      for obtaining this object will be the same as that used in obtaining the mteTriggerValueID
+      that fired. If such wildcarding is applied, mteObjectsIDWildcard must be 'true'
+      and if not it must be 'false'. Each instance that fills the wildcard is independent
+      of any additional instances, that is, wildcarded objects operate as if there
+      were a separate table entry for each instance that fills the wildcard without
+      having to actually predict all possible instances ahead of time.
+    name: mteObjectsID
+  - OID: 1.3.6.1.2.1.88.1.3.1.1.4
+    description: Control for whether mteObjectsID is to be treated as fully-specified
+      or wildcarded, with 'true' indicating wildcard.
+    name: mteObjectsIDWildcard
+  - OID: 1.3.6.1.2.1.88.1.3.1.1.5
+    description: The control that allows creation and deletion of entries. Once made
+      active an entry MAY not be modified except to delete it.
+    name: mteObjectsEntryStatus
+  - OID: 1.3.6.1.2.1.88.1.3.1.1.6
+    description: 'The storage type for this conceptual row. Conceptual rows having
+      the value ''permanent'' need not allow write-access to any columnar objects
+      in the row. '
+    name: mteObjectsEntryStorageType
+  table:
+    OID: 1.3.6.1.2.1.88.1.3.1
+    description: A table of objects that can be added to notifications based on the
+      trigger, trigger test, or event, as pointed to by entries in those tables.
+    name: mteObjectsTable
+- MIB: DISMAN-EVENT-MIB
+  symbols:
+  - OID: 1.3.6.1.2.1.88.1.4.2.1.1
+    description: A locally-unique, administratively assigned name for the event.
+    name: mteEventName
+  - OID: 1.3.6.1.2.1.88.1.4.2.1.2
+    description: A description of the event's function and use.
+    name: mteEventComment
+  - OID: 1.3.6.1.2.1.88.1.4.2.1.3
+    description: The actions to perform when this event occurs. For 'notification',
+      Traps and/or Informs are sent according to the configuration in the SNMP Notification
+      MIB. For 'set', an SNMP Set operation is performed according to control values
+      in this entry.
+    name: mteEventActions
+  - OID: 1.3.6.1.2.1.88.1.4.2.1.4
+    description: A control to allow an event to be configured but not used. When the
+      value is 'false' the event does not execute even if triggered.
+    name: mteEventEnabled
+  - OID: 1.3.6.1.2.1.88.1.4.2.1.5
+    description: The control that allows creation and deletion of entries. Once made
+      active an entry MAY not be modified except to modify the value of mteEventEnabled
+      or to delete the entry.
+    name: mteEventEntryStatus
+  - OID: 1.3.6.1.2.1.88.1.4.2.1.6
+    description: 'The storage type for this conceptual row. Conceptual rows having
+      the value ''permanent'' need not allow write-access to any columnar objects
+      in the row. '
+    name: mteEventEntryStorageType
+  table:
+    OID: 1.3.6.1.2.1.88.1.4.2
+    description: A table of management event action information.
+    name: mteEventTable
+- MIB: DISMAN-EVENT-MIB
+  symbols:
+  - OID: 1.3.6.1.2.1.88.1.4.3.1.1
+    description: The object identifier from the NOTIFICATION-TYPE for the notification
+      to use if mteEventActions has 'notification' set.
+    name: mteEventNotification
+  - OID: 1.3.6.1.2.1.88.1.4.3.1.2
+    description: To go with mteEventNotificationObjects, the mteOwner of a group of
+      objects from mteObjectsTable.
+    name: mteEventNotificationObjectsOwner
+  - OID: 1.3.6.1.2.1.88.1.4.3.1.3
+    description: The mteObjectsName of a group of objects from mteObjectsTable if
+      mteEventActions has 'notification' set. These objects are to be added to any
+      Notification generated by this event. Objects may also be added based on the
+      trigger that stimulated the event. A length of 0 indicates no additional objects.
+    name: mteEventNotificationObjects
+  table:
+    OID: 1.3.6.1.2.1.88.1.4.3
+    description: A table of information about notifications to be sent as a consequence
+      of management events.
+    name: mteEventNotificationTable
+- MIB: ENTITY-MIB
+  symbols:
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.1
+    description: The index for this entry.
+    name: entPhysicalIndex
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.2
+    description: A textual description of physical entity. This object should contain
+      a string that identifies the manufacturer's name for the physical entity and
+      should be set to a distinct value for each version or model of the physical
+      entity.
+    name: entPhysicalDescr
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.3
+    description: An indication of the vendor-specific hardware type of the physical
+      entity. Note that this is different from the definition of MIB-II's sysObjectID.
+      An agent should set this object to an enterprise-specific registration identifier
+      value indicating the specific equipment type in detail. The associated instance
+      of entPhysicalClass is used to indicate the general type of hardware device.
+      If no vendor-specific registration identifier exists for this physical entity,
+      or the value is unknown by this agent, then the value { 0 0 } is returned.
+    name: entPhysicalVendorType
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.4
+    description: The value of entPhysicalIndex for the physical entity that 'contains'
+      this physical entity. A value of zero indicates this physical entity is not
+      contained in any other physical entity. Note that the set of 'containment' relationships
+      define a strict hierarchy; that is, recursion is not allowed. In the event that
+      a physical entity is contained by more than one physical entity (e.g., double-wide
+      modules), this object should identify the containing entity with the lowest
+      value of entPhysicalIndex.
+    name: entPhysicalContainedIn
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.5
+    description: An indication of the general hardware type of the physical entity.
+      An agent should set this object to the standard enumeration value that most
+      accurately indicates the general class of the physical entity, or the primary
+      class if there is more than one entity. If no appropriate standard registration
+      identifier exists for this physical entity, then the value 'other(1)' is returned.
+      If the value is unknown by this agent, then the value 'unknown(2)' is returned.
+    name: entPhysicalClass
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.6
+    description: 'An indication of the relative position of this ''child'' component
+      among all its ''sibling'' components. Sibling components are defined as entPhysicalEntries
+      that share the same instance values of each of the entPhysicalContainedIn and
+      entPhysicalClass objects. An NMS can use this object to identify the relative
+      ordering for all sibling components of a particular parent (identified by the
+      entPhysicalContainedIn instance in each sibling entry). If possible, this value
+      should match any external labeling of the physical component. For example, for
+      a container (e.g., card slot) labeled as ''slot #3'', entPhysicalParentRelPos
+      should have the value ''3''. Note that the entPhysicalEntry for the module plugged
+      in slot 3 should have an entPhysicalParentRelPos value of ''1''. If the physical
+      position of this component does not match any external numbering or clearly
+      visible ordering, then user documentation or other external reference material
+      should be used to determine the parent-relative position. If this is not possible,
+      then the agent should assign a consistent (but possibly arbitrary) ordering
+      to a given set of ''sibling'' components, perhaps based on internal representation
+      of the components. If the agent cannot determine the parent-relative position
+      for some reason, or if the associated value of entPhysicalContainedIn is ''0'',
+      then the value ''-1'' is returned. Otherwise, a non-negative integer is returned,
+      indicating the parent-relative position of this physical entity. Parent-relative
+      ordering normally starts from ''1'' and continues to ''N'', where ''N'' represents
+      the highest positioned child entity. However, if the physical entities (e.g.,
+      slots) are labeled from a starting position of zero, then the first sibling
+      should be associated with an entPhysicalParentRelPos value of ''0''. Note that
+      this ordering may be sparse or dense, depending on agent implementation. The
+      actual values returned are not globally meaningful, as each ''parent'' component
+      may use different numbering algorithms. The ordering is only meaningful among
+      siblings of the same parent component. The agent should retain parent-relative
+      position values across reboots, either through algorithmic assignment or use
+      of non-volatile storage.'
+    name: entPhysicalParentRelPos
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.7
+    description: The textual name of the physical entity. The value of this object
+      should be the name of the component as assigned by the local device and should
+      be suitable for use in commands entered at the device's 'console'. This might
+      be a text name (e.g., 'console') or a simple component number (e.g., port or
+      module number, such as '1'), depending on the physical component naming syntax
+      of the device. If there is no local name, or if this object is otherwise not
+      applicable, then this object contains a zero-length string. Note that the value
+      of entPhysicalName for two physical entities will be the same in the event that
+      the console interface does not distinguish between them, e.g., slot-1 and the
+      card in slot-1.
+    name: entPhysicalName
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.8
+    description: The vendor-specific hardware revision string for the physical entity.
+      The preferred value is the hardware revision identifier actually printed on
+      the component itself (if present). Note that if revision information is stored
+      internally in a non-printable (e.g., binary) format, then the agent must convert
+      such information to a printable format in an implementation-specific manner.
+      If no specific hardware revision string is associated with the physical component,
+      or if this information is unknown to the agent, then this object will contain
+      a zero-length string.
+    name: entPhysicalHardwareRev
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.9
+    description: The vendor-specific firmware revision string for the physical entity.
+      Note that if revision information is stored internally in a non-printable (e.g.,
+      binary) format, then the agent must convert such information to a printable
+      format in an implementation-specific manner. If no specific firmware programs
+      are associated with the physical component, or if this information is unknown
+      to the agent, then this object will contain a zero-length string.
+    name: entPhysicalFirmwareRev
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.10
+    description: The vendor-specific software revision string for the physical entity.
+      Note that if revision information is stored internally in a non-printable (e.g.,
+      binary) format, then the agent must convert such information to a printable
+      format in an implementation-specific manner. If no specific software programs
+      are associated with the physical component, or if this information is unknown
+      to the agent, then this object will contain a zero-length string.
+    name: entPhysicalSoftwareRev
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.11
+    description: The vendor-specific serial number string for the physical entity.
+      The preferred value is the serial number string actually printed on the component
+      itself (if present). On the first instantiation of a physical entity, the value
+      of entPhysicalSerialNum associated with that entity is set to the correct vendor-assigned
+      serial number, if this information is available to the agent. If a serial number
+      is unknown or non-existent, the entPhysicalSerialNum will be set to a zero-length
+      string instead. Note that implementations that can correctly identify the serial
+      numbers of all installed physical entities do not need to provide write access
+      to the entPhysicalSerialNum object. Agents that cannot provide non-volatile
+      storage for the entPhysicalSerialNum strings are not required to implement write
+      access for this object. Not every physical component will have a serial number,
+      or even need one. Physical entities for which the associated value of the entPhysicalIsFRU
+      object is equal to 'false(2)' (e.g., the repeater ports within a repeater module)
+      do not need their own unique serial numbers. An agent does not have to provide
+      write access for such entities and may return a zero-length string. If write
+      access is implemented for an instance of entPhysicalSerialNum and a value is
+      written into the instance, the agent must retain the supplied value in the entPhysicalSerialNum
+      instance (associated with the same physical entity) for as long as that entity
+      remains instantiated. This includes instantiations across all re-initializations/reboots
+      of the network management system, including those resulting in a change of the
+      physical entity's entPhysicalIndex value.
+    name: entPhysicalSerialNum
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.12
+    description: The name of the manufacturer of this physical component. The preferred
+      value is the manufacturer name string actually printed on the component itself
+      (if present). Note that comparisons between instances of the entPhysicalModelName,
+      entPhysicalFirmwareRev, entPhysicalSoftwareRev, and the entPhysicalSerialNum
+      objects are only meaningful amongst entPhysicalEntries with the same value of
+      entPhysicalMfgName. If the manufacturer name string associated with the physical
+      component is unknown to the agent, then this object will contain a zero-length
+      string.
+    name: entPhysicalMfgName
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.13
+    description: The vendor-specific model name identifier string associated with
+      this physical component. The preferred value is the customer-visible part number,
+      which may be printed on the component itself. If the model name string associated
+      with the physical component is unknown to the agent, then this object will contain
+      a zero-length string.
+    name: entPhysicalModelName
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.14
+    description: This object is an 'alias' name for the physical entity, as specified
+      by a network manager, and provides a non-volatile 'handle' for the physical
+      entity. On the first instantiation of a physical entity, the value of entPhysicalAlias
+      associated with that entity is set to the zero-length string. However, the agent
+      may set the value to a locally unique default value, instead of a zero-length
+      string. If write access is implemented for an instance of entPhysicalAlias and
+      a value is written into the instance, the agent must retain the supplied value
+      in the entPhysicalAlias instance (associated with the same physical entity)
+      for as long as that entity remains instantiated. This includes instantiations
+      across all re-initializations/reboots of the network management system, including
+      those resulting in a change of the physical entity's entPhysicalIndex value.
+    name: entPhysicalAlias
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.15
+    description: This object is a user-assigned asset tracking identifier (as specified
+      by a network manager) for the physical entity and provides non-volatile storage
+      of this information. On the first instantiation of a physical entity, the value
+      of entPhysicalAssetID associated with that entity is set to the zero-length
+      string. Not every physical component will have an asset tracking identifier
+      or even need one. Physical entities for which the associated value of the entPhysicalIsFRU
+      object is equal to 'false(2)' (e.g., the repeater ports within a repeater module)
+      do not need their own unique asset tracking identifier. An agent does not have
+      to provide write access for such entities and may instead return a zero-length
+      string. If write access is implemented for an instance of entPhysicalAssetID
+      and a value is written into the instance, the agent must retain the supplied
+      value in the entPhysicalAssetID instance (associated with the same physical
+      entity) for as long as that entity remains instantiated. This includes instantiations
+      across all re-initializations/reboots of the network management system, including
+      those resulting in a change of the physical entity's entPhysicalIndex value.
+      If no asset tracking information is associated with the physical component,
+      then this object will contain a zero-length string.
+    name: entPhysicalAssetID
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.16
+    description: This object indicates whether or not this physical entity is considered
+      a 'field replaceable unit' by the vendor. If this object contains the value
+      'true(1)', then this entPhysicalEntry identifies a field replaceable unit. For
+      all entPhysicalEntries that represent components permanently contained within
+      a field replaceable unit, the value 'false(2)' should be returned for this object.
+    name: entPhysicalIsFRU
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.17
+    description: This object contains the date of manufacturing of the managed entity.
+      If the manufacturing date is unknown or not supported, the object is not instantiated.
+      The special value '0000000000000000'H may also be returned in this case.
+    name: entPhysicalMfgDate
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.18
+    description: This object contains identification information about the physical
+      entity. The object contains URIs; therefore, the syntax of this object must
+      conform to RFC 3986, Section 3. Multiple URIs may be present and are separated
+      by white space characters. Leading and trailing white space characters are ignored.
+      If no URI identification information is known about the physical entity, the
+      object is not instantiated. A zero-length octet string may also be returned
+      in this case.
+    name: entPhysicalUris
+  - OID: 1.3.6.1.2.1.47.1.1.1.1.19
+    description: This object contains identification information about the physical
+      entity. The object contains a Universally Unique Identifier, the syntax of this
+      object must conform to RFC 4122, Section 4.1. A zero-length octet string is
+      returned if no UUID information is known.
+    name: entPhysicalUUID
+  table:
+    OID: 1.3.6.1.2.1.47.1.1.1
+    description: This table contains one row per physical entity. There is always
+      at least one row for an 'overall' physical entity.
+    name: entPhysicalTable
+- MIB: ENTITY-MIB
+  symbols:
+  - OID: 1.3.6.1.2.1.47.1.2.1.1.1
+    description: The value of this object uniquely identifies the logical entity.
+      The value should be a small positive integer; index values for different logical
+      entities are not necessarily contiguous.
+    name: entLogicalIndex
+  - OID: 1.3.6.1.2.1.47.1.2.1.1.2
+    description: A textual description of the logical entity. This object should contain
+      a string that identifies the manufacturer's name for the logical entity and
+      should be set to a distinct value for each version of the logical entity.
+    name: entLogicalDescr
+  - OID: 1.3.6.1.2.1.47.1.2.1.1.3
+    description: 'An indication of the type of logical entity. This will typically
+      be the OBJECT IDENTIFIER name of the node in the SMI''s naming hierarchy that
+      represents the major MIB module, or the majority of the MIB modules, supported
+      by the logical entity. For example: a logical entity of a regular host/router
+      -> mib-2 a logical entity of a 802.1d bridge -> dot1dBridge a logical entity
+      of a 802.3 repeater -> snmpDot3RptrMgmt If an appropriate node in the SMI''s
+      naming hierarchy cannot be identified, the value ''mib-2'' should be used.'
+    name: entLogicalType
+  - OID: 1.3.6.1.2.1.47.1.2.1.1.4
+    description: An SNMPv1 or SNMPv2c community string, which can be used to access
+      detailed management information for this logical entity. The agent should allow
+      read access with this community string (to an appropriate subset of all managed
+      objects) and may also return a community string based on the privileges of the
+      request used to read this object. Note that an agent may return a community
+      string with read-only privileges, even if this object is accessed with a read-write
+      community string. However, the agent must take care not to return a community
+      string that allows more privileges than the community string used to access
+      this object. A compliant SNMP agent may wish to conserve naming scopes by representing
+      multiple logical entities in a single 'default' naming scope. This is possible
+      when the logical entities, represented by the same value of entLogicalCommunity,
+      have no object instances in common. For example, 'bridge1' and 'repeater1' may
+      be part of the main naming scope, but at least one additional community string
+      is needed to represent 'bridge2' and 'repeater2'. Logical entities 'bridge1'
+      and 'repeater1' would be represented by sysOREntries associated with the 'default'
+      naming scope. For agents not accessible via SNMPv1 or SNMPv2c, the value of
+      this object is the empty string. This object may also contain an empty string
+      if a community string has not yet been assigned by the agent or if no community
+      string with suitable access rights can be returned for a particular SNMP request.
+      Note that this object is deprecated. Agents that implement SNMPv3 access should
+      use the entLogicalContextEngineID and entLogicalContextName objects to identify
+      the context associated with each logical entity. SNMPv3 agents may return a
+      zero-length string for this object or may continue to return a community string
+      (e.g., tri-lingual agent support).
+    name: entLogicalCommunity
+  - OID: 1.3.6.1.2.1.47.1.2.1.1.5
+    description: 'The transport service address by which the logical entity receives
+      network management traffic, formatted according to the corresponding value of
+      entLogicalTDomain. For snmpUDPDomain, a TAddress is 6 octets long: the initial
+      4 octets contain the IP-address in network-byte order, and the last 2 contain
+      the UDP port in network-byte order. Consult RFC 3417 for further information
+      on snmpUDPDomain.'
+    name: entLogicalTAddress
+  - OID: 1.3.6.1.2.1.47.1.2.1.1.6
+    description: Indicates the kind of transport service by which the logical entity
+      receives network management traffic. Possible values for this object are presently
+      found in RFC 3417.
+    name: entLogicalTDomain
+  - OID: 1.3.6.1.2.1.47.1.2.1.1.7
+    description: The authoritative contextEngineID that can be used to send an SNMP
+      message concerning information held by this logical entity to the address specified
+      by the associated 'entLogicalTAddress/entLogicalTDomain' pair. This object,
+      together with the associated entLogicalContextName object, defines the context
+      associated with a particular logical entity and allows access to SNMP engines
+      identified by a contextEngineID and contextName pair. If no value has been configured
+      by the agent, a zero-length string is returned, or the agent may choose not
+      to instantiate this object at all.
+    name: entLogicalContextEngineID
+  - OID: 1.3.6.1.2.1.47.1.2.1.1.8
+    description: The contextName that can be used to send an SNMP message concerning
+      information held by this logical entity to the address specified by the associated
+      'entLogicalTAddress/entLogicalTDomain' pair. This object, together with the
+      associated entLogicalContextEngineID object, defines the context associated
+      with a particular logical entity and allows access to SNMP engines identified
+      by a contextEngineID and contextName pair. If no value has been configured by
+      the agent, a zero-length string is returned, or the agent may choose not to
+      instantiate this object at all.
+    name: entLogicalContextName
+  table:
+    OID: 1.3.6.1.2.1.47.1.2.1
+    description: This table contains one row per logical entity. For agents that implement
+      more than one naming scope, at least one entry must exist. Agents that instantiate
+      all MIB objects within a single naming scope are not required to implement this
+      table.
+    name: entLogicalTable
+- MIB: ENTITY-MIB
+  symbols:
+  - OID: 1.3.6.1.2.1.47.1.3.1.1.1
+    description: The value of this object identifies the index value of a particular
+      entPhysicalEntry associated with the indicated entLogicalEntity.
+    name: entLPPhysicalIndex
+  table:
+    OID: 1.3.6.1.2.1.47.1.3.1
+    description: This table contains zero or more rows of logical entity to physical
+      equipment associations. For each logical entity known by this agent, there are
+      zero or more mappings to the physical resources, which are used to realize that
+      logical entity. An agent should limit the number and nature of entries in this
+      table such that only meaningful and non-redundant information is returned. For
+      example, in a system that contains a single power supply, mappings between logical
+      entities and the power supply are not useful and should not be included. Also,
+      only the most appropriate physical component, which is closest to the root of
+      a particular containment tree, should be identified in an entLPMapping entry.
+      For example, suppose a bridge is realized on a particular module, and all ports
+      on that module are ports on this bridge. A mapping between the bridge and the
+      module would be useful, but additional mappings between the bridge and each
+      of the ports on that module would be redundant (because the entPhysicalContainedIn
+      hierarchy can provide the same information). On the other hand, if more than
+      one bridge were utilizing ports on this module, then mappings between each bridge
+      and the ports it used would be appropriate. Also, in the case of a single backplane
+      repeater, a mapping for the backplane to the single repeater entity is not necessary.
+    name: entLPMappingTable
+- MIB: ENTITY-MIB
+  symbols:
+  - OID: 1.3.6.1.2.1.47.1.3.2.1.1
+    description: 'The value of this object identifies the logical entity that defines
+      the naming scope for the associated instance of the entAliasMappingIdentifier
+      object. If this object has a non-zero value, then it identifies the logical
+      entity named by the same value of entLogicalIndex. If this object has a value
+      of zero, then the mapping between the physical component and the alias identifier
+      for this entAliasMapping entry is associated with all unspecified logical entities.
+      That is, a value of zero (the default mapping) identifies any logical entity
+      that does not have an explicit entry in this table for a particular entPhysicalIndex/entAliasMappingIdentifier
+      pair. For example, to indicate that a particular interface (e.g., physical component
+      33) is identified by the same value of ifIndex for all logical entities, the
+      following instance might exist: entAliasMappingIdentifier.33.0 = ifIndex.5 In
+      the event an entPhysicalEntry is associated differently for some logical entities,
+      additional entAliasMapping entries may exist, e.g.: entAliasMappingIdentifier.33.0
+      = ifIndex.6 entAliasMappingIdentifier.33.4 = ifIndex.1 entAliasMappingIdentifier.33.5
+      = ifIndex.1 entAliasMappingIdentifier.33.10 = ifIndex.12 Note that entries with
+      non-zero entAliasLogicalIndexOrZero index values have precedence over zero-indexed
+      entries. In this example, all logical entities except 4, 5, and 10 associate
+      physical entity 33 with ifIndex.6.'
+    name: entAliasLogicalIndexOrZero
+  - OID: 1.3.6.1.2.1.47.1.3.2.1.2
+    description: 'The value of this object identifies a particular conceptual row
+      associated with the indicated entPhysicalIndex and entLogicalIndex pair. Because
+      only physical ports are modeled in this table, only entries that represent interfaces
+      or ports are allowed. If an ifEntry exists on behalf of a particular physical
+      port, then this object should identify the associated ifEntry. For repeater
+      ports, the appropriate row in the ''rptrPortGroupTable'' should be identified
+      instead. For example, suppose a physical port was represented by entPhysicalEntry.3,
+      entLogicalEntry.15 existed for a repeater, and entLogicalEntry.22 existed for
+      a bridge. Then there might be two related instances of entAliasMappingIdentifier:
+      entAliasMappingIdentifier.3.15 == rptrPortGroupIndex.5.2 entAliasMappingIdentifier.3.22
+      == ifIndex.17 It is possible that other mappings (besides interfaces and repeater
+      ports) may be defined in the future, as required. Bridge ports are identified
+      by examining the Bridge MIB and appropriate ifEntries associated with each ''dot1dBasePort''
+      and are thus not represented in this table.'
+    name: entAliasMappingIdentifier
+  table:
+    OID: 1.3.6.1.2.1.47.1.3.2
+    description: This table contains zero or more rows, representing mappings of logical
+      entities and physical components to external MIB identifiers. Each physical
+      port in the system may be associated with a mapping to an external identifier,
+      which itself is associated with a particular logical entity's naming scope.
+      A 'wildcard' mechanism is provided to indicate that an identifier is associated
+      with more than one logical entity.
+    name: entAliasMappingTable
+- MIB: ENTITY-MIB
+  symbols:
+  - OID: 1.3.6.1.2.1.47.1.3.3.1.1
+    description: The value of entPhysicalIndex for the contained physical entity.
+    name: entPhysicalChildIndex
+  table:
+    OID: 1.3.6.1.2.1.47.1.3.3
+    description: A table that exposes the container/'containee' relationships between
+      physical entities. This table provides all the information found by constructing
+      the virtual containment tree for a given entPhysicalTable, but in a more direct
+      format. In the event a physical entity is contained by more than one other physical
+      entity (e.g., double-wide modules), this table should include these additional
+      mappings, which cannot be represented in the entPhysicalTable virtual containment
+      tree.
+    name: entPhysicalContainsTable
+- MIB: ENTITY-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.47.1.4.1.0
+    description: 'The value of sysUpTime at the time a conceptual row is created,
+      modified, or deleted in any of these tables: - entPhysicalTable - entLogicalTable
+      - entLPMappingTable - entAliasMappingTable - entPhysicalContainsTable '
+    name: entLastChangeTime
+- MIB: EXPRESSION-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.1.1.1
+    description: The unique name of the expression, the same as expName. Use this
+      object to change the expression's name without changing its expExpressionIndex.
+    name: expExpressionName
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.1.1.2
+    description: 'The expression to be evaluated. This object is the same as a DisplayString
+      (RFC 1903) except for its maximum length. Except for the variable names the
+      expression is in ANSI C syntax. Only the subset of ANSI C operators and functions
+      listed here is allowed. Variables are expressed as a dollar sign (''$'') and
+      an integer that corresponds to an expObjectIndex. An example of a valid expression
+      is: ($1-$5)*100 Expressions may not be recursive, that is although an expression
+      may use the results of another expression, it may not contain any variable that
+      is directly or indirectly a result of its own evaluation. The only allowed operators
+      are: ( ) - (unary) + - * / % & | ^ << >> ~ ! && || == != > >= < <= Note the
+      parentheses are included for parenthesizing the expression, not for casting
+      data types. The only constant types defined are: int (32-bit signed) long (64-bit
+      signed) unsigned int unsigned long hexadecimal character string oid The default
+      type for a positive integer is int unless it is too large in which case it is
+      long. All but oid are as defined for ANSI C. Note that a hexadecimal constant
+      may end up as a scalar or an array of 8-bit integers. A string constant is enclosed
+      in double quotes and may contain back-slashed individual characters as in ANSI
+      C. An oid constant comprises 32-bit, unsigned integers and at least one period,
+      for example: 0. .0 1.3.6.1 Integer-typed objects are treated as 32- or 64-bit,
+      signed or unsigned integers, as appropriate. The results of mixing them are
+      as for ANSI C, including the type of the result. Note that a 32-bit value is
+      thus promoted to 64 bits only in an operation with a 64-bit value. There is
+      no provision for larger values to handle overflow. Relative to SNMP data types,
+      a resulting value becomes unsigned when calculating it uses any unsigned value,
+      including a counter. To force the final value to be of data type counter the
+      expression must explicitly use the counter32() or counter64() function (defined
+      below). OCTET STRINGS and OBJECT IDENTIFIERs are treated as 1-based arrays of
+      unsigned 8-bit integers and unsigned 32-bit integers, respectively. IpAddresses
+      are treated as 32-bit, unsigned integers in network byte order, that is, the
+      hex version of 255.0.0.0 is 0xff000000. Conditional expressions result in a
+      32-bit, unsigned integer of value 0 for false or 1 for true. When an arbitrary
+      value is used as a boolean 0 is false and non-zero is true. Rules for the resulting
+      data type from an operation, based on the operator: For << and >> the result
+      is the same as the left hand operand. For &&, ||, ==, !=, <, <=, >, and >= the
+      result is always Unsigned32. For unary - the result is always Integer32. For
+      +, -, *, /, %, &, |, and ^ the result is promoted according to the following
+      rules, in order from most to least preferred: If left hand and right hand operands
+      are the same type, use that. If either side is Counter64, use that. If either
+      side is IpAddress, use that. If either side is TimeTicks, use that. If either
+      side is Counter32, use that. Otherwise use Unsigned32. The following rules say
+      what operators apply with what data types. Any combination not explicitly defined
+      does not work. For all operators any of the following can be the left hand or
+      right hand operand: Integer32, Counter32, Unsigned32, Counter64. The operators
+      +, -, *, /, %, <, <=, >, and >= also work with TimeTicks. The operators &, |,
+      and ^ also work with IpAddress. The operators << and >> also work with IpAddress
+      but only as the left hand operand. The + operator performs a concatenation of
+      two OCTET STRINGs or two OBJECT IDENTIFIERs. The operators &, | perform bitwise
+      operations on OCTET STRINGs. If the OCTET STRING happens to be a DisplayString
+      the results may be meaningless, but the agent system does not check this as
+      some such systems do not have this information. The operators << and >> perform
+      bitwise operations on OCTET STRINGs appearing as the left hand operand. The
+      only functions defined are: counter32 counter64 arraySection stringBegins stringEnds
+      stringContains oidBegins oidEnds oidContains sum exists The following function
+      definitions indicate their by naming the data type of the parameter in the parameter''s
+      position in the parameter list. The parameter must be of the type indicated
+      and generally may be a constant, a MIB object, a function, or an expression.
+      counter32(integer) - wrapped around an integer value counter32 forces Counter32
+      as a data type. counter64(integer) - similar to counter32 except that the resulting
+      data type is ''counter64''. arraySection(array, integer, integer) - selects
+      a piece of an array (i.e. part of an OCTET STRING or OBJECT IDENTIFIER). The
+      integer arguments are in the range 0 to 4,294,967,295. The first is an initial
+      array index (1-based) and the second is an ending array index. A value of 0
+      indicates first or last element, respectively. If the first element is larger
+      than the array length the result is 0 length. If the second integer is less
+      than or equal to the first, the result is 0 length. If the second is larger
+      than the array length it indicates last element. stringBegins/Ends/Contains(octetString,
+      octetString) - looks for the second string (which can be a string constant)
+      in the first and returns the 1-based index where the match began. A return value
+      of 0 indicates no match (i.e. boolean false). oidBegins/Ends/Contains(oid, oid)
+      - looks for the second OID (which can be an OID constant) in the first and returns
+      the the 1-based index where the match began. A return value of 0 indicates no
+      match (i.e. boolean false). sum(integerObject*) - sums all availiable values
+      of the wildcarded integer object, resulting in an integer scalar. Must be used
+      with caution as it wraps on overflow with no notification. exists(anyTypeObject)
+      - verifies the object instance exists. A return value of 0 indicates NoSuchInstance
+      (i.e. boolean false).'
+    name: expExpression
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.1.1.3
+    description: The type of the expression value. One and only one of the value objects
+      in expValueTable will be instantiated to match this type. If the result of the
+      expression can not be made into this type, an invalidOperandType error will
+      occur.
+    name: expExpressionValueType
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.1.1.4
+    description: A comment to explain the use or meaning of the expression.
+    name: expExpressionComment
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.1.1.5
+    description: Sampling interval for objects in this expression with expObjectSampleType
+      'deltaValue'. This object is not instantiated if not applicable. A value of
+      0 indicates no automated sampling. In this case the delta is the difference
+      from the last time the expression was evaluated. Note that this is subject to
+      unpredictable delta times in the face of retries or multiple managers. A value
+      greater than zero is the number of seconds between automated samples. Until
+      the delta interval has expired once the delta for the object is effectively
+      not instantiated and evaluating the expression has results as if the object
+      itself were not instantiated. Note that delta values potentially consume large
+      amounts of system CPU and memory. Delta state and processing must continue constantly
+      even if the expression is not being used. That is, the expression is being evaluated
+      every delta interval, even if no application is reading those values. For wildcarded
+      objects this can be substantial overhead. Note that delta intervals, external
+      expression value sampling intervals and delta intervals for expressions within
+      other expressions can have unusual interactions as they are impossible to synchronize
+      accurately. In general one interval embedded below another must be enough shorter
+      that the higher sample sees relatively smooth, predictable behavior.
+    name: expExpressionDeltaInterval
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.1.1.6
+    description: An object prefix to assist an application in determining the instance
+      indexing to use in expValueTable, relieving the application of the need to scan
+      the expObjectTable to determine such a prefix. See expObjectTable for information
+      on wildcarded objects. If the expValueInstance portion of the value OID may
+      be treated as a scalar (that is, normally, 0) the value of expExpressionPrefix
+      is zero length, that is, no OID at all. Otherwise expExpressionPrefix is the
+      value of any wildcarded instance of expObjectID for the expression. This is
+      sufficient as the remainder, that is, the instance fragment relevant to instancing
+      the values must be the same for all wildcarded objects in the expression.
+    name: expExpressionPrefix
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.1.1.7
+    description: The number of errors encountered while evaluating this expression.
+      Note that an object in the expression not being accessible is not considered
+      an error. It is a legitimate condition that causes the corresponding expression
+      value not to be instantiated.
+    name: expExpressionErrors
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.1.1.8
+    description: The value of sysUpTime the last time an error caused a failure to
+      evaluate this expression. This object is not instantiated if there have been
+      no errors.
+    name: expExpressionErrorTime
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.1.1.9
+    description: The 1-based character index into expExpression for where the error
+      occurred. The value zero indicates irrelevance. This object is not instantiated
+      if there have been no errors.
+    name: expExpressionErrorIndex
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.1.1.10
+    description: The error that occurred. In the following explanations the expected
+      timing of the error is in parentheses. 'S' means the error occurs on a Set request.
+      'E' means the error occurs on the attempt to evaluate the expression either
+      due to Get from expValueTable or in ongoing delta processing. invalidSyntax
+      the value sent for expExpression is not valid Expression MIB expression syntax
+      (S) undefinedObjectIndex an object reference ($n) in expExpression does not
+      have a matching instance in expObjectTable (E) unrecognizedOperator the value
+      sent for expExpression held an unrecognized operator (S) unrecognizedFunction
+      the value sent for expExpression held an unrecognized function name (S) invalidOperandType
+      an operand in expExpression is not the right type for the associated operator
+      or result (SE) unmatchedParenthesis the value sent for expExpression is not
+      correctly parenthesized (S) tooManyWildcardValues evaluating the expression
+      exceeded the limit set by expResourceDelta WildcardInstanceMaximum (E) recursion
+      through some chain of embedded expressions the expression invokes itself (E)
+      deltaTooShort the delta for the next evaluation passed before the system could
+      evaluate the present sample (E) resourceUnavailable some resource, typically
+      dynamic memory, was unavailable (SE) divideByZero an attempt to divide by zero
+      occurred (E) For the errors that occur when the attempt is made to set expExpression
+      Set request fails with the SNMP error code 'wrongValue'. Such failures refer
+      to the most recent failure to Set expExpression, not to the present value of
+      expExpression which must be either unset or syntactically correct. Errors that
+      occur during evalutaion for a Get* operation return the SNMP error code 'genErr'
+      except for 'tooManyWildcardValues' and 'resourceUnavailable' which return the
+      SNMP error code 'resourceUnavailable'. This object is not instantiated if there
+      have been no errors.
+    name: expExpressionError
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.1.1.11
+    description: The expValueInstance being evaluated when the error occurred. A zero-length
+      indicates irrelevance. This object is not instantiated if there have been no
+      errors.
+    name: expExpressionInstance
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.1.1.12
+    description: The entity that configured this entry and is therefore using the
+      resources assigned to it.
+    name: expExpressionOwner
+  table:
+    OID: 1.3.6.1.4.1.9.10.22.1.3.1
+    description: A table of expression definitions.
+    name: expExpressionTable
+- MIB: EXPRESSION-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.2.1.1
+    description: Within an expression, a unique, numeric identification for an object.
+      Prefixed with a dollar sign ('$') this is used to reference the object in the
+      corresponding expExpression.
+    name: expObjectIndex
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.2.1.2
+    description: 'The OBJECT IDENTIFIER (OID) of this object. The OID may be fully
+      qualified, meaning it includes a complete instance identifier part (e.g., ifInOctets.1
+      or sysUpTime.0), or it may not be fully qualified, meaning it may lack all or
+      part of the instance identifier. If the expObjectID is not fully qualified,
+      then expObjectWildcard must be set to true(1). The value of the expression will
+      be multiple values, as if done for a GetNext sweep of the object. An object
+      here may itself be the result of an expression but recursion is not allowed.
+      NOTE: The simplest implementations of this MIB may not allow wildcards.'
+    name: expObjectID
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.2.1.3
+    description: 'A true value indicates the expObjecID of this row is a wildcard
+      object. False indicates that expObjectID is fully instanced. If all expObjectWildcard
+      values for a given expression are FALSE, expExpressionPrefix will reflect a
+      scalar object (ie will be 0.0). NOTE: The simplest implementations of this MIB
+      may not allow wildcards.'
+    name: expObjectIDWildcard
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.2.1.4
+    description: The method of sampling the selected variable. An 'absoluteValue'
+      is simply the present value of the object. A 'deltaValue' is the present value
+      minus the previous value, which was sampled expExpressionDeltaInterval seconds
+      ago. This is intended primarily for use with SNMP counters, which are meaningless
+      as an 'absoluteValue', but may be used with any integer-based value. When an
+      expression contains both delta and absolute values the absolute values are obtained
+      at the end of the delta period.
+    name: expObjectSampleType
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.2.1.5
+    description: The OBJECT IDENTIFIER (OID) of a TimeTicks or TimeStamp object that
+      indicates a discontinuity in the value at expObjectID. This object is not instantiated
+      if expObject is not 'deltaValue'. The OID may be for a leaf object (e.g. sysUpTime.0)
+      or may be wildcarded to match expObjectID. This object supports normal checking
+      for a discontinuity in a counter. Note that if this object does not point to
+      sysUpTime discontinuity checking must still check sysUpTime for an overall discontinuity.
+      If the object identified is not accessible no discontinuity check will be made.
+    name: expObjectDeltaDiscontinuityID
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.2.1.6
+    description: 'A true value indicates the expObjectDeltaDiscontinuityID of this
+      row is a wildcard object. False indicates that expObjectDeltaDiscontinuityID
+      is fully instanced. This object is not instantiated if expObject is not ''deltaValue''.
+      NOTE: The simplest implementations of this MIB may not allow wildcards.'
+    name: expObjectDiscontinuityIDWildcard
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.2.1.7
+    description: The value 'timeTicks' indicates the expObjectDeltaDiscontinuityID
+      of this row is of syntax TimeTicks. The value 'timeStamp' indicates that expObjectDeltaDiscontinuityID
+      is of syntax TimeStamp. This object is not instantiated if expObject is not
+      'deltaValue'.
+    name: expObjectDiscontinuityIDType
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.2.1.8
+    description: The OBJECT IDENTIFIER (OID) of an object that overrides whether the
+      instance of expObjectID is to be considered usable. If the value of the object
+      at expObjectConditional is 0 or not instantiated, the object at expObjectID
+      is treated as if it is not instantiated. In other words, expObjectConditional
+      is a filter that controls whether or not to use the value at expObjectID. The
+      OID may be for a leaf object (e.g. sysObjectID.0) or may be wildcarded to match
+      expObjectID. If expObject is wildcarded and expObjectID in the same row is not,
+      the wild portion of expObjectConditional must match the wildcarding of the rest
+      of the expression. If no object in the expression is wildcarded but expObjectConditional
+      is, use the lexically first instance (if any) of expObjectConditional. If the
+      value of expObjectConditional is 0.0 operation is as if the value pointed to
+      by expObjectConditional is a non-zero (true) value. Note that expObjectConditional
+      can not trivially use an object of syntax TruthValue, since the underlying value
+      is not 0 or 1.
+    name: expObjectConditional
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.2.1.9
+    description: 'A true value indicates the expObjectConditional of this row is a
+      wildcard object. False indicates that expObjectConditional is fully instanced.
+      NOTE: The simplest implementations of this MIB may not allow wildcards.'
+    name: expObjectConditionalWildcard
+  - OID: 1.3.6.1.4.1.9.10.22.1.3.2.1.10
+    description: The control that allows creation/deletion of entries. Objects in
+      this table may be changed while expObjectStatus is in any state.
+    name: expObjectStatus
+  table:
+    OID: 1.3.6.1.4.1.9.10.22.1.3.2
+    description: 'A table of object definitions for each expExpression. Wildcarding
+      instance IDs: It is legal to omit all or part of the instance portion for some
+      or all of the objects in an expression. (See the DESCRIPTION of expObjectID
+      for details. However, note that if more than one object in the same expression
+      is wildcarded in this way, they all must be objects where that portion of the
+      instance is the same. In other words, all objects may be in the same SEQUENCE
+      or in different SEQUENCEs but with the same semantic index value (e.g., a value
+      of ifIndex) for the wildcarded portion.'
+    name: expObjectTable
+- MIB: EXPRESSION-MIB
+  symbols:
+  - OID: 1.3.6.1.4.1.9.10.22.1.4.1.1.1
+    description: The final instance portion of a value's OID according to the wildcarding
+      in instances of expObjectID for the expression. The prefix of this OID fragment
+      is 0.0, leading to the following behavior. If there is no wildcarding, the value
+      is 0.0.0. In other words, there is one value which standing alone would have
+      been a scalar with a 0 at the end of its OID. If there is wildcarding, the value
+      is 0.0 followed by a value that the wildcard can take, thus defining one value
+      instance for each real, possible value of the wildcard. So, for example, if
+      the wildcard worked out to be an ifIndex, there is an expValueInstance for each
+      applicable ifIndex.
+    name: expValueInstance
+  - OID: 1.3.6.1.4.1.9.10.22.1.4.1.1.2
+    description: The value when expExpressionValueType is 'counter32'.
+    name: expValueCounter32Val
+  - OID: 1.3.6.1.4.1.9.10.22.1.4.1.1.3
+    description: The value when expExpressionValueType is 'unsignedOrGauge32' or 'timeTicks'.
+    name: expValueUnsigned32Val
+  - OID: 1.3.6.1.4.1.9.10.22.1.4.1.1.4
+    description: The value when expExpressionValueType is 'integer32'.
+    name: expValueInteger32Val
+  - OID: 1.3.6.1.4.1.9.10.22.1.4.1.1.5
+    description: The value when expExpressionValueType is 'ipAddress'.
+    name: expValueIpAddressVal
+  - OID: 1.3.6.1.4.1.9.10.22.1.4.1.1.6
+    description: The value when expExpressionValueType is 'octetString'.
+    name: expValueOctetStringVal
+  - OID: 1.3.6.1.4.1.9.10.22.1.4.1.1.7
+    description: The value when expExpressionValueType is 'objectId'.
+    name: expValueOidVal
+  - OID: 1.3.6.1.4.1.9.10.22.1.4.1.1.8
+    description: The value when expExpressionValueType is 'counter64'.
+    name: expValueCounter64Val
+  table:
+    OID: 1.3.6.1.4.1.9.10.22.1.4.1
+    description: A table of values from evaluated expressions.
+    name: expValueTable
+- MIB: IF-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.2.1.0
+    description: The number of network interfaces (regardless of their current state)
+      present on this system.
+    name: ifNumber
+- MIB: IF-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.31.1.5.0
+    description: The value of sysUpTime at the time of the last creation or deletion
+      of an entry in the ifTable. If the number of entries has been unchanged since
+      the last re-initialization of the local network management subsystem, then this
+      object contains a zero value.
+    name: ifTableLastChange
+- MIB: IF-MIB
+  symbols:
+  - OID: 1.3.6.1.2.1.31.1.2.1.1
+    description: The value of ifIndex corresponding to the higher sub-layer of the
+      relationship, i.e., the sub-layer which runs on 'top' of the sub-layer identified
+      by the corresponding instance of ifStackLowerLayer. If there is no higher sub-layer
+      (below the internetwork layer), then this object has the value 0.
+    name: ifStackHigherLayer
+  - OID: 1.3.6.1.2.1.31.1.2.1.2
+    description: The value of ifIndex corresponding to the lower sub-layer of the
+      relationship, i.e., the sub-layer which runs 'below' the sub-layer identified
+      by the corresponding instance of ifStackHigherLayer. If there is no lower sub-layer,
+      then this object has the value 0.
+    name: ifStackLowerLayer
+  - OID: 1.3.6.1.2.1.31.1.2.1.3
+    description: The status of the relationship between two sub-layers. Changing the
+      value of this object from 'active' to 'notInService' or 'destroy' will likely
+      have consequences up and down the interface stack. Thus, write access to this
+      object is likely to be inappropriate for some types of interfaces, and many
+      implementations will choose not to support write-access for any type of interface.
+    name: ifStackStatus
+  table:
+    OID: 1.3.6.1.2.1.31.1.2
+    description: 'The table containing information on the relationships between the
+      multiple sub-layers of network interfaces. In particular, it contains information
+      on which sub-layers run ''on top of'' which other sub-layers, where each sub-layer
+      corresponds to a conceptual row in the ifTable. For example, when the sub-layer
+      with ifIndex value x runs over the sub-layer with ifIndex value y, then this
+      table contains: ifStackStatus.x.y=active For each ifIndex value, I, which identifies
+      an active interface, there are always at least two instantiated rows in this
+      table associated with I. For one of these rows, I is the value of ifStackHigherLayer;
+      for the other, I is the value of ifStackLowerLayer. (If I is not involved in
+      multiplexing, then these are the only two rows associated with I.) For example,
+      two rows exist even for an interface which has no others stacked on top or below
+      it: ifStackStatus.0.x=active ifStackStatus.x.0=active '
+    name: ifStackTable
+- MIB: IF-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.31.1.6.0
+    description: The value of sysUpTime at the time of the last change of the (whole)
+      interface stack. A change of the interface stack is defined to be any creation,
+      deletion, or change in value of any instance of ifStackStatus. If the interface
+      stack has been unchanged since the last re-initialization of the local network
+      management subsystem, then this object contains a zero value.
+    name: ifStackLastChange
+- MIB: IF-MIB
+  symbols:
+  - OID: 1.3.6.1.2.1.31.1.4.1.1
+    description: An address for which the system will accept packets/frames on this
+      entry's interface.
+    name: ifRcvAddressAddress
+  - OID: 1.3.6.1.2.1.31.1.4.1.2
+    description: This object is used to create and delete rows in the ifRcvAddressTable.
+    name: ifRcvAddressStatus
+  - OID: 1.3.6.1.2.1.31.1.4.1.3
+    description: This object has the value nonVolatile(3) for those entries in the
+      table which are valid and will not be deleted by the next restart of the managed
+      system. Entries having the value volatile(2) are valid and exist, but have not
+      been saved, so that will not exist after the next restart of the managed system.
+      Entries having the value other(1) are valid and exist but are not classified
+      as to whether they will continue to exist after the next restart.
+    name: ifRcvAddressType
+  table:
+    OID: 1.3.6.1.2.1.31.1.4
+    description: 'This table contains an entry for each address (broadcast, multicast,
+      or uni-cast) for which the system will receive packets/frames on a particular
+      interface, except as follows: - for an interface operating in promiscuous mode,
+      entries are only required for those addresses for which the system would receive
+      frames were it not operating in promiscuous mode. - for 802.5 functional addresses,
+      only one entry is required, for the address which has the functional address
+      bit ANDed with the bit mask of all functional addresses for which the interface
+      will accept frames. A system is normally able to use any unicast address which
+      corresponds to an entry in this table as a source address.'
+    name: ifRcvAddressTable
+- MIB: IF-MIB
+  symbols:
+  - OID: 1.3.6.1.2.1.31.1.3.1.1
+    description: This object identifies the current invocation of the interface's
+      test.
+    name: ifTestId
+  - OID: 1.3.6.1.2.1.31.1.3.1.2
+    description: This object indicates whether or not some manager currently has the
+      necessary 'ownership' required to invoke a test on this interface. A write to
+      this object is only successful when it changes its value from 'notInUse(1)'
+      to 'inUse(2)'. After completion of a test, the agent resets the value back to
+      'notInUse(1)'.
+    name: ifTestStatus
+  - OID: 1.3.6.1.2.1.31.1.3.1.3
+    description: 'A control variable used to start and stop operator- initiated interface
+      tests. Most OBJECT IDENTIFIER values assigned to tests are defined elsewhere,
+      in association with specific types of interface. However, this document assigns
+      a value for a full-duplex loopback test, and defines the special meanings of
+      the subject identifier: noTest OBJECT IDENTIFIER ::= { 0 0 } When the value
+      noTest is written to this object, no action is taken unless a test is in progress,
+      in which case the test is aborted. Writing any other value to this object is
+      only valid when no test is currently in progress, in which case the indicated
+      test is initiated. When read, this object always returns the most recent value
+      that ifTestType was set to. If it has not been set since the last initialization
+      of the network management subsystem on the agent, a value of noTest is returned.'
+    name: ifTestType
+  - OID: 1.3.6.1.2.1.31.1.3.1.4
+    description: This object contains the result of the most recently requested test,
+      or the value none(1) if no tests have been requested since the last reset. Note
+      that this facility provides no provision for saving the results of one test
+      when starting another, as could be required if used by multiple managers concurrently.
+    name: ifTestResult
+  - OID: 1.3.6.1.2.1.31.1.3.1.5
+    description: 'This object contains a code which contains more specific information
+      on the test result, for example an error-code after a failed test. Error codes
+      and other values this object may take are specific to the type of interface
+      and/or test. The value may have the semantics of either the AutonomousType or
+      InstancePointer textual conventions as defined in RFC 2579. The identifier:
+      testCodeUnknown OBJECT IDENTIFIER ::= { 0 0 } is defined for use if no additional
+      result code is available.'
+    name: ifTestCode
+  - OID: 1.3.6.1.2.1.31.1.3.1.6
+    description: The entity which currently has the 'ownership' required to invoke
+      a test on this interface.
+    name: ifTestOwner
+  table:
+    OID: 1.3.6.1.2.1.31.1.3
+    description: 'This table contains one entry per interface. It defines objects
+      which allow a network manager to instruct an agent to test an interface for
+      various faults. Tests for an interface are defined in the media-specific MIB
+      for that interface. After invoking a test, the object ifTestResult can be read
+      to determine the outcome. If an agent can not perform the test, ifTestResult
+      is set to so indicate. The object ifTestCode can be used to provide further
+      test- specific or interface-specific (or even enterprise-specific) information
+      concerning the outcome of the test. Only one test can be in progress on each
+      interface at any one time. If one test is in progress when another test is invoked,
+      the second test is rejected. Some agents may reject a test when a prior test
+      is active on another interface. Before starting a test, a manager-station must
+      first obtain ''ownership'' of the entry in the ifTestTable for the interface
+      to be tested. This is accomplished with the ifTestId and ifTestStatus objects
+      as follows: try_again: get (ifTestId, ifTestStatus) while (ifTestStatus != notInUse)
+      /* * Loop while a test is running or some other * manager is configuring a test.
+      */ short delay get (ifTestId, ifTestStatus) } /* * Is not being used right now
+      -- let''s compete * to see who gets it. */ lock_value = ifTestId if ( set(ifTestId
+      = lock_value, ifTestStatus = inUse, ifTestOwner = ''my-IP-address'') == FAILURE)
+      /* * Another manager got the ifTestEntry -- go * try again */ goto try_again;
+      /* * I have the lock */ set up any test parameters. /* * This starts the test
+      */ set(ifTestType = test_to_run); wait for test completion by polling ifTestResult
+      when test completes, agent sets ifTestResult agent also sets ifTestStatus =
+      ''notInUse'' retrieve any additional test results, and ifTestId if (ifTestId
+      == lock_value+1) results are valid A manager station first retrieves the value
+      of the appropriate ifTestId and ifTestStatus objects, periodically repeating
+      the retrieval if necessary, until the value of ifTestStatus is ''notInUse''.
+      The manager station then tries to set the same ifTestId object to the value
+      it just retrieved, the same ifTestStatus object to ''inUse'', and the corresponding
+      ifTestOwner object to a value indicating itself. If the set operation succeeds
+      then the manager has obtained ownership of the ifTestEntry, and the value of
+      the ifTestId object is incremented by the agent (per the semantics of TestAndIncr).
+      Failure of the set operation indicates that some other manager has obtained
+      ownership of the ifTestEntry. Once ownership is obtained, any test parameters
+      can be setup, and then the test is initiated by setting ifTestType. On completion
+      of the test, the agent sets ifTestStatus to ''notInUse''. Once this occurs,
+      the manager can retrieve the results. In the (rare) event that the invocation
+      of tests by two network managers were to overlap, then there would be a possibility
+      that the first test''s results might be overwritten by the second test''s results
+      prior to the first results being read. This unlikely circumstance can be detected
+      by a network manager retrieving ifTestId at the same time as retrieving the
+      test results, and ensuring that the results are for the desired request. If
+      ifTestType is not set within an abnormally long period of time after ownership
+      is obtained, the agent should time-out the manager, and reset the value of the
+      ifTestStatus object back to ''notInUse''. It is suggested that this time-out
+      period be 5 minutes. In general, a management station must not retransmit a
+      request to invoke a test for which it does not receive a response; instead,
+      it properly inspects an agent''s MIB to determine if the invocation was successful.
+      Only if the invocation was unsuccessful, is the invocation request retransmitted.
+      Some tests may require the interface to be taken off-line in order to execute
+      them, or may even require the agent to reboot after completion of the test.
+      In these circumstances, communication with the management station invoking the
+      test may be lost until after completion of the test. An agent is not required
+      to support such tests. However, if such tests are supported, then the agent
+      should make every effort to transmit a response to the request which invoked
+      the test prior to losing communication. When the agent is restored to normal
+      service, the results of the test are properly made available in the appropriate
+      objects. Note that this requires that the ifIndex value assigned to an interface
+      must be unchanged even if the test causes a reboot. An agent must reject any
+      test for which it cannot, perhaps due to resource constraints, make available
+      at least the minimum amount of information after that test completes.'
+    name: ifTestTable
+- MIB: NAT-MIB
+  symbols:
+  - OID: 1.3.6.1.2.1.123.1.4.1.1
+    description: Along with ifIndex, this object uniquely identifies an entry in the
+      natAddrMapTable. Address map entries are applied in the order specified by natAddrMapIndex.
+      Deprecated in favor of NATV2-MIB.
+    name: natAddrMapIndex
+  - OID: 1.3.6.1.2.1.123.1.4.1.2
+    description: Name identifying all map entries in the table associated with the
+      same interface. All map entries with the same ifIndex MUST have the same map
+      name. Deprecated in favor of NATV2-MIB.
+    name: natAddrMapName
+  - OID: 1.3.6.1.2.1.123.1.4.1.3
+    description: This parameter can be used to set up static or dynamic address maps.
+      Deprecated in favor of NATV2-MIB.
+    name: natAddrMapEntryType
+  - OID: 1.3.6.1.2.1.123.1.4.1.4
+    description: The endpoint entity (source or destination) in inbound or outbound
+      sessions (i.e., first packets) that may be translated by an address map entry.
+      Session direction (inbound or outbound) is derived from the direction of the
+      first packet of a session traversing a NAT interface. NAT address (and Transport-ID)
+      maps may be defined to effect inbound or outbound sessions. Traditionally, address
+      maps for Basic NAT and NAPT are configured on a public interface for outbound
+      sessions, effecting translation of source endpoint. The value of this object
+      must be set to outboundSrcEndPoint for those interfaces. Alternately, if address
+      maps for Basic NAT and NAPT were to be configured on a private interface, the
+      desired value for this object for the map entries would be inboundSrcEndPoint
+      (i.e., effecting translation of source endpoint for inbound sessions). If twiceNAT
+      were to be configured on a private interface, the desired value for this object
+      for the map entries would be a bitmask of inboundSrcEndPoint and inboundDstEndPoint.
+      Deprecated in favor of NATV2-MIB.
+    name: natAddrMapTranslationEntity
+  - OID: 1.3.6.1.2.1.123.1.4.1.5
+    description: This object specifies the address type used for natAddrMapLocalAddrFrom
+      and natAddrMapLocalAddrTo. Deprecated in favor of NATV2-MIB.
+    name: natAddrMapLocalAddrType
+  - OID: 1.3.6.1.2.1.123.1.4.1.6
+    description: This object specifies the first IP address of the range of IP addresses
+      mapped by this translation entry. The value of this object must be less than
+      or equal to the value of the natAddrMapLocalAddrTo object. The type of this
+      address is determined by the value of the natAddrMapLocalAddrType object. Deprecated
+      in favor of NATV2-MIB.
+    name: natAddrMapLocalAddrFrom
+  - OID: 1.3.6.1.2.1.123.1.4.1.7
+    description: This object specifies the last IP address of the range of IP addresses
+      mapped by this translation entry. If only a single address is being mapped,
+      the value of this object is equal to the value of natAddrMapLocalAddrFrom. For
+      a static NAT, the number of addresses in the range defined by natAddrMapLocalAddrFrom
+      and natAddrMapLocalAddrTo must be equal to the number of addresses in the range
+      defined by natAddrMapGlobalAddrFrom and natAddrMapGlobalAddrTo. The value of
+      this object must be greater than or equal to the value of the natAddrMapLocalAddrFrom
+      object. The type of this address is determined by the value of the natAddrMapLocalAddrType
+      object. Deprecated in favor of NATV2-MIB.
+    name: natAddrMapLocalAddrTo
+  - OID: 1.3.6.1.2.1.123.1.4.1.8
+    description: If this conceptual row describes a Basic NAT address mapping, then
+      the value of this object must be zero. If this conceptual row describes NAPT,
+      then the value of this object specifies the first port number in the range of
+      ports being mapped. The value of this object must be less than or equal to the
+      value of the natAddrMapLocalPortTo object. If the translation specifies a single
+      port, then the value of this object is equal to the value of natAddrMapLocalPortTo.
+      Deprecated in favor of NATV2-MIB.
+    name: natAddrMapLocalPortFrom
+  - OID: 1.3.6.1.2.1.123.1.4.1.9
+    description: If this conceptual row describes a Basic NAT address mapping, then
+      the value of this object must be zero. If this conceptual row describes NAPT,
+      then the value of this object specifies the last port number in the range of
+      ports being mapped. The value of this object must be greater than or equal to
+      the value of the natAddrMapLocalPortFrom object. If the translation specifies
+      a single port, then the value of this object is equal to the value of natAddrMapLocalPortFrom.
+      Deprecated in favor of NATV2-MIB.
+    name: natAddrMapLocalPortTo
+  - OID: 1.3.6.1.2.1.123.1.4.1.10
+    description: This object specifies the address type used for natAddrMapGlobalAddrFrom
+      and natAddrMapGlobalAddrTo. Deprecated in favor of NATV2-MIB.
+    name: natAddrMapGlobalAddrType
+  - OID: 1.3.6.1.2.1.123.1.4.1.11
+    description: This object specifies the first IP address of the range of IP addresses
+      being mapped to. The value of this object must be less than or equal to the
+      value of the natAddrMapGlobalAddrTo object. The type of this address is determined
+      by the value of the natAddrMapGlobalAddrType object. Deprecated in favor of
+      NATV2-MIB.
+    name: natAddrMapGlobalAddrFrom
+  - OID: 1.3.6.1.2.1.123.1.4.1.12
+    description: This object specifies the last IP address of the range of IP addresses
+      being mapped to. If only a single address is being mapped to, the value of this
+      object is equal to the value of natAddrMapGlobalAddrFrom. For a static NAT,
+      the number of addresses in the range defined by natAddrMapGlobalAddrFrom and
+      natAddrMapGlobalAddrTo must be equal to the number of addresses in the range
+      defined by natAddrMapLocalAddrFrom and natAddrMapLocalAddrTo. The value of this
+      object must be greater than or equal to the value of the natAddrMapGlobalAddrFrom
+      object. The type of this address is determined by the value of the natAddrMapGlobalAddrType
+      object. Deprecated in favor of NATV2-MIB.
+    name: natAddrMapGlobalAddrTo
+  - OID: 1.3.6.1.2.1.123.1.4.1.13
+    description: If this conceptual row describes a Basic NAT address mapping, then
+      the value of this object must be zero. If this conceptual row describes NAPT,
+      then the value of this object specifies the first port number in the range of
+      ports being mapped to. The value of this object must be less than or equal to
+      the value of the natAddrMapGlobalPortTo object. If the translation specifies
+      a single port, then the value of this object is equal to the value natAddrMapGlobalPortTo.
+      Deprecated in favor of NATV2-MIB.
+    name: natAddrMapGlobalPortFrom
+  - OID: 1.3.6.1.2.1.123.1.4.1.14
+    description: If this conceptual row describes a Basic NAT address mapping, then
+      the value of this object must be zero. If this conceptual row describes NAPT,
+      then the value of this object specifies the last port number in the range of
+      ports being mapped to. The value of this object must be greater than or equal
+      to the value of the natAddrMapGlobalPortFrom object. If the translation specifies
+      a single port, then the value of this object is equal to the value of natAddrMapGlobalPortFrom.
+      Deprecated in favor of NATV2-MIB.
+    name: natAddrMapGlobalPortTo
+  - OID: 1.3.6.1.2.1.123.1.4.1.15
+    description: This object specifies a bitmap of protocol identifiers. Deprecated
+      in favor of NATV2-MIB.
+    name: natAddrMapProtocol
+  - OID: 1.3.6.1.2.1.123.1.4.1.16
+    description: The number of inbound packets pertaining to this address map entry
+      that were translated. Discontinuities in the value of this counter can occur
+      at reinitialization of the management system and at other times, as indicated
+      by the value of ifCounterDiscontinuityTime on the relevant interface. Deprecated
+      in favor of NATV2-MIB.
+    name: natAddrMapInTranslates
+  - OID: 1.3.6.1.2.1.123.1.4.1.17
+    description: The number of outbound packets pertaining to this address map entry
+      that were translated. Discontinuities in the value of this counter can occur
+      at reinitialization of the management system and at other times, as indicated
+      by the value of ifCounterDiscontinuityTime on the relevant interface. Deprecated
+      in favor of NATV2-MIB.
+    name: natAddrMapOutTranslates
+  - OID: 1.3.6.1.2.1.123.1.4.1.18
+    description: The number of packets pertaining to this address map entry that were
+      dropped due to lack of addresses in the address pool identified by this address
+      map. The value of this object must always be zero in case of a static address
+      map. Discontinuities in the value of this counter can occur at reinitialization
+      of the management system and at other times, as indicated by the value of ifCounterDiscontinuityTime
+      on the relevant interface. Deprecated in favor of NATV2-MIB.
+    name: natAddrMapDiscards
+  - OID: 1.3.6.1.2.1.123.1.4.1.19
+    description: The number of addresses pertaining to this address map that are currently
+      being used from the NAT pool. The value of this object must always be zero in
+      the case of a static address map. Deprecated in favor of NATV2-MIB.
+    name: natAddrMapAddrUsed
+  - OID: 1.3.6.1.2.1.123.1.4.1.20
+    description: The storage type for this conceptual row. Conceptual rows having
+      the value 'permanent' need not allow write-access to any columnar objects in
+      the row. Deprecated in favor of NATV2-MIB.
+    name: natAddrMapStorageType
+  - OID: 1.3.6.1.2.1.123.1.4.1.21
+    description: The status of this conceptual row. Until instances of all corresponding
+      columns are appropriately configured, the value of the corresponding instance
+      of the natAddrMapRowStatus column is 'notReady'. None of the objects in this
+      row may be modified while the value of this object is active(1). Deprecated
+      in favor of NATV2-MIB.
+    name: natAddrMapRowStatus
+  table:
+    OID: 1.3.6.1.2.1.123.1.4
+    description: This table lists address map parameters for NAT. Deprecated in favor
+      of NATV2-MIB.
+    name: natAddrMapTable
+- MIB: SNMP-FRAMEWORK-MIB
+  symbol:
+    OID: 1.3.6.1.6.3.10.2.1.1.0
+    description: 'An SNMP engine''s administratively-unique identifier. This information
+      SHOULD be stored in non-volatile storage so that it remains constant across
+      re-initializations of the SNMP engine. '
+    name: snmpEngineID
+- MIB: SNMP-FRAMEWORK-MIB
+  symbol:
+    OID: 1.3.6.1.6.3.10.2.1.2.0
+    description: 'The number of times that the SNMP engine has (re-)initialized itself
+      since snmpEngineID was last configured. '
+    name: snmpEngineBoots
+- MIB: SNMP-FRAMEWORK-MIB
+  symbol:
+    OID: 1.3.6.1.6.3.10.2.1.3.0
+    description: 'The number of seconds since the value of the snmpEngineBoots object
+      last changed. When incrementing this object''s value would cause it to exceed
+      its maximum, snmpEngineBoots is incremented as if a re-initialization had occurred,
+      and this object''s value consequently reverts to zero. '
+    name: snmpEngineTime
+- MIB: SNMP-FRAMEWORK-MIB
+  symbol:
+    OID: 1.3.6.1.6.3.10.2.1.4.0
+    description: 'The maximum length in octets of an SNMP message which this SNMP
+      engine can send or receive and process, determined as the minimum of the maximum
+      message size values supported among all of the transports available to and supported
+      by the engine. '
+    name: snmpEngineMaxMessageSize
+- MIB: SNMP-TARGET-MIB
+  symbols:
+  - OID: 1.3.6.1.6.3.12.1.2.1.1
+    description: The locally arbitrary, but unique identifier associated with this
+      snmpTargetAddrEntry.
+    name: snmpTargetAddrName
+  - OID: 1.3.6.1.6.3.12.1.2.1.2
+    description: This object indicates the transport type of the address contained
+      in the snmpTargetAddrTAddress object.
+    name: snmpTargetAddrTDomain
+  - OID: 1.3.6.1.6.3.12.1.2.1.3
+    description: This object contains a transport address. The format of this address
+      depends on the value of the snmpTargetAddrTDomain object.
+    name: snmpTargetAddrTAddress
+  - OID: 1.3.6.1.6.3.12.1.2.1.4
+    description: This object should reflect the expected maximum round trip time for
+      communicating with the transport address defined by this row. When a message
+      is sent to this address, and a response (if one is expected) is not received
+      within this time period, an implementation may assume that the response will
+      not be delivered. Note that the time interval that an application waits for
+      a response may actually be derived from the value of this object. The method
+      for deriving the actual time interval is implementation dependent. One such
+      method is to derive the expected round trip time based on a particular retransmission
+      algorithm and on the number of timeouts which have occurred. The type of message
+      may also be considered when deriving expected round trip times for retransmissions.
+      For example, if a message is being sent with a securityLevel that indicates
+      both authentication and privacy, the derived value may be increased to compensate
+      for extra processing time spent during authentication and encryption processing.
+    name: snmpTargetAddrTimeout
+  - OID: 1.3.6.1.6.3.12.1.2.1.5
+    description: This object specifies a default number of retries to be attempted
+      when a response is not received for a generated message. An application may
+      provide its own retry count, in which case the value of this object is ignored.
+    name: snmpTargetAddrRetryCount
+  - OID: 1.3.6.1.6.3.12.1.2.1.6
+    description: This object contains a list of tag values which are used to select
+      target addresses for a particular operation.
+    name: snmpTargetAddrTagList
+  - OID: 1.3.6.1.6.3.12.1.2.1.7
+    description: The value of this object identifies an entry in the snmpTargetParamsTable.
+      The identified entry contains SNMP parameters to be used when generating messages
+      to be sent to this transport address.
+    name: snmpTargetAddrParams
+  - OID: 1.3.6.1.6.3.12.1.2.1.8
+    description: The storage type for this conceptual row. Conceptual rows having
+      the value 'permanent' need not allow write-access to any columnar objects in
+      the row.
+    name: snmpTargetAddrStorageType
+  - OID: 1.3.6.1.6.3.12.1.2.1.9
+    description: 'The status of this conceptual row. To create a row in this table,
+      a manager must set this object to either createAndGo(4) or createAndWait(5).
+      Until instances of all corresponding columns are appropriately configured, the
+      value of the corresponding instance of the snmpTargetAddrRowStatus column is
+      ''notReady''. In particular, a newly created row cannot be made active until
+      the corresponding instances of snmpTargetAddrTDomain, snmpTargetAddrTAddress,
+      and snmpTargetAddrParams have all been set. The following objects may not be
+      modified while the value of this object is active(1): - snmpTargetAddrTDomain
+      - snmpTargetAddrTAddress An attempt to set these objects while the value of
+      snmpTargetAddrRowStatus is active(1) will result in an inconsistentValue error.'
+    name: snmpTargetAddrRowStatus
+  table:
+    OID: 1.3.6.1.6.3.12.1.2
+    description: A table of transport addresses to be used in the generation of SNMP
+      messages.
+    name: snmpTargetAddrTable
+- MIB: SNMP-TARGET-MIB
+  symbols:
+  - OID: 1.3.6.1.6.3.12.1.3.1.1
+    description: The locally arbitrary, but unique identifier associated with this
+      snmpTargetParamsEntry.
+    name: snmpTargetParamsName
+  - OID: 1.3.6.1.6.3.12.1.3.1.2
+    description: The Message Processing Model to be used when generating SNMP messages
+      using this entry.
+    name: snmpTargetParamsMPModel
+  - OID: 1.3.6.1.6.3.12.1.3.1.3
+    description: The Security Model to be used when generating SNMP messages using
+      this entry. An implementation may choose to return an inconsistentValue error
+      if an attempt is made to set this variable to a value for a security model which
+      the implementation does not support.
+    name: snmpTargetParamsSecurityModel
+  - OID: 1.3.6.1.6.3.12.1.3.1.4
+    description: The securityName which identifies the Principal on whose behalf SNMP
+      messages will be generated using this entry.
+    name: snmpTargetParamsSecurityName
+  - OID: 1.3.6.1.6.3.12.1.3.1.5
+    description: The Level of Security to be used when generating SNMP messages using
+      this entry.
+    name: snmpTargetParamsSecurityLevel
+  - OID: 1.3.6.1.6.3.12.1.3.1.6
+    description: The storage type for this conceptual row. Conceptual rows having
+      the value 'permanent' need not allow write-access to any columnar objects in
+      the row.
+    name: snmpTargetParamsStorageType
+  - OID: 1.3.6.1.6.3.12.1.3.1.7
+    description: 'The status of this conceptual row. To create a row in this table,
+      a manager must set this object to either createAndGo(4) or createAndWait(5).
+      Until instances of all corresponding columns are appropriately configured, the
+      value of the corresponding instance of the snmpTargetParamsRowStatus column
+      is ''notReady''. In particular, a newly created row cannot be made active until
+      the corresponding snmpTargetParamsMPModel, snmpTargetParamsSecurityModel, snmpTargetParamsSecurityName,
+      and snmpTargetParamsSecurityLevel have all been set. The following objects may
+      not be modified while the value of this object is active(1): - snmpTargetParamsMPModel
+      - snmpTargetParamsSecurityModel - snmpTargetParamsSecurityName - snmpTargetParamsSecurityLevel
+      An attempt to set these objects while the value of snmpTargetParamsRowStatus
+      is active(1) will result in an inconsistentValue error.'
+    name: snmpTargetParamsRowStatus
+  table:
+    OID: 1.3.6.1.6.3.12.1.3
+    description: A table of SNMP target information to be used in the generation of
+      SNMP messages.
+    name: snmpTargetParamsTable
+- MIB: SNMP-USER-BASED-SM-MIB
+  symbols:
+  - OID: 1.3.6.1.6.3.15.1.2.2.1.1
+    description: 'An SNMP engine''s administratively-unique identifier. In a simple
+      agent, this value is always that agent''s own snmpEngineID value. The value
+      can also take the value of the snmpEngineID of a remote SNMP engine with which
+      this user can communicate. '
+    name: usmUserEngineID
+  - OID: 1.3.6.1.6.3.15.1.2.2.1.2
+    description: 'A human readable string representing the name of the user. This
+      is the (User-based Security) Model dependent security ID. '
+    name: usmUserName
+  - OID: 1.3.6.1.6.3.15.1.2.2.1.3
+    description: 'A human readable string representing the user in Security Model
+      independent format. The default transformation of the User-based Security Model
+      dependent security ID to the securityName and vice versa is the identity function
+      so that the securityName is the same as the userName. '
+    name: usmUserSecurityName
+  - OID: 1.3.6.1.6.3.15.1.2.2.1.4
+    description: 'A pointer to another conceptual row in this usmUserTable. The user
+      in this other conceptual row is called the clone-from user. When a new user
+      is created (i.e., a new conceptual row is instantiated in this table), the privacy
+      and authentication parameters of the new user must be cloned from its clone-from
+      user. These parameters are: - authentication protocol (usmUserAuthProtocol)
+      - privacy protocol (usmUserPrivProtocol) They will be copied regardless of what
+      the current value is. Cloning also causes the initial values of the secret authentication
+      key (authKey) and the secret encryption key (privKey) of the new user to be
+      set to the same values as the corresponding secrets of the clone-from user to
+      allow the KeyChange process to occur as required during user creation. The first
+      time an instance of this object is set by a management operation (either at
+      or after its instantiation), the cloning process is invoked. Subsequent writes
+      are successful but invoke no action to be taken by the receiver. The cloning
+      process fails with an ''inconsistentName'' error if the conceptual row representing
+      the clone-from user does not exist or is not in an active state when the cloning
+      process is invoked. When this object is read, the ZeroDotZero OID is returned. '
+    name: usmUserCloneFrom
+  - OID: 1.3.6.1.6.3.15.1.2.2.1.5
+    description: 'An indication of whether messages sent on behalf of this user to/from
+      the SNMP engine identified by usmUserEngineID, can be authenticated, and if
+      so, the type of authentication protocol which is used. An instance of this object
+      is created concurrently with the creation of any other object instance for the
+      same user (i.e., as part of the processing of the set operation which creates
+      the first object instance in the same conceptual row). If an initial set operation
+      (i.e. at row creation time) tries to set a value for an unknown or unsupported
+      protocol, then a ''wrongValue'' error must be returned. The value will be overwritten/set
+      when a set operation is performed on the corresponding instance of usmUserCloneFrom.
+      Once instantiated, the value of such an instance of this object can only be
+      changed via a set operation to the value of the usmNoAuthProtocol. If a set
+      operation tries to change the value of an existing instance of this object to
+      any value other than usmNoAuthProtocol, then an ''inconsistentValue'' error
+      must be returned. If a set operation tries to set the value to the usmNoAuthProtocol
+      while the usmUserPrivProtocol value in the same row is not equal to usmNoPrivProtocol,
+      then an ''inconsistentValue'' error must be returned. That means that an SNMP
+      command generator application must first ensure that the usmUserPrivProtocol
+      is set to the usmNoPrivProtocol value before it can set the usmUserAuthProtocol
+      value to usmNoAuthProtocol. '
+    name: usmUserAuthProtocol
+  - OID: 1.3.6.1.6.3.15.1.2.2.1.6
+    description: 'An object, which when modified, causes the secret authentication
+      key used for messages sent on behalf of this user to/from the SNMP engine identified
+      by usmUserEngineID, to be modified via a one-way function. The associated protocol
+      is the usmUserAuthProtocol. The associated secret key is the user''s secret
+      authentication key (authKey). The associated hash algorithm is the algorithm
+      used by the user''s usmUserAuthProtocol. When creating a new user, it is an
+      ''inconsistentName'' error for a set operation to refer to this object unless
+      it is previously or concurrently initialized through a set operation on the
+      corresponding instance of usmUserCloneFrom. When the value of the corresponding
+      usmUserAuthProtocol is usmNoAuthProtocol, then a set is successful, but effectively
+      is a no-op. When this object is read, the zero-length (empty) string is returned.
+      The recommended way to do a key change is as follows: 1) GET(usmUserSpinLock.0)
+      and save in sValue. 2) generate the keyChange value based on the old (existing)
+      secret key and the new secret key, let us call this kcValue. If you do the key
+      change on behalf of another user: 3) SET(usmUserSpinLock.0=sValue, usmUserAuthKeyChange=kcValue
+      usmUserPublic=randomValue) If you do the key change for yourself: 4) SET(usmUserSpinLock.0=sValue,
+      usmUserOwnAuthKeyChange=kcValue usmUserPublic=randomValue) If you get a response
+      with error-status of noError, then the SET succeeded and the new key is active.
+      If you do not get a response, then you can issue a GET(usmUserPublic) and check
+      if the value is equal to the randomValue you did send in the SET. If so, then
+      the key change succeeded and the new key is active (probably the response got
+      lost). If not, then the SET request probably never reached the target and so
+      you can start over with the procedure above. '
+    name: usmUserAuthKeyChange
+  - OID: 1.3.6.1.6.3.15.1.2.2.1.7
+    description: 'Behaves exactly as usmUserAuthKeyChange, with one notable difference:
+      in order for the set operation to succeed, the usmUserName of the operation
+      requester must match the usmUserName that indexes the row which is targeted
+      by this operation. In addition, the USM security model must be used for this
+      operation. The idea here is that access to this column can be public, since
+      it will only allow a user to change his own secret authentication key (authKey).
+      Note that this can only be done once the row is active. When a set is received
+      and the usmUserName of the requester is not the same as the umsUserName that
+      indexes the row which is targeted by this operation, then a ''noAccess'' error
+      must be returned. When a set is received and the security model in use is not
+      USM, then a ''noAccess'' error must be returned. '
+    name: usmUserOwnAuthKeyChange
+  - OID: 1.3.6.1.6.3.15.1.2.2.1.8
+    description: 'An indication of whether messages sent on behalf of this user to/from
+      the SNMP engine identified by usmUserEngineID, can be protected from disclosure,
+      and if so, the type of privacy protocol which is used. An instance of this object
+      is created concurrently with the creation of any other object instance for the
+      same user (i.e., as part of the processing of the set operation which creates
+      the first object instance in the same conceptual row). If an initial set operation
+      (i.e. at row creation time) tries to set a value for an unknown or unsupported
+      protocol, then a ''wrongValue'' error must be returned. The value will be overwritten/set
+      when a set operation is performed on the corresponding instance of usmUserCloneFrom.
+      Once instantiated, the value of such an instance of this object can only be
+      changed via a set operation to the value of the usmNoPrivProtocol. If a set
+      operation tries to change the value of an existing instance of this object to
+      any value other than usmNoPrivProtocol, then an ''inconsistentValue'' error
+      must be returned. Note that if any privacy protocol is used, then you must also
+      use an authentication protocol. In other words, if usmUserPrivProtocol is set
+      to anything else than usmNoPrivProtocol, then the corresponding instance of
+      usmUserAuthProtocol cannot have a value of usmNoAuthProtocol. If it does, then
+      an ''inconsistentValue'' error must be returned. '
+    name: usmUserPrivProtocol
+  - OID: 1.3.6.1.6.3.15.1.2.2.1.9
+    description: 'An object, which when modified, causes the secret encryption key
+      used for messages sent on behalf of this user to/from the SNMP engine identified
+      by usmUserEngineID, to be modified via a one-way function. The associated protocol
+      is the usmUserPrivProtocol. The associated secret key is the user''s secret
+      privacy key (privKey). The associated hash algorithm is the algorithm used by
+      the user''s usmUserAuthProtocol. When creating a new user, it is an ''inconsistentName''
+      error for a set operation to refer to this object unless it is previously or
+      concurrently initialized through a set operation on the corresponding instance
+      of usmUserCloneFrom. When the value of the corresponding usmUserPrivProtocol
+      is usmNoPrivProtocol, then a set is successful, but effectively is a no-op.
+      When this object is read, the zero-length (empty) string is returned. See the
+      description clause of usmUserAuthKeyChange for a recommended procedure to do
+      a key change. '
+    name: usmUserPrivKeyChange
+  - OID: 1.3.6.1.6.3.15.1.2.2.1.10
+    description: 'Behaves exactly as usmUserPrivKeyChange, with one notable difference:
+      in order for the Set operation to succeed, the usmUserName of the operation
+      requester must match the usmUserName that indexes the row which is targeted
+      by this operation. In addition, the USM security model must be used for this
+      operation. The idea here is that access to this column can be public, since
+      it will only allow a user to change his own secret privacy key (privKey). Note
+      that this can only be done once the row is active. When a set is received and
+      the usmUserName of the requester is not the same as the umsUserName that indexes
+      the row which is targeted by this operation, then a ''noAccess'' error must
+      be returned. When a set is received and the security model in use is not USM,
+      then a ''noAccess'' error must be returned. '
+    name: usmUserOwnPrivKeyChange
+  - OID: 1.3.6.1.6.3.15.1.2.2.1.11
+    description: 'A publicly-readable value which can be written as part of the procedure
+      for changing a user''s secret authentication and/or privacy key, and later read
+      to determine whether the change of the secret was effected. '
+    name: usmUserPublic
+  - OID: 1.3.6.1.6.3.15.1.2.2.1.12
+    description: 'The storage type for this conceptual row. Conceptual rows having
+      the value ''permanent'' must allow write-access at a minimum to: - usmUserAuthKeyChange,
+      usmUserOwnAuthKeyChange and usmUserPublic for a user who employs authentication,
+      and - usmUserPrivKeyChange, usmUserOwnPrivKeyChange and usmUserPublic for a
+      user who employs privacy. Note that any user who employs authentication or privacy
+      must allow its secret(s) to be updated and thus cannot be ''readOnly''. If an
+      initial set operation tries to set the value to ''readOnly'' for a user who
+      employs authentication or privacy, then an ''inconsistentValue'' error must
+      be returned. Note that if the value has been previously set (implicit or explicit)
+      to any value, then the rules as defined in the StorageType Textual Convention
+      apply. It is an implementation issue to decide if a SET for a readOnly or permanent
+      row is accepted at all. In some contexts this may make sense, in others it may
+      not. If a SET for a readOnly or permanent row is not accepted at all, then a
+      ''wrongValue'' error must be returned. '
+    name: usmUserStorageType
+  - OID: 1.3.6.1.6.3.15.1.2.2.1.13
+    description: 'The status of this conceptual row. Until instances of all corresponding
+      columns are appropriately configured, the value of the corresponding instance
+      of the usmUserStatus column is ''notReady''. In particular, a newly created
+      row for a user who employs authentication, cannot be made active until the corresponding
+      usmUserCloneFrom and usmUserAuthKeyChange have been set. Further, a newly created
+      row for a user who also employs privacy, cannot be made active until the usmUserPrivKeyChange
+      has been set. The RowStatus TC [RFC2579] requires that this DESCRIPTION clause
+      states under which circumstances other objects in this row can be modified:
+      The value of this object has no effect on whether other objects in this conceptual
+      row can be modified, except for usmUserOwnAuthKeyChange and usmUserOwnPrivKeyChange.
+      For these 2 objects, the value of usmUserStatus MUST be active. '
+    name: usmUserStatus
+  table:
+    OID: 1.3.6.1.6.3.15.1.2.2
+    description: 'The table of users configured in the SNMP engine''s Local Configuration
+      Datastore (LCD). To create a new user (i.e., to instantiate a new conceptual
+      row in this table), it is recommended to follow this procedure: 1) GET(usmUserSpinLock.0)
+      and save in sValue. 2) SET(usmUserSpinLock.0=sValue, usmUserCloneFrom=templateUser,
+      usmUserStatus=createAndWait) You should use a template user to clone from which
+      has the proper auth/priv protocol defined. If the new user is to use privacy:
+      3) generate the keyChange value based on the secret privKey of the clone-from
+      user and the secret key to be used for the new user. Let us call this pkcValue.
+      4) GET(usmUserSpinLock.0) and save in sValue. 5) SET(usmUserSpinLock.0=sValue,
+      usmUserPrivKeyChange=pkcValue usmUserPublic=randomValue1) 6) GET(usmUserPulic)
+      and check it has randomValue1. If not, repeat steps 4-6. If the new user will
+      never use privacy: 7) SET(usmUserPrivProtocol=usmNoPrivProtocol) If the new
+      user is to use authentication: 8) generate the keyChange value based on the
+      secret authKey of the clone-from user and the secret key to be used for the
+      new user. Let us call this akcValue. 9) GET(usmUserSpinLock.0) and save in sValue.
+      10) SET(usmUserSpinLock.0=sValue, usmUserAuthKeyChange=akcValue usmUserPublic=randomValue2)
+      11) GET(usmUserPulic) and check it has randomValue2. If not, repeat steps 9-11.
+      If the new user will never use authentication: 12) SET(usmUserAuthProtocol=usmNoAuthProtocol)
+      Finally, activate the new user: 13) SET(usmUserStatus=active) The new user should
+      now be available and ready to be used for SNMPv3 communication. Note however
+      that access to MIB data must be provided via configuration of the SNMP-VIEW-BASED-ACM-MIB.
+      The use of usmUserSpinlock is to avoid conflicts with another SNMP command generator
+      application which may also be acting on the usmUserTable. '
+    name: usmUserTable
+- MIB: SNMP-VIEW-BASED-ACM-MIB
+  symbols:
+  - OID: 1.3.6.1.6.3.16.1.2.1.1
+    description: 'The Security Model, by which the vacmSecurityName referenced by
+      this entry is provided. Note, this object may not take the ''any'' (0) value. '
+    name: vacmSecurityModel
+  - OID: 1.3.6.1.6.3.16.1.2.1.2
+    description: 'The securityName for the principal, represented in a Security Model
+      independent format, which is mapped by this entry to a groupName. '
+    name: vacmSecurityName
+  - OID: 1.3.6.1.6.3.16.1.2.1.3
+    description: 'The name of the group to which this entry (e.g., the combination
+      of securityModel and securityName) belongs. This groupName is used as index
+      into the vacmAccessTable to select an access control policy. However, a value
+      in this table does not imply that an instance with the value exists in table
+      vacmAccesTable. '
+    name: vacmGroupName
+  - OID: 1.3.6.1.6.3.16.1.2.1.4
+    description: 'The storage type for this conceptual row. Conceptual rows having
+      the value ''permanent'' need not allow write-access to any columnar objects
+      in the row. '
+    name: vacmSecurityToGroupStorageType
+  - OID: 1.3.6.1.6.3.16.1.2.1.5
+    description: 'The status of this conceptual row. Until instances of all corresponding
+      columns are appropriately configured, the value of the corresponding instance
+      of the vacmSecurityToGroupStatus column is ''notReady''. In particular, a newly
+      created row cannot be made active until a value has been set for vacmGroupName.
+      The RowStatus TC [RFC2579] requires that this DESCRIPTION clause states under
+      which circumstances other objects in this row can be modified: The value of
+      this object has no effect on whether other objects in this conceptual row can
+      be modified. '
+    name: vacmSecurityToGroupStatus
+  table:
+    OID: 1.3.6.1.6.3.16.1.2
+    description: 'This table maps a combination of securityModel and securityName
+      into a groupName which is used to define an access control policy for a group
+      of principals. '
+    name: vacmSecurityToGroupTable
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.1.1.0
+    description: A textual description of the entity. This value should include the
+      full name and version identification of the system's hardware type, software
+      operating-system, and networking software.
+    name: sysDescr
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.1.2.0
+    description: The vendor's authoritative identification of the network management
+      subsystem contained in the entity. This value is allocated within the SMI enterprises
+      subtree (1.3.6.1.4.1) and provides an easy and unambiguous means for determining
+      `what kind of box' is being managed. For example, if vendor `Flintstones, Inc.'
+      was assigned the subtree 1.3.6.1.4.1.424242, it could assign the identifier
+      1.3.6.1.4.1.424242.1.1 to its `Fred Router'.
+    name: sysObjectID
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.1.3.0
+    description: The time (in hundredths of a second) since the network management
+      portion of the system was last re-initialized.
+    name: sysUpTime
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.1.4.0
+    description: The textual identification of the contact person for this managed
+      node, together with information on how to contact this person. If no contact
+      information is known, the value is the zero-length string.
+    name: sysContact
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.1.5.0
+    description: An administratively-assigned name for this managed node. By convention,
+      this is the node's fully-qualified domain name. If the name is unknown, the
+      value is the zero-length string.
+    name: sysName
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.1.6.0
+    description: The physical location of this node (e.g., 'telephone closet, 3rd
+      floor'). If the location is unknown, the value is the zero-length string.
+    name: sysLocation
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.1.7.0
+    description: 'A value which indicates the set of services that this entity may
+      potentially offer. The value is a sum. This sum initially takes the value zero.
+      Then, for each layer, L, in the range 1 through 7, that this node performs transactions
+      for, 2 raised to (L - 1) is added to the sum. For example, a node which performs
+      only routing functions would have a value of 4 (2^(3-1)). In contrast, a node
+      which is a host offering application services would have a value of 72 (2^(4-1)
+      + 2^(7-1)). Note that in the context of the Internet suite of protocols, values
+      should be calculated accordingly: layer functionality 1 physical (e.g., repeaters)
+      2 datalink/subnetwork (e.g., bridges) 3 internet (e.g., supports the IP) 4 end-to-end
+      (e.g., supports the TCP) 7 applications (e.g., supports the SMTP) For systems
+      including OSI protocols, layers 5 and 6 may also be counted.'
+    name: sysServices
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.1.8.0
+    description: The value of sysUpTime at the time of the most recent change in state
+      or value of any instance of sysORID.
+    name: sysORLastChange
+- MIB: SNMPv2-MIB
+  symbols:
+  - OID: 1.3.6.1.2.1.1.9.1.1
+    description: The auxiliary variable used for identifying instances of the columnar
+      objects in the sysORTable.
+    name: sysORIndex
+  - OID: 1.3.6.1.2.1.1.9.1.2
+    description: An authoritative identification of a capabilities statement with
+      respect to various MIB modules supported by the local SNMP application acting
+      as a command responder.
+    name: sysORID
+  - OID: 1.3.6.1.2.1.1.9.1.3
+    description: A textual description of the capabilities identified by the corresponding
+      instance of sysORID.
+    name: sysORDescr
+  - OID: 1.3.6.1.2.1.1.9.1.4
+    description: The value of sysUpTime at the time this conceptual row was last instantiated.
+    name: sysORUpTime
+  table:
+    OID: 1.3.6.1.2.1.1.9
+    description: The (conceptual) table listing the capabilities of the local SNMP
+      application acting as a command responder with respect to various MIB modules.
+      SNMP entities having dynamically-configurable support of MIB modules will have
+      a dynamically-varying number of conceptual rows.
+    name: sysORTable
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.1.0
+    description: The total number of messages delivered to the SNMP entity from the
+      transport service.
+    name: snmpInPkts
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.3.0
+    description: The total number of SNMP messages which were delivered to the SNMP
+      entity and were for an unsupported SNMP version.
+    name: snmpInBadVersions
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.4.0
+    description: The total number of community-based SNMP messages (for example, SNMPv1)
+      delivered to the SNMP entity which used an SNMP community name not known to
+      said entity. Also, implementations which authenticate community-based SNMP messages
+      using check(s) in addition to matching the community name (for example, by also
+      checking whether the message originated from a transport address allowed to
+      use a specified community name) MAY include in this value the number of messages
+      which failed the additional check(s). It is strongly RECOMMENDED that the documentation
+      for any security model which is used to authenticate community-based SNMP messages
+      specify the precise conditions that contribute to this value.
+    name: snmpInBadCommunityNames
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.5.0
+    description: The total number of community-based SNMP messages (for example, SNMPv1)
+      delivered to the SNMP entity which represented an SNMP operation that was not
+      allowed for the SNMP community named in the message. The precise conditions
+      under which this counter is incremented (if at all) depend on how the SNMP entity
+      implements its access control mechanism and how its applications interact with
+      that access control mechanism. It is strongly RECOMMENDED that the documentation
+      for any access control mechanism which is used to control access to and visibility
+      of MIB instrumentation specify the precise conditions that contribute to this
+      value.
+    name: snmpInBadCommunityUses
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.6.0
+    description: The total number of ASN.1 or BER errors encountered by the SNMP entity
+      when decoding received SNMP messages.
+    name: snmpInASNParseErrs
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.30.0
+    description: Indicates whether the SNMP entity is permitted to generate authenticationFailure
+      traps. The value of this object overrides any configuration information; as
+      such, it provides a means whereby all authenticationFailure traps may be disabled.
+      Note that it is strongly recommended that this object be stored in non-volatile
+      memory so that it remains constant across re-initializations of the network
+      management system.
+    name: snmpEnableAuthenTraps
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.31.0
+    description: The total number of Confirmed Class PDUs (such as GetRequest-PDUs,
+      GetNextRequest-PDUs, GetBulkRequest-PDUs, SetRequest-PDUs, and InformRequest-PDUs)
+      delivered to the SNMP entity which were silently dropped because the size of
+      a reply containing an alternate Response Class PDU (such as a Response-PDU)
+      with an empty variable-bindings field was greater than either a local constraint
+      or the maximum message size associated with the originator of the request.
+    name: snmpSilentDrops
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.32.0
+    description: The total number of Confirmed Class PDUs (such as GetRequest-PDUs,
+      GetNextRequest-PDUs, GetBulkRequest-PDUs, SetRequest-PDUs, and InformRequest-PDUs)
+      delivered to the SNMP entity which were silently dropped because the transmission
+      of the (possibly translated) message to a proxy target failed in a manner (other
+      than a time-out) such that no Response Class PDU (such as a Response-PDU) could
+      be returned.
+    name: snmpProxyDrops
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.6.3.1.1.4.1.0
+    description: The authoritative identification of the notification currently being
+      sent. This variable occurs as the second varbind in every SNMPv2-Trap-PDU and
+      InformRequest-PDU.
+    name: snmpTrapOID
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.6.3.1.1.4.3.0
+    description: The authoritative identification of the enterprise associated with
+      the trap currently being sent. When an SNMP proxy agent is mapping an RFC1157
+      Trap-PDU into a SNMPv2-Trap-PDU, this variable occurs as the last varbind.
+    name: snmpTrapEnterprise
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.6.3.1.1.6.1.0
+    description: An advisory lock used to allow several cooperating command generator
+      applications to coordinate their use of the SNMP set operation. This object
+      is used for coarse-grain coordination. To achieve fine-grain coordination, one
+      or more similar objects might be defined within each MIB group, as appropriate.
+    name: snmpSetSerialNo
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.2.0
+    description: The total number of SNMP Messages which were passed from the SNMP
+      protocol entity to the transport service.
+    name: snmpOutPkts
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.8.0
+    description: The total number of SNMP PDUs which were delivered to the SNMP protocol
+      entity and for which the value of the error-status field was `tooBig'.
+    name: snmpInTooBigs
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.9.0
+    description: The total number of SNMP PDUs which were delivered to the SNMP protocol
+      entity and for which the value of the error-status field was `noSuchName'.
+    name: snmpInNoSuchNames
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.10.0
+    description: The total number of SNMP PDUs which were delivered to the SNMP protocol
+      entity and for which the value of the error-status field was `badValue'.
+    name: snmpInBadValues
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.11.0
+    description: The total number valid SNMP PDUs which were delivered to the SNMP
+      protocol entity and for which the value of the error-status field was `readOnly'.
+      It should be noted that it is a protocol error to generate an SNMP PDU which
+      contains the value `readOnly' in the error-status field, as such this object
+      is provided as a means of detecting incorrect implementations of the SNMP.
+    name: snmpInReadOnlys
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.12.0
+    description: The total number of SNMP PDUs which were delivered to the SNMP protocol
+      entity and for which the value of the error-status field was `genErr'.
+    name: snmpInGenErrs
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.13.0
+    description: The total number of MIB objects which have been retrieved successfully
+      by the SNMP protocol entity as the result of receiving valid SNMP Get-Request
+      and Get-Next PDUs.
+    name: snmpInTotalReqVars
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.14.0
+    description: The total number of MIB objects which have been altered successfully
+      by the SNMP protocol entity as the result of receiving valid SNMP Set-Request
+      PDUs.
+    name: snmpInTotalSetVars
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.15.0
+    description: The total number of SNMP Get-Request PDUs which have been accepted
+      and processed by the SNMP protocol entity.
+    name: snmpInGetRequests
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.16.0
+    description: The total number of SNMP Get-Next PDUs which have been accepted and
+      processed by the SNMP protocol entity.
+    name: snmpInGetNexts
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.17.0
+    description: The total number of SNMP Set-Request PDUs which have been accepted
+      and processed by the SNMP protocol entity.
+    name: snmpInSetRequests
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.18.0
+    description: The total number of SNMP Get-Response PDUs which have been accepted
+      and processed by the SNMP protocol entity.
+    name: snmpInGetResponses
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.19.0
+    description: The total number of SNMP Trap PDUs which have been accepted and processed
+      by the SNMP protocol entity.
+    name: snmpInTraps
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.20.0
+    description: The total number of SNMP PDUs which were generated by the SNMP protocol
+      entity and for which the value of the error-status field was `tooBig.'
+    name: snmpOutTooBigs
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.21.0
+    description: The total number of SNMP PDUs which were generated by the SNMP protocol
+      entity and for which the value of the error-status was `noSuchName'.
+    name: snmpOutNoSuchNames
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.22.0
+    description: The total number of SNMP PDUs which were generated by the SNMP protocol
+      entity and for which the value of the error-status field was `badValue'.
+    name: snmpOutBadValues
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.24.0
+    description: The total number of SNMP PDUs which were generated by the SNMP protocol
+      entity and for which the value of the error-status field was `genErr'.
+    name: snmpOutGenErrs
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.25.0
+    description: The total number of SNMP Get-Request PDUs which have been generated
+      by the SNMP protocol entity.
+    name: snmpOutGetRequests
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.26.0
+    description: The total number of SNMP Get-Next PDUs which have been generated
+      by the SNMP protocol entity.
+    name: snmpOutGetNexts
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.27.0
+    description: The total number of SNMP Set-Request PDUs which have been generated
+      by the SNMP protocol entity.
+    name: snmpOutSetRequests
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.28.0
+    description: The total number of SNMP Get-Response PDUs which have been generated
+      by the SNMP protocol entity.
+    name: snmpOutGetResponses
+- MIB: SNMPv2-MIB
+  symbol:
+    OID: 1.3.6.1.2.1.11.29.0
+    description: The total number of SNMP Trap PDUs which have been generated by the
+      SNMP protocol entity.
+    name: snmpOutTraps


### PR DESCRIPTION
### What does this PR do?
Based on [ftp://ftp.cisco.com/pub/mibs/supportlists/asa/asa-supportlist.html](Cisco ASA support MIBs), adding a profile that includes all metrics supported by the Cisco ASA device family.

Profile is missing `metric_tags` and forced types. It was generated using the SNMP profile generator -  will open a separate PR for its code in ddev.

As a first step in this review, some metrics might need to be removed as they could be useless.

### Motivation
Generalise support for Cisco ASA family


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
