### PR TITLE
change default monitor tag group from service to windows_service

### DIFF
--- a/windows_service/assets/service_checks.json
+++ b/windows_service/assets/service_checks.json
@@ -11,7 +11,7 @@
         ],
         "groups": [
             "host",
-            "service"
+            "windows_service"
         ],
         "name": "Service state",
         "description": "Returns `OK` if the windows service is in Running state, `CRITICAL` if it is Stopped, `UNKNOWN` if it is Unknown, and `WARNING` for the other service states."


### PR DESCRIPTION
### What does this PR do?
Change the default tag for windows_service monitor scope from service to windows_service.

### Motivation
The service_check doesn't always come with a service tag, but does with a windows_service tag

### Additional Notes
https://dd.datad0g.com/monitors#create/integration

https://a.cl.ly/5zudn5NP

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
