### PR TITLE
Add tags to the new `system.disk.directory.exists` service check

### DIFF
--- a/directory/assets/service_checks.json
+++ b/directory/assets/service_checks.json
@@ -4,7 +4,7 @@
     "integration": "Directory",
     "check": "system.disk.directory.exists",
     "statuses": ["ok", "warning"],
-    "groups": ["host"],
+    "groups": ["host", "dir_name"],
     "name": "Exists",
     "description": "Returns `WARNING` if the Agent is unable to find or access the directory to monitor, `OK` otherwise."
   }

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -44,13 +44,15 @@ class DirectoryCheck(AgentCheck):
         self.config = DirectoryConfig(self.instance)
 
     def check(self, _):
+        service_check_tags = ['dir_name:{}'.format(self.config.name)]
+        service_check_tags.extend(self.config.tags)
         if not exists(self.config.abs_directory):
             msg = (
                 "Either directory '{}' doesn't exist or the Agent doesn't "
                 "have permissions to access it, skipping.".format(self.config.abs_directory)
             )
             # report missing directory
-            self.service_check(name=SERVICE_DIRECTORY_EXISTS, status=self.WARNING, message=msg)
+            self.service_check(name=SERVICE_DIRECTORY_EXISTS, status=self.WARNING, tags=service_check_tags, message=msg)
 
             # raise exception if `ignore_missing` is False
             if not self.config.ignore_missing:
@@ -61,7 +63,7 @@ class DirectoryCheck(AgentCheck):
             # return gracefully, nothing to look for
             return
 
-        self.service_check(name=SERVICE_DIRECTORY_EXISTS, status=self.OK)
+        self.service_check(name=SERVICE_DIRECTORY_EXISTS, tags=service_check_tags, status=self.OK)
         self._get_stats()
 
     def _get_stats(self):

--- a/directory/tests/test_directory.py
+++ b/directory/tests/test_directory.py
@@ -280,11 +280,12 @@ def test_non_existent_directory(aggregator):
     """
     Missing or inaccessible directory coverage.
     """
-    config = {'directory': '/non-existent/directory'}
+    config = {'directory': '/non-existent/directory', 'tags': ['foo:bar']}
     with pytest.raises(CheckException):
         dir_check = DirectoryCheck('directory', {}, [config])
         dir_check.check(config)
-    aggregator.assert_service_check('system.disk.directory.exists', DirectoryCheck.WARNING)
+    expected_tags = ['dir_name:/non-existent/directory', 'foo:bar']
+    aggregator.assert_service_check('system.disk.directory.exists', DirectoryCheck.WARNING, tags=expected_tags)
 
 
 def test_missing_directory_config():
@@ -293,12 +294,14 @@ def test_missing_directory_config():
 
 
 def test_non_existent_directory_ignore_missing(aggregator):
-    config = {'directory': '/non-existent/directory', 'ignore_missing': True}
+    config = {'directory': '/non-existent/directory', 'ignore_missing': True, 'tags': ['foo:bar']}
     check = DirectoryCheck('directory', {}, [config])
     check._get_stats = mock.MagicMock()
     check.check(config)
     check._get_stats.assert_not_called()
-    aggregator.assert_service_check('system.disk.directory.exists', DirectoryCheck.WARNING)
+
+    expected_tags = ['dir_name:/non-existent/directory', 'foo:bar']
+    aggregator.assert_service_check('system.disk.directory.exists', DirectoryCheck.WARNING, tags=expected_tags)
 
 
 def test_no_recursive_symlink_loop(aggregator):


### PR DESCRIPTION
The service check needs tags:
1. custom tags in the config should be reflected
2. The service check needs to be tagged by the dir name, otherwise there's no way to differentiate them if mulitple directory checks are running on the same agent.