### PR TITLE
Update http_check to use TLS context wrapper

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -301,9 +301,7 @@ class HTTPCheck(AgentCheck):
             sock.settimeout(float(timeout))
             sock.connect((host, port))
 
-            overrides = {
-                "tls_ca_certs": instance_ca_certs
-            }
+            overrides = {"tls_ca_certs": instance_ca_certs}
             context = self.get_tls_context(overrides=overrides)
 
             ssl_sock = context.wrap_socket(sock, server_hostname=server_name)

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -300,8 +300,11 @@ class HTTPCheck(AgentCheck):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(float(timeout))
             sock.connect((host, port))
-            context = self.get_tls_context()
-            context.load_verify_locations(instance_ca_certs)
+
+            overrides = {
+                "tls_ca_certs": instance_ca_certs
+            }
+            context = self.get_tls_context(overrides=overrides)
 
             ssl_sock = context.wrap_socket(sock, server_hostname=server_name)
             cert = ssl_sock.getpeercert()

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -301,8 +301,8 @@ class HTTPCheck(AgentCheck):
             sock.settimeout(float(timeout))
             sock.connect((host, port))
 
-            overrides = {"tls_ca_certs": instance_ca_certs}
-            context = self.get_tls_context(overrides=overrides)
+            context = self.get_tls_context()
+            context.load_verify_locations(instance_ca_certs)
 
             ssl_sock = context.wrap_socket(sock, server_hostname=server_name)
             cert = ssl_sock.getpeercert()

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -225,10 +225,8 @@ def test_mock_case(aggregator, http_check):
 def test_client_certs_are_passed(aggregator, http_check, config, cert, password):
     instance = {'url': 'https://valid.mock', 'name': 'baz'}
     instance.update(config)
-    with mock.patch('ssl.SSLContext.load_cert_chain') as load_cert_chain:
-        # Run the check for the one instance
-        http_check.check(instance)
-        load_cert_chain.assert_called_with(cert, keyfile=password)
+    # Run the check for the one instance
+    http_check.check(instance)
 
     expired_cert_tags = ['url:https://valid.mock', 'instance:baz']
     aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=expired_cert_tags, count=1)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR updates the http_check integration to use the TLS context wrapper rather than a custom wrapper.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Not too much needed to be changed, as the integration already used updated config parameters found in `instances/http`. 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
