### PR TITLE
Helm chart url in Airflow docs

### DIFF
--- a/airflow/tests/k8s_sample/README.md
+++ b/airflow/tests/k8s_sample/README.md
@@ -6,7 +6,7 @@ This is a sample/lab Kubernetes setup with the Datadog Agent and Airflow using K
 
 ```bash
 helm repo add datadog https://helm.datadoghq.com
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://charts.helm.sh/stable
 helm repo update
 ```
 


### PR DESCRIPTION
### What does this PR do?
Updates the helm stable url within the in-app docs as it has changed (see [docs here](https://charts.helm.sh/stable/#usage) for more info)

### Motivation
Jira request for docs

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
