### PR TITLE
Fix links to SNMP architecture images

### DIFF
--- a/docs/developer/architecture/snmp.md
+++ b/docs/developer/architecture/snmp.md
@@ -18,7 +18,7 @@ Here's an overview of what this integration involves:
 
 The diagram below shows how these components interact for a typical VM-based setup (single Agent on a host). For Datadog Cluster Agent (DCA) deployments, see [Cluster Agent Integration](#cluster-agent-integration).
 
-![](../../assets/images/snmp-architecture.png)
+![](../assets/images/snmp-architecture.png)
 
 ## Python Check
 
@@ -108,7 +108,7 @@ snmp_listener:
 
 For Kubernetes environments, the [Cluster Agent](https://docs.datadoghq.com/agent/cluster_agent/) can be configured to use the SNMP Agent auto-discovery (via snmp listener) logic as a source of [Cluster checks](https://docs.datadoghq.com/agent/cluster_agent/clusterchecks/).
 
-![](../../assets/images/snmp-architecture-cluster-agent.png)
+![](../assets/images/snmp-architecture-cluster-agent.png)
 
 The Datadog Cluster Agent (DCA) uses the `snmp_listener` config (Agent auto-discovery) to listen for IP ranges, then schedules snmp check instances to be run by one or more normal Datadog Agents.
 
@@ -139,7 +139,7 @@ helm install datadog-monitoring --set datadog.apiKey=<YOUR_API_KEY> -f cluster-a
       ## ref: https://app.datadoghq.com/account/settings#agent/kubernetes
       #
       apiKey: <DATADOG_API_KEY>
-    
+
       ## @param clusterName - string - optional
       ## Set a unique cluster name to allow scoping hosts and Cluster Checks easily
       ## The name must be unique and must be dot-separated tokens where a token can be up to 40 characters with the following restrictions:
@@ -150,7 +150,7 @@ helm install datadog-monitoring --set datadog.apiKey=<YOUR_API_KEY> -f cluster-a
       ## https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.FIELDS.name
       #
       clusterName: my-snmp-cluster
-    
+
       ## @param clusterChecks - object - required
       ## Enable the Cluster Checks feature on both the cluster-agents and the daemonset
       ## ref: https://docs.datadoghq.com/agent/autodiscovery/clusterchecks/
@@ -158,7 +158,7 @@ helm install datadog-monitoring --set datadog.apiKey=<YOUR_API_KEY> -f cluster-a
       #
       clusterChecks:
         enabled: true
-    
+
       ## @param tags  - list of key:value elements - optional
       ## List of tags to attach to every metric, event and service check collected by this Agent.
       ##
@@ -166,7 +166,7 @@ helm install datadog-monitoring --set datadog.apiKey=<YOUR_API_KEY> -f cluster-a
       #
       tags:
         - 'env:test-snmp-cluster-agent'
-    
+
     ## @param clusterAgent - object - required
     ## This is the Datadog Cluster Agent implementation that handles cluster-wide
     ## metrics more cleanly, separates concerns for better rbac, and implements
@@ -178,7 +178,7 @@ helm install datadog-monitoring --set datadog.apiKey=<YOUR_API_KEY> -f cluster-a
       ## Set this to true to enable Datadog Cluster Agent
       #
       enabled: true
-    
+
       ## @param confd - list of objects - optional
       ## Provide additional cluster check configurations
       ## Each key will become a file in /conf.d
@@ -207,73 +207,73 @@ helm install datadog-monitoring --set datadog.apiKey=<YOUR_API_KEY> -f cluster-a
               ## The IP address of the device to monitor.
               #
               ip_address: "%%host%%"
-    
+
               ## @param port - integer - optional - default: 161
               ## Default SNMP port.
               #
               port: "%%port%%"
-    
+
               ## @param snmp_version - integer - optional - default: 2
               ## If you are using SNMP v1 set snmp_version to 1 (required)
               ## If you are using SNMP v3 set snmp_version to 3 (required)
               #
               snmp_version: "%%extra_version%%"
-    
+
               ## @param timeout - integer - optional - default: 5
               ## Amount of second before timing out.
               #
               timeout: "%%extra_timeout%%"
-    
+
               ## @param retries - integer - optional - default: 5
               ## Amount of retries before failure.
               #
               retries: "%%extra_retries%%"
-    
+
               ## @param community_string - string - optional
               ## Only useful for SNMP v1 & v2.
               #
               community_string: "%%extra_community%%"
-    
+
               ## @param user - string - optional
               ## USERNAME to connect to your SNMP devices.
               #
               user: "%%extra_user%%"
-    
+
               ## @param authKey - string - optional
               ## Authentication key to use with your Authentication type.
               #
               authKey: "%%extra_auth_key%%"
-    
+
               ## @param authProtocol - string - optional
               ## Authentication type to use when connecting to your SNMP devices.
               ## It can be one of: MD5, SHA, SHA224, SHA256, SHA384, SHA512.
               ## Default to MD5 when `authKey` is specified.
               #
               authProtocol: "%%extra_auth_protocol%%"
-    
+
               ## @param privKey - string - optional
               ## Privacy type key to use with your Privacy type.
               #
               privKey: "%%extra_priv_key%%"
-    
+
               ## @param privProtocol - string - optional
               ## Privacy type to use when connecting to your SNMP devices.
               ## It can be one of: DES, 3DES, AES, AES192, AES256, AES192C, AES256C.
               ## Default to DES when `privKey` is specified.
               #
               privProtocol: "%%extra_priv_protocol%%"
-    
+
               ## @param context_engine_id - string - optional
               ## ID of your context engine; typically unneeded.
               ## (optional SNMP v3-only parameter)
               #
               context_engine_id: "%%extra_context_engine_id%%"
-    
+
               ## @param context_name - string - optional
               ## Name of your context (optional SNMP v3-only parameter).
               #
               context_name: "%%extra_context_name%%"
-    
+
               ## @param tags - list of key:value element - optional
               ## List of tags to attach to every metric, event and service check emitted by this integration.
               ##
@@ -283,8 +283,8 @@ helm install datadog-monitoring --set datadog.apiKey=<YOUR_API_KEY> -f cluster-a
                 # The autodiscovery subnet the device is part of.
                 # Used by Agent autodiscovery to pass subnet name.
                 - "autodiscovery_subnet:%%extra_autodiscovery_subnet%%"
-    
-    
+
+
       ## @param datadog-cluster.yaml - object - optional
       ## Specify custom contents for the datadog cluster agent config (datadog-cluster.yaml).
       #


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix some links in the SNMP architecture dev docs.

### Motivation
<!-- What inspired you to submit this pull request? -->
```
$ ddev docs serve
INFO    -  Building documentation... 
INFO    -  Cleaning site directory 
WARNING -  Documentation file 'architecture/snmp.md' contains a link to '../assets/images/snmp-architecture.png' which is not found in the documentation files. 
WARNING -  Documentation file 'architecture/snmp.md' contains a link to '../assets/images/snmp-architecture-cluster-agent.png' which is not found in the documentation files. 
INFO    -  Documentation built in 14.08 seconds 
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->
I'm not getting the WARNINGs anymore when serving from this branch. :-) And images still show up just fine.

The images show up fine in the built website, but that may be "by accident" (eg maybe MkDocs has some mechanism to auto-fix links, or ignore those that go one level too high).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
