### PR TITLE
Handle unavailable specific resource information

### DIFF
--- a/marklogic/datadog_checks/marklogic/check.py
+++ b/marklogic/datadog_checks/marklogic/check.py
@@ -143,14 +143,23 @@ class MarklogicCheck(AgentCheck):
                 if res.get('group'):
                     tags.append('{}:{}'.format(RESOURCE_TYPES['group']['tag_name'], res['group']))
 
-                if RESOURCE_METRICS_AVAILABLE[res_type]['status']:
-                    self._collect_resource_status_metrics(res_type, res['uri'], tags)
+                try:
+                    if RESOURCE_METRICS_AVAILABLE[res_type]['status']:
+                        self._collect_resource_status_metrics(res_type, res['uri'], tags)
+                except Exception as e:
+                    self.log.warning('Status information unavailable for resource %s: %s', res, str(e))
 
-                if RESOURCE_METRICS_AVAILABLE[res_type]['storage']:
-                    self._collect_resource_storage_metrics(res_type, res['name'], res.get('group'), tags)
+                try:
+                    if RESOURCE_METRICS_AVAILABLE[res_type]['storage']:
+                        self._collect_resource_storage_metrics(res_type, res['name'], res.get('group'), tags)
+                except Exception as e:
+                    self.log.warning('Storage information unavailable for resource %s: %s', res, str(e))
 
-                if RESOURCE_METRICS_AVAILABLE[res_type]['requests']:
-                    self._collect_resource_request_metrics(res_type, res['name'], res.get('group'), tags)
+                try:
+                    if RESOURCE_METRICS_AVAILABLE[res_type]['requests']:
+                        self._collect_resource_request_metrics(res_type, res['name'], res.get('group'), tags)
+                except Exception as e:
+                    self.log.warning('Requests information unavailable for resource %s: %s', res, str(e))
 
     def _collect_resource_status_metrics(self, resource_type, uri, tags):
         # type: (str, str, List[str]) -> None

--- a/marklogic/tests/fixtures/bad_resource_storage.yaml
+++ b/marklogic/tests/fixtures/bad_resource_storage.yaml
@@ -1,0 +1,35 @@
+forest-storage-list:
+    id: '4259429487027269237'
+    name: Documents
+    meta:
+      uri: "/manage/v2/forests?forest-id=Documents&view=storage"
+      current-time: '2020-11-05T11:43:28.611393Z'
+      elapsed-time:
+        units: sec
+        value: 0.008234
+    relations:
+      relation-group:
+      - typeref: databases
+        relation-count:
+          units: quantity
+          value: 1
+        relation:
+        - uriref: "/manage/v2/databases/Documents?view=status"
+          idref: '14041280532792470812'
+          nameref: Documents
+      - typeref: hosts
+        relation-count:
+          units: quantity
+          value: 1
+        relation:
+        - uriref: "/manage/v2/hosts/7a380b041d1e?view=status"
+          idref: '16250599935733697082'
+          nameref: 7a380b041d1e
+    storage-list-items:
+      storage-host:
+      - relation-id: '16250599935733697082'
+    related-views:
+      related-view:
+      - view-type: list
+        view-name: default
+        view-uri: "/manage/v2/forests?forest-id=Documents"

--- a/marklogic/tests/test_resource_filters.py
+++ b/marklogic/tests/test_resource_filters.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
 from typing import Any, Dict, List
 
 import mock
@@ -150,6 +151,7 @@ def test_collect_host_metrics(mock_requests, mock_status, aggregator):
 )
 def test_bad_resource_storage(mock_requests, aggregator, caplog):
     # type: (Any, Any, AggregatorStub) -> None
+    caplog.at_level(logging.WARNING)
     check = MarklogicCheck('marklogic', {}, [INSTANCE_FILTERS])
 
     check.resources_to_monitor = {
@@ -164,4 +166,5 @@ def test_bad_resource_storage(mock_requests, aggregator, caplog):
     check.collect_per_resource_metrics()
 
     # This can happen when the database owning this forest is disabled
-    assert "Status information unavailable for resource {'id':" in caplog.text
+    assert "Status information unavailable for resource {" in caplog.text
+    assert "Storage information unavailable for resource {" in caplog.text


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Handle exceptions when information about a filtered resource is not available.
This can happen when we try to get a forest information, but its database is disabled.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
