### PR TITLE
[ci] Fix checking out master

### DIFF
--- a/.azure-pipelines/templates/checkout-code.yml
+++ b/.azure-pipelines/templates/checkout-code.yml
@@ -14,8 +14,8 @@ steps:
 # we checkout the branches we need which also gets us out of a
 # detached HEAD state. This may be fixed soon, see:
 # https://developercommunity.visualstudio.com/content/problem/373462/git-get-sources-shallow-fetch-is-broken-subject-to.html
-- script: git checkout master
-  displayName: 'Checkout master'
+- script: git fetch origin master && git checkout master
+  displayName: 'Fetch and checkout master'
 
 # Switch to the pull request branch last. Also see:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables#system-variables


### PR DESCRIPTION
Azure updated how they checkout code from
```
git -c http.extraheader="AUTHORIZATION: basic ***" fetch --force --tags --prune --progress --no-recurse-submodules --depth=10 origin
```

to 
```
git -c http.extraheader="AUTHORIZATION: basic ***" fetch --force --tags --prune --progress --no-recurse-submodules --depth=10 origin +cf2cf619b65b333822e900d36a76a21393cceb4e:refs/remotes/origin/cf2cf619b65b333822e900d36a76a21393cceb4e
```

But we need the master ref in our CI