### PR TITLE
Support inline comment to skip http validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -68,7 +68,7 @@ def validate_use_http_wrapper_file(file, check):
     has_failed = False
     with open(file, 'r', encoding='utf-8') as f:
         for num, line in enumerate(f):
-            if ('self.http' in line or 'OpenMetricsBaseCheck' in line) and 'SKIP_HTTP' not in line:
+            if ('self.http' in line or 'OpenMetricsBaseCheck' in line) and 'SKIP_HTTP_VALIDATION' not in line:
                 return True, has_failed
 
             for http_func in REQUEST_LIBRARY_FUNCTIONS:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -68,7 +68,7 @@ def validate_use_http_wrapper_file(file, check):
     has_failed = False
     with open(file, 'r', encoding='utf-8') as f:
         for num, line in enumerate(f):
-            if 'self.http' in line or 'OpenMetricsBaseCheck' in line:
+            if ('self.http' in line or 'OpenMetricsBaseCheck' in line) and 'SKIP_HTTP' not in line:
                 return True, has_failed
 
             for http_func in REQUEST_LIBRARY_FUNCTIONS:


### PR DESCRIPTION
### What does this PR do?
Some integrations (snowflake) use the http wrapper but not necessarily utilizing the request function should skip validation.

This PR allows an inline comment `SKIP_HTTP_VALIDATION` which avoids failing for other use cases.

Use case:
- Snowflake uses `self.http.options` to use formatted proxies from config.

Snippet:
```
        try:
            proxies = self.http.options['proxies']  # SKIP_HTTP_VALIDATION
            with self.MONKEY_PATCH_LOCK:
```
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
