### PR TITLE
Fix deployment count metric

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -103,6 +103,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             'kube_job_owner': {'metric_name': 'job.count', 'allowed_labels': ['namespace', 'owner_name', 'owner_kind']},
             'kube_deployment_status_condition': {
                 'metric_name': 'deployment.count',
+                'allowed_labels': ['namespace', 'condition', 'status'],
             },
         }
 
@@ -130,7 +131,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             'kube_replicaset_owner': self.count_objects_by_tags,
             'kube_job_owner': self.count_objects_by_tags,
             # to get overall count is to filter by Available
-            'kube_deployment_status_condition': self.kube_deployment_count,
+            'kube_deployment_status_condition': self.count_objects_by_tags,
         }
 
         # Handling cron jobs succeeded/failed counts
@@ -886,22 +887,6 @@ class KubernetesState(OpenMetricsBaseCheck):
 
         for tags, count in iteritems(object_counter):
             self.gauge(metric_name, count, tags=list(tags))
-
-    def kube_deployment_count(self, metric, scraper_config):
-        config = self.object_count_params[metric.name]
-        metric_name = "{}.{}".format(scraper_config['namespace'], config['metric_name'])
-        seen = set()
-
-        for sample in metric.samples:
-            tags = []
-            namespace = self._label_to_tag("namespace", sample[self.SAMPLE_LABELS], scraper_config)
-            deployment = sample[self.SAMPLE_LABELS].get("deployment")
-            if (deployment, namespace) in seen:
-                continue
-            seen.add((deployment, namespace))
-            tags.append(namespace)
-            tags += scraper_config['custom_tags']
-            self.gauge(metric_name, 1, tags=list(tags))
 
     def _build_tags(self, label_name, label_value, scraper_config, hostname=None):
         """

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -101,9 +101,9 @@ class KubernetesState(OpenMetricsBaseCheck):
                 'allowed_labels': ['namespace', 'owner_name', 'owner_kind'],
             },
             'kube_job_owner': {'metric_name': 'job.count', 'allowed_labels': ['namespace', 'owner_name', 'owner_kind']},
-            'kube_deployment_status_condition': {
+            'kube_deployment_status_observed_generation': {
                 'metric_name': 'deployment.count',
-                'allowed_labels': ['namespace', 'condition', 'status'],
+                'allowed_labels': ['namespace'],
             },
         }
 
@@ -131,7 +131,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             'kube_replicaset_owner': self.count_objects_by_tags,
             'kube_job_owner': self.count_objects_by_tags,
             # to get overall count is to filter by Available
-            'kube_deployment_status_condition': self.count_objects_by_tags,
+            'kube_deployment_status_observed_generation': self.count_objects_by_tags,
         }
 
         # Handling cron jobs succeeded/failed counts
@@ -318,7 +318,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                     # _generation metrics are more metadata than metrics, no real use case for now
                     'kube_daemonset_metadata_generation',
                     'kube_deployment_metadata_generation',
-                    'kube_deployment_status_observed_generation',
+                    'kube_deployment_status_condition',
                     'kube_replicaset_metadata_generation',
                     'kube_replicaset_status_observed_generation',
                     'kube_replicationcontroller_metadata_generation',

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -135,12 +135,6 @@ kube_deployment_status_condition{namespace="default",deployment="redis-master",c
 kube_deployment_status_condition{namespace="default",deployment="redis-master",condition="Available",status="true"} 1
 kube_deployment_status_condition{namespace="default",deployment="redis-master",condition="Available",status="false"} 0
 kube_deployment_status_condition{namespace="default",deployment="redis-master",condition="Available",status="unknown"} 0
-kube_deployment_status_condition{namespace="test",deployment="redis-master",condition="Progressing",status="true"} 1
-kube_deployment_status_condition{namespace="test",deployment="redis-master",condition="Progressing",status="false"} 0
-kube_deployment_status_condition{namespace="test",deployment="redis-master",condition="Progressing",status="unknown"} 0
-kube_deployment_status_condition{namespace="test",deployment="redis-master",condition="Available",status="true"} 1
-kube_deployment_status_condition{namespace="test",deployment="redis-master",condition="Available",status="false"} 0
-kube_deployment_status_condition{namespace="test",deployment="redis-master",condition="Available",status="unknown"} 0
 # HELP kube_replicaset_owner Information about the ReplicaSet's owner.
 # TYPE kube_replicaset_owner gauge
 kube_replicaset_owner{namespace="kube-system",replicaset="l7-default-backend-678889f899",owner_kind="Deployment",owner_name="l7-default-backend",owner_is_controller="true"} 1

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -27,7 +27,6 @@ METRICS = [
     NAMESPACE + '.node.gpu.cards_allocatable',
     NAMESPACE + '.nodes.by_condition',
     # deployments
-    NAMESPACE + '.deployment.count',
     NAMESPACE + '.deployment.replicas',
     NAMESPACE + '.deployment.replicas_available',
     NAMESPACE + '.deployment.replicas_unavailable',
@@ -149,7 +148,6 @@ TAGS = {
         'namespace:kube-system',
     ],
     NAMESPACE + '.pod.count': ['uid:b6fb4273-2dd6-4edb-9a23-7642bb121806', 'created_by_kind:daemonset'],
-    NAMESPACE + '.deployment.count': ['condition:progressing', 'condition:available', 'status:true'],
     NAMESPACE + '.replicaset.count': ['owner_kind:deployment', 'owner_name:metrics-server-v0.3.6'],
     NAMESPACE + '.namespace.count': ['phase:active', 'phase:terminating'],
     NAMESPACE + '.job.count': ['owner_kind:cronjob', 'owner_name:a-cronjob'],
@@ -373,6 +371,18 @@ def test_update_kube_state_metrics(aggregator, instance, check):
         NAMESPACE + '.persistentvolumes.by_phase',
         tags=['storageclass:local-data', 'phase:released', 'optional:tag1'],
         value=0,
+    )
+
+    # deployment counts
+    aggregator.assert_metric(
+        NAMESPACE + '.deployment.count',
+        tags=['namespace:default', 'optional:tag1'],
+        value=2,
+    )
+    aggregator.assert_metric(
+        NAMESPACE + '.deployment.count',
+        tags=['namespace:kube-system', 'optional:tag1'],
+        value=2,
     )
 
     for metric in METRICS:
@@ -806,10 +816,10 @@ def test_telemetry(aggregator, instance):
     for _ in range(2):
         check.check(instance)
     aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=93895.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=998.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=994.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1326.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.blacklist.count', tags=['optional:tag1'], value=24.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=328.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=332.0)
     aggregator.assert_metric(
         NAMESPACE + '.telemetry.collector.metrics.count',
         tags=['resource_name:pod', 'resource_namespace:default', 'optional:tag1'],

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -149,7 +149,7 @@ TAGS = {
         'namespace:kube-system',
     ],
     NAMESPACE + '.pod.count': ['uid:b6fb4273-2dd6-4edb-9a23-7642bb121806', 'created_by_kind:daemonset'],
-    NAMESPACE + '.deployment.count': ['namespace:default', 'namespace:test'],
+    NAMESPACE + '.deployment.count': ['condition:progressing', 'condition:available', 'status:true'],
     NAMESPACE + '.replicaset.count': ['owner_kind:deployment', 'owner_name:metrics-server-v0.3.6'],
     NAMESPACE + '.namespace.count': ['phase:active', 'phase:terminating'],
     NAMESPACE + '.job.count': ['owner_kind:cronjob', 'owner_name:a-cronjob'],
@@ -373,19 +373,6 @@ def test_update_kube_state_metrics(aggregator, instance, check):
         NAMESPACE + '.persistentvolumes.by_phase',
         tags=['storageclass:local-data', 'phase:released', 'optional:tag1'],
         value=0,
-    )
-
-    # deployment counts
-    aggregator.assert_metric(
-        NAMESPACE + '.deployment.count',
-        tags=['namespace:default', 'optional:tag1'],
-        value=1,
-    )
-
-    aggregator.assert_metric(
-        NAMESPACE + '.deployment.count',
-        tags=['namespace:test', 'optional:tag1'],
-        value=1,
     )
 
     for metric in METRICS:
@@ -818,9 +805,9 @@ def test_telemetry(aggregator, instance):
 
     for _ in range(2):
         check.check(instance)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=94599.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=1010.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1338.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=93895.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=998.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1326.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.blacklist.count', tags=['optional:tag1'], value=24.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=328.0)
     aggregator.assert_metric(


### PR DESCRIPTION
### What does this PR do?

* Revert #8222 
* ignore `kube_deployment_status_condition` which is too high cardinality for our use
* use `kube_deployment_status_observed_generation` to count deployments instead

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
