### PR TITLE
Add support for database autodiscovery

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -61,6 +61,8 @@ files:
         therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
 
         When conflicts arise, included databases will take precedence.
+
+        Defaults to `.*` to include everything.
       value:
         type: array
         items:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -68,8 +68,8 @@ files:
         items:
           type: string
         example:
-          - master
-          - AdventureWorks2017
+          - master$
+          - AdventureWorks.*
     - name: autodiscovery_exclude
       description: |
         Regular expression for specific database names to always exclude as part of `database_autodiscovery`.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -39,10 +39,56 @@ files:
       value:
         type: string
     - name: database
-      description: Database name to query
+      description: |
+        Database name to query.  Not compatible with `database_autodiscovery`.
       value:
         type: string
         example: master
+    - name: database_autodiscovery
+      description: |
+        Auto-discover and monitor databases.  If `true`, overrides `database` option.
+        Can be combined with `autodiscovery_include` and `autodiscovery_exclude` options.
+      value:
+        type: boolean
+        example: false
+    - name: autodiscovery_include
+      description: |
+        Regular expression for specific database names to always include as part of `database_autodiscovery`.
+        Will only report metrics for databases that are actually found in this instance, so missing
+        databases from this option should be harmless.
+
+        Character casing is ignored. For convenience, the regular expressions start matching from the beginning and
+        therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
+
+        When conflicts arise, included databases will take precedence.
+      value:
+        type: array
+        items:
+          type: string
+        example:
+          - master
+          - AdventureWorks2017
+    - name: autodiscovery_exclude
+      description: |
+        Regular expression for specific database names to always exclude as part of `database_autodiscovery`.
+
+        Character casing is ignored. For convenience, the regular expressions start matching from the beginning and
+        therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
+
+        Can use expression `.*` to exclude everything, then selectively include databases from `autodiscovery_include`.
+      value:
+        type: array
+        items:
+          type: string
+        example:
+          - model
+          - msdb
+    - name: database_autodiscovery_interval
+      description: |
+        Frequency in seconds of scans for new databases.  Defaults to `3600`.
+      value:
+        type: integer
+        example: 3600
     - name: include_ao_metrics
       description: |
         Include AlwaysOn availability group metrics.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -60,8 +60,6 @@ files:
         Character casing is ignored. For convenience, the regular expressions start matching from the beginning and
         therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
 
-        When conflicts arise, included databases will take precedence.
-
         Defaults to `.*` to include everything.
       value:
         type: array
@@ -77,7 +75,7 @@ files:
         Character casing is ignored. For convenience, the regular expressions start matching from the beginning and
         therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
 
-        Can use expression `.*` to exclude everything, then selectively include databases from `autodiscovery_include`.
+        When conflicts arise, excluded databases will take precedence over any found from `autodiscovery_include`.
       value:
         type: array
         items:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -53,12 +53,11 @@ files:
         example: false
     - name: autodiscovery_include
       description: |
-        Regular expression for specific database names to always include as part of `database_autodiscovery`.
-        Will only report metrics for databases that are actually found in this instance, so missing
-        databases from this option should be harmless.
+        Regular expression for database names to include as part of `database_autodiscovery`.
+        Will report metrics for databases that are found in this instance, ignores databases listed but not found.
 
-        Character casing is ignored. For convenience, the regular expressions start matching from the beginning and
-        therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
+        Character casing is ignored. The regular expressions start matching from the beginning, so 
+        to match anywhere, prepend `.*`. For exact matches append `$`. 
 
         Defaults to `.*` to include everything.
       value:
@@ -70,12 +69,12 @@ files:
           - AdventureWorks.*
     - name: autodiscovery_exclude
       description: |
-        Regular expression for specific database names to always exclude as part of `database_autodiscovery`.
+        Regular expression for database names to exclude as part of `database_autodiscovery`.
 
-        Character casing is ignored. For convenience, the regular expressions start matching from the beginning and
-        therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
+        Character casing is ignored. The regular expressions start matching from the beginning, so
+        to match anywhere, prepend `.*`. For exact matches append `$`.
 
-        When conflicts arise, excluded databases will take precedence over any found from `autodiscovery_include`.
+        In case of conflicts, database exclusion via `autodiscovery_exclude` takes precedence over those found via `autodiscovery_include`.
       value:
         type: array
         items:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -74,7 +74,8 @@ files:
         Character casing is ignored. The regular expressions start matching from the beginning, so
         to match anywhere, prepend `.*`. For exact matches append `$`.
 
-        In case of conflicts, database exclusion via `autodiscovery_exclude` takes precedence over those found via `autodiscovery_include`.
+        In case of conflicts, database exclusion via `autodiscovery_exclude` takes precedence over
+        those found via `autodiscovery_include`.
       value:
         type: array
         items:

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -56,12 +56,11 @@ instances:
     # database_autodiscovery: false
 
     ## @param autodiscovery_include - list of strings - optional
-    ## Regular expression for specific database names to always include as part of `database_autodiscovery`.
-    ## Will only report metrics for databases that are actually found in this instance, so missing
-    ## databases from this option should be harmless.
+    ## Regular expression for database names to include as part of `database_autodiscovery`.
+    ## Will report metrics for databases that are found in this instance, ignores databases listed but not found.
     ##
-    ## Character casing is ignored. For convenience, the regular expressions start matching from the beginning and
-    ## therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
+    ## Character casing is ignored. The regular expressions start matching from the beginning, so 
+    ## to match anywhere, prepend `.*`. For exact matches append `$`. 
     ##
     ## Defaults to `.*` to include everything.
     #
@@ -70,12 +69,13 @@ instances:
     #   - AdventureWorks.*
 
     ## @param autodiscovery_exclude - list of strings - optional
-    ## Regular expression for specific database names to always exclude as part of `database_autodiscovery`.
+    ## Regular expression for database names to exclude as part of `database_autodiscovery`.
     ##
-    ## Character casing is ignored. For convenience, the regular expressions start matching from the beginning and
-    ## therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
+    ## Character casing is ignored. The regular expressions start matching from the beginning, so
+    ## to match anywhere, prepend `.*`. For exact matches append `$`.
     ##
-    ## When conflicts arise, excluded databases will take precedence over any found from `autodiscovery_include`.
+    ## In case of conflicts, database exclusion via `autodiscovery_exclude` takes precedence over
+    ## those found via `autodiscovery_include`.
     #
     # autodiscovery_exclude:
     #   - model

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -63,8 +63,6 @@ instances:
     ## Character casing is ignored. For convenience, the regular expressions start matching from the beginning and
     ## therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
     ##
-    ## When conflicts arise, included databases will take precedence.
-    ##
     ## Defaults to `.*` to include everything.
     #
     # autodiscovery_include:
@@ -77,7 +75,7 @@ instances:
     ## Character casing is ignored. For convenience, the regular expressions start matching from the beginning and
     ## therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
     ##
-    ## Can use expression `.*` to exclude everything, then selectively include databases from `autodiscovery_include`.
+    ## When conflicts arise, excluded databases will take precedence over any found from `autodiscovery_include`.
     #
     # autodiscovery_exclude:
     #   - model

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -45,9 +45,46 @@ instances:
     # password: <PASSWORD>
 
     ## @param database - string - optional - default: master
-    ## Database name to query
+    ## Database name to query.  Not compatible with `database_autodiscovery`.
     #
     # database: master
+
+    ## @param database_autodiscovery - boolean - optional - default: false
+    ## Auto-discover and monitor databases.  If `true`, overrides `database` option.
+    ## Can be combined with `autodiscovery_include` and `autodiscovery_exclude` options.
+    #
+    # database_autodiscovery: false
+
+    ## @param autodiscovery_include - list of strings - optional
+    ## Regular expression for specific database names to always include as part of `database_autodiscovery`.
+    ## Will only report metrics for databases that are actually found in this instance, so missing
+    ## databases from this option should be harmless.
+    ##
+    ## Character casing is ignored. For convenience, the regular expressions start matching from the beginning and
+    ## therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
+    ##
+    ## When conflicts arise, included databases will take precedence.
+    #
+    # autodiscovery_include:
+    #   - master
+    #   - AdventureWorks2017
+
+    ## @param autodiscovery_exclude - list of strings - optional
+    ## Regular expression for specific database names to always exclude as part of `database_autodiscovery`.
+    ##
+    ## Character casing is ignored. For convenience, the regular expressions start matching from the beginning and
+    ## therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
+    ##
+    ## Can use expression `.*` to exclude everything, then selectively include databases from `autodiscovery_include`.
+    #
+    # autodiscovery_exclude:
+    #   - model
+    #   - msdb
+
+    ## @param database_autodiscovery_interval - integer - optional - default: 3600
+    ## Frequency in seconds of scans for new databases.  Defaults to `3600`.
+    #
+    # database_autodiscovery_interval: 3600
 
     ## @param include_ao_metrics - boolean - optional - default: false
     ## Include AlwaysOn availability group metrics.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -68,8 +68,8 @@ instances:
     ## Defaults to `.*` to include everything.
     #
     # autodiscovery_include:
-    #   - master
-    #   - AdventureWorks2017
+    #   - master$
+    #   - AdventureWorks.*
 
     ## @param autodiscovery_exclude - list of strings - optional
     ## Regular expression for specific database names to always exclude as part of `database_autodiscovery`.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -64,6 +64,8 @@ instances:
     ## therefore to match anywhere you must prepend `.*`. For exact matches append `$`. Casing is ignored.
     ##
     ## When conflicts arise, included databases will take precedence.
+    ##
+    ## Defaults to `.*` to include everything.
     #
     # autodiscovery_include:
     #   - master

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -302,12 +302,8 @@ class SQLServer(AgentCheck):
                 'Autodiscovered databases: %s, excluding: %s, including: %s', all_dbs, excluded_dbs, included_dbs
             )
 
-            # remove all excluded dbs, but add back in any specifically included ones via `union`
-            filtered_dbs = (all_dbs - excluded_dbs).union(all_dbs.intersection(included_dbs))
-
-            # the case of excluding all, but including specific dbs
-            if all_dbs == excluded_dbs:
-                filtered_dbs = all_dbs.intersection(included_dbs)
+            # keep included dbs but remove any that were explicitly excluded
+            filtered_dbs = all_dbs.intersection(included_dbs) - excluded_dbs
 
             self.log.debug('Resulting filtered databases: %s', filtered_dbs)
             self.ad_last_check = now

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -299,8 +299,12 @@ class SQLServer(AgentCheck):
             self.log.debug('Found databases: %s, excluding: %s, including: %s', all_dbs, excluded_dbs, included_dbs)
 
             # remove all excluded dbs, but add back in any specifically included ones via `union`
-            # TODO need to revisit in case of .* for included and specifics for excluded
             filtered_dbs = (all_dbs - excluded_dbs).union(all_dbs.intersection(included_dbs))
+
+            # the case of excluding all, but including specific dbs
+            if all_dbs == excluded_dbs:
+                filtered_dbs = all_dbs.intersection(included_dbs)
+
             self.log.debug('Resulting database filter: %s', filtered_dbs)
             self.ad_last_check = now
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -3,7 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
+import re
+import time
 from collections import defaultdict
+from itertools import chain
 
 import six
 
@@ -53,6 +56,9 @@ BASE_NAME_QUERY = (
     % PERF_LARGE_RAW_BASE
 )
 
+DEFAULT_AUTODISCOVERY_INTERVAL = 3600
+AUTODISCOVERY_QUERY = "select name from sys.databases"
+
 
 class SQLServer(AgentCheck):
     __NAMESPACE__ = 'sqlserver'
@@ -65,21 +71,8 @@ class SQLServer(AgentCheck):
         # SQLServer:General Statistics
         ('sqlserver.stats.connections', 'User Connections', ''),  # LARGE_RAWCOUNT
         ('sqlserver.stats.procs_blocked', 'Processes blocked', ''),  # LARGE_RAWCOUNT
-        # SQLServer:Locks
-        ('sqlserver.stats.lock_waits', 'Lock Waits/sec', '_Total'),  # BULK_COUNT
         # SQLServer:Access Methods
         ('sqlserver.access.page_splits', 'Page Splits/sec', ''),  # BULK_COUNT
-        # SQLServer:Plan Cache
-        ('sqlserver.cache.object_counts', 'Cache Object Counts', '_Total'),
-        ('sqlserver.cache.pages', 'Cache Pages', '_Total'),
-        # SQLServer:Databases
-        ('sqlserver.database.backup_restore_throughput', 'Backup/Restore Throughput/sec', '_Total'),
-        ('sqlserver.database.log_bytes_flushed', 'Log Bytes Flushed/sec', '_Total'),
-        ('sqlserver.database.log_flushes', 'Log Flushes/sec', '_Total'),
-        ('sqlserver.database.log_flush_wait', 'Log Flush Wait Time', '_Total'),
-        ('sqlserver.database.transactions', 'Transactions/sec', '_Total'),  # BULK_COUNT
-        ('sqlserver.database.write_transactions', 'Write Transactions/sec', '_Total'),  # BULK_COUNT
-        ('sqlserver.database.active_transactions', 'Active Transactions', '_Total'),  # BULK_COUNT
         # SQLServer:Memory Manager
         ('sqlserver.memory.memory_grants_pending', 'Memory Grants Pending', ''),
         ('sqlserver.memory.total_server_memory', 'Total Server Memory (KB)', ''),
@@ -96,6 +89,25 @@ class SQLServer(AgentCheck):
         ('sqlserver.stats.batch_requests', 'Batch Requests/sec', ''),  # BULK_COUNT
         ('sqlserver.stats.sql_compilations', 'SQL Compilations/sec', ''),  # BULK_COUNT
         ('sqlserver.stats.sql_recompilations', 'SQL Re-Compilations/sec', ''),  # BULK_COUNT
+    ]
+
+    # Performance table metrics, initially configured to track at instance-level only
+    # With auto-discovery enabled, these metrics will be extended accordingly
+    # datadog metric name, counter name, instance name
+    INSTANCE_METRICS_TOTAL = [
+        # SQLServer:Locks
+        ('sqlserver.stats.lock_waits', 'Lock Waits/sec', '_Total'),  # BULK_COUNT
+        # SQLServer:Plan Cache
+        ('sqlserver.cache.object_counts', 'Cache Object Counts', '_Total'),
+        ('sqlserver.cache.pages', 'Cache Pages', '_Total'),
+        # SQLServer:Databases
+        ('sqlserver.database.backup_restore_throughput', 'Backup/Restore Throughput/sec', '_Total'),
+        ('sqlserver.database.log_bytes_flushed', 'Log Bytes Flushed/sec', '_Total'),
+        ('sqlserver.database.log_flushes', 'Log Flushes/sec', '_Total'),
+        ('sqlserver.database.log_flush_wait', 'Log Flush Wait Time', '_Total'),
+        ('sqlserver.database.transactions', 'Transactions/sec', '_Total'),  # BULK_COUNT
+        ('sqlserver.database.write_transactions', 'Write Transactions/sec', '_Total'),  # BULK_COUNT
+        ('sqlserver.database.active_transactions', 'Active Transactions', '_Total'),  # BULK_COUNT
     ]
 
     # AlwaysOn metrics
@@ -182,6 +194,18 @@ class SQLServer(AgentCheck):
         self.instance_per_type_metrics = defaultdict(list)
         self.do_check = True
 
+        # autodiscovery parameters
+        self.autodiscovery = self.instance.get('database_autodiscovery')
+        if self.autodiscovery and self.instance.get('database'):
+            self.log.warning('sqlserver `database_autodiscovery` and `database` options defined in same instance '
+                             'autodiscovery will take precedence.')
+        self.autodiscovery_include = self.instance.get('autodiscovery_include', [])
+        self.autodiscovery_exclude = self.instance.get('autodiscovery_exclude', [])
+        self._compile_patterns()
+        self.autodiscovery_interval = self.instance.get('autodiscovery_interval', DEFAULT_AUTODISCOVERY_INTERVAL)
+        self.databases = None
+        self.ad_last_check = 0
+
         self.proc = self.instance.get('stored_procedure')
         self.proc_type_mapping = {'gauge': self.gauge, 'rate': self.rate, 'histogram': self.histogram}
         self.custom_metrics = init_config.get('custom_metrics', [])
@@ -202,6 +226,8 @@ class SQLServer(AgentCheck):
             if db_exists:
                 if self.instance.get('stored_procedure') is None:
                     with self.connection.open_managed_default_connection():
+                        with self.connection.get_managed_cursor() as cursor:
+                            self.autodiscover_databases(cursor)
                         self._make_metric_list_to_collect(self.custom_metrics)
             else:
                 # How much do we care that the DB doesn't exist?
@@ -234,6 +260,48 @@ class SQLServer(AgentCheck):
 
         self.service_check(self.SERVICE_CHECK_NAME, status, tags=service_check_tags, message=message, raw=True)
 
+    def _compile_patterns(self):
+        self._include_patterns = self._compile_valid_patterns(self.autodiscovery_include)
+        self._exclude_patterns = self._compile_valid_patterns(self.autodiscovery_exclude)
+
+    def _compile_valid_patterns(self, patterns):
+        valid_patterns = []
+
+        for pattern in patterns:
+            # Ignore empty patterns as they match everything
+            if not pattern:
+                continue
+
+            try:
+                re.compile(pattern, re.IGNORECASE)
+            except Exception:
+                self.log.warning('%s is not a valid regular expression and will be ignored', pattern)
+            else:
+                valid_patterns.append(pattern)
+
+        if valid_patterns:
+            return re.compile('|'.join(valid_patterns), re.IGNORECASE)
+
+    def autodiscover_databases(self, cursor):
+        if not self.autodiscovery:
+            return False
+
+        now = time.time()
+        if now - self.ad_last_check < self.autodiscovery_interval:
+            cursor.execute(AUTODISCOVERY_QUERY)
+            all_dbs = set(cursor.fetchall())
+            excluded_dbs = set([d for d in all_dbs if not self._exclude_patterns.match(d)])
+            included_dbs = set([d for d in all_dbs if self._include_patterns.match(d)])
+
+            # remove all excluded dbs, but add back in any specifically included ones via `union`
+            filtered_dbs = (all_dbs - excluded_dbs).union(all_dbs.intersection(included_dbs))
+            self.ad_last_check = now
+
+            if filtered_dbs != self.databases:
+                self.databases = filtered_dbs
+                return True
+        return False
+
     def _make_metric_list_to_collect(self, custom_metrics):
         """
         Store the list of metrics to collect by instance_key.
@@ -247,33 +315,22 @@ class SQLServer(AgentCheck):
         # If several check instances are querying the same server host, it can be wise to turn these off
         # to avoid sending duplicate metrics
         if is_affirmative(self.instance.get('include_instance_metrics', True)):
-            for name, counter_name, instance_name in self.INSTANCE_METRICS:
-                try:
-                    sql_type, base_name = self.get_sql_type(counter_name)
-                    cfg = {
-                        'name': name,
-                        'counter_name': counter_name,
-                        'instance_name': instance_name,
-                        'tags': tags,
-                    }
+            self._add_performance_counters(
+                chain(self.INSTANCE_METRICS, self.INSTANCE_METRICS_TOTAL), metrics_to_collect, tags, db=None
+            )
 
-                    metrics_to_collect.append(
-                        self.typed_metric(
-                            cfg_inst=cfg, table=DEFAULT_PERFORMANCE_TABLE, base_name=base_name, sql_type=sql_type
-                        )
-                    )
-                except SQLConnectionError:
-                    raise
-                except Exception:
-                    self.log.warning("Can't load the metric %s, ignoring", name, exc_info=True)
-                    continue
+        # populated through autodiscovery
+        if self.databases is not None:
+            for db in self.databases:
+                self._add_performance_counters(self.INSTANCE_METRICS_TOTAL, metrics_to_collect, tags, db=db)
 
         # Load database statistics
         for name, table, column in self.DATABASE_METRICS:
             # include database as a filter option
-            db_name = self.instance.get('database', self.connection.DEFAULT_DATABASE)
-            cfg = {'name': name, 'table': table, 'column': column, 'instance_name': db_name, 'tags': tags}
-            metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
+            db_names = self.databases or [self.instance.get('database', self.connection.DEFAULT_DATABASE)]
+            for db_name in db_names:
+                cfg = {'name': name, 'table': table, 'column': column, 'instance_name': db_name, 'tags': tags}
+                metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
 
         # Load AlwaysOn metrics
         if is_affirmative(self.instance.get('include_ao_metrics', False)):
@@ -310,18 +367,19 @@ class SQLServer(AgentCheck):
 
         # Load DB Fragmentation metrics
         if is_affirmative(self.instance.get('include_db_fragmentation_metrics', False)):
-            db_name = self.instance.get('database', self.connection.DEFAULT_DATABASE)
             db_fragmentation_object_names = self.instance.get('db_fragmentation_object_names', [])
-            for name, table, column in self.DATABASE_FRAGMENTATION_METRICS:
-                cfg = {
-                    'name': name,
-                    'table': table,
-                    'column': column,
-                    'instance_name': db_name,
-                    'tags': tags,
-                    'db_fragmentation_object_names': db_fragmentation_object_names,
-                }
-                metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
+            db_names = self.databases or [self.instance.get('database', self.connection.DEFAULT_DATABASE)]
+            for db_name in db_names:
+                for name, table, column in self.DATABASE_FRAGMENTATION_METRICS:
+                    cfg = {
+                        'name': name,
+                        'table': table,
+                        'column': column,
+                        'instance_name': db_name,
+                        'tags': tags,
+                        'db_fragmentation_object_names': db_fragmentation_object_names,
+                    }
+                    metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
 
         # Load any custom metrics from conf.d/sqlserver.yaml
         for cfg in custom_metrics:
@@ -383,6 +441,28 @@ class SQLServer(AgentCheck):
             self.instance_per_type_metrics[cls].append(name)
             if m.base_name:
                 self.instance_per_type_metrics[cls].append(m.base_name)
+
+    def _add_performance_counters(self, metrics, metrics_to_collect, tags, db=None):
+        for name, counter_name, instance_name in metrics:
+            try:
+                sql_type, base_name = self.get_sql_type(counter_name)
+                cfg = {
+                    'name': name,
+                    'counter_name': counter_name,
+                    'instance_name': db or instance_name,
+                    'tags': tags,
+                }
+
+                metrics_to_collect.append(
+                    self.typed_metric(
+                        cfg_inst=cfg, table=DEFAULT_PERFORMANCE_TABLE, base_name=base_name, sql_type=sql_type
+                    )
+                )
+            except SQLConnectionError:
+                raise
+            except Exception:
+                self.log.warning("Can't load the metric %s, ignoring", name, exc_info=True)
+                continue
 
     def get_sql_type(self, counter_name):
         """
@@ -459,12 +539,10 @@ class SQLServer(AgentCheck):
         """Fetch the metrics from all of the associated database tables."""
 
         with self.connection.open_managed_default_connection():
-            # if the server was down at check __init__ key could be missing.
-            if not self.instance_metrics:
-                self._make_metric_list_to_collect(self.custom_metrics)
-            metrics_to_collect = self.instance_metrics
-
             with self.connection.get_managed_cursor() as cursor:
+                # initiate autodiscovery or if the server was down at check __init__ key could be missing.
+                if self.autodiscover_databases(cursor) or not self.instance_metrics:
+                    self._make_metric_list_to_collect(self.custom_metrics)
 
                 instance_results = {}
 
@@ -477,7 +555,7 @@ class SQLServer(AgentCheck):
                         instance_results[cls] = rows, cols
 
                 # Using the cached data, extract and report individual metrics
-                for metric in metrics_to_collect:
+                for metric in self.instance_metrics:
                     if type(metric) is metrics.SqlIncrFractionMetric:
                         # special case, since it uses the same results as SqlFractionMetric
                         rows, cols = instance_results['SqlFractionMetric']

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -95,6 +95,7 @@ INSTANCE_SQL2017 = {
     'include_task_scheduler_metrics': True,
     'include_db_fragmentation_metrics': True,
     'include_fci_metrics': True,
+    'include_ao_metrics': False,
 }
 
 INIT_CONFIG = {

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -3,6 +3,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from itertools import chain
+
 from datadog_checks.dev import get_docker_hostname, get_here
 from datadog_checks.dev.utils import ON_MACOS, ON_WINDOWS
 from datadog_checks.sqlserver import SQLServer
@@ -32,11 +34,14 @@ CHECK_NAME = "sqlserver"
 CUSTOM_METRICS = ['sqlserver.clr.execution', 'sqlserver.db.commit_table_entries', 'sqlserver.exec.in_progress']
 EXPECTED_METRICS = [
     m[0]
-    for m in SQLServer.INSTANCE_METRICS
-    + SQLServer.TASK_SCHEDULER_METRICS
-    + SQLServer.DATABASE_METRICS
-    + SQLServer.DATABASE_FRAGMENTATION_METRICS
-    + SQLServer.FCI_METRICS
+    for m in chain(
+        SQLServer.INSTANCE_METRICS,
+        SQLServer.INSTANCE_METRICS_TOTAL,
+        SQLServer.TASK_SCHEDULER_METRICS,
+        SQLServer.DATABASE_METRICS,
+        SQLServer.DATABASE_FRAGMENTATION_METRICS,
+        SQLServer.FCI_METRICS,
+    )
 ] + CUSTOM_METRICS
 
 EXPECTED_AO_METRICS_PRIMARY = [m[0] for m in SQLServer.AO_METRICS_PRIMARY]

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -91,6 +91,13 @@ def instance_ao_docker_secondary():
     return deepcopy(INSTANCE_AO_DOCKER_SECONDARY)
 
 
+@pytest.fixture
+def instance_autodiscovery():
+    instance = INSTANCE_DOCKER
+    instance['database_autodiscovery'] = True
+    return deepcopy(instance)
+
+
 @pytest.fixture(scope='session')
 def dd_environment():
     if pyodbc is None:

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -62,28 +62,28 @@ def instance_e2e():
 
 @pytest.fixture
 def instance_ao_docker_primary():
-    instance = INSTANCE_DOCKER
+    instance = deepcopy(INSTANCE_DOCKER)
     instance['include_ao_metrics'] = True
     instance['driver'] = 'FreeTDS'
-    return deepcopy(instance)
+    return instance
 
 
 @pytest.fixture
 def instance_ao_docker_primary_local_only():
-    instance = INSTANCE_DOCKER
+    instance = deepcopy(INSTANCE_DOCKER)
     instance['include_ao_metrics'] = True
     instance['driver'] = 'FreeTDS'
     instance['only_emit_local'] = True
-    return deepcopy(instance)
+    return instance
 
 
 @pytest.fixture
 def instance_ao_docker_primary_non_existing_ag():
-    instance = INSTANCE_DOCKER
+    instance = deepcopy(INSTANCE_DOCKER)
     instance['include_ao_metrics'] = True
     instance['driver'] = 'FreeTDS'
     instance['availability_group'] = 'AG2'
-    return deepcopy(instance)
+    return instance
 
 
 @pytest.fixture
@@ -93,9 +93,9 @@ def instance_ao_docker_secondary():
 
 @pytest.fixture
 def instance_autodiscovery():
-    instance = INSTANCE_DOCKER
+    instance = deepcopy(INSTANCE_DOCKER)
     instance['database_autodiscovery'] = True
-    return deepcopy(instance)
+    return instance
 
 
 @pytest.fixture(scope='session')

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -127,31 +127,30 @@ def test_autodiscovery_patterns(instance_autodiscovery, dd_run_check):
     instance['autodiscovery_include'] = ['missingdb', 'fakedb']
     check = SQLServer(CHECK_NAME, {}, [instance])
     check.autodiscover_databases(mock_cursor)
-    assert check.databases == all_dbs
+    assert check.databases == set()
 
     # check included found and missing additions
     mock_cursor.fetchall.return_value = iter(fetchall_results)
     instance['autodiscovery_include'] = ['master', 'fancy2020db', 'missingdb', 'fakedb']
-    instance['autodiscovery_exclude'] = ['.*']
     check = SQLServer(CHECK_NAME, {}, [instance])
     check.autodiscover_databases(mock_cursor)
     assert check.databases == set(['master', 'Fancy2020db'])
 
     # check excluded dbs
     mock_cursor.fetchall.return_value = iter(fetchall_results)
-    instance['autodiscovery_include'] = []  # remove default `.*`
+    instance['autodiscovery_include'] = ['.*']  # replace default `.*`
     instance['autodiscovery_exclude'] = ['.*2020db$', 'm.*']
     check = SQLServer(CHECK_NAME, {}, [instance])
     check.autodiscover_databases(mock_cursor)
     assert check.databases == set(['tempdb', 'AdventureWorks2017', 'CaseSensitive2018'])
 
-    # check included overrides excluded
+    # check excluded overrides included
     mock_cursor.fetchall.return_value = iter(fetchall_results)
-    instance['autodiscovery_include'] = ['master']  # remove default `.*`
+    instance['autodiscovery_include'] = ['t.*', 'master']  # remove default `.*`
     instance['autodiscovery_exclude'] = ['.*2020db$', 'm.*']
     check = SQLServer(CHECK_NAME, {}, [instance])
     check.autodiscover_databases(mock_cursor)
-    assert check.databases == set(['master', 'tempdb', 'AdventureWorks2017', 'CaseSensitive2018'])
+    assert check.databases == set(['tempdb'])
 
 
 def test_set_default_driver_conf():

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -99,6 +99,61 @@ def test_db_exists(get_cursor, mock_connect, instance_sql2017, dd_run_check):
         check.initialize_connection()
 
 
+def test_autodiscovery_patterns(instance_autodiscovery, dd_run_check):
+    Row = namedtuple('Row', 'name')
+    fetchall_results = [
+        Row('master'),
+        Row('tempdb'),
+        Row('model'),
+        Row('msdb'),
+        Row('AdventureWorks2017'),
+        Row('CaseSensitive2018'),
+        Row('Fancy2020db'),
+    ]
+    all_dbs = set([r.name for r in fetchall_results])
+
+    mock_cursor = mock.MagicMock()
+    mock_cursor.fetchall.return_value = iter(fetchall_results)
+
+    instance = copy.deepcopy(instance_autodiscovery)
+
+    # check base case of default filters
+    check = SQLServer(CHECK_NAME, {}, [instance])
+    check.autodiscover_databases(mock_cursor)
+    assert check.databases == all_dbs
+
+    # check missing additions, but no exclusions
+    mock_cursor.fetchall.return_value = iter(fetchall_results)  # reset the mock results
+    instance['autodiscovery_include'] = ['missingdb', 'fakedb']
+    check = SQLServer(CHECK_NAME, {}, [instance])
+    check.autodiscover_databases(mock_cursor)
+    assert check.databases == all_dbs
+
+    # check included found and missing additions
+    mock_cursor.fetchall.return_value = iter(fetchall_results)
+    instance['autodiscovery_include'] = ['master', 'fancy2020db', 'missingdb', 'fakedb']
+    instance['autodiscovery_exclude'] = ['.*']
+    check = SQLServer(CHECK_NAME, {}, [instance])
+    check.autodiscover_databases(mock_cursor)
+    assert check.databases == set(['master', 'Fancy2020db'])
+
+    # check excluded dbs
+    mock_cursor.fetchall.return_value = iter(fetchall_results)
+    instance['autodiscovery_include'] = []  # remove default `.*`
+    instance['autodiscovery_exclude'] = ['.*2020db$', 'm.*']
+    check = SQLServer(CHECK_NAME, {}, [instance])
+    check.autodiscover_databases(mock_cursor)
+    assert check.databases == set(['tempdb', 'AdventureWorks2017', 'CaseSensitive2018'])
+
+    # check included overrides excluded
+    mock_cursor.fetchall.return_value = iter(fetchall_results)
+    instance['autodiscovery_include'] = ['master']  # remove default `.*`
+    instance['autodiscovery_exclude'] = ['.*2020db$', 'm.*']
+    check = SQLServer(CHECK_NAME, {}, [instance])
+    check.autodiscover_databases(mock_cursor)
+    assert check.databases == set(['master', 'tempdb', 'AdventureWorks2017', 'CaseSensitive2018'])
+
+
 def test_set_default_driver_conf():
     # Docker Agent with ODBCSYSINI env var
     # The only case where we set ODBCSYSINI to the the default odbcinst.ini folder


### PR DESCRIPTION
### What does this PR do?
Add support for database autodiscovery via additional configuration options:

- `database_autodiscovery` - toggles the feature on or off
- `autodiscovery_include` - list of patterns to always include, defaults to `.*`
- `autodiscovery_exclude` - list of patterns to exclude, overridden by the include option if there are conflicts
- `database_autodiscovery_interval` - how often to recheck, defaults to an hour

When enabled and databases have been found, metrics which have the ability to report at the database level will be created.  This largely affects the performance counter metrics, but also other database-level metrics.

### Motivation
Feature enhancement.

### Additional Notes
The pattern matching and options selection were largely borrowed from the `disk` check to make things more uniform across checks, though there are some differences to how the filter gets calculated.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
