### PR TITLE
Drop --use-feature=2020-resolver

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ skip_install = true
 ; for CLI & API auto-documentation of ddev
 sitepackages = true
 deps =
-    --use-feature=2020-resolver
     mkdocs>=1.1.1
     ; theme
     mkdocs-material>=5.2.1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Drop `--use-feature=2020-resolver` in our `tox.ini` configuration.

### Motivation
<!-- What inspired you to submit this pull request? -->
As noted by @mgarabed, pip 20.3 is out, which enables the resolver automatically. We are effectively already using it in CI.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Locally I had set `--use-feature=2020-resolver` in my `.zshrc`, so `pip` started warning about it:

```
WARNING: --use-feature=2020-resolver no longer has any effect, since it is now the default dependency resolver in pip. This will become an error in pip 21.0.
```

For some reason, we don't see these warnings in CI. My best bet is that they may be swallowed by tox, somehow, since we _are_ using pip 20.3.* in CI already: https://github.com/DataDog/integrations-core/runs/1524211865?check_suite_focus=true#step:4:31

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
