### PR TITLE
Allow asserting metrics types with metadata in integration tests

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -62,6 +62,15 @@ class AggregatorStub(object):
     GAUGE, RATE, COUNT, MONOTONIC_COUNT, COUNTER, HISTOGRAM, HISTORATE = list(METRIC_ENUM_MAP.values())
     AGGREGATE_TYPES = {COUNT, COUNTER}
     IGNORED_METRICS = {'datadog.agent.profile.memory.check_run_alloc'}
+    METRIC_TYPE_SUBMISSION_TO_BACKEND_MAP = {
+        'gauge': 'gauge',
+        'rate': 'gauge',
+        'count': 'count',
+        'monotonic_count': 'count',
+        'counter': 'rate',
+        'histogram': 'gauge',
+        'historate': 'rate',
+    }
 
     def __init__(self):
         self._metrics = defaultdict(list)
@@ -320,13 +329,16 @@ class AggregatorStub(object):
             msg += '\nMissing Metrics:{}{}'.format(prefix, prefix.join(sorted(self.not_asserted())))
         assert condition, msg
 
-    def assert_metrics_using_metadata(self, metadata_metrics, check_metric_type=True, exclude=None):
+    def assert_metrics_using_metadata(
+        self, metadata_metrics, check_metric_type=True, check_submission_type=False, exclude=None
+    ):
         """
         Assert metrics using metadata.csv
 
-        Checking type: Since we are asserting the in-app metric type (NOT submission type),
-        asserting the type make sense only for e2e (metrics collected from agent).
-        For integration tests, set kwarg `check_metric_type=False`.
+        Checking type: By default we are asserting the in-app metric type (`check_submission_type=False`),
+        asserting this type make sense for e2e (metrics collected from agent).
+        For integrations tests, we can check the submission type with `check_submission_type=True`, or
+        use `check_metric_type=True` not to check types.
 
         Usage:
 
@@ -350,8 +362,11 @@ class AggregatorStub(object):
                     expected_metric_type = metadata_metrics[metric_stub_name]['metric_type']
                     actual_metric_type = AggregatorStub.METRIC_ENUM_MAP_REV[metric_stub.type]
 
-                    if actual_metric_type == 'monotonic_count' and expected_metric_type == 'count':
-                        actual_metric_type = 'count'
+                    if check_submission_type:
+                        actual_metric_type = AggregatorStub.METRIC_TYPE_SUBMISSION_TO_BACKEND_MAP[actual_metric_type]
+                    else:
+                        if actual_metric_type == 'monotonic_count' and expected_metric_type == 'count':
+                            actual_metric_type = 'count'
 
                     if expected_metric_type != actual_metric_type:
                         errors.add(

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -338,7 +338,7 @@ class AggregatorStub(object):
         Checking type: By default we are asserting the in-app metric type (`check_submission_type=False`),
         asserting this type make sense for e2e (metrics collected from agent).
         For integrations tests, we can check the submission type with `check_submission_type=True`, or
-        use `check_metric_type=True` not to check types.
+        use `check_metric_type=False` not to check types.
 
         Usage:
 

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -357,7 +357,7 @@ class AggregatorStub(object):
                 actual_metric_type = AggregatorStub.METRIC_ENUM_MAP_REV[metric_stub.type]
 
                 # We only check `*.count` metrics for histogram and historate submissions
-                # Note: all Openmetrics histogram and summary metrics are actually separatly submitted as gauges
+                # Note: all Openmetrics histogram and summary metrics are actually separatly submitted
                 if check_submission_type and actual_metric_type in ['histogram', 'historate']:
                     metric_stub_name += '.count'
 

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -373,7 +373,7 @@ class AggregatorStub(object):
                 else:
                     # E2E tests
                     if actual_metric_type == 'monotonic_count' and expected_metric_type == 'count':
-                            actual_metric_type = 'count'
+                        actual_metric_type = 'count'
 
                 if check_metric_type:
                     if expected_metric_type != actual_metric_type:

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -68,8 +68,8 @@ class AggregatorStub(object):
         'count': 'count',
         'monotonic_count': 'count',
         'counter': 'rate',
-        'histogram': 'rate', # Checking .count only, the other are gauges
-        'historate': 'rate', # Checking .count only, the other are gauges
+        'histogram': 'rate',  # Checking .count only, the other are gauges
+        'historate': 'rate',  # Checking .count only, the other are gauges
     }
 
     def __init__(self):

--- a/directory/tests/test_integration.py
+++ b/directory/tests/test_integration.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.directory import DirectoryCheck
 
 from . import common
@@ -18,3 +19,5 @@ def test_check(aggregator):
     check.check(config)
     for metric in common.EXPECTED_METRICS:
         aggregator.assert_metric(metric, tags=common.EXPECTED_TAGS)
+
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)

--- a/directory/tests/test_integration.py
+++ b/directory/tests/test_integration.py
@@ -4,7 +4,6 @@
 
 import pytest
 
-from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.directory import DirectoryCheck
 
 from . import common
@@ -19,5 +18,3 @@ def test_check(aggregator):
     check.check(config)
     for metric in common.EXPECTED_METRICS:
         aggregator.assert_metric(metric, tags=common.EXPECTED_TAGS)
-
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)

--- a/mapreduce/tests/test_mapreduce_integration_e2e.py
+++ b/mapreduce/tests/test_mapreduce_integration_e2e.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
+from datadog_checks.dev.utils import get_metadata_metrics
+
 from . import common
 
 pytestmark = pytest.mark.integration
@@ -18,6 +20,7 @@ def test_integration_metrics(aggregator, check, instance, datadog_agent):
     for metric in common.ELAPSED_TIME_METRICS:
         aggregator.assert_metric(metric)
     assert_metrics_covered(aggregator)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 
 
 @pytest.mark.integration
@@ -47,6 +50,7 @@ def test_e2e(dd_agent_check, instance):
     for metric in common.ELAPSED_TIME_BUCKET_METRICS:
         aggregator.assert_metric(metric)
     assert_metrics_covered(aggregator)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 def assert_metrics_covered(aggregator):

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -46,7 +46,7 @@ def test_integration_mongos(instance_integration, aggregator, check):
             'dd.custom.mongo.query_a.amount',
             'dd.custom.mongo.query_a.el',
         ],
-        check_metric_type=False,
+        check_submission_type=True,
     )
     assert len(aggregator._events) == 0
 
@@ -85,7 +85,7 @@ def test_integration_replicaset_primary_in_shard(instance_integration, aggregato
             'dd.custom.mongo.query_a.amount',
             'dd.custom.mongo.query_a.el',
         ],
-        check_metric_type=False,
+        check_submission_type=True,
     )
     assert len(aggregator._events) == 3
     aggregator.assert_event(
@@ -158,7 +158,7 @@ def test_integration_replicaset_secondary_in_shard(instance_integration, aggrega
             'dd.custom.mongo.query_a.amount',
             'dd.custom.mongo.query_a.el',
         ],
-        check_metric_type=False,
+        check_submission_type=True,
     )
     assert len(aggregator._events) == 0
 
@@ -197,7 +197,7 @@ def test_integration_configsvr_primary(instance_integration, aggregator, check):
             'dd.custom.mongo.query_a.amount',
             'dd.custom.mongo.query_a.el',
         ],
-        check_metric_type=False,
+        check_submission_type=True,
     )
     assert len(aggregator._events) == 3
     aggregator.assert_event(
@@ -270,7 +270,7 @@ def test_integration_configsvr_secondary(instance_integration, aggregator, check
             'dd.custom.mongo.query_a.amount',
             'dd.custom.mongo.query_a.el',
         ],
-        check_metric_type=False,
+        check_submission_type=True,
     )
     assert len(aggregator._events) == 0
 
@@ -308,7 +308,7 @@ def test_integration_replicaset_primary(instance_integration, aggregator, check)
             'dd.custom.mongo.query_a.amount',
             'dd.custom.mongo.query_a.el',
         ],
-        check_metric_type=False,
+        check_submission_type=True,
     )
     assert len(aggregator._events) == 3
     aggregator.assert_event(
@@ -383,7 +383,7 @@ def test_integration_replicaset_secondary(instance_integration, aggregator, chec
             'dd.custom.mongo.query_a.amount',
             'dd.custom.mongo.query_a.el',
         ],
-        check_metric_type=False,
+        check_submission_type=True,
     )
     assert len(aggregator._events) == 0
 
@@ -416,6 +416,6 @@ def test_standalone(instance_integration, aggregator, check):
             'dd.custom.mongo.query_a.amount',
             'dd.custom.mongo.query_a.el',
         ],
-        check_metric_type=False,
+        check_submission_type=True,
     )
     assert len(aggregator._events) == 0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add `check_submission_type` argument to check submission type instead in-app type.
The goal would be to update integration tests using `check_metric_type=False` along with their `metadata.csv` to get rid of this argument.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Updated mapreduce and mongo tests to use `check_submission_type=True`

Used information from https://github.com/DataDog/datadog-agent/tree/master/pkg/metrics to create the type mapping

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
