### PR TITLE
Document new collect_default_jvm_metrics flag for JMXFetch integrations

### DIFF
--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -143,10 +143,10 @@ instances:
     #
     # rmi_client_timeout: 15000
 
-    ## @param collect_default_jvm_metrics - boolean - optional - default: false
-    ## Allows disabling the collection of default JVM metrics
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Allows disabling the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -144,7 +144,7 @@ instances:
     # rmi_client_timeout: 15000
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics.
+    ## Configures the collection of default JVM metrics.
     #
     # collect_default_jvm_metrics: true
 

--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -143,6 +143,11 @@ instances:
     #
     # rmi_client_timeout: 15000
 
+    ## @param collect_default_jvm_metrics - boolean - optional - default: false
+    ## Allows disabling the collection of default JVM metrics
+    #
+    # collect_default_jvm_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -149,6 +149,11 @@ instances:
     #
     # rmi_client_timeout: 15000
 
+    ## @param collect_default_jvm_metrics - boolean - optional - default: false
+    ## Allows disabling the collection of default JVM metrics
+    #
+    # collect_default_jvm_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -150,7 +150,7 @@ instances:
     # rmi_client_timeout: 15000
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics.
+    ## Configures the collection of default JVM metrics.
     #
     # collect_default_jvm_metrics: true
 

--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -149,10 +149,10 @@ instances:
     #
     # rmi_client_timeout: 15000
 
-    ## @param collect_default_jvm_metrics - boolean - optional - default: false
-    ## Allows disabling the collection of default JVM metrics
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Allows disabling the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+++ b/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
@@ -155,7 +155,7 @@ instances:
     # rmi_client_timeout: 15000
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics.
+    ## Configures the collection of default JVM metrics.
     #
     # collect_default_jvm_metrics: true
 

--- a/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+++ b/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
@@ -154,10 +154,10 @@ instances:
     #
     # rmi_client_timeout: 15000
 
-    ## @param collect_default_jvm_metrics - boolean - optional - default: false
-    ## Allows disabling the collection of default JVM metrics
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Allows disabling the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+++ b/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
@@ -154,6 +154,11 @@ instances:
     #
     # rmi_client_timeout: 15000
 
+    ## @param collect_default_jvm_metrics - boolean - optional - default: false
+    ## Allows disabling the collection of default JVM metrics
+    #
+    # collect_default_jvm_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
@@ -104,6 +104,12 @@
     will give up on that connection and retry.
   value:
     example: 15000
-    type: number
+    type: number 
+
+- name: collect_default_jvm_metrics
+  description: Allows disabling the collection of default JVM metrics
+  value:
+    example: false
+    type: boolean
 
 - template: instances/default

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
@@ -107,7 +107,7 @@
     type: number 
 
 - name: collect_default_jvm_metrics
-  description: Allows disabling the collection of default JVM metrics.
+  description: Configures the collection of default JVM metrics.
   value:
     example: true
     type: boolean

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
@@ -107,9 +107,9 @@
     type: number 
 
 - name: collect_default_jvm_metrics
-  description: Allows disabling the collection of default JVM metrics
+  description: Allows disabling the collection of default JVM metrics.
   value:
-    example: false
+    example: true
     type: boolean
 
 - template: instances/default

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -192,7 +192,7 @@ instances:
     # rmi_client_timeout: 15000
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics.
+    ## Configures the collection of default JVM metrics.
     #
     # collect_default_jvm_metrics: true
 

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -191,10 +191,10 @@ instances:
     #
     # rmi_client_timeout: 15000
 
-    ## @param collect_default_jvm_metrics - boolean - optional - default: false
-    ## Allows disabling the collection of default JVM metrics
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Allows disabling the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -191,6 +191,11 @@ instances:
     #
     # rmi_client_timeout: 15000
 
+    ## @param collect_default_jvm_metrics - boolean - optional - default: false
+    ## Allows disabling the collection of default JVM metrics
+    #
+    # collect_default_jvm_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -143,10 +143,10 @@ instances:
     #
     # rmi_client_timeout: 15000
 
-    ## @param collect_default_jvm_metrics - boolean - optional - default: false
-    ## Allows disabling the collection of default JVM metrics
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Allows disabling the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -144,7 +144,7 @@ instances:
     # rmi_client_timeout: 15000
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics.
+    ## Configures the collection of default JVM metrics.
     #
     # collect_default_jvm_metrics: true
 

--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -143,6 +143,11 @@ instances:
     #
     # rmi_client_timeout: 15000
 
+    ## @param collect_default_jvm_metrics - boolean - optional - default: false
+    ## Allows disabling the collection of default JVM metrics
+    #
+    # collect_default_jvm_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/hivemq/datadog_checks/hivemq/data/conf.yaml.example
+++ b/hivemq/datadog_checks/hivemq/data/conf.yaml.example
@@ -143,10 +143,10 @@ instances:
     #
     # rmi_client_timeout: 15000
 
-    ## @param collect_default_jvm_metrics - boolean - optional - default: false
-    ## Allows disabling the collection of default JVM metrics
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Allows disabling the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/hivemq/datadog_checks/hivemq/data/conf.yaml.example
+++ b/hivemq/datadog_checks/hivemq/data/conf.yaml.example
@@ -144,7 +144,7 @@ instances:
     # rmi_client_timeout: 15000
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics.
+    ## Configures the collection of default JVM metrics.
     #
     # collect_default_jvm_metrics: true
 

--- a/hivemq/datadog_checks/hivemq/data/conf.yaml.example
+++ b/hivemq/datadog_checks/hivemq/data/conf.yaml.example
@@ -143,6 +143,11 @@ instances:
     #
     # rmi_client_timeout: 15000
 
+    ## @param collect_default_jvm_metrics - boolean - optional - default: false
+    ## Allows disabling the collection of default JVM metrics
+    #
+    # collect_default_jvm_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/ignite/datadog_checks/ignite/data/conf.yaml.example
+++ b/ignite/datadog_checks/ignite/data/conf.yaml.example
@@ -143,10 +143,10 @@ instances:
     #
     # rmi_client_timeout: 15000
 
-    ## @param collect_default_jvm_metrics - boolean - optional - default: false
-    ## Allows disabling the collection of default JVM metrics
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Allows disabling the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/ignite/datadog_checks/ignite/data/conf.yaml.example
+++ b/ignite/datadog_checks/ignite/data/conf.yaml.example
@@ -144,7 +144,7 @@ instances:
     # rmi_client_timeout: 15000
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics.
+    ## Configures the collection of default JVM metrics.
     #
     # collect_default_jvm_metrics: true
 

--- a/ignite/datadog_checks/ignite/data/conf.yaml.example
+++ b/ignite/datadog_checks/ignite/data/conf.yaml.example
@@ -143,6 +143,11 @@ instances:
     #
     # rmi_client_timeout: 15000
 
+    ## @param collect_default_jvm_metrics - boolean - optional - default: false
+    ## Allows disabling the collection of default JVM metrics
+    #
+    # collect_default_jvm_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -156,10 +156,10 @@ instances:
     #
     # rmi_client_timeout: 15000
 
-    ## @param collect_default_jvm_metrics - boolean - optional - default: false
-    ## Allows disabling the collection of default JVM metrics
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Allows disabling the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -156,6 +156,11 @@ instances:
     #
     # rmi_client_timeout: 15000
 
+    ## @param collect_default_jvm_metrics - boolean - optional - default: false
+    ## Allows disabling the collection of default JVM metrics
+    #
+    # collect_default_jvm_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -157,7 +157,7 @@ instances:
     # rmi_client_timeout: 15000
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics.
+    ## Configures the collection of default JVM metrics.
     #
     # collect_default_jvm_metrics: true
 

--- a/kafka/datadog_checks/kafka/data/conf.yaml.example
+++ b/kafka/datadog_checks/kafka/data/conf.yaml.example
@@ -143,10 +143,10 @@ instances:
     #
     # rmi_client_timeout: 15000
 
-    ## @param collect_default_jvm_metrics - boolean - optional - default: false
-    ## Allows disabling the collection of default JVM metrics
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Allows disabling the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/kafka/datadog_checks/kafka/data/conf.yaml.example
+++ b/kafka/datadog_checks/kafka/data/conf.yaml.example
@@ -144,7 +144,7 @@ instances:
     # rmi_client_timeout: 15000
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics.
+    ## Configures the collection of default JVM metrics.
     #
     # collect_default_jvm_metrics: true
 

--- a/kafka/datadog_checks/kafka/data/conf.yaml.example
+++ b/kafka/datadog_checks/kafka/data/conf.yaml.example
@@ -143,6 +143,11 @@ instances:
     #
     # rmi_client_timeout: 15000
 
+    ## @param collect_default_jvm_metrics - boolean - optional - default: false
+    ## Allows disabling the collection of default JVM metrics
+    #
+    # collect_default_jvm_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/presto/datadog_checks/presto/data/conf.yaml.example
+++ b/presto/datadog_checks/presto/data/conf.yaml.example
@@ -143,10 +143,10 @@ instances:
     #
     # rmi_client_timeout: 15000
 
-    ## @param collect_default_jvm_metrics - boolean - optional - default: false
-    ## Allows disabling the collection of default JVM metrics
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Allows disabling the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/presto/datadog_checks/presto/data/conf.yaml.example
+++ b/presto/datadog_checks/presto/data/conf.yaml.example
@@ -144,7 +144,7 @@ instances:
     # rmi_client_timeout: 15000
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics.
+    ## Configures the collection of default JVM metrics.
     #
     # collect_default_jvm_metrics: true
 

--- a/presto/datadog_checks/presto/data/conf.yaml.example
+++ b/presto/datadog_checks/presto/data/conf.yaml.example
@@ -143,6 +143,11 @@ instances:
     #
     # rmi_client_timeout: 15000
 
+    ## @param collect_default_jvm_metrics - boolean - optional - default: false
+    ## Allows disabling the collection of default JVM metrics
+    #
+    # collect_default_jvm_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/solr/datadog_checks/solr/data/conf.yaml.example
+++ b/solr/datadog_checks/solr/data/conf.yaml.example
@@ -143,10 +143,10 @@ instances:
     #
     # rmi_client_timeout: 15000
 
-    ## @param collect_default_jvm_metrics - boolean - optional - default: false
-    ## Allows disabling the collection of default JVM metrics
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Allows disabling the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/solr/datadog_checks/solr/data/conf.yaml.example
+++ b/solr/datadog_checks/solr/data/conf.yaml.example
@@ -144,7 +144,7 @@ instances:
     # rmi_client_timeout: 15000
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics.
+    ## Configures the collection of default JVM metrics.
     #
     # collect_default_jvm_metrics: true
 

--- a/solr/datadog_checks/solr/data/conf.yaml.example
+++ b/solr/datadog_checks/solr/data/conf.yaml.example
@@ -143,6 +143,11 @@ instances:
     #
     # rmi_client_timeout: 15000
 
+    ## @param collect_default_jvm_metrics - boolean - optional - default: false
+    ## Allows disabling the collection of default JVM metrics
+    #
+    # collect_default_jvm_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -229,10 +229,10 @@ instances:
     #
     # rmi_client_timeout: 15000
 
-    ## @param collect_default_jvm_metrics - boolean - optional - default: false
-    ## Allows disabling the collection of default JVM metrics
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Allows disabling the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -230,7 +230,7 @@ instances:
     # rmi_client_timeout: 15000
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics.
+    ## Configures the collection of default JVM metrics.
     #
     # collect_default_jvm_metrics: true
 

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -229,6 +229,11 @@ instances:
     #
     # rmi_client_timeout: 15000
 
+    ## @param collect_default_jvm_metrics - boolean - optional - default: false
+    ## Allows disabling the collection of default JVM metrics
+    #
+    # collect_default_jvm_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/tomcat/datadog_checks/tomcat/data/conf.yaml.example
+++ b/tomcat/datadog_checks/tomcat/data/conf.yaml.example
@@ -143,10 +143,10 @@ instances:
     #
     # rmi_client_timeout: 15000
 
-    ## @param collect_default_jvm_metrics - boolean - optional - default: false
-    ## Allows disabling the collection of default JVM metrics
+    ## @param collect_default_jvm_metrics - boolean - optional - default: true
+    ## Allows disabling the collection of default JVM metrics.
     #
-    # collect_default_jvm_metrics: false
+    # collect_default_jvm_metrics: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/tomcat/datadog_checks/tomcat/data/conf.yaml.example
+++ b/tomcat/datadog_checks/tomcat/data/conf.yaml.example
@@ -144,7 +144,7 @@ instances:
     # rmi_client_timeout: 15000
 
     ## @param collect_default_jvm_metrics - boolean - optional - default: true
-    ## Allows disabling the collection of default JVM metrics.
+    ## Configures the collection of default JVM metrics.
     #
     # collect_default_jvm_metrics: true
 

--- a/tomcat/datadog_checks/tomcat/data/conf.yaml.example
+++ b/tomcat/datadog_checks/tomcat/data/conf.yaml.example
@@ -143,6 +143,11 @@ instances:
     #
     # rmi_client_timeout: 15000
 
+    ## @param collect_default_jvm_metrics - boolean - optional - default: false
+    ## Allows disabling the collection of default JVM metrics
+    #
+    # collect_default_jvm_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##


### PR DESCRIPTION
### What does this PR do?
Added docs for `collect_default_jvm_metrics`. This flag allows users to disable default jvm metrics in JMXFetch

Related PRs:
https://github.com/DataDog/datadog-agent/pull/6923
https://github.com/DataDog/jmxfetch/pull/345

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
