### PR TITLE
Fix squid version collection

### DIFF
--- a/squid/tests/test_squid.py
+++ b/squid/tests/test_squid.py
@@ -55,7 +55,16 @@ def test_check_ok(aggregator, check, instance):
             5,
         ),
         # these versions aren't valid squid versions, so the version metadata should not be submitted
-        ('squid/1.3', {}, 0),
+        (
+            'squid/1.3',
+            {
+                'version.scheme': 'semver',
+                'version.major': '1',
+                'version.minor': '3',
+                'version.raw': '1.3',
+            },
+            4,
+        ),
         (
             'squid/1',
             {},


### PR DESCRIPTION
Squid versions scheme has changed from `major.minor.patch` to simply `major.minor`