### PR TITLE
[network] Set the collect_connection_queues parameter default value to false

### DIFF
--- a/network/README.md
+++ b/network/README.md
@@ -40,13 +40,13 @@ sudo modprobe nf_conntrack_ipv6
      - collect_connection_state: false
 
      ## @param collect_connection_queues - boolean - optional
-     ## Set to false to disable connection queues collection
+     ## Set to true to enable connection queues collection
      ## Note: connection queues collections require both
      ## `collect_connection_state` and `collect_connection_queues` to be true
      ## because it also requires the command `ss` from system package `iproute2` or
      ## the command `netstat` from the system package `net-tools` to be installed
      #
-     - collect_connection_queues: true
+     - collect_connection_queues: false
    ```
 
 2. [Restart the Agent][5] to effect any configuration changes.

--- a/network/assets/configuration/spec.yaml
+++ b/network/assets/configuration/spec.yaml
@@ -23,13 +23,13 @@ files:
               type: boolean
           - name: collect_connection_queues
             description: |
-              Set to false to disable connection queues collection
+              Set to true to enable connection queues collection
               Note: connection queues collections require both
               `collect_connection_state` and `collect_connection_queues` to be true
               because it also requires the command `ss` from system package `iproute2` or
               the command `netstat` from the system package `net-tools` to be installed
             value:
-              example: true
+              example: false
               type: boolean
           - name: excluded_interfaces
             description: List of interface to exclude from the check.

--- a/network/datadog_checks/network/data/conf.yaml.default
+++ b/network/datadog_checks/network/data/conf.yaml.default
@@ -15,14 +15,14 @@ instances:
     #
   - collect_connection_state: false
 
-    ## @param collect_connection_queues - boolean - optional - default: true
-    ## Set to false to disable connection queues collection
+    ## @param collect_connection_queues - boolean - optional - default: false
+    ## Set to true to enable connection queues collection
     ## Note: connection queues collections require both
     ## `collect_connection_state` and `collect_connection_queues` to be true
     ## because it also requires the command `ss` from system package `iproute2` or
     ## the command `netstat` from the system package `net-tools` to be installed
     #
-    # collect_connection_queues: true
+    # collect_connection_queues: false
 
     ## @param excluded_interfaces - list of strings - optional
     ## List of interface to exclude from the check.

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -61,7 +61,7 @@ class Network(AgentCheck):
             )
 
         self._collect_cx_state = instance.get('collect_connection_state', False)
-        self._collect_cx_queues = instance.get('collect_connection_queues', True)
+        self._collect_cx_queues = instance.get('collect_connection_queues', False)
         self._collect_rate_metrics = instance.get('collect_rate_metrics', True)
         self._collect_count_metrics = instance.get('collect_count_metrics', False)
 

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -370,7 +370,7 @@ def test_ss_with_custom_procfs(is_linux, is_bsd, is_solaris, is_windows, aggrega
         check._get_net_proc_base_location = lambda x: "/something/proc"
         check.check(instance)
         get_subprocess_output.assert_called_with(
-            ["sh", "-c", "ss --numeric --tcp --all --ipv6"],
+            ["sh", "-c", "ss --numeric --udp --all --ipv6 | wc -l"],
             check.log,
             env={'PROC_ROOT': "/something/proc", 'PATH': os.environ["PATH"]},
         )


### PR DESCRIPTION
### What does this PR do?

Set the `collect_connection_queues` parameter default value to `false`.

### Motivation

On hosts which have a huge number of connection, the extra CPU and memory consumed 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
