### PR TITLE
Make role configuration step more explicit

### DIFF
--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -32,8 +32,17 @@ datadog-agent integration install datadog-snowflake==2.0.1
     <div class="alert alert-warning">Note: By default, this integration monitors the `SNOWFLAKE` database and `ACCOUNT_USAGE` schema.
     This database is available by default and only viewable by users in the `ACCOUNTADMIN` role or [any role granted by the ACCOUNTADMIN][8].
     
-    We recommend creating a `DATADOG` role with access to `ACCOUNT_USAGE`. Read more about controlling <a href="https://docs.snowflake.com/en/user-guide/security-access-control-considerations.html#control-the-assignment-of-the-accountadmin-role-to-users">ACCOUNTADMIN role</a> for more information.
+    Snowflake recommends granting permissions to an alternate role like `SYSADMIN`.
+    Read more about controlling <a href="https://docs.snowflake.com/en/user-guide/security-access-control-considerations.html#control-the-assignment-of-the-accountadmin-role-to-users">ACCOUNTADMIN role</a> for more information.
     </div>
+    ```text
+    use role ACCOUNTADMIN;
+    grant imported privileges on database snowflake to role SYSADMIN;
+    
+    use role SYSADMIN;
+    ```
+    
+    Alternatively, you can create a `DATADOG` custom role with access to `ACCOUNT_USAGE`.
     
     ```text
     -- Create a new role intended to monitor Snowflake usage.

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -41,9 +41,14 @@ datadog-agent integration install datadog-snowflake==2.0.1
    
     -- Grant privileges on the SNOWFLAKE database to the new role.
     grant imported privileges on database SNOWFLAKE to role DATADOG;
-   
-    -- Grant usage on the warehouse used to monitor Snowflake.
-    grant usage on warehouse <WAREHOUSE> to role DATADOG;
+
+    -- Create a user, skip this step if you are using an existing user.
+    create user DATADOG_USER
+    LOGIN_NAME = DATADOG_USER
+    password = '<PASSWORD>'
+    default_warehouse = <WAREHOUSE>
+    default_role = DATADOG
+    default_namespace = SNOWFLAKE.ACCOUNT_USAGE;
    
     -- Grant the monitor role to the user.
     grant role DATADOG to user <USER>;

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -27,12 +27,31 @@ datadog-agent integration install datadog-snowflake==2.0.1
 </div>
 
 ### Configuration
+1. Create a Datadog specific role and user to monitor Snowflake. In Snowflake, run the following to create a custom role with access to the ACCOUNT_USAGE schema.
+
+    <div class="alert alert-warning">Note: By default, this integration monitors the `SNOWFLAKE` database and `ACCOUNT_USAGE` schema.
+    This database is available by default and only viewable by users in the `ACCOUNTADMIN` role or [any role granted by the ACCOUNTADMIN][8].
+    
+    We recommend creating a `DATADOG` role with access to `ACCOUNT_USAGE`. Read more about controlling [ACCOUNTADMIN role][12] for more information.
+    </div>
+    
+    ```text
+    -- Create a new role intended to monitor Snowflake usage.
+    create role DATADOG;
+   
+    -- Grant privileges on the SNOWFLAKE database to the new role.
+    grant imported privileges on database SNOWFLAKE to role DATADOG;
+   
+    -- Grant usage on the warehouse used to monitor Snowflake.
+    grant usage on warehouse <WAREHOUSE> to role DATADOG;
+   
+    -- Grant the monitor role to the user.
+    grant role DATADOG to user <USER>;
+    ```
+   
 
 1. Edit the `snowflake.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your snowflake performance data. See the [sample snowflake.d/conf.yaml][3] for all available configuration options.
 
-    **Note**: By default, this integration monitors the `SNOWFLAKE` database and `ACCOUNT_USAGE` schema.
-    This database is available by default and only viewable by users in the `ACCOUNTADMIN` role or [any role granted by the ACCOUNTADMIN][8].
-    
     ```yaml
         ## @param account - string - required
         ## Name of your account (provided by Snowflake), including the platform and region if applicable.
@@ -50,6 +69,15 @@ datadog-agent integration install datadog-snowflake==2.0.1
         ## Password for the user
         #
         password: <PASSWORD>
+   
+        ## @param role - string - required
+        ## Name of the role to use.
+        ##
+        ## By default, the SNOWFLAKE database is only accessible by the ACCOUNTADMIN role. However, we recommend
+        ## to configure a role specific for monitoring:
+        ## https://docs.snowflake.com/en/sql-reference/account-usage.html#enabling-account-usage-for-other-roles
+        #
+        role: <ROLE>
    
         ## @param min_collection_interval - number - optional - default: 3600
         ## This changes the collection interval of the check. For more information, see:
@@ -171,3 +199,4 @@ Need help? Contact [Datadog support][7].
 [9]: https://docs.snowflake.com/en/sql-reference/account-usage/query_history.html
 [10]: https://raw.githubusercontent.com/DataDog/integrations-core/master/snowflake/images/custom_query.png
 [11]: https://docs.datadoghq.com/metrics/summary/
+[12]: https://docs.snowflake.com/en/user-guide/security-access-control-considerations.html#control-the-assignment-of-the-accountadmin-role-to-users

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -91,7 +91,7 @@ datadog-agent integration install datadog-snowflake==2.0.1
         ## NOTE: Most Snowflake ACCOUNT_USAGE views are populated on an hourly basis,
         ## so to minimize unnecessary queries the `min_collection_interval` defaults to 1 hour.
         #
-        # min_collection_interval: 3600
+        min_collection_interval: 3600
     ```
 
     <div class="alert alert-info">By default, the <code>min_collection_interval</code> is 1 hour. 

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -87,8 +87,8 @@ datadog-agent integration install datadog-snowflake==2.0.1
         ## @param role - string - required
         ## Name of the role to use.
         ##
-        ## By default, the SNOWFLAKE database is only accessible by the ACCOUNTADMIN role. However, we recommend
-        ## to configure a role specific for monitoring:
+        ## By default, the SNOWFLAKE database is only accessible by the ACCOUNTADMIN role. Snowflake recommends
+        ## configuring a role specific for monitoring:
         ## https://docs.snowflake.com/en/sql-reference/account-usage.html#enabling-account-usage-for-other-roles
         #
         role: <ROLE>

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -32,7 +32,7 @@ datadog-agent integration install datadog-snowflake==2.0.1
     <div class="alert alert-warning">Note: By default, this integration monitors the `SNOWFLAKE` database and `ACCOUNT_USAGE` schema.
     This database is available by default and only viewable by users in the `ACCOUNTADMIN` role or [any role granted by the ACCOUNTADMIN][8].
     
-    We recommend creating a `DATADOG` role with access to `ACCOUNT_USAGE`. Read more about controlling [ACCOUNTADMIN role][12] for more information.
+    We recommend creating a `DATADOG` role with access to `ACCOUNT_USAGE`. Read more about controlling <a href="https://docs.snowflake.com/en/user-guide/security-access-control-considerations.html#control-the-assignment-of-the-accountadmin-role-to-users">ACCOUNTADMIN role</a> for more information.
     </div>
     
     ```text
@@ -204,4 +204,3 @@ Need help? Contact [Datadog support][7].
 [9]: https://docs.snowflake.com/en/sql-reference/account-usage/query_history.html
 [10]: https://raw.githubusercontent.com/DataDog/integrations-core/master/snowflake/images/custom_query.png
 [11]: https://docs.datadoghq.com/metrics/summary/
-[12]: https://docs.snowflake.com/en/user-guide/security-access-control-considerations.html#control-the-assignment-of-the-accountadmin-role-to-users

--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -68,7 +68,6 @@ files:
           type: string
           example: <PASSWORD>
       - name: role
-        enable: true
         required: true
         description: |
           Name of the role to use.

--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -67,6 +67,17 @@ files:
         value:
           type: string
           example: <PASSWORD>
+      - name: role
+        enable: true
+        required: true
+        description: |
+          Name of the role to use.
+
+          By default, the SNOWFLAKE database is only accessible by the ACCOUNTADMIN role. However, we recommend
+          to configure a role specific for monitoring:
+          https://docs.snowflake.com/en/sql-reference/account-usage.html#enabling-account-usage-for-other-roles
+        value:
+          type: string
       - name: database
         description: Name of the default database to use.
         value:
@@ -77,11 +88,6 @@ files:
         value:
           type: string
           example: ACCOUNT_USAGE
-      - name: role
-        description: Name of the default role to use.
-        value:
-          type: string
-          example: ACCOUNTADMIN
       - name: warehouse
         description: Name of the default warehouse to use.
         value:

--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -73,8 +73,8 @@ files:
         description: |
           Name of the role to use.
 
-          By default, the SNOWFLAKE database is only accessible by the ACCOUNTADMIN role. However, we recommend
-          to configure a role specific for monitoring:
+          By default, the SNOWFLAKE database is only accessible by the ACCOUNTADMIN role. Snowflake recommends
+          configuring a role specific for monitoring:
           https://docs.snowflake.com/en/sql-reference/account-usage.html#enabling-account-usage-for-other-roles
         value:
           type: string

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -156,10 +156,11 @@ class SnowflakeCheck(AgentCheck):
             try:
                 return method(*args, **kwargs)
             except Exception as e:
+                msg = "Encountered error while attempting to connect to Snowflake "
                 if proxies:
-                    self.log.error(
-                        "Encountered error while attempting to connect to Snowflake via proxy settings: %s", str(e)
-                    )
+                    self.log.error("%s via proxy settings: %s", msg, str(e))
+                else:
+                    self.log.error("%s: %s", msg, str(e))
                 return
 
         return _request_exec

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -49,6 +49,12 @@ class SnowflakeCheck(AgentCheck):
         if self.config.password:
             self.register_secret(self.config.password)
 
+        if self.config.role == 'ACCOUNTADMIN':
+            self.log.info(
+                'Snowflake `role` is set as `ACCOUNTADMIN` which should be used cautiously, '
+                'refer to docs about custom roles.'
+            )
+
         self.metric_queries = []
         self.errors = []
         for mgroup in self.config.metric_groups:

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -40,7 +40,7 @@ class SnowflakeCheck(AgentCheck):
 
     def __init__(self, *args, **kwargs):
         super(SnowflakeCheck, self).__init__(*args, **kwargs)
-        self.config = Config(self.instance, self.log)
+        self.config = Config(self.instance)
         self._conn = None
 
         # Add default tags like account to all metrics
@@ -156,9 +156,10 @@ class SnowflakeCheck(AgentCheck):
             try:
                 return method(*args, **kwargs)
             except Exception as e:
-                self.log.error(
-                    "Encountered error while attempting to connect to Snowflake via proxy settings: %s", str(e)
-                )
+                if proxies:
+                    self.log.error(
+                        "Encountered error while attempting to connect to Snowflake via proxy settings: %s", str(e)
+                    )
                 return
 
         return _request_exec

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -40,7 +40,7 @@ class SnowflakeCheck(AgentCheck):
 
     def __init__(self, *args, **kwargs):
         super(SnowflakeCheck, self).__init__(*args, **kwargs)
-        self.config = Config(self.instance)
+        self.config = Config(self.instance, self.log)
         self._conn = None
 
         # Add default tags like account to all metrics

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -21,7 +21,7 @@ class Config(object):
 
     AUTHENTICATION_MODES = ['snowflake', 'oauth']
 
-    def __init__(self, log, instance=None):
+    def __init__(self, instance=None):
         if instance is None:
             instance = {}
 

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -21,7 +21,7 @@ class Config(object):
 
     AUTHENTICATION_MODES = ['snowflake', 'oauth']
 
-    def __init__(self, instance=None):
+    def __init__(self, log, instance=None):
         if instance is None:
             instance = {}
 
@@ -64,9 +64,11 @@ class Config(object):
 
         if role is None:
             raise ConfigurationError('Must specify a role')
-
-        if role == 'ACCOUNTADMIN':
-            self.log.info('Snowflake `role` is set as `ACCOUNTADMIN` which should be used cautiously. Please refer to docs to set up a custom role.')
+        elif role == 'ACCOUNTADMIN':
+            log.info(
+                'Snowflake `role` is set as `ACCOUNTADMIN` which should be used cautiously, '
+                'refer to docs about custom roles.'
+            )
 
         self.account = account  # type: str
         self.user = user  # type: str

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -28,7 +28,7 @@ class Config(object):
         account = instance.get('account')
         user = instance.get('user')
         password = instance.get('password')
-        role = instance.get('role', 'ACCOUNTADMIN')
+        role = instance.get('role')
         database = instance.get('database', 'SNOWFLAKE')
         schema = instance.get('schema', 'ACCOUNT_USAGE')
         warehouse = instance.get('warehouse')
@@ -61,6 +61,9 @@ class Config(object):
 
         if authenticator == 'oauth' and token is None:
             raise ConfigurationError('If using OAuth, you must specify a token')
+
+        if role == 'ACCOUNTADMIN':
+            self.log.warning('Snowflake `role` is set as `ACCOUNTADMIN` which should be used cautiously. Please refer to docs to set up a custom role.')
 
         self.account = account  # type: str
         self.user = user  # type: str

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -64,11 +64,6 @@ class Config(object):
 
         if role is None:
             raise ConfigurationError('Must specify a role')
-        elif role == 'ACCOUNTADMIN':
-            log.info(
-                'Snowflake `role` is set as `ACCOUNTADMIN` which should be used cautiously, '
-                'refer to docs about custom roles.'
-            )
 
         self.account = account  # type: str
         self.user = user  # type: str

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -63,7 +63,7 @@ class Config(object):
             raise ConfigurationError('If using OAuth, you must specify a token')
 
         if role == 'ACCOUNTADMIN':
-            self.log.warning('Snowflake `role` is set as `ACCOUNTADMIN` which should be used cautiously. Please refer to docs to set up a custom role.')
+            self.log.info('Snowflake `role` is set as `ACCOUNTADMIN` which should be used cautiously. Please refer to docs to set up a custom role.')
 
         self.account = account  # type: str
         self.user = user  # type: str

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -62,6 +62,9 @@ class Config(object):
         if authenticator == 'oauth' and token is None:
             raise ConfigurationError('If using OAuth, you must specify a token')
 
+        if role is None:
+            raise ConfigurationError('Must specify a role')
+
         if role == 'ACCOUNTADMIN':
             self.log.info('Snowflake `role` is set as `ACCOUNTADMIN` which should be used cautiously. Please refer to docs to set up a custom role.')
 

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -68,6 +68,15 @@ instances:
     #
     password: <PASSWORD>
 
+    ## @param role - string - required
+    ## Name of the role to use.
+    ##
+    ## By default, the SNOWFLAKE database is only accessible by the ACCOUNTADMIN role. However, we recommend
+    ## to configure a role specific for monitoring:
+    ## https://docs.snowflake.com/en/sql-reference/account-usage.html#enabling-account-usage-for-other-roles
+    #
+    role: <ROLE>
+
     ## @param database - string - optional - default: SNOWFLAKE
     ## Name of the default database to use.
     #
@@ -77,11 +86,6 @@ instances:
     ## Name of the default schema to use for the database.
     #
     # schema: ACCOUNT_USAGE
-
-    ## @param role - string - optional - default: ACCOUNTADMIN
-    ## Name of the default role to use.
-    #
-    # role: ACCOUNTADMIN
 
     ## @param warehouse - string - optional
     ## Name of the default warehouse to use.

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -71,7 +71,7 @@ instances:
     ## @param role - string - required
     ## Name of the role to use.
     ##
-    ## By default, the SNOWFLAKE database is only accessible by the ACCOUNTADMIN role. However, we recommend
+    ## By default, the SNOWFLAKE database is only accessible by the ACCOUNTADMIN role. Snowflake recommends
     ## to configure a role specific for monitoring:
     ## https://docs.snowflake.com/en/sql-reference/account-usage.html#enabling-account-usage-for-other-roles
     #

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -72,7 +72,7 @@ instances:
     ## Name of the role to use.
     ##
     ## By default, the SNOWFLAKE database is only accessible by the ACCOUNTADMIN role. Snowflake recommends
-    ## to configure a role specific for monitoring:
+    ## configuring a role specific for monitoring:
     ## https://docs.snowflake.com/en/sql-reference/account-usage.html#enabling-account-usage-for-other-roles
     #
     role: <ROLE>


### PR DESCRIPTION
### What does this PR do?
This PR emphasizes the creation of custom role to monitor Snowflake with sql example.

- make `role` config option required because default `ACCOUNTADMIN` is removed. 
- encourages users to use better security practices according to Snowflake
- Add example script for creating new user/role or just assigning permissions to sysadmin role
- clarify debug log for proxy 

### Motivation
Make note more obvious in configuration step.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
