### PR TITLE
Include openmetrics integrations in http validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -46,13 +46,13 @@ def validate_config_http(file, check):
 
     if not has_instance_http:
         echo_failure(
-            f"Detected {check}'s spec.yaml file does not contain `instances/http` but {check} uses http wrapper"
+            f"Detected {check} is missing `instances/http` or `instances/openmetrics` template in spec.yaml"
         )
         has_failed = True
 
     if not has_init_config_http:
         echo_failure(
-            f"Detected {check}'s spec.yaml file does not contain `init_config/http` but {check} uses http wrapper"
+            f"Detected {check} is missing `init_config/http` or `init_config/openmetrics` template in spec.yaml"
         )
         has_failed = True
 
@@ -70,8 +70,8 @@ def validate_use_http_wrapper_file(file, check):
     has_failed = False
     with open(file, 'r', encoding='utf-8') as f:
         for num, line in enumerate(f):
-            if 'self.http' in line or 'OpenMetricsBaseCheck':
-                file_uses_http_wrapper = True
+            if 'self.http' in line or 'OpenMetricsBaseCheck' in line:
+                return True, has_failed
 
             for http_func in REQUEST_LIBRARY_FUNCTIONS:
                 if http_func in line:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -70,7 +70,7 @@ def validate_use_http_wrapper_file(file, check):
     has_failed = False
     with open(file, 'r', encoding='utf-8') as f:
         for num, line in enumerate(f):
-            if 'self.http' in line:
+            if 'self.http' in line or 'OpenMetricsBaseCheck':
                 file_uses_http_wrapper = True
 
             for http_func in REQUEST_LIBRARY_FUNCTIONS:
@@ -93,9 +93,10 @@ def validate_use_http_wrapper(check):
     has_failed = False
     check_uses_http_wrapper = False
     for file in get_check_files(check, include_tests=False):
-        file_uses_http_wrapper, file_uses_request_lib = validate_use_http_wrapper_file(file, check)
-        has_failed = has_failed or file_uses_request_lib
-        check_uses_http_wrapper = check_uses_http_wrapper or file_uses_http_wrapper
+        if file.endswith('.py'):
+            file_uses_http_wrapper, file_uses_request_lib = validate_use_http_wrapper_file(file, check)
+            has_failed = has_failed or file_uses_request_lib
+            check_uses_http_wrapper = check_uses_http_wrapper or file_uses_http_wrapper
 
     if has_failed:
         abort()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -45,9 +45,7 @@ def validate_config_http(file, check):
                 has_init_config_http = True
 
     if not has_instance_http:
-        echo_failure(
-            f"Detected {check} is missing `instances/http` or `instances/openmetrics` template in spec.yaml"
-        )
+        echo_failure(f"Detected {check} is missing `instances/http` or `instances/openmetrics` template in spec.yaml")
         has_failed = True
 
     if not has_init_config_http:


### PR DESCRIPTION
### What does this PR do?
This PR makes sure that integrations that are not directly using the http wrapper but inherit the OpenMetricsBaseCheck are also validated. Also makes the validation a little bit faster by only checking python files and fixes message warning to incorporate openmetrics errors.

### Motivation
I noticed that some openmetrics integrations that were missing the openmetrics template did not fail validation because it was only looking for explicit `self.http` calls.
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
