### PR TITLE
Add scaffolding for testing Agent with Kerberos

### DIFF
--- a/datadog_checks_base/tests/compose/kerberos-agent.yaml
+++ b/datadog_checks_base/tests/compose/kerberos-agent.yaml
@@ -2,6 +2,33 @@ version: '3.7'
 
 services:
 
+  agent:
+    image: agent
+    build: ./kerberos-agent
+    environment:
+      DD_API_KEY: 7764dc7695819b69cc62a4e6ce98d121
+      KRB5_KEYTAB: ${KRB5_KEYTAB}
+      KRB5_CCNAME: ${KRB5_CCNAME}
+      KRB5_REALM: ${KRB5_REALM}
+      KRB5_SVC: ${KRB5_SVC}
+      KRB5_KDC: kerberos-kdc
+      WEBHOST: ${WEBHOST}
+      DOMAIN: example.com
+      KRB5_USER: datadog/admin
+      KRB5_PASS: 123pass
+    hostname: agent
+    domainname: example.com
+    volumes:
+      - ${SHARED_VOLUME}:${SHARED_VOLUME}
+    networks:
+      kdc-net:
+        aliases:
+          - agent.example.com
+    depends_on:
+      - web
+      - kerberos-kdc
+
+
   kerberos-kdc:
     build: ./kerberos-kdc
     image: kerberos-kdc
@@ -42,7 +69,7 @@ services:
       DOMAIN: example.com
       KRB5_USER: datadog/admin
       KRB5_PASS: 123pass
-      SERVICE_NAME: ${KRB5_SVC}/${HOSTNAME}.${DOMAIN}
+      SERVICE_NAME: ${KRB5_SVC}/compose_web_1.compose_kdc-net
     hostname: web
     domainname: example.com
     volumes: 

--- a/datadog_checks_base/tests/compose/kerberos-agent.yaml
+++ b/datadog_checks_base/tests/compose/kerberos-agent.yaml
@@ -6,7 +6,7 @@ services:
     image: agent
     build: ./kerberos-agent
     environment:
-      DD_API_KEY: 7764dc7695819b69cc62a4e6ce98d121
+      DD_API_KEY: $DD_API_KEY
       KRB5_KEYTAB: ${KRB5_KEYTAB}
       KRB5_CCNAME: ${KRB5_CCNAME}
       KRB5_REALM: ${KRB5_REALM}

--- a/datadog_checks_base/tests/compose/kerberos-agent.yaml
+++ b/datadog_checks_base/tests/compose/kerberos-agent.yaml
@@ -6,7 +6,7 @@ services:
     image: agent
     build: ./kerberos-agent
     environment:
-      DD_API_KEY: $DD_API_KEY
+      DD_API_KEY: ${DD_API_KEY}
       KRB5_KEYTAB: ${KRB5_KEYTAB}
       KRB5_CCNAME: ${KRB5_CCNAME}
       KRB5_REALM: ${KRB5_REALM}

--- a/datadog_checks_base/tests/compose/kerberos-agent/Dockerfile
+++ b/datadog_checks_base/tests/compose/kerberos-agent/Dockerfile
@@ -1,0 +1,17 @@
+FROM datadog/agent:7.25.0-rc.4
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y -qq && apt-get install -y --no-install-recommends \
+  less \
+  vim
+
+COPY configurenginx.sh /opt/install/configurenginx.sh
+COPY configurekerberos.sh /opt/install/configurekerberos.sh
+COPY entrypoint.sh /opt/install/entrypoint.sh
+
+RUN chmod +x /opt/install/configurenginx.sh \
+    && chmod +x /opt/install/configurekerberos.sh \
+    && chmod +x /opt/install/entrypoint.sh
+
+ENTRYPOINT ["/opt/install/entrypoint.sh"]

--- a/datadog_checks_base/tests/compose/kerberos-agent/configurekerberos.sh
+++ b/datadog_checks_base/tests/compose/kerberos-agent/configurekerberos.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+echo "configuring kerberos..."
+kdc=$KRB5_KDC
+cat > /etc/krb5.conf << EOF
+[libdefaults]
+    default_tkt_enctypes = aes256-cts arcfour-hmac-md5 des-cbc-crc des-cbc-md5
+    default_tgs_enctypes = aes256-cts arcfour-hmac-md5 des-cbc-crc des-cbc-md5
+    default_keytab_name  = FILE:$KRB5_KEYTAB
+    default_realm        = $KRB5_REALM 
+    ticket_lifetime      = 24h
+    kdc_timesync         = 1
+    ccache_type          = 4
+    forwardable          = false
+    proxiable            = false
+
+[realms]
+    $KRB5_REALM = {
+        kdc            = $kdc.$DOMAIN:8888
+        admin_server   = $kdc.$DOMAIN:8749
+        default_domain = $DOMAIN 
+        kpasswd_port = 8464
+    }
+
+[domain_realm]
+    .kerberos.server = $KRB5_REALM 
+    .fabric.local    = $KRB5_REALM 
+    .$DOMAIN = $KRB5_REALM 
+EOF
+echo "kerberos configured as: "
+cat /etc/krb5.conf

--- a/datadog_checks_base/tests/compose/kerberos-agent/configurenginx.sh
+++ b/datadog_checks_base/tests/compose/kerberos-agent/configurenginx.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+echo "configuring nginx check ..."
+cat > /etc/datadog-agent/conf.d/nginx.d/nginx.yaml << EOF
+init_config: {}
+instances:
+- auth_type: kerberos
+  kerberos_auth: required
+  kerberos_cache: DIR:$KRB5_CCNAME
+  kerberos_keytab: $KRB5_KEYTAB
+  kerberos_force_initiate: 'true'
+  kerberos_hostname: web.example.com
+  kerberos_principal: user/inkeytab@EXAMPLE.COM
+  nginx_status_url: http://web:8080/nginx_status
+  url: http://web:8080
+EOF
+echo "nginx configured as: "
+cat /etc/datadog-agent/conf.d/nginx.d/nginx.yaml

--- a/datadog_checks_base/tests/compose/kerberos-agent/entrypoint.sh
+++ b/datadog_checks_base/tests/compose/kerberos-agent/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+/opt/install/configurekerberos.sh
+/opt/install/configurenginx.sh
+/init

--- a/datadog_checks_base/tests/compose/kerberos-agent/nginx.yaml
+++ b/datadog_checks_base/tests/compose/kerberos-agent/nginx.yaml
@@ -1,0 +1,11 @@
+init_config: {}
+instances:
+- auth_type: kerberos
+  kerberos_auth: required
+  kerberos_cache: DIR:$KRB5_CCNAME
+  kerberos_keytab: $KRB5_KEYTAB
+  kerberos_force_initiate: 'true'
+  kerberos_hostname: web.example.com
+  kerberos_principal: user/inkeytab@EXAMPLE.COM
+  nginx_status_url: http://web:8080/nginx_status
+  url: http://web:8080

--- a/datadog_checks_base/tests/compose/kerberos-kdc/init.sh
+++ b/datadog_checks_base/tests/compose/kerberos-kdc/init.sh
@@ -119,6 +119,10 @@ EOF
     kadmin.local -r ${KRB5_REALM} -p "K/M@KRV.SVC" -q "ktadd -k ${KRB5_KEYTAB} ${KRB5_SVC}/${WEBHOST}@${KRB5_REALM}"
     kadmin.local -r ${KRB5_REALM} -p "K/M@KRV.SVC" -q "ktadd -k ${KRB5_KEYTAB} ${KRB5_SVC}/localhost@${KRB5_REALM}"
 
+    # Add for supporting Agent-based verification
+    kadmin.local -r ${KRB5_REALM} -p "K/M@KRV.SVC" -q "addprinc -requires_preauth -randkey ${KRB5_SVC}/compose_web_1.compose_kdc-net@${KRB5_REALM}"
+    kadmin.local -r ${KRB5_REALM} -p "K/M@KRV.SVC" -q "ktadd -k ${KRB5_KEYTAB} ${KRB5_SVC}/compose_web_1.compose_kdc-net@${KRB5_REALM}"
+
     kadmin.local -r ${KRB5_REALM} -p "K/M@KRV.SVC" -q "ktadd -k ${KRB5_KEYTAB} user/inkeytab@${KRB5_REALM}"
 
     ## Lists all principals in realm

--- a/datadog_checks_base/tests/compose/kerberos-nginx/configurenginx.sh
+++ b/datadog_checks_base/tests/compose/kerberos-nginx/configurenginx.sh
@@ -17,7 +17,7 @@ server {
 
     auth_gss on;
     auth_gss_keytab ${KRB5_KEYTAB};
-    auth_gss_service_name ${KRB5_SVC}/${HOSTNAME}.${DOMAIN};
+    auth_gss_service_name ${SERVICE_NAME};
     auth_gss_realm ${KRB5_REALM};
     auth_gss_allow_basic_fallback off;
   }

--- a/datadog_checks_base/tests/compose/kerberos-nginx/setupkeytab.sh
+++ b/datadog_checks_base/tests/compose/kerberos-nginx/setupkeytab.sh
@@ -10,7 +10,7 @@ echo "realm: ${KRB5_REALM}"
 set -x
 
 ## Load principals into cache
-kinit -kt ${KRB5_KEYTAB} ${KRB5_SVC}/${HOSTNAME}.${DOMAIN}@${KRB5_REALM} -V
+kinit -kt ${KRB5_KEYTAB} ${SERVICE_NAME}@${KRB5_REALM} -V
 echo ${KRB5_PASS} | kinit user/nokeytab@${KRB5_REALM} -c ${KRB5_CCNAME}/tkt_nokeytab -V
 
 ## List principals in cache

--- a/datadog_checks_base/tests/compose/kerberos.yaml
+++ b/datadog_checks_base/tests/compose/kerberos.yaml
@@ -42,7 +42,7 @@ services:
       DOMAIN: example.com
       KRB5_USER: datadog/admin
       KRB5_PASS: 123pass
-      SERVICE_NAME: ${KRB5_SVC}/${HOSTNAME}.${DOMAIN}
+      SERVICE_NAME: ${KRB5_SVC}/${WEBHOST}
     hostname: web
     domainname: example.com
     volumes: 

--- a/datadog_checks_base/tests/conftest.py
+++ b/datadog_checks_base/tests/conftest.py
@@ -80,18 +80,18 @@ def kerberos_agent():
         }
 
         with docker_run(
-                compose_file=compose_file,
-                env_vars={
-                    'SHARED_VOLUME': shared_volume,
-                    'KRB5_CONFIG': krb5_conf,
-                    'KRB5_KEYTAB': common_config['keytab'],
-                    'KRB5_CCNAME': common_config['cache'],
-                    'KRB5_REALM': common_config['realm'],
-                    'KRB5_SVC': common_config['svc'],
-                    'WEBHOST': common_config['hostname'],
-                    'WEBPORT': webserver_port,
-                },
-                conditions=[CheckDockerLogs(compose_file, "ReadyToConnect")],
+            compose_file=compose_file,
+            env_vars={
+                'SHARED_VOLUME': shared_volume,
+                'KRB5_CONFIG': krb5_conf,
+                'KRB5_KEYTAB': common_config['keytab'],
+                'KRB5_CCNAME': common_config['cache'],
+                'KRB5_REALM': common_config['realm'],
+                'KRB5_SVC': common_config['svc'],
+                'WEBHOST': common_config['hostname'],
+                'WEBPORT': webserver_port,
+            },
+            conditions=[CheckDockerLogs(compose_file, "ReadyToConnect")],
         ):
             yield common_config
 

--- a/datadog_checks_base/tests/conftest.py
+++ b/datadog_checks_base/tests/conftest.py
@@ -57,6 +57,46 @@ def kerberos():
 
 
 @pytest.fixture(scope="session")
+def kerberos_agent():
+
+    with TempDir() as tmp_dir:
+        shared_volume = os.path.join(tmp_dir, "shared-volume")
+        compose_file = os.path.join(HERE, "compose", "kerberos-agent.yaml")
+        realm = "EXAMPLE.COM"
+        svc = "HTTP"
+        webserver_hostname = "web.example.com"
+        webserver_port = "8080"
+        krb5_conf = os.path.join(HERE, "fixtures", "kerberos", "krb5.conf")
+
+        common_config = {
+            "url": "http://localhost:{}".format(webserver_port),
+            "keytab": os.path.join(shared_volume, "http.keytab"),
+            "cache": os.path.join(shared_volume),
+            "realm": realm,
+            "svc": svc,
+            "hostname": webserver_hostname,
+            "principal": "user/inkeytab@{}".format(realm),
+            "tmp_dir": tmp_dir,
+        }
+
+        with docker_run(
+                compose_file=compose_file,
+                env_vars={
+                    'SHARED_VOLUME': shared_volume,
+                    'KRB5_CONFIG': krb5_conf,
+                    'KRB5_KEYTAB': common_config['keytab'],
+                    'KRB5_CCNAME': common_config['cache'],
+                    'KRB5_REALM': common_config['realm'],
+                    'KRB5_SVC': common_config['svc'],
+                    'WEBHOST': common_config['hostname'],
+                    'WEBPORT': webserver_port,
+                },
+                conditions=[CheckDockerLogs(compose_file, "ReadyToConnect")],
+        ):
+            yield common_config
+
+
+@pytest.fixture(scope="session")
 def uds_path():
     if Platform.is_mac():
         # See: https://github.com/docker/for-mac/issues/483

--- a/datadog_checks_base/tests/conftest.py
+++ b/datadog_checks_base/tests/conftest.py
@@ -77,6 +77,7 @@ def kerberos_agent():
             "hostname": webserver_hostname,
             "principal": "user/inkeytab@{}".format(realm),
             "tmp_dir": tmp_dir,
+            "dd_api_key": os.getenv('DD_API_KEY'),
         }
 
         with docker_run(
@@ -90,6 +91,7 @@ def kerberos_agent():
                 'KRB5_SVC': common_config['svc'],
                 'WEBHOST': common_config['hostname'],
                 'WEBPORT': webserver_port,
+                'DD_API_KEY': common_config['dd_api_key'],
             },
             conditions=[CheckDockerLogs(compose_file, "ReadyToConnect")],
         ):

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -520,6 +520,7 @@ class TestAuth:
         response = http.get(instance["url"])
 
         import time
+
         time.sleep(3600)
 
         assert response.status_code == 200

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -491,7 +491,7 @@ class TestAuth:
         response = http.get(instance["url"])
         assert response.status_code == 200
 
-    @pytest.mark.skipif(False, reason='Test fixture for Agent QA only')
+    @pytest.mark.skipif(True, reason='Test fixture for Agent QA only')
     def test_kerberos_auth_with_agent(self, kerberos_agent):
         """
         Test setup to verify kerberos authorization from an actual Agent container.

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -500,30 +500,17 @@ class TestAuth:
         1. Change decorator above from `True` to `False` to enable test
         2. Edit compose/kerberos-agent/Dockerfile to appropriate Agent release
         3. Run test via `ddev test -k test_kerberos_auth_with_agent datadog_checks_base:py38`
-        4. After compose builds, exec into Agent container via `docker exec -it compose_agent_1 /bin/bash`
+        4. After compose builds, and during `time.sleep` exec into Agent container in separate shell
+           via `docker exec -it compose_agent_1 /bin/bash`
         5. Execute check via `agent check nginx` and verify successful result.
         6. Exit test via Ctrl-C (test will show as failed, but that's okay)
         """
-
-        instance = {
-            'url': kerberos_agent["url"],
-            'auth_type': 'kerberos',
-            'kerberos_auth': 'required',
-            'kerberos_hostname': kerberos_agent["hostname"],
-            'kerberos_cache': "DIR:{}".format(kerberos_agent["tmp_dir"]),
-            'kerberos_keytab': kerberos_agent["keytab"],
-            'kerberos_principal': "user/inkeytab@{}".format(kerberos_agent["realm"]),
-            'kerberos_force_initiate': 'true',
-        }
-        init_config = {}
-        http = RequestsWrapper(instance, init_config)
-        response = http.get(instance["url"])
-
         import time
 
         time.sleep(3600)
 
-        assert response.status_code == 200
+        # Assertion just to provide logical breakpoint.
+        assert True
 
     def test_config_ntlm(self):
         instance = {'auth_type': 'ntlm', 'ntlm_domain': 'domain\\user', 'password': 'pass'}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -132,6 +132,13 @@ def test(
         test_env_vars[E2E_PARENT_PYTHON] = sys.executable
         test_env_vars['TOX_TESTENV_PASSENV'] += f' {E2E_PARENT_PYTHON}'
 
+    org_name = ctx.obj['org']
+    org = ctx.obj['orgs'].get(org_name, {})
+    api_key = org.get('api_key') or ctx.obj['dd_api_key'] or os.getenv('DD_API_KEY')
+    if api_key:
+        test_env_vars['DD_API_KEY'] = api_key
+        test_env_vars['TOX_TESTENV_PASSENV'] += f' DD_API_KEY'
+
     check_envs = get_tox_envs(checks, style=style, format_style=format_style, benchmark=bench, changed_only=changed)
     tests_ran = False
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -137,7 +137,7 @@ def test(
     api_key = org.get('api_key') or ctx.obj['dd_api_key'] or os.getenv('DD_API_KEY')
     if api_key:
         test_env_vars['DD_API_KEY'] = api_key
-        test_env_vars['TOX_TESTENV_PASSENV'] += f' DD_API_KEY'
+        test_env_vars['TOX_TESTENV_PASSENV'] += ' DD_API_KEY'
 
     check_envs = get_tox_envs(checks, style=style, format_style=format_style, benchmark=bench, changed_only=changed)
     tests_ran = False


### PR DESCRIPTION
### What does this PR do?
For Agent QA, it can be helpful to test our Kerberos authentication using the actual Agent container, rather than just a stub.

This adds an additional docker-compose setup for testing.

This currently relies on a manual inspection of the Agent check, but it could also be improved to be fully automated if that need arises.

Steps to utilize the test fixture:

1. Change test decorator from `True` to `False` to enable test
2. Edit compose/kerberos-agent/Dockerfile to appropriate Agent release
3. Run test via `ddev test -k test_kerberos_auth_with_agent datadog_checks_base:py38`
4. After compose builds, exec into Agent container via `docker exec -it compose_agent_1 /bin/bash`
5. Execute check via `agent check nginx` and verify successful result.
6. Exit test via Ctrl-C (test will show as failed, but that's okay)


### Motivation
Agent QA

