### PR TITLE
Report UNKNOWN instead of CRITICAL if no Windows service matches the …

### DIFF
--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -82,7 +82,8 @@ class WindowsService(AgentCheck):
 
         if 'ALL' not in services:
             for service in services_unseen:
-                status = self.CRITICAL
+                # if a name doesn't match anything (wrong name or no permission to access the service), report UNKNOWN
+                status = self.UNKNOWN
 
                 tags = ['windows_service:{}'.format(service)]
                 tags.extend(custom_tags)

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -29,7 +29,7 @@ def test_basic(aggregator, check, instance_basic):
     )
     aggregator.assert_service_check(
         c.SERVICE_CHECK_NAME,
-        status=c.CRITICAL,
+        status=c.UNKNOWN,
         tags=['service:NonExistentService', 'windows_service:NonExistentService', 'optional:tag1'],
         count=1,
     )
@@ -75,7 +75,7 @@ def test_basic_disable_service_tag(aggregator, check, instance_basic_disable_ser
         c.SERVICE_CHECK_NAME, status=c.OK, tags=['windows_service:Dnscache', 'optional:tag1'], count=1
     )
     aggregator.assert_service_check(
-        c.SERVICE_CHECK_NAME, status=c.CRITICAL, tags=['windows_service:NonExistentService', 'optional:tag1'], count=1
+        c.SERVICE_CHECK_NAME, status=c.UNKNOWN, tags=['windows_service:NonExistentService', 'optional:tag1'], count=1
     )
 
 
@@ -91,7 +91,7 @@ def test_basic_e2e(dd_agent_check, check, instance_basic):
     )
     aggregator.assert_service_check(
         WindowsService.SERVICE_CHECK_NAME,
-        status=WindowsService.CRITICAL,
+        status=WindowsService.UNKNOWN,
         tags=['service:NonExistentService', 'windows_service:NonExistentService', 'optional:tag1'],
         count=1,
     )


### PR DESCRIPTION
…query

### What does this PR do?
Report UNKNOWN instead of CRITICAL if no Windows service matches the query.

### Motivation
The agent cannot access the service either due to permission restriction or the service doesn't exist, or the query string is incorrect. In those cases, reporting UNKNOWN would be better represent the fact that no data is collected.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
