### PR TITLE
[Config specs] Allow longer line in compact_example lists

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
@@ -148,7 +148,8 @@ def write_option(option, writer, indent='', start_list=False):
                     if isinstance(item, str):
                         compacted_item = construct_yaml(item, default_flow_style=True, default_style='"')
                     else:
-                        compacted_item = construct_yaml(item, default_flow_style=True)
+                        # Compact examples should stay on one line to prevent weird line wraps.
+                        compacted_item = construct_yaml(item, default_flow_style=True, width=float('inf'))
 
                     option_yaml_lines.append(f'- {compacted_item.strip()}')
 

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -1183,6 +1183,50 @@ def test_compact_example():
     )
 
 
+def test_compact_example_long_line():
+    long_str = "This string is very long and has 50 chars in it !!"
+    consumer = get_example_consumer(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - name: foo
+            description: words
+            value:
+              type: array
+              compact_example: true
+              example:
+                - - {0}
+                  - {0}
+                  - {0}
+                  - {0}
+              items:
+                type: array
+                items:
+                  type: string
+        """.format(
+            long_str
+        )
+    )
+    files = consumer.render()
+    contents, errors = files['test.yaml.example']
+    assert not errors
+    assert contents == normalize_yaml(
+        """
+        ## @param foo - list of lists - optional
+        ## words
+        #
+        # foo:
+        #   - [{0}, {0}, {0}, {0}]
+        """.format(
+            long_str
+        )
+    )
+
+
 def test_compact_example_nested():
     consumer = get_example_consumer(
         """


### PR DESCRIPTION
Fixes: https://github.com/DataDog/integrations-core/pull/7600/files#r506236986