### PR TITLE
Move ZooKeeper SSL info out of Hosts tab in README

### DIFF
--- a/zk/README.md
+++ b/zk/README.md
@@ -19,7 +19,6 @@ The ZooKeeper check is included in the [Datadog Agent][3] package, so you don't 
 As of version 3.5, ZooKeeper has a `4lw.commands.whitelist` parameter (see [ZooKeeper documentation][7]) that whitelists [four letter word commands][8]. By default, only `srvr` is whitelisted. Add `stat` and `mntr` to the whitelist, as the integration is based on these commands.
 
 #### Enabling SSL
-_Available for Agent versions >=7.24.0 and ZooKeeper integration versions >=2.9.0. [See Changelog][14]._
 
 ZooKeeper 3.5 introduced the ability to use SSL authentication. For information about setting up SSL with ZooKeeper, see the [ZooKeeper SSL User Guide][13]. 
 
@@ -204,4 +203,3 @@ Need help? Contact [Datadog support][11].
 [11]: https://docs.datadoghq.com/help/
 [12]: https://docs.datadoghq.com/agent/kubernetes/log/
 [13]: https://cwiki.apache.org/confluence/display/ZOOKEEPER/ZooKeeper+SSL+User+Guide
-[14]: https://github.com/DataDog/integrations-core/blob/master/zk/CHANGELOG.md

--- a/zk/README.md
+++ b/zk/README.md
@@ -18,18 +18,6 @@ The ZooKeeper check is included in the [Datadog Agent][3] package, so you don't 
 
 As of version 3.5, ZooKeeper has a `4lw.commands.whitelist` parameter (see [ZooKeeper documentation][7]) that whitelists [four letter word commands][8]. By default, only `srvr` is whitelisted. Add `stat` and `mntr` to the whitelist, as the integration is based on these commands.
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Host" xxx -->
-
-#### Host
-
-To configure this check for an Agent running on a host:
-
-1. Edit the `zk.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4] to start collecting your ZooKeeper [metrics](#metric-collection) and [logs](#log-collection).
-   See the [sample zk.d/conf.yaml][5] for all available configuration options.
-
-2. [Restart the Agent][6].
-
 #### Enabling SSL
 _Available for Agent versions >=7.24.0 and ZooKeeper integration versions >=2.9.0. [See Changelog][14]._
 
@@ -63,6 +51,18 @@ To convert the JKS files to PEM files:
    ```
    openssl pkcs12 -in cert.p12 -out cert.pem
    ``` 
+   
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Host" xxx -->
+
+#### Host
+
+To configure this check for an Agent running on a host:
+
+1. Edit the `zk.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][4] to start collecting your ZooKeeper [metrics](#metric-collection) and [logs](#log-collection).
+   See the [sample zk.d/conf.yaml][5] for all available configuration options.
+
+2. [Restart the Agent][6].
 
 #### Log collection
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

The ZooKeeper SSL information was accidentally placed under the Hosts tab, which could unintentionally convey that SSL is not supported for Containerized:
![image](https://user-images.githubusercontent.com/31313038/102931750-f1decf80-446c-11eb-8a41-54b8cf4bead7.png)

This PR moves the SSL information to under the ZooKeeper Whitelist tab.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
