### PR TITLE
Clarify effect of enabling `use_mount`

### DIFF
--- a/disk/assets/configuration/spec.yaml
+++ b/disk/assets/configuration/spec.yaml
@@ -44,7 +44,9 @@ files:
         options:
           - name: use_mount
             required: true
-            description: Instruct the check to collect using mount points instead of volumes.
+            description: |
+              If enabled, metrics are tagged using mount points (for example `device:/`) instead of volumes
+              (for example `device:/dev/disk1s5`).
             value:
               example: false
               type: boolean

--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -33,7 +33,8 @@ init_config:
 instances:
 
     ## @param use_mount - boolean - required
-    ## Instruct the check to collect using mount points instead of volumes.
+    ## If enabled, metrics are tagged using mount points (for example `device:/`) instead of volumes
+    ## (for example `device:/dev/disk1s5`).
     #
   - use_mount: false
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update description of `use_mount` option of `disk` check.

### Motivation
<!-- What inspired you to submit this pull request? -->
The current description is confusing because it seems to indicate that `use_mount` may affect collection, i.e. metric values and cardinality. In reality it is only a presentational knob that only affects the `device` tag:

https://github.com/DataDog/integrations-core/blob/a9caf4b06a4063e27376d45b4110f4c3cbc997b9/disk%2Fdatadog_checks%2Fdisk%2Fdisk.py#L144

https://github.com/DataDog/integrations-core/blob/a9caf4b06a4063e27376d45b4110f4c3cbc997b9/disk%2Fdatadog_checks%2Fdisk%2Fdisk.py#L161

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
