### PR TITLE
Remove sample kubernetes yaml file

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -24,8 +24,7 @@ To collect Kubernetes State metrics, please refer to the [kubernetes_state integ
 
 ### Configuration
 
-Edit the `kubernetes.yaml` file to point to your server and port, set the masters to monitor. See the [sample kubernetes.yaml][4] for all available configuration options.
-
+Edit the `kubernetes.yaml` file to point to your server and port, set the masters to monitor.
 
 ### Validation
 


### PR DESCRIPTION
### What does this PR do?
Removes the sample kubernetes yaml file from the Kubernetes docs as it no longer exists

### Motivation
Jira request

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached