### PR TITLE
Adds helpful multi-line rule suggestion for MySQL general log file

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -202,6 +202,11 @@ _Available for Agent versions >6.0_
        #   - type: multi_line
        #     name: new_log_start_with_date
        #     pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+       # If the logs start with a date with the format yymmdd but include a timestamp with each new second, rather than with each log, uncomment the following processing rule
+       # log_processing_rules:
+       #   - type: multi_line
+       #     name: new_logs_do_not_always_start_with_timestamp
+       #     pattern: \t\t\s*\d+\s+|\d{6}\s+\d{,2}:\d{2}:\d{2}\t\s*\d+\s+
    ```
 
     See our [sample mysql.yaml][9] for all available configuration options, including those for custom metrics.

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -258,6 +258,10 @@ files:
               - type: multi_line
                 name: new_log_start_with_date
                 pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+              # Useful when timestamp is only logged every second (not every log) and format is yymmdd. (This comment won't be present in the output.)
+              - type: multi_line
+                name: new_logs_do_not_always_start_with_timestamp
+                pattern: \t\t\s*\d+\s+|\d{6}\s+\d{,2}:\d{2}:\d{2}\t\s*\d+\s+
 
           - type: file
             path: "<ERROR_LOG_FILE_PATH>"

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -284,6 +284,9 @@ instances:
 #     - type: multi_line
 #       name: new_log_start_with_date
 #       pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+#     - type: multi_line
+#       name: new_logs_do_not_always_start_with_timestamp
+#       pattern: \t\t\s*\d+\s+|\d{6}\s+\d{,2}:\d{2}:\d{2}\t\s*\d+\s+
 #   - type: file
 #     path: <ERROR_LOG_FILE_PATH>
 #     source: mysql


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- The currently suggested multi-line aggregation rule for the MySQL general log file is appropriate for some, but not all customers.  A different format exists, and it is helpful to add the regular expression that will result in this different format being aggregated properly.  

- This rule was added to help users with the MySQL general log format wherein each new log does not start with a timestamp.  Instead, the timestamp is only logged once every second, and the logs in between those with a timestamp start with at least two tab characters (potentially followed by additional whitespace), followed by an integer, the thread ID, instead.

### Motivation
<!-- What inspired you to submit this pull request? -->

Support cases with improperly aggregated MySQL logs from the general log file where a different multi-line aggregation rule was needed to get each log to arrive separately.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
