### PR TITLE
Fix query tag for postgres to use the normalized query

### DIFF
--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -167,7 +167,7 @@ class PostgresStatementMetrics(object):
                     continue
                 value = row[column]
                 if column == 'query':
-                    value = normalize_query_tag(value)
+                    value = normalize_query_tag(normalized_query)
                 tags.append('{tag_name}:{value}'.format(tag_name=tag_name, value=value))
 
             for column, metric_name in PG_STAT_STATEMENTS_METRIC_COLUMNS.items():


### PR DESCRIPTION
### What does this PR do?

This causes a bug in display of the `query` tag that includes comments. Unfortunately, I can't add proper tests because it calls the datadog_agent API and the stub doesn't provide actual obfuscation.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
