### PR TITLE
Remove active_directory references from config

### DIFF
--- a/active_directory/assets/configuration/spec.yaml
+++ b/active_directory/assets/configuration/spec.yaml
@@ -10,6 +10,12 @@ files:
     - template: instances/pdh
       overrides:
           host.required: true
+          additional_metrics.value.example:
+          - [NTDS, none, DS % Writes from LDAP, active_directory.ds.writes_from_ldap, gauge]
+          counter_data_types.value.example:
+          - <METRIC_NAME>,<DATA_TYPE>
+          - active_directory.dra.inbound.bytes.total,int
+          - active_directory.ldap.bind_time,float
     - template: instances/default
   - template: logs
     example:

--- a/active_directory/datadog_checks/active_directory/data/conf.yaml.example
+++ b/active_directory/datadog_checks/active_directory/data/conf.yaml.example
@@ -54,9 +54,9 @@ instances:
     ## <DATA_TYPE>  : The type of your metric (int or float)
     #
     # counter_data_types:
-    #   - [<METRIC_NAME>, <DATA_TYPE>]
-    #   - [active_directory.dra.inbound.bytes.total, int]
-    #   - [active_directory.ldap.bind_time, float]
+    #   - <METRIC_NAME>,<DATA_TYPE>
+    #   - active_directory.dra.inbound.bytes.total,int
+    #   - active_directory.ldap.bind_time,float
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/pdh.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/pdh.yaml
@@ -34,7 +34,8 @@
                   rate, histogram, or count.
   value:
     example:
-    - ['NTDS', none, 'DS % Writes from LDAP', active_directory.ds.writes_from_ldap, gauge]
+    - ['Processor', none, '% Processor Time', processor.time, gauge]
+    - ['Processor', none, '% User Time', processor.user.time, gauge]
     type: array
     compact_example: true
     items:
@@ -50,10 +51,9 @@
     <DATA_TYPE>  : The type of your metric (int or float)
   value:
       example:
-        - [<METRIC_NAME>, <DATA_TYPE>]
-        - [active_directory.dra.inbound.bytes.total, int]
-        - [active_directory.ldap.bind_time, float]
+        - <METRIC_NAME>,<DATA_TYPE>
+        - processor.time,int
+        - processor.user.time,float
       type: array
-      compact_example: true
       items:
         type: string

--- a/hyperv/datadog_checks/hyperv/data/conf.yaml.example
+++ b/hyperv/datadog_checks/hyperv/data/conf.yaml.example
@@ -46,7 +46,8 @@ instances:
     ##               rate, histogram, or count.
     #
     # additional_metrics:
-    #   - [NTDS, none, DS % Writes from LDAP, active_directory.ds.writes_from_ldap, gauge]
+    #   - [Processor, none, '% Processor Time', processor.time, gauge]
+    #   - [Processor, none, '% User Time', processor.user.time, gauge]
 
     ## @param counter_data_types - list of strings - optional
     ## counter_data_types is a list of <METRIC_NAME>,<DATA_TYPE> elements that
@@ -55,9 +56,9 @@ instances:
     ## <DATA_TYPE>  : The type of your metric (int or float)
     #
     # counter_data_types:
-    #   - [<METRIC_NAME>, <DATA_TYPE>]
-    #   - [active_directory.dra.inbound.bytes.total, int]
-    #   - [active_directory.ldap.bind_time, float]
+    #   - <METRIC_NAME>,<DATA_TYPE>
+    #   - processor.time,int
+    #   - processor.user.time,float
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/pdh_check/datadog_checks/pdh_check/data/conf.yaml.example
+++ b/pdh_check/datadog_checks/pdh_check/data/conf.yaml.example
@@ -70,9 +70,9 @@ instances:
     ## <DATA_TYPE>  : The type of your metric (int or float)
     #
     # counter_data_types:
-    #   - [<METRIC_NAME>, <DATA_TYPE>]
-    #   - [active_directory.dra.inbound.bytes.total, int]
-    #   - [active_directory.ldap.bind_time, float]
+    #   - <METRIC_NAME>,<DATA_TYPE>
+    #   - processor.time,int
+    #   - processor.user.time,float
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.


### PR DESCRIPTION
Removes active directory references from the base template and fix counter_data_types which had been incorrectly formatted when adding the config specs.