### PR TITLE
Add support for custom SQL queries

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -135,6 +135,28 @@ files:
       value:
         type: integer
         example: 5
+    - name: custom_queries
+      description: |
+        Get metrics from a custom SQL query but only if the database is writable
+        (i.e. it's the master in an availability group) Notes:
+        - Custom SQL query must be defined in its own instance
+        - For performance counter queries, use `custom_metrics` instead
+        See XXX for more information.
+      value:
+        type: array
+        items:
+          type: object
+          properties: []
+        example:
+          - metric_prefix: sqlserver
+            query: <QUERY>
+            columns:
+              - name: <COLUNMS_1_NAME>
+                type: <COLUMNS_1_TYPE>
+              - name: <COLUNMS_2_NAME>
+                type: <COLUMNS_2_TYPE>
+            tags:
+              - <TAG_KEY>:<TAG_VALUE>
     - name: stored_procedure
       description: |
         Get metrics from custom proc in MyDB but only if the database is writable

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -17,6 +17,7 @@ files:
         example:
           - name: sqlserver.clr.execution
             counter_name: CLR Execution
+    - template: init_config/db
   - template: instances
     description: |
       Every instance is scheduled independent of the others.
@@ -136,8 +137,6 @@ files:
         type: integer
         example: 5
     - template: instances/db
-      overrides:
-        use_global_custom_queries.hidden: true
     - name: stored_procedure
       description: |
         Get metrics from custom proc in MyDB but only if the database is writable

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -135,28 +135,9 @@ files:
       value:
         type: integer
         example: 5
-    - name: custom_queries
-      description: |
-        Get metrics from a custom SQL query but only if the database is writable
-        (i.e. it's the master in an availability group) Notes:
-        - Custom SQL query must be defined in its own instance
-        - For performance counter queries, use `custom_metrics` instead
-        See XXX for more information.
-      value:
-        type: array
-        items:
-          type: object
-          properties: []
-        example:
-          - metric_prefix: sqlserver
-            query: <QUERY>
-            columns:
-              - name: <COLUNMS_1_NAME>
-                type: <COLUMNS_1_TYPE>
-              - name: <COLUNMS_2_NAME>
-                type: <COLUMNS_2_TYPE>
-            tags:
-              - <TAG_KEY>:<TAG_VALUE>
+    - template: instances/db
+      overrides:
+        use_global_custom_queries.hidden: true
     - name: stored_procedure
       description: |
         Get metrics from custom proc in MyDB but only if the database is writable

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -125,22 +125,35 @@ instances:
     # command_timeout: 5
 
     ## @param custom_queries - list of mappings - optional
-    ## Get metrics from a custom SQL query but only if the database is writable
-    ## (i.e. it's the master in an availability group) Notes:
-    ## - Custom SQL query must be defined in its own instance
-    ## - For performance counter queries, use `custom_metrics` instead
-    ## See XXX for more information.
+    ## Each query must have 2 fields, and can have a third optional field:
+    ##
+    ## 1. query - The SQL to execute. It can be a simple statement or a multi-line script.
+    ##            Use the pipe `|` if you require a multi-line script.
+    ## 2. columns - The list representing each column, ordered sequentially from left to right.
+    ##              The number of columns must equal the number of columns returned in the query.
+    ##              There are 2 required pieces of data:
+    ##                a. name - The suffix to append to `<INTEGRATION>.` to form
+    ##                          the full metric name. If `type` is `tag`, this column is
+    ##                          considered a tag and applied to every
+    ##                          metric collected by this particular query.
+    ##                b. type - The submission method (gauge, monotonic_count, etc.).
+    ##                          This can also be set to `tag` to tag each metric in the row
+    ##                          with the name and value of the item in this column. You can
+    ##                          use the `count` type to perform aggregation for queries that
+    ##                          return multiple rows with the same or no tags.
+    ##              Columns without a name are ignored. To skip a column, enter:
+    ##                - {}
+    ## 3. tags (optional) - A list of tags to apply to each metric.
     #
     # custom_queries:
-    #   - metric_prefix: sqlserver
-    #     query: <QUERY>
+    #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
     #     columns:
-    #     - name: <COLUNMS_1_NAME>
-    #       type: <COLUMNS_1_TYPE>
-    #     - name: <COLUNMS_2_NAME>
-    #       type: <COLUMNS_2_TYPE>
+    #     - name: foo
+    #       type: tag
+    #     - name: event.total
+    #       type: gauge
     #     tags:
-    #     - <TAG_KEY>:<TAG_VALUE>
+    #     - test:<INTEGRATION>
 
     ## @param stored_procedure - string - optional
     ## Get metrics from custom proc in MyDB but only if the database is writable

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -12,6 +12,17 @@ init_config:
     #   - name: sqlserver.clr.execution
     #     counter_name: CLR Execution
 
+    ## @param global_custom_queries - list of mappings - optional
+    ## See `custom_queries` defined below.
+    ##
+    ## Global custom queries can be applied to all instances using the
+    ## `use_global_custom_queries` setting at the instance level.
+    #
+    # global_custom_queries:
+    #   - query: <QUERY>
+    #     columns: <COLUMNS>
+    #     tags: <TAGS>
+
 ## Every instance is scheduled independent of the others.
 ##
 ## Note: All '%' characters must be escaped as '%%'.
@@ -123,6 +134,15 @@ instances:
     ## Timeout in seconds for the connection and each command run
     #
     # command_timeout: 5
+
+    ## @param use_global_custom_queries - string - optional - default: true
+    ## How `global_custom_queries` should be used for this instance. There are 3 options:
+    ##
+    ## 1. true - `global_custom_queries` override `custom_queries`.
+    ## 2. false - `custom_queries` override `global_custom_queries`.
+    ## 3. extend - `global_custom_queries` are used in addition to any `custom_queries`.
+    #
+    # use_global_custom_queries: 'true'
 
     ## @param custom_queries - list of mappings - optional
     ## Each query must have 2 fields, and can have a third optional field:

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -124,6 +124,24 @@ instances:
     #
     # command_timeout: 5
 
+    ## @param custom_queries - list of mappings - optional
+    ## Get metrics from a custom SQL query but only if the database is writable
+    ## (i.e. it's the master in an availability group) Notes:
+    ## - Custom SQL query must be defined in its own instance
+    ## - For performance counter queries, use `custom_metrics` instead
+    ## See XXX for more information.
+    #
+    # custom_queries:
+    #   - metric_prefix: sqlserver
+    #     query: <QUERY>
+    #     columns:
+    #     - name: <COLUNMS_1_NAME>
+    #       type: <COLUMNS_1_TYPE>
+    #     - name: <COLUNMS_2_NAME>
+    #       type: <COLUMNS_2_TYPE>
+    #     tags:
+    #     - <TAG_KEY>:<TAG_VALUE>
+
     ## @param stored_procedure - string - optional
     ## Get metrics from custom proc in MyDB but only if the database is writable
     ## (i.e. it's the master in an availability group) Note: Custom proc must be defined in its own instance

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -42,13 +42,9 @@ class CustomQueryMetric(object):
 
                 column_type = column.get('type')
                 if not column_type:
-                    errors.append(
-                        "column field `type` is required for column `{}`".format(name)
-                    )
+                    errors.append("column field `type` is required for column `{}`".format(name))
                 if column_type != 'tag' and not hasattr(AgentCheck, column_type):
-                    errors.append(
-                        "invalid submission method `{}` for column `{}`".format(column_type, name)
-                    )
+                    errors.append("invalid submission method `{}` for column `{}`".format(column_type, name))
         else:
             errors.append("custom query field `columns` is required")
 

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -37,30 +37,30 @@ class CustomQueryMetric(object):
         if not self.query:
             errors.append("custom query field `query` is required for metric_prefix `{}`".format(self.metric_prefix))
 
-        if not self.columns:
+        if self.columns:
+            for column in self.columns:
+                name = column.get('name')
+                if not name:
+                    errors.append("column field `name` is required for metric_prefix `{}`".format(self.metric_prefix))
+
+                column_type = column.get('type')
+                if not column_type:
+                    errors.append(
+                        "column field `type` is required for column `{}` of metric_prefix `{}`".format(
+                            name,
+                            self.metric_prefix,
+                        )
+                    )
+                if column_type != 'tag' and not hasattr(AgentCheck, column_type):
+                    errors.append(
+                        "invalid submission method `{}` for column `{}` of metric_prefix `{}`".format(
+                            column_type,
+                            name,
+                            self.metric_prefix,
+                        )
+                    )
+        else:
             errors.append("custom query field `columns` is required for metric_prefix `{}`".format(self.metric_prefix))
-
-        for column in self.columns:
-            name = column.get('name')
-            if not name:
-                errors.append("column field `name` is required for metric_prefix `{}`".format(self.metric_prefix))
-
-            column_type = column.get('type')
-            if not column_type:
-                errors.append(
-                    "column field `type` is required for column `{}` of metric_prefix `{}`".format(
-                        name,
-                        self.metric_prefix,
-                    )
-                )
-            if column_type != 'tag' and not hasattr(AgentCheck, column_type):
-                errors.append(
-                    "invalid submission method `{}` for column `{}` of metric_prefix `{}`".format(
-                        column_type,
-                        name,
-                        self.metric_prefix,
-                    )
-                )
 
         if errors:
             msg = 'Errors found while validating `custom_queries` configuration instance {}: {}'

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -472,24 +472,6 @@ class SQLServer(AgentCheck):
                 # except Exception as e:
                 #     self.log.warning("Could not fetch metric %s : %s", metric.datadog_name, e)
 
-    def _validate_custom_queries(self):
-        errors = []
-        for custom_query in self.custom_queries:
-            metric_prefix = custom_query.get('metric_prefix')
-            if not metric_prefix:
-                errors.append("custom query field `metric_prefix` is required")
-
-            query = custom_query.get('query')
-            if not query:
-                errors.append("custom query field `query` is required for metric_prefix `%s`", metric_prefix)
-
-            columns = custom_query.get('columns')
-            if not columns:
-                errors.append("custom query field `columns` is required for metric_prefix `%s`", metric_prefix)
-        if errors:
-            msg = 'Errors found while validating `custom_queries` configuration: %s'
-            raise ConfigurationError(msg, ';'.join(errors))
-
     def do_custom_queries(self):
         """
         Fetch metrics from custom SQL queries

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -64,14 +64,12 @@ INSTANCE_AO_DOCKER_SECONDARY = {
 }
 
 CUSTOM_QUERY_A = {
-    'metric_prefix': 'custom',
     'query': "SELECT letter, num FROM (VALUES (97, 'a'), (98, 'b'), (99, 'c')) AS t (num,letter)",
     'columns': [{'name': 'customtag', 'type': 'tag'}, {'name': 'num', 'type': 'gauge'}],
     'tags': ['query:custom'],
 }
 
 CUSTOM_QUERY_B = {
-    'metric_prefix': 'another_custom_one',
     'query': "SELECT letter, num FROM (VALUES (97, 'a'), (98, 'b'), (99, 'c')) AS t (num,letter)",
     'columns': [{'name': 'customtag', 'type': 'tag'}, {'name': 'num', 'type': 'gauge'}],
     'tags': ['query:another_custom_one'],

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -63,6 +63,20 @@ INSTANCE_AO_DOCKER_SECONDARY = {
     'include_ao_metrics': True,
 }
 
+CUSTOM_QUERY_A = {
+    'metric_prefix': 'custom',
+    'query': "SELECT letter, num FROM (VALUES (97, 'a'), (98, 'b'), (99, 'c')) AS t (num,letter)",
+    'columns': [{'name': 'customtag', 'type': 'tag'}, {'name': 'num', 'type': 'gauge'}],
+    'tags': ['query:custom'],
+}
+
+CUSTOM_QUERY_B = {
+    'metric_prefix': 'another_custom_one',
+    'query': "SELECT letter, num FROM (VALUES (97, 'a'), (98, 'b'), (99, 'c')) AS t (num,letter)",
+    'columns': [{'name': 'customtag', 'type': 'tag'}, {'name': 'num', 'type': 'gauge'}],
+    'tags': ['query:another_custom_one'],
+}
+
 INSTANCE_E2E = INSTANCE_DOCKER.copy()
 INSTANCE_E2E['driver'] = 'FreeTDS'
 

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -181,7 +181,7 @@ def test_custom_queries(aggregator, instance_docker):
     instance['custom_queries'] = [querya, queryb]
 
     check = SQLServer(CHECK_NAME, {}, [instance])
-    check.check(instance)
+    check.run()
     tags = list(instance['tags'])
 
     for tag in ('a', 'b', 'c'):

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -189,5 +189,5 @@ def test_custom_queries(aggregator, instance_docker):
         custom_tags = ['customtag:{}'.format(tag)]
         custom_tags.extend(tags)
 
-        aggregator.assert_metric('custom.num', value=value, tags=custom_tags + ['query:custom'])
-        aggregator.assert_metric('another_custom_one.num', value=value, tags=custom_tags + ['query:another_custom_one'])
+        aggregator.assert_metric('sqlserver.num', value=value, tags=custom_tags + ['query:custom'])
+        aggregator.assert_metric('sqlserver.num', value=value, tags=custom_tags + ['query:another_custom_one'])

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -13,7 +13,7 @@ from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.sqlserver import SQLConnectionError
 from datadog_checks.sqlserver.utils import set_default_driver_conf
 
-from .common import CHECK_NAME, CUSTOM_QUERY_A, CUSTOM_QUERY_B, LOCAL_SERVER, assert_metrics
+from .common import CHECK_NAME, LOCAL_SERVER, assert_metrics
 from .utils import windows_ci
 
 # mark the whole module
@@ -62,32 +62,6 @@ def test_set_default_driver_conf():
     with EnvVars({'ODBCSYSINI': 'ABC'}):
         set_default_driver_conf()
         assert os.environ['ODBCSYSINI'] == 'ABC'
-
-
-def test_custom_query_validation(instance_docker):
-    instance = copy.copy(instance_docker)
-
-    # missing query
-    with pytest.raises(ConfigurationError):
-        querya = copy.copy(CUSTOM_QUERY_A)
-        querya.pop('query')
-        instance['custom_queries'] = [querya]
-        SQLServer(CHECK_NAME, {}, [instance])
-
-    # missing columns
-    with pytest.raises(ConfigurationError):
-        querya = copy.copy(CUSTOM_QUERY_A)
-        querya.pop('columns')
-        instance['custom_queries'] = [querya]
-        SQLServer(CHECK_NAME, {}, [instance])
-
-    # invalid type
-    with pytest.raises(ConfigurationError):
-        querya = copy.copy(CUSTOM_QUERY_A)
-        queryb = copy.copy(CUSTOM_QUERY_B)
-        queryb['columns'][1]['type'] = 'notamethod'
-        instance['custom_queries'] = [querya, queryb]
-        SQLServer(CHECK_NAME, {}, [instance])
 
 
 @windows_ci

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -13,7 +13,7 @@ from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.sqlserver import SQLConnectionError
 from datadog_checks.sqlserver.utils import set_default_driver_conf
 
-from .common import CHECK_NAME, LOCAL_SERVER, assert_metrics
+from .common import CHECK_NAME, CUSTOM_QUERY_A, CUSTOM_QUERY_B, LOCAL_SERVER, assert_metrics
 from .utils import windows_ci
 
 # mark the whole module
@@ -62,6 +62,32 @@ def test_set_default_driver_conf():
     with EnvVars({'ODBCSYSINI': 'ABC'}):
         set_default_driver_conf()
         assert os.environ['ODBCSYSINI'] == 'ABC'
+
+
+def test_custom_query_validation(instance_docker):
+    instance = copy.copy(instance_docker)
+
+    # missing query
+    with pytest.raises(ConfigurationError):
+        querya = copy.copy(CUSTOM_QUERY_A)
+        querya.pop('query')
+        instance['custom_queries'] = [querya]
+        SQLServer(CHECK_NAME, {}, [instance])
+
+    # missing columns
+    with pytest.raises(ConfigurationError):
+        querya = copy.copy(CUSTOM_QUERY_A)
+        querya.pop('columns')
+        instance['custom_queries'] = [querya]
+        SQLServer(CHECK_NAME, {}, [instance])
+
+    # invalid type
+    with pytest.raises(ConfigurationError):
+        querya = copy.copy(CUSTOM_QUERY_A)
+        queryb = copy.copy(CUSTOM_QUERY_B)
+        queryb['columns'][1]['type'] = 'notamethod'
+        instance['custom_queries'] = [querya, queryb]
+        SQLServer(CHECK_NAME, {}, [instance])
 
 
 @windows_ci


### PR DESCRIPTION
### What does this PR do?
Adds the ability to configure custom SQL queries for metric extraction from SQL Server.

The approach was heavily influenced by the `postgres` [implementation](https://github.com/DataDog/integrations-core/blob/91203785970f30e95a11f63e73471e267aa330c8/postgres/datadog_checks/postgres/postgres.py#L321) and [associated tests](https://github.com/DataDog/integrations-core/blob/91203785970f30e95a11f63e73471e267aa330c8/postgres/tests/test_custom_metrics.py).  As a result, the queries can be largely open ended as long as they provide extractable data.

Limitations:
- Limited to tables other than performance counters and the `sys.dm_os_performance_counters` table, since those data points require the special handling as done with the myriad of sqlserver metrics classes.  But, if a user chooses to extract specific counters, they can instead use `custom_metrics`.
- Custom queries must be in their own check instance
