### PR TITLE
Add SSL support for connection

### DIFF
--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -48,7 +48,7 @@ files:
       - template: instances/db
       - name: use_tls
         description: |
-          This instructs the SAP HANA integration to connect using TLS.
+          Instructs the SAP HANA integration to connect using TLS.
         value:
           example: false
           type: boolean

--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -46,4 +46,11 @@ files:
           type: integer
           default: 10
       - template: instances/db
+      - name: use_tls
+        description: |
+          This instructs the SAP HANA integration to connect using TLS.
+        value:
+          example: false
+          type: boolean
+      - template: instances/tls
       - template: instances/default

--- a/sap_hana/datadog_checks/sap_hana/connection.py
+++ b/sap_hana/datadog_checks/sap_hana/connection.py
@@ -1,6 +1,6 @@
 import socket
 
-from pyhdb.connection import Connection, INITIALIZATION_BYTES, version_struct
+from pyhdb.connection import INITIALIZATION_BYTES, Connection, version_struct
 
 
 class HanaConnection(Connection):

--- a/sap_hana/datadog_checks/sap_hana/connection.py
+++ b/sap_hana/datadog_checks/sap_hana/connection.py
@@ -1,0 +1,36 @@
+import socket
+
+from pyhdb.connection import Connection, INITIALIZATION_BYTES, version_struct
+
+
+class HanaConnection(Connection):
+    def __init__(self, host, port, user, password, tls_context=None, autocommit=False, timeout=None):
+        super(HanaConnection, self).__init__(host, port, user, password, autocommit, timeout)
+        self.tls_context = tls_context
+
+    def _open_socket_and_init_protocoll(self):
+        """Overrides this method from pyhdb to add SSL support.
+        Original implementation here can be found here:
+        https://github.com/SAP/PyHDB/blob/v0.3.4/pyhdb/connection.py#L65"""
+
+        # CREATE SOCKET
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(self._timeout)
+
+        # WRAP SOCKET
+        if self.tls_context:
+            self._socket = self.tls_context.wrap_socket(sock, server_hostname=self.host)
+        else:
+            self._socket = sock
+
+        self._socket.connect((self.host, self.port))
+
+        # Initialization Handshake
+        self._socket.sendall(INITIALIZATION_BYTES)
+
+        response = self._socket.recv(8)
+        if len(response) != 8:
+            raise Exception("Connection failed")
+
+        self.product_version = version_struct.unpack(response[0:3])
+        self.protocol_version = version_struct.unpack_from(response[3:8])

--- a/sap_hana/datadog_checks/sap_hana/connection.py
+++ b/sap_hana/datadog_checks/sap_hana/connection.py
@@ -13,17 +13,12 @@ class HanaConnection(Connection):
         Original implementation here can be found here:
         https://github.com/SAP/PyHDB/blob/v0.3.4/pyhdb/connection.py#L65"""
 
-        # CREATE SOCKET
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(self._timeout)
+        # Create socket
+        self._socket = socket.create_connection((self.host, self.port), self._timeout)
 
-        # WRAP SOCKET
+        # Wrap socket if tls_context is set
         if self.tls_context:
-            self._socket = self.tls_context.wrap_socket(sock, server_hostname=self.host)
-        else:
-            self._socket = sock
-
-        self._socket.connect((self.host, self.port))
+            self._socket = self.tls_context.wrap_socket(self._socket, server_hostname=self.host)
 
         # Initialization Handshake
         self._socket.sendall(INITIALIZATION_BYTES)

--- a/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
+++ b/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
@@ -101,7 +101,7 @@ instances:
     #     - test:<INTEGRATION>
 
     ## @param use_tls - boolean - optional - default: false
-    ## This instructs the SAP HANA integration to connect using TLS.
+    ## Instructs the SAP HANA integration to connect using TLS.
     #
     # use_tls: false
 

--- a/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
+++ b/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
@@ -106,7 +106,7 @@ instances:
     # use_tls: false
 
     ## @param tls_verify - boolean - optional - default: true
-    ## Instructs the check to validate the TLS certificate of services.
+    ## Instructs the check to validate the TLS certificate(s) of the service(s).
     #
     # tls_verify: true
 

--- a/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
+++ b/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
@@ -100,6 +100,55 @@ instances:
     #     tags:
     #     - test:<INTEGRATION>
 
+    ## @param use_tls - boolean - optional - default: false
+    ## This instructs the SAP HANA integration to connect using TLS.
+    #
+    # use_tls: false
+
+    ## @param tls_verify - boolean - optional - default: true
+    ## Instructs the check to validate the TLS certificate of services.
+    #
+    # tls_verify: true
+
+    ## @param tls_ca_cert - string - optional
+    ## The path to a file of concatenated CA certificates in PEM format or a directory
+    ## containing several CA certificates in PEM format. If a directory, the directory
+    ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
+    ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+    ##
+    ## Setting this implicitly sets `tls_verify` to true.
+    #
+    # tls_ca_cert: <CA_CERT_PATH>
+
+    ## @param tls_cert - string - optional
+    ## The path to a single file in PEM format containing a certificate as well as any
+    ## number of CA certificates needed to establish the certificate's authenticity for
+    ## use when connecting to services. It may also contain an unencrypted private key to use.
+    ##
+    ## Setting this implicitly sets `tls_verify` to true.
+    #
+    # tls_cert: <CERT_PATH>
+
+    ## @param tls_private_key - string - optional
+    ## The unencrypted private key to use for `tls_cert` when connecting to services. This is
+    ## required if `tls_cert` is set and it does not already contain a private key.
+    ##
+    ## Setting this implicitly sets `tls_verify` to true.
+    #
+    # tls_private_key: <PRIVATE_KEY_PATH>
+
+    ## @param tls_private_key_password - string - optional
+    ## Optional password to decrypt tls_private_key.
+    ##
+    ## Setting this implicitly sets `tls_verify` to true.
+    #
+    # tls_private_key_password: <PRIVATE_KEY_PASSWORD>
+
+    ## @param tls_validate_hostname - boolean - optional - default: true
+    ## Verifies that the server's cert hostname matches the one requested.
+    #
+    # tls_validate_hostname: true
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -15,8 +15,8 @@ from datadog_checks.base.utils.common import total_time_to_temporal_percent
 from datadog_checks.base.utils.constants import MICROSECOND
 from datadog_checks.base.utils.containers import iter_unique
 
-from .connection import HanaConnection
 from . import queries
+from .connection import HanaConnection
 from .exceptions import QueryExecutionError
 from .utils import compute_percent, positive
 
@@ -551,7 +551,7 @@ class SapHanaCheck(AgentCheck):
                 user=self._username,
                 password=self._password,
                 tls_context=tls_context,
-                timeout=self._timeout
+                timeout=self._timeout,
             )
             connection.connect()
         except Exception as e:

--- a/sap_hana/setup.py
+++ b/sap_hana/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.2.0'
 
 
 setup(


### PR DESCRIPTION
The library we use (PyHDB) does not support SSL options when creating the connection to the database.  See https://github.com/SAP/PyHDB/issues/107

This PR updates the Connection class to add SSL support when opening the socket to the db.

The official SAP HANA python driver has all the necessary configuration to connect with SSL), but unfortunately it's using a license that doesn't permit redistribution so we aren't using it.