### PR TITLE
Fix release

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -12,7 +12,8 @@ securesystemslib.settings.SUBPROCESS_TIMEOUT = 60
 
 from securesystemslib.gpg.constants import GPG_COMMAND
 
-from in_toto import runlib, util
+from in_toto import runlib
+from securesystemslib.interface import import_rsa_privatekey_from_file
 
 from .constants import get_root
 from .git import ignored_by_git, tracked_by_git
@@ -109,7 +110,7 @@ def update_link_metadata(checks, core_workflow=True):
         options = {'gpg_keyid': key_id, 'normalize_line_endings': True}
     else:
         signing_key_path = os.getenv('IN_TOTO_SIGNING_KEY_PATH', '')
-        signing_key = util.import_rsa_key_from_file(signing_key_path, os.getenv('IN_TOTO_SIGNING_KEY_PASSWORD'))
+        signing_key = import_rsa_privatekey_from_file(signing_key_path, os.getenv('IN_TOTO_SIGNING_KEY_PASSWORD'))
 
         # NOTE: in-toto currently uses the first 8 characters of the signing keyID,
         # the latter of which we assume is the key filename.


### PR DESCRIPTION
Since `in-toto` v1.0.0 update, importing `util` from `in-toto` is not possible anymore.