### PR TITLE
Fix replicaset identification with old configuration

### DIFF
--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -299,7 +299,8 @@ class MongoDb(AgentCheck):
             elif 'clusterRole' in options['sharding']:
                 cluster_role = options['sharding']['clusterRole']
 
-        if 'replSetName' in options.get('replication', {}):
+        replication_options = options.get('replication', {})
+        if 'replSetName' in replication_options or 'replSet' in replication_options:
             repl_set_payload = admindb.command("replSetGetStatus")
             replset_name = repl_set_payload["set"]
             replset_state = repl_set_payload["myState"]

--- a/mongo/tests/fixtures/getCmdLineOpts-replica-secondary
+++ b/mongo/tests/fixtures/getCmdLineOpts-replica-secondary
@@ -20,7 +20,12 @@
         },
         "replication": {
             "enableMajorityReadConcern": true,
-            "replSetName": "replset"
+            "replSet": {
+                "unknown": [
+                    "data",
+                    "format"
+                ]
+            }
         },
         "security": {
             "authorization": "enabled",


### PR DESCRIPTION
There are two ways to configure a mongo replicaset, either by setting `replication->replSetName` in a yaml file (the documented way as mentioned here https://docs.mongodb.com/v4.4/reference/configuration-options/#replication.replSetName
or by using the old (pre v2.4) flat configuration file and setting `replSet` directly https://docs.mongodb.com/v2.4/reference/configuration-options/#replSet

Those two options are slightly different so even when parsed and exposed by mongo through `getCmdLineOpts`, they end up in different fields of the payload. In the first case, the replSetName value ends up in `replication->replSetName`, in the latter case it ends up in `replication->replSet`

This PR adds support for this.


For reviewers:
We could also assume that the node is a replica set, run the `replSetGetConfig` command, and check if it returns an error or not. But in case of standalone nodes this is one unnecessary query on every check run, and we're quite confident that `replSetName` and `replSet` are the two only options. For example, here's mongo source code that mentions only both: https://github.com/mongodb/mongo/blob/b7ff5816f4d9d468b1875013384e7e51184628a0/jstests/replsets/repl_options.js