### PR TITLE
Move connection initialization outside init function

### DIFF
--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -53,6 +53,7 @@ INSTANCE_DOCKER = {
     'include_task_scheduler_metrics': True,
     'include_db_fragmentation_metrics': True,
     'include_fci_metrics': True,
+    'include_ao_metrics': False,
 }
 
 INSTANCE_AO_DOCKER_SECONDARY = {

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -6,7 +6,7 @@ from copy import copy, deepcopy
 import pytest
 
 from datadog_checks.sqlserver import SQLServer
-from datadog_checks.sqlserver.sqlserver import SQLConnectionError
+from datadog_checks.sqlserver.connection import SQLConnectionError
 
 from .common import CHECK_NAME, CUSTOM_QUERY_A, CUSTOM_QUERY_B, assert_metrics
 from .utils import not_windows_ci
@@ -26,9 +26,9 @@ def test_check_invalid_password(aggregator, init_config, instance_docker):
 
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
 
-    with pytest.raises(SQLConnectionError) as excinfo:
+    with pytest.raises(SQLConnectionError):
+        sqlserver_check.initialize_connection()
         sqlserver_check.check(instance_docker)
-        assert excinfo.value.args[0] == 'Unable to connect to SQL Server'
     aggregator.assert_service_check(
         'sqlserver.can_connect',
         status=sqlserver_check.CRITICAL,
@@ -38,7 +38,7 @@ def test_check_invalid_password(aggregator, init_config, instance_docker):
 
 def test_check_docker(aggregator, init_config, instance_docker):
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
-    sqlserver_check.check(instance_docker)
+    sqlserver_check.run()
     expected_tags = instance_docker.get('tags', []) + ['host:{}'.format(instance_docker.get('host')), 'db:master']
     assert_metrics(aggregator, expected_tags)
 
@@ -115,7 +115,7 @@ def test_check_stored_procedure(aggregator, init_config, instance_docker):
     load_stored_procedure(instance_pass, proc, sp_tags)
 
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_pass])
-    sqlserver_check.check(instance_docker)
+    sqlserver_check.run()
 
     expected_tags = instance_pass.get('tags', []) + sp_tags.split(',')
     aggregator.assert_metric('sql.sp.testa', value=100, tags=expected_tags, count=1)
@@ -134,7 +134,7 @@ def test_check_stored_procedure_proc_if(aggregator, init_config, instance_docker
     load_stored_procedure(instance_fail, proc, sp_tags)
 
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_fail])
-    sqlserver_check.check(instance_fail)
+    sqlserver_check.run()
 
     # apply a proc check that will never fail and assert that the metrics remain unchanged
     assert len(aggregator._metrics) == 0
@@ -143,7 +143,7 @@ def test_check_stored_procedure_proc_if(aggregator, init_config, instance_docker
 def test_custom_metrics_object_name(aggregator, init_config_object_name, instance_docker):
 
     sqlserver_check = SQLServer(CHECK_NAME, init_config_object_name, [instance_docker])
-    sqlserver_check.check(instance_docker)
+    sqlserver_check.run()
 
     aggregator.assert_metric('sqlserver.cache.hit_ratio', tags=['optional:tag1', 'optional_tag:tag1'], count=1)
     aggregator.assert_metric('sqlserver.active_requests', tags=['optional:tag1', 'optional_tag:tag1'], count=1)
@@ -154,7 +154,7 @@ def test_custom_metrics_alt_tables(aggregator, init_config_alt_tables, instance_
     instance['include_task_scheduler_metrics'] = False
 
     sqlserver_check = SQLServer(CHECK_NAME, init_config_alt_tables, [instance])
-    sqlserver_check.check(instance_docker)
+    sqlserver_check.run()
 
     aggregator.assert_metric('sqlserver.LCK_M_S.max_wait_time_ms', tags=['optional:tag1'], count=1)
     aggregator.assert_metric('sqlserver.LCK_M_S.signal_wait_time_ms', tags=['optional:tag1'], count=1)
@@ -166,7 +166,7 @@ def test_custom_metrics_alt_tables(aggregator, init_config_alt_tables, instance_
     )
 
     # check a second time for io metrics to be processed
-    sqlserver_check.check(instance_docker)
+    sqlserver_check.run()
 
     aggregator.assert_metric('sqlserver.io_file_stats.num_of_reads')
     aggregator.assert_metric('sqlserver.io_file_stats.num_of_writes')

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -149,12 +149,12 @@ def test_custom_metrics_object_name(aggregator, dd_run_check, init_config_object
     aggregator.assert_metric('sqlserver.active_requests', tags=['optional:tag1', 'optional_tag:tag1'], count=1)
 
 
-def test_custom_metrics_alt_tables(aggregator, init_config_alt_tables, instance_docker):
+def test_custom_metrics_alt_tables(aggregator, dd_run_check, init_config_alt_tables, instance_docker):
     instance = deepcopy(instance_docker)
     instance['include_task_scheduler_metrics'] = False
 
     sqlserver_check = SQLServer(CHECK_NAME, init_config_alt_tables, [instance])
-    sqlserver_check.run()
+    dd_run_check(sqlserver_check)
 
     aggregator.assert_metric('sqlserver.LCK_M_S.max_wait_time_ms', tags=['optional:tag1'], count=1)
     aggregator.assert_metric('sqlserver.LCK_M_S.signal_wait_time_ms', tags=['optional:tag1'], count=1)
@@ -166,7 +166,7 @@ def test_custom_metrics_alt_tables(aggregator, init_config_alt_tables, instance_
     )
 
     # check a second time for io metrics to be processed
-    sqlserver_check.run()
+    dd_run_check(sqlserver_check)
 
     aggregator.assert_metric('sqlserver.io_file_stats.num_of_reads')
     aggregator.assert_metric('sqlserver.io_file_stats.num_of_writes')
@@ -174,14 +174,14 @@ def test_custom_metrics_alt_tables(aggregator, init_config_alt_tables, instance_
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_custom_queries(aggregator, instance_docker):
+def test_custom_queries(aggregator, dd_run_check, instance_docker):
     instance = copy(instance_docker)
     querya = copy(CUSTOM_QUERY_A)
     queryb = copy(CUSTOM_QUERY_B)
     instance['custom_queries'] = [querya, queryb]
 
     check = SQLServer(CHECK_NAME, {}, [instance])
-    check.run()
+    dd_run_check(check)
     tags = list(instance['tags'])
 
     for tag in ('a', 'b', 'c'):

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -69,20 +69,20 @@ def test_set_default_driver_conf():
 
 
 @windows_ci
-def test_check_local(aggregator, init_config, instance_sql2017):
+def test_check_local(aggregator, dd_run_check, init_config, instance_sql2017):
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_sql2017])
-    sqlserver_check.run()
+    dd_run_check(sqlserver_check)
     expected_tags = instance_sql2017.get('tags', []) + ['host:{}'.format(LOCAL_SERVER), 'db:master']
     assert_metrics(aggregator, expected_tags)
 
 
 @windows_ci
 @pytest.mark.parametrize('adoprovider', ['SQLOLEDB', 'SQLNCLI11'])
-def test_check_adoprovider(aggregator, init_config, instance_sql2017, adoprovider):
+def test_check_adoprovider(aggregator, dd_run_check, init_config, instance_sql2017, adoprovider):
     instance = copy.deepcopy(instance_sql2017)
     instance['adoprovider'] = adoprovider
 
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance])
-    sqlserver_check.run()
+    dd_run_check(sqlserver_check)
     expected_tags = instance.get('tags', []) + ['host:{}'.format(LOCAL_SERVER), 'db:master']
     assert_metrics(aggregator, expected_tags)

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -26,6 +26,7 @@ def test_get_cursor(instance_sql2017):
     connection pool is empty or the params for `get_cursor` are invalid.
     """
     check = SQLServer(CHECK_NAME, {}, [instance_sql2017])
+    check.initialize_connection()
     with pytest.raises(SQLConnectionError):
         check.connection.get_cursor('foo')
 
@@ -36,10 +37,12 @@ def test_missing_db(instance_sql2017):
     with mock.patch('datadog_checks.sqlserver.connection.Connection.check_database', return_value=(False, 'db')):
         with pytest.raises(ConfigurationError):
             check = SQLServer(CHECK_NAME, {}, [instance])
+            check.initialize_connection()
 
     instance['ignore_missing_database'] = True
     with mock.patch('datadog_checks.sqlserver.connection.Connection.check_database', return_value=(False, 'db')):
         check = SQLServer(CHECK_NAME, {}, [instance])
+        check.initialize_connection()
         assert check.do_check is False
 
 
@@ -67,7 +70,7 @@ def test_set_default_driver_conf():
 @windows_ci
 def test_check_local(aggregator, init_config, instance_sql2017):
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_sql2017])
-    sqlserver_check.check(instance_sql2017)
+    sqlserver_check.run()
     expected_tags = instance_sql2017.get('tags', []) + ['host:{}'.format(LOCAL_SERVER), 'db:master']
     assert_metrics(aggregator, expected_tags)
 
@@ -79,6 +82,6 @@ def test_check_adoprovider(aggregator, init_config, instance_sql2017, adoprovide
     instance['adoprovider'] = adoprovider
 
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance])
-    sqlserver_check.check(instance)
+    sqlserver_check.run()
     expected_tags = instance.get('tags', []) + ['host:{}'.format(LOCAL_SERVER), 'db:master']
     assert_metrics(aggregator, expected_tags)

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -31,7 +31,7 @@ def test_get_cursor(instance_sql2017):
         check.connection.get_cursor('foo')
 
 
-def test_missing_db(instance_sql2017):
+def test_missing_db(instance_sql2017, dd_run_check):
     instance = copy.copy(instance_sql2017)
     instance['ignore_missing_database'] = False
     with mock.patch('datadog_checks.sqlserver.connection.Connection.check_database', return_value=(False, 'db')):
@@ -43,6 +43,7 @@ def test_missing_db(instance_sql2017):
     with mock.patch('datadog_checks.sqlserver.connection.Connection.check_database', return_value=(False, 'db')):
         check = SQLServer(CHECK_NAME, {}, [instance])
         check.initialize_connection()
+        dd_run_check(check)
         assert check.do_check is False
 
 


### PR DESCRIPTION
### What does this PR do?
This minor change works around a possible bug with service check handling during initialization.

It was observed that running `ddev env check sqlserver py38-default` with multiple check instances configured would result in service checks showing up under the first check config.  By moving the connection checks outside of `__init__`, the resulting service checks appear in the correct place.

The underlying cause is still TBD, but it's deemed to be relatively minor in any case - the service checks only get conflated on check startup, but subsequent checks are associated correctly.

A separate PR to update best practices in the docs will follow.

