### PR TITLE
Allow back passing a list of Query objects

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -48,7 +48,11 @@ class QueryManager(object):
         self.executor = executor
         self.tags = tags or []
         self.error_handler = error_handler
-        self.queries = [Query(payload) for payload in queries or []]
+        # Accept either a `List[Query]` (< 7.24.0), or a `List[dict]` to be wrapped in `Query` (7.24.0+).
+        # The latter was introduced to avoid an issue with passing mutable query objects,
+        # see: https://github.com/DataDog/integrations-core/pull/7750
+        # But we still accept `List[Query]` for backwards compatibility.
+        self.queries = [Query(query) if not isinstance(query, Query) else query for query in queries or []]
         custom_queries = list(self.check.instance.get('custom_queries', []))
         use_global_custom_queries = self.check.instance.get('use_global_custom_queries', True)
 

--- a/datadog_checks_base/tests/test_db.py
+++ b/datadog_checks_base/tests/test_db.py
@@ -9,7 +9,7 @@ import pytz
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.stubs.aggregator import AggregatorStub
-from datadog_checks.base.utils.db import QueryManager
+from datadog_checks.base.utils.db import Query, QueryManager
 
 pytestmark = pytest.mark.db
 
@@ -1042,6 +1042,23 @@ class TestSubmission:
         assert not id(query_manager1.queries[0]) == id(
             query_manager2.queries[0]
         ), "QueryManager does not copy the queries"
+
+    def test_accept_query_objects(self):
+        class MyCheck(AgentCheck):
+            pass
+
+        check = MyCheck('test', {}, [{}])
+        dummy_query = {
+            'name': 'test query',
+            'query': 'foo',
+            'columns': [
+                {'name': 'test.foo', 'type': 'gauge', 'tags': ['override:ok']},
+                {'name': 'test.baz', 'type': 'gauge', 'raw': True},
+            ],
+            'tags': ['test:bar'],
+        }
+        query_manager = QueryManager(check, mock_executor(), [Query(dummy_query)])
+        query_manager.compile_queries()
 
     def test_query_execution_error(self, caplog, aggregator):
         class Result(object):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This is a cleanup for https://github.com/DataDog/integrations-core/pull/7750

### Motivation
<!-- What inspired you to submit this pull request? -->
#7750 changed `QueryManager` so that `queries=...` is expected to be a list of `dict`, rather than a list of `Query`.

The motivation was that since queries are statically declared in a `queries.py` module and referenced from there, we wanted to avoid passing those references directly, and so we unwrapped everything from `Query` to pass `queries=[<dict>, ...]`.

Yet by doing so we broke backwards compatibility (the PR does have a `changelog/Changed` label). Here's why:

* On < 7.24.0, checks must be written as `QueryManager(queries=[Query(<dict>), ...])`.
* On 7.24.0+, checks must be written as `QueryManager(queries=[<dict>, ...])` (and it internally converts them to `Query`).
* And those two are incompatible.

This means users won't be able to upgrade database integrations to versions released after #7750 without also upgrading their Agent to 7.24.0 (which hasn't been released yet, and won't be for a few weeks still, although RCs are available).

For my particular use case (VoltDB), it means I'm not able to write a `voltdb` that can both work on older Agents (eg 7.22.0, or whichever Agent the customer is using right now) and `master`. Yet I'd like to avoid requiring the prospect to update their Agents to use an RC — not a very sexy requirement for a sales pitch. :-)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
