### PR TITLE
Fix typo for ssl reuse metric

### DIFF
--- a/haproxy/datadog_checks/haproxy/metrics.py
+++ b/haproxy/datadog_checks/haproxy/metrics.py
@@ -89,7 +89,7 @@ METRIC_MAP = {
     'haproxy_process_current_tasks': 'process.current.tasks',
     'haproxy_process_current_zlib_memory': 'process.current.zlib.memory',
     'haproxy_process_dropped_logs_total': 'process.dropped.logs.total',
-    'haproxy_process_frontent_ssl_reuse': 'process.frontent.ssl.reuse',
+    'haproxy_process_frontend_ssl_reuse': 'process.frontend.ssl.reuse',
     'haproxy_process_hard_max_connections': 'process.hard.max.connections',
     'haproxy_process_http_comp_bytes_in_total': 'process.http.comp.bytes.in.total',
     'haproxy_process_http_comp_bytes_out_total': 'process.http.comp.bytes.out.total',

--- a/haproxy/metadata.csv
+++ b/haproxy/metadata.csv
@@ -135,7 +135,7 @@ haproxy.process.current.ssl.rate,gauge,,,,Current number of SSL sessions per sec
 haproxy.process.current.tasks,gauge,,,,Current number of tasks.,0,haproxy,
 haproxy.process.current.zlib.memory,gauge,,,,Current memory used for zlib in bytes.,0,haproxy,
 haproxy.process.dropped.logs.total,count,,,,Total number of dropped logs.,0,haproxy,
-haproxy.process.frontent.ssl.reuse,gauge,,,,SSL session reuse ratio (percent).,0,haproxy,
+haproxy.process.frontend.ssl.reuse,gauge,,,,SSL session reuse ratio (percent).,0,haproxy,
 haproxy.process.hard.max.connections,gauge,,,,Initial Maximum number of concurrent connections.,0,haproxy,
 haproxy.process.http.comp.bytes.in.total,count,,byte,,"Number of bytes per second over last elapsed second, before http compression.",0,haproxy,
 haproxy.process.http.comp.bytes.out.total,count,,byte,,"Number of bytes per second over last elapsed second, after http compression.",0,haproxy,

--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -27,9 +27,9 @@ setenv =
   16: HAPROXY_VERSION=1.6.15
   17: HAPROXY_VERSION=1.7.12
   18: HAPROXY_VERSION=1.8.27
-  20: HAPROXY_VERSION=2.0.19
-  21: HAPROXY_VERSION=2.1.10
-  22: HAPROXY_VERSION=2.2.6
+  20: HAPROXY_VERSION=2.0.20
+  21: HAPROXY_VERSION=2.1.11
+  22: HAPROXY_VERSION=2.2.7
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?

typo in s/frontent/frontend/

this typo has been fixed upstream by commit:
http://git.haproxy.org/?p=haproxy.git;a=commit;h=1e3697635292b0f194171958a26766ae3e8d8453
and backported in all minor versions

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
