### PR TITLE
Log the offending query when there is an error

### DIFF
--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -70,8 +70,11 @@ class PgBouncer(AgentCheck):
 
                         rows = cursor.fetchall()
 
-                    except pg.Error:
+                    except Exception as e:
+                        self.log.debug("There was an error running query %s", query)
                         self.log.exception("Not all metrics may be available")
+                        if not isinstance(e, pg.Error):
+                            raise
 
                     else:
                         for row in rows:


### PR DESCRIPTION
A customer is experiencing encoding issues. Being able to know which query is causing it will let us investigate the source data.