### PR TITLE
Use a KSM metric that reports a reason tag in recommended monitors

### DIFF
--- a/kubernetes/assets/monitors/monitor_pod_crashloopbackoff.json
+++ b/kubernetes/assets/monitors/monitor_pod_crashloopbackoff.json
@@ -1,7 +1,7 @@
 {
 	"name": "[kubernetes] Pod {{pod_name.name}} is CrashloopBackOff on namespace {{kube_namespace.name}}",
 	"type": "query alert",
-	"query": "max(last_10m):max:kubernetes_state.container.waiting{reason:crashloopbackoff} by {kube_namespace,pod_name} >= 1",
+	"query": "max(last_10m):max:kubernetes_state.container.status_report.count.waiting{reason:crashloopbackoff} by {kube_namespace,pod_name} >= 1",
 	"message": "pod {{pod_name.name}} is CrashloopBackOff on {{kube_namespace.name}} \n This alert could generate several alerts for a bad deployment. Adjust the thresholds of the query to suit your infrastructure.",
 	"tags": [
 		"integration:kubernetes"

--- a/kubernetes/assets/monitors/monitor_pod_imagepullbackoff.json
+++ b/kubernetes/assets/monitors/monitor_pod_imagepullbackoff.json
@@ -1,7 +1,7 @@
 {
 	"name": "[kubernetes] Pod {{pod_name.name}} is ImagePullBackOff on namespace {{kube_namespace.name}}",
 	"type": "query alert",
-	"query": "max(last_10m):max:kubernetes_state.container.waiting{reason:imagepullbackoff} by {kube_namespace,pod_name} >= 1",
+	"query": "max(last_10m):max:kubernetes_state.container.status_report.count.waiting{reason:imagepullbackoff} by {kube_namespace,pod_name} >= 1",
 	"message": "pod {{pod_name.name}} is ImagePullBackOff on {{kube_namespace.name}} \n This could happen for several reasons, for example a bad image path or tag or if the credentials for pulling images are not configured properly.",
 	"tags": [
 		"integration:kubernetes"


### PR DESCRIPTION
### What does this PR do?
Changes the Kubernetes recommended monitor metric to use a KSM metric that reports a `reason` tag

### Motivation
Customer report. `kubernetes_state.container.waiting` does not report a `reason` tag that the monitor is trying to scope over so the monitor won't be scoped over any timeseries. `kubernetes_state.container.status_report.count.waiting` does report a `reason` tag: https://github.com/kubernetes/kube-state-metrics/blob/master/docs/pod-metrics.md

### Additional Notes
N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
