### PR TITLE
Add deprecation notice for metric[].name syntax

### DIFF
--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -155,6 +155,8 @@ def _parse_oid_metric(metric):
     """
     Parse a fully resolved OID/name metric.
 
+    Note: This OID/name syntax is deprecated in favour of symbol.OID/symbol.name syntax.
+
     Example:
 
     ```

--- a/snmp/datadog_checks/snmp/parsing/metrics.py
+++ b/snmp/datadog_checks/snmp/parsing/metrics.py
@@ -155,7 +155,7 @@ def _parse_oid_metric(metric):
     """
     Parse a fully resolved OID/name metric.
 
-    Note: This OID/name syntax is deprecated in favour of symbol.OID/symbol.name syntax.
+    Note: This `OID/name` syntax is deprecated in favour of `symbol` syntax.
 
     Example:
 


### PR DESCRIPTION
Add deprecation notice for metric[].name syntax