### PR TITLE
Build developer docs in strict mode

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/build.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/docs/build.py
@@ -16,7 +16,7 @@ from .utils import insert_verbosity_flag
 @click.option('--pdf', is_flag=True, help='Also export the site as PDF')
 def build(verbose, pdf):
     """Build documentation."""
-    command = ['tox', '-e', 'docs', '--', 'build', '--clean']
+    command = ['tox', '-e', 'docs', '--', 'build', '--clean', '--strict']
     insert_verbosity_flag(command, verbose)
 
     env_vars = {'ENABLE_PDF_SITE_EXPORT': '1' if pdf else '0'}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Enable `--strict` mode when building docs.


### Motivation
<!-- What inspired you to submit this pull request? -->
In this mode, `mkdocs build` errors out if any warnings were discovered while building:

> Determines how warnings are handled. Set to true to halt processing when a warning is raised. Set to false to print a warning and continue processing.

https://www.mkdocs.org/user-guide/configuration/#strict

Prevents issues like #8150 from happening again. (We don't typically watch build logs to see if there are warnings, so they could sneak in unknowingly.)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
