### PR TITLE
Add recommended monitors for SQLServer

### DIFF
--- a/sqlserver/assets/recommended_monitors/sqlserver_ao_not_healthy.json
+++ b/sqlserver/assets/recommended_monitors/sqlserver_ao_not_healthy.json
@@ -1,0 +1,28 @@
+{
+	"name": "[SQLServer] Availability Group is not healthy",
+	"type": "query alert",
+	"query": "avg(last_5m):avg:sqlserver.ao.ag_sync_health{*} < 1",
+	"message": "Availability group has not been healthy for the last 5 minutes",
+	"tags": [
+      "integration:sqlserver"
+    ],
+	"options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+		"require_full_window": true,
+		"notify_no_data": false,
+		"renotify_interval": "0",
+		"escalation_message": "",
+		"no_data_timeframe": null,
+		"include_tags": true,
+		"thresholds": {
+			"critical": 1,
+			"warning": 2
+		}
+	},
+	"recommended_monitor_metadata": {
+		"description": "Notify your team when your availability group is not healthy."
+	}
+}

--- a/sqlserver/assets/recommended_monitors/sqlserver_ao_not_healthy.json
+++ b/sqlserver/assets/recommended_monitors/sqlserver_ao_not_healthy.json
@@ -4,7 +4,7 @@
 	"query": "avg(last_5m):avg:sqlserver.ao.ag_sync_health{*} < 1",
 	"message": "Availability group has not been healthy for the last 5 minutes",
 	"tags": [
-      "integration:sqlserver"
+      "integration:sql-server"
     ],
 	"options": {
 		"notify_audit": false,

--- a/sqlserver/assets/recommended_monitors/sqlserver_db_not_online.json
+++ b/sqlserver/assets/recommended_monitors/sqlserver_db_not_online.json
@@ -1,0 +1,27 @@
+{
+	"name": "[SQLServer] Database is not online",
+	"type": "query alert",
+	"query": "avg(last_5m):avg:sqlserver.database.state{*} > 0",
+	"message": "SQLServer database is not online for the last 5 minutes",
+	"tags": [
+      "integration:sqlserver"
+    ],
+	"options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+		"require_full_window": true,
+		"notify_no_data": false,
+		"renotify_interval": "0",
+		"escalation_message": "",
+		"no_data_timeframe": null,
+		"include_tags": true,
+		"thresholds": {
+			"critical": 0
+		}
+	},
+	"recommended_monitor_metadata": {
+		"description": "Notify your team when your database is not online."
+	}
+}

--- a/sqlserver/assets/recommended_monitors/sqlserver_db_not_online.json
+++ b/sqlserver/assets/recommended_monitors/sqlserver_db_not_online.json
@@ -4,7 +4,7 @@
 	"query": "avg(last_5m):avg:sqlserver.database.state{*} > 0",
 	"message": "SQLServer database is not online for the last 5 minutes",
 	"tags": [
-      "integration:sqlserver"
+      "integration:sql-server"
     ],
 	"options": {
 		"notify_audit": false,

--- a/sqlserver/assets/recommended_monitors/sqlserver_db_not_sync.json
+++ b/sqlserver/assets/recommended_monitors/sqlserver_db_not_sync.json
@@ -3,7 +3,9 @@
 	"type": "metric alert",
 	"query": "avg(last_5m):avg:sqlserver.database.is_sync_with_backup{*} < 1",
 	"message": "SQLServer database is not marked for replication sync. It may not be synced with its backup.",
-	"tags": [],
+	"tags": [
+      "integration:sql-server"
+    ],
 	"options": {
 		"notify_audit": false,
 		"locked": false,

--- a/sqlserver/assets/recommended_monitors/sqlserver_db_not_sync.json
+++ b/sqlserver/assets/recommended_monitors/sqlserver_db_not_sync.json
@@ -1,0 +1,25 @@
+{
+	"name": "[SQLServer] Database is not marked for replication sync",
+	"type": "metric alert",
+	"query": "avg(last_5m):avg:sqlserver.database.is_sync_with_backup{*} < 1",
+	"message": "SQLServer database is not marked for replication sync. It may not be synced with its backup.",
+	"tags": [],
+	"options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+		"require_full_window": true,
+		"notify_no_data": false,
+		"renotify_interval": "0",
+		"escalation_message": "",
+		"no_data_timeframe": null,
+		"include_tags": true,
+		"thresholds": {
+			"critical": 1
+		}
+	},
+  	"recommended_monitor_metadata": {
+		"description": "Notify your team when your database is not in sync with its backup."
+	}
+}

--- a/sqlserver/assets/recommended_monitors/sqlserver_high_number_failed_auto_param.json
+++ b/sqlserver/assets/recommended_monitors/sqlserver_high_number_failed_auto_param.json
@@ -4,7 +4,7 @@
 	"query": "avg(last_5m):avg:sqlserver.stats.failed_auto_param_attempts{*} > 10",
 	"message": "There is a high number of failed auto-parameterization attempts in the past 5 minutes",
 	"tags": [
-      "integration:sqlserver"
+      "integration:sql-server"
     ],
 	"options": {
 		"notify_audit": false,

--- a/sqlserver/assets/recommended_monitors/sqlserver_high_number_failed_auto_param.json
+++ b/sqlserver/assets/recommended_monitors/sqlserver_high_number_failed_auto_param.json
@@ -1,0 +1,27 @@
+{
+	"name": "[SQLServer] High number of failed auto-parameterization attempts",
+	"type": "query alert",
+	"query": "avg(last_5m):avg:sqlserver.stats.failed_auto_param_attempts{*} > 10",
+	"message": "There is a high number of failed auto-parameterization attempts in the past 5 minutes",
+	"tags": [
+      "integration:sqlserver"
+    ],
+	"options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+		"require_full_window": true,
+		"notify_no_data": false,
+		"renotify_interval": "0",
+		"escalation_message": "",
+		"no_data_timeframe": null,
+		"include_tags": true,
+		"thresholds": {
+			"critical": 10
+		}
+	},
+	"recommended_monitor_metadata": {
+		"description": "Notify your team when a high number of auto-parameterization are failing."
+	}
+}

--- a/sqlserver/assets/recommended_monitors/sqlserver_high_processes_blocked.json
+++ b/sqlserver/assets/recommended_monitors/sqlserver_high_processes_blocked.json
@@ -1,0 +1,27 @@
+{
+	"name": "[SQLServer] High number of processes blocked",
+	"type": "query alert",
+	"query": "avg(last_5m):avg:sqlserver.stats.procs_blocked{*} > 50",
+	"message": "There is a high number of processes being blocked in the past 5 minutes",
+	"tags": [
+      "integration:sqlserver"
+    ],
+    "options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+		"require_full_window": true,
+		"notify_no_data": false,
+		"renotify_interval": "0",
+		"escalation_message": "",
+		"no_data_timeframe": null,
+		"include_tags": true,
+		"thresholds": {
+			"critical": 50
+		}
+	},
+	"recommended_monitor_metadata": {
+		"description": "Notify your team when a high number of processes are being blocked."
+	}
+}

--- a/sqlserver/assets/recommended_monitors/sqlserver_high_processes_blocked.json
+++ b/sqlserver/assets/recommended_monitors/sqlserver_high_processes_blocked.json
@@ -4,7 +4,7 @@
 	"query": "avg(last_5m):avg:sqlserver.stats.procs_blocked{*} > 50",
 	"message": "There is a high number of processes being blocked in the past 5 minutes",
 	"tags": [
-      "integration:sqlserver"
+      "integration:sql-server"
     ],
     "options": {
 		"notify_audit": false,

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -29,7 +29,9 @@
     "monitors": {
       "SQLServer ao not healthy": "assets/recommended_monitors/sqlserver_ao_not_healthy.json",
       "SQLServer high processes blocked": "assets/recommended_monitors/sqlserver_high_processes_blocked.json",
-      "SQLServer high failed auto param": "assets/recommended_monitors/sqlserver_high_number_failed_auto_param.json"
+      "SQLServer high failed auto param": "assets/recommended_monitors/sqlserver_high_number_failed_auto_param.json",
+      "SQLServer db not online": "assets/recommended_monitors/sqlserver_db_not_online.json",
+      "SQLServer db not in sync": "assets/recommended_monitors/sqlserver_db_not_sync.json"
     },
     "dashboards": {},
     "service_checks": "assets/service_checks.json",

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -26,7 +26,11 @@
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
-    "monitors": {},
+    "monitors": {
+      "SQLServer ao not healthy": "assets/recommended_monitors/sqlserver_ao_not_healthy.json",
+      "SQLServer high processes blocked": "assets/recommended_monitors/sqlserver_high_processes_blocked.json",
+      "SQLServer high failed auto param": "assets/recommended_monitors/sqlserver_high_number_failed_auto_param.json"
+    },
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
     "logs": {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds 5 new recommended monitors for SQLServer.
1. `[SQLServer] Availability Group is not healthy`.
2. `[SQLServer] High number of processes blocked`.
3. `[SQLServer] High number of failed auto-parameterization attempts`.
4. `[SQLServer] Database is not marked for replication sync`.
5. `[SQLServer] Database is not online`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
