### PR TITLE
Add CentOS/RHEL version support note and instructions to install kernel-devel

### DIFF
--- a/oom_kill/README.md
+++ b/oom_kill/README.md
@@ -23,7 +23,7 @@ yum install -y kernel-headers-$(uname -r)
 yum install -y kernel-devel-$(uname -r)
 ```
 
-**Note**: CentOS/RHEL versions < 8 are not supported
+**Note**: CentOS/RHEL versions < 8 are not supported.
 
 ### Configuration
 

--- a/oom_kill/README.md
+++ b/oom_kill/README.md
@@ -23,7 +23,7 @@ yum install -y kernel-headers-$(uname -r)
 yum install -y kernel-devel-$(uname -r)
 ```
 
-**Note**: CentOS/RHEL versions < 8 are not suppoorted
+**Note**: CentOS/RHEL versions < 8 are not supported
 
 ### Configuration
 

--- a/oom_kill/README.md
+++ b/oom_kill/README.md
@@ -17,7 +17,7 @@ On Debian-like distributions, install the kernel headers like this:
 apt install -y linux-headers-$(uname -r)
 ```
 
-On RHEL-like distributions, install the kernel headers and kernel devels like this:
+On RHEL-like distributions, install the kernel headers like this:
 ```sh
 yum install -y kernel-headers-$(uname -r)
 yum install -y kernel-devel-$(uname -r)

--- a/oom_kill/README.md
+++ b/oom_kill/README.md
@@ -17,10 +17,13 @@ On Debian-like distributions, install the kernel headers like this:
 apt install -y linux-headers-$(uname -r)
 ```
 
-On RHEL-like distributions, install the kernel headers like this:
+On RHEL-like distributions, install the kernel headers and kernel devels like this:
 ```sh
 yum install -y kernel-headers-$(uname -r)
+yum install -y kernel-devel-$(uname -r)
 ```
+
+**Note**: CentOS/RHEL versions < 8 are not suppoorted
 
 ### Configuration
 

--- a/tcp_queue_length/README.md
+++ b/tcp_queue_length/README.md
@@ -23,7 +23,7 @@ yum install -y kernel-headers-$(uname -r)
 yum install -y kernel-devel-$(uname -r)
 ```
 
-**Note**: CentOS/RHEL versions < 8 are not supported
+**Note**: CentOS/RHEL versions < 8 are not supported.
 
 ### Configuration
 

--- a/tcp_queue_length/README.md
+++ b/tcp_queue_length/README.md
@@ -23,7 +23,7 @@ yum install -y kernel-headers-$(uname -r)
 yum install -y kernel-devel-$(uname -r)
 ```
 
-**Note**: CentOS/RHEL versions < 8 are not suppoorted
+**Note**: CentOS/RHEL versions < 8 are not supported
 
 ### Configuration
 

--- a/tcp_queue_length/README.md
+++ b/tcp_queue_length/README.md
@@ -17,7 +17,7 @@ On Debian-like distributions, install the kernel headers like this:
 apt install -y linux-headers-$(uname -r)
 ```
 
-On RHEL-like distributions, install the kernel headers and kernel devels like this:
+On RHEL-like distributions, install the kernel headers like this:
 ```sh
 yum install -y kernel-headers-$(uname -r)
 yum install -y kernel-devel-$(uname -r)

--- a/tcp_queue_length/README.md
+++ b/tcp_queue_length/README.md
@@ -17,10 +17,13 @@ On Debian-like distributions, install the kernel headers like this:
 apt install -y linux-headers-$(uname -r)
 ```
 
-On RHEL-like distributions, install the kernel headers like this:
+On RHEL-like distributions, install the kernel headers and kernel devels like this:
 ```sh
 yum install -y kernel-headers-$(uname -r)
+yum install -y kernel-devel-$(uname -r)
 ```
+
+**Note**: CentOS/RHEL versions < 8 are not suppoorted
 
 ### Configuration
 


### PR DESCRIPTION
### What does this PR do?
Adds a note about not supporting CentOS/RHEL versions < 8 and instructions on installing `kernel-devel` on those distributions to the `oom_kill` and `tcp_queue_length` checks

### Motivation
Customer report of the `oom_kill` check failing to compile on CentOS 7

### Additional Notes
N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
