### PR TITLE
Add metric to check for prometheus

### DIFF
--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -12,7 +12,10 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "haproxy.",
-  "metric_to_check": "haproxy.frontend.bytes.in_rate",
+  "metric_to_check": [
+    "haproxy.frontend.bytes.in_rate",
+    "haproxy.frontend.bytes.in.total"
+  ],
   "name": "haproxy",
   "process_signatures": [
     "haproxy",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The prometheus version of the check does not send `haproxy.frontend.bytes.in_rate` anymore, and it sends `haproxy.frontend.bytes.in.total`

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
