### PR TITLE
Update prometheus_metrics_prefix documentation

### DIFF
--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -80,7 +80,7 @@ instances:
     prometheus_url: <PROMETHEUS_URL>
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
@@ -56,7 +56,7 @@ instances:
     edge_agent_prometheus_url: http://edgeAgent:9600/metrics
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/cilium/datadog_checks/cilium/data/conf.yaml.example
+++ b/cilium/datadog_checks/cilium/data/conf.yaml.example
@@ -59,7 +59,7 @@ instances:
     # operator_endpoint: http://localhost:6942/metrics
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -51,7 +51,7 @@ instances:
   - prometheus_url: http://localhost:8080/_status/vars
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -70,7 +70,7 @@ instances:
       - coredns_template_rr_failures_total: template_resource_record_failures_count
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/crio/datadog_checks/crio/data/conf.yaml.example
+++ b/crio/datadog_checks/crio/data/conf.yaml.example
@@ -51,7 +51,7 @@ instances:
   - prometheus_url: http://localhost:9090/metrics
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -25,7 +25,7 @@
     items:
       type: string
 - name: prometheus_metrics_prefix
-  description: <PREFIX> for exposed Prometheus metrics.
+  description: Removes a given <PREFIX> from exposed Prometheus metrics.
   value:
     type: string
     example: <PREFIX>_

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -57,7 +57,7 @@ instances:
     prometheus_url: http://localhost:2379/metrics
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/external_dns/datadog_checks/external_dns/data/conf.yaml.example
+++ b/external_dns/datadog_checks/external_dns/data/conf.yaml.example
@@ -51,7 +51,7 @@ instances:
   - prometheus_url: http://localhost:7979/metrics
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -21,7 +21,7 @@ instances:
     prometheus_url: http://<GITLAB_URL>/-/metrics
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -105,7 +105,7 @@ instances:
     prometheus_endpoint: http://<PROMETHEUS_ENDPOINT>:<PROMETHEUS_PORT>/metrics
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -198,7 +198,7 @@ instances:
     prometheus_url: <PROMETHEUS_URL>
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -90,7 +90,7 @@ instances:
     # citadel_endpoint: http://istio-citadel.istio-system:15014/metrics
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -58,7 +58,7 @@ instances:
     # scheme: https
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -56,7 +56,7 @@ instances:
     # leader_election: true
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/linkerd/datadog_checks/linkerd/data/conf.yaml.example
+++ b/linkerd/datadog_checks/linkerd/data/conf.yaml.example
@@ -51,7 +51,7 @@ instances:
   - prometheus_url: http://localhost:9990/admin/metrics/prometheus
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -59,7 +59,7 @@ instances:
     # collect_nginx_histograms: false
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -65,7 +65,7 @@ instances:
       - io
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -73,7 +73,7 @@ instances:
     #   - scylla.tracing
 
     ## @param prometheus_metrics_prefix - string - optional
-    ## <PREFIX> for exposed Prometheus metrics.
+    ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #
     # prometheus_metrics_prefix: <PREFIX>_
 


### PR DESCRIPTION
`prometheus_metrics_prefix` is used when the prometheus all have the same prefix and removes that prefix before submitting the metrics. See https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L122

This PR makes this behavior a bit more clear.