### PR TITLE
Overcome GCP limit for cluster names (40 chars).

### DIFF
--- a/istio/tests/terraform/1.2.3/main.tf
+++ b/istio/tests/terraform/1.2.3/main.tf
@@ -1,6 +1,12 @@
+# Reusable local variable
+locals {
+  # short version of username (to avoid hitting GCP 40 chars limit for cluster name)
+  short_user = substr("${var.user}", 0, 15) 
+}
+
 # Shared common terraform config found in the templates/terraform folder in datadog_checks_dev
 resource "google_container_cluster" "gke_cluster" {
-  name = replace("istio-cluster-${var.user}-${random_string.suffix.result}", ".", "-")
+  name = replace("istio-cluster-${local.short_user}-${random_string.suffix.result}", ".", "-")
   location = random_shuffle.az.result[0]
 
   lifecycle {

--- a/istio/tests/terraform/1.2.3/main.tf
+++ b/istio/tests/terraform/1.2.3/main.tf
@@ -1,7 +1,7 @@
 # Reusable local variable
 locals {
   # short version of username (to avoid hitting GCP 40 chars limit for cluster name)
-  short_user = substr("${var.user}", 0, 15) 
+  short_user = substr("${var.user}", 0, 17) 
 }
 
 # Shared common terraform config found in the templates/terraform folder in datadog_checks_dev

--- a/istio/tests/terraform/1.5.1/main.tf
+++ b/istio/tests/terraform/1.5.1/main.tf
@@ -1,7 +1,7 @@
 # Reusable local variable
 locals {
-  # short version of username (to avoid hitting GCP limit for cluster name)
-  short_user = substr("${var.user}", 0, 15) 
+  # short version of username (to avoid hitting GCP 40 chars limit for cluster name)
+  short_user = substr("${var.user}", 0, 17) 
 }
 
 # Shared common terraform config found in the templates/terraform folder in datadog_checks_dev

--- a/istio/tests/terraform/1.5.1/main.tf
+++ b/istio/tests/terraform/1.5.1/main.tf
@@ -1,6 +1,12 @@
+# Reusable local variable
+locals {
+  # short version of username (to avoid hitting GCP limit for cluster name)
+  short_user = substr("${var.user}", 0, 15) 
+}
+
 # Shared common terraform config found in the templates/terraform folder in datadog_checks_dev
 resource "google_container_cluster" "gke_cluster" {
-  name = replace("istio-cluster-${var.user}-${random_string.suffix.result}", ".", "-")
+  name = replace("istio-cluster-${local.short_user}-${random_string.suffix.result}", ".", "-")
   location = random_shuffle.az.result[0]
 
   lifecycle {


### PR DESCRIPTION
### What does this PR do?

This PR truncates the user name to workaround GCP size limit of cluster names.

### Motivation

As a matter of fact, GCP limits cluster names to 40 characters (https://cloud.google.com/sdk/gcloud/reference/container/clusters/create#:~:text=The%20name%20of%20the%20cluster,no%20longer%20than%2040%20characters.&text=Attaches%20accelerators%20(e.g.%20GPUs)%20to%20all%20nodes.).

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
