### PR TITLE
Fix CockroachDB test setup for 20.2+ compatibility

### DIFF
--- a/cockroachdb/tests/docker/docker-compose.yaml
+++ b/cockroachdb/tests/docker/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   cockroachdb:
     container_name: cockroachdb
     image: cockroachdb/cockroach:${COCKROACHDB_VERSION}
-    command: start --insecure --store=attrs=ssd,path=/var/lib/cockroach/
+    command: ${COCKROACHDB_START_COMMAND} --insecure --store=attrs=ssd,path=/var/lib/cockroach/
     restart: always
     expose:
       - "8080"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix `cockroachdb` test setup to support 20.2+.

### Motivation
<!-- What inspired you to submit this pull request? -->
Latest version 20.2 made it required for [`start`](https://www.cockroachlabs.com/docs/stable/start-a-local-cluster.html) to include a `--join` flag, making CI fail:

```console
cockroachdb    | * ERROR: ERROR: no --join flags provided to 'cockroach start'
cockroachdb    | * HINT: Consider using 'cockroach init' or 'cockroach start-single-node' instead
```

This PR applies the hint above: on 20.2, use [`start-single-node`](https://www.cockroachlabs.com/docs/v20.2/cockroach-start-single-node) (we have a single-node test setup).

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Note: Cockroach switched to [a form of Calver](https://www.cockroachlabs.com/docs/releases/release-support-policy.html#current-supported-releases) end of 2019, so version history is like this: 2.0.5, 2.11.1, (switch) 19.1.11, …, 20.1.8, 20.2.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
