### PR TITLE
Update e2e config for more compatibility

### DIFF
--- a/sqlserver/tests/compose-ha/docker-compose.yaml
+++ b/sqlserver/tests/compose-ha/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3"
 services:
     sqlserver:
         build:


### PR DESCRIPTION
### What does this PR do?
Minor compatibility change so the HA environment can be brought up with earlier versions of macOS Docker.