### PR TITLE
Remove unused 'tls_load_default_certs' option 

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -28,8 +28,7 @@ STANDARD_FIELDS = {
     'tls_cert': None,
     'tls_private_key': None,
     'tls_private_key_password': None,
-    'tls_validate_hostname': True,
-    'tls_load_default_certs': True,
+    'tls_validate_hostname': True
 }
 
 
@@ -120,7 +119,7 @@ class TlsContextWrapper(object):
                 context.load_verify_locations(cafile=None, capath=ca_cert, cadata=None)
             else:
                 context.load_verify_locations(cafile=ca_cert, capath=None, cadata=None)
-        elif self.config['tls_load_default_certs']:
+        else:
             context.load_default_certs(ssl.Purpose.SERVER_AUTH)
 
         # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain

--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -28,7 +28,7 @@ STANDARD_FIELDS = {
     'tls_cert': None,
     'tls_private_key': None,
     'tls_private_key_password': None,
-    'tls_validate_hostname': True
+    'tls_validate_hostname': True,
 }
 
 

--- a/datadog_checks_base/tests/test_tls.py
+++ b/datadog_checks_base/tests/test_tls.py
@@ -144,12 +144,6 @@ class TestTLSContext:
             context = check.get_tls_context()  # type: MagicMock
             context.load_default_certs.assert_called_with(ssl.Purpose.SERVER_AUTH)
 
-    def test_no_ca_certs_no_default(self):
-        instance = {'tls_load_default_certs': False}
-        check = AgentCheck('test', {}, [instance])
-        context = check.get_tls_context()
-        assert len(context.get_ca_certs()) == 0
-
     def test_ca_cert_file(self):
         with patch('ssl.SSLContext'), TempDir("test_ca_cert_file") as tmp_dir:
             filename = os.path.join(tmp_dir, 'foo')


### PR DESCRIPTION
This option isn't used yet and doesn't provide any value, there's no point in verifying the TLS connection if no CA is provided