### PR TITLE
Add test filter to env test

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -1,4 +1,3 @@
-
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -1,3 +1,4 @@
+
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
@@ -43,8 +44,9 @@ from .stop import stop
 @click.option('--new-env', '-ne', is_flag=True, help='Execute setup and tear down actions')
 @click.option('--profile-memory', '-pm', is_flag=True, help='Whether to collect metrics about memory usage')
 @click.option('--junit', '-j', 'junit', is_flag=True, help='Generate junit reports')
+@click.option('--filter', '-k', 'test_filter', help='Only run tests matching given substring expression')
 @click.pass_context
-def test(ctx, checks, agent, python, dev, base, env_vars, new_env, profile_memory, junit):
+def test(ctx, checks, agent, python, dev, base, env_vars, new_env, profile_memory, junit, test_filter):
     """Test an environment."""
     check_envs = get_tox_envs(checks, e2e_tests_only=True)
     tests_ran = False
@@ -101,6 +103,7 @@ def test(ctx, checks, agent, python, dev, base, env_vars, new_env, profile_memor
                         e2e=True,
                         passenv=' '.join(persisted_env_vars) if persisted_env_vars else None,
                         junit=junit,
+                        test_filter=test_filter,
                     )
             finally:
                 if new_env:


### PR DESCRIPTION
### What does this PR do?
Add test filter to env test

Example:

```
$ ddev env test check snmp:py38-python_ad -k test_e2e_metric_types
```

### Motivation

Useful to filter tests.