### PR TITLE
[SNMP] add table recording example to docs

### DIFF
--- a/docs/developer/tutorials/snmp/how-to.md
+++ b/docs/developer/tutorials/snmp/how-to.md
@@ -233,7 +233,7 @@ snmpwalk -v 2c -c public -OentU 127.0.0.1:1161 1.3.6.1.2.1.2.2
 
 ## Generate table simulation data
 
-If you'd like to generate [simulation data for tables](./sim-format.md#tables) automatically, you can use the [`mib2dev.py`](https://github.com/etingof/snmpsim/blob/master/docs/source/documentation/building-simulation-data.rst#examples) tool shipped with `snmpsim`. (This tool will be renamed as `snmpsim-record-mibs` in the upcoming 1.0 release of the library.)
+To generate [simulation data for tables](./sim-format.md#tables) automatically, use the [`mib2dev.py`](https://github.com/etingof/snmpsim/blob/master/docs/source/documentation/building-simulation-data.rst#examples) tool shipped with `snmpsim`. This tool will be renamed as `snmpsim-record-mibs` in the upcoming 1.0 release of the library.
 
 First, install snmpsim:
 
@@ -249,7 +249,7 @@ For example:
 mib2dev.py --mib-module=<MIB> --start-oid=1.3.6.1.4.1.674.10892.1.400.20 --stop-oid=1.3.6.1.4.1.674.10892.1.600.12 > /path/to/mytable.snmprec
 ```
 
-The following command will generate 4 rows for the `IF-MIB:ifTable (1.3.6.1.2.1.2.2)`:
+The following command generates 4 rows for the `IF-MIB:ifTable (1.3.6.1.2.1.2.2)`:
 
 ```bash
 mib2dev.py --mib-module=IF-MIB --start-oid=1.3.6.1.2.1.2.2 --stop-oid=1.3.6.1.2.1.2.3 --table-size=4 > /path/to/mytable.snmprec

--- a/docs/developer/tutorials/snmp/how-to.md
+++ b/docs/developer/tutorials/snmp/how-to.md
@@ -249,6 +249,13 @@ For example:
 mib2dev.py --mib-module=<MIB> --start-oid=1.3.6.1.4.1.674.10892.1.400.20 --stop-oid=1.3.6.1.4.1.674.10892.1.600.12 > /path/to/mytable.snmprec
 ```
 
+The following command will generate 4 rows for the `IF-MIB:ifTable (1.3.6.1.2.1.2.2)`:
+
+```bash
+mib2dev.py --mib-module=IF-MIB --start-oid=1.3.6.1.2.1.2.2 --stop-oid=1.3.6.1.2.1.2.3 --table-size=4 > /path/to/mytable.snmprec
+```
+
+
 ## Generate simulation data from a walk
 
 As an alternative to [`.snmprec` files](./sim-format.md), it is possible to [use a walk as simulation data](http://snmplabs.com/snmpsim/documentation/building-simulation-data.html#using-snmpwalk-reporting). This is especially useful when debugging live devices, since you can export the device walk and use this real data locally.

--- a/docs/developer/tutorials/snmp/how-to.md
+++ b/docs/developer/tutorials/snmp/how-to.md
@@ -255,6 +255,19 @@ The following command generates 4 rows for the `IF-MIB:ifTable (1.3.6.1.2.1.2.2)
 mib2dev.py --mib-module=IF-MIB --start-oid=1.3.6.1.2.1.2.2 --stop-oid=1.3.6.1.2.1.2.3 --table-size=4 > /path/to/mytable.snmprec
 ```
 
+### Known issues
+`mib2dev` has a known issue with `IF-MIB::ifPhysAddress`, that is expected to contain an hexadecimal string, but `mib2dev` fills it with a string. To fix this, provide a valid hextring when prompted on the command line:
+
+```bash
+# Synthesizing row #1 of table 1.3.6.1.2.1.2.2.1
+*** Inconsistent value: Display format eval failure: b'driving kept zombies quaintly forward zombies': invalid literal for int() with base 16: 'driving kept zombies quaintly forward zombies'caused by <class 'ValueError'>: invalid literal for int() with base 16: 'driving kept zombies quaintly forward zombies'
+*** See constraints and suggest a better one for:
+# Table IF-MIB::ifTable
+# Row IF-MIB::ifEntry
+# Index IF-MIB::ifIndex (type InterfaceIndex)
+# Column IF-MIB::ifPhysAddress (type PhysAddress)
+# Value ['driving kept zombies quaintly forward zombies'] ? 001122334455
+```
 
 ## Generate simulation data from a walk
 

--- a/docs/developer/tutorials/snmp/how-to.md
+++ b/docs/developer/tutorials/snmp/how-to.md
@@ -233,7 +233,7 @@ snmpwalk -v 2c -c public -OentU 127.0.0.1:1161 1.3.6.1.2.1.2.2
 
 ## Generate table simulation data
 
-If you'd like to generate [simulation data for tables](./sim-format.md#tables) automatically, you can use the [`mib2dev.py`](http://snmplabs.com/snmpsim/documentation/building-simulation-data.html?highlight=snmpsim-record-mibs#examples) tool shipped with `snmpsim`. (This tool will be renamed as `snmpsim-record-mibs` in the upcoming 1.0 release of the library.)
+If you'd like to generate [simulation data for tables](./sim-format.md#tables) automatically, you can use the [`mib2dev.py`](https://github.com/etingof/snmpsim/blob/master/docs/source/documentation/building-simulation-data.rst#examples) tool shipped with `snmpsim`. (This tool will be renamed as `snmpsim-record-mibs` in the upcoming 1.0 release of the library.)
 
 First, install snmpsim:
 


### PR DESCRIPTION
### What does this PR do?
Adding an example to show how to use `mib2dev.py` to generate multiple rows for a table with the `--table-size`. Also replacing the `snmp` doc link with the github repo's, as `snmp` website is down 😞

### Motivation
We recently stumbled upon data generation and found this command very useful.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
