### PR TITLE
Upgrade mkdocs-click dep to 0.2.*

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     -e./datadog_checks_base[deps,http]
     -e./datadog_checks_dev[cli]
     ; for CLI auto-documentation of ddev
-    mkdocs-click==0.1.*
+    mkdocs-click==0.2.*
 setenv =
     ; Use a set timestamp for reproducible builds.
     ; See https://reproducible-builds.org/specs/source-date-epoch/


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Upgrade `mkdocs-click` dependency to `0.2.*` for building the docs site.

### Motivation
<!-- What inspired you to submit this pull request? -->
Released 0.2.0: https://pypi.org/project/mkdocs-click/0.2.0
See: https://github.com/DataDog/mkdocs-click/pull/23

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Ran the docs site locally using `ddev docs serve`, all look good. (Which is expected: version 0.2.0 doesn't contain breaking changes.)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
