### PR TITLE
Remove check_metric_type option

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -330,15 +330,14 @@ class AggregatorStub(object):
         assert condition, msg
 
     def assert_metrics_using_metadata(
-        self, metadata_metrics, check_metric_type=True, check_submission_type=False, exclude=None
+        self, metadata_metrics, check_submission_type=False, exclude=None
     ):
         """
         Assert metrics using metadata.csv
 
         Checking type: By default we are asserting the in-app metric type (`check_submission_type=False`),
         asserting this type make sense for e2e (metrics collected from agent).
-        For integrations tests, we can check the submission type with `check_submission_type=True`, or
-        use `check_metric_type=False` not to check types.
+        For integrations tests, we can check the submission type with `check_submission_type=True`.
 
         Usage:
 
@@ -375,13 +374,12 @@ class AggregatorStub(object):
                     if actual_metric_type == 'monotonic_count' and expected_metric_type == 'count':
                         actual_metric_type = 'count'
 
-                if check_metric_type:
-                    if expected_metric_type != actual_metric_type:
-                        errors.add(
-                            "Expect `{}` to have type `{}` but got `{}`.".format(
-                                metric_stub_name, expected_metric_type, actual_metric_type
-                            )
+                if expected_metric_type != actual_metric_type:
+                    errors.add(
+                        "Expect `{}` to have type `{}` but got `{}`.".format(
+                            metric_stub_name, expected_metric_type, actual_metric_type
                         )
+                    )
 
         assert not errors, "Metadata assertion errors using metadata.csv:" + "\n\t- ".join([''] + sorted(errors))
 

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -329,9 +329,7 @@ class AggregatorStub(object):
             msg += '\nMissing Metrics:{}{}'.format(prefix, prefix.join(sorted(self.not_asserted())))
         assert condition, msg
 
-    def assert_metrics_using_metadata(
-        self, metadata_metrics, check_submission_type=False, exclude=None
-    ):
+    def assert_metrics_using_metadata(self, metadata_metrics, check_submission_type=False, exclude=None):
         """
         Assert metrics using metadata.csv
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove `check_metric_type` from `assert_metrics_with_metadata`. 
The recommended way is to use `check_submission_type=True` for integration testing.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
