### PR TITLE
Add Ceph Recovery metrics

### DIFF
--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -201,6 +201,41 @@ class Ceph(AgentCheck):
                 except KeyError:
                     osdinfo['client_io_rate'].update({'write_bytes_sec': 0})
                     self._publish(osdinfo, self.gauge, ['client_io_rate', 'write_bytes_sec'], local_tags)
+
+                try:
+                    osdinfo['recovery']['misplaced_objects']
+                    self._publish(osdinfo, self.gauge, ['recovery', 'misplaced_objects'], local_tags)
+                except KeyError:
+                    osdinfo['recovery'].update({'misplaced_objects': 0})
+                    self._publish(osdinfo, self.gauge, ['recovery', 'misplaced_objects'], local_tags)
+
+                try:
+                    osdinfo['recovery']['misplaced_total']
+                    self._publish(osdinfo, self.gauge, ['recovery', 'misplaced_total'], local_tags)
+                except KeyError:
+                    osdinfo['recovery'].update({'misplaced_total': 0})
+                    self._publish(osdinfo, self.gauge, ['recovery', 'misplaced_total'], local_tags)
+
+                try:
+                    osdinfo['recovery_rate']['recovering_objects_per_sec']
+                    self._publish(osdinfo, self.gauge, ['recovery_rate', 'recovering_objects_per_sec'], local_tags)
+                except KeyError:
+                    osdinfo['recovery_rate'].update({'recovering_objects_per_sec': 0})
+                    self._publish(osdinfo, self.gauge, ['recovery_rate', 'recovering_objects_per_sec'], local_tags)
+
+                try:
+                    osdinfo['recovery_rate']['recovering_bytes_per_sec']
+                    self._publish(osdinfo, self.gauge, ['recovery_rate', 'recovering_bytes_per_sec'], local_tags)
+                except KeyError:
+                    osdinfo['recovery_rate'].update({'recovering_bytes_per_sec': 0})
+                    self._publish(osdinfo, self.gauge, ['recovery_rate', 'recovering_bytes_per_sec'], local_tags)
+
+                try:
+                    osdinfo['recovery_rate']['recovering_keys_per_sec']
+                    self._publish(osdinfo, self.gauge, ['recovery_rate', 'recovering_keys_per_sec'], local_tags)
+                except KeyError:
+                    osdinfo['recovery_rate'].update({'recovering_keys_per_sec': 0})
+                    self._publish(osdinfo, self.gauge, ['recovery_rate', 'recovering_keys_per_sec'], local_tags)
         except KeyError:
             self.log.debug('Error retrieving osd_pool_stats metrics')
 

--- a/ceph/metadata.csv
+++ b/ceph/metadata.csv
@@ -22,7 +22,7 @@ ceph.num_near_full_osds,gauge,,item,,Number of nearly full osds,-1,ceph,near ful
 ceph.num_full_osds,gauge,,item,,Number of full osds,-1,ceph,full osds
 ceph.osd.pct_used,gauge,,percent,,Percentage used of full/near full osds,-1,ceph,osd pct used
 ceph.misplaced_objects,gauge,,item,,Number of objects misplaced,-1,ceph,misplaced objects
-ceph.misplaced_objects_total,gauge,,item,,Total number of objects if there are misplaced objects,0,ceph,misplaced objects total
+ceph.misplaced_total,gauge,,item,,Total number of objects if there are misplaced objects,0,ceph,misplaced objects total
 ceph.recovery_objects_per_sec,gauge,,item,second,Rate of recovered objects,0,ceph,recovery objects per sec
 ceph.recovery_bytes_per_sec,gauge,,byte,second,Rate of recovered bytes,0,ceph,recovery bytes per sec
 ceph.recovery_keys_per_sec,gauge,,item,second,Rate of recovered keys,0,ceph,recovery keys per sec

--- a/ceph/metadata.csv
+++ b/ceph/metadata.csv
@@ -21,8 +21,8 @@ ceph.write_op_per_sec,gauge,,operation,second,Per-pool write operations/second,0
 ceph.num_near_full_osds,gauge,,item,,Number of nearly full osds,-1,ceph,near full osds
 ceph.num_full_osds,gauge,,item,,Number of full osds,-1,ceph,full osds
 ceph.osd.pct_used,gauge,,percent,,Percentage used of full/near full osds,-1,ceph,osd pct used
-ceph.misplaced_objects,guage,,item,,Number of objects misplaced,-1,ceph,misplaced objects
-ceph.misplaced_objects_total,guage,,item,,Total number of objects if there are misplaced objects,0,ceph,misplaced objects total
-ceph.recovery_objects_per_sec,guage,,item,object per second,Rate of recovered objects,0,ceph,recovery objects per sec
-ceph.recovery_bytes_per_sec,guage,,byte,byte per second,Rate of recovered bytes,0,ceph,recovery bytes per sec
-ceph.recovery_keys_per_sec,guage,,item,key per second,Rate of recovered keys,0,ceph,recovery keys per sec
+ceph.misplaced_objects,gauge,,item,,Number of objects misplaced,-1,ceph,misplaced objects
+ceph.misplaced_objects_total,gauge,,item,,Total number of objects if there are misplaced objects,0,ceph,misplaced objects total
+ceph.recovery_objects_per_sec,gauge,,item,second,Rate of recovered objects,0,ceph,recovery objects per sec
+ceph.recovery_bytes_per_sec,gauge,,byte,second,Rate of recovered bytes,0,ceph,recovery bytes per sec
+ceph.recovery_keys_per_sec,gauge,,item,second,Rate of recovered keys,0,ceph,recovery keys per sec

--- a/ceph/metadata.csv
+++ b/ceph/metadata.csv
@@ -21,3 +21,8 @@ ceph.write_op_per_sec,gauge,,operation,second,Per-pool write operations/second,0
 ceph.num_near_full_osds,gauge,,item,,Number of nearly full osds,-1,ceph,near full osds
 ceph.num_full_osds,gauge,,item,,Number of full osds,-1,ceph,full osds
 ceph.osd.pct_used,gauge,,percent,,Percentage used of full/near full osds,-1,ceph,osd pct used
+ceph.misplaced_objects,guage,,item,,Number of objects misplaced,-1,ceph,misplaced objects
+ceph.misplaced_objects_total,guage,,item,,Total number of objects if there are misplaced objects,0,ceph,misplaced objects total
+ceph.recovery_objects_per_sec,guage,,item,object per second,Rate of recovered objects,0,ceph,recovery objects per sec
+ceph.recovery_bytes_per_sec,guage,,byte,byte per second,Rate of recovered bytes,0,ceph,recovery bytes per sec
+ceph.recovery_keys_per_sec,guage,,item,key per second,Rate of recovered keys,0,ceph,recovery keys per sec

--- a/ceph/tests/common.py
+++ b/ceph/tests/common.py
@@ -33,6 +33,11 @@ EXPECTED_METRICS = [
     "ceph.write_op_per_sec",
     "ceph.num_near_full_osds",
     "ceph.num_full_osds",
+    "ceph.misplaced_objects",
+    "ceph.misplaced_total",
+    "ceph.recovering_objects_per_sec",
+    "ceph.recovering_bytes_per_sec",
+    "ceph.recovering_keys_per_sec",
     # "ceph.osd.pct_used",  # Not send or ceph luminous and above
 ]
 

--- a/ceph/tests/test_unit.py
+++ b/ceph/tests/test_unit.py
@@ -17,6 +17,18 @@ EXPECTED_METRICS = [
     'ceph.pgstate.active_clean',
 ]
 
+EXPECTED_METRICS_POOL_TAGS = [
+    'ceph.read_bytes',
+    'ceph.write_bytes',
+    'ceph.pct_used',
+    'ceph.num_objects',
+    'ceph.misplaced_objects',
+    'ceph.misplaced_total',
+    'ceph.recovering_objects_per_sec',
+    'ceph.recovering_bytes_per_sec',
+    'ceph.recovering_keys_per_sec',
+]
+
 EXPECTED_TAGS = ['ceph_fsid:e0efcf84-e8ed-4916-8ce1-9c70242d390a', 'ceph_mon_state:peon', 'optional:tag1']
 
 pytestmark = pytest.mark.unit
@@ -94,17 +106,7 @@ def test_tagged_metrics(_, aggregator):
     for pool in ['pool0', 'rbd']:
         expected_tags = EXPECTED_TAGS + ['ceph_pool:%s' % pool]
 
-        for metric in [
-            'ceph.read_bytes',
-            'ceph.write_bytes',
-            'ceph.pct_used',
-            'ceph.num_objects',
-            'ceph.misplaced_objects',
-            'ceph.misplaced_objects',
-            'ceph.recovering_objects_per_sec',
-            'ceph.recovering_bytes_per_sec',
-            'ceph.recovering_keys_per_sec',
-        ]:
+        for metric in EXPECTED_METRICS_POOL_TAGS:
             aggregator.assert_metric(metric, count=1, tags=expected_tags)
 
 

--- a/ceph/tests/test_unit.py
+++ b/ceph/tests/test_unit.py
@@ -11,7 +11,11 @@ from datadog_checks.ceph import Ceph
 
 from .common import BASIC_CONFIG, CHECK_NAME, EXPECTED_SERVICE_TAGS, mock_data
 
-EXPECTED_METRICS = ['ceph.num_mons', 'ceph.total_objects', 'ceph.pgstate.active_clean']
+EXPECTED_METRICS = [
+    'ceph.num_mons',
+    'ceph.total_objects',
+    'ceph.pgstate.active_clean',
+]
 
 EXPECTED_TAGS = ['ceph_fsid:e0efcf84-e8ed-4916-8ce1-9c70242d390a', 'ceph_mon_state:peon', 'optional:tag1']
 
@@ -90,7 +94,17 @@ def test_tagged_metrics(_, aggregator):
     for pool in ['pool0', 'rbd']:
         expected_tags = EXPECTED_TAGS + ['ceph_pool:%s' % pool]
 
-        for metric in ['ceph.read_bytes', 'ceph.write_bytes', 'ceph.pct_used', 'ceph.num_objects']:
+        for metric in [
+            'ceph.read_bytes',
+            'ceph.write_bytes',
+            'ceph.pct_used',
+            'ceph.num_objects',
+            'ceph.misplaced_objects',
+            'ceph.misplaced_objects',
+            'ceph.recovering_objects_per_sec',
+            'ceph.recovering_bytes_per_sec',
+            'ceph.recovering_keys_per_sec',
+        ]:
             aggregator.assert_metric(metric, count=1, tags=expected_tags)
 
 


### PR DESCRIPTION
### What does this PR do?
Add new metrics for tracking ceph recovery:
- `ceph.misplaced_objects`
- `ceph.misplaced_objects_total`
- `ceph.recovering_objects_per_sec`
- `ceph.recovering_bytes_per_sec`
- `ceph.recovering_keys_per_sec`

### Motivation
We caused a lot of degredation in our ceph cluster between migrating osds to bluestore and replacing hdds with ssds, and we wanted better visibility, so I made some patches for the ceph integration and just got around to reformatting them for PRs now.

### Additional Notes
I made a dashboard to demo some of what we've been using these metrics for ([here](https://p.datadoghq.com/sb/44f16805b-6c2c986346efa90ccc154519b68ff207)). There are a couple inconsistencies in the data (patches got applied and removed with updates and such), and we aren't causing as much degradation in our cluster at the moment, so it's not as interesting as it was a month ago, but it shows how it can be used.

I've been having a bit of trouble getting setup to run unit tests, so I haven't gotten them written yet, planning to try again over the weekend.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
