### PR TITLE
Fix small typos in metadata.csv

### DIFF
--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -1,7 +1,7 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 sqlserver.access.page_splits,gauge,,operation,second,The number of page splits per second.,-1,sql_server,page splits
 sqlserver.ao.ag_sync_health,gauge,,,,"Availability group synchronization health: 0 = Not healthy, 1 = Partially healthy, 2 = Healthy",0,sql_server,ag sync health
-sqlserver.ao.replica_sync_state,gauge,,,,"Replica synchronization state: 0 = Not synchronizing, 1 = Synchronizing, 2 = Reverting, 4 = Initializing",0,sql_server,replica sync state
+sqlserver.ao.replica_sync_state,gauge,,,,"Replica synchronization state: 0 = Not synchronizing, 1 = Synchronizing, 2 = Synchronized, 3 = Reverting, 4 = Initializing",0,sql_server,replica sync state
 sqlserver.ao.replica_failover_mode,gauge,,,,"Replica failover mode: 0 = Automatic failover, 1 = Manual failover",0,sql_server,replica failover mode
 sqlserver.ao.replica_failover_readiness,gauge,,,,"Replica failover readiness: 0 = Not ready for failover, 1 = Ready for failover",0,sql_server,replica failover readiness
 sqlserver.ao.primary_replica_health,gauge,,,,"Recovery health of primary replica: 0 = In progress, 1 = Online. The metric is not emitted if on a secondary replica",0,sql_server,primary replica health

--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -48,5 +48,5 @@ sqlserver.task.context_switches_count,gauge,,unit,,Number of scheduler context s
 sqlserver.task.pending_io_count,gauge,,unit,,Number of physical I/Os that are performed by this task.,0,sql_server,task io pending
 sqlserver.task.pending_io_byte_count,gauge,,byte,,Total byte count of I/Os that are performed by this task.,0,sql_server,task io byte
 sqlserver.task.pending_io_byte_average,gauge,,byte,,Average byte count of I/Os that are performed by this task.,0,sql_server,task avg io byte
-sqlserver.fci.status,gauge,,byte,,Status of the node in a SQL Server failover custer instance,0,sql_server,fci status
-sqlserver.fci.is_current_owner,gauge,,byte,,Whether or not this node is the current owner of the SQL Server FCI ,0,sql_server,fci current owner
+sqlserver.fci.status,gauge,,,,Status of the node in a SQL Server failover custer instance,0,sql_server,fci status
+sqlserver.fci.is_current_owner,gauge,,,,Whether or not this node is the current owner of the SQL Server FCI ,0,sql_server,fci current owner


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
There were some small typos in the description of metric `sqlserver.ao.replica_sync_state`with incorrect state names and FCI metrics that had `bytes` as a unit of measurement. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
