### PR TITLE
Use 2.0.1 with 7.23.0

### DIFF
--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -18,11 +18,11 @@ No additional installation is needed on your server.
 
 **Note**: Snowflake check is currently not available for MacOS in Datadog Agent 6 using Python 2.
 
-<div class="alert alert-warning">For users configuring the integration with Agent <code>v7.23.0</code>, upgrade the integration version to <code>2.1.0</code> to take advantage of latest features.
+<div class="alert alert-warning">For users configuring the integration with Agent <code>v7.23.0</code>, upgrade the integration version to <code>2.0.1</code> to take advantage of latest features.
 You can upgrade the integration with the following <a href=https://docs.datadoghq.com/agent/guide/integration-management/#install>command</a>:<br>
 
 ```text
-datadog-agent integration install datadog-snowflake==2.1.0
+datadog-agent integration install datadog-snowflake==2.0.1
 ```
 </div>
 


### PR DESCRIPTION
Looks like the release for 7.24.0. resulted in 2.1.0 being incompatible with 7.23.0

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
