### PR TITLE
Increase robustness of parsing of Unix socket responses in legacy implementation

### DIFF
--- a/haproxy/datadog_checks/haproxy/legacy/haproxy.py
+++ b/haproxy/datadog_checks/haproxy/legacy/haproxy.py
@@ -192,11 +192,12 @@ class HAProxyCheckLegacy(AgentCheck):
             output = sock.recv(BUFSIZE)
         sock.close()
 
-        responses = response.split('\n\n')
-        if len(responses) != len(commands) + 1 or responses[len(responses) - 1] != '':
-            raise CheckException("Got a different number of responses than expected")
+        responses = [r.strip() for r in response.split('\n\n') if r.strip()]
 
-        return tuple(r.splitlines() for r in responses[: len(commands)])
+        if len(responses) != len(commands):
+            raise CheckException("Expected {} responses, got {}".format(len(commands), len(responses)))
+
+        return tuple(r.splitlines() for r in responses)
 
     def _fetch_socket_data(self, parsed_url):
         """Hit a given stats socket and return the stats lines."""


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update the logic for parsing the Unix socket response so it's more robust to newlines.

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case — the customer is seeing the `CheckException` trigger on an output which seems to be missing the final newline.

Refs #6158 — this PR added this logic originally, but it breaks if there's an extra or missing newline character.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
