### PR TITLE
Add optional argument for overriding get_tls_context() parameters

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -12,7 +12,7 @@ import traceback
 import unicodedata
 from collections import defaultdict, deque
 from os.path import basename
-from typing import TYPE_CHECKING, Any, Callable, DefaultDict, Deque, Dict, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, AnyStr, Callable, DefaultDict, Deque, Dict, List, Optional, Sequence, Tuple, Union
 
 import yaml
 from six import binary_type, iteritems, text_type
@@ -310,9 +310,11 @@ class AgentCheck(object):
         return self._http
 
     def get_tls_context(self, refresh=False, overrides=None):
-        # type: (bool) -> ssl.SSLContext
+        # type: (bool, Dict[AnyStr, Any]) -> ssl.SSLContext
         """
         Creates and cache an SSLContext instance based on user configuration.
+        Note that user configuration can be overridden by using `overrides`.
+        This should only be applied to older integration that manually set config values.
 
         Since: Agent 7.24
         """

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -309,7 +309,7 @@ class AgentCheck(object):
 
         return self._http
 
-    def get_tls_context(self, refresh=False):
+    def get_tls_context(self, refresh=False, overrides=None):
         # type: (bool) -> ssl.SSLContext
         """
         Creates and cache an SSLContext instance based on user configuration.
@@ -317,7 +317,7 @@ class AgentCheck(object):
         Since: Agent 7.24
         """
         if not hasattr(self, '_tls_context_wrapper'):
-            self._tls_context_wrapper = TlsContextWrapper(self.instance or {}, self.TLS_CONFIG_REMAPPER)
+            self._tls_context_wrapper = TlsContextWrapper(self.instance or {}, self.TLS_CONFIG_REMAPPER, overrides)
 
         if refresh:
             self._tls_context_wrapper.refresh_tls_context()

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -332,7 +332,9 @@ class AgentCheck(object):
         Since: Agent 7.24
         """
         if not hasattr(self, '_tls_context_wrapper'):
-            self._tls_context_wrapper = TlsContextWrapper(self.instance or {}, self.TLS_CONFIG_REMAPPER, overrides)
+            self._tls_context_wrapper = TlsContextWrapper(
+                self.instance or {}, self.TLS_CONFIG_REMAPPER, overrides=overrides
+            )
 
         if refresh:
             self._tls_context_wrapper.refresh_tls_context()

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -12,7 +12,20 @@ import traceback
 import unicodedata
 from collections import defaultdict, deque
 from os.path import basename
-from typing import TYPE_CHECKING, Any, AnyStr, Callable, DefaultDict, Deque, Dict, List, Optional, Sequence, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AnyStr,
+    Callable,
+    DefaultDict,
+    Deque,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import yaml
 from six import binary_type, iteritems, text_type

--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -92,9 +92,10 @@ class TlsContextWrapper(object):
                 del config[unique_name]
 
         # Override existing config options if there exists any overrides
-        for overridden_field, data in iteritems(overrides):
-            if config[overridden_field]:
-                config[overridden_field] = data
+        if overrides:
+            for overridden_field, data in iteritems(overrides):
+                if config[overridden_field]:
+                    config[overridden_field] = data
 
         self.config = config
         self.tls_context = self._create_tls_context()

--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -39,6 +39,11 @@ class TlsContextWrapper(object):
         # type: (InstanceType, Dict[AnyStr, Dict[AnyStr, Any]], Dict[AnyStr, Any]) -> None
         default_fields = dict(STANDARD_FIELDS)
 
+        # Override existing config options if there exists any overrides
+        if overrides:
+            for overridden_field, data in iteritems(overrides):
+                instance[overridden_field] = data
+
         # Populate with the default values
         config = {field: instance.get(field, value) for field, value in iteritems(default_fields)}
         for field in STANDARD_FIELDS:
@@ -90,12 +95,6 @@ class TlsContextWrapper(object):
             if unique_name in config:
                 config[field] = config[unique_name]
                 del config[unique_name]
-
-        # Override existing config options if there exists any overrides
-        if overrides:
-            for overridden_field, data in iteritems(overrides):
-                if config[overridden_field]:
-                    config[overridden_field] = data
 
         self.config = config
         self.tls_context = self._create_tls_context()

--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -35,8 +35,8 @@ STANDARD_FIELDS = {
 class TlsContextWrapper(object):
     __slots__ = ('logger', 'config', 'tls_context')
 
-    def __init__(self, instance, remapper=None):
-        # type: (InstanceType, Dict[AnyStr, Dict[AnyStr, Any]]) -> None
+    def __init__(self, instance, remapper=None, overrides=None):
+        # type: (InstanceType, Dict[AnyStr, Dict[AnyStr, Any]], Dict[AnyStr, Any]) -> None
         default_fields = dict(STANDARD_FIELDS)
 
         # Populate with the default values
@@ -90,6 +90,11 @@ class TlsContextWrapper(object):
             if unique_name in config:
                 config[field] = config[unique_name]
                 del config[unique_name]
+
+        # Override existing config options if there exists any overrides
+        for overridden_field, data in iteritems(overrides):
+            if config[overridden_field]:
+                config[overridden_field] = data
 
         self.config = config
         self.tls_context = self._create_tls_context()

--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -42,7 +42,8 @@ class TlsContextWrapper(object):
         # Override existing config options if there exists any overrides
         if overrides:
             for overridden_field, data in iteritems(overrides):
-                instance[overridden_field] = data
+                if instance.get(overridden_field):
+                    instance[overridden_field] = data
 
         # Populate with the default values
         config = {field: instance.get(field, value) for field, value in iteritems(default_fields)}

--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -4,6 +4,7 @@
 import logging
 import os
 import ssl
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, AnyStr, Dict
 
 from six import iteritems
@@ -40,7 +41,7 @@ class TlsContextWrapper(object):
         default_fields = dict(STANDARD_FIELDS)
 
         # Override existing config options if there exists any overrides
-        overridden_instance = {field: data for field, data in iteritems(instance)}
+        overridden_instance = deepcopy(instance)
 
         if overrides:
             for overridden_field, data in iteritems(overrides):

--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -41,19 +41,19 @@ class TlsContextWrapper(object):
         default_fields = dict(STANDARD_FIELDS)
 
         # Override existing config options if there exists any overrides
-        overridden_instance = deepcopy(instance)
+        instance = deepcopy(instance)
 
         if overrides:
             for overridden_field, data in iteritems(overrides):
-                if overridden_instance.get(overridden_field):
-                    overridden_instance[overridden_field] = data
+                if instance.get(overridden_field):
+                    instance[overridden_field] = data
 
         # Populate with the default values
-        config = {field: overridden_instance.get(field, value) for field, value in iteritems(default_fields)}
+        config = {field: instance.get(field, value) for field, value in iteritems(default_fields)}
         for field in STANDARD_FIELDS:
             unique_name = UNIQUE_FIELD_PREFIX + field
-            if unique_name in overridden_instance:
-                config[unique_name] = overridden_instance[unique_name]
+            if unique_name in instance:
+                config[unique_name] = instance[unique_name]
 
         if remapper is None:
             remapper = {}
@@ -80,7 +80,7 @@ class TlsContextWrapper(object):
                 default = not default
 
             # Get value, with a possible default
-            value = overridden_instance.get(remapped_field, data.get('default', default))
+            value = instance.get(remapped_field, data.get('default', default))
 
             # Invert booleans if need be
             if data.get('invert'):

--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -40,17 +40,19 @@ class TlsContextWrapper(object):
         default_fields = dict(STANDARD_FIELDS)
 
         # Override existing config options if there exists any overrides
+        overridden_instance = {field: data for field, data in iteritems(instance)}
+
         if overrides:
             for overridden_field, data in iteritems(overrides):
-                if instance.get(overridden_field):
-                    instance[overridden_field] = data
+                if overridden_instance.get(overridden_field):
+                    overridden_instance[overridden_field] = data
 
         # Populate with the default values
-        config = {field: instance.get(field, value) for field, value in iteritems(default_fields)}
+        config = {field: overridden_instance.get(field, value) for field, value in iteritems(default_fields)}
         for field in STANDARD_FIELDS:
             unique_name = UNIQUE_FIELD_PREFIX + field
-            if unique_name in instance:
-                config[unique_name] = instance[unique_name]
+            if unique_name in overridden_instance:
+                config[unique_name] = overridden_instance[unique_name]
 
         if remapper is None:
             remapper = {}
@@ -77,7 +79,7 @@ class TlsContextWrapper(object):
                 default = not default
 
             # Get value, with a possible default
-            value = instance.get(remapped_field, data.get('default', default))
+            value = overridden_instance.get(remapped_field, data.get('default', default))
 
             # Invert booleans if need be
             if data.get('invert'):

--- a/datadog_checks_base/tests/test_tls.py
+++ b/datadog_checks_base/tests/test_tls.py
@@ -233,3 +233,15 @@ class TestTLSContextOverrides:
         overrides = {}
         tls = TlsContextWrapper(instance, overrides=overrides)
         assert tls.config['tls_verify'] is True
+
+    def test_override_instance_config(self):
+        instance = {'tls_verify': True}
+        overrides = {'tls_verify': False}
+        tls = TlsContextWrapper(instance, overrides=overrides)
+        assert instance['tls_verify'] is False
+
+    def test_override_non_exist_instance_config(self):
+        instance = {'tls_verify': True}
+        overrides = {'fake_config': 'foo'}
+        tls = TlsContextWrapper(instance, overrides=overrides)
+        assert instance.get('fake_config') is None

--- a/datadog_checks_base/tests/test_tls.py
+++ b/datadog_checks_base/tests/test_tls.py
@@ -227,6 +227,7 @@ class TestTLSContextOverrides:
         overrides = {'tls_verify': False}
         tls = TlsContextWrapper(instance, overrides=overrides)
         assert tls.config['tls_verify'] is False
+        assert instance['tls_verify'] is True  # Overrides should not affect the original instance
 
     def test_override_context_wrapper_config_empty(self):
         instance = {'tls_verify': True}
@@ -234,14 +235,9 @@ class TestTLSContextOverrides:
         tls = TlsContextWrapper(instance, overrides=overrides)
         assert tls.config['tls_verify'] is True
 
-    def test_override_instance_config(self):
-        instance = {'tls_verify': True}
-        overrides = {'tls_verify': False}
-        tls = TlsContextWrapper(instance, overrides=overrides)
-        assert instance['tls_verify'] is False
-
     def test_override_non_exist_instance_config(self):
         instance = {'tls_verify': True}
         overrides = {'fake_config': 'foo'}
         tls = TlsContextWrapper(instance, overrides=overrides)
         assert instance.get('fake_config') is None
+        assert tls.config['tls_verify'] is True

--- a/tls/datadog_checks/tls/tls.py
+++ b/tls/datadog_checks/tls/tls.py
@@ -340,18 +340,14 @@ class TLSCheck(AgentCheck):
         if self._tls_context is None:
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext
             # https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS
-
-            overrides = {
-                "tls_validate_hostname": False
-            }
-            self._tls_context = self.get_tls_context(overrides=overrides)
+            self._tls_context = ssl.SSLContext(protocol=PROTOCOL_TLS_CLIENT)
 
             # Run our own validation later on if need be
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname
             #
             # IMPORTANT: This must be set before verify_mode in Python 3.7+, see:
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname
-            # self._tls_context.check_hostname = False
+            self._tls_context.check_hostname = False
 
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.verify_mode
             self._tls_context.verify_mode = ssl.CERT_REQUIRED if self._validate_cert else ssl.CERT_NONE

--- a/tls/datadog_checks/tls/tls.py
+++ b/tls/datadog_checks/tls/tls.py
@@ -340,14 +340,18 @@ class TLSCheck(AgentCheck):
         if self._tls_context is None:
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext
             # https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS
-            self._tls_context = ssl.SSLContext(protocol=PROTOCOL_TLS_CLIENT)
+
+            overrides = {
+                "tls_validate_hostname": False
+            }
+            self._tls_context = self.get_tls_context(overrides=overrides)
 
             # Run our own validation later on if need be
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname
             #
             # IMPORTANT: This must be set before verify_mode in Python 3.7+, see:
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname
-            self._tls_context.check_hostname = False
+            # self._tls_context.check_hostname = False
 
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.verify_mode
             self._tls_context.verify_mode = ssl.CERT_REQUIRED if self._validate_cert else ssl.CERT_NONE


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR adds the option for `get_tls_context()` to add an `overrides` argument to set config values.

This is intended to be compatible with integrations that hardcode the values of SSL context config values in their checks. 

Note that the `overrides` argument takes precedent over reading the values for the respective config value. 

This change can affect 
- `http_check`: https://github.com/DataDog/integrations-core/blob/master/http_check/datadog_checks/http_check/http_check.py#L309-L311 
- `proxysql`: https://github.com/DataDog/integrations-core/blob/master/proxysql/datadog_checks/proxysql/ssl_utils.py#L17.

This can also be applied to recently updated SSL context checks, such as 
- `tls`: https://github.com/DataDog/integrations-core/pull/8230/files#r550231989
- `vertica`: https://github.com/DataDog/integrations-core/pull/8228/files#r550234204.

### Motivation
<!-- What inspired you to submit this pull request? -->
Some older integrations specifically set values for their SSL context without reading the config values. However the `get_tls_context()` function abstracts the creation of the SSL context away without allowing the check to manually set config values that should stay the same. This could affect the intended functionality of the check while lacking visibility.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
SSL context and TLS context in my other PRs are referring to the same things.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
