### PR TITLE
openmetrics: fix error in label_joins when metrics in label_mapping are not present anymore in active_label_mapping

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -497,7 +497,10 @@ class OpenMetricsScraperMixin(object):
             # Garbage collect unused mapping and reset active labels
             for metric, mapping in list(iteritems(scraper_config['_label_mapping'])):
                 for key in list(mapping):
-                    if key not in scraper_config['_active_label_mapping'][metric]:
+                    if (
+                        metric in scraper_config['_active_label_mapping']
+                        and key not in scraper_config['_active_label_mapping'][metric]
+                    ):
                         del scraper_config['_label_mapping'][metric][key]
             scraper_config['_active_label_mapping'] = {}
         finally:

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -8,6 +8,7 @@ import io
 import logging
 import math
 import os
+import re
 
 import mock
 import pytest
@@ -2251,7 +2252,11 @@ def test_label_joins_gc(aggregator, mocked_prometheus_check, mocked_prometheus_s
     check = mocked_prometheus_check
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
     mocked_prometheus_scraper_config['label_joins'] = {
-        'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node', 'pod_ip']}
+        'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node', 'pod_ip']},
+        'kube_persistentvolumeclaim_info': {
+            'labels_to_match': ['persistentvolumeclaim', 'namespace'],
+            'labels_to_get': ['storageclass'],
+        },
     }
     mocked_prometheus_scraper_config['metrics_mapper'] = {'kube_pod_status_ready': 'pod.ready'}
     # dry run to build mapping
@@ -2287,6 +2292,9 @@ def test_label_joins_gc(aggregator, mocked_prometheus_check, mocked_prometheus_s
 
     assert 15 == len(mocked_prometheus_scraper_config['_label_mapping']['pod'])
     text_data = mock_get.replace('dd-agent-62bgh', 'dd-agent-1337')
+    pvc_replace = re.compile(r'^kube_persistentvolumeclaim_.*\n', re.MULTILINE)
+    text_data = pvc_replace.sub('', text_data)
+
     mock_response = mock.MagicMock(
         status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': text_content_type}
     )


### PR DESCRIPTION
### What does this PR do?
Avoid KeyError reported by customer when metrics disappear from KSM output.

### Motivation
Customer report

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
