### PR TITLE
Enable logs support in -auth test environments

### DIFF
--- a/lighttpd/tests/docker/auth/docker-compose.yaml
+++ b/lighttpd/tests/docker/auth/docker-compose.yaml
@@ -8,3 +8,5 @@ services:
     volumes:
       - ./lighttpd.conf:/etc/lighttpd/lighttpd.conf
       - ./passwd:/etc/lighttpd/passwd
+      - ${DD_LOG_1}:/var/log/lighttpd/access.log
+      - ${DD_LOG_2}:/var/log/lighttpd/error.log

--- a/lighttpd/tests/docker/auth/lighttpd.conf
+++ b/lighttpd/tests/docker/auth/lighttpd.conf
@@ -5,7 +5,8 @@ server.modules = (
     "mod_compress",
     "mod_redirect",
     "mod_rewrite",
-    "mod_status"
+    "mod_status",
+    "mod_accesslog"
 )
 
 server.document-root           = "/var/www"
@@ -33,3 +34,6 @@ static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
 #include_shell "/usr/share/lighttpd/use-ipv6.pl"
 dir-listing.encoding           = "utf-8"
 server.dir-listing             = "enable"
+
+server.errorlog   = "/var/log/lighttpd/error.log"
+accesslog.filename = "/var/log/lighttpd/access.log"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Enable log collection in `-auth` test envs.

### Motivation
<!-- What inspired you to submit this pull request? -->
Cleanup for https://github.com/DataDog/integrations-core/pull/7719

#7719 only updated `docker-compose.yaml` and `lighttpd.conf` for the `-noauth` variant of the test env, which starting an env like `lighttpd py38-auth` would not collect logs.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
