### PR TITLE
Fix deployment count metric

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -124,9 +124,9 @@ class KubernetesState(OpenMetricsBaseCheck):
             'kube_node_spec_unschedulable': self.kube_node_spec_unschedulable,
             'kube_resourcequota': self.kube_resourcequota,
             'kube_limitrange': self.kube_limitrange,
-            'kube_persistentvolume_status_phase': self.count_values_by_tags,
+            'kube_persistentvolume_status_phase': self.sum_values_by_tags,
             'kube_service_spec_type': self.count_objects_by_tags,
-            'kube_namespace_status_phase': self.count_values_by_tags,
+            'kube_namespace_status_phase': self.sum_values_by_tags,
             'kube_replicaset_owner': self.count_objects_by_tags,
             'kube_job_owner': self.count_objects_by_tags,
             'kube_deployment_status_observed_generation': self.count_objects_by_tags,
@@ -867,8 +867,8 @@ class KubernetesState(OpenMetricsBaseCheck):
         else:
             self.log.error("Metric type %s unsupported for metric %s", metric.type, metric.name)
 
-    def count_values_by_tags(self, metric, scraper_config):
-        """ Count objects by allowed tags and submit counts as gauges. """
+    def sum_values_by_tags(self, metric, scraper_config):
+        """ Sum values by allowed tags and submit counts as gauges. """
         config = self.object_count_params[metric.name]
         metric_name = "{}.{}".format(scraper_config['namespace'], config['metric_name'])
         object_counter = Counter()

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -126,7 +126,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             'kube_limitrange': self.kube_limitrange,
             'kube_persistentvolume_status_phase': self.count_values_by_tags,
             'kube_service_spec_type': self.count_objects_by_tags,
-            'kube_namespace_status_phase': self.count_objects_by_tags,
+            'kube_namespace_status_phase': self.count_values_by_tags,
             'kube_replicaset_owner': self.count_objects_by_tags,
             'kube_job_owner': self.count_objects_by_tags,
             'kube_deployment_status_observed_generation': self.count_objects_by_tags,

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -100,9 +100,9 @@ kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="tiller-d
 # HELP kube_deployment_status_observed_generation The generation observed by the deployment controller.
 # TYPE kube_deployment_status_observed_generation gauge
 kube_deployment_status_observed_generation{deployment="failingtest",namespace="default"} 1
-kube_deployment_status_observed_generation{deployment="jaundiced-numbat-kube-state-metrics",namespace="default"} 1
+kube_deployment_status_observed_generation{deployment="jaundiced-numbat-kube-state-metrics",namespace="default"} 4
 kube_deployment_status_observed_generation{deployment="kube-dns",namespace="kube-system"} 1
-kube_deployment_status_observed_generation{deployment="tiller-deploy",namespace="kube-system"} 1
+kube_deployment_status_observed_generation{deployment="tiller-deploy",namespace="kube-system"} 5
 # HELP kube_deployment_status_replicas The number of replicas per deployment.
 # TYPE kube_deployment_status_replicas gauge
 kube_deployment_status_replicas{deployment="failingtest",namespace="default"} 1


### PR DESCRIPTION
### What does this PR do?

Count the number of objects instead of summing up values for certain count metrics.
Otherwise the deployment count metric would sum up the number of deployment generations

### Motivation
Fix deployment count metric

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
