### PR TITLE
Add metric_to_check validation redirection for snmp_<vendor> integrations

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -470,7 +470,11 @@ def manifest(ctx, fix):
             if metric_to_check:
                 metrics_to_check = metric_to_check if isinstance(metric_to_check, list) else [metric_to_check]
                 for metric in metrics_to_check:
-                    metric_integration_check_name = decoded.get('metric_integration_check_name') or check_name
+                    metric_integration_check_name = check_name
+                    # snmp vendor specific integrations define metric_to_check
+                    # with metrics from `snmp` integration
+                    if check_name.startswith('snmp_') and not metadata_in_manifest:
+                        metric_integration_check_name = 'snmp'
                     if (
                         not is_metric_in_metadata_file(metric, metric_integration_check_name)
                         and metric not in METRIC_TO_CHECK_WHITELIST

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -50,6 +50,10 @@ def get_manifest_schema():
                     "description": "The metric to use to determine the health of this integration",
                     "oneOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}],
                 },
+                "metric_integration_check_name": {
+                    "description": "The name of an external integration check providing metrics",
+                    "type": "string",
+                },
                 "creates_events": {"description": "Whether or not this integration emits events", "type": "boolean"},
                 "short_description": {
                     "description": "Brief description of this integration",
@@ -466,7 +470,11 @@ def manifest(ctx, fix):
             if metric_to_check:
                 metrics_to_check = metric_to_check if isinstance(metric_to_check, list) else [metric_to_check]
                 for metric in metrics_to_check:
-                    if not is_metric_in_metadata_file(metric, check_name) and metric not in METRIC_TO_CHECK_WHITELIST:
+                    metric_integration_check_name = decoded.get('metric_integration_check_name') or check_name
+                    if (
+                        not is_metric_in_metadata_file(metric, metric_integration_check_name)
+                        and metric not in METRIC_TO_CHECK_WHITELIST
+                    ):
                         file_failures += 1
                         display_queue.append((echo_failure, f'  metric_to_check not in metadata.csv: {metric!r}'))
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -50,10 +50,6 @@ def get_manifest_schema():
                     "description": "The metric to use to determine the health of this integration",
                     "oneOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}],
                 },
-                "metric_integration_check_name": {
-                    "description": "The name of an external integration check providing metrics",
-                    "type": "string",
-                },
                 "creates_events": {"description": "Whether or not this integration emits events", "type": "boolean"},
                 "short_description": {
                     "description": "Brief description of this integration",


### PR DESCRIPTION
### What does this PR do?
Validate `snmp_<vendor>` integrations `metric_to_check` using metrics defined in `snmp`

### Motivation
While working on snmp we decided to add one tile per vendor supported by this integration. Each tile will define `metric_to_check` specific to the vendor metrics. As metrics and snmp vendor have an N:M relation, we decided to keep all metrics in snmp root folder. This change makes it possible to use `snmp` metrics as `metric_to_check` values in a `snmp_<vendor>` integration.

### Additional Notes
Required by https://github.com/DataDog/integrations-core/pull/8156/commits/33cd21e2ff39e723a4c57cd470f67ed1a7244047

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
