### PR TITLE
Ensure default templates are included in config spec

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -153,6 +153,10 @@ def config(ctx, check, sync, verbose):
 def validate_default_template(spec_file):
     init_config_default = False
     instances_default = False
+    if 'template: init_config' not in spec_file and 'template: instances' not in spec_file:
+        # This config spec does not have init_config or instances
+        return True
+
     for line in spec_file.split('\n'):
         if any(template in line for template in ['init_config/default', 'init_config/openmetrics', 'init_config/jmx']):
             init_config_default = True

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -153,7 +153,7 @@ def config(ctx, check, sync, verbose):
 def validate_default_template(spec_file):
     init_config_default = False
     instances_default = False
-    if 'template: init_config' not in spec_file and 'template: instances' not in spec_file:
+    if 'template: init_config' not in spec_file or 'template: instances' not in spec_file:
         # This config spec does not have init_config or instances
         return True
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -79,9 +79,7 @@ def config(ctx, check, sync, verbose):
 
         if not default_temp:
             check_display_queue.append(
-                lambda **kwargs: echo_failure(
-                    f"Missing default template in init_config or instances section", **kwargs
-                )
+                lambda **kwargs: echo_failure("Missing default template in init_config or instances section")
             )
 
         if spec.errors:


### PR DESCRIPTION
### What does this PR do?
Some config specs are missing default template. These templates are used by the agent/global and should be present in all integrations.

CI failing because of pending fixes: https://github.com/DataDog/integrations-core/pull/8233/files
### Motivation
caught this in some contributor PRs and will make our own code reviews easier.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
