### PR TITLE
Add sharding_cluster_role tag to optime_lag metric

### DIFF
--- a/mongo/tests/results/metrics-replset-lag-from-primary-configsvr.json
+++ b/mongo/tests/results/metrics-replset-lag-from-primary-configsvr.json
@@ -7,7 +7,8 @@
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "member:mongo-mongodb-sharded-configsvr-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
             "replset_name:mongo-mongodb-sharded-configsvr",
-            "replset_state:primary"
+            "replset_state:primary",
+            "sharding_cluster_role:configsvr"
         ]
     },
     {
@@ -18,7 +19,8 @@
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "member:mongo-mongodb-sharded-configsvr-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
             "replset_name:mongo-mongodb-sharded-configsvr",
-            "replset_state:secondary"
+            "replset_state:secondary",
+            "sharding_cluster_role:configsvr"
         ]
     },
     {
@@ -29,7 +31,8 @@
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "member:mongo-mongodb-sharded-configsvr-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
             "replset_name:mongo-mongodb-sharded-configsvr",
-            "replset_state:secondary"
+            "replset_state:secondary",
+            "sharding_cluster_role:configsvr"
         ]
     }
 ]

--- a/mongo/tests/results/metrics-replset-lag-from-primary-in-shard.json
+++ b/mongo/tests/results/metrics-replset-lag-from-primary-in-shard.json
@@ -7,7 +7,8 @@
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "member:mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
             "replset_name:mongo-mongodb-sharded-shard-0",
-            "replset_state:primary"
+            "replset_state:primary",
+            "sharding_cluster_role:shardsvr"
         ]
     },
     {
@@ -18,7 +19,8 @@
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "member:mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
             "replset_name:mongo-mongodb-sharded-shard-0",
-            "replset_state:secondary"
+            "replset_state:secondary",
+            "sharding_cluster_role:shardsvr"
         ]
     },
     {
@@ -29,7 +31,8 @@
             "server:mongodb://testUser2:*****@localhost:27017/test",
             "member:mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
             "replset_name:mongo-mongodb-sharded-shard-0",
-            "replset_state:secondary"
+            "replset_state:secondary",
+            "sharding_cluster_role:shardsvr"
         ]
     }
 ]


### PR DESCRIPTION
The `mongo.replication.optime_lag` metric is computed from the primary for all secondaries. Thus the `repl_set_state` tags need to be removed and overriden with the state of the other nodes, not the current node.