### PR TITLE
Add support for AssumeRole in Amazon MSK check

### DIFF
--- a/amazon_msk/assets/configuration/spec.yaml
+++ b/amazon_msk/assets/configuration/spec.yaml
@@ -19,6 +19,13 @@ files:
         https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuration
       value:
         type: string
+    - name: assume_role
+      description: |
+        The ARN of the role to assume when retrieving MSK cluster metadata. If this is not set,
+        the default permissions used by boto3 will follow the rules according to:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuration
+      value:
+        type: string
     - name: jmx_exporter_port
       description: The port on which the JMX Exporter serves metrics.
       value:

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -57,6 +57,13 @@ instances:
     #
     # region_name: <REGION_NAME>
 
+    ## @param assume_role - string - optional
+    ## The ARN of the role to assume when retrieving MSK cluster metadata. If this is not set,
+    ## the default permissions used by boto3 will follow the rules according to:
+    ## https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuration
+    #
+    # assume_role: <ASSUME_ROLE>
+
     ## @param jmx_exporter_port - integer - optional - default: 11001
     ## The port on which the JMX Exporter serves metrics.
     #


### PR DESCRIPTION
### What does this PR do?
This allows the user to specify a role to assume when retrieving MSK metadata.

### Motivation
We are monitoring multiple MSK clusters across our company from centralized k8s clusters. The MSK clusters are in separate accounts from the k8s clusters which causes issues when trying to retrieve the MSK metadata during `list_nodes` call in the Amazon MSK check. This allows the user to set up a role that has MSK read only access in the account containing the target MSK cluster and allows the boto3 client to assume that role during runtime.

### Additional Notes
Couldn't really provide a great unit test for this as it requires access to the AWS STS API.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
