### PR TITLE
Fix cacti config

### DIFF
--- a/cacti/assets/configuration/spec.yaml
+++ b/cacti/assets/configuration/spec.yaml
@@ -74,7 +74,7 @@ files:
             value:
               example: <RRD_WHITELIST_FILE_PATH>
               type: string
-          - template: instances/tags
+          - template: instances/default
       - template: logs
         example:
           - type: file

--- a/cacti/datadog_checks/cacti/data/conf.yaml.example
+++ b/cacti/datadog_checks/cacti/data/conf.yaml.example
@@ -82,6 +82,26 @@ instances:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
 
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Overrides any `service` defined in the `init_config` section.
+    #
+    # service: <SERVICE>
+
+    ## @param min_collection_interval - number - optional - default: 15
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    # min_collection_interval: 15
+
+    ## @param empty_default_hostname - boolean - optional - default: false
+    ## This forces the check to send metrics with no hostname.
+    ##
+    ## This is useful for cluster-level checks.
+    #
+    # empty_default_hostname: false
+
 ## Log Section
 ##
 ## type - required - Type of log input source (tcp / udp / file / windows_event)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR fixes Cacti's `spec.yaml` to add in the `default` template. 
This is blocking https://github.com/DataDog/integrations-core/pull/8230 because the CI keeps failing.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
