### PR TITLE
Add option to OpenMetricsBaseCheck to send distribution counts/sums

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -21,6 +21,8 @@ STANDARD_FIELDS = [
     'send_distribution_buckets',
     'send_monotonic_counter',
     'send_monotonic_with_gauge',
+    'send_distribution_counts',
+    'send_distribution_sums',
     'send_distribution_counts_as_monotonic',
     'send_distribution_sums_as_monotonic',
     'exclude_labels',

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -122,6 +122,20 @@ instances:
     #
     # send_monotonic_counter: true
 
+    ## @param send_distribution_counts - boolean - optional - default: false
+    ## If set to true, sends histograms counters when also sending Datadog distribution metrics.
+    ## Only relevant if send_distribution_buckets is set also to true - counters are always sent if not using
+    ## distribution metrics
+    #
+    # send_distribution_counts: false
+
+    ## @param send_distribution_sums - boolean - optional - default: false
+    ## If set to true, sends histograms sums when also sending Datadog distribution metrics.
+    ## Only relevant if send_distribution_buckets is set also to true - sums are always sent if not using distribution
+    ## metrics
+    #
+    # send_distribution_sums: false
+
     ## @param send_distribution_counts_as_monotonic - boolean - optional - default: false
     ## If set to true, sends histograms and summary counters as monotonic counters (instead of gauges).
     #


### PR DESCRIPTION
### What does this PR do?
Add option to OpenMetricsBaseCheck to send count/sum metrics along with distribution metrics.

### Motivation
Currently the sum and count information is lost when enabling `send_distribution_buckets`, making certain use-cases (such as counting the number of requests from a duration histogram) no longer possible.

### Additional Notes
Took the approach to add additional options to send these metrics rather than just sending them by default to keep existing behaviour, although I would argue they should probably be enabled by default.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
