### PR TITLE
Add 'since' flag to manually specify tag to look from

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
@@ -13,10 +13,18 @@ from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_su
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Show all the pending PRs for a given check.')
 @click.argument('check', autocompletion=complete_valid_checks, callback=validate_check_arg)
 @click.option('--organization', '-r', default='DataDog', help="The Github organization the repository belongs to")
-@click.option('--tag-pattern', default=None, help="The regex pattern for the format of the tag. Required if the tag doesn't follow semver")
-@click.option('--tag-prefix', default=None, help="Specify the prefix of the tag to use if the tag doesn't follow semver")
+@click.option(
+    '--tag-pattern',
+    default=None,
+    help="The regex pattern for the format of the tag. Required if the tag doesn't follow semver",
+)
+@click.option(
+    '--tag-prefix', default=None, help="Specify the prefix of the tag to use if the tag doesn't follow semver"
+)
 @click.option('--dry-run', '-n', is_flag=True, help="Run the command in dry-run mode")
-@click.option('--since', default=None, help="The git ref to use instead of auto-detecting the tag to view changes since")
+@click.option(
+    '--since', default=None, help="The git ref to use instead of auto-detecting the tag to view changes since"
+)
 @click.pass_context
 def changes(ctx, check, tag_pattern, tag_prefix, dry_run, organization, since):
     """Show all the pending PRs for a given check."""

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
@@ -12,18 +12,19 @@ from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_su
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Show all the pending PRs for a given check.')
 @click.argument('check', autocompletion=complete_valid_checks, callback=validate_check_arg)
-@click.option('--organization', '-r', default='DataDog')
-@click.option('--tag-pattern', default=None)
-@click.option('--tag-prefix', default=None)
-@click.option('--dry-run', '-n', is_flag=True)
+@click.option('--organization', '-r', default='DataDog', help="The Github organization the repository belongs to")
+@click.option('--tag-pattern', default=None, help="The regex pattern for the format of the tag. Required if the tag doesn't follow semver")
+@click.option('--tag-prefix', default=None, help="Specify the prefix of the tag to use if the tag doesn't follow semver")
+@click.option('--dry-run', '-n', is_flag=True, help="Run the command in dry-run mode")
+@click.option('--since', help="The git ref to use instead of auto-detecting the tag to view changes since")
 @click.pass_context
-def changes(ctx, check, tag_pattern, tag_prefix, dry_run, organization):
+def changes(ctx, check, tag_pattern, tag_prefix, dry_run, organization, since):
     """Show all the pending PRs for a given check."""
     if not dry_run and check and check not in get_valid_checks():
         abort(f'Check `{check}` is not an Agent-based Integration')
 
     # get the name of the current release tag
-    cur_version = get_version_string(check, pattern=tag_pattern, tag_prefix=tag_prefix)
+    cur_version = since or get_version_string(check, pattern=tag_pattern, tag_prefix=tag_prefix)
     if not cur_version:
         abort(
             'Failed to retrieve the latest version. Please ensure your project or check has a proper set of tags '

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
@@ -16,7 +16,7 @@ from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_su
 @click.option('--tag-pattern', default=None, help="The regex pattern for the format of the tag. Required if the tag doesn't follow semver")
 @click.option('--tag-prefix', default=None, help="Specify the prefix of the tag to use if the tag doesn't follow semver")
 @click.option('--dry-run', '-n', is_flag=True, help="Run the command in dry-run mode")
-@click.option('--since', help="The git ref to use instead of auto-detecting the tag to view changes since")
+@click.option('--since', default=None, help="The git ref to use instead of auto-detecting the tag to view changes since")
 @click.pass_context
 def changes(ctx, check, tag_pattern, tag_prefix, dry_run, organization, since):
     """Show all the pending PRs for a given check."""


### PR DESCRIPTION
### What does this PR do?
Adds a new "since" flag to `ddev release show changes`
Adds help text to all `ddev release show changes` options to be viewable via `ddev release show changes --help`

### Motivation
When working with repositores that don't strictly adhere to semver (for example those that adhere to PEP440), the command can't autodetect the latest tag because it can't sort PEP440 tags. While it may be possible to have this command support arbitrary versioning schemas, instead this approach lets a user manually enter the tag that they want to query. This allows:
* bypassing the auto retrieval and work of sorting tags, and thus allowing arbitrary versioning schemas
* Seeing what changed since an arbitrary point in time, not strictly the last release. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
