### PR TITLE
Add new global fixture to mock HTTP requests

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/http.py
@@ -1,0 +1,24 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from io import BytesIO
+from textwrap import dedent
+
+from requests import Response
+
+
+class MockResponse(Response):
+    def __init__(self, content='', file_path=None, status_code=200, normalize_content=True):
+        super(MockResponse, self).__init__()
+
+        if file_path is not None:
+            with open(file_path, 'rb') as f:
+                self.raw = BytesIO(f.read())
+        else:
+            # For multi-line string literals
+            if normalize_content:
+                content = dedent(content[1:])
+
+            self.raw = BytesIO(content.encode('utf-8'))
+
+        self.status_code = status_code

--- a/datadog_checks_dev/datadog_checks/dev/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/http.py
@@ -21,4 +21,5 @@ class MockResponse(Response):
 
             self.raw = BytesIO(content.encode('utf-8'))
 
+        # Add new keyword arguments to set as needed
         self.status_code = status_code

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -28,6 +28,7 @@ from .._env import (
 
 __aggregator = None
 __datadog_agent = None
+MockResponse = None
 
 
 @pytest.fixture
@@ -229,6 +230,17 @@ def dd_get_state():
 @pytest.fixture
 def dd_save_state():
     return save_state
+
+
+@pytest.fixture
+def mock_http_response(mocker):
+    global MockResponse
+    if MockResponse is None:
+        from ..http import MockResponse
+
+    yield lambda *args, **kwargs: mocker.patch(
+        kwargs.pop('method', 'requests.get'), return_value=MockResponse(*args, **kwargs)
+    )
 
 
 def pytest_configure(config):

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -234,6 +234,7 @@ def dd_save_state():
 
 @pytest.fixture
 def mock_http_response(mocker):
+    # Lazily import `requests` as it may be costly under certain conditions
     global MockResponse
     if MockResponse is None:
         from ..http import MockResponse


### PR DESCRIPTION
### What does this PR do?

This adds a new global fixture that returns a function used to mock HTTP requests for the lifetime of a test

### Motivation

I am using this in a feature branch and realized we often need this