### PR TITLE
Ignore startup nodes for lagtime

### DIFF
--- a/mongo/datadog_checks/mongo/collectors/replica.py
+++ b/mongo/datadog_checks/mongo/collectors/replica.py
@@ -137,6 +137,9 @@ class ReplicaCollector(MongoCollector):
             lag_time_tags = [t for t in self.base_tags if not t.startswith('replset_state:')]
             # Compute a lag time
             for member in status.get('members', []):
+                if get_state_name(member.get('state')) not in ('SECONDARY', 'PRIMARY'):
+                    # Can only compute a meaningful lag time from secondaries and primaries
+                    continue
                 if 'optimeDate' in primary and 'optimeDate' in member:
                     lag = primary['optimeDate'] - member['optimeDate']
                     tags = lag_time_tags + [

--- a/mongo/tests/fixtures/replSetGetStatus-replica-primary-in-shard
+++ b/mongo/tests/fixtures/replSetGetStatus-replica-primary-in-shard
@@ -256,6 +256,33 @@
             "syncSourceId": 0,
             "infoMessage": "",
             "configVersion": 4
+        },
+        {
+            "_id": 4,
+            "name": "mongo-mongodb-sharded-shard0-data-3.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 5,
+            "stateStr": "STARTUP2",
+            "uptime": 4822185,
+            "optimeDate": {
+                "$date": 0
+            },
+            "optimeDurableDate": {
+                "$date": 0
+            },
+            "lastHeartbeat": {
+                "$date": 0
+            },
+            "lastHeartbeatRecv": {
+                "$date": 0
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceHost": "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceId": 0,
+            "infoMessage": "",
+            "configVersion": 4
         }
     ],
     "ok": 1.0,


### PR DESCRIPTION
For nodes that are neither a primary nor a secondary (they are starting up for example), mongo exposes an optimeData with a value of `ISODate("1970-01-01")`.
This PR ignores those nodes from the `mongodb.replication.optime_lag` metric, otherwise graphs get a huge spike when a new node is restarting.
This will help to make this metric more useful and to reliably trust monitors alerting on the value of the lag.

