### PR TITLE
[orchestrator] change cardinality of deployment count

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -895,7 +895,7 @@ class KubernetesState(OpenMetricsBaseCheck):
         for sample in metric.samples:
             tags = []
             namespace = self._label_to_tag("namespace", sample[self.SAMPLE_LABELS], scraper_config)
-            deployment = self._label_to_tag("deployment", sample[self.SAMPLE_LABELS], scraper_config)
+            deployment = sample[self.SAMPLE_LABELS].get("deployment")
             if (deployment, namespace) in seen:
                 continue
             seen.add((deployment, namespace))

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -103,7 +103,6 @@ class KubernetesState(OpenMetricsBaseCheck):
             'kube_job_owner': {'metric_name': 'job.count', 'allowed_labels': ['namespace', 'owner_name', 'owner_kind']},
             'kube_deployment_status_condition': {
                 'metric_name': 'deployment.count',
-                'allowed_labels': ['namespace', 'condition', 'status'],
             },
         }
 
@@ -131,7 +130,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             'kube_replicaset_owner': self.count_objects_by_tags,
             'kube_job_owner': self.count_objects_by_tags,
             # to get overall count is to filter by Available
-            'kube_deployment_status_condition': self.count_objects_by_tags,
+            'kube_deployment_status_condition': self.kube_deployment_count,
         }
 
         # Handling cron jobs succeeded/failed counts
@@ -887,6 +886,22 @@ class KubernetesState(OpenMetricsBaseCheck):
 
         for tags, count in iteritems(object_counter):
             self.gauge(metric_name, count, tags=list(tags))
+
+    def kube_deployment_count(self, metric, scraper_config):
+        config = self.object_count_params[metric.name]
+        metric_name = "{}.{}".format(scraper_config['namespace'], config['metric_name'])
+        seen = set()
+
+        for sample in metric.samples:
+            tags = []
+            namespace = self._label_to_tag("namespace", sample[self.SAMPLE_LABELS], scraper_config)
+            deployment = self._label_to_tag("deployment", sample[self.SAMPLE_LABELS], scraper_config)
+            if (deployment,namespace) in seen:
+                continue
+            seen.add((deployment, namespace))
+            tags.append(namespace)
+            tags += scraper_config['custom_tags']
+            self.gauge(metric_name, 1, tags=list(tags))
 
     def _build_tags(self, label_name, label_value, scraper_config, hostname=None):
         """

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -896,7 +896,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             tags = []
             namespace = self._label_to_tag("namespace", sample[self.SAMPLE_LABELS], scraper_config)
             deployment = self._label_to_tag("deployment", sample[self.SAMPLE_LABELS], scraper_config)
-            if (deployment,namespace) in seen:
+            if (deployment, namespace) in seen:
                 continue
             seen.add((deployment, namespace))
             tags.append(namespace)

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -135,6 +135,12 @@ kube_deployment_status_condition{namespace="default",deployment="redis-master",c
 kube_deployment_status_condition{namespace="default",deployment="redis-master",condition="Available",status="true"} 1
 kube_deployment_status_condition{namespace="default",deployment="redis-master",condition="Available",status="false"} 0
 kube_deployment_status_condition{namespace="default",deployment="redis-master",condition="Available",status="unknown"} 0
+kube_deployment_status_condition{namespace="test",deployment="redis-master",condition="Progressing",status="true"} 1
+kube_deployment_status_condition{namespace="test",deployment="redis-master",condition="Progressing",status="false"} 0
+kube_deployment_status_condition{namespace="test",deployment="redis-master",condition="Progressing",status="unknown"} 0
+kube_deployment_status_condition{namespace="test",deployment="redis-master",condition="Available",status="true"} 1
+kube_deployment_status_condition{namespace="test",deployment="redis-master",condition="Available",status="false"} 0
+kube_deployment_status_condition{namespace="test",deployment="redis-master",condition="Available",status="unknown"} 0
 # HELP kube_replicaset_owner Information about the ReplicaSet's owner.
 # TYPE kube_replicaset_owner gauge
 kube_replicaset_owner{namespace="kube-system",replicaset="l7-default-backend-678889f899",owner_kind="Deployment",owner_name="l7-default-backend",owner_is_controller="true"} 1

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -149,7 +149,7 @@ TAGS = {
         'namespace:kube-system',
     ],
     NAMESPACE + '.pod.count': ['uid:b6fb4273-2dd6-4edb-9a23-7642bb121806', 'created_by_kind:daemonset'],
-    NAMESPACE + '.deployment.count': ['condition:progressing', 'condition:available', 'status:true'],
+    NAMESPACE + '.deployment.count': ['namespace:default','namespace:test'],
     NAMESPACE + '.replicaset.count': ['owner_kind:deployment', 'owner_name:metrics-server-v0.3.6'],
     NAMESPACE + '.namespace.count': ['phase:active', 'phase:terminating'],
     NAMESPACE + '.job.count': ['owner_kind:cronjob', 'owner_name:a-cronjob'],
@@ -373,6 +373,19 @@ def test_update_kube_state_metrics(aggregator, instance, check):
         NAMESPACE + '.persistentvolumes.by_phase',
         tags=['storageclass:local-data', 'phase:released', 'optional:tag1'],
         value=0,
+    )
+
+    # deployment counts
+    aggregator.assert_metric(
+        NAMESPACE + '.deployment.count',
+        tags=['namespace:default', 'optional:tag1'],
+        value=1,
+    )
+
+    aggregator.assert_metric(
+        NAMESPACE + '.deployment.count',
+        tags=['namespace:test', 'optional:tag1'],
+        value=1,
     )
 
     for metric in METRICS:

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -818,9 +818,9 @@ def test_telemetry(aggregator, instance):
 
     for _ in range(2):
         check.check(instance)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=93895.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=998.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1326.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=94599.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=1010.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1338.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.blacklist.count', tags=['optional:tag1'], value=24.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=328.0)
     aggregator.assert_metric(

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -149,7 +149,7 @@ TAGS = {
         'namespace:kube-system',
     ],
     NAMESPACE + '.pod.count': ['uid:b6fb4273-2dd6-4edb-9a23-7642bb121806', 'created_by_kind:daemonset'],
-    NAMESPACE + '.deployment.count': ['namespace:default','namespace:test'],
+    NAMESPACE + '.deployment.count': ['namespace:default', 'namespace:test'],
     NAMESPACE + '.replicaset.count': ['owner_kind:deployment', 'owner_name:metrics-server-v0.3.6'],
     NAMESPACE + '.namespace.count': ['phase:active', 'phase:terminating'],
     NAMESPACE + '.job.count': ['owner_kind:cronjob', 'owner_name:a-cronjob'],


### PR DESCRIPTION
### What does this PR do?
changes the cardinality count of previous added deployment.count.
Now running `deployment.count` should return the expected number of deployments without the need to filter_by

### Motivation
Before one had to filter_by `condition:available, status:true` to get the correct count. But users would not expect this when calling `deployment.count`

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Check looks like this
```
    {
      "metric": "kubernetes_state.deployment.count",
      "points": [
        [
          1608292794,
          1
        ]
      ],
      "tags": [
        "namespace:default"
      ],
      "host": "agent-dev-nam",
      "type": "gauge",
      "interval": 0,
      "source_type_name": "System"
    },
```
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached

