### PR TITLE
Update prometheus mixin to use the request wrapper

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
@@ -88,6 +88,14 @@ class GenericPrometheusCheck(AgentCheck):
 
     DEFAULT_METRIC_LIMIT = 2000
 
+    HTTP_CONFIG_REMAPPER = {
+        'ssl_verify': {'name': 'tls_verify'},
+        'ssl_cert': {'name': 'tls_cert'},
+        'ssl_private_key': {'name': 'tls_private_key'},
+        'ssl_ca_cert': {'name': 'tls_ca_cert'},
+        'prometheus_timeout': {'name': 'timeout'},
+    }
+
     def __init__(self, name, init_config, agentConfig, instances=None, default_instances=None, default_namespace=""):
         super(GenericPrometheusCheck, self).__init__(name, init_config, agentConfig, instances)
         self.scrapers_map = {}

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
@@ -18,6 +18,7 @@ class PrometheusScraper(PrometheusScraperMixin):
     def __init__(self, check):
         super(PrometheusScraper, self).__init__()
         self.check = check
+        self._http_handlers = {}
 
     def _submit_rate(self, metric_name, val, metric, custom_tags=None, hostname=None):
         """
@@ -87,14 +88,6 @@ class GenericPrometheusCheck(AgentCheck):
     """
 
     DEFAULT_METRIC_LIMIT = 2000
-
-    HTTP_CONFIG_REMAPPER = {
-        'ssl_verify': {'name': 'tls_verify'},
-        'ssl_cert': {'name': 'tls_cert'},
-        'ssl_private_key': {'name': 'tls_private_key'},
-        'ssl_ca_cert': {'name': 'tls_ca_cert'},
-        'prometheus_timeout': {'name': 'timeout'},
-    }
 
     def __init__(self, name, init_config, agentConfig, instances=None, default_instances=None, default_namespace=""):
         super(GenericPrometheusCheck, self).__init__(name, init_config, agentConfig, instances)

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -44,8 +44,18 @@ class PrometheusScraperMixin(object):
     UNWANTED_LABELS = ["le", "quantile"]  # are specifics keys for prometheus itself
     REQUESTS_CHUNK_SIZE = 1024 * 10  # use 10kb as chunk size when using the Stream feature in requests.get
 
+    HTTP_CONFIG_REMAPPER = {
+        'ssl_verify': {'name': 'tls_verify'},
+        'ssl_cert': {'name': 'tls_cert'},
+        'ssl_private_key': {'name': 'tls_private_key'},
+        'ssl_ca_cert': {'name': 'tls_ca_cert'},
+        'prometheus_timeout': {'name': 'timeout'},
+    }
+
     def __init__(self, *args, **kwargs):
         super(PrometheusScraperMixin, self).__init__(*args, **kwargs)
+
+        self.init_config = {}
 
         # The scraper needs its own logger
         self.log = logging.getLogger(__name__)

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/prometheus_base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/prometheus_base.py
@@ -26,7 +26,16 @@ from .mixins import PrometheusScraperMixin
 class PrometheusCheck(PrometheusScraperMixin, AgentCheck):
     DEFAULT_METRIC_LIMIT = 2000
 
+    HTTP_CONFIG_REMAPPER = {
+        'ssl_verify': {'name': 'tls_verify'},
+        'ssl_cert': {'name': 'tls_cert'},
+        'ssl_private_key': {'name': 'tls_private_key'},
+        'ssl_ca_cert': {'name': 'tls_ca_cert'},
+        'prometheus_timeout': {'name': 'timeout'},
+    }
+
     def __init__(self, name, init_config, agentConfig, instances=None):
+        self._http_handlers = {}
         super(PrometheusCheck, self).__init__(name, init_config, agentConfig, instances)
 
     def check(self, instance):

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/prometheus_base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/prometheus_base.py
@@ -26,14 +26,6 @@ from .mixins import PrometheusScraperMixin
 class PrometheusCheck(PrometheusScraperMixin, AgentCheck):
     DEFAULT_METRIC_LIMIT = 2000
 
-    HTTP_CONFIG_REMAPPER = {
-        'ssl_verify': {'name': 'tls_verify'},
-        'ssl_cert': {'name': 'tls_cert'},
-        'ssl_private_key': {'name': 'tls_private_key'},
-        'ssl_ca_cert': {'name': 'tls_ca_cert'},
-        'prometheus_timeout': {'name': 'timeout'},
-    }
-
     def __init__(self, name, init_config, agentConfig, instances=None):
         self._http_handlers = {}
         super(PrometheusCheck, self).__init__(name, init_config, agentConfig, instances)

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -263,7 +263,7 @@ def test_process(bin_data, mocked_prometheus_check, ref_gauge):
     check.poll = mock.MagicMock(return_value=MockResponse(bin_data, protobuf_content_type))
     check.process_metric = mock.MagicMock()
     check.process(endpoint, instance=None)
-    check.poll.assert_called_with(endpoint)
+    check.poll.assert_called_with(endpoint, instance={})
     check.process_metric.assert_called_with(ref_gauge, instance=None)
 
 
@@ -274,7 +274,7 @@ def test_process_send_histograms_buckets(bin_data, mocked_prometheus_check, ref_
     check.poll = mock.MagicMock(return_value=MockResponse(bin_data, protobuf_content_type))
     check.process_metric = mock.MagicMock()
     check.process(endpoint, send_histograms_buckets=False, instance=None)
-    check.poll.assert_called_with(endpoint)
+    check.poll.assert_called_with(endpoint, instance={})
     check.process_metric.assert_called_with(ref_gauge, instance=None, send_histograms_buckets=False)
 
 
@@ -285,7 +285,7 @@ def test_process_send_monotonic_counter(bin_data, mocked_prometheus_check, ref_g
     check.poll = mock.MagicMock(return_value=MockResponse(bin_data, protobuf_content_type))
     check.process_metric = mock.MagicMock()
     check.process(endpoint, send_monotonic_counter=False, instance=None)
-    check.poll.assert_called_with(endpoint)
+    check.poll.assert_called_with(endpoint, instance={})
     check.process_metric.assert_called_with(ref_gauge, instance=None, send_monotonic_counter=False)
 
 
@@ -297,7 +297,7 @@ def test_process_instance_with_tags(bin_data, mocked_prometheus_check, ref_gauge
     check.process_metric = mock.MagicMock()
     instance = {'endpoint': 'IgnoreMe', 'tags': ['tag1:tagValue1', 'tag2:tagValue2']}
     check.process(endpoint, instance=instance)
-    check.poll.assert_called_with(endpoint)
+    check.poll.assert_called_with(endpoint, instance=instance)
     check.process_metric.assert_called_with(
         ref_gauge, custom_tags=['tag1:tagValue1', 'tag2:tagValue2'], instance=instance
     )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update `PrometheusScraperMixin` to use `RequestWrapper` instead of directly using the `requests` python package

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
