### PR TITLE
Add version verification for datadog-checks-base

### DIFF
--- a/activemq/setup.py
+++ b/activemq/setup.py
@@ -27,6 +27,9 @@ def get_dependencies():
         return f.readlines()
 
 
+CHECKS_BASE_REQ = 'datadog-checks-base'
+
+
 setup(
     name='datadog-activemq',
     version=ABOUT['__version__'],
@@ -54,7 +57,7 @@ setup(
     # The package we're going to ship
     packages=['datadog_checks.activemq'],
     # Run-time dependencies
-    install_requires=['datadog-checks-base'],
+    install_requires=[CHECKS_BASE_REQ],
     extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/cassandra/setup.py
+++ b/cassandra/setup.py
@@ -27,6 +27,9 @@ def get_dependencies():
         return f.readlines()
 
 
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+
+
 setup(
     name='datadog-cassandra',
     version=ABOUT['__version__'],
@@ -56,7 +59,7 @@ setup(
     # The package we're going to ship
     packages=['datadog_checks.cassandra'],
     # Run-time dependencies
-    install_requires=['datadog-checks-base>=11.0.0'],
+    install_requires=[CHECKS_BASE_REQ],
     extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/cassandra/setup.py
+++ b/cassandra/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 
 setup(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
@@ -4,7 +4,7 @@
 import click
 
 from ....utils import get_next
-from ...dependencies import read_agent_dependencies, read_check_dependencies
+from ...dependencies import read_agent_dependencies, read_check_dependencies, read_check_base_dependencies
 from ..console import CONTEXT_SETTINGS, abort, echo_failure
 
 
@@ -29,6 +29,36 @@ def format_check_usage(checks, default=None):
         remaining = num_checks - 2
         plurality = 's' if remaining > 1 else ''
         return f'{checks[0]}, {checks[1]}, and {remaining} other{plurality}'
+
+
+def verify_base_dependency(source, name, base_versions, force_pinned=True):
+    """Minimal dependency verification for `datadog-checks-base` dependencies.
+
+    Ensures that the version isn't specifically pinned since that will limit check installations.
+    Optionally ensures that dependencies which have no pins are reported as errors.
+    """
+    for specifier_set, dependency_definitions in base_versions.items():
+        checks = sorted(dep.check_name for dep in dependency_definitions)
+
+        if not specifier_set and force_pinned:
+            echo_failure(f'Unspecified version found for dependency `{name}`: {format_check_usage(checks, source)}')
+            return False
+        elif len(specifier_set) > 1:
+            echo_failure(
+                f'Multiple unstable version pins `{specifier_set}` found for dependency `{name}`: '
+                f'{format_check_usage(checks, source)}'
+            )
+            return False
+        elif specifier_set:
+            specifier = get_next(specifier_set)
+            if specifier.operator != '>=':
+                echo_failure(
+                    f'Forced version pin `{specifier}` found for dependency `{name}` '
+                    f'(use >= explicitly for base dependency): {format_check_usage(checks, source)}'
+                )
+                return False
+
+    return True
 
 
 def verify_dependency(source, name, versions):
@@ -76,7 +106,10 @@ def verify_dependency(source, name, versions):
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Verify dependencies across all checks')
-def dep():
+@click.option(
+    '--require-base-check-version', is_flag=True, help='Require specific version for datadog-checks-base requirement'
+)
+def dep(require_base_check_version):
     """
     This command will:
 
@@ -84,12 +117,22 @@ def dep():
     * Verify all the dependencies are pinned.
     * Verify the embedded Python environment defined in the base check and requirements
       listed in every integration are compatible.
+    * Verify each check specifies a `CHECKS_BASE_REQ` variable for `datadog-checks-base` requirement
+    * Optionally verify that the `datadog-checks-base` requirement is lower-bounded
     """
     failed = False
     check_dependencies, check_errors = read_check_dependencies()
 
     if check_errors:
         for check_error in check_errors:
+            echo_failure(check_error)
+
+        abort()
+
+    check_base_dependencies, check_base_errors = read_check_base_dependencies()
+
+    if check_base_errors:
+        for check_error in check_base_errors:
             echo_failure(check_error)
 
         abort()
@@ -109,6 +152,10 @@ def dep():
         if name not in agent_dependencies:
             failed = True
             echo_failure(f'Dependency needs to be synced: {name}')
+
+    for name, versions in sorted(check_base_dependencies.items()):
+        if not verify_base_dependency('Base Checks', name, versions, force_pinned=require_base_check_version):
+            failed = True
 
     for name, versions in sorted(agent_dependencies.items()):
         if not verify_dependency('Agent', name, versions):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
@@ -4,7 +4,7 @@
 import click
 
 from ....utils import get_next
-from ...dependencies import read_agent_dependencies, read_check_dependencies, read_check_base_dependencies
+from ...dependencies import read_agent_dependencies, read_check_base_dependencies, read_check_dependencies
 from ..console import CONTEXT_SETTINGS, abort, echo_failure
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
@@ -18,6 +18,9 @@ class DependencyDefinition:
         self.line_number = line_number
         self.check_name = check_name
 
+    def __repr__(self):
+        return f'<DependencyDefinition name={self.name} check_name={self.check_name} requirement={self.requirement}'
+
 
 def create_dependency_data():
     return defaultdict(lambda: defaultdict(lambda: []))
@@ -40,14 +43,48 @@ def load_dependency_data(req_file, dependencies, errors, check_name=None):
         dependency.append(DependencyDefinition(name, req, req_file, i, check_name))
 
 
+def load_base_check(req_file, dependencies, errors, check_name=None):
+    for i, line in enumerate(stream_file_lines(req_file)):
+        line = line.strip()
+        if line.startswith('CHECKS_BASE_REQ'):
+            try:
+                dep = line.split(' = ')[1]
+                req = Requirement(dep.strip("'"))
+            except InvalidRequirement as e:
+                errors.append(f'File `{req_file}` has an invalid base check dependency: `{line}`\n{e}')
+                return
+
+            name = req.name.lower()
+            dependency = dependencies[name][req.specifier]
+            dependency.append(DependencyDefinition(name, req, req_file, i, check_name))
+            return
+
+    # no `CHECKS_BASE_REQ` found in setup.py file ..
+    errors.append(f'File `{req_file}` missing base check dependency `CHECKS_BASE_REQ`')
+
+
 def read_check_dependencies():
     root = get_root()
     dependencies = create_dependency_data()
     errors = []
 
-    for check_name in get_valid_checks():
+    for check_name in sorted(get_valid_checks()):
         req_file = os.path.join(root, check_name, 'requirements.in')
         load_dependency_data(req_file, dependencies, errors, check_name)
+
+    return dependencies, errors
+
+
+def read_check_base_dependencies():
+    root = get_root()
+    dependencies = create_dependency_data()
+    errors = []
+
+    for check_name in sorted(get_valid_checks()):
+        if check_name.startswith('datadog_checks_'):
+            continue
+        req_file = os.path.join(root, check_name, 'setup.py')
+        load_base_check(req_file, dependencies, errors, check_name)
 
     return dependencies, errors
 

--- a/kafka/setup.py
+++ b/kafka/setup.py
@@ -27,6 +27,9 @@ def get_dependencies():
         return f.readlines()
 
 
+CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
+
+
 setup(
     name='datadog-kafka',
     version=ABOUT['__version__'],
@@ -56,7 +59,7 @@ setup(
     # The package we're going to ship
     packages=['datadog_checks.kafka'],
     # Run-time dependencies
-    install_requires=['datadog-checks-base>=11.0.0'],
+    install_requires=[CHECKS_BASE_REQ],
     extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/kafka/setup.py
+++ b/kafka/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base'
 
 
 setup(

--- a/proxysql/setup.py
+++ b/proxysql/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = ['datadog-checks-base>=15.2.0']
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.2.0'
 
 
 setup(
@@ -57,7 +57,7 @@ setup(
     # The package we're going to ship
     packages=['datadog_checks.proxysql'],
     # Run-time dependencies
-    install_requires=CHECKS_BASE_REQ,
+    install_requires=[CHECKS_BASE_REQ],
     extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/solr/setup.py
+++ b/solr/setup.py
@@ -27,6 +27,9 @@ def get_dependencies():
         return f.readlines()
 
 
+CHECKS_BASE_REQ = 'datadog-checks-base'
+
+
 setup(
     name='datadog-solr',
     version=ABOUT['__version__'],
@@ -54,7 +57,7 @@ setup(
     # The package we're going to ship
     packages=['datadog_checks.solr'],
     # Run-time dependencies
-    install_requires=['datadog-checks-base'],
+    install_requires=[CHECKS_BASE_REQ],
     extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,

--- a/tomcat/setup.py
+++ b/tomcat/setup.py
@@ -27,6 +27,9 @@ def get_dependencies():
         return f.readlines()
 
 
+CHECKS_BASE_REQ = 'datadog-checks-base'
+
+
 setup(
     name='datadog-tomcat',
     version=ABOUT['__version__'],
@@ -54,7 +57,7 @@ setup(
     # The package we're going to ship
     packages=['datadog_checks.tomcat'],
     # Run-time dependencies
-    install_requires=['datadog-checks-base'],
+    install_requires=[CHECKS_BASE_REQ],
     extras_require={'deps': get_dependencies()},
     # Extra files to ship with the wheel package
     include_package_data=True,


### PR DESCRIPTION
### What does this PR do?
Expands the `ddev validate dep` command to also examine check `setup.py` files ensuring they specify a dependency on `datadog-checks-base`.  

Also normalizes a few older check files to use the same format of `CHECKS_BASE_REQ = 'datadog-checks-base'`, so that the validation will pass.

By default, the validation only checks if the dependency exists, optionally it can ensure that it's pinned to a minimum version.  This extra option could be added to CI for PR's only, so that we don't force changes on checks all at once.  Output with this option enabled:

```
❯ ddev validate dep --require-base-check-version
Unspecified version found for dependency `datadog-checks-base`: activemq, btrfs, and 26 others
```

UPDATED:

Added option `--min-base-check-version` which allows for a version specifier to verify against each requirement.  Can be combined with the existing option for output like so:

```
❯ ddev validate dep --require-base-check-version --min-base-check-version '1.0.0'
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=11.2.0`: active_directory, aspdotnet, and 3 others
Unspecified version found for dependency `datadog-checks-base`: activemq, btrfs, and 26 others
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=11.0.0`: activemq_xml, apache, and 60 others
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=4.2.0`: aerospike, airflow, and 8 others
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=15.4.0`: amazon_msk, cilium, and 14 others
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=7.0.0`: ambari
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=11.4.0`: dotnetclr
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=11.1.0`: fluentd and mongo
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=15.5.0`: http_check
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=9.3.2`: ibm_mq
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=6.5.0`: kubelet
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=15.1.0`: marathon, mesos_master, and 2 others
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=15.2.0`: mysql, postgres, and 2 others
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=13.1.0`: network
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=11.3.1`: proxysql
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=5.1.0`: redisdb
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=15.7.0`: rethinkdb
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=15.0.0`: snowflake
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=11.3.0`: twistlock
Minimum datadog_checks_base version `1.0.0` not satisfied by dependency specifier `>=11.6.0`: wmi_check
```

Or standalone:

```
❯ ddev validate dep --min-base-check-version '11.0.0'
Minimum datadog_checks_base version `11.0.0` not satisfied by dependency specifier `>=11.2.0`: active_directory, aspdotnet, and 3 others
Minimum datadog_checks_base version `11.0.0` not satisfied by dependency specifier `>=15.4.0`: amazon_msk, cilium, and 14 others
Minimum datadog_checks_base version `11.0.0` not satisfied by dependency specifier `>=11.4.0`: dotnetclr
Minimum datadog_checks_base version `11.0.0` not satisfied by dependency specifier `>=11.1.0`: fluentd and mongo
Minimum datadog_checks_base version `11.0.0` not satisfied by dependency specifier `>=15.5.0`: http_check
Minimum datadog_checks_base version `11.0.0` not satisfied by dependency specifier `>=15.1.0`: marathon, mesos_master, and 2 others
Minimum datadog_checks_base version `11.0.0` not satisfied by dependency specifier `>=15.2.0`: mysql, postgres, and 2 others
Minimum datadog_checks_base version `11.0.0` not satisfied by dependency specifier `>=13.1.0`: network
Minimum datadog_checks_base version `11.0.0` not satisfied by dependency specifier `>=11.3.1`: proxysql
Minimum datadog_checks_base version `11.0.0` not satisfied by dependency specifier `>=15.7.0`: rethinkdb
Minimum datadog_checks_base version `11.0.0` not satisfied by dependency specifier `>=15.0.0`: snowflake
Minimum datadog_checks_base version `11.0.0` not satisfied by dependency specifier `>=11.3.0`: twistlock
Minimum datadog_checks_base version `11.0.0` not satisfied by dependency specifier `>=11.6.0`: wmi_check
```