### PR TITLE
Add exec command option to ddev env shell

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/shell.py
@@ -11,9 +11,10 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info
 @click.command('shell', context_settings=CONTEXT_SETTINGS, short_help='Run a shell inside agent container')
 @click.argument('check', autocompletion=complete_active_checks)
 @click.argument('env', autocompletion=complete_configured_envs, required=False)
+@click.option('-c', '--exec-command', help='Optionally execute command inside container, executes after any installs')
 @click.option('-v', '--install-vim', is_flag=True, help='Optionally install editing/viewing tools vim and less')
 @click.option('-i', '--install-tools', multiple=True, help='Optionally install custom tools')
-def shell(check, env, install_vim, install_tools):
+def shell(check, env, exec_command, install_vim, install_tools):
     """Run a shell inside the Agent docker container."""
     envs = get_configured_envs(check)
     if not envs:
@@ -45,6 +46,11 @@ def shell(check, env, install_vim, install_tools):
             tools.extend(('less', 'vim'))
         echo_info(f'Installing helper tools: {", ".join(tools)}')
         environment.exec_command('/bin/bash -c "apt update && apt install -y {}"'.format(" ".join(tools)))
+
+    if exec_command:
+        echo_info(f'Executing command: {exec_command}...')
+        environment.exec_command(f'/bin/bash -c "{exec_command}"')
+        return
 
     result = environment.shell()
 


### PR DESCRIPTION
### What does this PR do?
Adds a new option `--exec-command` to `ddev env shell` to execute a command directly.  

For example: `ddev env shell snowflake -c "apt update && apt install -y libssl-dev"`

In most cases the better approach is to edit the underlying Docker file, but when experimenting this can be a nice approach.  A side benefit: the commands will be stored in command history for easy repeatability.

### Motivation
Testing required manual tweaks.

