### PR TITLE
Drop metrics listing from README example config

### DIFF
--- a/activemq/README.md
+++ b/activemq/README.md
@@ -24,71 +24,19 @@ The check collects metrics via JMX, so you need a JVM on each node so the Agent 
 To configure this check for an Agent running on a host:
 
 1. **Make sure that [JMX Remote is enabled][4] on your ActiveMQ server.**
-2. Configure the agent to connect to ActiveMQ. Edit `activemq.d/conf.yaml`, in the `conf.d/` folder at the root of your [Agent's configuration directory][5]. See the [sample activemq.d/conf.yaml][6] for all available configuration options.
+2. Configure the Agent to connect to ActiveMQ. Edit `activemq.d/conf.yaml`, in the `conf.d/` folder at the root of your [Agent's configuration directory][5]. See the [sample activemq.d/conf.yaml][6] for all available configuration options. See the [`metrics.yaml` file][15] for the list of default collected metrics.
 
    ```yaml
+   init_config:
+     is_jmx: true
+     collect_default_metrics: true
+
    instances:
      - host: localhost
        port: 1616
        user: username
        password: password
        name: activemq_instance
-   # List of metrics to be collected by the integration
-   # You should not have to modify this.
-   init_config:
-     conf:
-       - include:
-         Type: Queue
-         attribute:
-           AverageEnqueueTime:
-             alias: activemq.queue.avg_enqueue_time
-             metric_type: gauge
-           ConsumerCount:
-             alias: activemq.queue.consumer_count
-             metric_type: gauge
-           ProducerCount:
-             alias: activemq.queue.producer_count
-             metric_type: gauge
-           MaxEnqueueTime:
-             alias: activemq.queue.max_enqueue_time
-             metric_type: gauge
-           MinEnqueueTime:
-             alias: activemq.queue.min_enqueue_time
-             metric_type: gauge
-           MemoryPercentUsage:
-             alias: activemq.queue.memory_pct
-             metric_type: gauge
-           QueueSize:
-             alias: activemq.queue.size
-             metric_type: gauge
-           DequeueCount:
-             alias: activemq.queue.dequeue_count
-             metric_type: counter
-           DispatchCount:
-             alias: activemq.queue.dispatch_count
-             metric_type: counter
-           EnqueueCount:
-             alias: activemq.queue.enqueue_count
-             metric_type: counter
-           ExpiredCount:
-             alias: activemq.queue.expired_count
-             type: counter
-           InFlightCount:
-             alias: activemq.queue.in_flight_count
-             metric_type: counter
-
-       - include:
-         Type: Broker
-         attribute:
-           StorePercentUsage:
-             alias: activemq.broker.store_pct
-             metric_type: gauge
-           TempPercentUsage:
-             alias: activemq.broker.temp_pct
-             metric_type: gauge
-           MemoryPercentUsage:
-             alias: activemq.broker.memory_pct
-             metric_type: gauge
    ```
 
 3. [Restart the agent][7]
@@ -191,3 +139,4 @@ Additional helpful documentation, links, and articles:
 [12]: https://www.datadoghq.com/blog/monitor-activemq-metrics-performance
 [13]: https://docs.datadoghq.com/agent/kubernetes/integrations/
 [14]: https://docs.datadoghq.com/agent/kubernetes/log/?tab=containerinstallation#setup
+[15]: https://github.com/DataDog/integrations-core/blob/master/activemq/datadog_checks/activemq/data/metrics.yaml


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update the ActiveMQ `README.md`:

- Remove `init_config.conf` field.
- Add missing `init_config.is_jmx` and `init_config.collect_default_metrics` fields.
- Add link to `metrics.yaml`.

### Motivation
<!-- What inspired you to submit this pull request? -->
The current example config in the ActiveMQ README is wrong. Configuring an integration with it will result in the Agent ignoring the filters and collecting all metrics emitted by JMX, soon exceeding the 350 metrics limit. This causes confusion for customers, and unnecessary support tickets. Also, I think `is_jmx: true` and `collect_default_metrics: true` were missing.

AFAIK the Agent should collect what's in `metrics.yaml` by default, so we don't actually need to have users specify the list of metrics if they're fine with the default ones.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
