### PR TITLE
Change DB utils behavior when a truncated row is found to only drop the row

### DIFF
--- a/datadog_checks_base/tests/test_db_statements.py
+++ b/datadog_checks_base/tests/test_db_statements.py
@@ -97,17 +97,17 @@ class TestStatementMetrics:
         ]
         # Simulate a stats reset by decreasing one of the metrics rather than increasing
         rows3 = [
-            add_to_dict(rows2[1], {'count': 1, 'time': 15, 'errors': 0}),
             add_to_dict(rows2[0], {'count': -1, 'time': 0, 'errors': 15}),
+            add_to_dict(rows2[1], {'count': 1, 'time': 15, 'errors': 0}),
         ]
         rows4 = [
-            add_to_dict(rows3[1], {'count': 1, 'time': 1, 'errors': 0}),
             add_to_dict(rows3[0], {'count': 1, 'time': 1, 'errors': 1}),
+            add_to_dict(rows3[1], {'count': 1, 'time': 1, 'errors': 0}),
         ]
         assert [] == sm.compute_derivative_rows(rows1, metrics, key=key)
-        assert 2 == len(sm.compute_derivative_rows(rows2, metrics, key=key))
-        assert [] == sm.compute_derivative_rows(rows3, metrics, key=key)
-        assert 2 == len(sm.compute_derivative_rows(rows4, metrics, key=key))
+        assert 2 == len(sm.compute_derivative_rows(rows2, metrics, key=key))  # both rows computed
+        assert 1 == len(sm.compute_derivative_rows(rows3, metrics, key=key))  # only 1 row computed
+        assert 2 == len(sm.compute_derivative_rows(rows4, metrics, key=key))  # both rows computed
 
     def test_apply_row_limits(self):
         def assert_any_order(a, b):


### PR DESCRIPTION
### What does this PR do?

For database stats tables, this changes the behavior when a truncated row is found. Because this function computes the difference in monotonic counters between check runs, a value lower than the previous check run is assumed to be invalid. Currently, all rows are dropped when a single row is negative. This can result in states where all rows are dropped every check run due to bad state on a single row. 

This was an edge case we caught early on, but forgot about when I opened the PR. I added a comment to avoid making the same mistake again.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
