### PR TITLE
Add test for tags

### DIFF
--- a/envoy/tests/test_envoy.py
+++ b/envoy/tests/test_envoy.py
@@ -28,9 +28,9 @@ def test_success(aggregator):
         if collected_metrics:
             expected_tags = [t for t in METRICS[metric]['tags'] if t]
             for tag_set in expected_tags:
-                assert all(all(any(tag in mt for mt in m.tags) for tag in tag_set) for m in collected_metrics if m.tags), (
-                    'tags ' + str(expected_tags) + ' not found in ' + metric
-                )
+                assert all(
+                    all(any(tag in mt for mt in m.tags) for tag in tag_set) for m in collected_metrics if m.tags
+                ), ('tags ' + str(expected_tags) + ' not found in ' + metric)
         metrics_collected += len(collected_metrics)
 
     assert metrics_collected >= 445

--- a/envoy/tests/test_envoy.py
+++ b/envoy/tests/test_envoy.py
@@ -24,7 +24,14 @@ def test_success(aggregator):
 
     metrics_collected = 0
     for metric in METRICS:
-        metrics_collected += len(aggregator.metrics(METRIC_PREFIX + metric))
+        collected_metrics = aggregator.metrics(METRIC_PREFIX + metric)
+        if collected_metrics:
+            expected_tags = [t for t in METRICS[metric]['tags'] if t]
+            for tag_set in expected_tags:
+                assert all(all(any(tag in mt for mt in m.tags) for tag in tag_set) for m in collected_metrics if m.tags), (
+                    'tags ' + str(expected_tags) + ' not found in ' + metric
+                )
+        metrics_collected += len(collected_metrics)
 
     assert metrics_collected >= 445
 


### PR DESCRIPTION
Test for #7740 since there is no test checking tags for envoy.
I don't know if the test is correct.
Metrics are defined as:
```
'cluster.grpc.success': {
        'tags': (
            ('cluster_name', ),
            ('grpc_service', 'grpc_method', ),
            (),
        ),
        'method': 'monotonic_count',
    },
```
I dont' understand very well this formatting. What does it mean each tuple, what's an empty tuple in the middle of non empty tuples, etc.

On this test I'm considering all tags should be there or no tags at all, but not all tags metrics are emmited.