### PR TITLE
haproxy: minor versions update and adding v2.2 tests

### DIFF
--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 basepython = py38
 envlist =
     py{27,38}-{16,17,18,20,21}-legacy
-    py{27,38}-{20,21}
+    py{27,38}-{20,21,22}
 
 [testenv]
 ensure_default_envdir = true
@@ -29,6 +29,7 @@ setenv =
   18: HAPROXY_VERSION=1.8.27
   20: HAPROXY_VERSION=2.0.19
   21: HAPROXY_VERSION=2.1.10
+  22: HAPROXY_VERSION=2.2.6
 commands =
     pip install -r requirements.in
     pytest -v {posargs}

--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -24,11 +24,11 @@ deps =
 setenv =
   HAPROXY_LEGACY=false
   legacy: HAPROXY_LEGACY=true
-  16: HAPROXY_VERSION=1.6.9
-  17: HAPROXY_VERSION=1.7.10
-  18: HAPROXY_VERSION=1.8.5
-  20: HAPROXY_VERSION=2.0.12
-  21: HAPROXY_VERSION=2.1.4
+  16: HAPROXY_VERSION=1.6.15
+  17: HAPROXY_VERSION=1.7.12
+  18: HAPROXY_VERSION=1.8.27
+  20: HAPROXY_VERSION=2.0.19
+  21: HAPROXY_VERSION=2.1.10
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?

    haproxy: bump all minors version we test against
    this will make sure we rely on the latest minors versions available

    haproxy: adding test support for v2.2.x
    for now avoid legacy tests, as prometheus metrics are now the advised
    ones
    v2.3.x has some incompatibilities I'm working on

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
