### PR TITLE
Make pgbouncer more reslient

### DIFF
--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -67,10 +67,9 @@ class PgBouncer(AgentCheck):
                     try:
                         self.log.debug("Running query: %s", query)
                         cursor.execute(query)
-
                         rows = cursor.fetchall()
 
-                    except pg.Error:
+                    except Exception:
                         self.log.exception("Not all metrics may be available")
 
                     else:


### PR DESCRIPTION
An error collecting one scope of metrics should not prevent the rest from being collected