### PR TITLE
create default monitor for disk space

### DIFF
--- a/disk/assets/monitors/disk_space_empty_forecast.json
+++ b/disk/assets/monitors/disk_space_empty_forecast.json
@@ -1,0 +1,29 @@
+{
+	"name": "[disk] Device {{device.name}} is going to be full on host {{host.name}}",
+	"type": "metric alert",
+	"query": "max(next_3d):forecast(( 1 - avg:system.disk.free{*} by {host,device} / avg:system.disk.total{*} by {host,device} ) * 100, 'seasonal', 1, interval='60m', seasonality='weekly') >= 99",
+	"message": "Device {{device.name}} on {{host.name}} is projected to exceed  {{value}}% usage within the next 3 days.",
+	"tags": [
+		"integration:disk"
+	],
+	"options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+		"require_full_window": false,
+		"notify_no_data": false,
+		"renotify_interval": "0",
+		"evaluation_delay": 300,
+		"escalation_message": "",
+		"no_data_timeframe": null,
+		"include_tags": true,
+		"thresholds": {
+			"critical": 99,
+			"critical_recovery": 89
+		}
+	},
+	"recommended_monitor_metadata": {
+		"description": "Notify your team when your disk memory usage approaches maximum capacity."
+	}
+}

--- a/disk/assets/monitors/disk_space_empty_forecast.json
+++ b/disk/assets/monitors/disk_space_empty_forecast.json
@@ -1,6 +1,6 @@
 {
 	"name": "[disk] Device {{device.name}} is going to be full on host {{host.name}}",
-	"type": "metric alert",
+	"type": "query alert",
 	"query": "max(next_3d):forecast(( 1 - avg:system.disk.free{*} by {host,device} / avg:system.disk.total{*} by {host,device} ) * 100, 'seasonal', 1, interval='60m', seasonality='weekly') >= 99",
 	"message": "Device {{device.name}} on {{host.name}} is projected to exceed  {{value}}% usage within the next 3 days.",
 	"tags": [

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -26,7 +26,7 @@
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {
-      "[disk] Device {{device.name}} is going to be full on host {{host.name}}": "assets/monitors/disk_space_empty_forecast.json"
+      "disk-space-forecast": "assets/monitors/disk_space_empty_forecast.json"
     },
     "dashboards": {},
     "service_checks": "assets/service_checks.json",

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -25,7 +25,9 @@
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
-    "monitors": {},
+    "monitors": {
+      "[disk] Device {{device.name}} is going to be full on host {{host.name}}": "assets/monitors/disk_space_empty_forecast.json"
+    },
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
     "logs": {},


### PR DESCRIPTION
### What does this PR do?
Adds a recommended monitor for disk space

### Motivation
This is a very common monitor request from customers, and I think having this available will help them.

### Additional Notes

I specifically used disk.free/disk.total, because disk.in_use only works for linux instances, not windows (as far as i know).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
