### PR TITLE
Fix marklogic.forests.total_load unit

### DIFF
--- a/marklogic/metadata.csv
+++ b/marklogic/metadata.csv
@@ -125,7 +125,7 @@ marklogic.forests.storage.host.forest_size,gauge,,mebibyte,,"The total ordinary 
 marklogic.forests.storage.host.large_data_size,gauge,,mebibyte,,"The amount of space large objects take up on disk.",0,marklogic,forest stor host large data size
 marklogic.forests.storage.host.remaining_space,gauge,,mebibyte,,"The total free storage for forests.",0,marklogic,forest stor host remaining space
 marklogic.forests.total_forests,gauge,,unit,,"The total number of forests.",0,marklogic,forest tot
-marklogic.forests.total_load,gauge,,mebibyte,second,"The sum of the processing load factors.",0,marklogic,forest tot load
+marklogic.forests.total_load,gauge,,,,"The sum of the processing load factors.",0,marklogic,forest tot load
 marklogic.forests.total_rate,gauge,,mebibyte,second,"The sum of the processing rate factors.",0,marklogic,forest tot rate
 marklogic.forests.triple_cache_hit_rate,gauge,,hit,second,"The average number of hits on the list cache.",0,marklogic,forest t cache hit rate
 marklogic.forests.triple_cache_miss_rate,gauge,,miss,second,"The average number of misses on the list cache.",0,marklogic,forest t cache miss rate


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix `marklogic.forests.total_load` unit
According to the [doc](https://docs.marklogic.com/REST/GET/manage/v2/forests@view=status): `The sum of the processing load factors in seconds per second.`

### Motivation
<!-- What inspired you to submit this pull request? -->
Noticed it in #8226 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
