### PR TITLE
Migrate cassandra preset dashboards

### DIFF
--- a/cassandra/assets/dashboards/cassandra_overview.json
+++ b/cassandra/assets/dashboards/cassandra_overview.json
@@ -1,0 +1,412 @@
+{
+    "title": "Cassandra - Overview",
+    "description": "This overview dashboard displays the high-level health of your Cassandra clusters. You can use it as a jumping-off point for troubleshooting with our more specialized dashboards covering the [read path](https://app.datadoghq.com/dash/integration/24/cassandra---read-path), [write path](https://app.datadoghq.com/dash/integration/25/cassandra---write-path), and [SSTable management](https://app.datadoghq.com/dash/integration/234/cassandra---sstable-management). Further reading on Cassandra monitoring:\n\n- [Datadog's blog post describing our suite of Cassandra dashboards](https://www.datadoghq.com/blog/tlp-cassandra-dashboards/)\n\n- [Our guide to key metrics for Cassandra monitoring](https://www.datadoghq.com/blog/how-to-monitor-cassandra-performance-metrics/)\n\n- [How to collect Cassandra metrics using built-in Cassandra and JDK tools](https://www.datadoghq.com/blog/how-to-collect-cassandra-metrics/)\n\n- [How to monitor Cassandra using Datadog](https://www.datadoghq.com/blog/monitoring-cassandra-with-datadog/)\n\n- [Datadog's integration docs for Cassandra](https://docs.datadoghq.com/integrations/cassandra/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
+    "layout_type": "ordered",
+    "template_variables": [
+        {
+            "default": "*",
+            "prefix": "environment",
+            "name": "environment"
+        },
+        {
+            "default": "*",
+            "prefix": "datacenter",
+            "name": "datacenter"
+        },
+        {
+            "default": "*",
+            "prefix": "host",
+            "name": "host"
+        }
+    ],
+    "widgets": [
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "top(avg:cassandra.nodetool.status.status{$environment,$datacenter,$host} by {node_address, node_id}, 10, 'last', 'asc')",
+                        "conditional_formats": [
+                            {
+                                "palette": "white_on_red",
+                                "value": 1,
+                                "comparator": "<"
+                            },
+                            {
+                                "palette": "white_on_green",
+                                "value": 1,
+                                "comparator": ">="
+                            }
+                        ]
+                    }
+                ],
+                "type": "toplist",
+                "title": "Node status"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "top(max:system.disk.in_use{$environment,$datacenter,$host} by {host, device}, 10, 'max', 'desc')",
+                        "conditional_formats": [
+                            {
+                                "palette": "white_on_red",
+                                "value": 0.8,
+                                "comparator": ">"
+                            },
+                            {
+                                "palette": "white_on_yellow",
+                                "value": 0.5,
+                                "comparator": ">="
+                            },
+                            {
+                                "palette": "white_on_green",
+                                "value": 0.5,
+                                "comparator": "<"
+                            }
+                        ]
+                    }
+                ],
+                "type": "toplist",
+                "title": "Total disk usage"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.dropped.one_minute_rate{$environment,$datacenter,$host} by {host,droppedmessage,datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "error dashed",
+                        "value": "y = 50",
+                        "label": "That many dropped messages is definitely an issue!"
+                    },
+                    {
+                        "display_type": "warning solid",
+                        "value": "y = 10",
+                        "label": "It happens that some messages get dropped..."
+                    }
+                ],
+                "title": "Dropped messages"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.latency.one_minute_rate{$environment,$datacenter,$host,clientrequest:read} by {datacenter,clientrequest}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Read request counts"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.latency.one_minute_rate{$environment,$datacenter,$host,clientrequest:write} by {datacenter,clientrequest}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Write request counts"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.latency.one_minute_rate{$environment,$datacenter,$host,clientrequest:casread} by {datacenter,clientrequest}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.latency.one_minute_rate{$environment,$datacenter,$host,clientrequest:caswrite} by {datacenter,clientrequest}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.latency.one_minute_rate{$environment,$datacenter,$host,clientrequest:rangeslice} by {datacenter,clientrequest}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.latency.one_minute_rate{$environment,$datacenter,$host,clientrequest:viewwrite} by {datacenter,clientrequest}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Other operations request counts"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.latency.75th_percentile{type:clientrequest,clientrequest:read,$environment,$datacenter,$host} by {datacenter,clientrequest}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.latency.95th_percentile{type:clientrequest,clientrequest:read,$environment,$datacenter,$host} by {datacenter,clientrequest}",
+                        "style": {
+                            "line_type": "dotted"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Read latencies - 75 and 95th percentiles"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.latency.75th_percentile{type:clientrequest,clientrequest:write,$environment,$datacenter,$host} by {datacenter,clientrequest}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.latency.95th_percentile{type:clientrequest,clientrequest:write,$environment,$datacenter,$host} by {datacenter,clientrequest}",
+                        "style": {
+                            "line_type": "dotted"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Write latencies - 75 and 95th percentiles"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.latency.75th_percentile{type:clientrequest,clientrequest:casread,$environment,$datacenter,$host} by {datacenter,clientrequest}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.latency.75th_percentile{type:clientrequest,clientrequest:caswrite,$environment,$datacenter,$host} by {datacenter,clientrequest}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.latency.75th_percentile{type:clientrequest,clientrequest:rangeslice,$environment,$datacenter,$host} by {datacenter,clientrequest}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.latency.75th_percentile{type:clientrequest,clientrequest:viewwrite,$environment,$datacenter,$host} by {datacenter,clientrequest}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.latency.95th_percentile{type:clientrequest,clientrequest:casread,$environment,$datacenter,$host} by {datacenter,clientrequest}",
+                        "style": {
+                            "line_type": "dotted"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.latency.95th_percentile{type:clientrequest,clientrequest:caswrite,$environment,$datacenter,$host} by {datacenter,clientrequest}",
+                        "style": {
+                            "line_type": "dotted"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.latency.95th_percentile{type:clientrequest,clientrequest:rangeslice,$environment,$datacenter,$host} by {datacenter,clientrequest}",
+                        "style": {
+                            "line_type": "dotted"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.latency.95th_percentile{type:clientrequest,clientrequest:viewwrite,$environment,$datacenter,$host} by {datacenter,clientrequest}",
+                        "style": {
+                            "line_type": "dotted"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Other operations latencies - 75 and 95th percentiles"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "max:cassandra.live_ss_table_count{$environment,$datacenter,$host} by {host,datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "SSTable count"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "max:cassandra.pending_compactions{$environment,$datacenter,$host} by {environment, host,datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "warning dashed",
+                        "value": "y = 10",
+                        "label": "Some pending compactions are not an issue..."
+                    },
+                    {
+                        "display_type": "error solid",
+                        "value": "y = 100",
+                        "label": "This is too many pending compactions!"
+                    }
+                ],
+                "title": "Pending compactions per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "top(max:cassandra.max_partition_size{$environment,$datacenter,$host} by {host,table}, 10, 'max', 'desc')"
+                    }
+                ],
+                "type": "toplist",
+                "title": "Max partition size per host and table (C*3+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "top(max:cassandra.max_row_size{$environment,$datacenter,$host} by {host,columnfamily}, 10, 'max', 'desc')"
+                    }
+                ],
+                "type": "toplist",
+                "title": "Max row size per host and table (pre- C*3.0)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:jmx.gc.minor_collection_time{$environment,$datacenter,$host} by {datacenter,host} + avg:jmx.gc.major_collection_count{$environment,$datacenter,$host} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "error dashed",
+                        "value": "y = 150",
+                        "label": "15% of the time spent in Garbage Collection (STW GC)"
+                    }
+                ],
+                "title": "Stop the world GC average per datacenter (Minor + Major GC)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.load.1{$environment,$datacenter,$host} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Unix CPU load per node (1 minute)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.cpu.idle{$environment,$datacenter,$host}, avg:system.cpu.user{$environment,$datacenter,$host}, avg:system.cpu.guest{$environment,$datacenter,$host}, avg:system.cpu.iowait{$environment,$datacenter,$host}, avg:system.cpu.stolen{$environment,$datacenter,$host}, avg:system.cpu.system{$environment,$datacenter,$host}"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "error dashed",
+                        "value": "y = 75",
+                        "label": "75 %"
+                    }
+                ],
+                "title": "CPU usage"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.mem.total{$environment,$datacenter,$host}",
+                        "display_type": "area"
+                    },
+                    {
+                        "q": "avg:system.mem.total{$environment,$datacenter,$host} - avg:system.mem.usable{$environment,$datacenter,$host}",
+                        "display_type": "area"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "System memory"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.net.bytes_rcvd{$environment,$datacenter,$host} by {datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:system.net.bytes_sent{$environment,$datacenter,$host} by {datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Network"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "max:system.io.await{$environment,$datacenter,$host} by {environment,datacenter,host,device}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "I/O wait (%)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:ntp.offset{$environment,$datacenter,$host} by {host,datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "error dashed",
+                        "value": "y = 0.01",
+                        "label": "y = 0.01"
+                    },
+                    {
+                        "display_type": "error dashed",
+                        "value": "y = -0.01",
+                        "label": "y = -0.01"
+                    }
+                ],
+                "title": "Clock drift"
+            }
+        }
+    ]
+}

--- a/cassandra/assets/dashboards/cassandra_read.json
+++ b/cassandra/assets/dashboards/cassandra_read.json
@@ -1,0 +1,720 @@
+{
+    "title": "Cassandra - Read Path",
+    "description": "You can use this dashboard to rapidly troubleshoot any read-related issues that you identified from the [Cassandra overview](https://app.datadoghq.com/dash/integration/23/cassandra---overview) dashboard. Aggregated metric graphs enable you to isolate issues to a particular table, host, or combination thereof. Further reading on Cassandra monitoring:\n\n- [Datadog's blog post describing our suite of Cassandra dashboards](https://www.datadoghq.com/blog/tlp-cassandra-dashboards/)\n\n- [Our guide to key metrics for Cassandra monitoring](https://www.datadoghq.com/blog/how-to-monitor-cassandra-performance-metrics/)\n\n- [How to collect Cassandra metrics using built-in Cassandra and JDK tools](https://www.datadoghq.com/blog/how-to-collect-cassandra-metrics/)\n\n- [How to monitor Cassandra using Datadog](https://www.datadoghq.com/blog/monitoring-cassandra-with-datadog/)\n\n- [Datadog's integration docs for Cassandra](https://docs.datadoghq.com/integrations/cassandra/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
+    "layout_type": "ordered",
+    "template_variables": [
+        {
+            "default": "*",
+            "prefix": "environment",
+            "name": "environment"
+        },
+        {
+            "default": "*",
+            "prefix": "datacenter",
+            "name": "datacenter"
+        },
+        {
+            "default": "*",
+            "prefix": "host",
+            "name": "host"
+        },
+        {
+            "default": "*",
+            "prefix": "keyspace",
+            "name": "keyspace"
+        },
+        {
+            "default": "*",
+            "prefix": "table",
+            "name": "table"
+        },
+        {
+            "default": "*",
+            "prefix": "columnfamily",
+            "name": "columnfamily"
+        }
+    ],
+    "widgets": [
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.pending_tasks{$environment,$datacenter,$host,threadpools:readstage} by {host,datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Pending reads per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.dropped.one_minute_rate{$environment,$datacenter,$host,droppedmessage:read} by{host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.dropped.one_minute_rate{$environment,$datacenter,$host,droppedmessage:range_slice} by{host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.dropped.one_minute_rate{$environment,$datacenter,$host,droppedmessage:paged_range} by{host,datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Dropped reads per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:jmx.gc.minor_collection_time{$environment,$datacenter,$host} by {datacenter,host} + avg:jmx.gc.major_collection_count{$environment,$datacenter,$host} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "error dashed",
+                        "value": "y = 150",
+                        "label": "15% of the time spent in Garbage Collection (STW GC)"
+                    }
+                ],
+                "title": "Stop the world GC average per datacenter (Minor + Major GC)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.read_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Read count per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.read_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Read count per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.read_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Read count per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.read_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.read_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Read Latency (p75 & p95) per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.read_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.read_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Read Latency (p75 & p95) per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.read_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.read_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Read Latency (p75 & p95) per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.read_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.read_latency.99th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dotted"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Read Latency (p95 & p99) per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.read_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.read_latency.99th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "style": {
+                            "line_type": "dotted"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Read Latency (p95 & p99) per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.read_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.read_latency.99th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dotted"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Read Latency (p95 & p99) per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.range_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Range request count per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.range_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Range request count per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.range_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Range request count per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.range_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.range_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Range request latency (p75 & p95) per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.range_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.range_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Range request latency (p75 & p95) per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.range_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.range_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Range request latency (p75 & p95) per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.tombstone_scanned_histogram.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.tombstone_scanned_histogram.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Tombstones per read per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.tombstone_scanned_histogram.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.tombstone_scanned_histogram.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Tombstones per read per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.tombstone_scanned_histogram.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.tombstone_scanned_histogram.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Tombstones per read per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.ss_tables_per_read_histogram.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.ss_tables_per_read_histogram.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Number of SSTable hit per read per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.ss_tables_per_read_histogram.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.ss_tables_per_read_histogram.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Number of SSTable hit per read per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.ss_tables_per_read_histogram.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.ss_tables_per_read_histogram.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Number of SSTable hit per read per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.max_partition_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.mean_partition_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.max_row_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.mean_row_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Max / Mean partition size per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.max_partition_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.mean_partition_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.max_row_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.mean_row_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Max / Mean partition size per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.max_partition_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.mean_partition_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.max_row_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.mean_row_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Max / Mean partition size per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.key_cache_hit_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Key cache hit rate per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.key_cache_hit_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Key cache hit rate per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.key_cache_hit_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Key cache hit rate per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.row_cache_hit_out_of_range.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.row_cache_hit.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.row_cache_miss.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Row cache stats per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.row_cache_hit_out_of_range.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.row_cache_hit.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.row_cache_miss.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Row cache stats per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.row_cache_hit_out_of_range.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.row_cache_hit.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.row_cache_miss.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Row cache stats per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.bloom_filter_false_ratio{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Bloom Filters (BF) stats per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.bloom_filter_false_ratio{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Bloom Filters (BF) stats per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.bloom_filter_false_ratio{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Bloom Filters (BF) stats per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.io.r_s{$environment,$datacenter,$host} by {host,datacenter,device}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Disk read count (io.r/s) per host and device"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.io.rkb_s{$environment,$datacenter,$host} by {host,datacenter,device}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Disk read throughput (io.rkb/s) per host and device"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "top(avg:system.io.r_await{$environment,$datacenter,$host} by {host,datacenter,device}, 10, 'mean', 'desc')",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Disk read latency (r_await) per host and device"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.io.rrqm_s{$environment,$datacenter,$host} by {host,datacenter,device}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Disk read queued (io.rrqm/s) per host and device"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.io.util{$environment,$datacenter,$host} by {host,datacenter,device}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Disk utilization (io.util%) per host and device"
+            }
+        }
+    ]
+}

--- a/cassandra/assets/dashboards/cassandra_sstable.json
+++ b/cassandra/assets/dashboards/cassandra_sstable.json
@@ -1,0 +1,670 @@
+{
+    "title": "Cassandra - SSTable Management",
+    "description": "You can use this dashboard to rapidly troubleshoot any issues with Cassandra's SSTables that you identified from the [Cassandra overview](https://app.datadoghq.com/dash/integration/23/cassandra---overview) dashboard. Aggregated metric graphs enable you to isolate issues to a particular table, host, or combination thereof. Further reading on Cassandra monitoring:\n\n- [Datadog's blog post describing our suite of Cassandra dashboards](https://www.datadoghq.com/blog/tlp-cassandra-dashboards/)\n\n- [Our guide to key metrics for Cassandra monitoring](https://www.datadoghq.com/blog/how-to-monitor-cassandra-performance-metrics/)\n\n- [How to collect Cassandra metrics using built-in Cassandra and JDK tools](https://www.datadoghq.com/blog/how-to-collect-cassandra-metrics/)\n\n- [How to monitor Cassandra using Datadog](https://www.datadoghq.com/blog/monitoring-cassandra-with-datadog/)\n\n- [Datadog's integration docs for Cassandra](https://docs.datadoghq.com/integrations/cassandra/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
+    "layout_type": "ordered",
+    "template_variables": [
+        {
+            "default": "*",
+            "prefix": "environment",
+            "name": "environment"
+        },
+        {
+            "default": "*",
+            "prefix": "datacenter",
+            "name": "datacenter"
+        },
+        {
+            "default": "*",
+            "prefix": "host",
+            "name": "host"
+        },
+        {
+            "default": "*",
+            "prefix": "keyspace",
+            "name": "keyspace"
+        },
+        {
+            "default": "*",
+            "prefix": "table",
+            "name": "table"
+        },
+        {
+            "default": "*",
+            "prefix": "columnfamily",
+            "name": "columnfamily"
+        }
+    ],
+    "widgets": [
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "top(max:system.disk.in_use{$environment,$datacenter,$host} by {host,device}, 10, 'max', 'desc')",
+                        "conditional_formats": [
+                            {
+                                "palette": "white_on_red",
+                                "value": 0.8,
+                                "comparator": ">"
+                            },
+                            {
+                                "palette": "white_on_yellow",
+                                "value": 0.5,
+                                "comparator": ">="
+                            },
+                            {
+                                "palette": "white_on_green",
+                                "value": 0.5,
+                                "comparator": "<"
+                            }
+                        ]
+                    }
+                ],
+                "type": "toplist",
+                "title": "Disk space used per host and device"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "top(max:cassandra.pending_compactions{$environment,$datacenter,$host} by {host}, 10, 'max', 'desc')",
+                        "conditional_formats": [
+                            {
+                                "palette": "white_on_red",
+                                "value": 100,
+                                "comparator": ">"
+                            },
+                            {
+                                "palette": "white_on_yellow",
+                                "value": 10,
+                                "comparator": ">="
+                            },
+                            {
+                                "palette": "white_on_green",
+                                "value": 0,
+                                "comparator": ">="
+                            }
+                        ]
+                    }
+                ],
+                "type": "toplist",
+                "title": "Compactions pending per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "top(max:cassandra.live_ss_table_count{$environment,$datacenter,$host} by {host}, 10, 'max', 'desc')"
+                    }
+                ],
+                "type": "toplist",
+                "title": "Number of SSTables per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.live_ss_table_count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "SSTable count per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.live_ss_table_count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "SSTable count per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.live_ss_table_count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "SSTable count per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.pending_compactions{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Pending compactions per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.pending_compactions{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Pending compactions per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.pending_compactions{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Pending compactions per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "per_second(avg:cassandra.compaction_bytes_written.count{$environment,$datacenter,$host,$keyspace,$table} by {datacenter,table,columnfamily,keyspace})",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Compacted data per table and DC (C*3+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "per_second(avg:cassandra.compaction_bytes_written.count{$environment,$datacenter,$host,$keyspace,$table} by {datacenter,host})",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Compacted data per host (C*3+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "per_second(avg:cassandra.compaction_bytes_written.count{$environment,$datacenter,$host,$keyspace,$table} by {host,datacenter,table,columnfamily,keyspace})",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Compacted data per host and table (C*3+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.pending_flushes.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Pending Flushes per table and DC (C*2.1+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.pending_flushes.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Pending Flushes per host (C*2.1+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.pending_flushes.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Pending Flushes per host and table (C*2.1+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "per_second(avg:cassandra.bytes_flushed.count{$environment,$datacenter,$host,$keyspace,$table} by {datacenter,table,columnfamily,keyspace})",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Flushed data per table and DC (C*3+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "per_second(avg:cassandra.bytes_flushed.count{$environment,$datacenter,$host,$keyspace,$table} by {datacenter,host})",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Flushed data per host (C*3+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "per_second(avg:cassandra.bytes_flushed.count{$environment,$datacenter,$host,$keyspace,$table} by {host,datacenter,table,columnfamily,keyspace})",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Flushed data per host and table (C*3+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "derivative(avg:cassandra.live_disk_space_used.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace})",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Live space growth per table and DC (Max rate per second)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "derivative(avg:cassandra.live_disk_space_used.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host})",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Live space growth per host (Max rate per second)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "derivative(avg:cassandra.live_disk_space_used.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace})",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Live space growth per host and table (Max rate per second)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "max:cassandra.total_disk_space_used.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Total space used per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "max:cassandra.total_disk_space_used.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Total space used per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "max:cassandra.total_disk_space_used.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Total space used per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "max:cassandra.snapshots_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Snapshot real size on disk per table and DC (C*2.1+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "max:cassandra.snapshots_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Snapshot real size on disk per host (C*2.1+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "max:cassandra.snapshots_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Snapshot real size on disk per host and table (C*2.1+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.compression_ratio{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "warning dashed",
+                        "value": "y = 0.9",
+                        "label": "Inefficient compression"
+                    },
+                    {
+                        "display_type": "ok dashed",
+                        "value": "y = 0.1",
+                        "label": "Good compression"
+                    }
+                ],
+                "title": "Compression ratio per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.compression_ratio{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "warning dashed",
+                        "value": "y = 0.9",
+                        "label": "Inefficient compression"
+                    },
+                    {
+                        "display_type": "ok dashed",
+                        "value": "y = 0.1",
+                        "label": "Good compression"
+                    }
+                ],
+                "title": "Compression ratio per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.compression_ratio{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "warning dashed",
+                        "value": "y = 0.9",
+                        "label": "Inefficient compression"
+                    },
+                    {
+                        "display_type": "ok dashed",
+                        "value": "y = 0.1",
+                        "label": "Good compression"
+                    }
+                ],
+                "title": "Compression ratio per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.db.droppable_tombstone_ratio{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "warning dashed",
+                        "value": "y = 0.33",
+                        "label": "A third of the data is deleted data"
+                    },
+                    {
+                        "display_type": "error solid",
+                        "value": "y = 0.8",
+                        "label": "80 % of the data is droppable"
+                    }
+                ],
+                "title": "Droppable tombstone ratio per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.db.droppable_tombstone_ratio{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "warning dashed",
+                        "value": "y = 0.33",
+                        "label": "A third of the data is deleted data"
+                    },
+                    {
+                        "display_type": "error solid",
+                        "value": "y = 0.8",
+                        "label": "80 % of the data is droppable"
+                    }
+                ],
+                "title": "Droppable tombstone ratio per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.db.droppable_tombstone_ratio{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "warning dashed",
+                        "value": "y = 0.33",
+                        "label": "A third of the data is deleted data"
+                    },
+                    {
+                        "display_type": "error solid",
+                        "value": "y = 0.8",
+                        "label": "80 % of the data is droppable"
+                    }
+                ],
+                "title": "Droppable tombstone ratio per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.max_partition_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.mean_partition_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.max_row_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.mean_row_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Max / Mean partition size per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.max_partition_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.mean_partition_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.max_row_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.mean_row_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Max / Mean partition size per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.max_partition_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.mean_partition_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.max_row_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.mean_row_size{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Max / Mean partition size per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.io.w_s{$environment,$datacenter,$host} by {host,datacenter,device}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Disk write count (io.w/s) per host and device"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.io.wkb_s{$environment,$datacenter,$host} by {host,datacenter,device}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Disk write throughput (io.wkb/s) per host and device"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "top(avg:system.io.w_await{$environment,$datacenter,$host} by {host,datacenter,device}, 10, 'mean', 'desc')",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Disk write latency (w_await) per host and device"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.io.wrqm_s{$environment,$datacenter,$host} by {host,datacenter,device}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Disk write queued (io.wrqm/s) per host and device"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.io.util{$environment,$datacenter,$host} by {host,datacenter,device}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Disk utilization (io.util%) per host and device"
+            }
+        }
+    ]
+}

--- a/cassandra/assets/dashboards/cassandra_write.json
+++ b/cassandra/assets/dashboards/cassandra_write.json
@@ -1,0 +1,934 @@
+{
+    "title": "Cassandra - Write Path",
+    "description": "You can use this dashboard to rapidly troubleshoot any write-related issues that you identified from the [Cassandra overview](https://app.datadoghq.com/dash/integration/23/cassandra---overview) dashboard. Aggregated metric graphs enable you to isolate issues to a particular table, host, or combination thereof. Further reading on Cassandra monitoring:\n\n- [Datadog's blog post describing our suite of Cassandra dashboards](https://www.datadoghq.com/blog/tlp-cassandra-dashboards/)\n\n- [Our guide to key metrics for Cassandra monitoring](https://www.datadoghq.com/blog/how-to-monitor-cassandra-performance-metrics/)\n\n- [How to collect Cassandra metrics using built-in Cassandra and JDK tools](https://www.datadoghq.com/blog/how-to-collect-cassandra-metrics/)\n\n- [How to monitor Cassandra using Datadog](https://www.datadoghq.com/blog/monitoring-cassandra-with-datadog/)\n\n- [Datadog's integration docs for Cassandra](https://docs.datadoghq.com/integrations/cassandra/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
+    "layout_type": "ordered",
+    "template_variables": [
+        {
+            "default": "*",
+            "prefix": "environment",
+            "name": "environment"
+        },
+        {
+            "default": "*",
+            "prefix": "datacenter",
+            "name": "datacenter"
+        },
+        {
+            "default": "*",
+            "prefix": "host",
+            "name": "host"
+        },
+        {
+            "default": "*",
+            "prefix": "keyspace",
+            "name": "keyspace"
+        },
+        {
+            "default": "*",
+            "prefix": "table",
+            "name": "table"
+        },
+        {
+            "default": "*",
+            "prefix": "columnfamily",
+            "name": "columnfamily"
+        }
+    ],
+    "widgets": [
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.pending_tasks{$environment,$datacenter,$host,threadpools:secondaryindexmanagement} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.pending_tasks{$environment,$datacenter,$host,threadpools:countermutationstage} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.pending_tasks{$environment,$datacenter,$host,threadpools:memtableflushwriter} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.pending_tasks{$environment,$datacenter,$host,threadpools:viewmutationstage} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.pending_tasks{$environment,$datacenter,$host,threadpools:memtablepostflush} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.pending_tasks{$environment,$datacenter,$host,threadpools:hintsdispatcher} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.pending_tasks{$environment,$datacenter,$host,threadpools:migrationstage} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.pending_tasks{$environment,$datacenter,$host,threadpools:mutationstage} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.pending_tasks{$environment,$datacenter,$host,threadpools:miscstage} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.pending_tasks{$environment,$datacenter,$host,type:commitlog} by {host,datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Pending threads per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.currently_blocked_tasks.count{$environment,$datacenter,$host,threadpools:secondaryindexmanagement} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.currently_blocked_tasks.count{$environment,$datacenter,$host,threadpools:countermutationstage} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.currently_blocked_tasks.count{$environment,$datacenter,$host,threadpools:memtableflushwriter} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.currently_blocked_tasks.count{$environment,$datacenter,$host,threadpools:viewmutationstage} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.currently_blocked_tasks.count{$environment,$datacenter,$host,threadpools:memtablepostflush} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.currently_blocked_tasks.count{$environment,$datacenter,$host,threadpools:hintsdispatcher} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.currently_blocked_tasks.count{$environment,$datacenter,$host,threadpools:migrationstage} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.currently_blocked_tasks.count{$environment,$datacenter,$host,threadpools:mutationstage} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.currently_blocked_tasks.count{$environment,$datacenter,$host,threadpools:miscstage} by {host,datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Currently blocked threads per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.dropped.one_minute_rate{$environment,$datacenter,$host,droppedmessage:counter_mutation} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.dropped.one_minute_rate{$environment,$datacenter,$host,droppedmessage:batch_remove} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.dropped.one_minute_rate{$environment,$datacenter,$host,droppedmessage:batch_store} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.dropped.one_minute_rate{$environment,$datacenter,$host,droppedmessage:_trace} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.dropped.one_minute_rate{$environment,$datacenter,$host,droppedmessage:mutation} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.dropped.one_minute_rate{$environment,$datacenter,$host,droppedmessage:hint} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Dropped messages per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:jmx.gc.minor_collection_time{$environment,$datacenter,$host} by {host,datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Minor GC time (New Gen) per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:jmx.gc.major_collection_time{$environment,$datacenter,$host} by {host,datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Major GC time (Old Gen) per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:jmx.gc.minor_collection_time{$environment,$datacenter,$host} by {datacenter,host} + avg:jmx.gc.major_collection_count{$environment,$datacenter,$host} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "error dashed",
+                        "value": "y = 150",
+                        "label": "15% of the time spent in Garbage Collection (STW GC)"
+                    }
+                ],
+                "title": "Stop the world GC average per datacenter (Minor + Major GC)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.write_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Write count per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.write_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Write count per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.write_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Write count per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.write_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.write_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Write Latency (p75 & p95) per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.write_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.write_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Write Latency (p75 & p95) per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.write_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.write_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Write Latency (p75 & p95) per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.write_latency.99th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dotted"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.write_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Write Latency (p95 & p99) per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.write_latency.99th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "style": {
+                            "line_type": "dotted"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.write_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Write Latency (p95 & p99) per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.write_latency.99th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "style": {
+                            "line_type": "dotted"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.write_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Write Latency (p95 & p99) per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.cas_commit_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.cas_prepare_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.cas_propose_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "CAS operations counts per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.cas_commit_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.cas_prepare_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.cas_propose_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "CAS operations counts per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.cas_commit_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.cas_prepare_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.cas_propose_latency.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "CAS operations counts per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.cas_commit_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {table,columnfamily,datacenter,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_prepare_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {table,columnfamily,datacenter,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_propose_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {table,columnfamily,datacenter,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_commit_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {table,columnfamily,datacenter,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_prepare_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {table,columnfamily,datacenter,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_propose_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {table,columnfamily,datacenter,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "CAS operations latencies (p75 & p95) per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.cas_commit_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_prepare_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_propose_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_commit_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_prepare_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_propose_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "CAS operations latencies (p75 & p95) per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.cas_commit_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_prepare_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_propose_latency.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_commit_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_prepare_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.cas_propose_latency.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,table,columnfamily,datacenter,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "CAS operations latencies (p75 & p95) per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.view_lock_acquire_time.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.view_read_time.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Materialized view count per table and DC (C*3+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.view_lock_acquire_time.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.view_read_time.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Materialized view count per host (C*3+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.view_lock_acquire_time.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:cassandra.view_read_time.one_minute_rate{$environment,$datacenter,$host,$keyspace,$table} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Materialized view count per host and table (C*3+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.view_lock_acquire_time.75th_percentile{$environment,$datacenter,$host,$keyspace,$table} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.view_read_time.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.view_lock_acquire_time.95th_percentile{$environment,$datacenter,$host,$keyspace,$table} by {datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.view_read_time.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Materialized view latencies (p75 & p95) per table and DC (C*3+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.view_lock_acquire_time.75th_percentile{$environment,$datacenter,$host,$keyspace,$table} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.view_read_time.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.view_lock_acquire_time.95th_percentile{$environment,$datacenter,$host,$keyspace,$table} by {datacenter,host}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.view_read_time.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Materialized view latencies (p75 & p95) per host (C*3+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.view_lock_acquire_time.75th_percentile{$environment,$datacenter,$host,$keyspace,$table} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.view_read_time.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.view_lock_acquire_time.95th_percentile{$environment,$datacenter,$host,$keyspace,$table} by {host,datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.view_read_time.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Materialized view latencies (p75 & p95) per host and table (C*3+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.pending_flushes.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Pending flushes per table and DC (C*2.1+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.pending_flushes.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Pending flushes per host (C*2.1+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "sum:cassandra.pending_flushes.count{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Pending flushes per host and table (C*2.1+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.waiting_on_free_memtable_space.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.waiting_on_free_memtable_space.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Waiting to free memtable space (p75 & p95) per table and DC (C*2.1+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.waiting_on_free_memtable_space.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.waiting_on_free_memtable_space.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Waiting to free memtable space (p75 & p95) per host (C*2.1+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.waiting_on_free_memtable_space.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.waiting_on_free_memtable_space.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Waiting to free memtable space (p75 & p95) per host and table (C*2.1+)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.col_update_time_delta_histogram.min{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.col_update_time_delta_histogram.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.col_update_time_delta_histogram.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Min delta on column update per table and DC"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.col_update_time_delta_histogram.min{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.col_update_time_delta_histogram.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.col_update_time_delta_histogram.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {datacenter,host}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Min delta on column update per host"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:cassandra.col_update_time_delta_histogram.min{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.col_update_time_delta_histogram.75th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:cassandra.col_update_time_delta_histogram.95th_percentile{$environment,$datacenter,$host,$keyspace,$table,$columnfamily} by {host,datacenter,table,columnfamily,keyspace}",
+                        "style": {
+                            "line_type": "dashed"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Min delta on column update per host and table"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:ntp.offset{$environment,$datacenter,$host} by {host,datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "error dashed",
+                        "value": "y = 0.01",
+                        "label": "y = 0.01"
+                    },
+                    {
+                        "display_type": "error dashed",
+                        "value": "y = -0.01",
+                        "label": "y = -0.01"
+                    }
+                ],
+                "title": "Clock drift"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.cpu.idle{$environment,$datacenter,$host}, avg:system.cpu.user{$environment,$datacenter,$host}, avg:system.cpu.guest{$environment,$datacenter,$host}, avg:system.cpu.iowait{$environment,$datacenter,$host}, avg:system.cpu.stolen{$environment,$datacenter,$host}, avg:system.cpu.system{$environment,$datacenter,$host}"
+                    }
+                ],
+                "type": "timeseries",
+                "markers": [
+                    {
+                        "display_type": "error dashed",
+                        "value": "y = 75",
+                        "label": "75 %"
+                    }
+                ],
+                "title": "CPU usage"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.load.1{$environment,$datacenter,$host} by {datacenter,host}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Unix CPU load per node (1 minute)"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.mem.total{$environment,$datacenter,$host}",
+                        "display_type": "area"
+                    },
+                    {
+                        "q": "avg:system.mem.total{$environment,$datacenter,$host} - avg:system.mem.usable{$environment,$datacenter,$host}",
+                        "display_type": "area"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "System memory"
+            }
+        },
+        {
+            "definition": {
+                "requests": [
+                    {
+                        "q": "avg:system.net.bytes_rcvd{$environment,$datacenter,$host} by {datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "avg:system.net.bytes_sent{$environment,$datacenter,$host} by {datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "type": "timeseries",
+                "title": "Network"
+            }
+        }
+    ]
+}

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -31,7 +31,12 @@
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {},
-    "dashboards": {},
+    "dashboards": {
+      "cassandra-overview": "assets/dashboards/cassandra_overview.json",
+      "cassandra-read": "assets/dashboards/cassandra_read.json",
+      "cassandra-sstables": "assets/dashboards/cassandra_sstable.json",
+      "cassandra-write": "assets/dashboards/cassandra_write.json"
+    },
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "cassandra"


### PR DESCRIPTION
### What does this PR do?
Moves preset dashboard payloads into integrations-core
### Motivation
Easier for future updates

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
