### PR TITLE
Add sub-watt metric metadata units

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -188,6 +188,9 @@ VALID_UNIT_NAMES = {
     'terawatt',
     'heap',
     'volume',
+    'milliwatt',
+    'microwatt',
+    'nanowatt'
 }
 
 PROVIDER_INTEGRATIONS = {'openmetrics', 'prometheus'}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -190,7 +190,7 @@ VALID_UNIT_NAMES = {
     'volume',
     'milliwatt',
     'microwatt',
-    'nanowatt'
+    'nanowatt',
 }
 
 PROVIDER_INTEGRATIONS = {'openmetrics', 'prometheus'}


### PR DESCRIPTION
### What does this PR do?
This PR adds sub-watt units to the validate command.

### Motivation
Validation works on manifests that contain sub-watt units, such as the Nvidia Jetson integration.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
