### PR TITLE
Improve arbiter support

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -65,7 +65,7 @@ files:
     - name: is_arbiter
       description: |
         Whether or not the current node is an arbiter. When enabled the check:
-          - skips authentication
+          - Skips authentication
           - only runs the allowed commands
           - creates an extra connection to the primary (using the provided username/password) to run additional
             monitoring commands.

--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -62,16 +62,6 @@ files:
       value:
         example: mongodb
         type: string
-    - name: is_arbiter
-      description: |
-        Whether or not the current node is an arbiter. When enabled the check:
-          - Skips authentication
-          - Only runs the allowed commands
-          - Creates an extra connection to the primary (using the provided username/password) to run additional
-            monitoring commands.
-      value:
-        example: false
-        type: boolean
     - name: replica_check
       description: |
         Whether or not to read from available replicas.

--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -66,7 +66,7 @@ files:
       description: |
         Whether or not the current node is an arbiter. When enabled the check:
           - Skips authentication
-          - only runs the allowed commands
+          - Only runs the allowed commands
           - Creates an extra connection to the primary (using the provided username/password) to run additional
             monitoring commands.
       value:

--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -67,7 +67,7 @@ files:
         Whether or not the current node is an arbiter. When enabled the check:
           - Skips authentication
           - only runs the allowed commands
-          - creates an extra connection to the primary (using the provided username/password) to run additional
+          - Creates an extra connection to the primary (using the provided username/password) to run additional
             monitoring commands.
       value:
         example: false

--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -62,6 +62,16 @@ files:
       value:
         example: mongodb
         type: string
+    - name: is_arbiter
+      description: |
+        Whether or not the current node is an arbiter. When enabled the check:
+          - skips authentication
+          - only runs the allowed commands
+          - creates an extra connection to the primary (using the provided username/password) to run additional
+            monitoring commands.
+      value:
+        example: false
+        type: boolean
     - name: replica_check
       description: |
         Whether or not to read from available replicas.

--- a/mongo/datadog_checks/mongo/collectors/base.py
+++ b/mongo/datadog_checks/mongo/collectors/base.py
@@ -30,6 +30,10 @@ class MongoCollector(object):
         Performs the actual collection and submission of the metrics."""
         raise NotImplementedError()
 
+    def compatible_with(self, deployment):
+        """Whether or not this specific collector is compatible with this specific deployment type."""
+        raise NotImplementedError()
+
     def _normalize(self, metric_name, submit_method, prefix=None):
         """Replace case-sensitive metric name characters, normalize the metric name,
         prefix and suffix according to its type.

--- a/mongo/datadog_checks/mongo/collectors/coll_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/coll_stats.py
@@ -18,6 +18,10 @@ class CollStatsCollector(MongoCollector):
         self.coll_names = coll_names
         self.db_name = db_name
 
+    def compatible_with(self, deployment):
+        # Can only be run once per cluster.
+        return deployment.is_principal()
+
     def collect(self, client):
         # Ensure that you're on the right db
         db = client[self.db_name]

--- a/mongo/datadog_checks/mongo/collectors/conn_pool_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/conn_pool_stats.py
@@ -1,4 +1,5 @@
 from datadog_checks.mongo.collectors.base import MongoCollector
+from datadog_checks.mongo.common import ReplicaSetDeployment
 
 
 class ConnPoolStatsCollector(MongoCollector):
@@ -8,6 +9,14 @@ class ConnPoolStatsCollector(MongoCollector):
     The output of connPoolStats varies depending on the deployment and the member against
     which you run connPoolStats among other factors.
     """
+
+    def compatible_with(self, deployment):
+        # Can only be run on:
+        #  - a mongod node in a sharded cluster, as long as it's not an arbiter
+        #  - a mongos
+        if isinstance(deployment, ReplicaSetDeployment) and deployment.is_arbiter:
+            return False
+        return deployment.use_shards
 
     def collect(self, client):
         db = client["admin"]

--- a/mongo/datadog_checks/mongo/collectors/custom_queries.py
+++ b/mongo/datadog_checks/mongo/collectors/custom_queries.py
@@ -3,7 +3,11 @@ from copy import deepcopy
 import pymongo
 
 from datadog_checks.mongo.collectors.base import MongoCollector
-from datadog_checks.mongo.common import ALLOWED_CUSTOM_METRICS_TYPES, ALLOWED_CUSTOM_QUERIES_COMMANDS
+from datadog_checks.mongo.common import (
+    ALLOWED_CUSTOM_METRICS_TYPES,
+    ALLOWED_CUSTOM_QUERIES_COMMANDS,
+    ReplicaSetDeployment,
+)
 
 
 class CustomQueriesCollector(MongoCollector):
@@ -13,6 +17,13 @@ class CustomQueriesCollector(MongoCollector):
         super(CustomQueriesCollector, self).__init__(check, tags)
         self.custom_queries = custom_queries
         self.db_name = db_name
+
+    def compatible_with(self, deployment):
+        # Can theoretically be run on any node as long as it contains data.
+        # i.e Arbiters are ruled out
+        if isinstance(deployment, ReplicaSetDeployment) and deployment.is_arbiter:
+            return False
+        return True
 
     @staticmethod
     def _extract_command_from_mongo_query(mongo_query):

--- a/mongo/datadog_checks/mongo/collectors/fsynclock.py
+++ b/mongo/datadog_checks/mongo/collectors/fsynclock.py
@@ -1,4 +1,5 @@
 from datadog_checks.mongo.collectors.base import MongoCollector
+from datadog_checks.mongo.common import MongosDeployment, ReplicaSetDeployment
 
 
 class FsyncLockCollector(MongoCollector):
@@ -8,6 +9,14 @@ class FsyncLockCollector(MongoCollector):
     def __init__(self, check, db_name, tags):
         super(FsyncLockCollector, self).__init__(check, tags)
         self.db_name = db_name
+
+    def compatible_with(self, deployment):
+        # Can be run on any mongod instance excepts arbiters.
+        if isinstance(deployment, ReplicaSetDeployment) and deployment.is_arbiter:
+            return False
+        if isinstance(deployment, MongosDeployment):
+            return False
+        return True
 
     def collect(self, client):
         db = client[self.db_name]

--- a/mongo/datadog_checks/mongo/collectors/index_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/index_stats.py
@@ -9,6 +9,10 @@ class IndexStatsCollector(MongoCollector):
         self.coll_names = coll_names
         self.db_name = db_name
 
+    def compatible_with(self, deployment):
+        # Can only be run once per cluster.
+        return deployment.is_principal()
+
     def collect(self, client):
         db = client[self.db_name]
         for coll_name in self.coll_names:

--- a/mongo/datadog_checks/mongo/collectors/jumbo_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/jumbo_stats.py
@@ -1,5 +1,6 @@
 from datadog_checks.base import AgentCheck
 from datadog_checks.mongo.collectors import MongoCollector
+from datadog_checks.mongo.common import MongosDeployment
 
 
 class JumboStatsCollector(MongoCollector):
@@ -7,6 +8,10 @@ class JumboStatsCollector(MongoCollector):
     MongoDB automatically splits chunks based on the shard key when they exceed the maximum size
     or number of documents.
     Sometimes, chunks grow beyond their maximum size but cannot be split they are considered 'jumbo'."""
+
+    def compatible_with(self, deployment):
+        # Can only be run on mongos nodes.
+        return isinstance(deployment, MongosDeployment)
 
     def collect(self, client):
         chunks = client['config']['chunks']

--- a/mongo/datadog_checks/mongo/collectors/replica.py
+++ b/mongo/datadog_checks/mongo/collectors/replica.py
@@ -100,9 +100,7 @@ class ReplicaCollector(MongoCollector):
 
         if self.check.deployment.is_arbiter:
             try:
-                # Authenticates if the config specifies a username;
-                do_auth = self.check.username is not None
-                cli_primary = self.check.setup_connection(do_auth, replicaset=self.check.deployment.replset_name)
+                cli_primary = self.check.setup_connection(replicaset=self.check.deployment.replset_name)
             except Exception:
                 self.log.warning(
                     "Current node is an arbiter, the extra connection to the primary was unsuccessful."

--- a/mongo/datadog_checks/mongo/collectors/replication_info.py
+++ b/mongo/datadog_checks/mongo/collectors/replication_info.py
@@ -2,11 +2,16 @@ import pymongo
 
 from datadog_checks.base.utils.common import round_value
 from datadog_checks.mongo.collectors.base import MongoCollector
+from datadog_checks.mongo.common import ReplicaSetDeployment
 
 
 class ReplicationOpLogCollector(MongoCollector):
     """Additional replication metrics regarding the operation log. Useful to check how backed up is a secondary
     compared to the primary."""
+
+    def compatible_with(self, deployment):
+        # Can only be run on mongod that are part of a replica set.
+        return isinstance(deployment, ReplicaSetDeployment)
 
     def collect(self, client):
         # Fetch information analogous to Mongo's db.getReplicationInfo()

--- a/mongo/datadog_checks/mongo/collectors/server_status.py
+++ b/mongo/datadog_checks/mongo/collectors/server_status.py
@@ -9,6 +9,10 @@ class ServerStatusCollector(MongoCollector):
         self.collect_tcmalloc_metrics = tcmalloc
         self.db_name = db_name
 
+    def compatible_with(self, deployment):
+        # Can be run on any node.
+        return True
+
     def collect(self, client):
         db = client[self.db_name]
         # No need to check for `result['ok']`, already handled by pymongo

--- a/mongo/datadog_checks/mongo/collectors/session_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/session_stats.py
@@ -1,10 +1,15 @@
 from datadog_checks.base import AgentCheck
 from datadog_checks.mongo.collectors.base import MongoCollector
+from datadog_checks.mongo.common import MongosDeployment
 
 
 class SessionStatsCollector(MongoCollector):
     """Gets the count of current sessions stored in the system.sessions config database.
     The system.sessions collection is sharded so it's only collected from mongos."""
+
+    def compatible_with(self, deployment):
+        # Can only be run on mongos nodes.
+        return isinstance(deployment, MongosDeployment)
 
     def collect(self, client):
         config_db = client["config"]

--- a/mongo/datadog_checks/mongo/collectors/top.py
+++ b/mongo/datadog_checks/mongo/collectors/top.py
@@ -1,6 +1,7 @@
 from six import iteritems
 
 from datadog_checks.mongo.collectors.base import MongoCollector
+from datadog_checks.mongo.common import MongosDeployment, ReplicaSetDeployment
 from datadog_checks.mongo.metrics import TOP_METRICS
 
 
@@ -8,6 +9,14 @@ class TopCollector(MongoCollector):
     """Additional metrics coming from the 'top' command. Needs to be explicitly defined in the 'additional_metrics'
     section of the configuration.
     Can only be fetched from a mongod service."""
+
+    def compatible_with(self, deployment):
+        # Can only be run on mongod nodes, and not on arbiters.
+        if isinstance(deployment, MongosDeployment):
+            return False
+        if isinstance(deployment, ReplicaSetDeployment) and deployment.is_arbiter:
+            return False
+        return True
 
     def collect(self, client):
         dbtop = client["admin"].command('top')

--- a/mongo/datadog_checks/mongo/common.py
+++ b/mongo/datadog_checks/mongo/common.py
@@ -80,6 +80,7 @@ class ReplicaSetDeployment(Deployment):
         self.cluster_role = cluster_role
         self.is_primary = replset_state == 1
         self.is_secondary = replset_state == 2
+        self.is_arbiter = replset_state == 7
 
     def is_principal(self):
         # There is only ever one primary node in a replica set.

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -62,6 +62,15 @@ instances:
     #
     # connection_scheme: mongodb
 
+    ## @param is_arbiter - boolean - optional - default: false
+    ## Whether or not the current node is an arbiter. When enabled the check:
+    ##   - skips authentication
+    ##   - only runs the allowed commands
+    ##   - creates an extra connection to the primary (using the provided username/password) to run additional
+    ##     monitoring commands.
+    #
+    # is_arbiter: false
+
     ## @param replica_check - boolean - optional - default: true
     ## Whether or not to read from available replicas.
     ## Disable this if any replicas are inaccessible to the Agent. This option is not supported for sharded clusters.

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -62,15 +62,6 @@ instances:
     #
     # connection_scheme: mongodb
 
-    ## @param is_arbiter - boolean - optional - default: false
-    ## Whether or not the current node is an arbiter. When enabled the check:
-    ##   - skips authentication
-    ##   - only runs the allowed commands
-    ##   - creates an extra connection to the primary (using the provided username/password) to run additional
-    ##     monitoring commands.
-    #
-    # is_arbiter: false
-
     ## @param replica_check - boolean - optional - default: true
     ## Whether or not to read from available replicas.
     ## Disable this if any replicas are inaccessible to the Agent. This option is not supported for sharded clusters.

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -283,7 +283,8 @@ class MongoDb(AgentCheck):
 
         return authenticated
 
-    def get_deployment(self, admindb):
+    @staticmethod
+    def get_deployment(admindb):
         # getCmdLineOpts is the runtime configuration of the mongo instance. Helpful to know whether the node is
         # a mongos or mongod, if the mongod is in a shard, if it's in a replica set, etc.
         options = admindb.command("getCmdLineOpts")['parsed']

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -318,7 +318,7 @@ class MongoDb(AgentCheck):
                 "Unable to determine arbiter status using the localhost exception. If the current "
                 "node '%s' is an arbiter, it won't be monitored. For monitoring it you need to configure an agent"
                 "on the same node as your arbiter.",
-                server
+                server,
             )
             return False
 

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -10,12 +10,23 @@ import mock
 import pymongo
 import pytest
 from mock import MagicMock
+
+from datadog_test_libs.utils.mock_dns import mock_local
 from tests.mocked_api import MockedPyMongoClient
 
 from datadog_checks.dev import LazyFunction, WaitFor, docker_run, run_command
 from datadog_checks.mongo import MongoDb
 
 from . import common
+
+
+HOSTNAME_TO_PORT_MAPPING = {
+    "mongo-mongodb-sharded-shard0-arbiter-0.mongo-mongodb-sharded-headless.default.svc.cluster.local": (
+    '127.0.0.1', 27017),
+    "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local": ('127.0.0.1', 27018),
+    "mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local": ('127.0.0.1', 27019),
+    "mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local": ('127.0.0.1', 27020),
+}
 
 
 @pytest.fixture(scope='session')
@@ -106,6 +117,11 @@ def instance_integration(instance_custom_queries):
     instance["collections_indexes_stats"] = True
     return instance
 
+
+@pytest.fixture(scope='session', autouse=True)
+def mock_local_tls_dns():
+    with mock_local(HOSTNAME_TO_PORT_MAPPING):
+        yield
 
 @contextmanager
 def mock_pymongo(deployment):

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -9,9 +9,8 @@ from contextlib import contextmanager
 import mock
 import pymongo
 import pytest
-from mock import MagicMock
-
 from datadog_test_libs.utils.mock_dns import mock_local
+from mock import MagicMock
 from tests.mocked_api import MockedPyMongoClient
 
 from datadog_checks.dev import LazyFunction, WaitFor, docker_run, run_command
@@ -19,13 +18,23 @@ from datadog_checks.mongo import MongoDb
 
 from . import common
 
-
 HOSTNAME_TO_PORT_MAPPING = {
     "mongo-mongodb-sharded-shard0-arbiter-0.mongo-mongodb-sharded-headless.default.svc.cluster.local": (
-    '127.0.0.1', 27017),
-    "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local": ('127.0.0.1', 27018),
-    "mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local": ('127.0.0.1', 27019),
-    "mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local": ('127.0.0.1', 27020),
+        '127.0.0.1',
+        27017,
+    ),
+    "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local": (
+        '127.0.0.1',
+        27018,
+    ),
+    "mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local": (
+        '127.0.0.1',
+        27019,
+    ),
+    "mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local": (
+        '127.0.0.1',
+        27020,
+    ),
 }
 
 
@@ -122,6 +131,7 @@ def instance_integration(instance_custom_queries):
 def mock_local_tls_dns():
     with mock_local(HOSTNAME_TO_PORT_MAPPING):
         yield
+
 
 @contextmanager
 def mock_pymongo(deployment):

--- a/mongo/tests/fixtures/getCmdLineOpts-replica-arbiter
+++ b/mongo/tests/fixtures/getCmdLineOpts-replica-arbiter
@@ -1,0 +1,49 @@
+{
+    "argv": [
+        "/opt/bitnami/mongodb/bin/mongod",
+        "--config=/opt/bitnami/mongodb/conf/mongodb.conf"
+    ],
+    "parsed": {
+        "config": "/opt/bitnami/mongodb/conf/mongodb.conf",
+        "net": {
+            "bindIp": "*",
+            "ipv6": false,
+            "port": 27017,
+            "unixDomainSocket": {
+                "enabled": true,
+                "pathPrefix": "/opt/bitnami/mongodb/tmp"
+            }
+        },
+        "processManagement": {
+            "fork": false,
+            "pidFilePath": "/opt/bitnami/mongodb/tmp/mongodb.pid"
+        },
+        "replication": {
+            "enableMajorityReadConcern": true,
+            "replSetName": "replset"
+        },
+        "security": {
+            "authorization": "disabled",
+            "keyFile": "/opt/bitnami/mongodb/conf/keyfile"
+        },
+        "setParameter": {
+            "enableLocalhostAuthBypass": "true"
+        },
+        "storage": {
+            "dbPath": "/bitnami/mongodb/data/db",
+            "directoryPerDB": false,
+            "journal": {
+                "enabled": true
+            }
+        },
+        "systemLog": {
+            "destination": "file",
+            "logAppend": true,
+            "logRotate": "reopen",
+            "path": "/opt/bitnami/mongodb/logs/mongodb.log",
+            "quiet": false,
+            "verbosity": 0
+        }
+    },
+    "ok": 1.0
+}

--- a/mongo/tests/fixtures/getCmdLineOpts-replica-arbiter-in-shard
+++ b/mongo/tests/fixtures/getCmdLineOpts-replica-arbiter-in-shard
@@ -1,0 +1,52 @@
+{
+    "argv": [
+        "/opt/bitnami/mongodb/bin/mongod",
+        "--config=/opt/bitnami/mongodb/conf/mongodb.conf"
+    ],
+    "parsed": {
+        "config": "/opt/bitnami/mongodb/conf/mongodb.conf",
+        "net": {
+            "bindIp": "*",
+            "ipv6": false,
+            "port": 27017,
+            "unixDomainSocket": {
+                "enabled": true,
+                "pathPrefix": "/opt/bitnami/mongodb/tmp"
+            }
+        },
+        "processManagement": {
+            "fork": false,
+            "pidFilePath": "/opt/bitnami/mongodb/tmp/mongodb.pid"
+        },
+        "replication": {
+            "enableMajorityReadConcern": true,
+            "replSetName": "mongo-mongodb-sharded-shard-0"
+        },
+        "security": {
+            "authorization": "disabled",
+            "keyFile": "/opt/bitnami/mongodb/conf/keyfile"
+        },
+        "setParameter": {
+            "enableLocalhostAuthBypass": "true"
+        },
+        "sharding": {
+            "clusterRole": "shardsvr"
+        },
+        "storage": {
+            "dbPath": "/bitnami/mongodb/data/db",
+            "directoryPerDB": false,
+            "journal": {
+                "enabled": true
+            }
+        },
+        "systemLog": {
+            "destination": "file",
+            "logAppend": true,
+            "logRotate": "reopen",
+            "path": "/opt/bitnami/mongodb/logs/mongodb.log",
+            "quiet": false,
+            "verbosity": 0
+        }
+    },
+    "ok": 1.0
+}

--- a/mongo/tests/fixtures/replSetGetStatus-replica-arbiter
+++ b/mongo/tests/fixtures/replSetGetStatus-replica-arbiter
@@ -1,0 +1,311 @@
+{
+    "set": "replset",
+    "date": {
+        "$date": 1601626042162
+    },
+    "myState": 7,
+    "term": 24,
+    "syncingTo": "",
+    "syncSourceHost": "",
+    "syncSourceId": -1,
+    "heartbeatIntervalMillis": 2000,
+    "majorityVoteCount": 3,
+    "writeMajorityCount": 3,
+    "optimes": {
+        "lastCommittedOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1601384207,
+                    "i": 1
+                }
+            },
+            "t": 24
+        },
+        "lastCommittedWallTime": {
+            "$date": 1601384207410
+        },
+        "readConcernMajorityOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1601384207,
+                    "i": 1
+                }
+            },
+            "t": 24
+        },
+        "readConcernMajorityWallTime": {
+            "$date": 1601384207410
+        },
+        "appliedOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1601384207,
+                    "i": 1
+                }
+            },
+            "t": 24
+        },
+        "durableOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1601384207,
+                    "i": 1
+                }
+            },
+            "t": 24
+        },
+        "lastAppliedWallTime": {
+            "$date": 1601384207410
+        },
+        "lastDurableWallTime": {
+            "$date": 1601384207410
+        }
+    },
+    "lastStableRecoveryTimestamp": {
+        "$timestamp": {
+            "t": 1601384207,
+            "i": 1
+        }
+    },
+    "lastStableCheckpointTimestamp": {
+        "$timestamp": {
+            "t": 1601384207,
+            "i": 1
+        }
+    },
+    "electionCandidateMetrics": {
+        "lastElectionReason": "priorityTakeover",
+        "lastElectionDate": {
+            "$date": 1596803917118
+        },
+        "electionTerm": 24,
+        "lastCommittedOpTimeAtElection": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1596803912,
+                    "i": 1
+                }
+            },
+            "t": 23
+        },
+        "lastSeenOpTimeAtElection": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1596803912,
+                    "i": 1
+                }
+            },
+            "t": 23
+        },
+        "numVotesNeeded": 3,
+        "priorityAtElection": 5.0,
+        "electionTimeoutMillis": 10000,
+        "priorPrimaryMemberId": 2,
+        "numCatchUpOps": 0,
+        "newTermStartDate": {
+            "$date": 1596803917125
+        },
+        "wMajorityWriteAvailabilityDate": {
+            "$date": 1596803919128
+        }
+    },
+    "members": [
+        {
+            "_id": 0,
+            "name": "replset-data-0.mongo.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 1,
+            "stateStr": "PRIMARY",
+            "uptime": 4822189,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1601384207,
+                        "i": 1
+                    }
+                },
+                "t": 24
+            },
+            "optimeDate": {
+                "$date": 1601384207000
+            },
+            "syncingTo": "",
+            "syncSourceHost": "",
+            "syncSourceId": -1,
+            "infoMessage": "",
+            "electionTime": {
+                "$timestamp": {
+                    "t": 1596803917,
+                    "i": 1
+                }
+            },
+            "electionDate": {
+                "$date": 1596803917000
+            },
+            "configVersion": 4,
+            "lastHeartbeatMessage": ""
+        },
+        {
+            "_id": 1,
+            "name": "replset-arbiter-0.mongo.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 7,
+            "stateStr": "ARBITER",
+            "uptime": 4822185,
+            "lastHeartbeat": {
+                "$date": 1601626040978
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1601626041204
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "",
+            "syncSourceHost": "",
+            "syncSourceId": -1,
+            "infoMessage": "",
+            "configVersion": 4,
+            "self": true
+        },
+        {
+            "_id": 2,
+            "name": "replset-data-1.mongo.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 2,
+            "stateStr": "SECONDARY",
+            "uptime": 4822185,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1601384207,
+                        "i": 1
+                    }
+                },
+                "t": 24
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1601384207,
+                        "i": 1
+                    }
+                },
+                "t": 24
+            },
+            "optimeDate": {
+                "$date": 1601384107000
+            },
+            "optimeDurableDate": {
+                "$date": 1601384207000
+            },
+            "lastHeartbeat": {
+                "$date": 1601626040980
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1601626041076
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceHost": "mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceId": 3,
+            "infoMessage": "",
+            "configVersion": 4
+        },
+        {
+            "_id": 3,
+            "name": "replset-data-2.mongo.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 2,
+            "stateStr": "SECONDARY",
+            "uptime": 4822185,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1601384207,
+                        "i": 1
+                    }
+                },
+                "t": 24
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1601384207,
+                        "i": 1
+                    }
+                },
+                "t": 24
+            },
+            "optimeDate": {
+                "$date": 1601384202000
+            },
+            "optimeDurableDate": {
+                "$date": 1601384207000
+            },
+            "lastHeartbeat": {
+                "$date": 1601626041190
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1601626040934
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceHost": "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceId": 0,
+            "infoMessage": "",
+            "configVersion": 4
+        }
+    ],
+    "ok": 1.0,
+    "$gleStats": {
+        "lastOpTime": {
+            "$timestamp": {
+                "t": 0,
+                "i": 0
+            }
+        },
+        "electionId": {
+            "$oid": "7fffffff0000000000000018"
+        }
+    },
+    "lastCommittedOpTime": {
+        "$timestamp": {
+            "t": 1601384207,
+            "i": 1
+        }
+    },
+    "$configServerState": {
+        "opTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1601626035,
+                    "i": 1
+                }
+            },
+            "t": 2
+        }
+    },
+    "$clusterTime": {
+        "clusterTime": {
+            "$timestamp": {
+                "t": 1601626035,
+                "i": 1
+            }
+        },
+        "signature": {
+            "hash": {
+                "$binary": "GDIYxUuFam0+pL9BpjPXgskjojA=",
+                "$type": "00"
+            },
+            "keyId": 6857852638906548233
+        }
+    },
+    "operationTime": {
+        "$timestamp": {
+            "t": 1601384207,
+            "i": 1
+        }
+    }
+}

--- a/mongo/tests/fixtures/replSetGetStatus-replica-arbiter-in-shard
+++ b/mongo/tests/fixtures/replSetGetStatus-replica-arbiter-in-shard
@@ -1,0 +1,266 @@
+{
+    "set": "mongo-mongodb-sharded-shard-0",
+    "date": {
+        "$date": 1607692721343
+    },
+    "myState": 7,
+    "term": 20,
+    "syncingTo": "",
+    "syncSourceHost": "",
+    "syncSourceId": -1,
+    "heartbeatIntervalMillis": 2000,
+    "majorityVoteCount": 3,
+    "writeMajorityCount": 3,
+    "optimes": {
+        "lastCommittedOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1607692716,
+                    "i": 1
+                }
+            },
+            "t": 20
+        },
+        "lastCommittedWallTime": {
+            "$date": 1607692716969
+        },
+        "readConcernMajorityOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1607692716,
+                    "i": 1
+                }
+            },
+            "t": 20
+        },
+        "readConcernMajorityWallTime": {
+            "$date": 1607692716969
+        },
+        "appliedOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1607692716,
+                    "i": 1
+                }
+            },
+            "t": 20
+        },
+        "durableOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 0,
+                    "i": 0
+                }
+            },
+            "t": -1
+        },
+        "lastAppliedWallTime": {
+            "$date": 1607692716969
+        },
+        "lastDurableWallTime": {
+            "$date": 0
+        }
+    },
+    "lastStableRecoveryTimestamp": {
+        "$timestamp": {
+            "t": 1607692716,
+            "i": 1
+        }
+    },
+    "lastStableCheckpointTimestamp": {
+        "$timestamp": {
+            "t": 1607692716,
+            "i": 1
+        }
+    },
+    "electionParticipantMetrics": {
+        "votedForCandidate": true,
+        "electionTerm": 20,
+        "lastVoteDate": {
+            "$date": 1607612714163
+        },
+        "electionCandidateMemberId": 0,
+        "voteReason": "",
+        "lastAppliedOpTimeAtElection": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1607612709,
+                    "i": 1
+                }
+            },
+            "t": 19
+        },
+        "maxAppliedOpTimeInSet": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1607612709,
+                    "i": 1
+                }
+            },
+            "t": 19
+        },
+        "priorityAtElection": 0.0
+    },
+    "members": [
+        {
+            "_id": 0,
+            "name": "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 1,
+            "stateStr": "PRIMARY",
+            "uptime": 80007,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1607692716,
+                        "i": 1
+                    }
+                },
+                "t": 20
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1607692716,
+                        "i": 1
+                    }
+                },
+                "t": 20
+            },
+            "optimeDate": {
+                "$date": 1607692716000
+            },
+            "optimeDurableDate": {
+                "$date": 1607692716000
+            },
+            "lastHeartbeat": {
+                "$date": 1607692721326
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1607692720831
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "",
+            "syncSourceHost": "",
+            "syncSourceId": -1,
+            "infoMessage": "",
+            "electionTime": {
+                "$timestamp": {
+                    "t": 1607612714,
+                    "i": 2
+                }
+            },
+            "electionDate": {
+                "$date": 1607612714000
+            },
+            "configVersion": 4
+        },
+        {
+            "_id": 1,
+            "name": "mongo-mongodb-sharded-shard0-arbiter-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 7,
+            "stateStr": "ARBITER",
+            "uptime": 80180,
+            "syncingTo": "",
+            "syncSourceHost": "",
+            "syncSourceId": -1,
+            "infoMessage": "",
+            "configVersion": 4,
+            "self": true,
+            "lastHeartbeatMessage": ""
+        },
+        {
+            "_id": 2,
+            "name": "mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 2,
+            "stateStr": "SECONDARY",
+            "uptime": 80102,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1607692716,
+                        "i": 1
+                    }
+                },
+                "t": 20
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1607692716,
+                        "i": 1
+                    }
+                },
+                "t": 20
+            },
+            "optimeDate": {
+                "$date": 1607692716000
+            },
+            "optimeDurableDate": {
+                "$date": 1607692716000
+            },
+            "lastHeartbeat": {
+                "$date": 1607692720386
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1607692719877
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceHost": "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceId": 0,
+            "infoMessage": "",
+            "configVersion": 4
+        },
+        {
+            "_id": 3,
+            "name": "mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 2,
+            "stateStr": "SECONDARY",
+            "uptime": 80177,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1607692716,
+                        "i": 1
+                    }
+                },
+                "t": 20
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1607692716,
+                        "i": 1
+                    }
+                },
+                "t": 20
+            },
+            "optimeDate": {
+                "$date": 1607692716000
+            },
+            "optimeDurableDate": {
+                "$date": 1607692716000
+            },
+            "lastHeartbeat": {
+                "$date": 1607692721325
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1607692719550
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceHost": "mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceId": 2,
+            "infoMessage": "",
+            "configVersion": 4
+        }
+    ],
+    "ok": 1.0
+}

--- a/mongo/tests/results/metrics-count-dbs.json
+++ b/mongo/tests/results/metrics-count-dbs.json
@@ -1,0 +1,10 @@
+[
+    {
+        "name": "mongodb.dbs",
+        "type": 0,
+        "value": 4.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test"
+        ]
+    }
+]

--- a/mongo/tests/results/metrics-replset-arbiter.json
+++ b/mongo/tests/results/metrics-replset-arbiter.json
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "mongodb.replset.health",
+        "type": 0,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test"
+        ]
+    },
+    {
+        "name": "mongodb.replset.state",
+        "type": 0,
+        "value": 7.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test"
+        ]
+    },
+    {
+        "name": "mongodb.replset.votes",
+        "type": 0,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test"
+        ]
+    },
+    {
+        "name": "mongodb.replset.votefraction",
+        "type": 0,
+        "value": 0.25,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test"
+        ]
+    }
+]

--- a/mongo/tests/results/metrics-serverStatus.json
+++ b/mongo/tests/results/metrics-serverStatus.json
@@ -1,13 +1,5 @@
 [
     {
-        "name": "mongodb.dbs",
-        "type": 0,
-        "value": 4.0,
-        "tags": [
-            "server:mongodb://testUser2:*****@localhost:27017/test"
-        ]
-    },
-    {
         "name": "mongodb.asserts.msgps",
         "type": 1,
         "value": 0.0,

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -190,7 +190,7 @@ def test_integration_replicaset_arbiter_in_shard(instance_integration, aggregato
         'replset_state:arbiter',
         'sharding_cluster_role:shardsvr',
     ]
-    metrics_categories = ['serverStatus', 'replset-arbiter', 'oplog']
+    metrics_categories = ['serverStatus', 'replset-arbiter']
 
     _assert_metrics(aggregator, metrics_categories, replica_tags)
 
@@ -448,7 +448,7 @@ def test_integration_replicaset_arbiter(instance_integration, aggregator, check)
         mongo_check.check(None)
 
     replica_tags = ['replset_name:replset', 'replset_state:arbiter']
-    metrics_categories = ['serverStatus', 'replset-arbiter', 'oplog']
+    metrics_categories = ['serverStatus', 'replset-arbiter']
 
     _assert_metrics(aggregator, metrics_categories, replica_tags)
 

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -33,7 +33,17 @@ def test_integration_mongos(instance_integration, aggregator, check):
 
     _assert_metrics(
         aggregator,
-        ['default', 'custom-queries', 'dbstats', 'indexes-stats', 'collection', 'connection-pool', 'jumbo', 'sessions'],
+        [
+            'count-dbs',
+            'serverStatus',
+            'custom-queries',
+            'dbstats',
+            'indexes-stats',
+            'collection',
+            'connection-pool',
+            'jumbo',
+            'sessions',
+        ],
         ['sharding_cluster_role:mongos'],
     )
 
@@ -64,7 +74,8 @@ def test_integration_replicaset_primary_in_shard(instance_integration, aggregato
         'sharding_cluster_role:shardsvr',
     ]
     metrics_categories = [
-        'default',
+        'count-dbs',
+        'serverStatus',
         'custom-queries',
         'oplog',
         'replset-primary',
@@ -139,7 +150,8 @@ def test_integration_replicaset_secondary_in_shard(instance_integration, aggrega
         'sharding_cluster_role:shardsvr',
     ]
     metrics_categories = [
-        'default',
+        'count-dbs',
+        'serverStatus',
         'oplog',
         'replset-secondary',
         'top',
@@ -147,6 +159,39 @@ def test_integration_replicaset_secondary_in_shard(instance_integration, aggrega
         'fsynclock',
         'connection-pool',
     ]
+    _assert_metrics(aggregator, metrics_categories, replica_tags)
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(
+        get_metadata_metrics(),
+        exclude=[
+            'dd.custom.mongo.aggregate.total',
+            'dd.custom.mongo.count',
+            'dd.custom.mongo.query_a.amount',
+            'dd.custom.mongo.query_a.el',
+        ],
+        check_submission_type=True,
+    )
+    assert len(aggregator._events) == 0
+
+
+def test_integration_replicaset_arbiter_in_shard(instance_integration, aggregator, check):
+    for query in instance_integration['custom_queries']:
+        query['run_on_secondary'] = True
+    instance_integration['is_arbiter'] = True
+    mongo_check = check(instance_integration)
+    mongo_check.last_states_by_server = {0: 2, 1: 1, 2: 7, 3: 2}
+
+    with mock_pymongo("replica-arbiter-in-shard"):
+        mongo_check.check(None)
+
+    replica_tags = [
+        'replset_name:mongo-mongodb-sharded-shard-0',
+        'replset_state:arbiter',
+        'sharding_cluster_role:shardsvr',
+    ]
+    metrics_categories = ['serverStatus', 'replset-arbiter', 'oplog']
+
     _assert_metrics(aggregator, metrics_categories, replica_tags)
 
     aggregator.assert_all_metrics_covered()
@@ -176,7 +221,8 @@ def test_integration_configsvr_primary(instance_integration, aggregator, check):
         'sharding_cluster_role:configsvr',
     ]
     metrics_categories = [
-        'default',
+        'count-dbs',
+        'serverStatus',
         'custom-queries',
         'oplog',
         'replset-primary',
@@ -251,7 +297,8 @@ def test_integration_configsvr_secondary(instance_integration, aggregator, check
         'sharding_cluster_role:configsvr',
     ]
     metrics_categories = [
-        'default',
+        'count-dbs',
+        'serverStatus',
         'oplog',
         'replset-secondary',
         'top',
@@ -284,7 +331,8 @@ def test_integration_replicaset_primary(instance_integration, aggregator, check)
 
     replica_tags = ['replset_name:replset', 'replset_state:primary']
     metrics_categories = [
-        'default',
+        'count-dbs',
+        'serverStatus',
         'custom-queries',
         'oplog',
         'replset-primary',
@@ -362,7 +410,8 @@ def test_integration_replicaset_secondary(instance_integration, aggregator, chec
 
     replica_tags = ['replset_name:replset', 'replset_state:secondary']
     metrics_categories = [
-        'default',
+        'count-dbs',
+        'serverStatus',
         'oplog',
         'replset-secondary',
         'top',
@@ -388,6 +437,35 @@ def test_integration_replicaset_secondary(instance_integration, aggregator, chec
     assert len(aggregator._events) == 0
 
 
+def test_integration_replicaset_arbiter(instance_integration, aggregator, check):
+    for query in instance_integration['custom_queries']:
+        query['run_on_secondary'] = True
+    instance_integration['is_arbiter'] = True
+    mongo_check = check(instance_integration)
+    mongo_check.last_states_by_server = {0: 2, 1: 1, 2: 7, 3: 2}
+
+    with mock_pymongo("replica-arbiter"):
+        mongo_check.check(None)
+
+    replica_tags = ['replset_name:replset', 'replset_state:arbiter']
+    metrics_categories = ['serverStatus', 'replset-arbiter', 'oplog']
+
+    _assert_metrics(aggregator, metrics_categories, replica_tags)
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(
+        get_metadata_metrics(),
+        exclude=[
+            'dd.custom.mongo.aggregate.total',
+            'dd.custom.mongo.count',
+            'dd.custom.mongo.query_a.amount',
+            'dd.custom.mongo.query_a.el',
+        ],
+        check_submission_type=True,
+    )
+    assert len(aggregator._events) == 0
+
+
 def test_standalone(instance_integration, aggregator, check):
     mongo_check = check(instance_integration)
     mongo_check.last_states_by_server = {0: 2, 1: 1, 2: 7, 3: 2}
@@ -396,7 +474,8 @@ def test_standalone(instance_integration, aggregator, check):
         mongo_check.check(None)
 
     metrics_categories = [
-        'default',
+        'count-dbs',
+        'serverStatus',
         'custom-queries',
         'top',
         'dbstats-local',

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -135,7 +135,7 @@ def test_parse_server_config(check):
         'options': {'replicaSet': 'bar!baz'},  # Special character
     }
     check = check(instance)
-    assert check.server == 'mongodb://john+doe:p%40ss%5Cword@localhost,localhost:27018/test?replicaSet=bar%21baz'
+    assert check.server == 'mongodb://localhost,localhost:27018/test?replicaSet=bar%21baz'
     assert check.username == 'john doe'
     assert check.password == 'p@ss\\word'
     assert check.db_name == 'test'
@@ -154,7 +154,7 @@ def test_username_no_password(check):
         'options': {'replicaSet': 'bar!baz'},  # Special character
     }
     check = check(instance)
-    assert check.server == 'mongodb://john+doe@localhost,localhost:27018/test?replicaSet=bar%21baz'
+    assert check.server == 'mongodb://localhost,localhost:27018/test?replicaSet=bar%21baz'
     assert check.username == 'john doe'
     assert check.db_name == 'test'
     assert check.nodelist == [('localhost', 27017), ('localhost', 27018)]

--- a/mongo/tox.ini
+++ b/mongo/tox.ini
@@ -20,6 +20,7 @@ passenv =
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
+    -e../datadog_checks_tests_helper
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
## Context
An arbiter node is a mongo node in a replica set used for election but which doesn't store any data. Most of the metrics we collect don't make sense on a arbiter but the most important ones are:
- The `serverStatus` ones (low level information on the node itself, like memory, number of connections etc.) (can be run without authentication)
- The number of votes this arbiter has (can't be fetched from the arbiter)
- The health of the arbiter (can't be fetched from the arbiter)

Unfortunately arbiters can't be monitored in exactly the same way as other nodes as they don't support authentication, the only way to connect is either to create a user before transforming the mongod node into an arbiter or leverage the "localhost exception". This localhost exception provides just enough permissions for us to get connection information for the primary. This way, a second connection to the primary is created to collect metrics like the number of votes and the arbiter health.

## This PR
Improves support for arbiter nodes in a cluster, for doing so the following have been changes:

### Collector logic
Previously, the main check class was deciding which collectors to use based on both the config and the deployment type. Part of that logic has moved to each collector class to limit cluttering of the `refresh_collectors` method.

Now the base check creates a list of candidate collectors based uniquely on the configuration. Then these collectors are filtered using a new collector method called `is_compatible_with`.

Without that, the `refresh_collectors` method would have been cluttered too much by checking if the node is an arbiter.

### Replica collection
Nothing changes for regular nodes. For arbiter nodes, a new connection is created to the primary of the replica set, on which the command `replSetGetConfig` is performed

### Configuration
It is required to specify `is_arbiter: true` in the config. Trying to guess leads to many authentication issues and extra api calls.
Not too much of an issue as arbiters have different configuration than regular mongod nodes.

### Authentication
Because connecting to the arbiter can't be done with user/pass, but connecting to the primary usually requires authentication the following is done:
- The main server URI is generated without the pair username/password to prevent authentication.
- When creating the additional connection to the primary, authentication is based on the config.
