### PR TITLE
Update sim-format.md

### DIFF
--- a/docs/developer/tutorials/snmp/sim-format.md
+++ b/docs/developer/tutorials/snmp/sim-format.md
@@ -15,7 +15,7 @@ Lines must be formatted as follows:
 <OID>|<type>|<value>
 ```
 
-For the list of supported types, see the [`snmpsim` simulation data file format](http://snmplabs.com/snmpsim/managing-simulation-data.html#file-format) documentation.
+For the list of supported types, see the [`snmpsim` simulation data file format](https://github.com/etingof/snmpsim/blob/69751eb81381ce1fe89bc1cd1154f9daaa5b697b/docs/source/documentation/managing-simulation-data.rst#file-format) documentation.
 
 !!! warning
     Due to a limitation of `snmpsim`, contents of `.snmprec` files must be **sorted in lexicographic order**.

--- a/docs/developer/tutorials/snmp/sim-format.md
+++ b/docs/developer/tutorials/snmp/sim-format.md
@@ -15,7 +15,7 @@ Lines must be formatted as follows:
 <OID>|<type>|<value>
 ```
 
-For the list of supported types, see the [`snmpsim` simulation data file format](https://github.com/etingof/snmpsim/blob/69751eb81381ce1fe89bc1cd1154f9daaa5b697b/docs/source/documentation/managing-simulation-data.rst#file-format) documentation.
+For the list of supported types, see the [`snmpsim` simulation data file format](https://github.com/etingof/snmpsim/blob/master/docs/source/documentation/managing-simulation-data.rst#file-format) documentation.
 
 !!! warning
     Due to a limitation of `snmpsim`, contents of `.snmprec` files must be **sorted in lexicographic order**.


### PR DESCRIPTION
### What does this PR do?
Redirect to snmpsim repo as snmpsim website is unreachable

### Motivation
All pysnmp websites are down, redirecting `snmprec` type definition to github as there's still trace of type format

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
