### PR TITLE
SNMP Use device dashboard short_name in datacenter dashboard

### DIFF
--- a/snmp/assets/dashboards/datacenter_overview.json
+++ b/snmp/assets/dashboards/datacenter_overview.json
@@ -43,7 +43,7 @@
                 "custom_links": [
                     {
                         "label": "Interface Performance",
-                        "link": "/screen/integration/30545/device-dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}"
+                        "link": "/screen/integration/Device%20Dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}"
                     }
                 ],
                 "has_search_bar": "auto",
@@ -84,7 +84,7 @@
                 "custom_links": [
                     {
                         "label": "Device Dashboard",
-                        "link": "/screen/integration/30545/device-dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}"
+                        "link": "/screen/integration/Device%20Dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}"
                     }
                 ],
                 "legend_size": "0",
@@ -137,7 +137,7 @@
                 "custom_links": [
                     {
                         "label": "Device Performance",
-                        "link": "/screen/integration/30545/device-dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}&tpl_var_interface={{interface.value}}"
+                        "link": "/screen/integration/Device%20Dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}&tpl_var_interface={{interface.value}}"
                     }
                 ],
                 "requests": [
@@ -182,7 +182,7 @@
                 "custom_links": [
                     {
                         "label": "Device Performance",
-                        "link": "/screen/integration/30545/device-dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}&tpl_var_interface={{interface.value}}"
+                        "link": "/screen/integration/Device%20Dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}&tpl_var_interface={{interface.value}}"
                     }
                 ],
                 "requests": [
@@ -208,7 +208,7 @@
                 "custom_links": [
                     {
                         "label": "Device Performance",
-                        "link": "/screen/integration/30545/device-dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}&tpl_var_interface={{interface.value}}"
+                        "link": "/screen/integration/Device%20Dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}&tpl_var_interface={{interface.value}}"
                     }
                 ],
                 "requests": [
@@ -253,7 +253,7 @@
                 "custom_links": [
                     {
                         "label": "Device Performance",
-                        "link": "/screen/integration/30545/device-dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}&tpl_var_interface={{interface.value}}"
+                        "link": "/screen/integration/Device%20Dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}&tpl_var_interface={{interface.value}}"
                     }
                 ],
                 "requests": [
@@ -336,7 +336,7 @@
                 "custom_links": [
                     {
                         "label": "Device Dashboard",
-                        "link": "/screen/integration/30545/device-dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}"
+                        "link": "/screen/integration/Device%20Dashboard?from_ts=1602800672906&live=true&to_ts=1602804272906&tpl_var_snmp_host={{snmp_host.value}}"
                     }
                 ],
                 "legend_size": "0",


### PR DESCRIPTION
### What does this PR do?
Fixing custom links in datacenter overview dashboard to target device dashboard using only `short_name` (`Device%20Dashboard`) 

### Motivation
Fix custom links in datacenter dashboard

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
