### PR TITLE
Only send ssl metrics if a connection succeeded

### DIFF
--- a/http_check/assets/service_checks.json
+++ b/http_check/assets/service_checks.json
@@ -22,7 +22,8 @@
         "statuses": [
             "ok",
             "warning",
-            "critical"
+            "critical",
+            "unknown"
         ],
         "groups": [
             "host",

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -320,7 +320,7 @@ class HTTPCheck(AgentCheck):
 
         except Exception as e:
             msg = str(e)
-            if 'expiration' in msg:
+            if any(word in msg for word in ['expired', 'expiration']):
                 self.log.debug("error: %s. Cert might be expired.", e)
                 return AgentCheck.CRITICAL, 0, 0, msg
             elif 'Hostname mismatch' in msg or "doesn't match" in msg:

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -243,9 +243,9 @@ class HTTPCheck(AgentCheck):
             tags_list = list(tags)
             tags_list.append('url:{}'.format(addr))
             tags_list.append("instance:{}".format(instance_name))
-            if days_left >=0:
+            if days_left >= 0:
                 self.gauge('http.ssl.days_left', days_left, tags=tags_list)
-            if seconds_left >=0:
+            if seconds_left >= 0:
                 self.gauge('http.ssl.seconds_left', seconds_left, tags=tags_list)
 
             service_checks.append((self.SC_SSL_CERT, status, msg))

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -243,8 +243,10 @@ class HTTPCheck(AgentCheck):
             tags_list = list(tags)
             tags_list.append('url:{}'.format(addr))
             tags_list.append("instance:{}".format(instance_name))
-            self.gauge('http.ssl.days_left', days_left, tags=tags_list)
-            self.gauge('http.ssl.seconds_left', seconds_left, tags=tags_list)
+            if days_left >=0:
+                self.gauge('http.ssl.days_left', days_left, tags=tags_list)
+            if seconds_left >=0:
+                self.gauge('http.ssl.seconds_left', seconds_left, tags=tags_list)
 
             service_checks.append((self.SC_SSL_CERT, status, msg))
 
@@ -323,10 +325,10 @@ class HTTPCheck(AgentCheck):
                 return AgentCheck.CRITICAL, 0, 0, msg
             elif 'Hostname mismatch' in msg or "doesn't match" in msg:
                 self.log.debug("The hostname on the SSL certificate does not match the given host: %s", e)
-                return AgentCheck.CRITICAL, 0, 0, msg
+                return AgentCheck.CRITICAL, -1, -1, msg
             else:
                 self.log.debug("Site is down, unable to connect to get cert expiration: %s", e)
-                return AgentCheck.CRITICAL, 0, 0, msg
+                return AgentCheck.CRITICAL, -1, -1, msg
 
         exp_date = datetime.strptime(cert['notAfter'], "%b %d %H:%M:%S %Y %Z")
         time_left = exp_date - datetime.utcnow()

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -243,9 +243,9 @@ class HTTPCheck(AgentCheck):
             tags_list = list(tags)
             tags_list.append('url:{}'.format(addr))
             tags_list.append("instance:{}".format(instance_name))
-            if days_left >= 0:
+            if days_left >=0:
                 self.gauge('http.ssl.days_left', days_left, tags=tags_list)
-            if seconds_left >= 0:
+            if seconds_left >=0:
                 self.gauge('http.ssl.seconds_left', seconds_left, tags=tags_list)
 
             service_checks.append((self.SC_SSL_CERT, status, msg))

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -243,10 +243,8 @@ class HTTPCheck(AgentCheck):
             tags_list = list(tags)
             tags_list.append('url:{}'.format(addr))
             tags_list.append("instance:{}".format(instance_name))
-            if days_left >=0:
-                self.gauge('http.ssl.days_left', days_left, tags=tags_list)
-            if seconds_left >=0:
-                self.gauge('http.ssl.seconds_left', seconds_left, tags=tags_list)
+            self.gauge('http.ssl.days_left', days_left, tags=tags_list)
+            self.gauge('http.ssl.seconds_left', seconds_left, tags=tags_list)
 
             service_checks.append((self.SC_SSL_CERT, status, msg))
 
@@ -325,10 +323,10 @@ class HTTPCheck(AgentCheck):
                 return AgentCheck.CRITICAL, 0, 0, msg
             elif 'Hostname mismatch' in msg or "doesn't match" in msg:
                 self.log.debug("The hostname on the SSL certificate does not match the given host: %s", e)
-                return AgentCheck.CRITICAL, -1, -1, msg
+                return AgentCheck.CRITICAL, 0, 0, msg
             else:
                 self.log.debug("Site is down, unable to connect to get cert expiration: %s", e)
-                return AgentCheck.CRITICAL, -1, -1, msg
+                return AgentCheck.CRITICAL, 0, 0, msg
 
         exp_date = datetime.strptime(cert['notAfter'], "%b %d %H:%M:%S %Y %Z")
         time_left = exp_date - datetime.utcnow()

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -323,10 +323,10 @@ class HTTPCheck(AgentCheck):
                 return AgentCheck.CRITICAL, 0, 0, msg
             elif 'Hostname mismatch' in msg or "doesn't match" in msg:
                 self.log.debug("The hostname on the SSL certificate does not match the given host: %s", e)
-                return AgentCheck.CRITICAL, 0, 0, msg
+                return AgentCheck.UNKNOWN, None, None, msg
             else:
                 self.log.debug("Site is down, unable to connect to get cert expiration: %s", e)
-                return AgentCheck.CRITICAL, 0, 0, msg
+                return AgentCheck.UNKNOWN, None, None, msg
 
         exp_date = datetime.strptime(cert['notAfter'], "%b %d %H:%M:%S %Y %Z")
         time_left = exp_date - datetime.utcnow()

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -117,7 +117,7 @@ def test_check_ssl(aggregator, http_check):
 
     connection_err_tags = ['url:https://thereisnosuchlink.com', 'instance:conn_error']
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.CRITICAL, tags=connection_err_tags, count=1)
-    aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.CRITICAL, tags=connection_err_tags, count=1)
+    aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.UNKNOWN, tags=connection_err_tags, count=1)
 
 
 @pytest.mark.usefixtures("dd_environment")
@@ -153,7 +153,7 @@ def test_check_ssl_expire_error(aggregator, http_check):
 
     expired_cert_tags = ['url:https://valid.mock', 'instance:expired_cert']
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=expired_cert_tags, count=1)
-    aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.CRITICAL, tags=expired_cert_tags, count=1)
+    aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.UNKNOWN, tags=expired_cert_tags, count=1)
 
 
 @pytest.mark.usefixtures("dd_environment")
@@ -164,7 +164,7 @@ def test_check_ssl_expire_error_secs(aggregator, http_check):
 
     expired_cert_tags = ['url:https://valid.mock', 'instance:expired_cert_seconds']
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=expired_cert_tags, count=1)
-    aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.CRITICAL, tags=expired_cert_tags, count=1)
+    aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.UNKNOWN, tags=expired_cert_tags, count=1)
 
 
 @pytest.mark.usefixtures("dd_environment")
@@ -177,7 +177,7 @@ def test_check_hostname_override(aggregator, http_check):
     cert_validation_fail_tags = ['url:https://valid.mock:443', 'instance:cert_validation_fails']
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=cert_validation_fail_tags, count=1)
     aggregator.assert_service_check(
-        HTTPCheck.SC_SSL_CERT, status=HTTPCheck.CRITICAL, tags=cert_validation_fail_tags, count=1
+        HTTPCheck.SC_SSL_CERT, status=HTTPCheck.UNKNOWN, tags=cert_validation_fail_tags, count=1
     )
 
     cert_validation_pass_tags = ['url:https://valid.mock:443', 'instance:cert_validation_passes']
@@ -203,7 +203,14 @@ def test_mock_case(aggregator, http_check):
 
     expired_cert_tags = ['url:https://valid.mock', 'instance:expired_cert']
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=expired_cert_tags, count=1)
-    aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.CRITICAL, tags=expired_cert_tags, count=1)
+    if sys.version_info[0] < 3:
+        aggregator.assert_service_check(
+            HTTPCheck.SC_SSL_CERT, status=HTTPCheck.UNKNOWN, tags=expired_cert_tags, count=1
+        )
+    else:
+        aggregator.assert_service_check(
+            HTTPCheck.SC_SSL_CERT, status=HTTPCheck.CRITICAL, tags=expired_cert_tags, count=1
+        )
 
 
 @pytest.mark.usefixtures("dd_environment")

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -4,6 +4,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+import sys
 
 import mock
 import pytest
@@ -39,24 +40,31 @@ def test_check_cert_expiration(http_check):
     # bad hostname
     instance = {'url': 'https://wronghost.mock/'}
     status, days_left, seconds_left, msg = http_check.check_cert_expiration(instance, 10, cert_path, check_hostname)
-    assert status == AgentCheck.CRITICAL
-    assert days_left == -1
-    assert seconds_left == -1
+    assert status == AgentCheck.UNKNOWN
+    assert days_left is None
+    assert seconds_left is None
     assert 'Hostname mismatch' in msg or "doesn't match" in msg
 
     # site is down
     instance = {'url': 'https://this.does.not.exist.foo'}
     status, days_left, seconds_left, msg = http_check.check_cert_expiration(instance, 10, cert_path, check_hostname)
-    assert status == AgentCheck.CRITICAL
-    assert days_left == -1
-    assert seconds_left == -1
+    assert status == AgentCheck.UNKNOWN
+    assert days_left is None
+    assert seconds_left is None
 
     # cert expired
     instance = {'url': 'https://expired.mock/'}
     status, days_left, seconds_left, msg = http_check.check_cert_expiration(instance, 10, cert_path, check_hostname)
-    assert status == AgentCheck.CRITICAL
-    assert days_left == 0
-    assert seconds_left == 0
+    if sys.version_info[0] < 3:
+        # Python 2 returns ambiguous "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed"
+        # Same as site is down
+        assert status == AgentCheck.UNKNOWN
+        assert days_left is None
+        assert seconds_left is None
+    else:
+        assert status == AgentCheck.CRITICAL
+        assert days_left == 0
+        assert seconds_left == 0
 
     # critical in days
     days_critical = 200

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -40,16 +40,16 @@ def test_check_cert_expiration(http_check):
     instance = {'url': 'https://wronghost.mock/'}
     status, days_left, seconds_left, msg = http_check.check_cert_expiration(instance, 10, cert_path, check_hostname)
     assert status == AgentCheck.CRITICAL
-    assert days_left == 0
-    assert seconds_left == 0
+    assert days_left == -1
+    assert seconds_left == -1
     assert 'Hostname mismatch' in msg or "doesn't match" in msg
 
     # site is down
     instance = {'url': 'https://this.does.not.exist.foo'}
     status, days_left, seconds_left, msg = http_check.check_cert_expiration(instance, 10, cert_path, check_hostname)
     assert status == AgentCheck.CRITICAL
-    assert days_left == 0
-    assert seconds_left == 0
+    assert days_left == -1
+    assert seconds_left == -1
 
     # cert expired
     instance = {'url': 'https://expired.mock/'}


### PR DESCRIPTION
### What does this PR do?
Only send ssl metrics if a connection succeeded

### Motivation
- AGENT-5349

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
