### PR TITLE
Remove unused value in Varnish

### DIFF
--- a/varnish/tests/test_varnish.py
+++ b/varnish/tests/test_varnish.py
@@ -11,15 +11,6 @@ from . import common
 pytestmark = [pytest.mark.usefixtures('dd_environment'), pytest.mark.integration]
 
 
-GAUGE_IN_5_RATE_IN_6 = [
-    "varnish.n_expired",
-    "varnish.n_lru_moved",
-    "varnish.n_lru_nuked",
-    "varnish.n_obj_purged",
-    "varnish.n_purges",
-]
-
-
 def test_check(aggregator, check, instance):
     check.check(instance)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR removes `GAUGE_IN_5_RATE_IN_6` in the varnish check, since it is no longer being used.

`GAUGE_IN_5_RATE_IN_6` was only used for `test_check` and was removed in https://github.com/DataDog/integrations-core/pull/8075.


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
