### PR TITLE
Ensure connection failure message is shown on Python 2

### DIFF
--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -253,8 +253,8 @@ class ZookeeperCheck(AgentCheck):
                         return self._get_data(ssock, command)
                 else:
                     return self._get_data(sock, command)
-        except (socket.timeout, socket.error):
-            raise ZKConnectionFailure()
+        except (socket.timeout, socket.error) as exc:
+            raise ZKConnectionFailure(exc)  # Include `exc` message for PY2.
 
     def parse_stat(self, buf):
         """


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Bundle the socket error `exc` message with connection failure exceptions.

### Motivation
<!-- What inspired you to submit this pull request? -->
Found while QAing #7884 — this is a small UX improvement for Py2 users.

When an SSL error occurs (eg because the cert is invalid), we raise a `ZkConnectionFailure()`. On Python 3.8, there's exception chaining so the traceback of the original `socket.error` is shown as well. However on Python 2.7 there's no exception chaining, so only the last exception is shown. As a result we get this blank traceback in the Agent status:

```console
Error: 
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py", line 876, in run
    self.check(instance)
  File "/home/zk/datadog_checks/zk/zk.py", line 131, in check
    ruok_out = self._send_command('ruok')
  File "/home/zk/datadog_checks/zk/zk.py", line 257, in _send_command
    raise ZKConnectionFailure()
ZKConnectionFailure
```

This PR makes it so that we get this instead:

```console
Error: [X509] PEM lib (_ssl.c:3063)
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py", line 876, in run
    self.check(instance)
  File "/home/zk/datadog_checks/zk/zk.py", line 131, in check
    ruok_out = self._send_command('ruok')
  File "/home/zk/datadog_checks/zk/zk.py", line 257, in _send_command
    raise ZKConnectionFailure(exc)
ZKConnectionFailure: [X509] PEM lib (_ssl.c:3063)
```

(The SSL error itself isn't very helpful to the layperson :wink: but at least we get to see it now, which can help in support cases.)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached

### QA notes

* Start a py27 env, eg:

```
ddev env start --agent datadog/agent:6.25.0-rc.2 zk py28-3.5-ssl
```

* Modify `tests/compose/client/cert.pem` by one character so the cert becomes invalid.
* Run the check, the `PEM lib` error message (or similar) should be present in the check output.