### PR TITLE
Remove default `encoding` example in logs config

### DIFF
--- a/lighttpd/README.md
+++ b/lighttpd/README.md
@@ -66,7 +66,6 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
    ```yaml
    logs:
      - type: file
-       encoding: utf-16-le
        path: /path/to/my/directory/file.log
        source: lighttpd
    ```

--- a/lighttpd/assets/configuration/spec.yaml
+++ b/lighttpd/assets/configuration/spec.yaml
@@ -19,12 +19,10 @@ files:
   - template: logs
     example:
       - type: file
-        encoding: utf-16-le
         path: /var/log/lighttpd/access.log
         source: lighttpd
         service: lighttpd
       - type: file
-        encoding: utf-16-le
         path: /var/log/lighttpd/error.log
         source: lighttpd
         service: lighttpd

--- a/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
+++ b/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
@@ -374,12 +374,10 @@ instances:
 #
 # logs:
 #   - type: file
-#     encoding: utf-16-le
 #     path: /var/log/lighttpd/access.log
 #     source: lighttpd
 #     service: lighttpd
 #   - type: file
-#     encoding: utf-16-le
 #     path: /var/log/lighttpd/error.log
 #     source: lighttpd
 #     service: lighttpd


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Drop `encoding: utf-16-le` option from logs config for lighttpd.

Cleanup for #7719 
### Motivation
<!-- What inspired you to submit this pull request? -->
Found during QA

With the current setup, where `mount_logs=True` injects the `encoding: utf-16-le` option defined in `spec.yaml`, I am not able to have the Agent collect logs.

```
==========
Logs Agent
==========
    Sending uncompressed logs in SSL encrypted TCP to agent-intake.logs.datad0g.com on port 10516
    You are currently sending Logs to Datadog through TCP (either because logs_config.use_tcp or logs_config.socks5_proxy_address is set or the HTTP connectivity test has failed). To benefit from increased reliability and better network performances, we strongly encourage switching over to compressed HTTPS which is now the default protocol.
    BytesSent: 0
    EncodedBytesSent: 28
    LogsProcessed: 0
    LogsSent: 0
  lighttpd
  --------
    Type: file
    Path: /var/log/lighttpd/dd_log_1
    Status: OK
    Inputs: /var/log/lighttpd/dd_log_1 
    BytesRead: 1430
    Type: file
    Path: /var/log/lighttpd/dd_log_2
    Status: OK
    Inputs: /var/log/lighttpd/dd_log_2 
    BytesRead: 0
```

Note how `BytesRead` > 0 and yet `LogsSent` remains at 0. It looks like the Agent tails the file correctly but then decodes it using `utf-16` and fails, which means logs don't get sent. Or maybe the Agent tries to _encode_ the logs to `utf-16` (the reverse) before sending them to the backend, I'm not sure. And `utf-16` is not just a superset of `utf-8`, it's a totally different encoding:

```python
>>> 'hello'.encode('utf-8').decode('utf-16-le')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/florimond.manca/.pyenv/versions/3.8.5/lib/python3.8/encodings/utf_16_le.py", line 16, in decode
    return codecs.utf_16_le_decode(input, errors, True)
UnicodeDecodeError: 'utf-16-le' codec can't decode byte 0x6f in position 4: truncated data
```

In any case, the Lighttpd logs seem to be plain `utf-8`. I'm able to tail them in the terminal just fine:

```console
$ docker exec dd_lighttpd_py38-auth tail -f /var/log/lighttpd/dd_log_1
172.30.0.1 localhost:9449 - [03/Nov/2020:14:24:40 +0000] "GET /server-status?auto HTTP/1.1" 401 347 "-" "Datadog Agent/7.24.0"
172.30.0.1 localhost:9449 username [03/Nov/2020:14:24:40 +0000] "GET /server-status?auto HTTP/1.1" 200 218 "-" "Datadog Agent/7.24.0
```

So it _looks_ like we don't have to specify a specific encoding for `lighttpd` here?

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
