### PR TITLE
Support proxy settings

### DIFF
--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -5,6 +5,44 @@ files:
   - template: init_config
     options:
       - template: init_config/db
+      - name: proxy
+        value:
+          example:
+            http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+            https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+            no_proxy:
+              - <HOSTNAME_1>
+              - <HOSTNAME_2>
+          type: object
+          properties:
+            - name: http
+              type: string
+            - name: https
+              type: string
+            - name: no_proxy
+              type: array
+              items:
+                type: string
+        description: |
+          Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
+          to specify hosts that must bypass proxies.
+
+          The SOCKS protocol is also supported like so:
+
+            socks5://user:pass@host:port
+
+          Using the scheme `socks5` causes the DNS resolution to happen on the
+          client, rather than on the proxy server. This is in line with `curl`,
+          which uses the scheme to decide whether to do the DNS resolution on
+          the client or proxy. If you want to resolve the domains on the proxy
+          server, use `socks5h` as the scheme.
+      - name: skip_proxy
+        value:
+          example: false
+          type: boolean
+        description: |
+          If set to `true`, this makes the check bypass any proxy
+          settings enabled and attempt to reach services directly.
       - template: init_config/default
   - template: instances
     options:
@@ -127,6 +165,48 @@ files:
                   type: gauge
               tags:
                 - test:snowflake
+      - name: proxy
+        value:
+          example:
+            http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+            https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+            no_proxy:
+              - <HOSTNAME_1>
+              - <HOSTNAME_2>
+          type: object
+          properties:
+            - name: http
+              type: string
+            - name: https
+              type: string
+            - name: no_proxy
+              type: array
+              items:
+                type: string
+        description: |
+          This overrides the `proxy` setting in `init_config`.
+
+          Set HTTP or HTTPS proxies for this instance. Use the `no_proxy` list
+          to specify hosts that must bypass proxies.
+
+          The SOCKS protocol is also supported, for example:
+
+            socks5://user:pass@host:port
+
+          Using the scheme `socks5` causes the DNS resolution to happen on the
+          client, rather than on the proxy server. This is in line with `curl`,
+          which uses the scheme to decide whether to do the DNS resolution on
+          the client or proxy. If you want to resolve the domains on the proxy
+          server, use `socks5h` as the scheme.
+      - name: skip_proxy
+        value:
+          example: false
+          type: boolean
+        description: |
+          This overrides the `skip_proxy` setting in `init_config`.
+
+          If set to `true`, this makes the check bypass any proxy
+          settings enabled and attempt to reach services directly.
       - template: instances/default
         overrides:
           min_collection_interval.description: |

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -150,7 +150,7 @@ class SnowflakeCheck(AgentCheck):
             try:
                 return method(*args, **kwargs)
             except Exception as e:
-                self.warning(
+                self.log.error(
                     "Encountered error while attempting to connect to Snowflake via proxy settings: %s", str(e)
                 )
                 return

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -105,7 +105,7 @@ class SnowflakeCheck(AgentCheck):
         )
 
         try:
-            proxies = self.http.options['proxies']  # SKIP_HTTP
+            proxies = self.http.options['proxies']  # SKIP_HTTP_VALIDATION
             with self.MONKEY_PATCH_LOCK:
                 # Monkey patch proxies to request_exec
                 SnowflakeRestful._request_exec = self._make_snowflake_request_func(

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -75,7 +75,6 @@ class Config(object):
         self.login_timeout = login_timeout  # type: int
         self.ocsp_response_cache_filename = ocsp_response_cache_filename  # type: Optional[str]
         self.tags = tags  # type: List[str]
-        self.min_collection = min_collection
         self.metric_groups = metric_groups
         self.authenticator = authenticator
         self.token = token

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -42,9 +42,6 @@ class Config(object):
         token = instance.get('token', None)
         client_keep_alive = instance.get('client_session_keep_alive', False)
 
-        # min_collection_interval defaults to 60 minutes
-        min_collection = instance.get('min_collection_interval', 3600)
-
         metric_groups = instance.get('metric_groups', self.DEFAULT_METRIC_GROUP)
 
         if account is None:

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -13,6 +13,33 @@ init_config:
     #     columns: <COLUMNS>
     #     tags: <TAGS>
 
+    ## @param proxy - mapping - optional
+    ## Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
+    ## to specify hosts that must bypass proxies.
+    ##
+    ## The SOCKS protocol is also supported like so:
+    ##
+    ##   socks5://user:pass@host:port
+    ##
+    ## Using the scheme `socks5` causes the DNS resolution to happen on the
+    ## client, rather than on the proxy server. This is in line with `curl`,
+    ## which uses the scheme to decide whether to do the DNS resolution on
+    ## the client or proxy. If you want to resolve the domains on the proxy
+    ## server, use `socks5h` as the scheme.
+    #
+    # proxy:
+    #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+    #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+    #   no_proxy:
+    #   - <HOSTNAME_1>
+    #   - <HOSTNAME_2>
+
+    ## @param skip_proxy - boolean - optional - default: false
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
+
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
     ##
@@ -160,6 +187,37 @@ instances:
     #       type: gauge
     #     tags:
     #     - test:snowflake
+
+    ## @param proxy - mapping - optional
+    ## This overrides the `proxy` setting in `init_config`.
+    ##
+    ## Set HTTP or HTTPS proxies for this instance. Use the `no_proxy` list
+    ## to specify hosts that must bypass proxies.
+    ##
+    ## The SOCKS protocol is also supported, for example:
+    ##
+    ##   socks5://user:pass@host:port
+    ##
+    ## Using the scheme `socks5` causes the DNS resolution to happen on the
+    ## client, rather than on the proxy server. This is in line with `curl`,
+    ## which uses the scheme to decide whether to do the DNS resolution on
+    ## the client or proxy. If you want to resolve the domains on the proxy
+    ## server, use `socks5h` as the scheme.
+    #
+    # proxy:
+    #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+    #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+    #   no_proxy:
+    #   - <HOSTNAME_1>
+    #   - <HOSTNAME_2>
+
+    ## @param skip_proxy - boolean - optional - default: false
+    ## This overrides the `skip_proxy` setting in `init_config`.
+    ##
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/snowflake/tests/test_unit.py
+++ b/snowflake/tests/test_unit.py
@@ -6,6 +6,7 @@ import copy
 import mock
 import pytest
 
+from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.snowflake import SnowflakeCheck, queries
 
 from .conftest import CHECK_NAME
@@ -147,3 +148,12 @@ def test_metric_group_exceptions(instance):
         check.log.warning.assert_called_once_with(
             "Invalid metric_groups found in snowflake conf.yaml: fake.metric.group"
         )
+
+
+def test_proxy_config():
+    instance = {}
+    init_config = {}
+    http = RequestsWrapper(instance, init_config)
+
+    assert http.options['proxies'] is None
+    assert http.no_proxy_uris is None


### PR DESCRIPTION
### What does this PR do?
This PR introduces a workaround to add proxy support to Snowflake.

Currently, Snowflake python connector supports proxy by setting environment variables `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`. We want to avoid using this as these configuration settings will affect other services and the integration will not be using proxy settings specified in the Agent.

https://docs.snowflake.com/en/user-guide/python-connector-example.html#using-a-proxy-server

This PR also removes the min_collection config in the code since we don't use this at the check level.

### Motivation
There is an upstream PR for this fix `https://github.com/snowflakedb/snowflake-connector-python/pull/352`.
We can remove the workaround once the fix is available.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Manually tested with squid proxy
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
