### PR TITLE
Removed duplicated metrics

### DIFF
--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -132,7 +132,6 @@ SELECT mode,
 
 REL_METRICS = {
     'descriptors': [('relname', 'table'), ('schemaname', 'schema')],
-    # This field contains old metrics that need to be deprecated. For now we keep sending them.
     'metrics': {
         'seq_scan': ('postgresql.seq_scans', AgentCheck.rate),
         'seq_tup_read': ('postgresql.seq_rows_read', AgentCheck.rate),

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -133,11 +133,9 @@ SELECT mode,
 REL_METRICS = {
     'descriptors': [('relname', 'table'), ('schemaname', 'schema')],
     # This field contains old metrics that need to be deprecated. For now we keep sending them.
-    'deprecated_metrics': {'idx_tup_fetch': ('postgresql.index_rows_fetched', AgentCheck.rate)},
     'metrics': {
         'seq_scan': ('postgresql.seq_scans', AgentCheck.rate),
         'seq_tup_read': ('postgresql.seq_rows_read', AgentCheck.rate),
-        'idx_scan': ('postgresql.index_scans', AgentCheck.rate),
         'idx_tup_fetch': ('postgresql.index_rel_rows_fetched', AgentCheck.rate),
         'n_tup_ins': ('postgresql.rows_inserted', AgentCheck.rate),
         'n_tup_upd': ('postgresql.rows_updated', AgentCheck.rate),

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -136,6 +136,7 @@ REL_METRICS = {
     'metrics': {
         'seq_scan': ('postgresql.seq_scans', AgentCheck.rate),
         'seq_tup_read': ('postgresql.seq_rows_read', AgentCheck.rate),
+        'idx_scan': ('postgresql.index_rel_scans', AgentCheck.rate),
         'idx_tup_fetch': ('postgresql.index_rel_rows_fetched', AgentCheck.rate),
         'n_tup_ins': ('postgresql.rows_inserted', AgentCheck.rate),
         'n_tup_upd': ('postgresql.rows_updated', AgentCheck.rate),

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -26,7 +26,8 @@ postgresql.bgwriter.sync_time,count,,millisecond,,The total amount of checkpoint
 postgresql.locks,gauge,,lock,,The number of locks active for this database.,0,postgres,locks
 postgresql.seq_scans,gauge,,,,The number of sequential scans initiated on this table.,0,postgres,seq scans
 postgresql.seq_rows_read,gauge,,row,second,The number of live rows fetched by sequential scans.,0,postgres,seq rows rd
-postgresql.index_scans,gauge,,,,The number of index scans initiated on this table.,0,postgres,idx scans
+postgresql.index_scans,gauge,,,,The number of index scans initiated on this table, tagged by index.,0,postgres,idx scans
+postgresql.index_rel_scans,gauge,,,,The overall number of index scans initiated on this table.,0,postgres,idx scans
 postgresql.index_rows_fetched,gauge,,row,second,The number of live rows fetched by index scans.,0,postgres,idx rows fetch
 postgresql.index_rel_rows_fetched,gauge,,row,second,The number of live rows fetched by index scans.,0,postgres,idx rows fetch
 postgresql.rows_hot_updated,gauge,,row,second,"The number of rows HOT updated, meaning no separate index update was needed.",0,postgres,rows hot updated

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -26,7 +26,7 @@ postgresql.bgwriter.sync_time,count,,millisecond,,The total amount of checkpoint
 postgresql.locks,gauge,,lock,,The number of locks active for this database.,0,postgres,locks
 postgresql.seq_scans,gauge,,,,The number of sequential scans initiated on this table.,0,postgres,seq scans
 postgresql.seq_rows_read,gauge,,row,second,The number of live rows fetched by sequential scans.,0,postgres,seq rows rd
-postgresql.index_scans,gauge,,,,The number of index scans initiated on this table, tagged by index.,0,postgres,idx scans
+postgresql.index_scans,gauge,,,,"The number of index scans initiated on this table, tagged by index.",0,postgres,idx scans
 postgresql.index_rel_scans,gauge,,,,The overall number of index scans initiated on this table.,0,postgres,idx scans
 postgresql.index_rows_fetched,gauge,,row,second,The number of live rows fetched by index scans.,0,postgres,idx rows fetch
 postgresql.index_rel_rows_fetched,gauge,,row,second,The number of live rows fetched by index scans.,0,postgres,idx rows fetch


### PR DESCRIPTION
Two metrics are submitted twice:

- `postgresql.index_scans` is submitted from the `idx_scan` column in the `pg_stat_user_tables` table tagged by table and schema. This metric is also submitted from the `idx_scan` column in the `pg_stat_user_indexes` tagged this time by table, schema and index.
- `postgresql. index_rows_fetched` is submitted from the `idx_tup_fetched` column in the `pg_stat_user_tables` table tagged by table and schema. This metric is also submitted from the `idx_scan` column in the `pg_stat_user_indexes` tagged this time by table, schema and index. Also another metric called `postgresql.index_rel_rows_fetched` is submitted from the `idx_typ_fetched` column in the `pg_stat_user_tables` table tagged by table and schema.


For the second metric, this PR simply removes the `postgresql.index_rows_fetched` metric coming from the `pg_stat_user_tables` as it isn't tagged per index and creates `index:N/A` in the backend.
If the original value is needed, the existing metric `postgresql.index_rel_rows_fetched` provides that information.

For the first metric, this PR adds a new metric called `postgresql.index_rel_scans` which contains the old value not tagged by value and stops the check from submitting `postgresql.index_scans` without the index tag.