### PR TITLE
CI: persist credentials when checking out code

### DIFF
--- a/.azure-pipelines/templates/checkout-code.yml
+++ b/.azure-pipelines/templates/checkout-code.yml
@@ -2,6 +2,9 @@ steps:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema#checkout
 - checkout: self
   fetchDepth: 10
+  # Allow `script` steps to interact with the git remote (required for such operations to succeed on private repos).
+  # See: https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/git-commands?view=azure-devops&tabs=yaml#allow-scripts-to-access-the-system-token
+  persistCredentials: true
 
 # Azure checks out the code from the PR but leaves us in a detached state.
 # Because ddev cannot work in that state, we create a branch.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Enable `persistCredentials` when checking out the repo in CI.

Follow-up to #7975 

### Motivation
<!-- What inspired you to submit this pull request? -->
After #7975, we're still seeing issues with `git fetch origin master` on our private repos (eg `marketplace`).

```console
git fetch origin master && git checkout master
========================== Starting Command Output ===========================
/bin/bash --noprofile --norc /home/vsts/work/_temp/5f115d19-c0d2-4256-a31a-3a9a0e99a2c1.sh
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

I don't know if something changed (seems so), but it looks like `script` tasks aren't allowed to interact with the remote by default.

Azure docs indicate turning on this flag to allow this: https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/git-commands?view=azure-devops&tabs=yaml#allow-scripts-to-access-the-system-token

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Just validated that this fixes the issue for `marketplace`: [CI logs](https://dev.azure.com/datadog-marketplace/marketplace/_build/results?buildId=581&view=logs&j=9720347a-34cb-5824-38aa-606c39f81a9d&t=c89b8b3f-6f6b-5402-5977-ff4d373e1f6a)


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
