### PR TITLE
Fix E2E tests for Ignite 2.9

### DIFF
--- a/ignite/tests/common.py
+++ b/ignite/tests/common.py
@@ -1,7 +1,18 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import os
+from pkg_resources import parse_version
+
+from datadog_checks.dev import get_here
 from datadog_checks.dev.jmx import JVM_E2E_METRICS
+
+HERE = get_here()
+
+IGNITE_IMAGE = os.environ['IGNITE_IMAGE']
+IGNITE_VERSION = os.environ.get('IGNITE_VERSION', '')
+
+IS_PRE_2_9 = False if not IGNITE_VERSION else parse_version(IGNITE_VERSION) < parse_version('2.9')
 
 GAUGES = [
     'ignite.cache.offheap_miss_percentage',
@@ -22,7 +33,6 @@ GAUGES = [
     'ignite.heap_memory_committed',
     'ignite.cache.rebalancing_keys_rate',
     'ignite.total_server_nodes',
-    'ignite.cache.cluster_owning_partitions',
     'ignite.checkpoint.last_pages_write_duration',
     'ignite.cache.offheap_allocated_size',
     'ignite.cache.thread_map_size',
@@ -139,7 +149,6 @@ GAUGES = [
     'ignite.jobs.maximum_failover',
     'ignite.cache.committed_versions_size',
     'ignite.total_baseline_nodes',
-    'ignite.cache.cluster_moving_partitions',
     'ignite.cache.offheap_hit_percentage',
     'ignite.jobs.active.average',
     'ignite.cache.dht_xid_map_size',
@@ -154,6 +163,12 @@ GAUGES = [
     'ignite.checkpoint.last_copied_on_write_pages',
     'ignite.wal.last_rollover',
 ] + JVM_E2E_METRICS
+
+if IS_PRE_2_9:
+    GAUGES += [
+        'ignite.cache.cluster_owning_partitions',
+        'ignite.cache.cluster_moving_partitions',
+    ]
 
 MONOTONIC_COUNTS = [
     "ignite.cache.commits",

--- a/ignite/tests/common.py
+++ b/ignite/tests/common.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import os
+
 from pkg_resources import parse_version
 
 from datadog_checks.dev import get_here

--- a/ignite/tests/compose/docker-compose.yml
+++ b/ignite/tests/compose/docker-compose.yml
@@ -2,13 +2,13 @@ version: '3'
 services:
   ignite:
     container_name: dd-ignite
-    image: apacheignite/ignite
+    image: $IGNITE_IMAGE
     environment:
-     - CONFIG_URI=file:///config.xml
+      CONFIG_URI: file:///config.xml
+      JVM_OPTS: $JVM_OPTS
     ports:
      - 49112:49112
      - 10800:10800
     volumes:
      - ./config.xml:/config.xml
-     - ./functions.sh:/opt/ignite/apache-ignite/bin/include/functions.sh
      - $LOG_DIR:/opt/ignite/apache-ignite/work/log

--- a/ignite/tests/conftest.py
+++ b/ignite/tests/conftest.py
@@ -27,9 +27,7 @@ def dd_environment():
         if common.IS_PRE_2_9:
             # Activate JMX through 'control.sh' and functions made available to 'ignite.sh'.
             functions_sh = os.path.join(common.HERE, 'compose', 'functions.sh')
-            docker_volumes.append(
-                '{}:/opt/ignite/apache-ignite/bin/include/functions.sh'.format(functions_sh)
-            )
+            docker_volumes.append('{}:/opt/ignite/apache-ignite/bin/include/functions.sh'.format(functions_sh))
             conditions.append(WaitFor(control_sh_activate))
         else:
             # On 2.9.0 and above, the Ignite Docker image calls the JVM directly,

--- a/ignite/tests/conftest.py
+++ b/ignite/tests/conftest.py
@@ -10,6 +10,8 @@ from datadog_checks.dev import TempDir, docker_run, get_docker_hostname, get_her
 from datadog_checks.dev.conditions import WaitFor
 from datadog_checks.dev.utils import load_jmx_config
 
+from . import common
+
 E2E_METADATA = {
     'use_jmx': True,
 }
@@ -18,21 +20,50 @@ E2E_METADATA = {
 @pytest.fixture(scope="session")
 def dd_environment():
     with TempDir('log') as log_dir:
+        docker_volumes = ['{}:/var/log/ignite'.format(log_dir)]
+        conditions = []
+        jvm_opts = ''
+
+        if common.IS_PRE_2_9:
+            # Activate JMX through 'control.sh' and functions made available to 'ignite.sh'.
+            functions_sh = os.path.join(common.HERE, 'compose', 'functions.sh')
+            docker_volumes.append(
+                '{}:/opt/ignite/apache-ignite/bin/include/functions.sh'.format(functions_sh)
+            )
+            conditions.append(WaitFor(control_sh_activate))
+        else:
+            # On 2.9.0 and above, the Ignite Docker image calls the JVM directly,
+            # so JMX configuration should be set via JVM options.
+            # See: https://ignite.apache.org/docs/latest/installation/installing-using-docker
+            jvm_opts = (
+                '-Dcom.sun.management.jmxremote '
+                '-Dcom.sun.management.jmxremote.port=49112 '
+                '-Dcom.sun.management.jmxremote.rmi.port=49112 '
+                '-Dcom.sun.management.jmxremote.authenticate=false '
+                '-Dcom.sun.management.jmxremote.ssl=false'
+            )
+
+        env_vars = {
+            'IGNITE_IMAGE': common.IGNITE_IMAGE,
+            'JVM_OPTS': jvm_opts,
+            'LOG_DIR': log_dir,
+        }
+
         with docker_run(
             os.path.join(get_here(), 'compose', 'docker-compose.yml'),
-            env_vars={'LOG_DIR': log_dir},
-            conditions=[WaitFor(setup_ignite)],
+            env_vars=env_vars,
+            conditions=conditions,
             log_patterns="Ignite node started OK",
         ):
             instance = load_jmx_config()
             instance['instances'][0]['port'] = 49112
             instance['instances'][0]['host'] = get_docker_hostname()
             metadata = E2E_METADATA.copy()
-            metadata['docker_volumes'] = ['{}:/var/log/ignite'.format(log_dir)]
+            metadata['docker_volumes'] = docker_volumes
             yield instance, metadata
 
 
-def setup_ignite():
+def control_sh_activate():
     result = run_command("docker exec dd-ignite /opt/ignite/apache-ignite/bin/control.sh --activate", capture=True)
     if result.stderr:
         raise Exception(result.stderr)

--- a/ignite/tox.ini
+++ b/ignite/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py38
+    py38-{2.8.1,latest}
 
 [testenv]
 ensure_default_envdir = true
@@ -22,3 +22,7 @@ passenv =
     COMPOSE*
 commands =
     pytest -v {posargs}
+setenv =
+    2.8.1: IGNITE_IMAGE = apacheignite/ignite:2.8.1
+    2.8.1: IGNITE_VERSION = 2.8.1
+    latest: IGNITE_IMAGE = apacheignite/ignite:latest


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update E2E tests for `ignite` to add support for Ignite 2.9 and above.

### Motivation
<!-- What inspired you to submit this pull request? -->
These E2E failures on Ignite have been preventing the CI pipeline from succeeding for a few days.

The Ignite 2.9 Docker image changed: instead of calling into `ignite.sh` (the ignite setup script), it calls the JVM directly, so JMX must be configured through standard JVM options (rather than the custom `functions.sh` script we have, which is run by `ignite.sh` on < 2.9).

### Additional Notes
<!-- Anything else we should know when reviewing? -->
2.9 Docker docs: https://ignite.apache.org/docs/latest/installation/installing-using-docker
2.9 release notes: https://github.com/apache/ignite/blob/master/RELEASE_NOTES.txt
> * Replaced ignite.sh invocation with the direct JVM call for Docker deployment

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
