### PR TITLE
Handle case sensitivity on database names

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -194,10 +194,10 @@ class Connection(object):
         Check for existence of a database, but take into consideration whether the db is case-sensitive or not.
 
         If not case-sensitive, then we normalize the database name to lowercase on both sides and check.
-        If so, then we only accept exact-name matches.
+        If case-sensitive, then we only accept exact-name matches.
 
-        If the check fails, then we either won't do any checks if `ignore_missing_database` is enabled, or will fail
-        with a ConfigurationError.
+        If the check fails, then we won't do any checks if `ignore_missing_database` is enabled, or we will fail
+        with a ConfigurationError otherwise.
         """
 
         dsn, host, username, password, database, driver = self._get_access_info(self.DEFAULT_DB_KEY)

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -209,7 +209,8 @@ class Connection(object):
                 self.existing_databases = {}
                 cursor.execute(DATABASE_EXISTS_QUERY)
                 for row in cursor:
-                    self.existing_databases[row.name.lower()] = 'CI' in row.collation_name, row.name
+                    case_insensitive = 'CI' in row.collation_name
+                    self.existing_databases[row.name.lower()] = case_insensitive, row.name
 
             except Exception as e:
                 self.log.error("Failed to check if database %s exists: %s", database, e)


### PR DESCRIPTION
### What does this PR do?
We are now raising a ConfigurationError if database names don't match exactly, but that is too restrictive.  This PR handles the process more gracefully, allowing mixed case database names where it doesn't matter, but enforcing it when a database is explicitly case sensitive.

### Motivation
Support ticket.
