### PR TITLE
Update MySQL dashboard to be blog-like and migrate old dashboard

### DIFF
--- a/mysql/assets/dashboards/overview-screenboard.json
+++ b/mysql/assets/dashboards/overview-screenboard.json
@@ -1,0 +1,951 @@
+{
+  "title": "MySQL - Overview",
+  "description": "",
+  "widgets": [
+    {
+      "id": 2932944765675138,
+      "definition": {
+        "type": "note",
+        "content": "MySQL LOGO HERE",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      },
+      "layout": {
+        "x": 1,
+        "y": 1,
+        "width": 30,
+        "height": 10
+      }
+    },
+    {
+      "id": 7819738301267990,
+      "definition": {
+        "type": "note",
+        "content": "Using this dashboard, you can get a high-level view of your MySQL metrics related to throughput, performance, and resource utilization.\n\nTo learn more about our MySQL integration, see:\n\n- [Our official integration documentation](https://docs.datadoghq.com/integrations/mysql/?tab=host).\n\n- [Monitoring MySQL Performance Metrics](https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/).\n\n- [Collecting MySQL statistics and metrics](https://www.datadoghq.com/blog/collecting-mysql-statistics-and-metrics/).\n\n- [Our blog post on MySQL monitoring](https://www.datadoghq.com/blog/mysql-monitoring-with-datadog/).\n\n\nYou can clone this dashboard, copy and paste widgets from other out-of-the-box dashboards, and create your own visualizations for your custom applications.\n\n\n",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      },
+      "layout": {
+        "x": 1,
+        "y": 12,
+        "width": 30,
+        "height": 31
+      }
+    },
+    {
+      "id": 4949655736738342,
+      "definition": {
+        "type": "note",
+        "content": "Basic Activity Monitor",
+        "background_color": "vivid_blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 33,
+        "y": 1,
+        "width": 70,
+        "height": 5
+      }
+    },
+    {
+      "id": 2053914314500650,
+      "definition": {
+        "type": "note",
+        "content": "Throughput",
+        "background_color": "vivid_blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 105,
+        "y": 1,
+        "width": 70,
+        "height": 5
+      }
+    },
+    {
+      "id": 33563484962610,
+      "definition": {
+        "type": "note",
+        "content": "MySQL Resource Utilization",
+        "background_color": "blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 33,
+        "y": 46,
+        "width": 70,
+        "height": 5
+      }
+    },
+    {
+      "id": 7813434609764132,
+      "definition": {
+        "type": "note",
+        "content": "Performance",
+        "background_color": "vivid_blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 33,
+        "y": 24,
+        "width": 70,
+        "height": 5
+      }
+    },
+    {
+      "id": 8724911101387132,
+      "definition": {
+        "type": "note",
+        "content": "Logs",
+        "background_color": "blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 177,
+        "y": 16,
+        "width": 47,
+        "height": 5
+      }
+    },
+    {
+      "id": 3510484440766506,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "avg:mysql.net.max_connections{*}",
+            "aggregator": "avg"
+          }
+        ],
+        "title": "Number of Connctions",
+        "title_size": "16",
+        "title_align": "left",
+        "autoscale": true,
+        "precision": 2
+      },
+      "layout": {
+        "x": 33,
+        "y": 7,
+        "width": 20,
+        "height": 15
+      }
+    },
+    {
+      "id": 4580303685497888,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.threads_running{*}",
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Threads Running",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 33,
+        "y": 52,
+        "width": 33,
+        "height": 15
+      }
+    },
+    {
+      "id": 7333327975143908,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.threads_connected{*}",
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Threads Connected",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 68,
+        "y": 52,
+        "width": 35,
+        "height": 15
+      }
+    },
+    {
+      "id": 3132289999982172,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.innodb.buffer_pool_pages_total{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          },
+          {
+            "q": "avg:mysql.innodb.buffer_pool_pages_free{*}",
+            "display_type": "area",
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          },
+          {
+            "q": "avg:mysql.innodb.buffer_pool_pages_data{*}",
+            "display_type": "area",
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "InnoDB Buffer Pool Pages",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 68,
+        "y": 68,
+        "width": 35,
+        "height": 15
+      }
+    },
+    {
+      "id": 3757592705691892,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.innodb.buffer_pool_free{*}",
+            "display_type": "area",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          },
+          {
+            "q": "avg:mysql.innodb.buffer_pool_used{*}",
+            "display_type": "area",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          },
+          {
+            "q": "avg:mysql.innodb.buffer_pool_total{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "InnoDB Buffer Pool",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 33,
+        "y": 68,
+        "width": 33,
+        "height": 15
+      }
+    },
+    {
+      "id": 3026433805375000,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.com_select{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Rate of Select Queries",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 105,
+        "y": 7,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 8459550148722216,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.query_run_time.avg{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Query Average Runtime",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 33,
+        "y": 30,
+        "width": 33,
+        "height": 15
+      }
+    },
+    {
+      "id": 8995043206631004,
+      "definition": {
+        "type": "note",
+        "content": "System Resource Utilization",
+        "background_color": "blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 105,
+        "y": 39,
+        "width": 70,
+        "height": 5
+      }
+    },
+    {
+      "id": 5133552342659276,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:system.load.1{$scope}"
+          },
+          {
+            "q": "avg:system.load.5{$scope}"
+          },
+          {
+            "q": "avg:system.load.15{$scope}"
+          }
+        ],
+        "title": "System load",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 141,
+        "y": 45,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 3174962352359576,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:system.cpu.idle{$scope}, avg:system.cpu.system{$scope}, avg:system.cpu.iowait{$scope}, avg:system.cpu.user{$scope}, avg:system.cpu.stolen{$scope}, avg:system.cpu.guest{$scope}"
+          }
+        ],
+        "title": "CPU usage (%)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 105,
+        "y": 45,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 7146327569259880,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "max:mysql.performance.kernel_time{$scope}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "MySQL CPU Time (%)",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 105,
+        "y": 61,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 3433922753288356,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:system.mem.usable{$scope}, sum:system.mem.total{$scope}-sum:system.mem.usable{$scope}"
+          }
+        ],
+        "title": "System memory",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 141,
+        "y": 61,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 824726960195446,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:system.net.bytes_rcvd{$scope}"
+          },
+          {
+            "q": "sum:system.net.bytes_sent{$scope}"
+          }
+        ],
+        "title": "Network traffic (per sec)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 105,
+        "y": 77,
+        "width": 70,
+        "height": 15
+      }
+    },
+    {
+      "id": 3597777553720704,
+      "definition": {
+        "type": "log_stream",
+        "indexes": [],
+        "query": "source:mysql",
+        "sort": {
+          "column": "time",
+          "order": "desc"
+        },
+        "columns": [
+          "core_host",
+          "core_service"
+        ],
+        "show_date_column": true,
+        "show_message_column": true,
+        "message_display": "expanded-md",
+        "title": "",
+        "title_size": "16",
+        "title_align": "left"
+      },
+      "layout": {
+        "x": 177,
+        "y": 22,
+        "width": 47,
+        "height": 55
+      }
+    },
+    {
+      "id": 8463261690002896,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.com_update{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Rate of Update Queries",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 141,
+        "y": 7,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 6252548321364566,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.com_insert{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Rate of Insert Queries",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 105,
+        "y": 23,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 756419659654490,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.com_delete{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Rate of Delete Queries",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 141,
+        "y": 23,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 2368466329359410,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.innodb.data_reads{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mysql.innodb.data_writes{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Rate of Data Reads/Writes",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false
+      },
+      "layout": {
+        "x": 33,
+        "y": 84,
+        "width": 33,
+        "height": 15
+      }
+    },
+    {
+      "id": 3221412590263788,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "avg:mysql.net.connections{*}",
+            "aggregator": "avg"
+          }
+        ],
+        "title": "Rate of Connections to Server",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "precision": 2
+      },
+      "layout": {
+        "x": 80,
+        "y": 7,
+        "width": 23,
+        "height": 15
+      }
+    },
+    {
+      "id": 8368115667870794,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.key_cache_utilization{*} by {service}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Cache Utilization Ratio",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false
+      },
+      "layout": {
+        "x": 68,
+        "y": 84,
+        "width": 35,
+        "height": 15
+      }
+    },
+    {
+      "id": 2637040087034578,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.slow_queries{*}",
+            "display_type": "area",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Slow Query Rate",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false
+      },
+      "layout": {
+        "x": 68,
+        "y": 30,
+        "width": 35,
+        "height": 15
+      }
+    },
+    {
+      "id": 2902465927202362,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "avg:mysql.net.aborted_connects{*}",
+            "aggregator": "avg",
+            "conditional_formats": [
+              {
+                "comparator": "<=",
+                "value": 0,
+                "palette": "white_on_green"
+              },
+              {
+                "comparator": ">",
+                "value": 0,
+                "palette": "white_on_red"
+              }
+            ]
+          }
+        ],
+        "title": "Failed MySQL Connects",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "precision": 2
+      },
+      "layout": {
+        "x": 54,
+        "y": 7,
+        "width": 25,
+        "height": 15
+      }
+    },
+    {
+      "id": 5811070951344460,
+      "definition": {
+        "type": "note",
+        "content": "InnoDB is the storage management system for both MariaDB and MySQL.",
+        "background_color": "gray",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "right"
+      },
+      "layout": {
+        "x": 1,
+        "y": 70,
+        "width": 30,
+        "height": 8
+      }
+    },
+    {
+      "id": 7403239476791868,
+      "definition": {
+        "type": "note",
+        "content": "Most of the metrics and monitoring strategies outlined here also apply to MySQL-compatible technologies such MariaDB and Percona Server, with some notable differences. For instance, some of the features in the MySQL Workbench are not compatible with currently available versions of MariaDB.\n\nAmazon RDS users should check out our specialized monitoring guides for [MySQL on RDS](https://www.datadoghq.com/blog/monitoring-rds-mysql-performance-metrics/) and for the MySQL-compatible [Amazon Aurora](https://www.datadoghq.com/blog/monitoring-amazon-aurora-performance-metrics/).\n\n",
+        "background_color": "gray",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "right"
+      },
+      "layout": {
+        "x": 1,
+        "y": 44,
+        "width": 30,
+        "height": 24
+      }
+    },
+    {
+      "id": 400903025136302,
+      "definition": {
+        "type": "note",
+        "content": "The current rate of queries will naturally rise and fall, and as such it’s not always an actionable metric based on fixed thresholds. But it is worthwhile to alert on sudden changes in query volume—drastic drops in throughput, especially, can indicate a serious problem.",
+        "background_color": "gray",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      },
+      "layout": {
+        "x": 177,
+        "y": 1,
+        "width": 47,
+        "height": 13
+      }
+    }
+  ],
+  "template_variables": [
+    {
+      "name": "scope",
+      "default": "*",
+      "prefix": null
+    }
+  ],
+  "layout_type": "free",
+  "is_read_only": false,
+  "notify_list": [],
+  "id": "5ga-gvj-t8m"
+}

--- a/mysql/assets/dashboards/overview-screenboard.json
+++ b/mysql/assets/dashboards/overview-screenboard.json
@@ -3,26 +3,13 @@
   "description": "",
   "widgets": [
     {
-      "id": 2932944765675138,
-      "definition": {
-        "type": "note",
-        "content": "MySQL LOGO HERE",
-        "background_color": "white",
-        "font_size": "14",
-        "text_align": "left",
-        "show_tick": false,
-        "tick_pos": "50%",
-        "tick_edge": "left"
-      },
+      "id": 7819738301267990,
       "layout": {
         "x": 1,
-        "y": 1,
+        "y": 14,
         "width": 30,
-        "height": 10
-      }
-    },
-    {
-      "id": 7819738301267990,
+        "height": 40
+      },
       "definition": {
         "type": "note",
         "content": "Using this dashboard, you can get a high-level view of your MySQL metrics related to throughput, performance, and resource utilization.\n\nTo learn more about our MySQL integration, see:\n\n- [Our official integration documentation](https://docs.datadoghq.com/integrations/mysql/?tab=host).\n\n- [Monitoring MySQL Performance Metrics](https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/).\n\n- [Collecting MySQL statistics and metrics](https://www.datadoghq.com/blog/collecting-mysql-statistics-and-metrics/).\n\n- [Our blog post on MySQL monitoring](https://www.datadoghq.com/blog/mysql-monitoring-with-datadog/).\n\n\nYou can clone this dashboard, copy and paste widgets from other out-of-the-box dashboards, and create your own visualizations for your custom applications.\n\n\n",
@@ -32,16 +19,16 @@
         "show_tick": false,
         "tick_pos": "50%",
         "tick_edge": "left"
-      },
-      "layout": {
-        "x": 1,
-        "y": 12,
-        "width": 30,
-        "height": 31
       }
     },
     {
       "id": 4949655736738342,
+      "layout": {
+        "x": 33,
+        "y": 1,
+        "width": 70,
+        "height": 5
+      },
       "definition": {
         "type": "note",
         "content": "Basic Activity Monitor",
@@ -51,16 +38,16 @@
         "show_tick": false,
         "tick_pos": "50%",
         "tick_edge": "bottom"
-      },
-      "layout": {
-        "x": 33,
-        "y": 1,
-        "width": 70,
-        "height": 5
       }
     },
     {
       "id": 2053914314500650,
+      "layout": {
+        "x": 105,
+        "y": 1,
+        "width": 70,
+        "height": 5
+      },
       "definition": {
         "type": "note",
         "content": "Throughput",
@@ -70,16 +57,16 @@
         "show_tick": false,
         "tick_pos": "50%",
         "tick_edge": "bottom"
-      },
-      "layout": {
-        "x": 105,
-        "y": 1,
-        "width": 70,
-        "height": 5
       }
     },
     {
       "id": 33563484962610,
+      "layout": {
+        "x": 33,
+        "y": 46,
+        "width": 70,
+        "height": 5
+      },
       "definition": {
         "type": "note",
         "content": "MySQL Resource Utilization",
@@ -89,16 +76,16 @@
         "show_tick": false,
         "tick_pos": "50%",
         "tick_edge": "bottom"
-      },
-      "layout": {
-        "x": 33,
-        "y": 46,
-        "width": 70,
-        "height": 5
       }
     },
     {
       "id": 7813434609764132,
+      "layout": {
+        "x": 33,
+        "y": 24,
+        "width": 70,
+        "height": 5
+      },
       "definition": {
         "type": "note",
         "content": "Performance",
@@ -108,16 +95,16 @@
         "show_tick": false,
         "tick_pos": "50%",
         "tick_edge": "bottom"
-      },
-      "layout": {
-        "x": 33,
-        "y": 24,
-        "width": 70,
-        "height": 5
       }
     },
     {
       "id": 8724911101387132,
+      "layout": {
+        "x": 177,
+        "y": 16,
+        "width": 47,
+        "height": 5
+      },
       "definition": {
         "type": "note",
         "content": "Logs",
@@ -127,12 +114,6 @@
         "show_tick": false,
         "tick_pos": "50%",
         "tick_edge": "bottom"
-      },
-      "layout": {
-        "x": 177,
-        "y": 16,
-        "width": 47,
-        "height": 5
       }
     },
     {
@@ -368,7 +349,6 @@
         "title": "Rate of Select Queries",
         "title_size": "16",
         "title_align": "left",
-        "time": {},
         "show_legend": false,
         "legend_size": "0"
       },
@@ -417,6 +397,12 @@
     },
     {
       "id": 8995043206631004,
+      "layout": {
+        "x": 105,
+        "y": 39,
+        "width": 70,
+        "height": 5
+      },
       "definition": {
         "type": "note",
         "content": "System Resource Utilization",
@@ -426,12 +412,6 @@
         "show_tick": false,
         "tick_pos": "50%",
         "tick_edge": "bottom"
-      },
-      "layout": {
-        "x": 105,
-        "y": 39,
-        "width": 70,
-        "height": 5
       }
     },
     {
@@ -509,7 +489,6 @@
         "title": "MySQL CPU Time (%)",
         "title_size": "16",
         "title_align": "left",
-        "time": {},
         "show_legend": false,
         "legend_size": "0"
       },
@@ -569,7 +548,16 @@
     },
     {
       "id": 3597777553720704,
+      "layout": {
+        "x": 177,
+        "y": 22,
+        "width": 47,
+        "height": 55
+      },
       "definition": {
+        "title": "",
+        "title_size": "16",
+        "title_align": "left",
         "type": "log_stream",
         "indexes": [],
         "query": "source:mysql",
@@ -583,16 +571,7 @@
         ],
         "show_date_column": true,
         "show_message_column": true,
-        "message_display": "expanded-md",
-        "title": "",
-        "title_size": "16",
-        "title_align": "left"
-      },
-      "layout": {
-        "x": 177,
-        "y": 22,
-        "width": 47,
-        "height": 55
+        "message_display": "expanded-md"
       }
     },
     {
@@ -621,7 +600,6 @@
         "title": "Rate of Update Queries",
         "title_size": "16",
         "title_align": "left",
-        "time": {},
         "show_legend": false,
         "legend_size": "0"
       },
@@ -658,7 +636,6 @@
         "title": "Rate of Insert Queries",
         "title_size": "16",
         "title_align": "left",
-        "time": {},
         "show_legend": false,
         "legend_size": "0"
       },
@@ -695,7 +672,6 @@
         "title": "Rate of Delete Queries",
         "title_size": "16",
         "title_align": "left",
-        "time": {},
         "show_legend": false,
         "legend_size": "0"
       },
@@ -740,8 +716,8 @@
         "title": "Rate of Data Reads/Writes",
         "title_size": "16",
         "title_align": "left",
-        "time": {},
-        "show_legend": false
+        "show_legend": false,
+        "legend_size": "0"
       },
       "layout": {
         "x": 33,
@@ -763,7 +739,6 @@
         "title": "Rate of Connections to Server",
         "title_size": "16",
         "title_align": "left",
-        "time": {},
         "precision": 2
       },
       "layout": {
@@ -798,8 +773,8 @@
         "title": "Cache Utilization Ratio",
         "title_size": "16",
         "title_align": "left",
-        "time": {},
-        "show_legend": false
+        "show_legend": false,
+        "legend_size": "0"
       },
       "layout": {
         "x": 68,
@@ -834,8 +809,8 @@
         "title": "Slow Query Rate",
         "title_size": "16",
         "title_align": "left",
-        "time": {},
-        "show_legend": false
+        "show_legend": false,
+        "legend_size": "0"
       },
       "layout": {
         "x": 68,
@@ -869,7 +844,6 @@
         "title": "Failed MySQL Connects",
         "title_size": "16",
         "title_align": "left",
-        "time": {},
         "precision": 2
       },
       "layout": {
@@ -881,6 +855,12 @@
     },
     {
       "id": 5811070951344460,
+      "layout": {
+        "x": 1,
+        "y": 81,
+        "width": 30,
+        "height": 8
+      },
       "definition": {
         "type": "note",
         "content": "InnoDB is the storage management system for both MariaDB and MySQL.",
@@ -890,16 +870,16 @@
         "show_tick": true,
         "tick_pos": "50%",
         "tick_edge": "right"
-      },
-      "layout": {
-        "x": 1,
-        "y": 70,
-        "width": 30,
-        "height": 8
       }
     },
     {
       "id": 7403239476791868,
+      "layout": {
+        "x": 1,
+        "y": 55,
+        "width": 30,
+        "height": 25
+      },
       "definition": {
         "type": "note",
         "content": "Most of the metrics and monitoring strategies outlined here also apply to MySQL-compatible technologies such MariaDB and Percona Server, with some notable differences. For instance, some of the features in the MySQL Workbench are not compatible with currently available versions of MariaDB.\n\nAmazon RDS users should check out our specialized monitoring guides for [MySQL on RDS](https://www.datadoghq.com/blog/monitoring-rds-mysql-performance-metrics/) and for the MySQL-compatible [Amazon Aurora](https://www.datadoghq.com/blog/monitoring-amazon-aurora-performance-metrics/).\n\n",
@@ -909,16 +889,16 @@
         "show_tick": true,
         "tick_pos": "50%",
         "tick_edge": "right"
-      },
-      "layout": {
-        "x": 1,
-        "y": 44,
-        "width": 30,
-        "height": 24
       }
     },
     {
       "id": 400903025136302,
+      "layout": {
+        "x": 177,
+        "y": 1,
+        "width": 47,
+        "height": 13
+      },
       "definition": {
         "type": "note",
         "content": "The current rate of queries will naturally rise and fall, and as such it’s not always an actionable metric based on fixed thresholds. But it is worthwhile to alert on sudden changes in query volume—drastic drops in throughput, especially, can indicate a serious problem.",
@@ -928,12 +908,20 @@
         "show_tick": true,
         "tick_pos": "50%",
         "tick_edge": "left"
-      },
+      }
+    },
+    {
+      "id": 1801107147992128,
       "layout": {
-        "x": 177,
+        "x": 1,
         "y": 1,
-        "width": 47,
-        "height": 13
+        "width": 30,
+        "height": 12
+      },
+      "definition": {
+        "type": "image",
+        "url": "/static/images/saas_logos/bot/mysql@2x.png",
+        "sizing": "fit"
       }
     }
   ],

--- a/mysql/assets/dashboards/overview-screenboard.json
+++ b/mysql/assets/dashboards/overview-screenboard.json
@@ -126,7 +126,7 @@
             "aggregator": "avg"
           }
         ],
-        "title": "Number of Connctions",
+        "title": "Number of Connections",
         "title_size": "16",
         "title_align": "left",
         "autoscale": true,

--- a/mysql/assets/dashboards/overview-screenboard.json
+++ b/mysql/assets/dashboards/overview-screenboard.json
@@ -1,5 +1,5 @@
 {
-  "title": "MySQL - Overview",
+  "title": "MySQL",
   "description": "",
   "widgets": [
     {

--- a/mysql/assets/dashboards/overview.json
+++ b/mysql/assets/dashboards/overview.json
@@ -1,0 +1,951 @@
+{
+  "title": "MySQL - Overview",
+  "description": "",
+  "widgets": [
+    {
+      "id": 2932944765675138,
+      "definition": {
+        "type": "note",
+        "content": "MySQL LOGO HERE",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      },
+      "layout": {
+        "x": 1,
+        "y": 1,
+        "width": 30,
+        "height": 10
+      }
+    },
+    {
+      "id": 7819738301267990,
+      "definition": {
+        "type": "note",
+        "content": "Using this dashboard, you can get a high-level view of your MySQL metrics related to throughput, performance, and resource utilization.\n\nTo learn more about our MySQL integration, see:\n\n- [Our official integration documentation](https://docs.datadoghq.com/integrations/mysql/?tab=host).\n\n- [Monitoring MySQL Performance Metrics](https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/).\n\n- [Collecting MySQL statistics and metrics](https://www.datadoghq.com/blog/collecting-mysql-statistics-and-metrics/).\n\n- [Our blog post on MySQL monitoring](https://www.datadoghq.com/blog/mysql-monitoring-with-datadog/).\n\n\nYou can clone this dashboard, copy and paste widgets from other out-of-the-box dashboards, and create your own visualizations for your custom applications.\n\n\n",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      },
+      "layout": {
+        "x": 1,
+        "y": 12,
+        "width": 30,
+        "height": 31
+      }
+    },
+    {
+      "id": 4949655736738342,
+      "definition": {
+        "type": "note",
+        "content": "Basic Activity Monitor",
+        "background_color": "vivid_blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 33,
+        "y": 1,
+        "width": 70,
+        "height": 5
+      }
+    },
+    {
+      "id": 2053914314500650,
+      "definition": {
+        "type": "note",
+        "content": "Throughput",
+        "background_color": "vivid_blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 105,
+        "y": 1,
+        "width": 70,
+        "height": 5
+      }
+    },
+    {
+      "id": 33563484962610,
+      "definition": {
+        "type": "note",
+        "content": "MySQL Resource Utilization",
+        "background_color": "blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 33,
+        "y": 46,
+        "width": 70,
+        "height": 5
+      }
+    },
+    {
+      "id": 7813434609764132,
+      "definition": {
+        "type": "note",
+        "content": "Performance",
+        "background_color": "vivid_blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 33,
+        "y": 24,
+        "width": 70,
+        "height": 5
+      }
+    },
+    {
+      "id": 8724911101387132,
+      "definition": {
+        "type": "note",
+        "content": "Logs",
+        "background_color": "blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 177,
+        "y": 16,
+        "width": 47,
+        "height": 5
+      }
+    },
+    {
+      "id": 3510484440766506,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "avg:mysql.net.max_connections{*}",
+            "aggregator": "avg"
+          }
+        ],
+        "title": "Number of Connctions",
+        "title_size": "16",
+        "title_align": "left",
+        "autoscale": true,
+        "precision": 2
+      },
+      "layout": {
+        "x": 33,
+        "y": 7,
+        "width": 20,
+        "height": 15
+      }
+    },
+    {
+      "id": 4580303685497888,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.threads_running{*}",
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Threads Running",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 33,
+        "y": 52,
+        "width": 33,
+        "height": 15
+      }
+    },
+    {
+      "id": 7333327975143908,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.threads_connected{*}",
+            "display_type": "bars",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Threads Connected",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 68,
+        "y": 52,
+        "width": 35,
+        "height": 15
+      }
+    },
+    {
+      "id": 3132289999982172,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.innodb.buffer_pool_pages_total{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          },
+          {
+            "q": "avg:mysql.innodb.buffer_pool_pages_free{*}",
+            "display_type": "area",
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          },
+          {
+            "q": "avg:mysql.innodb.buffer_pool_pages_data{*}",
+            "display_type": "area",
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "InnoDB Buffer Pool Pages",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 68,
+        "y": 68,
+        "width": 35,
+        "height": 15
+      }
+    },
+    {
+      "id": 3757592705691892,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.innodb.buffer_pool_free{*}",
+            "display_type": "area",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          },
+          {
+            "q": "avg:mysql.innodb.buffer_pool_used{*}",
+            "display_type": "area",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          },
+          {
+            "q": "avg:mysql.innodb.buffer_pool_total{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "InnoDB Buffer Pool",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 33,
+        "y": 68,
+        "width": 33,
+        "height": 15
+      }
+    },
+    {
+      "id": 3026433805375000,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.com_select{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Rate of Select Queries",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 105,
+        "y": 7,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 8459550148722216,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.query_run_time.avg{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Query Average Runtime",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 33,
+        "y": 30,
+        "width": 33,
+        "height": 15
+      }
+    },
+    {
+      "id": 8995043206631004,
+      "definition": {
+        "type": "note",
+        "content": "System Resource Utilization",
+        "background_color": "blue",
+        "font_size": "18",
+        "text_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      },
+      "layout": {
+        "x": 105,
+        "y": 39,
+        "width": 70,
+        "height": 5
+      }
+    },
+    {
+      "id": 5133552342659276,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:system.load.1{$scope}"
+          },
+          {
+            "q": "avg:system.load.5{$scope}"
+          },
+          {
+            "q": "avg:system.load.15{$scope}"
+          }
+        ],
+        "title": "System load",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 141,
+        "y": 45,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 3174962352359576,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:system.cpu.idle{$scope}, avg:system.cpu.system{$scope}, avg:system.cpu.iowait{$scope}, avg:system.cpu.user{$scope}, avg:system.cpu.stolen{$scope}, avg:system.cpu.guest{$scope}"
+          }
+        ],
+        "title": "CPU usage (%)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 105,
+        "y": 45,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 7146327569259880,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "max:mysql.performance.kernel_time{$scope}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "MySQL CPU Time (%)",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 105,
+        "y": 61,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 3433922753288356,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:system.mem.usable{$scope}, sum:system.mem.total{$scope}-sum:system.mem.usable{$scope}"
+          }
+        ],
+        "title": "System memory",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 141,
+        "y": 61,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 824726960195446,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:system.net.bytes_rcvd{$scope}"
+          },
+          {
+            "q": "sum:system.net.bytes_sent{$scope}"
+          }
+        ],
+        "title": "Network traffic (per sec)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 105,
+        "y": 77,
+        "width": 70,
+        "height": 15
+      }
+    },
+    {
+      "id": 3597777553720704,
+      "definition": {
+        "type": "log_stream",
+        "indexes": [],
+        "query": "source:mysql",
+        "sort": {
+          "column": "time",
+          "order": "desc"
+        },
+        "columns": [
+          "core_host",
+          "core_service"
+        ],
+        "show_date_column": true,
+        "show_message_column": true,
+        "message_display": "expanded-md",
+        "title": "",
+        "title_size": "16",
+        "title_align": "left"
+      },
+      "layout": {
+        "x": 177,
+        "y": 22,
+        "width": 47,
+        "height": 55
+      }
+    },
+    {
+      "id": 8463261690002896,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.com_update{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Rate of Update Queries",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 141,
+        "y": 7,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 6252548321364566,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.com_insert{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Rate of Insert Queries",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 105,
+        "y": 23,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 756419659654490,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.com_delete{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Rate of Delete Queries",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false,
+        "legend_size": "0"
+      },
+      "layout": {
+        "x": 141,
+        "y": 23,
+        "width": 34,
+        "height": 15
+      }
+    },
+    {
+      "id": 2368466329359410,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.innodb.data_reads{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          },
+          {
+            "q": "avg:mysql.innodb.data_writes{*}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Rate of Data Reads/Writes",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false
+      },
+      "layout": {
+        "x": 33,
+        "y": 84,
+        "width": 33,
+        "height": 15
+      }
+    },
+    {
+      "id": 3221412590263788,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "avg:mysql.net.connections{*}",
+            "aggregator": "avg"
+          }
+        ],
+        "title": "Rate of Connections to Server",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "precision": 2
+      },
+      "layout": {
+        "x": 80,
+        "y": 7,
+        "width": 23,
+        "height": 15
+      }
+    },
+    {
+      "id": 8368115667870794,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.key_cache_utilization{*} by {service}",
+            "display_type": "line",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            }
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Cache Utilization Ratio",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false
+      },
+      "layout": {
+        "x": 68,
+        "y": 84,
+        "width": 35,
+        "height": 15
+      }
+    },
+    {
+      "id": 2637040087034578,
+      "definition": {
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:mysql.performance.slow_queries{*}",
+            "display_type": "area",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "on_right_yaxis": false
+          }
+        ],
+        "yaxis": {
+          "label": "",
+          "scale": "linear",
+          "min": "auto",
+          "max": "auto",
+          "include_zero": true
+        },
+        "title": "Slow Query Rate",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "show_legend": false
+      },
+      "layout": {
+        "x": 68,
+        "y": 30,
+        "width": 35,
+        "height": 15
+      }
+    },
+    {
+      "id": 2902465927202362,
+      "definition": {
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "avg:mysql.net.aborted_connects{*}",
+            "aggregator": "avg",
+            "conditional_formats": [
+              {
+                "comparator": "<=",
+                "value": 0,
+                "palette": "white_on_green"
+              },
+              {
+                "comparator": ">",
+                "value": 0,
+                "palette": "white_on_red"
+              }
+            ]
+          }
+        ],
+        "title": "Failed MySQL Connects",
+        "title_size": "16",
+        "title_align": "left",
+        "time": {},
+        "precision": 2
+      },
+      "layout": {
+        "x": 54,
+        "y": 7,
+        "width": 25,
+        "height": 15
+      }
+    },
+    {
+      "id": 5811070951344460,
+      "definition": {
+        "type": "note",
+        "content": "InnoDB is the storage management system for both MariaDB and MySQL.",
+        "background_color": "gray",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "right"
+      },
+      "layout": {
+        "x": 1,
+        "y": 70,
+        "width": 30,
+        "height": 8
+      }
+    },
+    {
+      "id": 7403239476791868,
+      "definition": {
+        "type": "note",
+        "content": "Most of the metrics and monitoring strategies outlined here also apply to MySQL-compatible technologies such MariaDB and Percona Server, with some notable differences. For instance, some of the features in the MySQL Workbench are not compatible with currently available versions of MariaDB.\n\nAmazon RDS users should check out our specialized monitoring guides for [MySQL on RDS](https://www.datadoghq.com/blog/monitoring-rds-mysql-performance-metrics/) and for the MySQL-compatible [Amazon Aurora](https://www.datadoghq.com/blog/monitoring-amazon-aurora-performance-metrics/).\n\n",
+        "background_color": "gray",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "right"
+      },
+      "layout": {
+        "x": 1,
+        "y": 44,
+        "width": 30,
+        "height": 24
+      }
+    },
+    {
+      "id": 400903025136302,
+      "definition": {
+        "type": "note",
+        "content": "The current rate of queries will naturally rise and fall, and as such it’s not always an actionable metric based on fixed thresholds. But it is worthwhile to alert on sudden changes in query volume—drastic drops in throughput, especially, can indicate a serious problem.",
+        "background_color": "gray",
+        "font_size": "14",
+        "text_align": "left",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "left"
+      },
+      "layout": {
+        "x": 177,
+        "y": 1,
+        "width": 47,
+        "height": 13
+      }
+    }
+  ],
+  "template_variables": [
+    {
+      "name": "scope",
+      "default": "*",
+      "prefix": null
+    }
+  ],
+  "layout_type": "free",
+  "is_read_only": false,
+  "notify_list": [],
+  "id": "5ga-gvj-t8m"
+}

--- a/mysql/assets/dashboards/overview.json
+++ b/mysql/assets/dashboards/overview.json
@@ -1,951 +1,150 @@
 {
-  "title": "MySQL - Overview",
-  "description": "",
-  "widgets": [
-    {
-      "id": 2932944765675138,
-      "definition": {
-        "type": "note",
-        "content": "MySQL LOGO HERE",
-        "background_color": "white",
-        "font_size": "14",
-        "text_align": "left",
-        "show_tick": false,
-        "tick_pos": "50%",
-        "tick_edge": "left"
-      },
-      "layout": {
-        "x": 1,
-        "y": 1,
-        "width": 30,
-        "height": 10
-      }
-    },
-    {
-      "id": 7819738301267990,
-      "definition": {
-        "type": "note",
-        "content": "Using this dashboard, you can get a high-level view of your MySQL metrics related to throughput, performance, and resource utilization.\n\nTo learn more about our MySQL integration, see:\n\n- [Our official integration documentation](https://docs.datadoghq.com/integrations/mysql/?tab=host).\n\n- [Monitoring MySQL Performance Metrics](https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/).\n\n- [Collecting MySQL statistics and metrics](https://www.datadoghq.com/blog/collecting-mysql-statistics-and-metrics/).\n\n- [Our blog post on MySQL monitoring](https://www.datadoghq.com/blog/mysql-monitoring-with-datadog/).\n\n\nYou can clone this dashboard, copy and paste widgets from other out-of-the-box dashboards, and create your own visualizations for your custom applications.\n\n\n",
-        "background_color": "white",
-        "font_size": "14",
-        "text_align": "left",
-        "show_tick": false,
-        "tick_pos": "50%",
-        "tick_edge": "left"
-      },
-      "layout": {
-        "x": 1,
-        "y": 12,
-        "width": 30,
-        "height": 31
-      }
-    },
-    {
-      "id": 4949655736738342,
-      "definition": {
-        "type": "note",
-        "content": "Basic Activity Monitor",
-        "background_color": "vivid_blue",
-        "font_size": "18",
-        "text_align": "center",
-        "show_tick": false,
-        "tick_pos": "50%",
-        "tick_edge": "bottom"
-      },
-      "layout": {
-        "x": 33,
-        "y": 1,
-        "width": 70,
-        "height": 5
-      }
-    },
-    {
-      "id": 2053914314500650,
-      "definition": {
-        "type": "note",
-        "content": "Throughput",
-        "background_color": "vivid_blue",
-        "font_size": "18",
-        "text_align": "center",
-        "show_tick": false,
-        "tick_pos": "50%",
-        "tick_edge": "bottom"
-      },
-      "layout": {
-        "x": 105,
-        "y": 1,
-        "width": 70,
-        "height": 5
-      }
-    },
-    {
-      "id": 33563484962610,
-      "definition": {
-        "type": "note",
-        "content": "MySQL Resource Utilization",
-        "background_color": "blue",
-        "font_size": "18",
-        "text_align": "center",
-        "show_tick": false,
-        "tick_pos": "50%",
-        "tick_edge": "bottom"
-      },
-      "layout": {
-        "x": 33,
-        "y": 46,
-        "width": 70,
-        "height": 5
-      }
-    },
-    {
-      "id": 7813434609764132,
-      "definition": {
-        "type": "note",
-        "content": "Performance",
-        "background_color": "vivid_blue",
-        "font_size": "18",
-        "text_align": "center",
-        "show_tick": false,
-        "tick_pos": "50%",
-        "tick_edge": "bottom"
-      },
-      "layout": {
-        "x": 33,
-        "y": 24,
-        "width": 70,
-        "height": 5
-      }
-    },
-    {
-      "id": 8724911101387132,
-      "definition": {
-        "type": "note",
-        "content": "Logs",
-        "background_color": "blue",
-        "font_size": "18",
-        "text_align": "center",
-        "show_tick": false,
-        "tick_pos": "50%",
-        "tick_edge": "bottom"
-      },
-      "layout": {
-        "x": 177,
-        "y": 16,
-        "width": 47,
-        "height": 5
-      }
-    },
-    {
-      "id": 3510484440766506,
-      "definition": {
-        "type": "query_value",
-        "requests": [
-          {
-            "q": "avg:mysql.net.max_connections{*}",
-            "aggregator": "avg"
-          }
-        ],
-        "title": "Number of Connctions",
-        "title_size": "16",
-        "title_align": "left",
-        "autoscale": true,
-        "precision": 2
-      },
-      "layout": {
-        "x": 33,
-        "y": 7,
-        "width": 20,
-        "height": 15
-      }
-    },
-    {
-      "id": 4580303685497888,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:mysql.performance.threads_running{*}",
-            "display_type": "bars",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          }
-        ],
-        "yaxis": {
-          "label": "",
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "include_zero": true
-        },
-        "title": "Threads Running",
-        "title_size": "16",
-        "title_align": "left",
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 33,
-        "y": 52,
-        "width": 33,
-        "height": 15
-      }
-    },
-    {
-      "id": 7333327975143908,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:mysql.performance.threads_connected{*}",
-            "display_type": "bars",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          }
-        ],
-        "yaxis": {
-          "label": "",
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "include_zero": true
-        },
-        "title": "Threads Connected",
-        "title_size": "16",
-        "title_align": "left",
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 68,
-        "y": 52,
-        "width": 35,
-        "height": 15
-      }
-    },
-    {
-      "id": 3132289999982172,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:mysql.innodb.buffer_pool_pages_total{*}",
-            "display_type": "line",
-            "style": {
-              "palette": "cool",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          },
-          {
-            "q": "avg:mysql.innodb.buffer_pool_pages_free{*}",
-            "display_type": "area",
-            "style": {
-              "palette": "cool",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          },
-          {
-            "q": "avg:mysql.innodb.buffer_pool_pages_data{*}",
-            "display_type": "area",
-            "style": {
-              "palette": "cool",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          }
-        ],
-        "yaxis": {
-          "label": "",
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "include_zero": true
-        },
-        "title": "InnoDB Buffer Pool Pages",
-        "title_size": "16",
-        "title_align": "left",
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 68,
-        "y": 68,
-        "width": 35,
-        "height": 15
-      }
-    },
-    {
-      "id": 3757592705691892,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:mysql.innodb.buffer_pool_free{*}",
-            "display_type": "area",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          },
-          {
-            "q": "avg:mysql.innodb.buffer_pool_used{*}",
-            "display_type": "area",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          },
-          {
-            "q": "avg:mysql.innodb.buffer_pool_total{*}",
-            "display_type": "line",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          }
-        ],
-        "yaxis": {
-          "label": "",
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "include_zero": true
-        },
-        "title": "InnoDB Buffer Pool",
-        "title_size": "16",
-        "title_align": "left",
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 33,
-        "y": 68,
-        "width": 33,
-        "height": 15
-      }
-    },
-    {
-      "id": 3026433805375000,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:mysql.performance.com_select{*}",
-            "display_type": "line",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          }
-        ],
-        "yaxis": {
-          "label": "",
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "include_zero": true
-        },
-        "title": "Rate of Select Queries",
-        "title_size": "16",
-        "title_align": "left",
-        "time": {},
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 105,
-        "y": 7,
-        "width": 34,
-        "height": 15
-      }
-    },
-    {
-      "id": 8459550148722216,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:mysql.performance.query_run_time.avg{*}",
-            "display_type": "line",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          }
-        ],
-        "yaxis": {
-          "label": "",
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "include_zero": true
-        },
-        "title": "Query Average Runtime",
-        "title_size": "16",
-        "title_align": "left",
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 33,
-        "y": 30,
-        "width": 33,
-        "height": 15
-      }
-    },
-    {
-      "id": 8995043206631004,
-      "definition": {
-        "type": "note",
-        "content": "System Resource Utilization",
-        "background_color": "blue",
-        "font_size": "18",
-        "text_align": "center",
-        "show_tick": false,
-        "tick_pos": "50%",
-        "tick_edge": "bottom"
-      },
-      "layout": {
-        "x": 105,
-        "y": 39,
-        "width": 70,
-        "height": 5
-      }
-    },
-    {
-      "id": 5133552342659276,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:system.load.1{$scope}"
-          },
-          {
-            "q": "avg:system.load.5{$scope}"
-          },
-          {
-            "q": "avg:system.load.15{$scope}"
-          }
-        ],
-        "title": "System load",
-        "title_size": "16",
-        "title_align": "left",
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 141,
-        "y": 45,
-        "width": 34,
-        "height": 15
-      }
-    },
-    {
-      "id": 3174962352359576,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:system.cpu.idle{$scope}, avg:system.cpu.system{$scope}, avg:system.cpu.iowait{$scope}, avg:system.cpu.user{$scope}, avg:system.cpu.stolen{$scope}, avg:system.cpu.guest{$scope}"
-          }
-        ],
-        "title": "CPU usage (%)",
-        "title_size": "16",
-        "title_align": "left",
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 105,
-        "y": 45,
-        "width": 34,
-        "height": 15
-      }
-    },
-    {
-      "id": 7146327569259880,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "max:mysql.performance.kernel_time{$scope}",
-            "display_type": "line",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
+    "title": "MySQL - Overview",
+    "description": "This dashboard brings together key metrics from your MySQL servers so you can spot excessive numbers of [slow queries](https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/#query-performance) and quickly identify any resource constraints that may be impacting performance. Further reading on MySQL monitoring:\n\n- [Datadog's guide to key metrics for MySQL](https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/)\n\n- [How to collect MySQL metrics using built-in tools](https://www.datadoghq.com/blog/collecting-mysql-statistics-and-metrics/)\n\n- [How to monitor MySQL using Datadog](https://www.datadoghq.com/blog/mysql-monitoring-with-datadog/)\n\n- [Datadog's MySQL integration docs](https://docs.datadoghq.com/integrations/mysql/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
+    "layout_type": "ordered",
+    "template_variables": [
+        {
+            "default": "*",
+            "prefix": null,
+            "name": "scope"
+        }
+    ],
+    "widgets": [
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:mysql.net.connections{$scope}"
+                    },
+                    {
+                        "q": "sum:mysql.net.max_connections{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "MySQL connections"
             }
-          }
-        ],
-        "yaxis": {
-          "label": "",
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "include_zero": true
         },
-        "title": "MySQL CPU Time (%)",
-        "title_size": "16",
-        "title_align": "left",
-        "time": {},
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 105,
-        "y": 61,
-        "width": 34,
-        "height": 15
-      }
-    },
-    {
-      "id": 3433922753288356,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "sum:system.mem.usable{$scope}, sum:system.mem.total{$scope}-sum:system.mem.usable{$scope}"
-          }
-        ],
-        "title": "System memory",
-        "title_size": "16",
-        "title_align": "left",
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 141,
-        "y": 61,
-        "width": 34,
-        "height": 15
-      }
-    },
-    {
-      "id": 824726960195446,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "sum:system.net.bytes_rcvd{$scope}"
-          },
-          {
-            "q": "sum:system.net.bytes_sent{$scope}"
-          }
-        ],
-        "title": "Network traffic (per sec)",
-        "title_size": "16",
-        "title_align": "left",
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 105,
-        "y": 77,
-        "width": 70,
-        "height": 15
-      }
-    },
-    {
-      "id": 3597777553720704,
-      "definition": {
-        "type": "log_stream",
-        "indexes": [],
-        "query": "source:mysql",
-        "sort": {
-          "column": "time",
-          "order": "desc"
-        },
-        "columns": [
-          "core_host",
-          "core_service"
-        ],
-        "show_date_column": true,
-        "show_message_column": true,
-        "message_display": "expanded-md",
-        "title": "",
-        "title_size": "16",
-        "title_align": "left"
-      },
-      "layout": {
-        "x": 177,
-        "y": 22,
-        "width": 47,
-        "height": 55
-      }
-    },
-    {
-      "id": 8463261690002896,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:mysql.performance.com_update{*}",
-            "display_type": "line",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          }
-        ],
-        "yaxis": {
-          "label": "",
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "include_zero": true
-        },
-        "title": "Rate of Update Queries",
-        "title_size": "16",
-        "title_align": "left",
-        "time": {},
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 141,
-        "y": 7,
-        "width": 34,
-        "height": 15
-      }
-    },
-    {
-      "id": 6252548321364566,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:mysql.performance.com_insert{*}",
-            "display_type": "line",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          }
-        ],
-        "yaxis": {
-          "label": "",
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "include_zero": true
-        },
-        "title": "Rate of Insert Queries",
-        "title_size": "16",
-        "title_align": "left",
-        "time": {},
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 105,
-        "y": 23,
-        "width": 34,
-        "height": 15
-      }
-    },
-    {
-      "id": 756419659654490,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:mysql.performance.com_delete{*}",
-            "display_type": "line",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          }
-        ],
-        "yaxis": {
-          "label": "",
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "include_zero": true
-        },
-        "title": "Rate of Delete Queries",
-        "title_size": "16",
-        "title_align": "left",
-        "time": {},
-        "show_legend": false,
-        "legend_size": "0"
-      },
-      "layout": {
-        "x": 141,
-        "y": 23,
-        "width": 34,
-        "height": 15
-      }
-    },
-    {
-      "id": 2368466329359410,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:mysql.innodb.data_reads{*}",
-            "display_type": "line",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:mysql.innodb.data_reads{$scope}"
+                    },
+                    {
+                        "q": "sum:mysql.innodb.data_writes{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "MySQL reads and writes (per sec)"
             }
-          },
-          {
-            "q": "avg:mysql.innodb.data_writes{*}",
-            "display_type": "line",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:mysql.innodb.os_log_fsyncs{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "MySQL fsync op count (per sec)"
             }
-          }
-        ],
-        "yaxis": {
-          "label": "",
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "include_zero": true
         },
-        "title": "Rate of Data Reads/Writes",
-        "title_size": "16",
-        "title_align": "left",
-        "time": {},
-        "show_legend": false
-      },
-      "layout": {
-        "x": 33,
-        "y": 84,
-        "width": 33,
-        "height": 15
-      }
-    },
-    {
-      "id": 3221412590263788,
-      "definition": {
-        "type": "query_value",
-        "requests": [
-          {
-            "q": "avg:mysql.net.connections{*}",
-            "aggregator": "avg"
-          }
-        ],
-        "title": "Rate of Connections to Server",
-        "title_size": "16",
-        "title_align": "left",
-        "time": {},
-        "precision": 2
-      },
-      "layout": {
-        "x": 80,
-        "y": 7,
-        "width": 23,
-        "height": 15
-      }
-    },
-    {
-      "id": 8368115667870794,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:mysql.performance.key_cache_utilization{*} by {service}",
-            "display_type": "line",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:mysql.performance.slow_queries{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "MySQL slow queries"
             }
-          }
-        ],
-        "yaxis": {
-          "label": "",
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "include_zero": true
         },
-        "title": "Cache Utilization Ratio",
-        "title_size": "16",
-        "title_align": "left",
-        "time": {},
-        "show_legend": false
-      },
-      "layout": {
-        "x": 68,
-        "y": 84,
-        "width": 35,
-        "height": 15
-      }
-    },
-    {
-      "id": 2637040087034578,
-      "definition": {
-        "type": "timeseries",
-        "requests": [
-          {
-            "q": "avg:mysql.performance.slow_queries{*}",
-            "display_type": "area",
-            "style": {
-              "palette": "dog_classic",
-              "line_type": "solid",
-              "line_width": "normal"
-            },
-            "on_right_yaxis": false
-          }
-        ],
-        "yaxis": {
-          "label": "",
-          "scale": "linear",
-          "min": "auto",
-          "max": "auto",
-          "include_zero": true
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "rate(sum:mysql.performance.table_locks_waited{$scope})"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "MySQL locking rate (per sec)"
+            }
         },
-        "title": "Slow Query Rate",
-        "title_size": "16",
-        "title_align": "left",
-        "time": {},
-        "show_legend": false
-      },
-      "layout": {
-        "x": 68,
-        "y": 30,
-        "width": 35,
-        "height": 15
-      }
-    },
-    {
-      "id": 2902465927202362,
-      "definition": {
-        "type": "query_value",
-        "requests": [
-          {
-            "q": "avg:mysql.net.aborted_connects{*}",
-            "aggregator": "avg",
-            "conditional_formats": [
-              {
-                "comparator": "<=",
-                "value": 0,
-                "palette": "white_on_green"
-              },
-              {
-                "comparator": ">",
-                "value": 0,
-                "palette": "white_on_red"
-              }
-            ]
-          }
-        ],
-        "title": "Failed MySQL Connects",
-        "title_size": "16",
-        "title_align": "left",
-        "time": {},
-        "precision": 2
-      },
-      "layout": {
-        "x": 54,
-        "y": 7,
-        "width": 25,
-        "height": 15
-      }
-    },
-    {
-      "id": 5811070951344460,
-      "definition": {
-        "type": "note",
-        "content": "InnoDB is the storage management system for both MariaDB and MySQL.",
-        "background_color": "gray",
-        "font_size": "14",
-        "text_align": "left",
-        "show_tick": true,
-        "tick_pos": "50%",
-        "tick_edge": "right"
-      },
-      "layout": {
-        "x": 1,
-        "y": 70,
-        "width": 30,
-        "height": 8
-      }
-    },
-    {
-      "id": 7403239476791868,
-      "definition": {
-        "type": "note",
-        "content": "Most of the metrics and monitoring strategies outlined here also apply to MySQL-compatible technologies such MariaDB and Percona Server, with some notable differences. For instance, some of the features in the MySQL Workbench are not compatible with currently available versions of MariaDB.\n\nAmazon RDS users should check out our specialized monitoring guides for [MySQL on RDS](https://www.datadoghq.com/blog/monitoring-rds-mysql-performance-metrics/) and for the MySQL-compatible [Amazon Aurora](https://www.datadoghq.com/blog/monitoring-amazon-aurora-performance-metrics/).\n\n",
-        "background_color": "gray",
-        "font_size": "14",
-        "text_align": "left",
-        "show_tick": true,
-        "tick_pos": "50%",
-        "tick_edge": "right"
-      },
-      "layout": {
-        "x": 1,
-        "y": 44,
-        "width": 30,
-        "height": 24
-      }
-    },
-    {
-      "id": 400903025136302,
-      "definition": {
-        "type": "note",
-        "content": "The current rate of queries will naturally rise and fall, and as such it’s not always an actionable metric based on fixed thresholds. But it is worthwhile to alert on sudden changes in query volume—drastic drops in throughput, especially, can indicate a serious problem.",
-        "background_color": "gray",
-        "font_size": "14",
-        "text_align": "left",
-        "show_tick": true,
-        "tick_pos": "50%",
-        "tick_edge": "left"
-      },
-      "layout": {
-        "x": 177,
-        "y": 1,
-        "width": 47,
-        "height": 13
-      }
-    }
-  ],
-  "template_variables": [
-    {
-      "name": "scope",
-      "default": "*",
-      "prefix": null
-    }
-  ],
-  "layout_type": "free",
-  "is_read_only": false,
-  "notify_list": [],
-  "id": "5ga-gvj-t8m"
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "mysql.performance.user_time{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "MySQL CPU time (per sec)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "system.load.1{$scope}"
+                    },
+                    {
+                        "q": "system.load.5{$scope}"
+                    },
+                    {
+                        "q": "system.load.15{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "System load"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "system.cpu.idle{$scope}, system.cpu.system{$scope}, system.cpu.iowait{$scope}, system.cpu.user{$scope}, system.cpu.stolen{$scope}, system.cpu.guest{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "CPU usage (%)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "max:system.cpu.iowait{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "I/O wait (%)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:system.mem.usable{$scope},sum:system.mem.total{$scope}-sum:system.mem.usable{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "System memory"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:system.net.bytes_rcvd{$scope}"
+                    },
+                    {
+                        "q": "sum:system.net.bytes_sent{$scope}"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Network traffic (per sec)"
+            }
+        }
+    ]
 }

--- a/mysql/assets/dashboards/overview.json
+++ b/mysql/assets/dashboards/overview.json
@@ -1,5 +1,5 @@
 {
-    "title": "MySQL - Overview",
+    "title": "MySQL",
     "description": "This dashboard brings together key metrics from your MySQL servers so you can spot excessive numbers of [slow queries](https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/#query-performance) and quickly identify any resource constraints that may be impacting performance. Further reading on MySQL monitoring:\n\n- [Datadog's guide to key metrics for MySQL](https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/)\n\n- [How to collect MySQL metrics using built-in tools](https://www.datadoghq.com/blog/collecting-mysql-statistics-and-metrics/)\n\n- [How to monitor MySQL using Datadog](https://www.datadoghq.com/blog/mysql-monitoring-with-datadog/)\n\n- [Datadog's MySQL integration docs](https://docs.datadoghq.com/integrations/mysql/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
     "layout_type": "ordered",
     "template_variables": [

--- a/mysql/assets/dashboards/overview.json
+++ b/mysql/assets/dashboards/overview.json
@@ -1,5 +1,5 @@
 {
-    "title": "MySQL",
+    "title": "MySQL - Overview",
     "description": "This dashboard brings together key metrics from your MySQL servers so you can spot excessive numbers of [slow queries](https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/#query-performance) and quickly identify any resource constraints that may be impacting performance. Further reading on MySQL monitoring:\n\n- [Datadog's guide to key metrics for MySQL](https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics/)\n\n- [How to collect MySQL metrics using built-in tools](https://www.datadoghq.com/blog/collecting-mysql-statistics-and-metrics/)\n\n- [How to monitor MySQL using Datadog](https://www.datadoghq.com/blog/mysql-monitoring-with-datadog/)\n\n- [Datadog's MySQL integration docs](https://docs.datadoghq.com/integrations/mysql/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
     "layout_type": "ordered",
     "template_variables": [

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -32,7 +32,8 @@
     },
     "monitors": {},
     "dashboards": {
-      "mysql": "assets/dashboards/overview.json"
+      "mysql": "assets/dashboards/overview.json",
+      "mysql-screenboard": "assets/dashboards/overview-screenboard.json"
 
     },
     "saved_views": {

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -31,7 +31,10 @@
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {},
-    "dashboards": {},
+    "dashboards": {
+      "mysql": "assets/dashboards/overview.json"
+
+    },
     "saved_views": {
       "operations": "assets/saved_views/operations.json",
       "operations_overview": "assets/saved_views/operations_overview.json",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR does two things:
1. Migrates the original timeboard from `dogweb` to `integrations-core` for compatibility.
2. Adds a new screenboard dashboard for MySQL that is more blog-like.

*Current:*
![image](https://user-images.githubusercontent.com/31313038/98302083-d3d71180-1f89-11eb-95bc-ecf9792528be.png)


*New:*
![image](https://user-images.githubusercontent.com/31313038/98302573-a048b700-1f8a-11eb-9af6-4720930ae912.png)

Staging link: https://dd.datad0g.com/screen/integration/30536/mysql?from_ts=1605626831278&live=true&to_ts=1605630431278

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
TODO: Migrate the existing dashboard from dogweb to integrations-core. This PR is more just to get eyes on the new dashboard for edits. PR for migration: https://github.com/DataDog/dogweb/pull/52934

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
