### PR TITLE
Add new documentation to explain how to map JKS to PEM files for ZooKeeper SSL

### DIFF
--- a/zk/README.md
+++ b/zk/README.md
@@ -43,8 +43,8 @@ The following example commands assume that your JKS `truststore` and `keystore` 
 - `client_truststore.jks`
 - `client_keystore.jks`
 
-We also assume that both sides' `keystore`s and `truststore`s have each other's certificates with alias `server_cert` and `client_cert`, meaning that a Java ZooKeeper client can already connect to a ZooKeeper server.
-If you need to enter a password, add the option `-tls_private_key_password <PASSWORD>` to each command.
+We also assume that both sides' `keystore`s and `truststore`s have each other's certificates with aliases `server_cert` and `client_cert`, meaning that a Java ZooKeeper client can already connect to a ZooKeeper server.
+If your private key has a password, make sure this password is included in the `config.yaml` file for config option `tls_private_key_password`.
 
 To convert the JKS files to PEM files:
 

--- a/zk/README.md
+++ b/zk/README.md
@@ -43,7 +43,7 @@ The following example commands assume that your JKS `truststore` and `keystore` 
 - `client_truststore.jks`
 - `client_keystore.jks`
 
-We also assume that both sides' `keystore`s and `truststore`s have each other's certificates with aliases `server_cert` and `client_cert`, meaning that a Java ZooKeeper client can already connect to a ZooKeeper server.
+The instructions also assume that both sides' `keystore` and `truststore` files have each other's certificates with aliases `server_cert` and `client_cert`, meaning that a Java ZooKeeper client can already connect to a ZooKeeper server.
 If your private key has a password, make sure this password is included in the `config.yaml` file for config option `tls_private_key_password`.
 
 To convert the JKS files to PEM files:

--- a/zk/README.md
+++ b/zk/README.md
@@ -61,9 +61,12 @@ To convert the JKS files to PEM files:
 3. Get the `private_key.pem` file from `client_keystore.jks`, since the client's `keystore` contains the private key of the client for alias `client-cert`:
     ```
     keytool -importkeystore -srckeystore client_keystore.jks -destkeystore private_key.p12 -srcstoretype jks -deststoretype pkcs12 -srcalias client-cert
+    ```   
+
 4. Run the `openssl pkcs12` command, which exports both the client `cert.pem` and the `private_key.pem` for the certificate, so the Zookeeper integration can use them via the `tls_cert` option. Add `-nodes` to this command if you want to get a non-password-protected `private_key.pem` file:
-    openssl pkcs12 -in private_key.p12 -out private_key.pem
- 
+   ```
+   openssl pkcs12 -in private_key.p12 -out private_key.pem
+   ``` 
 
 #### Log collection
 

--- a/zk/README.md
+++ b/zk/README.md
@@ -61,11 +61,9 @@ To convert the JKS files to PEM files:
 3. Get the `private_key.pem` file from `client_keystore.jks`, since the client's `keystore` contains the private key of the client for alias `client-cert`:
     ```
     keytool -importkeystore -srckeystore client_keystore.jks -destkeystore private_key.p12 -srcstoretype jks -deststoretype pkcs12 -srcalias client-cert
+4. Run the `openssl pkcs12` command, which exports both the client `cert.pem` and the `private_key.pem` for the certificate, so the Zookeeper integration can use them via the `tls_cert` option. Add `-nodes` to this command if you want to get a non-password-protected `private_key.pem` file:
     openssl pkcs12 -in private_key.p12 -out private_key.pem
-    ```
-
-Note: Adding `-nodes` to the `openssl` command is required here if you want to get a non-password protected `private_key.pem`.
-Note2: This exports both the client cert.pem and the `private_key.pem` for the certificate, which makes it easy for the integration to use via the `tls_cert` option.
+ 
 
 #### Log collection
 

--- a/zk/README.md
+++ b/zk/README.md
@@ -50,22 +50,17 @@ To convert the JKS files to PEM files:
 
 1. Get the `ca_cert.pem` file from `client_truststore.jks`, since the client's truststore contains the certificate of the server that is trustable:
     ```
-    keytool -exportcert -file ca_cert.pem -keystore client_truststore.jks -alias server-cert -rfc
+    keytool -exportcert -file ca_cert.pem -keystore client_truststore.jks -alias server_cert -rfc
     ```
    
-2. Get the `cert.pem` file from `server_truststore.jks`, since `server_truststore.jks` contains the trusted certificates of clients connecting to it:
+2. Get the `cert.pem` file from `client_keystore.jks`, since the client's `keystore` contains the cert of the client for alias `client_cert`:
     ```
-    keytool -exportcert -file cert.pem -keystore server_truststore.jks -alias client-cert -rfc
-    ```
-
-3. Get the `private_key.pem` file from `client_keystore.jks`, since the client's `keystore` contains the private key of the client for alias `client-cert`:
-    ```
-    keytool -importkeystore -srckeystore client_keystore.jks -destkeystore private_key.p12 -srcstoretype jks -deststoretype pkcs12 -srcalias client-cert
+    keytool -importkeystore -srckeystore client_keystore.jks -destkeystore cert.p12 -srcstoretype jks -deststoretype pkcs12 -srcalias client_cert
     ```   
 
-4. Run the `openssl pkcs12` command, which exports both the client `cert.pem` and the `private_key.pem` for the certificate, so the ZooKeeper integration can use them via the `tls_cert` option. Add `-nodes` to this command if you want to get a non-password-protected `private_key.pem` file:
+3. Run the `openssl pkcs12` command, which exports both the client cert and the private key for the certificate. The `tls_cert` config option is able to read and parse the PEM file which contains both the cert and private key. Add `-nodes` to this command if you want to get a non-password-protected file:
    ```
-   openssl pkcs12 -in private_key.p12 -out private_key.pem
+   openssl pkcs12 -in cert.p12 -out cert.pem
    ``` 
 
 #### Log collection

--- a/zk/README.md
+++ b/zk/README.md
@@ -53,7 +53,7 @@ To convert the JKS files to PEM files:
     keytool -exportcert -file ca_cert.pem -keystore client_truststore.jks -alias server-cert -rfc
     ```
    
-2. Get the `cert.pem` file from `server_truststore.jks`, since `cert.pem`:
+2. Get the `cert.pem` file from `server_truststore.jks`, since `server_truststore.jks` contains the trusted certificates of clients connecting to it:
     ```
     keytool -exportcert -file cert.pem -keystore server_truststore.jks -alias client-cert -rfc
     ```

--- a/zk/README.md
+++ b/zk/README.md
@@ -1,22 +1,22 @@
-# Agent Check: Zookeeper
+# Agent Check: ZooKeeper
 
-![Zookeeper Dashboard][1]
+![ZooKeeper Dashboard][1]
 
 ## Overview
 
-The Zookeeper check tracks client connections and latencies, monitors the number of unprocessed requests, and more.
+The ZooKeeper check tracks client connections and latencies, monitors the number of unprocessed requests, and more.
 
 ## Setup
 
 ### Installation
 
-The Zookeeper check is included in the [Datadog Agent][3] package, so you don't need to install anything else on your Zookeeper servers.
+The ZooKeeper check is included in the [Datadog Agent][3] package, so you don't need to install anything else on your ZooKeeper servers.
 
 ### Configuration
 
-#### Zookeeper whitelist
+#### ZooKeeper whitelist
 
-As of version 3.5, Zookeeper has a `4lw.commands.whitelist` parameter (see [Zookeeper documentation][7]) that whitelists [four letter word commands][8]. By default, only `srvr` is whitelisted. Add `stat` and `mntr` to the whitelist, as the integration is based on these commands.
+As of version 3.5, ZooKeeper has a `4lw.commands.whitelist` parameter (see [ZooKeeper documentation][7]) that whitelists [four letter word commands][8]. By default, only `srvr` is whitelisted. Add `stat` and `mntr` to the whitelist, as the integration is based on these commands.
 
 <!-- xxx tabs xxx -->
 <!-- xxx tab "Host" xxx -->
@@ -25,16 +25,16 @@ As of version 3.5, Zookeeper has a `4lw.commands.whitelist` parameter (see [Zook
 
 To configure this check for an Agent running on a host:
 
-1. Edit the `zk.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4] to start collecting your Zookeeper [metrics](#metric-collection) and [logs](#log-collection).
+1. Edit the `zk.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4] to start collecting your ZooKeeper [metrics](#metric-collection) and [logs](#log-collection).
    See the [sample zk.d/conf.yaml][5] for all available configuration options.
 
 2. [Restart the Agent][6].
 
 #### Enabling SSL
 
-Zookeeper 3.5 introduced the ability to use SSL authentication. For information about setting up SSL with Zookeeper, see the [Zookeeper SSL User Guide][13]. 
+ZooKeeper 3.5 introduced the ability to use SSL authentication. For information about setting up SSL with ZooKeeper, see the [ZooKeeper SSL User Guide][13]. 
 
-After you have Zookeeper set up with SSL, you can also configure the Datadog Agent to connect to Zookeeper using SSL. If you already have authentication set up using JKS files, follow the steps below to convert them to PEM files for TLS/SSL configuration.
+After you have ZooKeeper set up with SSL, you can also configure the Datadog Agent to connect to ZooKeeper using SSL. If you already have authentication set up using JKS files, follow the steps below to convert them to PEM files for TLS/SSL configuration.
 
 The following example commands assume that your JKS `truststore` and `keystore` files are called:
 
@@ -43,7 +43,7 @@ The following example commands assume that your JKS `truststore` and `keystore` 
 - `client_truststore.jks`
 - `client_keystore.jks`
 
-We also assume that both sides' `keystore`s and `truststore`s have each other's certificates with alias `server_cert` and `client_cert`, meaning that a Java Zookeeper client can already connect to a Zookeeper server.
+We also assume that both sides' `keystore`s and `truststore`s have each other's certificates with alias `server_cert` and `client_cert`, meaning that a Java ZooKeeper client can already connect to a ZooKeeper server.
 If you need to enter a password, add the option `-tls_private_key_password <PASSWORD>` to each command.
 
 To convert the JKS files to PEM files:
@@ -63,7 +63,7 @@ To convert the JKS files to PEM files:
     keytool -importkeystore -srckeystore client_keystore.jks -destkeystore private_key.p12 -srcstoretype jks -deststoretype pkcs12 -srcalias client-cert
     ```   
 
-4. Run the `openssl pkcs12` command, which exports both the client `cert.pem` and the `private_key.pem` for the certificate, so the Zookeeper integration can use them via the `tls_cert` option. Add `-nodes` to this command if you want to get a non-password-protected `private_key.pem` file:
+4. Run the `openssl pkcs12` command, which exports both the client `cert.pem` and the `private_key.pem` for the certificate, so the ZooKeeper integration can use them via the `tls_cert` option. Add `-nodes` to this command if you want to get a non-password-protected `private_key.pem` file:
    ```
    openssl pkcs12 -in private_key.p12 -out private_key.pem
    ``` 
@@ -72,7 +72,7 @@ To convert the JKS files to PEM files:
 
 _Available for Agent versions >6.0_
 
-1. Zookeeper uses the `log4j` logger per default. To activate the logging into a file and customize the format edit the `log4j.properties` file:
+1. ZooKeeper uses the `log4j` logger per default. To activate the logging into a file and customize the format edit the `log4j.properties` file:
 
    ```text
      # Set root logger level to INFO and its only appender to R
@@ -181,7 +181,7 @@ Following metrics are still sent but will be removed eventually:
 
 ### Events
 
-The Zookeeper check does not include any events.
+The ZooKeeper check does not include any events.
 
 ### Service Checks
 
@@ -189,7 +189,7 @@ The Zookeeper check does not include any events.
 Sends `ruok` to the monitored node. Returns `OK` with an `imok` response, `WARN` in the case of a different response and `CRITICAL` if no response is received..
 
 **zookeeper.mode**:<br>
-The Agent submits this service check if `expected_mode` is configured in `zk.yaml`. The check returns `OK` when Zookeeper's actual mode matches `expected_mode`, otherwise returns `CRITICAL`.
+The Agent submits this service check if `expected_mode` is configured in `zk.yaml`. The check returns `OK` when ZooKeeper's actual mode matches `expected_mode`, otherwise returns `CRITICAL`.
 
 ## Troubleshooting
 

--- a/zk/README.md
+++ b/zk/README.md
@@ -32,35 +32,33 @@ To configure this check for an Agent running on a host:
 
 #### Enabling SSL
 
-Zookeeper 3.5 introduced the ability to use SSL authentication. The agent is able to connect to Zookeeper using SSL as well.
+Zookeeper 3.5 introduced the ability to use SSL authentication. For information about setting up SSL with Zookeeper, see the [Zookeeper SSL User Guide][13]. 
 
-One thing to note is that Zookeeper uses `truststores` and `keystores` JKS files while the Agent TLS/SSL configuration uses `tls_ca_cert`, `tls_cert`, and `tls_private_key` config options that accept PEM files.
-It may be confusing at first for those familiar with the JKS files to map to PEM files.
+After you have Zookeeper set up with SSL, you can also configure the Datadog Agent to connect to Zookeeper using SSL. If you already have authentication set up using JKS files, follow the steps below to convert them to PEM files for TLS/SSL configuration.
 
-It is assumed that one already has the server and client truststore and keystore files to start Zookeeper in SSL mode in the first place.
-More information on setting up Zookeeper in SSL mode first can be found [here][13].
+The following example commands assume that your JKS `truststore` and `keystore` files are called:
 
-We will use following files as examples:
 - `server_truststore.jks`
 - `server_keystore.jks` 
 - `client_truststore.jks`
 - `client_keystore.jks`
 
 We also assume that both sides' `keystore`s and `truststore`s have each other's certificates with alias `server_cert` and `client_cert`, meaning that a Java Zookeeper client can already connect to a Zookeeper server.
-You may need to enter a password for these commands, in which case this password should be included in the `tls_private_key_password` config option.
+If you need to enter a password, add the option `-tls_private_key_password <PASSWORD>` to each command.
 
+To convert the JKS files to PEM files:
 
-1. We can get `ca_cert.pem` file from `client_truststore.jks`, since the client's truststore should contain the certificate of the server that is trustable.
+1. Get the `ca_cert.pem` file from `client_truststore.jks`, since the client's truststore contains the certificate of the server that is trustable:
     ```
     keytool -exportcert -file ca_cert.pem -keystore client_truststore.jks -alias server-cert -rfc
     ```
    
-2. Next, we can get `cert.pem` file from `server_truststore.jks`, since `cert.pem` is the certificate of the client.
+2. Get the `cert.pem` file from `server_truststore.jks`, since `cert.pem`:
     ```
     keytool -exportcert -file cert.pem -keystore server_truststore.jks -alias client-cert -rfc
     ```
 
-3. Finally, we will get `private_key.pem` file from `client_keystore.jks`, as the client's `keystore` contains the private key of the client for alias `client-cert`.
+3. Get the `private_key.pem` file from `client_keystore.jks`, since the client's `keystore` contains the private key of the client for alias `client-cert`:
     ```
     keytool -importkeystore -srckeystore client_keystore.jks -destkeystore private_key.p12 -srcstoretype jks -deststoretype pkcs12 -srcalias client-cert
     openssl pkcs12 -in private_key.p12 -out private_key.pem

--- a/zk/README.md
+++ b/zk/README.md
@@ -30,6 +30,59 @@ To configure this check for an Agent running on a host:
 
 2. [Restart the Agent][6].
 
+#### Enabling SSL
+
+Zookeeper 3.5 introduced the ability to use SSL authentication. The agent is able to connect to Zookeeper using SSL as well.
+
+One thing to note is that Zookeeper uses `truststores` and `keystores` JKS files while the Agent TLS/SSL configuration uses `tls_ca_cert`, `tls_cert`, and `tls_private_key` config options that accept PEM files.
+It may be confusing at first for those familiar with the JKS files to map to PEM files.
+
+It is assumed that one already has the server and client truststore and keystore files to start Zookeeper in SSL mode in the first place.
+More information on setting up Zookeeper in SSL mode first can be found [here][13].
+
+We will use following files as examples:
+- `server_truststore.jks`
+- `server_keystore.jks` 
+- `client_truststore.jks`
+- `client_keystore.jks`
+
+We also assume that both sides' `keystore`s and `truststore`s have each other's certificates, meaning that a Java Zookeeper client can already connect to a Zookeeper server.
+
+
+_We first will get `cert.pem` file from `client_truststore.jks`._
+1. Use `keytool` to export `client_truststore.jks` to a PKCS12 file called `cert.p12`:
+    ```
+    keytool -importkeystore -srckeystore client_truststore.jks -destkeystore cert.p12 -srcstoretype jks -deststoretype pkcs12
+    ```
+2. Use `openssl` to export the new PKCS12 `cert.p12` file to `cert.pem` PEM file:
+    ```
+    openssl pkcs12 -in cert.p12 -out cert.pem
+    ```
+
+_Next we will get `ca_cert.pem` file from `server_truststore.jks`._
+1. Use `keytool` to export `server_truststore.jks` to a PKCS12 file called `ca_cert.p12`:
+
+    ```
+    keytool -importkeystore -srckeystore server_truststore.jks -destkeystore ca_cert.p12 -srcstoretype jks -deststoretype pkcs12
+    ```
+2. Use `openssl` to export the new PKCS12 `ca_cert.p12` file to `ca_cert.pem` PEM file:
+    ```
+    openssl pkcs12 -in ca_cert.p12 -out ca_cert.pem
+    ```
+
+_Finally we will get `private_key.pem` file from `client_keystore.jks`._
+1. Use `keytool` to export `client_keystore.jks` to a PKCS12 file called `private_key.p12`:
+    ```
+    keytool -importkeystore -srckeystore client_keystore.jks -destkeystore private_key.p12 -srcstoretype jks -deststoretype pkcs12
+    ```
+   
+2. Use `openssl` to export the new PKCS12 `private_key.p12` file to `private_key.pem` PEM file:
+    ```
+    openssl pkcs12 -in private_key.p12 -out private_key.pem
+    ```
+
+You may need to enter a password for these commands, in which case this password should be included in the `tls_private_key_password` config option.
+
 #### Log collection
 
 _Available for Agent versions >6.0_
@@ -169,3 +222,4 @@ Need help? Contact [Datadog support][11].
 [10]: https://github.com/DataDog/integrations-core/blob/master/zk/metadata.csv
 [11]: https://docs.datadoghq.com/help/
 [12]: https://docs.datadoghq.com/agent/kubernetes/log/
+[13]: https://cwiki.apache.org/confluence/display/ZOOKEEPER/ZooKeeper+SSL+User+Guide


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR does two things:
- Add new documentation to the README to help users understand how to map ZooKeeper's JKS file format to PEM file format. 
- Change `Zookeeper` to `ZooKeeper` to be more aligned with Apache's standards.

### Motivation
<!-- What inspired you to submit this pull request? -->

In https://github.com/DataDog/integrations-core/pull/7884, SSL support was added for the ZooKeeper check. Customers that are used to ZooKeeper's JKS file format may not be familiar with PEM file format, hence this documentation update to help map JKS to PEM.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
