### PR TITLE
Fix ddev env test last error

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -129,7 +129,14 @@ def replay_check_run(agent_collector, stub_aggregator, stub_agent):
             )
 
         if runner.get('LastError'):
-            errors.extend(json.loads(runner['LastError']))
+            try:
+                new_errors = json.loads(runner['LastError'])
+            except json.decoder.JSONDecodeError:
+                new_errors = [{
+                    'message': str(runner['LastError']),
+                    'traceback': '',
+                }]
+            errors.extend(new_errors)
     if errors:
         raise Exception("\n".join("Message: {}\n{}".format(err['message'], err['traceback']) for err in errors))
 

--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -132,10 +132,12 @@ def replay_check_run(agent_collector, stub_aggregator, stub_agent):
             try:
                 new_errors = json.loads(runner['LastError'])
             except json.decoder.JSONDecodeError:
-                new_errors = [{
-                    'message': str(runner['LastError']),
-                    'traceback': '',
-                }]
+                new_errors = [
+                    {
+                        'message': str(runner['LastError']),
+                        'traceback': '',
+                    }
+                ]
             errors.extend(new_errors)
     if errors:
         raise Exception("\n".join("Message: {}\n{}".format(err['message'], err['traceback']) for err in errors))


### PR DESCRIPTION
### What does this PR do?

Fix ddev env test last error

### Motivation

Last error might not be a json object: https://github.com/DataDog/integrations-core/blob/12f3147323b6012845141b08ade3cb1c8f6bd5c6/datadog_checks_base/datadog_checks/base/checks/base.py#L882

Corecheck integration errors are not json object with message and traceback.

This doesn't change current behaviour.

We test python snmp impl against corecheck snmp impl, when there is an error, it will throw a json decoding error, this PR should fix that.