### PR TITLE
Update deprecation notice

### DIFF
--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -86,8 +86,7 @@ files:
           of consumer groups to topics. For details, see KIP-88. For older Kafka brokers, the consumer groups
           must be specified. This requirement only applies to the brokers, not the consumers--they can be any version.
 
-          Deprecation notice: This feature works for Zookeeper-based consumers. However, all
-          functionality related to fetching offsets from Zookeeper is deprecated.
+          Deprecation notice: Functionality related to consumers fetching offsets from Zookeeper is deprecated.
         value:
           type: boolean
           example: false

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -76,8 +76,7 @@ instances:
     ## of consumer groups to topics. For details, see KIP-88. For older Kafka brokers, the consumer groups
     ## must be specified. This requirement only applies to the brokers, not the consumers--they can be any version.
     ##
-    ## Deprecation notice: This feature works for Zookeeper-based consumers. However, all
-    ## functionality related to fetching offsets from Zookeeper is deprecated.
+    ## Deprecation notice: Functionality related to consumers fetching offsets from Zookeeper is deprecated.
     #
     # monitor_unlisted_consumer_groups: false
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -335,7 +335,7 @@ class KafkaCheck(AgentCheck):
                 1. Issue a ListGroupsRequest to every broker
                 2. Attach a callback to each ListGroupsRequest that issues OffsetFetchRequests for every group.
                    Note: Because a broker only returns groups for which it is the coordinator, as an optimization we
-                  skip the FindCoordinatorRequest
+                   skip the FindCoordinatorRequest
             B: When fetching only listed groups:
                 1. Issue a FindCoordintorRequest for each group
                 2. Attach a callback to each FindCoordinatorResponse that issues OffsetFetchRequests for that group


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Some consumers (like `HighLevelConsumer`) used to store and fetch offset from Zookeeper. This is deprecated and the supported way is to fetch offset from kafka brokers.

https://www.confluent.io/blog/tutorial-getting-started-with-the-new-apache-kafka-0-9-consumer-client/
A customer asked for clarification about this deprecation note.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Config specs added https://github.com/DataDog/integrations-core/pull/8108, let's be careful not to override the note update

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
