### PR TITLE
Add Mapping index to tag string value documentation

### DIFF
--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -277,7 +277,7 @@ External table indexes must be a subset of the indexes of the current table, or 
 
 ##### Using an index
 
-Note: Here, "_index_" refers to one of the values in the `INDEX` field of the table MIB definition.
+Important: "_index_" refers to one digit of the index part of the OID. Example, if the column OID is `1.2.3.1.2` and the row OID is `1.2.3.1.2.7.8.9`, the full index is `7.8.9`. In this example, when using `index: 1`, we will refer to `7`, `index: 2` will refer to `8`, and so on. 
 
 ```yaml
 metrics:
@@ -314,7 +314,6 @@ metrics:
 You can use the following syntax to map indexes to tag string values.
 In the example below, the submitted metrics will be `snmp.ipSystemStatsHCInReceives` with tags like `ipversion:ipv6`.
 
-
 ```yaml
 metrics:
 - MIB: IP-MIB
@@ -336,6 +335,9 @@ metrics:
       4: ipv6z
       16: dns
 ```
+
+See meaning of index as used here in [Using an index](#using-an-index) section.
+
 
 ##### Tagging tips
 

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -277,7 +277,7 @@ External table indexes must be a subset of the indexes of the current table, or 
 
 ##### Using an index
 
-Important: "_index_" refers to one digit of the index part of the OID. Example, if the column OID is `1.2.3.1.2` and the row OID is `1.2.3.1.2.7.8.9`, the full index is `7.8.9`. In this example, when using `index: 1`, we will refer to `7`, `index: 2` will refer to `8`, and so on. 
+Important: "_index_" refers to one digit of the index part of the row OID. Example, if the column OID is `1.2.3.1.2` and the row OID is `1.2.3.1.2.7.8.9`, the full index is `7.8.9`. In this example, when using `index: 1`, we will refer to `7`, `index: 2` will refer to `8`, and so on.
 
 ```yaml
 metrics:

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -311,8 +311,8 @@ metrics:
 
 ##### Mapping index to tag string value
 
-You can use the following syntax to map index to tags string value.
-In the example below, the metrics will be `snmp.ipSystemStatsHCInReceives` with tags like `ipversion:ipv6`.
+You can use the following syntax to map indexes to tag string values.
+In the example below, the submitted metrics will be `snmp.ipSystemStatsHCInReceives` with tags like `ipversion:ipv6`.
 
 
 ```yaml

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -309,6 +309,36 @@ metrics:
         index: 1
 ```
 
+##### Mapping index to tag string value
+
+You can use the following syntax to map index to tags string value.
+In the example below, the metrics will be `snmp.ipSystemStatsHCInReceives` with tags like `ipversion:ipv6`.
+
+
+```yaml
+metrics:
+- MIB: IP-MIB
+  table:
+    OID: 1.3.6.1.2.1.4.31.1
+    name: ipSystemStatsTable
+  forced_type: monotonic_count
+  symbols:
+  - OID: 1.3.6.1.2.1.4.31.1.1.4
+    name: ipSystemStatsHCInReceives
+  metric_tags:
+  - index: 1
+    tag: ipversion
+    mapping:
+      0: unknown
+      1: ipv4
+      2: ipv6
+      3: ipv4z
+      4: ipv6z
+      16: dns
+```
+
+##### Tagging tips
+
 !!! note
     General guidelines on [Datadog tagging](https://docs.datadoghq.com/tagging/) also apply to table metric tags.
 


### PR DESCRIPTION
### What does this PR do?

Add Mapping index to tag string value

### Motivation

The doc was missing, example:

https://github.com/DataDog/integrations-core/blob/ccd8854297c40c6df8b6b5543445a349c4c3193a/snmp/datadog_checks/snmp/data/profiles/_generic-ip.yaml#L68-L77

