### PR TITLE
Replace old tls_verify implementation with in-house TLS library.

### DIFF
--- a/vertica/assets/configuration/spec.yaml
+++ b/vertica/assets/configuration/spec.yaml
@@ -93,44 +93,12 @@ files:
             value:
               type: integer
               example: 10
-          - name: tls_verify
-            description: Whether or not to connect securely using TLS. The server must also support this.
-            value:
-              type: boolean
-              example: false
+          - template: instances/tls
           - name: validate_hostname
             description: Whether or not to verify the TLS certificate was issued for `server` if `tls_verify` is true.
             value:
               type: boolean
               example: true
-          - name: cert
-            description: |
-              The path to a single file in PEM format containing a certificate as well as any
-              number of CA certificates needed to establish the certificate’s authenticity for
-              use when connecting to `server`. It may also contain an unencrypted private key to use.
-
-              Setting this implicitly sets `tls_verify` to true.
-            value:
-              type: string
-              example: <CERT_PATH>
-          - name: private_key
-            description: |
-              The unencrypted private key to use for `cert` when connecting to `server`. This is
-              required if `cert` is set and it does not already contain a private key.
-            value:
-              type: string
-              example: <PRIVATE_KEY_PATH>
-          - name: ca_cert
-            description: |
-              The path to a file of concatenated CA certificates in PEM format or a directory
-              containing several CA certificates in PEM format. If a directory, the directory
-              must have been processed using the c_rehash utility supplied with OpenSSL. See:
-              https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
-
-              Setting this implicitly sets `tls_verify` to true.
-            value:
-              type: string
-              example: <CA_CERT_PATH>
           - template: instances/tags
           - template: instances/db
             overrides:

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -86,32 +86,12 @@ instances:
     #
     # timeout: 10
 
-    ## @param tls_verify - boolean - optional - default: false
-    ## Whether or not to connect securely using TLS. The server must also support this.
+    ## @param tls_verify - boolean - optional - default: true
+    ## Instructs the check to validate the TLS certificate(s) of the service(s).
     #
-    # tls_verify: false
+    # tls_verify: true
 
-    ## @param validate_hostname - boolean - optional - default: true
-    ## Whether or not to verify the TLS certificate was issued for `server` if `tls_verify` is true.
-    #
-    # validate_hostname: true
-
-    ## @param cert - string - optional
-    ## The path to a single file in PEM format containing a certificate as well as any
-    ## number of CA certificates needed to establish the certificate’s authenticity for
-    ## use when connecting to `server`. It may also contain an unencrypted private key to use.
-    ##
-    ## Setting this implicitly sets `tls_verify` to true.
-    #
-    # cert: <CERT_PATH>
-
-    ## @param private_key - string - optional
-    ## The unencrypted private key to use for `cert` when connecting to `server`. This is
-    ## required if `cert` is set and it does not already contain a private key.
-    #
-    # private_key: <PRIVATE_KEY_PATH>
-
-    ## @param ca_cert - string - optional
+    ## @param tls_ca_cert - string - optional
     ## The path to a file of concatenated CA certificates in PEM format or a directory
     ## containing several CA certificates in PEM format. If a directory, the directory
     ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
@@ -119,7 +99,41 @@ instances:
     ##
     ## Setting this implicitly sets `tls_verify` to true.
     #
-    # ca_cert: <CA_CERT_PATH>
+    # tls_ca_cert: <CA_CERT_PATH>
+
+    ## @param tls_cert - string - optional
+    ## The path to a single file in PEM format containing a certificate as well as any
+    ## number of CA certificates needed to establish the certificate's authenticity for
+    ## use when connecting to services. It may also contain an unencrypted private key to use.
+    ##
+    ## Setting this implicitly sets `tls_verify` to true.
+    #
+    # tls_cert: <CERT_PATH>
+
+    ## @param tls_private_key - string - optional
+    ## The unencrypted private key to use for `tls_cert` when connecting to services. This is
+    ## required if `tls_cert` is set and it does not already contain a private key.
+    ##
+    ## Setting this implicitly sets `tls_verify` to true.
+    #
+    # tls_private_key: <PRIVATE_KEY_PATH>
+
+    ## @param tls_private_key_password - string - optional
+    ## Optional password to decrypt tls_private_key.
+    ##
+    ## Setting this implicitly sets `tls_verify` to true.
+    #
+    # tls_private_key_password: <PRIVATE_KEY_PASSWORD>
+
+    ## @param tls_validate_hostname - boolean - optional - default: true
+    ## Verifies that the server's cert hostname matches the one requested.
+    #
+    # tls_validate_hostname: true
+
+    ## @param validate_hostname - boolean - optional - default: true
+    ## Whether or not to verify the TLS certificate was issued for `server` if `tls_verify` is true.
+    #
+    # validate_hostname: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -19,7 +19,6 @@ from . import views
 from .utils import kilobytes_to_bytes, node_state_to_service_check
 
 # Python 3 only
-# PROTOCOL_TLS_CLIENT = getattr(ssl, 'PROTOCOL_TLS_CLIENT', ssl.PROTOCOL_TLS)
 
 
 class VerticaCheck(AgentCheck):

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -4,11 +4,9 @@
 from __future__ import division
 
 import logging
-import ssl
 from collections import OrderedDict, defaultdict
 from datetime import datetime
 from itertools import chain
-from os.path import expanduser, isdir
 
 import vertica_python as vertica
 from six import iteritems
@@ -562,8 +560,6 @@ class VerticaCheck(AgentCheck):
             connection_options['log_path'] = ''
 
         if self._tls_verify:
-            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext
-            # https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS
             tls_context = self.get_tls_context()
             connection_options['ssl'] = tls_context
 

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -21,7 +21,7 @@ from . import views
 from .utils import kilobytes_to_bytes, node_state_to_service_check
 
 # Python 3 only
-PROTOCOL_TLS_CLIENT = getattr(ssl, 'PROTOCOL_TLS_CLIENT', ssl.PROTOCOL_TLS)
+# PROTOCOL_TLS_CLIENT = getattr(ssl, 'PROTOCOL_TLS_CLIENT', ssl.PROTOCOL_TLS)
 
 
 class VerticaCheck(AgentCheck):
@@ -47,29 +47,8 @@ class VerticaCheck(AgentCheck):
 
         self._client_lib_log_level = self.instance.get('client_lib_log_level', self._get_default_client_lib_log_level())
 
-        self._tls_verify = is_affirmative(self.instance.get('tls_verify', False))
+        self._tls_verify = is_affirmative(self.instance.get('tls_verify', True))
         self._validate_hostname = is_affirmative(self.instance.get('validate_hostname', True))
-
-        self._cert = self.instance.get('cert', '')
-        if self._cert:  # no cov
-            self._cert = expanduser(self._cert)
-            self._tls_verify = True
-
-        self._private_key = self.instance.get('private_key', '')
-        if self._private_key:  # no cov
-            self._private_key = expanduser(self._private_key)
-
-        self._cafile = None
-        self._capath = None
-        ca_cert = self.instance.get('ca_cert', '')
-        if ca_cert:  # no cov
-            ca_cert = expanduser(ca_cert)
-            if isdir(ca_cert):
-                self._capath = ca_cert
-            else:
-                self._cafile = ca_cert
-
-            self._tls_verify = True
 
         custom_queries = self.instance.get('custom_queries', [])
         use_global_custom_queries = self.instance.get('use_global_custom_queries', True)
@@ -103,7 +82,7 @@ class VerticaCheck(AgentCheck):
         # Default to no library logs, since they're too verbose even at the INFO level.
         return None
 
-    def check(self, instance):
+    def check(self, _):
         if self._connection is None:
             connection = self.get_connection()
             if connection is None:
@@ -582,29 +561,10 @@ class VerticaCheck(AgentCheck):
             # but we still get logs via parent root logger
             connection_options['log_path'] = ''
 
-        if self._tls_verify:  # no cov
+        if self._tls_verify:
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext
             # https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS
-            tls_context = ssl.SSLContext(protocol=PROTOCOL_TLS_CLIENT)
-
-            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.verify_mode
-            tls_context.verify_mode = ssl.CERT_REQUIRED
-
-            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname
-            tls_context.check_hostname = self._validate_hostname
-
-            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_verify_locations
-            if self._cafile or self._capath:
-                tls_context.load_verify_locations(self._cafile, self._capath, None)
-
-            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_default_certs
-            else:
-                tls_context.load_default_certs(ssl.Purpose.SERVER_AUTH)
-
-            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain
-            if self._cert:
-                tls_context.load_cert_chain(self._cert, keyfile=self._private_key)
-
+            tls_context = self.get_tls_context()
             connection_options['ssl'] = tls_context
 
         try:

--- a/vertica/setup.py
+++ b/vertica/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.11.1'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.2.0'
 
 
 setup(

--- a/vertica/tests/common.py
+++ b/vertica/tests/common.py
@@ -29,16 +29,16 @@ cert = os.path.join(CERTIFICATE_DIR, 'cert.cert')
 private_key = os.path.join(CERTIFICATE_DIR, 'server.pem')
 
 TLS_CONFIG = {
-        'db': 'abc',
-        'server': 'localhost',
-        'port': '999',
-        'username': 'dbadmin',
-        'password': 'monitor',
-        'timeout': 10,
-        'tags': ['foo:bar'],
-        'tls_verify': True,
-        'validate_hostname': True,
-        'tls_cert': cert,
-        'tls_private_key': private_key,
-        'tls_ca_cert': CERTIFICATE_DIR,
-    }
+    'db': 'abc',
+    'server': 'localhost',
+    'port': '999',
+    'username': 'dbadmin',
+    'password': 'monitor',
+    'timeout': 10,
+    'tags': ['foo:bar'],
+    'tls_verify': True,
+    'validate_hostname': True,
+    'tls_cert': cert,
+    'tls_private_key': private_key,
+    'tls_ca_cert': CERTIFICATE_DIR,
+}

--- a/vertica/tests/common.py
+++ b/vertica/tests/common.py
@@ -20,4 +20,25 @@ CONFIG = {
     'password': 'monitor',
     'timeout': 10,
     'tags': ['foo:bar'],
+    'tls_verify': False,
 }
+
+# TLS certs
+CERTIFICATE_DIR = os.path.join(os.path.dirname(__file__), 'certificate')
+cert = os.path.join(CERTIFICATE_DIR, 'cert.cert')
+private_key = os.path.join(CERTIFICATE_DIR, 'server.pem')
+
+TLS_CONFIG = {
+        'db': 'abc',
+        'server': 'localhost',
+        'port': '999',
+        'username': 'dbadmin',
+        'password': 'monitor',
+        'timeout': 10,
+        'tags': ['foo:bar'],
+        'tls_verify': True,
+        'validate_hostname': True,
+        'tls_cert': cert,
+        'tls_private_key': private_key,
+        'tls_ca_cert': CERTIFICATE_DIR,
+    }

--- a/vertica/tests/conftest.py
+++ b/vertica/tests/conftest.py
@@ -38,7 +38,7 @@ class InitializeDB(LazyFunction):
 @pytest.fixture(scope='session')
 def dd_environment():
     with docker_run(
-        common.COMPOSE_FILE, log_patterns=['Vertica is now running'], conditions=[InitializeDB(common.CONFIG)]
+            common.COMPOSE_FILE, log_patterns=['Vertica is now running'], conditions=[InitializeDB(common.CONFIG)]
     ):
         yield common.CONFIG
 
@@ -46,3 +46,8 @@ def dd_environment():
 @pytest.fixture
 def instance():
     return deepcopy(common.CONFIG)
+
+
+@pytest.fixture
+def tls_instance():
+    return deepcopy(common.TLS_CONFIG)

--- a/vertica/tests/conftest.py
+++ b/vertica/tests/conftest.py
@@ -38,7 +38,7 @@ class InitializeDB(LazyFunction):
 @pytest.fixture(scope='session')
 def dd_environment():
     with docker_run(
-            common.COMPOSE_FILE, log_patterns=['Vertica is now running'], conditions=[InitializeDB(common.CONFIG)]
+        common.COMPOSE_FILE, log_patterns=['Vertica is now running'], conditions=[InitializeDB(common.CONFIG)]
     ):
         yield common.CONFIG
 

--- a/vertica/tests/test_unit.py
+++ b/vertica/tests/test_unit.py
@@ -80,7 +80,7 @@ def test_client_logging_disabled(aggregator, instance):
     'agent_log_level, expected_vertica_log_level', [(logging.DEBUG, logging.DEBUG), (TRACE_LEVEL, logging.DEBUG)]
 )
 def test_client_logging_enabled_debug_if_agent_uses_debug_or_trace(
-        aggregator, instance, agent_log_level, expected_vertica_log_level
+    aggregator, instance, agent_log_level, expected_vertica_log_level
 ):
     """
     Improve collection of debug flares by automatically enabling client DEBUG logs when the Agent uses DEBUG logs.

--- a/vertica/tests/test_vertica.py
+++ b/vertica/tests/test_vertica.py
@@ -23,106 +23,104 @@ def test_check_e2e(dd_agent_check, instance):
     aggregator.assert_all_metrics_covered()
 
 
-# @pytest.mark.usefixtures('dd_environment')
-# def test_check(aggregator, datadog_agent, instance, dd_run_check):
-#
-#     check = VerticaCheck('vertica', {}, [instance])
-#     check.check_id = 'test:123'
-#     dd_run_check(check)
-#
-#     for metric in ALL_METRICS:
-#         aggregator.assert_metric_has_tag(metric, 'db:datadog')
-#         aggregator.assert_metric_has_tag(metric, 'foo:bar')
-#
-#     aggregator.assert_all_metrics_covered()
-#
-#     version_metadata = {'version.scheme': 'semver', 'version.major': os.environ['VERTICA_VERSION'][0]}
-#     datadog_agent.assert_metadata('test:123', version_metadata)
-#     datadog_agent.assert_metadata_count(len(version_metadata) + 4)
+@pytest.mark.usefixtures('dd_environment')
+def test_check(aggregator, datadog_agent, instance, dd_run_check):
+
+    check = VerticaCheck('vertica', {}, [instance])
+    check.check_id = 'test:123'
+    dd_run_check(check)
+
+    for metric in ALL_METRICS:
+        aggregator.assert_metric_has_tag(metric, 'db:datadog')
+        aggregator.assert_metric_has_tag(metric, 'foo:bar')
+
+    aggregator.assert_all_metrics_covered()
+
+    version_metadata = {'version.scheme': 'semver', 'version.major': os.environ['VERTICA_VERSION'][0]}
+    datadog_agent.assert_metadata('test:123', version_metadata)
+    datadog_agent.assert_metadata_count(len(version_metadata) + 4)
 
 
-# @pytest.mark.usefixtures('dd_environment')
-# def test_vertica_log_file_not_created(aggregator, instance, dd_run_check):
-#     instance['client_lib_log_level'] = 'DEBUG'
-#
-#     vertica_default_log = os.path.join(os.path.dirname(common.HERE), 'vertica_python.log')
-#     if os.path.exists(vertica_default_log):
-#         os.remove(vertica_default_log)
-#
-#     check = VerticaCheck('vertica', {}, [instance])
-#     dd_run_check(check)
-#     assert not os.path.exists(vertica_default_log)
-#
-#
-# @pytest.mark.usefixtures('dd_environment')
-# def test_check_connection_load_balance(instance, dd_run_check):
-#     instance['connection_load_balance'] = True
-#     check = VerticaCheck('vertica', {}, [instance])
-#
-#     def mock_reset_connection():
-#         raise Exception('reset_connection was called')
-#
-#     with mock.patch('vertica_python.vertica.connection.Connection.reset_connection', side_effect=mock_reset_connection):
-#         dd_run_check(check)
-#
-#         with pytest.raises(Exception, match='reset_connection was called'):
-#             dd_run_check(check, extract_message=True)
-#
-#
-# @pytest.mark.usefixtures('dd_environment')
-# def test_custom_queries(aggregator, instance, dd_run_check):
-#     instance['custom_queries'] = [
-#         {
-#             'tags': ['test:vertica'],
-#             'query': 'SELECT force_outer, table_name FROM v_catalog.tables',
-#             'columns': [{'name': 'table.force_outer', 'type': 'gauge'}, {'name': 'table_name', 'type': 'tag'}],
-#         }
-#     ]
-#
-#     check = VerticaCheck('vertica', {}, [instance])
-#     dd_run_check(check)
-#
-#     aggregator.assert_metric(
-#         'vertica.table.force_outer', metric_type=0, tags=['db:datadog', 'foo:bar', 'test:vertica', 'table_name:datadog']
-#     )
-#
-#
-# @pytest.mark.usefixtures('dd_environment')
-# def test_include_all_metric_groups(aggregator, instance, dd_run_check):
-#     check = VerticaCheck('vertica', {}, [instance])
-#     dd_run_check(check)
-#
-#     aggregator.assert_metric('vertica.license.expiration', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.license.size', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.node.total', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.projection.total', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.row.total', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.delete_vectors', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.memory.swap.total', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.query.active', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.resource_pool.memory.max', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.storage.size', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.node.resource_requests', metric_type=aggregator.GAUGE)
-#
-#
-# @pytest.mark.usefixtures('dd_environment')
-# def test_include_system_metric_group(aggregator, instance, dd_run_check):
-#     instance['metric_groups'] = ['system']
-#
-#     check = VerticaCheck('vertica', {}, [instance])
-#     dd_run_check(check)
-#
-#     aggregator.assert_metric('vertica.license.expiration', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.node.total', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.node.down', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.node.allowed', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.node.available', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.ksafety.current', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.ksafety.intended', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.epoch.ahm', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.epoch.current', metric_type=aggregator.GAUGE)
-#     aggregator.assert_metric('vertica.epoch.last_good', metric_type=aggregator.GAUGE)
-#
-#     aggregator.assert_all_metrics_covered()
+@pytest.mark.usefixtures('dd_environment')
+def test_vertica_log_file_not_created(aggregator, instance, dd_run_check):
+    instance['client_lib_log_level'] = 'DEBUG'
 
-# Add test for SSL verification
+    vertica_default_log = os.path.join(os.path.dirname(common.HERE), 'vertica_python.log')
+    if os.path.exists(vertica_default_log):
+        os.remove(vertica_default_log)
+
+    check = VerticaCheck('vertica', {}, [instance])
+    dd_run_check(check)
+    assert not os.path.exists(vertica_default_log)
+
+
+@pytest.mark.usefixtures('dd_environment')
+def test_check_connection_load_balance(instance, dd_run_check):
+    instance['connection_load_balance'] = True
+    check = VerticaCheck('vertica', {}, [instance])
+
+    def mock_reset_connection():
+        raise Exception('reset_connection was called')
+
+    with mock.patch('vertica_python.vertica.connection.Connection.reset_connection', side_effect=mock_reset_connection):
+        dd_run_check(check)
+
+        with pytest.raises(Exception, match='reset_connection was called'):
+            dd_run_check(check, extract_message=True)
+
+
+@pytest.mark.usefixtures('dd_environment')
+def test_custom_queries(aggregator, instance, dd_run_check):
+    instance['custom_queries'] = [
+        {
+            'tags': ['test:vertica'],
+            'query': 'SELECT force_outer, table_name FROM v_catalog.tables',
+            'columns': [{'name': 'table.force_outer', 'type': 'gauge'}, {'name': 'table_name', 'type': 'tag'}],
+        }
+    ]
+
+    check = VerticaCheck('vertica', {}, [instance])
+    dd_run_check(check)
+
+    aggregator.assert_metric(
+        'vertica.table.force_outer', metric_type=0, tags=['db:datadog', 'foo:bar', 'test:vertica', 'table_name:datadog']
+    )
+
+
+@pytest.mark.usefixtures('dd_environment')
+def test_include_all_metric_groups(aggregator, instance, dd_run_check):
+    check = VerticaCheck('vertica', {}, [instance])
+    dd_run_check(check)
+
+    aggregator.assert_metric('vertica.license.expiration', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.license.size', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.node.total', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.projection.total', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.row.total', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.delete_vectors', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.memory.swap.total', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.query.active', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.resource_pool.memory.max', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.storage.size', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.node.resource_requests', metric_type=aggregator.GAUGE)
+
+
+@pytest.mark.usefixtures('dd_environment')
+def test_include_system_metric_group(aggregator, instance, dd_run_check):
+    instance['metric_groups'] = ['system']
+
+    check = VerticaCheck('vertica', {}, [instance])
+    dd_run_check(check)
+
+    aggregator.assert_metric('vertica.license.expiration', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.node.total', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.node.down', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.node.allowed', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.node.available', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.ksafety.current', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.ksafety.intended', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.epoch.ahm', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.epoch.current', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('vertica.epoch.last_good', metric_type=aggregator.GAUGE)
+
+    aggregator.assert_all_metrics_covered()

--- a/vertica/tests/test_vertica.py
+++ b/vertica/tests/test_vertica.py
@@ -23,104 +23,106 @@ def test_check_e2e(dd_agent_check, instance):
     aggregator.assert_all_metrics_covered()
 
 
-@pytest.mark.usefixtures('dd_environment')
-def test_check(aggregator, datadog_agent, instance, dd_run_check):
-
-    check = VerticaCheck('vertica', {}, [instance])
-    check.check_id = 'test:123'
-    dd_run_check(check)
-
-    for metric in ALL_METRICS:
-        aggregator.assert_metric_has_tag(metric, 'db:datadog')
-        aggregator.assert_metric_has_tag(metric, 'foo:bar')
-
-    aggregator.assert_all_metrics_covered()
-
-    version_metadata = {'version.scheme': 'semver', 'version.major': os.environ['VERTICA_VERSION'][0]}
-    datadog_agent.assert_metadata('test:123', version_metadata)
-    datadog_agent.assert_metadata_count(len(version_metadata) + 4)
-
-
-@pytest.mark.usefixtures('dd_environment')
-def test_vertica_log_file_not_created(aggregator, instance, dd_run_check):
-    instance['client_lib_log_level'] = 'DEBUG'
-
-    vertica_default_log = os.path.join(os.path.dirname(common.HERE), 'vertica_python.log')
-    if os.path.exists(vertica_default_log):
-        os.remove(vertica_default_log)
-
-    check = VerticaCheck('vertica', {}, [instance])
-    dd_run_check(check)
-    assert not os.path.exists(vertica_default_log)
+# @pytest.mark.usefixtures('dd_environment')
+# def test_check(aggregator, datadog_agent, instance, dd_run_check):
+#
+#     check = VerticaCheck('vertica', {}, [instance])
+#     check.check_id = 'test:123'
+#     dd_run_check(check)
+#
+#     for metric in ALL_METRICS:
+#         aggregator.assert_metric_has_tag(metric, 'db:datadog')
+#         aggregator.assert_metric_has_tag(metric, 'foo:bar')
+#
+#     aggregator.assert_all_metrics_covered()
+#
+#     version_metadata = {'version.scheme': 'semver', 'version.major': os.environ['VERTICA_VERSION'][0]}
+#     datadog_agent.assert_metadata('test:123', version_metadata)
+#     datadog_agent.assert_metadata_count(len(version_metadata) + 4)
 
 
-@pytest.mark.usefixtures('dd_environment')
-def test_check_connection_load_balance(instance, dd_run_check):
-    instance['connection_load_balance'] = True
-    check = VerticaCheck('vertica', {}, [instance])
+# @pytest.mark.usefixtures('dd_environment')
+# def test_vertica_log_file_not_created(aggregator, instance, dd_run_check):
+#     instance['client_lib_log_level'] = 'DEBUG'
+#
+#     vertica_default_log = os.path.join(os.path.dirname(common.HERE), 'vertica_python.log')
+#     if os.path.exists(vertica_default_log):
+#         os.remove(vertica_default_log)
+#
+#     check = VerticaCheck('vertica', {}, [instance])
+#     dd_run_check(check)
+#     assert not os.path.exists(vertica_default_log)
+#
+#
+# @pytest.mark.usefixtures('dd_environment')
+# def test_check_connection_load_balance(instance, dd_run_check):
+#     instance['connection_load_balance'] = True
+#     check = VerticaCheck('vertica', {}, [instance])
+#
+#     def mock_reset_connection():
+#         raise Exception('reset_connection was called')
+#
+#     with mock.patch('vertica_python.vertica.connection.Connection.reset_connection', side_effect=mock_reset_connection):
+#         dd_run_check(check)
+#
+#         with pytest.raises(Exception, match='reset_connection was called'):
+#             dd_run_check(check, extract_message=True)
+#
+#
+# @pytest.mark.usefixtures('dd_environment')
+# def test_custom_queries(aggregator, instance, dd_run_check):
+#     instance['custom_queries'] = [
+#         {
+#             'tags': ['test:vertica'],
+#             'query': 'SELECT force_outer, table_name FROM v_catalog.tables',
+#             'columns': [{'name': 'table.force_outer', 'type': 'gauge'}, {'name': 'table_name', 'type': 'tag'}],
+#         }
+#     ]
+#
+#     check = VerticaCheck('vertica', {}, [instance])
+#     dd_run_check(check)
+#
+#     aggregator.assert_metric(
+#         'vertica.table.force_outer', metric_type=0, tags=['db:datadog', 'foo:bar', 'test:vertica', 'table_name:datadog']
+#     )
+#
+#
+# @pytest.mark.usefixtures('dd_environment')
+# def test_include_all_metric_groups(aggregator, instance, dd_run_check):
+#     check = VerticaCheck('vertica', {}, [instance])
+#     dd_run_check(check)
+#
+#     aggregator.assert_metric('vertica.license.expiration', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.license.size', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.node.total', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.projection.total', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.row.total', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.delete_vectors', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.memory.swap.total', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.query.active', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.resource_pool.memory.max', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.storage.size', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.node.resource_requests', metric_type=aggregator.GAUGE)
+#
+#
+# @pytest.mark.usefixtures('dd_environment')
+# def test_include_system_metric_group(aggregator, instance, dd_run_check):
+#     instance['metric_groups'] = ['system']
+#
+#     check = VerticaCheck('vertica', {}, [instance])
+#     dd_run_check(check)
+#
+#     aggregator.assert_metric('vertica.license.expiration', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.node.total', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.node.down', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.node.allowed', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.node.available', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.ksafety.current', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.ksafety.intended', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.epoch.ahm', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.epoch.current', metric_type=aggregator.GAUGE)
+#     aggregator.assert_metric('vertica.epoch.last_good', metric_type=aggregator.GAUGE)
+#
+#     aggregator.assert_all_metrics_covered()
 
-    def mock_reset_connection():
-        raise Exception('reset_connection was called')
-
-    with mock.patch('vertica_python.vertica.connection.Connection.reset_connection', side_effect=mock_reset_connection):
-        dd_run_check(check)
-
-        with pytest.raises(Exception, match='reset_connection was called'):
-            dd_run_check(check, extract_message=True)
-
-
-@pytest.mark.usefixtures('dd_environment')
-def test_custom_queries(aggregator, instance, dd_run_check):
-    instance['custom_queries'] = [
-        {
-            'tags': ['test:vertica'],
-            'query': 'SELECT force_outer, table_name FROM v_catalog.tables',
-            'columns': [{'name': 'table.force_outer', 'type': 'gauge'}, {'name': 'table_name', 'type': 'tag'}],
-        }
-    ]
-
-    check = VerticaCheck('vertica', {}, [instance])
-    dd_run_check(check)
-
-    aggregator.assert_metric(
-        'vertica.table.force_outer', metric_type=0, tags=['db:datadog', 'foo:bar', 'test:vertica', 'table_name:datadog']
-    )
-
-
-@pytest.mark.usefixtures('dd_environment')
-def test_include_all_metric_groups(aggregator, instance, dd_run_check):
-    check = VerticaCheck('vertica', {}, [instance])
-    dd_run_check(check)
-
-    aggregator.assert_metric('vertica.license.expiration', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.license.size', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.node.total', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.projection.total', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.row.total', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.delete_vectors', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.memory.swap.total', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.query.active', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.resource_pool.memory.max', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.storage.size', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.node.resource_requests', metric_type=aggregator.GAUGE)
-
-
-@pytest.mark.usefixtures('dd_environment')
-def test_include_system_metric_group(aggregator, instance, dd_run_check):
-    instance['metric_groups'] = ['system']
-
-    check = VerticaCheck('vertica', {}, [instance])
-    dd_run_check(check)
-
-    aggregator.assert_metric('vertica.license.expiration', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.node.total', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.node.down', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.node.allowed', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.node.available', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.ksafety.current', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.ksafety.intended', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.epoch.ahm', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.epoch.current', metric_type=aggregator.GAUGE)
-    aggregator.assert_metric('vertica.epoch.last_good', metric_type=aggregator.GAUGE)
-
-    aggregator.assert_all_metrics_covered()
+# Add test for SSL verification


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR updates Vertica's TLS verify implementation to use updated in-house TLS library.

Note: Vertica's SSL/TLS implementation is only used for `tls_verify`. There is no official support to connect to Vertica via SSL/TLS yet. Another PR will add this feature.

### Motivation
<!-- What inspired you to submit this pull request? -->
Reduce Tech debt

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
