### PR TITLE
[network] Add a parameter to disable receive and send queues collection

### DIFF
--- a/network/README.md
+++ b/network/README.md
@@ -38,6 +38,15 @@ sudo modprobe nf_conntrack_ipv6
      ## the command `netstat` from the system package `net-tools` to be installed
      #
      - collect_connection_state: false
+
+     ## @param collect_connection_queues - boolean - optional
+     ## Set to false to disable connection queues collection
+     ## Note: connection queues collections require both
+     ## `collect_connection_state` and `collect_connection_queues` to be true
+     ## because it also requires the command `ss` from system package `iproute2` or
+     ## the command `netstat` from the system package `net-tools` to be installed
+     #
+     - collect_connection_queues: true
    ```
 
 2. [Restart the Agent][5] to effect any configuration changes.

--- a/network/assets/configuration/spec.yaml
+++ b/network/assets/configuration/spec.yaml
@@ -21,6 +21,16 @@ files:
             value:
               example: false
               type: boolean
+          - name: collect_connection_queues
+            description: |
+              Set to false to disable connection queues collection
+              Note: connection queues collections require both
+              `collect_connection_state` and `collect_connection_queues` to be true
+              because it also requires the command `ss` from system package `iproute2` or
+              the command `netstat` from the system package `net-tools` to be installed
+            value:
+              example: true
+              type: boolean
           - name: excluded_interfaces
             description: List of interface to exclude from the check.
             value:

--- a/network/datadog_checks/network/data/conf.yaml.default
+++ b/network/datadog_checks/network/data/conf.yaml.default
@@ -15,6 +15,15 @@ instances:
     #
   - collect_connection_state: false
 
+    ## @param collect_connection_queues - boolean - optional - default: true
+    ## Set to false to disable connection queues collection
+    ## Note: connection queues collections require both
+    ## `collect_connection_state` and `collect_connection_queues` to be true
+    ## because it also requires the command `ss` from system package `iproute2` or
+    ## the command `netstat` from the system package `net-tools` to be installed
+    #
+    # collect_connection_queues: true
+
     ## @param excluded_interfaces - list of strings - optional
     ## List of interface to exclude from the check.
     #


### PR DESCRIPTION
### What does this PR do?

Add a parameter to disable receive and send queues collection implemented in #7861.

### Motivation

Receive and send queues collection generate two data points per `ss` (or `netstat`) line.
The data are then aggregated on agent side in an histogram.
If this aggregation process consumes too much CPU, a new `network` check parameter `collect_connection_queues` can be used to disable this feature.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
