### PR TITLE
Fix version metadata collection

### DIFF
--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -83,8 +83,7 @@ class Nginx(AgentCheck):
         if not use_plus_api:
             response, content_type, version = self._get_data(instance, url)
             # for unpaid versions
-            if self.is_metadata_collection_enabled():
-                self._set_version_metadata(version)
+            self._set_version_metadata(version)
 
             self.log.debug("Nginx status `response`: %s", response)
             self.log.debug("Nginx status `content_type`: %s", content_type)
@@ -109,11 +108,11 @@ class Nginx(AgentCheck):
 
                 try:
                     if isinstance(response, dict):
-                        version_plus = response.get('nginx_version', None)
+                        version_plus = response.get('nginx_version')
                     else:
-                        version_plus = json.loads(response).get('nginx_version', None)
-                    if version_plus and self.is_metadata_collection_enabled():
-                        self._set_version_metadata(version_plus)
+                        version_plus = json.loads(response).get('nginx_version')
+
+                    self._set_version_metadata(version_plus)
                 except Exception as e:
                     self.log.warning("Couldn't submit nginx version: %s", e)
 

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -106,15 +106,15 @@ class Nginx(AgentCheck):
             for endpoint, nest in plus_api_chain_list:
                 response = self._get_plus_api_data(url, plus_api_version, endpoint, nest)
 
-                try:
-                    if isinstance(response, dict):
-                        version_plus = response.get('nginx_version')
-                    else:
-                        version_plus = json.loads(response).get('nginx_version')
-
-                    self._set_version_metadata(version_plus)
-                except Exception as e:
-                    self.log.debug("Couldn't submit nginx version: %s", e)
+                if endpoint == 'nginx':
+                    try:
+                        if isinstance(response, dict):
+                            version_plus = response.get('version')
+                        else:
+                            version_plus = json.loads(response).get('version')
+                        self._set_version_metadata(version_plus)
+                    except Exception as e:
+                        self.log.debug("Couldn't submit nginx version: %s", e)
 
                 self.log.debug("Nginx Plus API version %s `response`: %s", plus_api_version, response)
                 metrics.extend(self.parse_json(response, tags))

--- a/nginx/datadog_checks/nginx/nginx.py
+++ b/nginx/datadog_checks/nginx/nginx.py
@@ -114,7 +114,7 @@ class Nginx(AgentCheck):
 
                     self._set_version_metadata(version_plus)
                 except Exception as e:
-                    self.log.warning("Couldn't submit nginx version: %s", e)
+                    self.log.debug("Couldn't submit nginx version: %s", e)
 
                 self.log.debug("Nginx Plus API version %s `response`: %s", plus_api_version, response)
                 metrics.extend(self.parse_json(response, tags))

--- a/nginx/tests/test_nginx.py
+++ b/nginx/tests/test_nginx.py
@@ -64,7 +64,7 @@ def test_metadata(check, instance, datadog_agent):
 
 @mock.patch(
     'datadog_checks.nginx.Nginx._get_plus_api_data',
-    return_value=open(os.path.join(FIXTURES_PATH, 'nginx_plus_in.json')).read(),
+    return_value=open(os.path.join(FIXTURES_PATH, 'plus_api_nginx.json')).read(),
 )
 def test_metadata_plus(_, aggregator, check, datadog_agent):
     # Hardcoded in the fixture


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix how we submit the nginx version metadata.

~Send it only when the configuration enables it~
Send the correct nginx version:
* From the header response in the classic API
* `version` from the `/nginx` endpoint  of the PLUS API https://docs.nginx.com/nginx/admin-guide/monitoring/live-activity-monitoring/#getting-statistics-with-the-api, that it different from the API version, also named `version` in a different endpoint.

We explicitly get the version from the correct endpoint, so it's not override in the metric loop.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
