### PR TITLE
Support octopus version

### DIFF
--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -74,6 +74,8 @@ class Ceph(AgentCheck):
         if 'min_mon_release_name' in mon_map and mon_map['min_mon_release_name'] == 'octopus':
             self.log.debug("Detected octopus version of ceph...")
             self._octopus = True
+        else:
+            self._octopus = False
 
         return raw
 

--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -72,7 +72,7 @@ class Ceph(AgentCheck):
 
         mon_map = raw['status']['monmap']
         if 'min_mon_release_name' in mon_map and mon_map['min_mon_release_name'] == 'octopus':
-            self.log.debug("Detected octopus version of ceph... Some metrics may be missing due to changes")
+            self.log.debug("Detected octopus version of ceph...")
             self._octopus = True
 
         return raw

--- a/ceph/tests/common.py
+++ b/ceph/tests/common.py
@@ -24,7 +24,6 @@ EXPECTED_METRICS = [
     "ceph.num_pgs",
     "ceph.num_mons",
     "ceph.aggregate_pct_used",
-    "ceph.total_objects",
     "ceph.num_objects",
     "ceph.read_bytes",
     "ceph.write_bytes",

--- a/ceph/tests/test_integration.py
+++ b/ceph/tests/test_integration.py
@@ -20,6 +20,9 @@ def test_check(aggregator):
     for metric in EXPECTED_METRICS:
         aggregator.assert_metric(metric, at_least=1)
 
+    if not ceph_check._octopus:
+        aggregator.assert_metric("ceph.total_objects", at_least=1)
+
     for sc in EXPECTED_SERVICE_CHECKS:
         aggregator.assert_service_check(sc, status=Ceph.OK, tags=EXPECTED_SERVICE_TAGS)
     aggregator.assert_service_check('ceph.overall_status', status=Ceph.OK, tags=EXPECTED_SERVICE_TAGS)

--- a/ceph/tox.ini
+++ b/ceph/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{3,15}
+    py{27,38}-{3,5}
 
 [testenv]
 ensure_default_envdir = true
@@ -19,7 +19,7 @@ deps =
     -rrequirements-dev.txt
 setenv =
     3: CEPH_VERSION=v3.2.1-stable-3.2-mimic-centos-7
-    15: CEPH_VERSION=v5.0.4-stable-5.0-octopus-centos-8
+    5: CEPH_VERSION=v5.0.4-stable-5.0-octopus-centos-8
 passenv =
     DOCKER*
     COMPOSE*

--- a/ceph/tox.ini
+++ b/ceph/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}
+    py{27,38}-{3,15}
 
 [testenv]
 ensure_default_envdir = true
@@ -18,7 +18,8 @@ deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =
-    CEPH_VERSION=v3.2.1-stable-3.2-mimic-centos-7
+    3: CEPH_VERSION=v3.2.1-stable-3.2-mimic-centos-7
+    15: CEPH_VERSION=v5.0.4-stable-5.0-octopus-centos-8
 passenv =
     DOCKER*
     COMPOSE*


### PR DESCRIPTION
### What does this PR do?
Resolves https://github.com/DataDog/integrations-core/issues/8067

- detects octopus version
- updates logic to ensure metrics are compatible (`mon_status` is deprecated )
- updates fsid tag detection
- adds octopus e2e test environment
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
