### PR TITLE
Add missing metrics for node status, pod resource

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -213,15 +213,19 @@ class KubernetesState(OpenMetricsBaseCheck):
                         'kube_node_status_capacity_memory_bytes': 'node.memory_capacity',
                         'kube_node_status_capacity_pods': 'node.pods_capacity',
                         'kube_node_status_allocatable_nvidia_gpu_cards': 'node.gpu.cards_allocatable',
+                        'kube_node_status_allocatable': 'node.allocatable',
                         'kube_node_status_capacity_nvidia_gpu_cards': 'node.gpu.cards_capacity',
+                        'kube_node_status_capacity': 'node.capacity'
                         'kube_pod_container_status_terminated': 'container.terminated',
                         'kube_pod_container_status_waiting': 'container.waiting',
                         'kube_persistentvolumeclaim_status_phase': 'persistentvolumeclaim.status',
                         'kube_persistentvolumeclaim_resource_requests_storage_bytes': 'persistentvolumeclaim.request_storage',  # noqa: E501
                         'kube_pod_container_resource_limits_cpu_cores': 'container.cpu_limit',
                         'kube_pod_container_resource_limits_memory_bytes': 'container.memory_limit',
+                        'kube_pod_container_resource_limits': 'container.limit',
                         'kube_pod_container_resource_requests_cpu_cores': 'container.cpu_requested',
                         'kube_pod_container_resource_requests_memory_bytes': 'container.memory_requested',
+                        'kube_pod_container_resource_requests': 'container.requested',
                         'kube_pod_container_status_ready': 'container.ready',
                         'kube_pod_container_status_restarts': 'container.restarts',  # up to kube-state-metrics 1.1.x
                         'kube_pod_container_status_restarts_total': 'container.restarts',  # noqa: E501, from kube-state-metrics 1.2.0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds new metrics that replaces deprecated metrics. 

### Motivation
<!-- What inspired you to submit this pull request? -->
Old metrics were deprecated and eventually removed, adding the metrics that replaced them

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Metrics 
 - `kube_node_status_allocatable*`
 - `kube_node_status_capacity*`
 - `kube_pod_container_resource_limits*`
 - `kube_pod_container_resource_requests*` 
are removed as of kube-state-metrics v2.0.0 (some were even removed earlier like the nvidia gpu metric)

See release notes: https://github.com/kubernetes/kube-state-metrics/releases

and metric docs for [node](https://github.com/kubernetes/kube-state-metrics/blob/v2.0.0-alpha.2/docs/node-metrics.md) and [pod](https://github.com/kubernetes/kube-state-metrics/blob/v2.0.0-alpha.2/docs/pod-metrics.md) notice that the metrics I mention above are not present, and have been deprecated for about 2 years now. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
