### PR TITLE
Bump base check package

### DIFF
--- a/zk/setup.py
+++ b/zk/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.2.0'
 
 setup(
     name='datadog-zk',


### PR DESCRIPTION
Zookeeper makes use of get_tls_context that was introduced in 15.2.0