### PR TITLE
Fix instance fixture scope

### DIFF
--- a/snowflake/tests/conftest.py
+++ b/snowflake/tests/conftest.py
@@ -20,6 +20,6 @@ def dd_environment(instance):
     yield instance
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def instance():
     return INSTANCE


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix scope of `instance` fixture in Snowflake tests.

### Motivation
<!-- What inspired you to submit this pull request? -->
We can't `ddev env start` without this change because `dd_environment(instance)` is session-scoped but `instance` is function-scoped (and pytest disallows this).

### Additional Notes
<!-- Anything else we should know when reviewing? -->
I checked and `instance` isn't modified by tests, so we don't need to `deepcopy`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
