### PR TITLE
Add `tag_list` column type, allowing to ingest variable-size database-provided tags

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -138,6 +138,8 @@ class QueryManager(object):
                         continue
                     elif column_type == 'tag':
                         tags.append(transformer(None, value))
+                    elif column_type == 'tag_list':
+                        tags.extend(transformer(None, value))
                     else:
                         submission_queue.append((transformer, value))
 

--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -109,7 +109,7 @@ class Query(object):
                 # this we set the context to None. https://www.python.org/dev/peps/pep-0409/
                 raise_from(type(e)(error), None)
             else:
-                if column_type == 'tag':
+                if column_type in ('tag', 'tag_list'):
                     column_data.append((column_name, (column_type, transformer)))
                 else:
                     # All these would actually submit data. As that is the default case, we represent it as
@@ -118,6 +118,7 @@ class Query(object):
 
         submission_transformers = column_transformers.copy()
         submission_transformers.pop('tag')
+        submission_transformers.pop('tag_list')
 
         extras = self.query_data.get('extras', [])
         if not isinstance(extras, list):

--- a/datadog_checks_base/datadog_checks/base/utils/db/transform.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/transform.py
@@ -55,8 +55,8 @@ def get_tag_list(transformers, column_name, **modifiers):
     Tag name is determined by `column_name`. The column value represents a list of values. It is expected to be either
     a list of strings, or a comma-separated string.
 
-    For example, if the column is named `server_tag` and the column returned the value 'us,primary', then all
-    submissions for that row will be tagged by 'server_tag:us' and 'server_tag:primary'.
+    For example, if the column is named `server_tag` and the column returned the value `'us,primary'`, then all
+    submissions for that row will be tagged by `server_tag:us` and `server_tag:primary`.
     """
     template = '%s:{}' % column_name
 

--- a/datadog_checks_base/datadog_checks/base/utils/db/transform.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/transform.py
@@ -48,6 +48,25 @@ def get_tag(transformers, column_name, **modifiers):
     return tag
 
 
+def get_tag_list(transformers, column_name, **modifiers):
+    """
+    Convert a column to a list of tags that will be used in every submission.
+    Tag name is determined by `column_name`. The column value represents a list of values. It is expected to be either
+    a list of strings, or a comma-separated string.
+    For example, if the column is named `server_tag` and the column returned the value 'us,primary', then all
+    submissions for that row will be tagged by 'server_tag:us' and 'server_tag:primary'.
+    """
+    template = '%s:{}' % column_name
+
+    def tag_list(_, value, **kwargs):
+        if isinstance(value, str):
+            value = [v.strip() for v in value.split(',')]
+
+        return [template.format(v) for v in value]
+
+    return tag_list
+
+
 def get_monotonic_gauge(transformers, column_name, **modifiers):
     """
     Send the result as both a `gauge` suffixed by `.total` and a `monotonic_count` suffixed by `.count`.
@@ -410,6 +429,7 @@ COLUMN_TRANSFORMERS = {
     'temporal_percent': get_temporal_percent,
     'monotonic_gauge': get_monotonic_gauge,
     'tag': get_tag,
+    'tag_list': get_tag_list,
     'match': get_match,
     'service_check': get_service_check,
     'time_elapsed': get_time_elapsed,

--- a/datadog_checks_base/datadog_checks/base/utils/db/transform.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/transform.py
@@ -51,8 +51,10 @@ def get_tag(transformers, column_name, **modifiers):
 def get_tag_list(transformers, column_name, **modifiers):
     """
     Convert a column to a list of tags that will be used in every submission.
+
     Tag name is determined by `column_name`. The column value represents a list of values. It is expected to be either
     a list of strings, or a comma-separated string.
+
     For example, if the column is named `server_tag` and the column returned the value 'us,primary', then all
     submissions for that row will be tagged by 'server_tag:us' and 'server_tag:primary'.
     """


### PR DESCRIPTION
Prompted by https://github.com/DataDog/integrations-core/pull/8143#discussion_r537394319

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add a new `tag_list` column type to `QueryManager`.

Example usage:

Database tuples:

```console
["us,primary,default", 42]
["eu", 12]
["eu,primary", 21]
```

Query definition:

```python
query = {
    "name": "example",
    "query": "...",
    "columns": [
        {"name": "server_tag", "type": "tag_list"},
        {"name": "foo", "type": "gauge"},
    ]
}
```

Resulting submissions:

```python
gauge("foo", tags=["server_tag:us", "server_tag:primary", "server_tag:default"])
gauge("foo", tags=["server_tag:eu"])
gauge("foo", tags=["server_tag:eu", "server_tag:primary"])
```

### Motivation
<!-- What inspired you to submit this pull request? -->
After analyzing the situation, I need this to migrate RethinkDB to `QueryManager` (see #8143). RethinkDB allows users to define "server tags" at startup. The integration surfaces those in Datadog. It's useful because it allows grouping metrics by those tags. So we need to keep this after the refactor. But right now `QueryManager` only supports fixed-size rows, so there's currently no way to ingest a variable amount of tags provided by the DB. This `tag_list` allows us to address the RethinkDB use case, and could also be useful for some other use cases in the future.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Note that RethinkDB only strictly requires processing a `list` of strings, but I added comma-separated string support since it's cheap enough and more likely to be what SQL databases would return (whereas RethinkDB returns JSON documents).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
