### PR TITLE
Change rates from metadata.csv into gauges with a per_unit_name of se…

### DIFF
--- a/varnish/metadata.csv
+++ b/varnish/metadata.csv
@@ -1,343 +1,343 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 varnish.accept_fail,gauge,,connection,,Accept failures. This metric is only provided by varnish 3.x.,0,varnish,accept fail
-varnish.backend_busy,rate,,connection,,Maximum number of connections to a given backend.,0,varnish,backend busy
-varnish.backend_conn,rate,,connection,,Successful connections to a given backend.,0,varnish,backend conn
-varnish.backend_fail,rate,,connection,,Failed connections for a given backend.,0,varnish,backend fail
-varnish.backend_recycle,rate,,connection,,Backend connections with keep-alive that are returned to the pool of connections.,0,varnish,backend recycle
-varnish.backend_req,rate,,request,,Backend requests.,0,varnish,backend req
-varnish.backend_retry,rate,,connection,,Backend connection retries.,0,varnish,backend retry
-varnish.backend_reuse,rate,,connection,,Recycled connections that has were reused.,0,varnish,backend reuse
-varnish.backend_toolate,rate,,connection,,Backend connections closed because they were idle too long.,0,varnish,backend toolate
-varnish.backend_unhealthy,rate,,connection,,Backend connections not tried because the backend was unhealthy.,0,varnish,backend unhealthy
+varnish.backend_busy,gauge,,connection,second,Maximum number of connections to a given backend.,0,varnish,backend busy
+varnish.backend_conn,gauge,,connection,second,Successful connections to a given backend.,0,varnish,backend conn
+varnish.backend_fail,gauge,,connection,second,Failed connections for a given backend.,0,varnish,backend fail
+varnish.backend_recycle,gauge,,connection,second,Backend connections with keep-alive that are returned to the pool of connections.,0,varnish,backend recycle
+varnish.backend_req,gauge,,request,second,Backend requests.,0,varnish,backend req
+varnish.backend_retry,gauge,,connection,second,Backend connection retries.,0,varnish,backend retry
+varnish.backend_reuse,gauge,,connection,second,Recycled connections that has were reused.,0,varnish,backend reuse
+varnish.backend_toolate,gauge,,connection,second,Backend connections closed because they were idle too long.,0,varnish,backend toolate
+varnish.backend_unhealthy,gauge,,connection,second,Backend connections not tried because the backend was unhealthy.,0,varnish,backend unhealthy
 varnish.bans,gauge,,object,,"Bans in system, including bans superseded by newer bans and bans already checked by the ban-lurker. This metric is only provided by varnish >=4.x.",0,varnish,bans
-varnish.bans_added,rate,,object,,Bans added to ban list. This metric is only provided by varnish >=4.x.,0,varnish,bans added
+varnish.bans_added,gauge,,object,second,Bans added to ban list. This metric is only provided by varnish >=4.x.,0,varnish,bans added
 varnish.bans_completed,gauge,,object,,"Bans which are no longer active, either because they got checked by the ban-lurker or superseded by newer identical bans. This metric is only provided by varnish >=4.x.",0,varnish,bans completed
-varnish.bans_deleted,rate,,object,,Bans deleted from ban list. This metric is only provided by varnish >=4.x.,0,varnish,bans deleted
-varnish.bans_dups,rate,,object,,Bans replaced by later identical bans. This metric is only provided by varnish >=4.x.,0,varnish,bans duplicated
-varnish.bans_lurker_contention,rate,,event,,Times the ban-lurker waited for lookups. This metric is only provided by varnish >=4.x.,0,varnish,bans lurker contention
-varnish.bans_lurker_obj_killed,rate,,object,,Objects killed by ban-lurker. This metric is only provided by varnish >=4.x.,0,varnish,bans lurker obj killed
-varnish.bans_lurker_tested,rate,,object,,Bans and objects tested against each other by the ban-lurker. This metric is only provided by varnish >=4.x.,0,varnish,bans lurker tested
-varnish.bans_lurker_tests_tested,rate,,object,,Tests and objects tested against each other by the ban-lurker. 'ban req.url == foo && req.http.host == bar' counts as one in 'bans_tested' and as two in 'bans_tests_tested'. This metric is only provided by varnish >=4.x.,0,varnish,bans lurker tests tested
+varnish.bans_deleted,gauge,,object,second,Bans deleted from ban list. This metric is only provided by varnish >=4.x.,0,varnish,bans deleted
+varnish.bans_dups,gauge,,object,second,Bans replaced by later identical bans. This metric is only provided by varnish >=4.x.,0,varnish,bans duplicated
+varnish.bans_lurker_contention,gauge,,event,second,Times the ban-lurker waited for lookups. This metric is only provided by varnish >=4.x.,0,varnish,bans lurker contention
+varnish.bans_lurker_obj_killed,gauge,,object,second,Objects killed by ban-lurker. This metric is only provided by varnish >=4.x.,0,varnish,bans lurker obj killed
+varnish.bans_lurker_tested,gauge,,object,second,Bans and objects tested against each other by the ban-lurker. This metric is only provided by varnish >=4.x.,0,varnish,bans lurker tested
+varnish.bans_lurker_tests_tested,gauge,,object,second,Tests and objects tested against each other by the ban-lurker. 'ban req.url == foo && req.http.host == bar' counts as one in 'bans_tested' and as two in 'bans_tests_tested'. This metric is only provided by varnish >=4.x.,0,varnish,bans lurker tests tested
 varnish.bans_obj,gauge,,object,,Bans which use obj.* variables. These bans can possibly be washed by the ban-lurker. This metric is only provided by varnish >=4.x.,0,varnish,bans obj
-varnish.bans_obj_killed,rate,,object,,Objects killed by bans during object lookup. This metric is only provided by varnish >=4.x.,0,varnish,bans obj killed
+varnish.bans_obj_killed,gauge,,object,second,Objects killed by bans during object lookup. This metric is only provided by varnish >=4.x.,0,varnish,bans obj killed
 varnish.bans_persisted_bytes,gauge,,byte,,Bytes used by the persisted ban lists. This metric is only provided by varnish >=4.x.,0,varnish,bans persisted bytes
 varnish.bans_persisted_fragmentation,gauge,,byte,,Extra bytes accumulated through dropped and completed bans in the persistent ban lists. This metric is only provided by varnish >=4.x.,0,varnish,bans persisted fragmentation
 varnish.bans_req,gauge,,object,,Bans which use req.* variables. These bans can not be washed by the ban-lurker. This metric is only provided by varnish >=4.x.,0,varnish,bans req
-varnish.bans_tested,rate,,object,,Bans and objects tested against each other during hash lookup. This metric is only provided by varnish >=4.x.,0,varnish,bans tested
-varnish.bans_tests_tested,rate,,object,,Tests and objects tested against each other during lookup. 'ban req.url == foo && req.http.host == bar' counts as one in 'bans_tested' and as two in 'bans_tests_tested'. This metric is only provided by varnish >=4.x.,0,varnish,bans tests tested
-varnish.busy_sleep,rate,,request,,Requests sent to sleep without a worker thread because they found a busy object. This metric is only provided by varnish >=4.x.,0,varnish,busy sleep
-varnish.busy_wakeup,rate,,request,,Requests taken off the busy object sleep list and and rescheduled. This metric is only provided by varnish >=4.x.,0,varnish,busy wakeup
-varnish.cache_hit,rate,,request,,Requests served from the cache.,0,varnish,hit
-varnish.cache_hitpass,rate,,request,,Requests passed to a backend where the decision to pass them found in the cache.,0,varnish,hitpass
-varnish.cache_miss,rate,,request,,Requests fetched from a backend server.,0,varnish,miss
+varnish.bans_tested,gauge,,object,second,Bans and objects tested against each other during hash lookup. This metric is only provided by varnish >=4.x.,0,varnish,bans tested
+varnish.bans_tests_tested,gauge,,object,second,Tests and objects tested against each other during lookup. 'ban req.url == foo && req.http.host == bar' counts as one in 'bans_tested' and as two in 'bans_tests_tested'. This metric is only provided by varnish >=4.x.,0,varnish,bans tests tested
+varnish.busy_sleep,gauge,,request,second,Requests sent to sleep without a worker thread because they found a busy object. This metric is only provided by varnish >=4.x.,0,varnish,busy sleep
+varnish.busy_wakeup,gauge,,request,second,Requests taken off the busy object sleep list and and rescheduled. This metric is only provided by varnish >=4.x.,0,varnish,busy wakeup
+varnish.cache_hit,gauge,,request,second,Requests served from the cache.,0,varnish,hit
+varnish.cache_hitpass,gauge,,request,second,Requests passed to a backend where the decision to pass them found in the cache.,0,varnish,hitpass
+varnish.cache_miss,gauge,,request,second,Requests fetched from a backend server.,0,varnish,miss
 varnish.client_conn,gauge,,connection,,Client connections accepted. This metric is only provided by varnish 3.x.,0,varnish,client conn
 varnish.client_drop,gauge,,connection,,"Client connection dropped, no session. This metric is only provided by varnish 3.x.",0,varnish,client drop
 varnish.client_drop_late,gauge,,connection,,Client connection dropped late. This metric is only provided by varnish 3.x.,0,varnish,client drop late
-varnish.client_req,rate,,request,,Parseable client requests seen.,0,varnish,client req
-varnish.client_req_400,rate,,request,,Requests that were malformed in some drastic way. This metric is only provided by varnish >=4.x.,-1,varnish,client req 400
-varnish.client_req_411,rate,,request,,Requests that were missing a Content-Length: header. This metric is only provided by varnish >=4.x.,-1,varnish,client req 411
-varnish.client_req_413,rate,,request,,Requests that were too big. This metric is only provided by varnish >=4.x.,-1,varnish,client req 413
-varnish.client_req_417,rate,,request,,Requests with a bad Expect: header. This metric is only provided by varnish >=4.x.,-1,varnish,client req 417
-varnish.dir_dns_cache_full,rate,,event,,DNS director full DNS cache. This metric is only provided by varnish 3.x.,0,varnish,dir dns cache full
-varnish.dir_dns_failed,rate,,event,,DNS director failed lookup. This metric is only provided by varnish 3.x.,0,varnish,dir dns fail
-varnish.dir_dns_hit,rate,,event,,DNS director cached lookup hit. This metric is only provided by varnish 3.x.,0,varnish,dir dns hit
-varnish.dir_dns_lookups,rate,,event,,DNS director lookups. This metric is only provided by varnish 3.x.,0,varnish,dir dns lookups
-varnish.esi_errors,rate,,event,,Edge Side Includes (ESI) parse errors.,0,varnish,esi errors
-varnish.esi_warnings,rate,,event,,Edge Side Includes (ESI) parse warnings.,0,varnish,esi warnings
-varnish.exp_mailed,rate,,object,,Objects mailed to expiry thread for handling. This metric is only provided by varnish >=4.x.,0,varnish,exp mailed
-varnish.exp_received,rate,,object,,Objects received by expiry thread for handling. This metric is only provided by varnish >=4.x.,0,varnish,exp received
-varnish.fetch_1xx,rate,,response,,Back end response with no body because of 1XX response (Informational).,0,varnish,fetch 1xx
-varnish.fetch_204,rate,,response,,Back end response with no body because of 204 response (No Content).,0,varnish,fetch 204
-varnish.fetch_304,rate,,response,,Back end response with no body because of 304 response (Not Modified).,0,varnish,fetch 304
-varnish.fetch_bad,rate,,response,,Back end response's body length could not be determined and/or had bad headers.,-1,varnish,fetch bad
-varnish.fetch_chunked,rate,,response,,Back end response bodies that were chunked.,0,varnish,fetch chunked
-varnish.fetch_close,rate,,response,,Fetch wanted close.,0,varnish,fetch close
-varnish.fetch_eof,rate,,response,,Back end response bodies with EOF.,0,varnish,fetch eof
-varnish.fetch_failed,rate,,response,,Back end response fetches that failed.,-1,varnish,fetch failed
-varnish.fetch_head,rate,,response,,Back end HEAD requests.,0,varnish,fetch head
-varnish.fetch_length,rate,,response,,Back end response bodies with Content-Length.,0,varnish,fetch length
-varnish.fetch_no_thread,rate,,response,,Back end fetches that failed because no thread was available. This metric is only provided by varnish >=4.x.,-1,varnish,fetch no thread
-varnish.fetch_oldhttp,rate,,response,,Number of responses served by backends with http < 1.1,0,varnish,fetch oldhttp
-varnish.fetch_zero,rate,,response,,Number of responses that have zero length.,0,varnish,fetch zero
-varnish.hcb_insert,rate,,event,,HCB inserts.,0,varnish,HCB insert
-varnish.hcb_lock,rate,,event,,HCB lookups with lock.,0,varnish,HCB lock
-varnish.hcb_nolock,rate,,event,,HCB lookups without lock.,0,varnish,HCB nolock
+varnish.client_req,gauge,,request,second,Parseable client requests seen.,0,varnish,client req
+varnish.client_req_400,gauge,,request,second,Requests that were malformed in some drastic way. This metric is only provided by varnish >=4.x.,-1,varnish,client req 400
+varnish.client_req_411,gauge,,request,second,Requests that were missing a Content-Length: header. This metric is only provided by varnish >=4.x.,-1,varnish,client req 411
+varnish.client_req_413,gauge,,request,second,Requests that were too big. This metric is only provided by varnish >=4.x.,-1,varnish,client req 413
+varnish.client_req_417,gauge,,request,second,Requests with a bad Expect: header. This metric is only provided by varnish >=4.x.,-1,varnish,client req 417
+varnish.dir_dns_cache_full,gauge,,event,second,DNS director full DNS cache. This metric is only provided by varnish 3.x.,0,varnish,dir dns cache full
+varnish.dir_dns_failed,gauge,,event,second,DNS director failed lookup. This metric is only provided by varnish 3.x.,0,varnish,dir dns fail
+varnish.dir_dns_hit,gauge,,event,second,DNS director cached lookup hit. This metric is only provided by varnish 3.x.,0,varnish,dir dns hit
+varnish.dir_dns_lookups,gauge,,event,second,DNS director lookups. This metric is only provided by varnish 3.x.,0,varnish,dir dns lookups
+varnish.esi_errors,gauge,,event,second,Edge Side Includes (ESI) parse errors.,0,varnish,esi errors
+varnish.esi_warnings,gauge,,event,second,Edge Side Includes (ESI) parse warnings.,0,varnish,esi warnings
+varnish.exp_mailed,gauge,,object,second,Objects mailed to expiry thread for handling. This metric is only provided by varnish >=4.x.,0,varnish,exp mailed
+varnish.exp_received,gauge,,object,second,Objects received by expiry thread for handling. This metric is only provided by varnish >=4.x.,0,varnish,exp received
+varnish.fetch_1xx,gauge,,response,second,Back end response with no body because of 1XX response (Informational).,0,varnish,fetch 1xx
+varnish.fetch_204,gauge,,response,second,Back end response with no body because of 204 response (No Content).,0,varnish,fetch 204
+varnish.fetch_304,gauge,,response,second,Back end response with no body because of 304 response (Not Modified).,0,varnish,fetch 304
+varnish.fetch_bad,gauge,,response,second,Back end response's body length could not be determined and/or had bad headers.,-1,varnish,fetch bad
+varnish.fetch_chunked,gauge,,response,second,Back end response bodies that were chunked.,0,varnish,fetch chunked
+varnish.fetch_close,gauge,,response,second,Fetch wanted close.,0,varnish,fetch close
+varnish.fetch_eof,gauge,,response,second,Back end response bodies with EOF.,0,varnish,fetch eof
+varnish.fetch_failed,gauge,,response,second,Back end response fetches that failed.,-1,varnish,fetch failed
+varnish.fetch_head,gauge,,response,second,Back end HEAD requests.,0,varnish,fetch head
+varnish.fetch_length,gauge,,response,second,Back end response bodies with Content-Length.,0,varnish,fetch length
+varnish.fetch_no_thread,gauge,,response,second,Back end fetches that failed because no thread was available. This metric is only provided by varnish >=4.x.,-1,varnish,fetch no thread
+varnish.fetch_oldhttp,gauge,,response,second,Number of responses served by backends with http < 1.1,0,varnish,fetch oldhttp
+varnish.fetch_zero,gauge,,response,second,Number of responses that have zero length.,0,varnish,fetch zero
+varnish.hcb_insert,gauge,,event,second,HCB inserts.,0,varnish,HCB insert
+varnish.hcb_lock,gauge,,event,second,HCB lookups with lock.,0,varnish,HCB lock
+varnish.hcb_nolock,gauge,,event,second,HCB lookups without lock.,0,varnish,HCB nolock
 varnish.LCK.backend.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,backend colls
-varnish.LCK.backend.creat,rate,,lock,,Created locks.,0,varnish,backend create
-varnish.LCK.backend.destroy,rate,,lock,,Destroyed locks.,0,varnish,backend destroy
-varnish.LCK.backend.locks,rate,,lock,,Lock operations.,0,varnish,backend locks
+varnish.LCK.backend.creat,gauge,,lock,second,Created locks.,0,varnish,backend create
+varnish.LCK.backend.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,backend destroy
+varnish.LCK.backend.locks,gauge,,lock,second,Lock operations.,0,varnish,backend locks
 varnish.LCK.ban.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,ban colls
-varnish.LCK.ban.creat,rate,,lock,,Created locks.,0,varnish,ban create
-varnish.LCK.ban.destroy,rate,,lock,,Destroyed locks.,0,varnish,ban destroy
-varnish.LCK.ban.locks,rate,,lock,,Lock operations.,0,varnish,ban locks
-varnish.LCK.busyobj.creat,rate,,lock,,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,busyobj create
-varnish.LCK.busyobj.destroy,rate,,lock,,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,busyobj destroy
-varnish.LCK.busyobj.locks,rate,,lock,,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,busyobj locks
+varnish.LCK.ban.creat,gauge,,lock,second,Created locks.,0,varnish,ban create
+varnish.LCK.ban.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,ban destroy
+varnish.LCK.ban.locks,gauge,,lock,second,Lock operations.,0,varnish,ban locks
+varnish.LCK.busyobj.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,busyobj create
+varnish.LCK.busyobj.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,busyobj destroy
+varnish.LCK.busyobj.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,busyobj locks
 varnish.LCK.cli.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,cli colls
-varnish.LCK.cli.creat,rate,,lock,,Created locks.,0,varnish,cli create
-varnish.LCK.cli.destroy,rate,,lock,,Destroyed locks.,0,varnish,cli destroy
-varnish.LCK.cli.locks,rate,,lock,,Lock operations.,0,varnish,cli locks
+varnish.LCK.cli.creat,gauge,,lock,second,Created locks.,0,varnish,cli create
+varnish.LCK.cli.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,cli destroy
+varnish.LCK.cli.locks,gauge,,lock,second,Lock operations.,0,varnish,cli locks
 varnish.LCK.exp.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,exp colls
-varnish.LCK.exp.creat,rate,,lock,,Created locks.,0,varnish,exp create
-varnish.LCK.exp.destroy,rate,,lock,,Destroyed locks.,0,varnish,exp destroy
-varnish.LCK.exp.locks,rate,,lock,,Lock operations.,0,varnish,exp locks
+varnish.LCK.exp.creat,gauge,,lock,second,Created locks.,0,varnish,exp create
+varnish.LCK.exp.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,exp destroy
+varnish.LCK.exp.locks,gauge,,lock,second,Lock operations.,0,varnish,exp locks
 varnish.LCK.hcb.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,hcb colls
-varnish.LCK.hcb.creat,rate,,lock,,Created locks.,0,varnish,hcb create
-varnish.LCK.hcb.destroy,rate,,lock,,Destroyed locks.,0,varnish,hcb destroy
-varnish.LCK.hcb.locks,rate,,lock,,Lock operations.,0,varnish,hcb locks
+varnish.LCK.hcb.creat,gauge,,lock,second,Created locks.,0,varnish,hcb create
+varnish.LCK.hcb.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,hcb destroy
+varnish.LCK.hcb.locks,gauge,,lock,second,Lock operations.,0,varnish,hcb locks
 varnish.LCK.hcl.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,hcl colls
-varnish.LCK.hcl.creat,rate,,lock,,Created locks.,0,varnish,hcl create
-varnish.LCK.hcl.destroy,rate,,lock,,Destroyed locks.,0,varnish,hcl destroy
-varnish.LCK.hcl.locks,rate,,lock,,Lock operations.,0,varnish,hcl locks
+varnish.LCK.hcl.creat,gauge,,lock,second,Created locks.,0,varnish,hcl create
+varnish.LCK.hcl.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,hcl destroy
+varnish.LCK.hcl.locks,gauge,,lock,second,Lock operations.,0,varnish,hcl locks
 varnish.LCK.herder.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,herder colls
-varnish.LCK.herder.creat,rate,,lock,,Created locks.,0,varnish,herder create
-varnish.LCK.herder.destroy,rate,,lock,,Destroyed locks.,0,varnish,herder destroy
-varnish.LCK.herder.locks,rate,,lock,,Lock operations.,0,varnish,herder locks
+varnish.LCK.herder.creat,gauge,,lock,second,Created locks.,0,varnish,herder create
+varnish.LCK.herder.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,herder destroy
+varnish.LCK.herder.locks,gauge,,lock,second,Lock operations.,0,varnish,herder locks
 varnish.LCK.hsl.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,hsl colls
-varnish.LCK.hsl.creat,rate,,lock,,Created locks.,0,varnish,hsl create
-varnish.LCK.hsl.destroy,rate,,lock,,Destroyed locks.,0,varnish,hsl destroy
-varnish.LCK.hsl.locks,rate,,lock,,Lock operations.,0,varnish,hsl locks
+varnish.LCK.hsl.creat,gauge,,lock,second,Created locks.,0,varnish,hsl create
+varnish.LCK.hsl.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,hsl destroy
+varnish.LCK.hsl.locks,gauge,,lock,second,Lock operations.,0,varnish,hsl locks
 varnish.LCK.lru.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,lru colls
-varnish.LCK.lru.creat,rate,,lock,,Created locks.,0,varnish,lru create
-varnish.LCK.lru.destroy,rate,,lock,,Destroyed locks.,0,varnish,lru destroy
-varnish.LCK.lru.locks,rate,,lock,,Lock operations.,0,varnish,lru locks
-varnish.LCK.mempool.creat,rate,,lock,,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,mempool create
-varnish.LCK.mempool.destroy,rate,,lock,,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,mempool destroy
-varnish.LCK.mempool.locks,rate,,lock,,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,mempool locks
-varnish.LCK.nbusyobj.creat,rate,,lock,,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,nbusyobj create
-varnish.LCK.nbusyobj.destroy,rate,,lock,,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,nbusyobj destroy
-varnish.LCK.nbusyobj.locks,rate,,lock,,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,nbusyobj locks
+varnish.LCK.lru.creat,gauge,,lock,second,Created locks.,0,varnish,lru create
+varnish.LCK.lru.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,lru destroy
+varnish.LCK.lru.locks,gauge,,lock,second,Lock operations.,0,varnish,lru locks
+varnish.LCK.mempool.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,mempool create
+varnish.LCK.mempool.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,mempool destroy
+varnish.LCK.mempool.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,mempool locks
+varnish.LCK.nbusyobj.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,nbusyobj create
+varnish.LCK.nbusyobj.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,nbusyobj destroy
+varnish.LCK.nbusyobj.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,nbusyobj locks
 varnish.LCK.objhdr.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,objhdr colls
-varnish.LCK.objhdr.creat,rate,,lock,,Created locks.,0,varnish,objhdr create
-varnish.LCK.objhdr.destroy,rate,,lock,,Destroyed locks.,0,varnish,objhdr destroy
-varnish.LCK.objhdr.locks,rate,,lock,,Lock operations.,0,varnish,objhdr locks
-varnish.LCK.pipestat.creat,rate,,lock,,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,pipestat create
-varnish.LCK.pipestat.destroy,rate,,lock,,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,pipestat destroy
-varnish.LCK.pipestat.locks,rate,,lock,,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,pipestat locks
-varnish.LCK.sess.creat,rate,,lock,,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,sess create
-varnish.LCK.sess.destroy,rate,,lock,,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,sess destroy
-varnish.LCK.sess.locks,rate,,lock,,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,sess locks
+varnish.LCK.objhdr.creat,gauge,,lock,second,Created locks.,0,varnish,objhdr create
+varnish.LCK.objhdr.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,objhdr destroy
+varnish.LCK.objhdr.locks,gauge,,lock,second,Lock operations.,0,varnish,objhdr locks
+varnish.LCK.pipestat.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,pipestat create
+varnish.LCK.pipestat.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,pipestat destroy
+varnish.LCK.pipestat.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,pipestat locks
+varnish.LCK.sess.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,sess create
+varnish.LCK.sess.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,sess destroy
+varnish.LCK.sess.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,sess locks
 varnish.LCK.sessmem.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,sessmem colls
-varnish.LCK.sessmem.creat,rate,,lock,,Created locks.,0,varnish,sessmem create
-varnish.LCK.sessmem.destroy,rate,,lock,,Destroyed locks.,0,varnish,sessmem destroy
-varnish.LCK.sessmem.locks,rate,,lock,,Lock operations.,0,varnish,sessmem locks
+varnish.LCK.sessmem.creat,gauge,,lock,second,Created locks.,0,varnish,sessmem create
+varnish.LCK.sessmem.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,sessmem destroy
+varnish.LCK.sessmem.locks,gauge,,lock,second,Lock operations.,0,varnish,sessmem locks
 varnish.LCK.sma.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,sma colls
-varnish.LCK.sma.creat,rate,,lock,,Created locks.,0,varnish,sma create
-varnish.LCK.sma.destroy,rate,,lock,,Destroyed locks.,0,varnish,sma destroy
-varnish.LCK.sma.locks,rate,,lock,,Lock operations.,0,varnish,sma locks
+varnish.LCK.sma.creat,gauge,,lock,second,Created locks.,0,varnish,sma create
+varnish.LCK.sma.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,sma destroy
+varnish.LCK.sma.locks,gauge,,lock,second,Lock operations.,0,varnish,sma locks
 varnish.LCK.smf.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,smf colls
-varnish.LCK.smf.creat,rate,,lock,,Created locks.,0,varnish,smf create
-varnish.LCK.smf.destroy,rate,,lock,,Destroyed locks.,0,varnish,smf destroy
-varnish.LCK.smf.locks,rate,,lock,,Lock operations.,0,varnish,smf locks
+varnish.LCK.smf.creat,gauge,,lock,second,Created locks.,0,varnish,smf create
+varnish.LCK.smf.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,smf destroy
+varnish.LCK.smf.locks,gauge,,lock,second,Lock operations.,0,varnish,smf locks
 varnish.LCK.smp.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,smp colls
-varnish.LCK.smp.creat,rate,,lock,,Created locks.,0,varnish,smp create
-varnish.LCK.smp.destroy,rate,,lock,,Destroyed locks.,0,varnish,smp destroy
-varnish.LCK.smp.locks,rate,,lock,,Lock operations.,0,varnish,smp locks
+varnish.LCK.smp.creat,gauge,,lock,second,Created locks.,0,varnish,smp create
+varnish.LCK.smp.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,smp destroy
+varnish.LCK.smp.locks,gauge,,lock,second,Lock operations.,0,varnish,smp locks
 varnish.LCK.sms.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,sms colls
-varnish.LCK.sms.creat,rate,,lock,,Created locks.,0,varnish,sms create
-varnish.LCK.sms.destroy,rate,,lock,,Destroyed locks.,0,varnish,sms destroy
-varnish.LCK.sms.locks,rate,,lock,,Lock operations.,0,varnish,sms locks
+varnish.LCK.sms.creat,gauge,,lock,second,Created locks.,0,varnish,sms create
+varnish.LCK.sms.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,sms destroy
+varnish.LCK.sms.locks,gauge,,lock,second,Lock operations.,0,varnish,sms locks
 varnish.LCK.stat.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,stat colls
-varnish.LCK.stat.creat,rate,,lock,,Created locks. This metric is only provided by varnish 3.x.,0,varnish,stat create
-varnish.LCK.stat.destroy,rate,,lock,,Destroyed locks. This metric is only provided by varnish 3.x.,0,varnish,stat destroy
-varnish.LCK.stat.locks,rate,,lock,,Lock operations. This metric is only provided by varnish 3.x.,0,varnish,stat locks
+varnish.LCK.stat.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish 3.x.,0,varnish,stat create
+varnish.LCK.stat.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish 3.x.,0,varnish,stat destroy
+varnish.LCK.stat.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish 3.x.,0,varnish,stat locks
 varnish.LCK.vbe.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,vbe colls
-varnish.LCK.vbe.creat,rate,,lock,,Created locks. This metric is only provided by varnish 3.x.,0,varnish,vbe create
-varnish.LCK.vbe.destroy,rate,,lock,,Destroyed locks. This metric is only provided by varnish 3.x.,0,varnish,vbe destroy
-varnish.LCK.vbe.locks,rate,,lock,,Lock operations. This metric is only provided by varnish 3.x.,0,varnish,vbe locks
+varnish.LCK.vbe.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish 3.x.,0,varnish,vbe create
+varnish.LCK.vbe.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish 3.x.,0,varnish,vbe destroy
+varnish.LCK.vbe.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish 3.x.,0,varnish,vbe locks
 varnish.LCK.vbp.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,vbp colls
-varnish.LCK.vbp.creat,rate,,lock,,Created locks.,0,varnish,vbp create
-varnish.LCK.vbp.destroy,rate,,lock,,Destroyed locks.,0,varnish,vbp destroy
-varnish.LCK.vbp.locks,rate,,lock,,Lock operations.,0,varnish,vbp locks
-varnish.LCK.vcapace.creat,rate,,lock,,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,vcapace create
-varnish.LCK.vcapace.destroy,rate,,lock,,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,vcapace destroy
-varnish.LCK.vcapace.locks,rate,,lock,,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,vcapace locks
+varnish.LCK.vbp.creat,gauge,,lock,second,Created locks.,0,varnish,vbp create
+varnish.LCK.vbp.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,vbp destroy
+varnish.LCK.vbp.locks,gauge,,lock,second,Lock operations.,0,varnish,vbp locks
+varnish.LCK.vcapace.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,vcapace create
+varnish.LCK.vcapace.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,vcapace destroy
+varnish.LCK.vcapace.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,vcapace locks
 varnish.LCK.vcl.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,vcl colls
-varnish.LCK.vcl.creat,rate,,lock,,Created locks.,0,varnish,vcl create
-varnish.LCK.vcl.destroy,rate,,lock,,Destroyed locks.,0,varnish,vcl destroy
-varnish.LCK.vcl.locks,rate,,lock,,Lock operations.,0,varnish,vcl locks
-varnish.LCK.vxid.creat,rate,,lock,,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,vxid create
-varnish.LCK.vxid.destroy,rate,,lock,,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,vxid destroy
-varnish.LCK.vxid.locks,rate,,lock,,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,vxid locks
+varnish.LCK.vcl.creat,gauge,,lock,second,Created locks.,0,varnish,vcl create
+varnish.LCK.vcl.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,vcl destroy
+varnish.LCK.vcl.locks,gauge,,lock,second,Lock operations.,0,varnish,vcl locks
+varnish.LCK.vxid.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,vxid create
+varnish.LCK.vxid.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,vxid destroy
+varnish.LCK.vxid.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,vxid locks
 varnish.LCK.wq.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,wq colls
-varnish.LCK.wq.creat,rate,,lock,,Created locks.,0,varnish,wq create
-varnish.LCK.wq.destroy,rate,,lock,,Destroyed locks.,0,varnish,wq destroy
-varnish.LCK.wq.locks,rate,,lock,,Lock operations.,0,varnish,wq locks
+varnish.LCK.wq.creat,gauge,,lock,second,Created locks.,0,varnish,wq create
+varnish.LCK.wq.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,wq destroy
+varnish.LCK.wq.locks,gauge,,lock,second,Lock operations.,0,varnish,wq locks
 varnish.LCK.wstat.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,wstat colls
-varnish.LCK.wstat.creat,rate,,lock,,Created locks.,0,varnish,wstat create
-varnish.LCK.wstat.destroy,rate,,lock,,Destroyed locks.,0,varnish,wstat destroy
-varnish.LCK.wstat.locks,rate,,lock,,Lock operations.,0,varnish,wstat locks
-varnish.losthdr,rate,,event,,HTTP header overflows.,-1,varnish,lost headers
-varnish.MEMPOOL.busyobj.allocs,rate,,event,,Allocations. This metric is only provided by varnish >=4.x.,0,varnish,busyobj allocs
-varnish.MEMPOOL.busyobj.frees,rate,,event,,Frees. This metric is only provided by varnish >=4.x.,0,varnish,busyobj frees
+varnish.LCK.wstat.creat,gauge,,lock,second,Created locks.,0,varnish,wstat create
+varnish.LCK.wstat.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,wstat destroy
+varnish.LCK.wstat.locks,gauge,,lock,second,Lock operations.,0,varnish,wstat locks
+varnish.losthdr,gauge,,event,second,HTTP header overflows.,-1,varnish,lost headers
+varnish.MEMPOOL.busyobj.allocs,gauge,,event,second,Allocations. This metric is only provided by varnish >=4.x.,0,varnish,busyobj allocs
+varnish.MEMPOOL.busyobj.frees,gauge,,event,second,Frees. This metric is only provided by varnish >=4.x.,0,varnish,busyobj frees
 varnish.MEMPOOL.busyobj.live,gauge,,,,In use. This metric is only provided by varnish >=4.x.,0,varnish,busyobj live
 varnish.MEMPOOL.busyobj.pool,gauge,,,,In pool. This metric is only provided by varnish >=4.x.,0,varnish,busyobj pool
-varnish.MEMPOOL.busyobj.randry,rate,,event,,Pool ran dry. This metric is only provided by varnish >=4.x.,0,varnish,busyobj randry
-varnish.MEMPOOL.busyobj.recycle,rate,,event,,Recycled from pool. This metric is only provided by varnish >=4.x.,0,varnish,busyobj recycle
-varnish.MEMPOOL.busyobj.surplus,rate,,event,,Too many for pool. This metric is only provided by varnish >=4.x.,0,varnish,busyobj surplus
+varnish.MEMPOOL.busyobj.randry,gauge,,event,second,Pool ran dry. This metric is only provided by varnish >=4.x.,0,varnish,busyobj randry
+varnish.MEMPOOL.busyobj.recycle,gauge,,event,second,Recycled from pool. This metric is only provided by varnish >=4.x.,0,varnish,busyobj recycle
+varnish.MEMPOOL.busyobj.surplus,gauge,,event,second,Too many for pool. This metric is only provided by varnish >=4.x.,0,varnish,busyobj surplus
 varnish.MEMPOOL.busyobj.sz_needed,gauge,,byte,,Size allocated. This metric is only provided by varnish >=4.x.,0,varnish,busyobj sz_needed
 varnish.MEMPOOL.busyobj.sz_wanted,gauge,,byte,,Size requested. This metric is only provided by varnish >=4.x.,0,varnish,busyobj sz_wanted
-varnish.MEMPOOL.busyobj.timeout,rate,,event,,Timed out from pool. This metric is only provided by varnish >=4.x.,0,varnish,busyobj timeout
-varnish.MEMPOOL.busyobj.toosmall,rate,,event,,Too small to recycle. This metric is only provided by varnish >=4.x.,0,varnish,busyobj toosmall
-varnish.MEMPOOL.req0.allocs,rate,,event,,Allocations. This metric is only provided by varnish >=4.x.,0,varnish,req0 allocs
-varnish.MEMPOOL.req0.frees,rate,,event,,Frees. This metric is only provided by varnish >=4.x.,0,varnish,req0 frees
+varnish.MEMPOOL.busyobj.timeout,gauge,,event,second,Timed out from pool. This metric is only provided by varnish >=4.x.,0,varnish,busyobj timeout
+varnish.MEMPOOL.busyobj.toosmall,gauge,,event,second,Too small to recycle. This metric is only provided by varnish >=4.x.,0,varnish,busyobj toosmall
+varnish.MEMPOOL.req0.allocs,gauge,,event,second,Allocations. This metric is only provided by varnish >=4.x.,0,varnish,req0 allocs
+varnish.MEMPOOL.req0.frees,gauge,,event,second,Frees. This metric is only provided by varnish >=4.x.,0,varnish,req0 frees
 varnish.MEMPOOL.req0.live,gauge,,,,In use. This metric is only provided by varnish >=4.x.,0,varnish,req0 live
 varnish.MEMPOOL.req0.pool,gauge,,,,In pool. This metric is only provided by varnish >=4.x.,0,varnish,req0 pool
-varnish.MEMPOOL.req0.randry,rate,,event,,Pool ran dry. This metric is only provided by varnish >=4.x.,0,varnish,req0 randry
-varnish.MEMPOOL.req0.recycle,rate,,event,,Recycled from pool. This metric is only provided by varnish >=4.x.,0,varnish,req0 recycle
-varnish.MEMPOOL.req0.surplus,rate,,event,,Too many for pool. This metric is only provided by varnish >=4.x.,0,varnish,req0 surplus
+varnish.MEMPOOL.req0.randry,gauge,,event,second,Pool ran dry. This metric is only provided by varnish >=4.x.,0,varnish,req0 randry
+varnish.MEMPOOL.req0.recycle,gauge,,event,second,Recycled from pool. This metric is only provided by varnish >=4.x.,0,varnish,req0 recycle
+varnish.MEMPOOL.req0.surplus,gauge,,event,second,Too many for pool. This metric is only provided by varnish >=4.x.,0,varnish,req0 surplus
 varnish.MEMPOOL.req0.sz_needed,gauge,,byte,,Size allocated. This metric is only provided by varnish >=4.x.,0,varnish,req0 sz_needed
 varnish.MEMPOOL.req0.sz_wanted,gauge,,byte,,Size requested. This metric is only provided by varnish >=4.x.,0,varnish,req0 sz_wanted
-varnish.MEMPOOL.req0.timeout,rate,,event,,Timed out from pool. This metric is only provided by varnish >=4.x.,0,varnish,req0 timeout
-varnish.MEMPOOL.req0.toosmall,rate,,event,,Too small to recycle. This metric is only provided by varnish >=4.x.,0,varnish,req0 toosmall
-varnish.MEMPOOL.req1.allocs,rate,,event,,Allocations. This metric is only provided by varnish >=4.x.,0,varnish,req1 allocs
-varnish.MEMPOOL.req1.frees,rate,,event,,Frees. This metric is only provided by varnish >=4.x.,0,varnish,req1 frees
+varnish.MEMPOOL.req0.timeout,gauge,,event,second,Timed out from pool. This metric is only provided by varnish >=4.x.,0,varnish,req0 timeout
+varnish.MEMPOOL.req0.toosmall,gauge,,event,second,Too small to recycle. This metric is only provided by varnish >=4.x.,0,varnish,req0 toosmall
+varnish.MEMPOOL.req1.allocs,gauge,,event,second,Allocations. This metric is only provided by varnish >=4.x.,0,varnish,req1 allocs
+varnish.MEMPOOL.req1.frees,gauge,,event,second,Frees. This metric is only provided by varnish >=4.x.,0,varnish,req1 frees
 varnish.MEMPOOL.req1.live,gauge,,,,In use. This metric is only provided by varnish >=4.x.,0,varnish,req1 live
 varnish.MEMPOOL.req1.pool,gauge,,,,In pool. This metric is only provided by varnish >=4.x.,0,varnish,req1 pool
-varnish.MEMPOOL.req1.randry,rate,,event,,Pool ran dry. This metric is only provided by varnish >=4.x.,0,varnish,req1 randry
-varnish.MEMPOOL.req1.recycle,rate,,event,,Recycled from pool. This metric is only provided by varnish >=4.x.,0,varnish,req1 recycle
-varnish.MEMPOOL.req1.surplus,rate,,event,,Too many for pool. This metric is only provided by varnish >=4.x.,0,varnish,req1 surplus
+varnish.MEMPOOL.req1.randry,gauge,,event,second,Pool ran dry. This metric is only provided by varnish >=4.x.,0,varnish,req1 randry
+varnish.MEMPOOL.req1.recycle,gauge,,event,second,Recycled from pool. This metric is only provided by varnish >=4.x.,0,varnish,req1 recycle
+varnish.MEMPOOL.req1.surplus,gauge,,event,second,Too many for pool. This metric is only provided by varnish >=4.x.,0,varnish,req1 surplus
 varnish.MEMPOOL.req1.sz_needed,gauge,,byte,,Size allocated. This metric is only provided by varnish >=4.x.,0,varnish,req1 sz_needed
 varnish.MEMPOOL.req1.sz_wanted,gauge,,byte,,Size requested. This metric is only provided by varnish >=4.x.,0,varnish,req1 sz_wanted
-varnish.MEMPOOL.req1.timeout,rate,,event,,Timed out from pool. This metric is only provided by varnish >=4.x.,0,varnish,req1 timeout
-varnish.MEMPOOL.req1.toosmall,rate,,event,,Too small to recycle. This metric is only provided by varnish >=4.x.,0,varnish,req1 toosmall
-varnish.MEMPOOL.sess0.allocs,rate,,event,,Allocations. This metric is only provided by varnish >=4.x.,0,varnish,sess0 allocs
-varnish.MEMPOOL.sess0.frees,rate,,event,,Frees. This metric is only provided by varnish >=4.x.,0,varnish,sess0 frees
+varnish.MEMPOOL.req1.timeout,gauge,,event,second,Timed out from pool. This metric is only provided by varnish >=4.x.,0,varnish,req1 timeout
+varnish.MEMPOOL.req1.toosmall,gauge,,event,second,Too small to recycle. This metric is only provided by varnish >=4.x.,0,varnish,req1 toosmall
+varnish.MEMPOOL.sess0.allocs,gauge,,event,second,Allocations. This metric is only provided by varnish >=4.x.,0,varnish,sess0 allocs
+varnish.MEMPOOL.sess0.frees,gauge,,event,second,Frees. This metric is only provided by varnish >=4.x.,0,varnish,sess0 frees
 varnish.MEMPOOL.sess0.live,gauge,,,,In use. This metric is only provided by varnish >=4.x.,0,varnish,sess0 live
 varnish.MEMPOOL.sess0.pool,gauge,,,,In pool. This metric is only provided by varnish >=4.x.,0,varnish,sess0 pool
-varnish.MEMPOOL.sess0.randry,rate,,event,,Pool ran dry. This metric is only provided by varnish >=4.x.,0,varnish,sess0 randry
-varnish.MEMPOOL.sess0.recycle,rate,,event,,Recycled from pool. This metric is only provided by varnish >=4.x.,0,varnish,sess0 recycle
-varnish.MEMPOOL.sess0.surplus,rate,,event,,Too many for pool. This metric is only provided by varnish >=4.x.,0,varnish,sess0 surplus
+varnish.MEMPOOL.sess0.randry,gauge,,event,second,Pool ran dry. This metric is only provided by varnish >=4.x.,0,varnish,sess0 randry
+varnish.MEMPOOL.sess0.recycle,gauge,,event,second,Recycled from pool. This metric is only provided by varnish >=4.x.,0,varnish,sess0 recycle
+varnish.MEMPOOL.sess0.surplus,gauge,,event,second,Too many for pool. This metric is only provided by varnish >=4.x.,0,varnish,sess0 surplus
 varnish.MEMPOOL.sess0.sz_needed,gauge,,byte,,Size allocated. This metric is only provided by varnish >=4.x.,0,varnish,sess0 sz_needed
 varnish.MEMPOOL.sess0.sz_wanted,gauge,,byte,,Size requested. This metric is only provided by varnish >=4.x.,0,varnish,sess0 sz_wanted
-varnish.MEMPOOL.sess0.timeout,rate,,event,,Timed out from pool. This metric is only provided by varnish >=4.x.,0,varnish,sess0 timeout
-varnish.MEMPOOL.sess0.toosmall,rate,,event,,Too small to recycle. This metric is only provided by varnish >=4.x.,0,varnish,sess0 toosmall
-varnish.MEMPOOL.sess1.allocs,rate,,event,,Allocations. This metric is only provided by varnish >=4.x.,0,varnish,sess1 allocs
-varnish.MEMPOOL.sess1.frees,rate,,event,,Frees. This metric is only provided by varnish >=4.x.,0,varnish,sess1 frees
+varnish.MEMPOOL.sess0.timeout,gauge,,event,second,Timed out from pool. This metric is only provided by varnish >=4.x.,0,varnish,sess0 timeout
+varnish.MEMPOOL.sess0.toosmall,gauge,,event,second,Too small to recycle. This metric is only provided by varnish >=4.x.,0,varnish,sess0 toosmall
+varnish.MEMPOOL.sess1.allocs,gauge,,event,second,Allocations. This metric is only provided by varnish >=4.x.,0,varnish,sess1 allocs
+varnish.MEMPOOL.sess1.frees,gauge,,event,second,Frees. This metric is only provided by varnish >=4.x.,0,varnish,sess1 frees
 varnish.MEMPOOL.sess1.live,gauge,,,,In use. This metric is only provided by varnish >=4.x.,0,varnish,sess1 live
 varnish.MEMPOOL.sess1.pool,gauge,,,,In pool. This metric is only provided by varnish >=4.x.,0,varnish,sess1 pool
-varnish.MEMPOOL.sess1.randry,rate,,event,,Pool ran dry. This metric is only provided by varnish >=4.x.,0,varnish,sess1 randry
-varnish.MEMPOOL.sess1.recycle,rate,,event,,Recycled from pool. This metric is only provided by varnish >=4.x.,0,varnish,sess1 recycle
-varnish.MEMPOOL.sess1.surplus,rate,,event,,Too many for pool. This metric is only provided by varnish >=4.x.,0,varnish,sess1 surplus
+varnish.MEMPOOL.sess1.randry,gauge,,event,second,Pool ran dry. This metric is only provided by varnish >=4.x.,0,varnish,sess1 randry
+varnish.MEMPOOL.sess1.recycle,gauge,,event,second,Recycled from pool. This metric is only provided by varnish >=4.x.,0,varnish,sess1 recycle
+varnish.MEMPOOL.sess1.surplus,gauge,,event,second,Too many for pool. This metric is only provided by varnish >=4.x.,0,varnish,sess1 surplus
 varnish.MEMPOOL.sess1.sz_needed,gauge,,byte,,Size allocated. This metric is only provided by varnish >=4.x.,0,varnish,sess1 sz_needed
 varnish.MEMPOOL.sess1.sz_wanted,gauge,,byte,,Size requested. This metric is only provided by varnish >=4.x.,0,varnish,sess1 sz_wanted
-varnish.MEMPOOL.sess1.timeout,rate,,event,,Timed out from pool. This metric is only provided by varnish >=4.x.,0,varnish,sess1 timeout
-varnish.MEMPOOL.sess1.toosmall,rate,,event,,Too small to recycle. This metric is only provided by varnish >=4.x.,0,varnish,sess1 toosmall
-varnish.MEMPOOL.vbc.allocs,rate,,event,,Allocations. This metric is only provided by varnish >=4.x.,0,varnish,vbc allocs
-varnish.MEMPOOL.vbc.frees,rate,,event,,Frees. This metric is only provided by varnish >=4.x.,0,varnish,vbc frees
+varnish.MEMPOOL.sess1.timeout,gauge,,event,second,Timed out from pool. This metric is only provided by varnish >=4.x.,0,varnish,sess1 timeout
+varnish.MEMPOOL.sess1.toosmall,gauge,,event,second,Too small to recycle. This metric is only provided by varnish >=4.x.,0,varnish,sess1 toosmall
+varnish.MEMPOOL.vbc.allocs,gauge,,event,second,Allocations. This metric is only provided by varnish >=4.x.,0,varnish,vbc allocs
+varnish.MEMPOOL.vbc.frees,gauge,,event,second,Frees. This metric is only provided by varnish >=4.x.,0,varnish,vbc frees
 varnish.MEMPOOL.vbc.live,gauge,,,,In use. This metric is only provided by varnish >=4.x.,0,varnish,vbc live
 varnish.MEMPOOL.vbc.pool,gauge,,,,In pool. This metric is only provided by varnish >=4.x.,0,varnish,vbc pool
-varnish.MEMPOOL.vbc.randry,rate,,event,,Pool ran dry. This metric is only provided by varnish >=4.x.,0,varnish,vbc randry
-varnish.MEMPOOL.vbc.recycle,rate,,event,,Recycled from pool. This metric is only provided by varnish >=4.x.,0,varnish,vbc recycle
-varnish.MEMPOOL.vbc.surplus,rate,,event,,Too many for pool. This metric is only provided by varnish >=4.x.,0,varnish,vbc surplus
+varnish.MEMPOOL.vbc.randry,gauge,,event,second,Pool ran dry. This metric is only provided by varnish >=4.x.,0,varnish,vbc randry
+varnish.MEMPOOL.vbc.recycle,gauge,,event,second,Recycled from pool. This metric is only provided by varnish >=4.x.,0,varnish,vbc recycle
+varnish.MEMPOOL.vbc.surplus,gauge,,event,second,Too many for pool. This metric is only provided by varnish >=4.x.,0,varnish,vbc surplus
 varnish.MEMPOOL.vbc.sz_needed,gauge,,byte,,Size allocated. This metric is only provided by varnish >=4.x.,0,varnish,vbc sz_needed
 varnish.MEMPOOL.vbc.sz_wanted,gauge,,byte,,Size requested. This metric is only provided by varnish >=4.x.,0,varnish,vbc sz_wanted
-varnish.MEMPOOL.vbc.timeout,rate,,event,,Timed out from pool. This metric is only provided by varnish >=4.x.,0,varnish,vbc timeout
-varnish.MEMPOOL.vbc.toosmall,rate,,event,,Too small to recycle. This metric is only provided by varnish >=4.x.,0,varnish,vbc toosmall
-varnish.MGT.child_died,rate,,process,,Child processes that died due to signals. This metric is only provided by varnish >=4.x.,0,varnish,mgt child died
-varnish.MGT.child_dump,rate,,process,,Child processes that produced core dumps. This metric is only provided by varnish >=4.x.,0,varnish,mgt child dump
-varnish.MGT.child_exit,rate,,process,,Child processes the were cleanly stopped. This metric is only provided by varnish >=4.x.,0,varnish,mgt child exit
-varnish.MGT.child_panic,rate,,process,,Child processes that panicked. This metric is only provided by varnish >=4.x.,0,varnish,mgt child panic
-varnish.MGT.child_start,rate,,process,,Child processes that started. This metric is only provided by varnish >=4.x.,0,varnish,mgt child start
-varnish.MGT.child_stop,rate,,process,,Child processes that exited with an unexpected return code. This metric is only provided by varnish >=4.x.,0,varnish,mgt child stop
-varnish.MGT.uptime,rate,,second,,This metric is only provided by varnish >=4.x.,0,varnish,mgt uptime
+varnish.MEMPOOL.vbc.timeout,gauge,,event,second,Timed out from pool. This metric is only provided by varnish >=4.x.,0,varnish,vbc timeout
+varnish.MEMPOOL.vbc.toosmall,gauge,,event,second,Too small to recycle. This metric is only provided by varnish >=4.x.,0,varnish,vbc toosmall
+varnish.MGT.child_died,gauge,,process,second,Child processes that died due to signals. This metric is only provided by varnish >=4.x.,0,varnish,mgt child died
+varnish.MGT.child_dump,gauge,,process,second,Child processes that produced core dumps. This metric is only provided by varnish >=4.x.,0,varnish,mgt child dump
+varnish.MGT.child_exit,gauge,,process,second,Child processes the were cleanly stopped. This metric is only provided by varnish >=4.x.,0,varnish,mgt child exit
+varnish.MGT.child_panic,gauge,,process,second,Child processes that panicked. This metric is only provided by varnish >=4.x.,0,varnish,mgt child panic
+varnish.MGT.child_start,gauge,,process,second,Child processes that started. This metric is only provided by varnish >=4.x.,0,varnish,mgt child start
+varnish.MGT.child_stop,gauge,,process,second,Child processes that exited with an unexpected return code. This metric is only provided by varnish >=4.x.,0,varnish,mgt child stop
+varnish.MGT.uptime,gauge,,second,second,This metric is only provided by varnish >=4.x.,0,varnish,mgt uptime
 varnish.n_backend,gauge,,,,Number of backends.,0,varnish,n backend
-varnish.n_ban,rate,,object,,Active bans. This metric is only provided by varnish 3.x.,0,varnish,n ban
-varnish.n_ban_add,rate,,object,,New bans added. This metric is only provided by varnish 3.x.,0,varnish,n ban add
-varnish.n_ban_dups,rate,,object,,Duplicate bans removed. This metric is only provided by varnish 3.x.,0,varnish,n ban dups
-varnish.n_ban_obj_test,rate,,object,,Objects tested. This metric is only provided by varnish 3.x.,0,varnish,n ban obj test
-varnish.n_ban_re_test,rate,,object,,Regexps tested against. This metric is only provided by varnish 3.x.,0,varnish,n ban re test
-varnish.n_ban_retire,rate,,object,,Old bans deleted. This metric is only provided by varnish 3.x.,0,varnish,n ban retire
+varnish.n_ban,gauge,,object,second,Active bans. This metric is only provided by varnish 3.x.,0,varnish,n ban
+varnish.n_ban_add,gauge,,object,second,New bans added. This metric is only provided by varnish 3.x.,0,varnish,n ban add
+varnish.n_ban_dups,gauge,,object,second,Duplicate bans removed. This metric is only provided by varnish 3.x.,0,varnish,n ban dups
+varnish.n_ban_obj_test,gauge,,object,second,Objects tested. This metric is only provided by varnish 3.x.,0,varnish,n ban obj test
+varnish.n_ban_re_test,gauge,,object,second,Regexps tested against. This metric is only provided by varnish 3.x.,0,varnish,n ban re test
+varnish.n_ban_retire,gauge,,object,second,Old bans deleted. This metric is only provided by varnish 3.x.,0,varnish,n ban retire
 varnish.n_expired,gauge,,object,,Objects that expired from cache because of TTL.,0,varnish,n expired
-varnish.n_gunzip,rate,,event,,Gunzip operations.,0,varnish,n gunzip
-varnish.n_gzip,rate,,event,,Gzip operations.,0,varnish,n gzip
+varnish.n_gunzip,gauge,,event,second,Gunzip operations.,0,varnish,n gunzip
+varnish.n_gzip,gauge,,event,second,Gzip operations.,0,varnish,n gzip
 varnish.n_lru_moved,gauge,,operation,,Move operations done on the LRU list.,0,varnish,n lru moved
 varnish.n_lru_nuked,gauge,,operation,,Objects forcefully evicted from storage to make room for new objects.,0,varnish,n lru nuked
 varnish.n_obj_purged,gauge,,object,,Purged objects. This metric is only provided by varnish >=4.x.,0,varnish,n obj purged
 varnish.n_object,gauge,,object,,object structs made.,0,varnish,n object
 varnish.n_objectcore,gauge,,object,,objectcore structs made.,0,varnish,n objectcore
 varnish.n_objecthead,gauge,,object,,objecthead structs made.,0,varnish,n objecthead
-varnish.n_objoverflow,rate,,object,,Objects overflowing workspace. This metric is only provided by varnish 3.x.,0,varnish,n objoverflow
-varnish.n_objsendfile,rate,,object,,Objects sent with sendfile. This metric is only provided by varnish 3.x.,0,varnish,n objsendfile
-varnish.n_objwrite,rate,,object,,Objects sent with write. This metric is only provided by varnish 3.x.,0,varnish,n objwrite
+varnish.n_objoverflow,gauge,,object,second,Objects overflowing workspace. This metric is only provided by varnish 3.x.,0,varnish,n objoverflow
+varnish.n_objsendfile,gauge,,object,second,Objects sent with sendfile. This metric is only provided by varnish 3.x.,0,varnish,n objsendfile
+varnish.n_objwrite,gauge,,object,second,Objects sent with write. This metric is only provided by varnish 3.x.,0,varnish,n objwrite
 varnish.n_purges,gauge,,event,,Purges executed. This metric is only provided by varnish >=4.x.,0,varnish,n purges
-varnish.n_sess,rate,,object,,sess structs made. This metric is only provided by varnish 3.x.,0,varnish,n sess
-varnish.n_sess_mem,rate,,object,,sess_mem structs made. This metric is only provided by varnish 3.x.,0,varnish,n sess mem
+varnish.n_sess,gauge,,object,second,sess structs made. This metric is only provided by varnish 3.x.,0,varnish,n sess
+varnish.n_sess_mem,gauge,,object,second,sess_mem structs made. This metric is only provided by varnish 3.x.,0,varnish,n sess mem
 varnish.n_vampireobject,gauge,,object,,Unresurrected objects.,0,varnish,n vampireobject
-varnish.n_vbc,rate,,object,,vbc structs made. This metric is only provided by varnish 3.x.,0,varnish,n vbc
+varnish.n_vbc,gauge,,object,second,vbc structs made. This metric is only provided by varnish 3.x.,0,varnish,n vbc
 varnish.n_vcl,gauge,,object,,Total VCLs loaded.,0,varnish,n vcl
 varnish.n_vcl_avail,gauge,,object,,Available VCLs.,0,varnish,n vcl avail
 varnish.n_vcl_discard,gauge,,object,,Discarded VCLs.,0,varnish,n vcl discard
-varnish.n_waitinglist,rate,,object,,waitinglist structs made.,0,varnish,n waitinglist
-varnish.n_wrk,rate,,thread,,Worker threads. This metric is only provided by varnish 3.x.,0,varnish,n wrk
-varnish.n_wrk_create,rate,,event,,Worker threads created. This metric is only provided by varnish 3.x.,0,varnish,n wrk create
-varnish.n_wrk_drop,rate,,event,,Dropped work requests. This metric is only provided by varnish 3.x.,-1,varnish,n wrk drop
-varnish.n_wrk_failed,rate,,event,,Worker threads not created. This metric is only provided by varnish 3.x.,-1,varnish,n wrk failed
-varnish.n_wrk_lqueue,rate,,event,,Work request queue length. This metric is only provided by varnish 3.x.,0,varnish,n wrk lqueue
-varnish.n_wrk_max,rate,,event,,Worker threads limited. This metric is only provided by varnish 3.x.,0,varnish,n wrk max
-varnish.n_wrk_queued,rate,,event,,Queued work requests. This metric is only provided by varnish 3.x.,0,varnish,n wrk queued
+varnish.n_waitinglist,gauge,,object,second,waitinglist structs made.,0,varnish,n waitinglist
+varnish.n_wrk,gauge,,thread,second,Worker threads. This metric is only provided by varnish 3.x.,0,varnish,n wrk
+varnish.n_wrk_create,gauge,,event,second,Worker threads created. This metric is only provided by varnish 3.x.,0,varnish,n wrk create
+varnish.n_wrk_drop,gauge,,event,second,Dropped work requests. This metric is only provided by varnish 3.x.,-1,varnish,n wrk drop
+varnish.n_wrk_failed,gauge,,event,second,Worker threads not created. This metric is only provided by varnish 3.x.,-1,varnish,n wrk failed
+varnish.n_wrk_lqueue,gauge,,event,second,Work request queue length. This metric is only provided by varnish 3.x.,0,varnish,n wrk lqueue
+varnish.n_wrk_max,gauge,,event,second,Worker threads limited. This metric is only provided by varnish 3.x.,0,varnish,n wrk max
+varnish.n_wrk_queued,gauge,,event,second,Queued work requests. This metric is only provided by varnish 3.x.,0,varnish,n wrk queued
 varnish.pools,gauge,,,,Thread pools. This metric is only provided by varnish >=4.x.,0,varnish,pools
-varnish.s_bodybytes,rate,,byte,,Total body size. This metric is only provided by varnish 3.x.,0,varnish,s bodybytes
-varnish.s_fetch,rate,,request,,Backend fetches.,0,varnish,s fetch
-varnish.s_hdrbytes,rate,,byte,,Total header size. This metric is only provided by varnish 3.x.,0,varnish,s hdrbytes
-varnish.s_pass,rate,,request,,Passed requests.,0,varnish,s pass
-varnish.s_pipe,rate,,connection,,Pipe sessions seen.,0,varnish,s pipe
-varnish.s_pipe_hdrbytes,rate,,byte,,Total request bytes received for piped sessions. This metric is only provided by varnish >=4.x.,0,varnish,s pipe hdrbytes
-varnish.s_pipe_in,rate,,byte,,Total number of bytes forwarded from clients in pipe sessions. This metric is only provided by varnish >=4.x.,0,varnish,s pipe in
-varnish.s_pipe_out,rate,,byte,,Total number of bytes forwarded to clients in pipe sessions. This metric is only provided by varnish >=4.x.,0,varnish,s pipe out
-varnish.s_req,rate,,request,,Requests.,0,varnish,s req
-varnish.s_req_bodybytes,rate,,byte,,Total request body bytes received. This metric is only provided by varnish >=4.x.,0,varnish,s req bodybytes
-varnish.s_req_hdrbytes,rate,,byte,,Total request header bytes received. This metric is only provided by varnish >=4.x.,0,varnish,s req hdrbytes
-varnish.s_resp_bodybytes,rate,,byte,,Total response body bytes transmitted. This metric is only provided by varnish >=4.x.,0,varnish,s resp bodybytes
-varnish.s_resp_hdrbytes,rate,,byte,,Total response header bytes transmitted. This metric is only provided by varnish >=4.x.,0,varnish,s resp hdrbytes
-varnish.s_sess,rate,,connection,,Client connections.,0,varnish,s sess
-varnish.s_synth,rate,,response,,Synthetic responses made. This metric is only provided by varnish >=4.x.,0,varnish,s synth
-varnish.sess_closed,rate,,connection,,Client connections closed.,0,varnish,sess closed
-varnish.sess_conn,rate,,connection,,Client connections accepted. This metric is only provided by varnish >=4.x.,0,varnish,sess conn
-varnish.sess_drop,rate,,connection,,Client connections dropped due to lack of worker thread. This metric is only provided by varnish 4.x and 5.x,-1,varnish,sess drop
-varnish.sess_dropped,rate,,connection,,Client connections dropped due to a full queue. This metric is only provided by varnish 4.x and 6.x,-1,varnish,sess dropped
-varnish.sess_fail,rate,,connection,,"Failures to accept a TCP connection. Either the client changed its mind, or the kernel ran out of some resource like file descriptors. This metric is only provided by varnish >=4.x.",-1,varnish,sess fail
-varnish.sess_herd,rate,,connection,,,0,varnish,sess herd
-varnish.sess_linger,rate,,connection,,This metric is only provided by varnish 3.x.,0,varnish,sess linger
-varnish.sess_pipe_overflow,rate,,connection,,This metric is only provided by varnish >=4.x.,0,varnish,sess pipe overflow
-varnish.sess_pipeline,rate,,connection,,,0,varnish,sess pipeline
-varnish.sess_queued,rate,,connection,,Client connections queued to wait for a thread. This metric is only provided by varnish >=4.x.,-1,varnish,sess queued
-varnish.sess_readahead,rate,,connection,,,0,varnish,sess readahead
-varnish.shm_cont,rate,,event,,SHM MTX contention.,0,varnish,shm cont
-varnish.shm_cycles,rate,,event,,SHM cycles through buffer.,0,varnish,shm cycles
-varnish.shm_flushes,rate,,event,,SHM flushes due to overflow.,0,varnish,shm flushes
-varnish.shm_records,rate,,event,,SHM records.,0,varnish,shm records
-varnish.shm_writes,rate,,event,,SHM writes.,0,varnish,shm writes
-varnish.SMA.s0.c_bytes,rate,,byte,,Total space allocated by this storage.,0,varnish,SMA s0 c bytes
-varnish.SMA.s0.c_fail,rate,,event,,Times the storage has failed to provide a storage segment.,0,varnish,SMA s0 c fail
-varnish.SMA.s0.c_freed,rate,,byte,,Total space returned to this storage.,0,varnish,SMA s0 c freed
-varnish.SMA.s0.c_req,rate,,event,,Times the storage has been asked to provide a storage segment.,0,varnish,SMA s0 c req
+varnish.s_bodybytes,gauge,,byte,second,Total body size. This metric is only provided by varnish 3.x.,0,varnish,s bodybytes
+varnish.s_fetch,gauge,,request,second,Backend fetches.,0,varnish,s fetch
+varnish.s_hdrbytes,gauge,,byte,second,Total header size. This metric is only provided by varnish 3.x.,0,varnish,s hdrbytes
+varnish.s_pass,gauge,,request,second,Passed requests.,0,varnish,s pass
+varnish.s_pipe,gauge,,connection,second,Pipe sessions seen.,0,varnish,s pipe
+varnish.s_pipe_hdrbytes,gauge,,byte,second,Total request bytes received for piped sessions. This metric is only provided by varnish >=4.x.,0,varnish,s pipe hdrbytes
+varnish.s_pipe_in,gauge,,byte,second,Total number of bytes forwarded from clients in pipe sessions. This metric is only provided by varnish >=4.x.,0,varnish,s pipe in
+varnish.s_pipe_out,gauge,,byte,second,Total number of bytes forwarded to clients in pipe sessions. This metric is only provided by varnish >=4.x.,0,varnish,s pipe out
+varnish.s_req,gauge,,request,second,Requests.,0,varnish,s req
+varnish.s_req_bodybytes,gauge,,byte,second,Total request body bytes received. This metric is only provided by varnish >=4.x.,0,varnish,s req bodybytes
+varnish.s_req_hdrbytes,gauge,,byte,second,Total request header bytes received. This metric is only provided by varnish >=4.x.,0,varnish,s req hdrbytes
+varnish.s_resp_bodybytes,gauge,,byte,second,Total response body bytes transmitted. This metric is only provided by varnish >=4.x.,0,varnish,s resp bodybytes
+varnish.s_resp_hdrbytes,gauge,,byte,second,Total response header bytes transmitted. This metric is only provided by varnish >=4.x.,0,varnish,s resp hdrbytes
+varnish.s_sess,gauge,,connection,second,Client connections.,0,varnish,s sess
+varnish.s_synth,gauge,,response,second,Synthetic responses made. This metric is only provided by varnish >=4.x.,0,varnish,s synth
+varnish.sess_closed,gauge,,connection,second,Client connections closed.,0,varnish,sess closed
+varnish.sess_conn,gauge,,connection,second,Client connections accepted. This metric is only provided by varnish >=4.x.,0,varnish,sess conn
+varnish.sess_drop,gauge,,connection,second,Client connections dropped due to lack of worker thread. This metric is only provided by varnish 4.x and 5.x,-1,varnish,sess drop
+varnish.sess_dropped,gauge,,connection,second,Client connections dropped due to a full queue. This metric is only provided by varnish 4.x and 6.x,-1,varnish,sess dropped
+varnish.sess_fail,gauge,,connection,second,"Failures to accept a TCP connection. Either the client changed its mind, or the kernel ran out of some resource like file descriptors. This metric is only provided by varnish >=4.x.",-1,varnish,sess fail
+varnish.sess_herd,gauge,,connection,second,,0,varnish,sess herd
+varnish.sess_linger,gauge,,connection,second,This metric is only provided by varnish 3.x.,0,varnish,sess linger
+varnish.sess_pipe_overflow,gauge,,connection,second,This metric is only provided by varnish >=4.x.,0,varnish,sess pipe overflow
+varnish.sess_pipeline,gauge,,connection,second,,0,varnish,sess pipeline
+varnish.sess_queued,gauge,,connection,second,Client connections queued to wait for a thread. This metric is only provided by varnish >=4.x.,-1,varnish,sess queued
+varnish.sess_readahead,gauge,,connection,second,,0,varnish,sess readahead
+varnish.shm_cont,gauge,,event,second,SHM MTX contention.,0,varnish,shm cont
+varnish.shm_cycles,gauge,,event,second,SHM cycles through buffer.,0,varnish,shm cycles
+varnish.shm_flushes,gauge,,event,second,SHM flushes due to overflow.,0,varnish,shm flushes
+varnish.shm_records,gauge,,event,second,SHM records.,0,varnish,shm records
+varnish.shm_writes,gauge,,event,second,SHM writes.,0,varnish,shm writes
+varnish.SMA.s0.c_bytes,gauge,,byte,second,Total space allocated by this storage.,0,varnish,SMA s0 c bytes
+varnish.SMA.s0.c_fail,gauge,,event,second,Times the storage has failed to provide a storage segment.,0,varnish,SMA s0 c fail
+varnish.SMA.s0.c_freed,gauge,,byte,second,Total space returned to this storage.,0,varnish,SMA s0 c freed
+varnish.SMA.s0.c_req,gauge,,event,second,Times the storage has been asked to provide a storage segment.,0,varnish,SMA s0 c req
 varnish.SMA.s0.g_alloc,gauge,,event,,Storage allocations outstanding.,0,varnish,SMA s0 g alloc
 varnish.SMA.s0.g_bytes,gauge,,byte,,Space allocated from the storage.,0,varnish,SMA s0 g bytes
 varnish.SMA.s0.g_space,gauge,,byte,,Space left in the storage.,0,varnish,SMA s0 g space
-varnish.SMA.Transient.c_bytes,rate,,byte,,Total space allocated by this storage.,0,varnish,SMA Transient c bytes
-varnish.SMA.Transient.c_fail,rate,,event,,Times the storage has failed to provide a storage segment.,0,varnish,SMA Transient c fail
-varnish.SMA.Transient.c_freed,rate,,byte,,Total space returned to this storage.,0,varnish,SMA Transient c freed
-varnish.SMA.Transient.c_req,rate,,event,,Times the storage has been asked to provide a storage segment.,0,varnish,SMA Transient c req
+varnish.SMA.Transient.c_bytes,gauge,,byte,second,Total space allocated by this storage.,0,varnish,SMA Transient c bytes
+varnish.SMA.Transient.c_fail,gauge,,event,second,Times the storage has failed to provide a storage segment.,0,varnish,SMA Transient c fail
+varnish.SMA.Transient.c_freed,gauge,,byte,second,Total space returned to this storage.,0,varnish,SMA Transient c freed
+varnish.SMA.Transient.c_req,gauge,,event,second,Times the storage has been asked to provide a storage segment.,0,varnish,SMA Transient c req
 varnish.SMA.Transient.g_alloc,gauge,,event,,Storage allocations outstanding.,0,varnish,SMA Transient g alloc
 varnish.SMA.Transient.g_bytes,gauge,,byte,,Space allocated from the storage.,0,varnish,SMA Transient g bytes
 varnish.SMA.Transient.g_space,gauge,,byte,,Space left in the storage.,0,varnish,SMA Transient g space
-varnish.sms_balloc,rate,,byte,,SMS space allocated.,0,varnish,sms balloc
-varnish.sms_bfree,rate,,byte,,SMS space freed.,0,varnish,sms bfree
-varnish.sms_nbytes,rate,,byte,,SMS outstanding space.,0,varnish,sms nbytes
-varnish.sms_nobj,rate,,event,,SMS outstanding allocations.,0,varnish,sms nobj
-varnish.sms_nreq,rate,,event,,SMS allocator requests.,0,varnish,sms nreq
+varnish.sms_balloc,gauge,,byte,second,SMS space allocated.,0,varnish,sms balloc
+varnish.sms_bfree,gauge,,byte,second,SMS space freed.,0,varnish,sms bfree
+varnish.sms_nbytes,gauge,,byte,second,SMS outstanding space.,0,varnish,sms nbytes
+varnish.sms_nobj,gauge,,event,second,SMS outstanding allocations.,0,varnish,sms nobj
+varnish.sms_nreq,gauge,,event,second,SMS allocator requests.,0,varnish,sms nreq
 varnish.thread_queue_len,gauge,,connection,,Length of session queue waiting for threads. This metric is only provided by varnish >=4.x.,0,varnish,thread queue len
 varnish.threads,gauge,,thread,,Number of threads. This metric is only provided by varnish >=4.x.,0,varnish,threads
-varnish.threads_created,rate,,thread,,Threads created. This metric is only provided by varnish >=4.x.,0,varnish,threads created
-varnish.threads_destroyed,rate,,thread,,Threads destroyed. This metric is only provided by varnish >=4.x.,0,varnish,threads destroyed
-varnish.threads_failed,rate,,thread,,Threads that failed to get created. This metric is only provided by varnish >=4.x.,-1,varnish,threads failed
-varnish.threads_limited,rate,,thread,,Threads that were needed but couldn't be created because of a thread pool limit. This metric is only provided by varnish >=4.x.,-1,varnish,threads limited
-varnish.uptime,rate,,second,,,0,varnish,uptime
+varnish.threads_created,gauge,,thread,second,Threads created. This metric is only provided by varnish >=4.x.,0,varnish,threads created
+varnish.threads_destroyed,gauge,,thread,second,Threads destroyed. This metric is only provided by varnish >=4.x.,0,varnish,threads destroyed
+varnish.threads_failed,gauge,,thread,second,Threads that failed to get created. This metric is only provided by varnish >=4.x.,-1,varnish,threads failed
+varnish.threads_limited,gauge,,thread,second,Threads that were needed but couldn't be created because of a thread pool limit. This metric is only provided by varnish >=4.x.,-1,varnish,threads limited
+varnish.uptime,gauge,,second,second,,0,varnish,uptime
 varnish.vmods,gauge,,object,,Loaded VMODs. This metric is only provided by varnish >=4.x.,0,varnish,vmods
 varnish.vsm_cooling,gauge,,byte,,"Space which will soon (max 1 minute) be freed in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm cooling
 varnish.vsm_free,gauge,,byte,,"Free space in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm free
 varnish.vsm_overflow,gauge,,byte,,"Data which does not fit in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm overflow
 varnish.vsm_overflowed,gauge,,byte,,"Total data which did not fit in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm overflowed
 varnish.vsm_used,gauge,,byte,,"Used space in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm used
-varnish.n_purgesps,rate,,event,,Purges executed. This metric is only provided by varnish 4.x and 5.x,0,varnish,n purges
+varnish.n_purgesps,gauge,,event,second,Purges executed. This metric is only provided by varnish 4.x and 5.x,0,varnish,n purges

--- a/varnish/metadata.csv
+++ b/varnish/metadata.csv
@@ -1,5 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-varnish.accept_fail,gauge,,connection,,Accept failures. This metric is only provided by varnish 3.x.,0,varnish,accept fail
+varnish.accept_fail,gauge,,connection,second,Accept failures. This metric is only provided by varnish 3.x.,0,varnish,accept fail
 varnish.backend_busy,gauge,,connection,second,Maximum number of connections to a given backend.,0,varnish,backend busy
 varnish.backend_conn,gauge,,connection,second,Successful connections to a given backend.,0,varnish,backend conn
 varnish.backend_fail,gauge,,connection,second,Failed connections for a given backend.,0,varnish,backend fail
@@ -30,9 +30,9 @@ varnish.busy_wakeup,gauge,,request,second,Requests taken off the busy object sle
 varnish.cache_hit,gauge,,request,second,Requests served from the cache.,0,varnish,hit
 varnish.cache_hitpass,gauge,,request,second,Requests passed to a backend where the decision to pass them found in the cache.,0,varnish,hitpass
 varnish.cache_miss,gauge,,request,second,Requests fetched from a backend server.,0,varnish,miss
-varnish.client_conn,gauge,,connection,,Client connections accepted. This metric is only provided by varnish 3.x.,0,varnish,client conn
-varnish.client_drop,gauge,,connection,,"Client connection dropped, no session. This metric is only provided by varnish 3.x.",0,varnish,client drop
-varnish.client_drop_late,gauge,,connection,,Client connection dropped late. This metric is only provided by varnish 3.x.,0,varnish,client drop late
+varnish.client_conn,gauge,,connection,second,Client connections accepted. This metric is only provided by varnish 3.x.,0,varnish,client conn
+varnish.client_drop,gauge,,connection,second,"Client connection dropped, no session. This metric is only provided by varnish 3.x.",0,varnish,client drop
+varnish.client_drop_late,gauge,,connection,second,Client connection dropped late. This metric is only provided by varnish 3.x.,0,varnish,client drop late
 varnish.client_req,gauge,,request,second,Parseable client requests seen.,0,varnish,client req
 varnish.client_req_400,gauge,,request,second,Requests that were malformed in some drastic way. This metric is only provided by varnish >=4.x.,-1,varnish,client req 400
 varnish.client_req_411,gauge,,request,second,Requests that were missing a Content-Length: header. This metric is only provided by varnish >=4.x.,-1,varnish,client req 411
@@ -62,42 +62,42 @@ varnish.fetch_zero,gauge,,response,second,Number of responses that have zero len
 varnish.hcb_insert,gauge,,event,second,HCB inserts.,0,varnish,HCB insert
 varnish.hcb_lock,gauge,,event,second,HCB lookups with lock.,0,varnish,HCB lock
 varnish.hcb_nolock,gauge,,event,second,HCB lookups without lock.,0,varnish,HCB nolock
-varnish.LCK.backend.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,backend colls
+varnish.LCK.backend.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,backend colls
 varnish.LCK.backend.creat,gauge,,lock,second,Created locks.,0,varnish,backend create
 varnish.LCK.backend.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,backend destroy
 varnish.LCK.backend.locks,gauge,,lock,second,Lock operations.,0,varnish,backend locks
-varnish.LCK.ban.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,ban colls
+varnish.LCK.ban.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,ban colls
 varnish.LCK.ban.creat,gauge,,lock,second,Created locks.,0,varnish,ban create
 varnish.LCK.ban.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,ban destroy
 varnish.LCK.ban.locks,gauge,,lock,second,Lock operations.,0,varnish,ban locks
 varnish.LCK.busyobj.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,busyobj create
 varnish.LCK.busyobj.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,busyobj destroy
 varnish.LCK.busyobj.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,busyobj locks
-varnish.LCK.cli.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,cli colls
+varnish.LCK.cli.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,cli colls
 varnish.LCK.cli.creat,gauge,,lock,second,Created locks.,0,varnish,cli create
 varnish.LCK.cli.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,cli destroy
 varnish.LCK.cli.locks,gauge,,lock,second,Lock operations.,0,varnish,cli locks
-varnish.LCK.exp.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,exp colls
+varnish.LCK.exp.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,exp colls
 varnish.LCK.exp.creat,gauge,,lock,second,Created locks.,0,varnish,exp create
 varnish.LCK.exp.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,exp destroy
 varnish.LCK.exp.locks,gauge,,lock,second,Lock operations.,0,varnish,exp locks
-varnish.LCK.hcb.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,hcb colls
+varnish.LCK.hcb.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,hcb colls
 varnish.LCK.hcb.creat,gauge,,lock,second,Created locks.,0,varnish,hcb create
 varnish.LCK.hcb.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,hcb destroy
 varnish.LCK.hcb.locks,gauge,,lock,second,Lock operations.,0,varnish,hcb locks
-varnish.LCK.hcl.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,hcl colls
+varnish.LCK.hcl.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,hcl colls
 varnish.LCK.hcl.creat,gauge,,lock,second,Created locks.,0,varnish,hcl create
 varnish.LCK.hcl.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,hcl destroy
 varnish.LCK.hcl.locks,gauge,,lock,second,Lock operations.,0,varnish,hcl locks
-varnish.LCK.herder.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,herder colls
+varnish.LCK.herder.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,herder colls
 varnish.LCK.herder.creat,gauge,,lock,second,Created locks.,0,varnish,herder create
 varnish.LCK.herder.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,herder destroy
 varnish.LCK.herder.locks,gauge,,lock,second,Lock operations.,0,varnish,herder locks
-varnish.LCK.hsl.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,hsl colls
+varnish.LCK.hsl.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,hsl colls
 varnish.LCK.hsl.creat,gauge,,lock,second,Created locks.,0,varnish,hsl create
 varnish.LCK.hsl.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,hsl destroy
 varnish.LCK.hsl.locks,gauge,,lock,second,Lock operations.,0,varnish,hsl locks
-varnish.LCK.lru.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,lru colls
+varnish.LCK.lru.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,lru colls
 varnish.LCK.lru.creat,gauge,,lock,second,Created locks.,0,varnish,lru create
 varnish.LCK.lru.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,lru destroy
 varnish.LCK.lru.locks,gauge,,lock,second,Lock operations.,0,varnish,lru locks
@@ -107,7 +107,7 @@ varnish.LCK.mempool.locks,gauge,,lock,second,Lock operations. This metric is onl
 varnish.LCK.nbusyobj.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,nbusyobj create
 varnish.LCK.nbusyobj.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,nbusyobj destroy
 varnish.LCK.nbusyobj.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,nbusyobj locks
-varnish.LCK.objhdr.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,objhdr colls
+varnish.LCK.objhdr.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,objhdr colls
 varnish.LCK.objhdr.creat,gauge,,lock,second,Created locks.,0,varnish,objhdr create
 varnish.LCK.objhdr.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,objhdr destroy
 varnish.LCK.objhdr.locks,gauge,,lock,second,Lock operations.,0,varnish,objhdr locks
@@ -117,53 +117,53 @@ varnish.LCK.pipestat.locks,gauge,,lock,second,Lock operations. This metric is on
 varnish.LCK.sess.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,sess create
 varnish.LCK.sess.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,sess destroy
 varnish.LCK.sess.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,sess locks
-varnish.LCK.sessmem.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,sessmem colls
+varnish.LCK.sessmem.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,sessmem colls
 varnish.LCK.sessmem.creat,gauge,,lock,second,Created locks.,0,varnish,sessmem create
 varnish.LCK.sessmem.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,sessmem destroy
 varnish.LCK.sessmem.locks,gauge,,lock,second,Lock operations.,0,varnish,sessmem locks
-varnish.LCK.sma.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,sma colls
+varnish.LCK.sma.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,sma colls
 varnish.LCK.sma.creat,gauge,,lock,second,Created locks.,0,varnish,sma create
 varnish.LCK.sma.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,sma destroy
 varnish.LCK.sma.locks,gauge,,lock,second,Lock operations.,0,varnish,sma locks
-varnish.LCK.smf.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,smf colls
+varnish.LCK.smf.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,smf colls
 varnish.LCK.smf.creat,gauge,,lock,second,Created locks.,0,varnish,smf create
 varnish.LCK.smf.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,smf destroy
 varnish.LCK.smf.locks,gauge,,lock,second,Lock operations.,0,varnish,smf locks
-varnish.LCK.smp.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,smp colls
+varnish.LCK.smp.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,smp colls
 varnish.LCK.smp.creat,gauge,,lock,second,Created locks.,0,varnish,smp create
 varnish.LCK.smp.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,smp destroy
 varnish.LCK.smp.locks,gauge,,lock,second,Lock operations.,0,varnish,smp locks
-varnish.LCK.sms.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,sms colls
+varnish.LCK.sms.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,sms colls
 varnish.LCK.sms.creat,gauge,,lock,second,Created locks.,0,varnish,sms create
 varnish.LCK.sms.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,sms destroy
 varnish.LCK.sms.locks,gauge,,lock,second,Lock operations.,0,varnish,sms locks
-varnish.LCK.stat.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,stat colls
+varnish.LCK.stat.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,stat colls
 varnish.LCK.stat.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish 3.x.,0,varnish,stat create
 varnish.LCK.stat.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish 3.x.,0,varnish,stat destroy
 varnish.LCK.stat.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish 3.x.,0,varnish,stat locks
-varnish.LCK.vbe.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,vbe colls
+varnish.LCK.vbe.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,vbe colls
 varnish.LCK.vbe.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish 3.x.,0,varnish,vbe create
 varnish.LCK.vbe.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish 3.x.,0,varnish,vbe destroy
 varnish.LCK.vbe.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish 3.x.,0,varnish,vbe locks
-varnish.LCK.vbp.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,vbp colls
+varnish.LCK.vbp.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,vbp colls
 varnish.LCK.vbp.creat,gauge,,lock,second,Created locks.,0,varnish,vbp create
 varnish.LCK.vbp.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,vbp destroy
 varnish.LCK.vbp.locks,gauge,,lock,second,Lock operations.,0,varnish,vbp locks
 varnish.LCK.vcapace.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,vcapace create
 varnish.LCK.vcapace.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,vcapace destroy
 varnish.LCK.vcapace.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,vcapace locks
-varnish.LCK.vcl.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,vcl colls
+varnish.LCK.vcl.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,vcl colls
 varnish.LCK.vcl.creat,gauge,,lock,second,Created locks.,0,varnish,vcl create
 varnish.LCK.vcl.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,vcl destroy
 varnish.LCK.vcl.locks,gauge,,lock,second,Lock operations.,0,varnish,vcl locks
 varnish.LCK.vxid.creat,gauge,,lock,second,Created locks. This metric is only provided by varnish >=4.x.,0,varnish,vxid create
 varnish.LCK.vxid.destroy,gauge,,lock,second,Destroyed locks. This metric is only provided by varnish >=4.x.,0,varnish,vxid destroy
 varnish.LCK.vxid.locks,gauge,,lock,second,Lock operations. This metric is only provided by varnish >=4.x.,0,varnish,vxid locks
-varnish.LCK.wq.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,wq colls
+varnish.LCK.wq.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,wq colls
 varnish.LCK.wq.creat,gauge,,lock,second,Created locks.,0,varnish,wq create
 varnish.LCK.wq.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,wq destroy
 varnish.LCK.wq.locks,gauge,,lock,second,Lock operations.,0,varnish,wq locks
-varnish.LCK.wstat.colls,gauge,,lock,,Collisions. This metric is only provided by varnish 3.x.,0,varnish,wstat colls
+varnish.LCK.wstat.colls,gauge,,lock,second,Collisions. This metric is only provided by varnish 3.x.,0,varnish,wstat colls
 varnish.LCK.wstat.creat,gauge,,lock,second,Created locks.,0,varnish,wstat create
 varnish.LCK.wstat.destroy,gauge,,lock,second,Destroyed locks.,0,varnish,wstat destroy
 varnish.LCK.wstat.locks,gauge,,lock,second,Lock operations.,0,varnish,wstat locks
@@ -240,7 +240,7 @@ varnish.MGT.child_exit,gauge,,process,second,Child processes the were cleanly st
 varnish.MGT.child_panic,gauge,,process,second,Child processes that panicked. This metric is only provided by varnish >=4.x.,0,varnish,mgt child panic
 varnish.MGT.child_start,gauge,,process,second,Child processes that started. This metric is only provided by varnish >=4.x.,0,varnish,mgt child start
 varnish.MGT.child_stop,gauge,,process,second,Child processes that exited with an unexpected return code. This metric is only provided by varnish >=4.x.,0,varnish,mgt child stop
-varnish.MGT.uptime,gauge,,second,second,This metric is only provided by varnish >=4.x.,0,varnish,mgt uptime
+varnish.MGT.uptime,gauge,,second,,This metric is only provided by varnish >=4.x.,0,varnish,mgt uptime
 varnish.n_backend,gauge,,,,Number of backends.,0,varnish,n backend
 varnish.n_ban,gauge,,object,second,Active bans. This metric is only provided by varnish 3.x.,0,varnish,n ban
 varnish.n_ban_add,gauge,,object,second,New bans added. This metric is only provided by varnish 3.x.,0,varnish,n ban add
@@ -322,10 +322,10 @@ varnish.SMA.Transient.c_req,gauge,,event,second,Times the storage has been asked
 varnish.SMA.Transient.g_alloc,gauge,,event,,Storage allocations outstanding.,0,varnish,SMA Transient g alloc
 varnish.SMA.Transient.g_bytes,gauge,,byte,,Space allocated from the storage.,0,varnish,SMA Transient g bytes
 varnish.SMA.Transient.g_space,gauge,,byte,,Space left in the storage.,0,varnish,SMA Transient g space
-varnish.sms_balloc,gauge,,byte,second,SMS space allocated.,0,varnish,sms balloc
-varnish.sms_bfree,gauge,,byte,second,SMS space freed.,0,varnish,sms bfree
-varnish.sms_nbytes,gauge,,byte,second,SMS outstanding space.,0,varnish,sms nbytes
-varnish.sms_nobj,gauge,,event,second,SMS outstanding allocations.,0,varnish,sms nobj
+varnish.sms_balloc,gauge,,byte,,SMS space allocated.,0,varnish,sms balloc
+varnish.sms_bfree,gauge,,byte,,SMS space freed.,0,varnish,sms bfree
+varnish.sms_nbytes,gauge,,byte,,SMS outstanding space.,0,varnish,sms nbytes
+varnish.sms_nobj,gauge,,event,,SMS outstanding allocations.,0,varnish,sms nobj
 varnish.sms_nreq,gauge,,event,second,SMS allocator requests.,0,varnish,sms nreq
 varnish.thread_queue_len,gauge,,connection,,Length of session queue waiting for threads. This metric is only provided by varnish >=4.x.,0,varnish,thread queue len
 varnish.threads,gauge,,thread,,Number of threads. This metric is only provided by varnish >=4.x.,0,varnish,threads
@@ -333,7 +333,7 @@ varnish.threads_created,gauge,,thread,second,Threads created. This metric is onl
 varnish.threads_destroyed,gauge,,thread,second,Threads destroyed. This metric is only provided by varnish >=4.x.,0,varnish,threads destroyed
 varnish.threads_failed,gauge,,thread,second,Threads that failed to get created. This metric is only provided by varnish >=4.x.,-1,varnish,threads failed
 varnish.threads_limited,gauge,,thread,second,Threads that were needed but couldn't be created because of a thread pool limit. This metric is only provided by varnish >=4.x.,-1,varnish,threads limited
-varnish.uptime,gauge,,second,second,,0,varnish,uptime
+varnish.uptime,gauge,,second,,,0,varnish,uptime
 varnish.vmods,gauge,,object,,Loaded VMODs. This metric is only provided by varnish >=4.x.,0,varnish,vmods
 varnish.vsm_cooling,gauge,,byte,,"Space which will soon (max 1 minute) be freed in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm cooling
 varnish.vsm_free,gauge,,byte,,"Free space in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm free

--- a/varnish/metadata.csv
+++ b/varnish/metadata.csv
@@ -337,7 +337,7 @@ varnish.uptime,gauge,,second,,,0,varnish,uptime
 varnish.vmods,gauge,,object,,Loaded VMODs. This metric is only provided by varnish >=4.x.,0,varnish,vmods
 varnish.vsm_cooling,gauge,,byte,,"Space which will soon (max 1 minute) be freed in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm cooling
 varnish.vsm_free,gauge,,byte,,"Free space in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm free
-varnish.vsm_overflow,gauge,,byte,,"Data which does not fit in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm overflow
-varnish.vsm_overflowed,gauge,,byte,,"Total data which did not fit in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm overflowed
+varnish.vsm_overflow,gauge,,byte,,"Number of bytes which does not fit in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm overflow
+varnish.vsm_overflowed,gauge,,byte,second,"Total number of bytes which did not fit in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm overflowed
 varnish.vsm_used,gauge,,byte,,"Used space in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm used
 varnish.n_purgesps,gauge,,event,second,Purges executed. This metric is only provided by varnish 4.x and 5.x,0,varnish,n purges

--- a/varnish/tests/conftest.py
+++ b/varnish/tests/conftest.py
@@ -28,7 +28,7 @@ def check():
 @pytest.fixture(scope='session')
 def dd_environment():
     varnish_version = os.getenv("VARNISH_VERSION")
-    if varnish_version.startswith("5"):
+    if int(varnish_version[0]) <= 5:
         compose_file = os.path.join(common.HERE, 'compose', 'docker-compose-4-5.yaml')
     else:
         compose_file = os.path.join(common.HERE, 'compose', 'docker-compose.yaml')

--- a/varnish/tests/test_varnish.py
+++ b/varnish/tests/test_varnish.py
@@ -31,7 +31,8 @@ def test_check(aggregator, check, instance):
         aggregator.assert_metric(mname, count=1, tags=['cluster:webs', 'varnish_name:default'])
 
     metadata_metrics = get_metadata_metrics()
-    aggregator.assert_metrics_using_metadata(metadata_metrics, check_metric_type=False)
+    exclude = [m for m in aggregator.metric_names if m not in metadata_metrics]
+    aggregator.assert_metrics_using_metadata(metadata_metrics, exclude=exclude, check_metric_type=False)
 
 
 def test_inclusion_filter(aggregator, check, instance):

--- a/varnish/tests/test_varnish.py
+++ b/varnish/tests/test_varnish.py
@@ -22,19 +22,16 @@ GAUGE_IN_5_RATE_IN_6 = [
 
 def test_check(aggregator, check, instance):
     check.check(instance)
-    exclude = []
 
     if common.VARNISH_VERSION.startswith("5"):
         metrics_to_check = common.COMMON_METRICS + common.METRICS_5
     else:
-        exclude = GAUGE_IN_5_RATE_IN_6
         metrics_to_check = common.COMMON_METRICS + common.METRICS_6
     for mname in metrics_to_check:
         aggregator.assert_metric(mname, count=1, tags=['cluster:webs', 'varnish_name:default'])
 
     metadata_metrics = get_metadata_metrics()
-    exclude.extend([m for m in aggregator.metric_names if m not in metadata_metrics])
-    aggregator.assert_metrics_using_metadata(metadata_metrics, exclude=exclude)
+    aggregator.assert_metrics_using_metadata(metadata_metrics, check_metric_type=False)
 
 
 def test_inclusion_filter(aggregator, check, instance):


### PR DESCRIPTION
Agent integrations do not actually submit rates so these should be set as gauges with a per_unit_name of second.

Removing the test assertion as it would fail and raising an internal issue to fix it

These undoes some of the changes of:
* https://github.com/DataDog/integrations-core/pull/8058
* https://github.com/DataDog/integrations-core/pull/8060

Excepting:

Metrics that were set as a rate originally and have been fixed to be gauge with `second` as `per_unit_name`:
* varnish.n_purgesps

Metrics that were missing `second` originally but are submitted with `self.rate`. `second` has been added:
* varnish.n_sess
* varnish.n_sess_mem
* varnish.n_wrk

Metrics that had `second` originally and have been confirmed to be submitted with `self.gauge` (leaving without `second`):
* varnish.n_vcl,gauge,,object,second,Total VCLs loaded.,0,varnish,n vcl
* varnish.n_vcl_avail,gauge,,object,second,Available VCLs.,0,varnish,n vcl avail
* varnish.n_vcl_discard,gauge,,object,second,Discarded VCLs.,0,varnish,n vcl discard

Metrics that had `second` originally and I have not been able to verify either way (adding `second` back):
* varnish.vsm_overflowed,gauge,,byte,second,"Total data which did not fit in the shared memory used to communicate with tools like varnishstat, varnishlog etc. This metric is only provided by varnish >=4.x.",0,varnish,vsm overflowed
* All the v3 only ones
