### PR TITLE
Add missing mongodb.extra_info.heap_usage_bytesps in metadata.csv

### DIFF
--- a/mongo/metadata.csv
+++ b/mongo/metadata.csv
@@ -28,6 +28,7 @@ mongodb.dur.timems.writetodatafiles,gauge,,millisecond,,Amount of time spent wri
 mongodb.dur.timems.writetojournal,gauge,,millisecond,,Amount of time spent writing to the journal,-1,mongodb,dur time ms write to journal
 mongodb.dur.writetodatafilesmb,gauge,,mebibyte,,Amount of data written from journal to the data files during the last journal group commit interval.,-1,mongodb,dur write to data files mb
 mongodb.extra_info.page_faultsps,gauge,,fault,second,Number of page faults per second that require disk operations.,0,mongodb,pagefaults ps
+mongodb.extra_info.heap_usage_bytesps,gauge,,byte,second,The total size in bytes of heap space used by the database process. Available on Unix/Linux systems only.,0,mongodb,heap usage bytesps
 mongodb.fsynclocked,gauge,,,,Number of fsynclocked performed on a mongo instance.,0,mongodb,fsynclocked
 mongodb.globallock.activeclients.readers,gauge,,connection,,Count of the active client connections performing read operations.,0,mongodb,active clients readers
 mongodb.globallock.activeclients.total,gauge,,connection,,Total number of active client connections to the database.,0,mongodb,active clients total

--- a/mongo/tests/fixtures/serverStatus
+++ b/mongo/tests/fixtures/serverStatus
@@ -62,7 +62,8 @@
         "page_reclaims": 11199,
         "page_faults": 20,
         "voluntary_context_switches": 141314,
-        "involuntary_context_switches": 82166
+        "involuntary_context_switches": 82166,
+        "heap_usage_bytes": 2562568
     },
     "globalLock": {
         "lockTime": 42,

--- a/mongo/tests/results/metrics-default.json
+++ b/mongo/tests/results/metrics-default.json
@@ -128,6 +128,14 @@
         ]
     },
     {
+        "name": "mongodb.extra_info.heap_usage_bytesps",
+        "type": 1,
+        "value": 2562568.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test"
+        ]
+    },
+    {
         "name": "mongodb.globallock.activeclients.readers",
         "type": 0,
         "value": 18.0,

--- a/mongo/tests/test_mongo.py
+++ b/mongo/tests/test_mongo.py
@@ -5,6 +5,7 @@ import logging
 
 import pytest
 
+from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.mongo import MongoDb
 
 from . import common
@@ -67,6 +68,7 @@ def test_mongo(aggregator, check, instance_authdb):
         if metric_name in METRIC_VAL_CHECKS:
             metric = aggregator.metrics(metric_name)[0]
             assert METRIC_VAL_CHECKS[metric_name](metric.value)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 
 
 @pytest.mark.parametrize(
@@ -87,6 +89,7 @@ def test_mongo2(aggregator, check, instance_user):
         if metric_name in METRIC_VAL_CHECKS:
             metric = aggregator.metrics(metric_name)[0]
             assert METRIC_VAL_CHECKS[metric_name](metric.value)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 
 
 def test_mongo_old_config(aggregator, check, instance):
@@ -100,6 +103,7 @@ def test_mongo_old_config(aggregator, check, instance):
         if metric_name in METRIC_VAL_CHECKS_OLD:
             metric = aggregator.metrics(metric_name)[0]
             assert METRIC_VAL_CHECKS_OLD[metric_name](metric.value)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 
 
 def test_mongo_old_config_2(aggregator, check, instance):
@@ -113,6 +117,7 @@ def test_mongo_old_config_2(aggregator, check, instance):
         if metric_name in METRIC_VAL_CHECKS_OLD:
             metric = aggregator.metrics(metric_name)[0]
             assert METRIC_VAL_CHECKS_OLD[metric_name](metric.value)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 
 
 def test_mongo_1valid_and_1invalid_custom_queries(aggregator, check, instance_1valid_and_1invalid_custom_queries):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update the `metadata.csv` adding a missing metric 

### Motivation
<!-- What inspired you to submit this pull request? -->
CI of #8204 failing

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
