### PR TITLE
Add mysql slowlog multi-line rule suggestion for versions < 5.7 (README only)

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -192,6 +192,13 @@ _Available for Agent versions >6.0_
            pattern: "# Time:"
            # If mysqld was started with `--log-short-format`, use:
            # pattern: "# Query_time:"
+           # If using mysql version <5.7, use the following rules instead:
+           # - type: multi_line
+           #   name: new_slow_query_log_entry
+           #   pattern: "# Time|# User@Host"
+           # - type: exclude_at_match
+           #   name: exclude_timestamp_only_line
+           #   pattern: "# Time:"
 
      - type: file
        path: "<GENERAL_LOG_FILE_PATH>"


### PR DESCRIPTION
### What does this PR do?

Adds a multi-line aggregation rule suggestion to the README for the mysql slowlog for versions < 5.7.

### Motivation

The currently suggested rule can cause improper line aggregation for versions < 5.7.  
This comment added to the README should help guide any customers using these versions.

note: Version 5.6 is due to reach end of support in Febuary 2021.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
