### PR TITLE
Add support for tabular check output

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
@@ -26,6 +26,7 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
 )
 @click.option('--log-level', '-l', help='Set the log level (default `off`)')
 @click.option('--json', 'as_json', is_flag=True, help='Format the aggregator and check runner output as JSON')
+@click.option('--table', 'as_table', is_flag=True, help='Format the aggregator and check runner output as tabular')
 @click.option(
     '--breakpoint',
     '-b',
@@ -35,7 +36,7 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
 )
 @click.option('--config', 'config_file', help='Path to a JSON check configuration to use')
 @click.option('--jmx-list', 'jmx_list', help='JMX metrics listing method')
-def check_run(check, env, rate, times, pause, delay, log_level, as_json, break_point, config_file, jmx_list):
+def check_run(check, env, rate, times, pause, delay, log_level, as_json, as_table, break_point, config_file, jmx_list):
     """Run an Agent check."""
     envs = get_configured_envs(check)
     if not envs:
@@ -64,6 +65,7 @@ def check_run(check, env, rate, times, pause, delay, log_level, as_json, break_p
         delay=delay,
         log_level=log_level,
         as_json=as_json,
+        as_table=as_table,
         break_point=break_point,
         jmx_list=jmx_list,
     )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -108,6 +108,7 @@ class DockerInterface(object):
         delay=None,
         log_level=None,
         as_json=False,
+        as_table=False,
         break_point=None,
         jmx_list=None,
     ):
@@ -133,6 +134,9 @@ class DockerInterface(object):
 
             if as_json:
                 command += f' --json {as_json}'
+
+            if as_table:
+                command += f' --table'
 
             if break_point is not None:
                 command += f' --breakpoint {break_point}'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -136,7 +136,7 @@ class DockerInterface(object):
                 command += f' --json {as_json}'
 
             if as_table:
-                command += f' --table'
+                command += ' --table'
 
             if break_point is not None:
                 command += f' --breakpoint {break_point}'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -144,6 +144,7 @@ class LocalAgentInterface(object):
         delay=None,
         log_level=None,
         as_json=False,
+        as_table=False,
         break_point=None,
         jmx_list=None,
     ):
@@ -169,6 +170,9 @@ class LocalAgentInterface(object):
 
             if as_json:
                 command += f' --json {as_json}'
+
+            if as_table:
+                command += f' --table'
 
             if break_point is not None:
                 command += f' --breakpoint {break_point}'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -172,7 +172,7 @@ class LocalAgentInterface(object):
                 command += f' --json {as_json}'
 
             if as_table:
-                command += f' --table'
+                command += ' --table'
 
             if break_point is not None:
                 command += f' --breakpoint {break_point}'


### PR DESCRIPTION
### What does this PR do?
Add `--table` option to `ddev env check`.

Takes advantage of new feature added to agent from this PR: https://github.com/DataDog/datadog-agent/pull/6836

### Additional Notes
Note: this option will only be available on dev versions of the Agent or once it gets compiled into the next version release (`7.25.0`).

It can be tested with the following dev image: `datadog/agent-dev:mg-table-writer-py3`.

For example:
> ddev env start -a datadog/agent-dev:mg-table-writer-py3 --dev sqlserver py38-default

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
