### PR TITLE
Cache the client connection when there are no errors

### DIFF
--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -87,8 +87,7 @@ class Oracle(AgentCheck):
 
     def check(self, _):
         try:
-            with closing(self._connection):
-                self._query_manager.execute()
+            self._query_manager.execute()
         except Exception as e:
             self._cached_connection = None
             self.service_check(self.SERVICE_CHECK_NAME, self.CRITICAL, tags=self._service_check_tags)

--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -37,27 +37,26 @@ class Oracle(AgentCheck):
 
     def __init__(self, name, init_config, instances):
         super(Oracle, self).__init__(name, init_config, instances)
-        (
-            self._server,
-            self._user,
-            self._password,
-            self._service,
-            self._jdbc_driver,
-            self._tags,
-            only_custom_queries,
-        ) = self._get_config(self.instance)
+        self._server = self.instance.get('server')
+        self._user = self.instance.get('user')
+        self._password = self.instance.get('password')
+        self._service = self.instance.get('service_name')
+        self._jdbc_driver = self.instance.get('jdbc_driver_path')
+        self._tags = self.instance.get('tags') or []
+        self._service_check_tags = ['server:{}'.format(self._server)]
+        self._service_check_tags.extend(self._tags)
 
-        self.check_initializations.append(self.validate_config)
-
-        self._connection = None
+        self._cached_connection = None
 
         manager_queries = []
-        if not only_custom_queries:
+        if not self.instance.get('only_custom_queries', False):
             manager_queries.extend([queries.ProcessMetrics, queries.SystemMetrics, queries.TableSpaceMetrics])
 
         self._fix_custom_queries()
 
         self._query_manager = QueryManager(self, self.execute_query_raw, queries=manager_queries, tags=self._tags)
+
+        self.check_initializations.append(self.validate_config)
         self.check_initializations.append(self._query_manager.compile_queries)
 
     def _fix_custom_queries(self):
@@ -87,40 +86,33 @@ class Oracle(AgentCheck):
             return cursor.fetchall()
 
     def check(self, _):
-        self.create_connection()
-        with closing(self._connection):
-            self._query_manager.execute()
-            self._connection = None
-
-    def _get_config(self, instance):
-        server = instance.get('server')
-        user = instance.get('user')
-        password = instance.get('password')
-        service = instance.get('service_name')
-        jdbc_driver = instance.get('jdbc_driver_path')
-        tags = instance.get('tags') or []
-        only_custom_queries = instance.get('only_custom_queries', False)
-
-        return server, user, password, service, jdbc_driver, tags, only_custom_queries
-
-    def create_connection(self):
-        service_check_tags = ['server:%s' % self._server]
-        service_check_tags.extend(self._tags)
-
         try:
-            # Check if the instantclient is available
-            cx_Oracle.clientversion()
-        except cx_Oracle.DatabaseError as e:
-            # Fallback to JDBC
-            use_oracle_client = False
-            self.log.debug('Oracle instant client unavailable, falling back to JDBC: %s', e)
-            connect_string = self.JDBC_CONNECT_STRING.format(self._server, self._service)
+            with closing(self._connection):
+                self._query_manager.execute()
+        except Exception as e:
+            self._cached_connection = None
+            self.service_check(self.SERVICE_CHECK_NAME, self.CRITICAL, tags=self._service_check_tags)
+            self.log.error(e)
+            raise
         else:
-            use_oracle_client = True
-            self.log.debug('Running cx_Oracle version %s', cx_Oracle.version)
-            connect_string = self.CX_CONNECT_STRING.format(self._user, self._password, self._server, self._service)
+            self.service_check(self.SERVICE_CHECK_NAME, self.OK, tags=self._service_check_tags)
 
-        try:
+    @property
+    def _connection(self):
+        if self._cached_connection is None:
+            try:
+                # Check if the instantclient is available
+                cx_Oracle.clientversion()
+            except cx_Oracle.DatabaseError as e:
+                # Fallback to JDBC
+                use_oracle_client = False
+                self.log.debug('Oracle instant client unavailable, falling back to JDBC: %s', e)
+                connect_string = self.JDBC_CONNECT_STRING.format(self._server, self._service)
+            else:
+                use_oracle_client = True
+                self.log.debug('Running cx_Oracle version %s', cx_Oracle.version)
+                connect_string = self.CX_CONNECT_STRING.format(self._user, self._password, self._server, self._service)
+
             if use_oracle_client:
                 connection = cx_Oracle.connect(connect_string)
             elif JDBC_IMPORT_ERROR:
@@ -157,9 +149,6 @@ class Oracle(AgentCheck):
                     raise
 
             self.log.debug("Connected to Oracle DB")
-            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags)
-        except Exception as e:
-            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags)
-            self.log.error(e)
-            raise
-        self._connection = connection
+            self._cached_connection = connection
+
+        return self._cached_connection

--- a/oracle/tests/test_config.py
+++ b/oracle/tests/test_config.py
@@ -14,13 +14,15 @@ def test__get_config(check, instance):
     """
     Test the _get_config method
     """
-    _, user, password, service, jdbc_driver, tags, only_custom_queries = check._get_config(instance)
-    assert user == 'system'
-    assert password == 'oracle'
-    assert service == 'xe'
-    assert jdbc_driver is None
-    assert tags == ['optional:tag1']
-    assert only_custom_queries is False
+    check = Oracle(CHECK_NAME, {}, [instance])
+
+    assert check._user == 'system'
+    assert check._password == 'oracle'
+    assert check._service == 'xe'
+    assert check._jdbc_driver is None
+    assert check._tags == ['optional:tag1']
+    assert check._service_check_tags == ['server:{}'.format(instance['server']), 'optional:tag1']
+    assert len(check._query_manager.queries) == 3
 
 
 def test_check_misconfig(instance):

--- a/oracle/tests/test_metrics.py
+++ b/oracle/tests/test_metrics.py
@@ -16,7 +16,7 @@ def test_sys_metrics(aggregator, check):
     metrics = copy.deepcopy(queries.SystemMetrics['columns'][1]['items'])
     cur.fetchall.return_value = zip([0] * len(metrics.keys()), metrics.keys())
 
-    check._connection = con
+    check._cached_connection = con
     check._query_manager.queries = [Query(queries.SystemMetrics)]
     check._query_manager.tags = ['custom_tag']
     check._query_manager.compile_queries()
@@ -39,7 +39,7 @@ def test_process_metrics(aggregator, check):
     ]
     cur.fetchall.return_value = [[program] + ([0] * len(metrics)) for program in programs]
 
-    check._connection = con
+    check._cached_connection = con
     check._query_manager.queries = [Query(queries.ProcessMetrics)]
     check._query_manager.tags = ['custom_tag']
     check._query_manager.compile_queries()
@@ -66,7 +66,7 @@ def test_tablespace_metrics(aggregator, check):
     ]
     con.cursor.return_value = cur
 
-    check._connection = con
+    check._cached_connection = con
     check._query_manager.queries = [Query(queries.TableSpaceMetrics)]
     check._query_manager.tags = ['custom_tag']
     check._query_manager.compile_queries()
@@ -128,7 +128,7 @@ def test_custom_metrics(aggregator, check):
     ]
     check.instance['custom_queries'] = custom_queries
     check._fix_custom_queries()
-    check._connection = con
+    check._cached_connection = con
     query_manager = QueryManager(check, check.execute_query_raw, tags=['custom_tag'])
     query_manager.compile_queries()
 
@@ -171,7 +171,7 @@ def test_custom_metrics_multiple_results(aggregator, check):
 
     check.instance['custom_queries'] = custom_queries
     check._fix_custom_queries()
-    check._connection = con
+    check._cached_connection = con
     query_manager = QueryManager(check, check.execute_query_raw, tags=['custom_tag'])
     query_manager.compile_queries()
 

--- a/oracle/tests/test_oracle.py
+++ b/oracle/tests/test_oracle.py
@@ -7,7 +7,6 @@ except ImportError:
     from contextlib2 import ExitStack
 
 import mock
-import pytest
 
 from datadog_checks.oracle import Oracle
 
@@ -60,8 +59,8 @@ def test__get_connection_jdbc(check, dd_run_check):
         for mock_call in mocks:
             stack.enter_context(mock.patch(*mock_call))
         dd_run_check(check)
+        assert check._connection == con
 
-    assert check._connection == con
     jdb.connect.assert_called_with(
         'oracle.jdbc.OracleDriver', 'jdbc:oracle:thin:@//localhost:1521/xe', ['system', 'oracle'], None
     )
@@ -75,9 +74,7 @@ def test__get_connection_failure(check, dd_run_check):
     expected_tags = ['server:localhost:1521', 'optional:tag1']
     service_check = mock.MagicMock()
     check.service_check = service_check
-    check._query_manager.queries = []
-    with pytest.raises(Exception):
-        dd_run_check(check)
+    dd_run_check(check)
     service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.CRITICAL, tags=expected_tags)
 
 

--- a/oracle/tests/test_oracle.py
+++ b/oracle/tests/test_oracle.py
@@ -14,28 +14,30 @@ from datadog_checks.oracle import Oracle
 from .common import CHECK_NAME
 
 
-def test__get_connection_instant_client(check):
+def test__get_connection_instant_client(check, dd_run_check):
     """
     Test the _get_connection method using the instant client
     """
     check.use_oracle_client = True
+    check._query_manager.queries = []
     con = mock.MagicMock()
     service_check = mock.MagicMock()
     check.service_check = service_check
     expected_tags = ['server:localhost:1521', 'optional:tag1']
     with mock.patch('datadog_checks.oracle.oracle.cx_Oracle') as cx:
         cx.connect.return_value = con
-        check.create_connection()
+        dd_run_check(check)
         assert check._connection == con
         cx.connect.assert_called_with('system/oracle@//localhost:1521/xe')
         service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.OK, tags=expected_tags)
 
 
-def test__get_connection_jdbc(check):
+def test__get_connection_jdbc(check, dd_run_check):
     """
     Test the _get_connection method using the JDBC client
     """
     check.use_oracle_client = False
+    check._query_manager.queries = []
     con = mock.MagicMock()
     service_check = mock.MagicMock()
     check.service_check = service_check
@@ -57,7 +59,7 @@ def test__get_connection_jdbc(check):
     with ExitStack() as stack:
         for mock_call in mocks:
             stack.enter_context(mock.patch(*mock_call))
-        check.create_connection()
+        dd_run_check(check)
 
     assert check._connection == con
     jdb.connect.assert_called_with(
@@ -66,15 +68,16 @@ def test__get_connection_jdbc(check):
     service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.OK, tags=expected_tags)
 
 
-def test__get_connection_failure(check):
+def test__get_connection_failure(check, dd_run_check):
     """
     Test the right service check is sent upon _get_connection failures
     """
     expected_tags = ['server:localhost:1521', 'optional:tag1']
     service_check = mock.MagicMock()
     check.service_check = service_check
+    check._query_manager.queries = []
     with pytest.raises(Exception):
-        check.create_connection()
+        dd_run_check(check)
     service_check.assert_called_with(check.SERVICE_CHECK_NAME, check.CRITICAL, tags=expected_tags)
 
 


### PR DESCRIPTION
### Motivation

Establishing a connection can be flaky, which over time may result in many unsuccessful check runs and therefore noisy logs.