### PR TITLE
Adds a `replication_role` tag to metrics emitted from AWS Aurora instances

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -128,7 +128,7 @@ class MySql(AgentCheck):
                 self._put_qcache_stats()
 
                 # Custom queries
-                self._query_manager.execute()
+                self._query_manager.execute(extra_tags=tags)
 
             except Exception as e:
                 self.log.exception("error!")

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -74,7 +74,7 @@ class MySql(AgentCheck):
         self.qcache_stats = {}
         self.version = None
         self._is_aurora = None
-        self.config = MySQLConfig(self.instance)
+        self._config = MySQLConfig(self.instance)
 
         # Create a new connection on every check run
         self._conn = None
@@ -103,7 +103,7 @@ class MySql(AgentCheck):
         return {'pymysql': pymysql.__version__}
 
     def check(self, _):
-        tags = list(self.config.tags)
+        tags = list(self._config.tags)
         self._set_qcache_stats()
         with self._connect() as db:
             try:

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -43,6 +43,7 @@ from .queries import (
     SQL_PROCESS_LIST,
     SQL_QUERY_SCHEMA_SIZE,
     SQL_REPLICATION_ROLE_AWS_AURORA,
+    SQL_SERVER_ID_AWS_AURORA,
     SQL_WORKER_THREADS,
     show_replica_status_query,
 )
@@ -81,6 +82,7 @@ class MySql(AgentCheck):
         self.check_initializations.append(self._query_manager.compile_queries)
         self.innodb_stats = InnoDBMetrics()
         self.check_initializations.append(self._config.configuration_checks)
+        self.check_initializations.append(self.init_with_connection)
         self._statement_metrics = MySQLStatementMetrics(self._config)
         self._statement_samples = MySQLStatementSamples(self, self._config, self._get_connection_args())
 
@@ -99,6 +101,18 @@ class MySql(AgentCheck):
     def get_library_versions(cls):
         return {'pymysql': pymysql.__version__}
 
+    def init_with_connection(self):
+        """
+        Run one-time check initialization tasks which require a connection to the DB.
+        """
+        tags = []
+
+        with self._connect() as db:
+            if self._get_is_aurora(db):
+                tags.extend(self._get_runtime_aurora_tags(db))
+
+        self.config.tags = list(set(self.config.tags) | set(tags))
+
     def check(self, _):
         self._set_qcache_stats()
         with self._connect() as db:
@@ -108,9 +122,6 @@ class MySql(AgentCheck):
                 # version collection
                 self.version = get_version(db)
                 self._send_metadata()
-
-                # Supplement tags with runtime data
-                self.config.tags += self._get_runtime_tags(db)
 
                 # Metric collection
                 self._collect_metrics(db)
@@ -467,28 +478,18 @@ class MySql(AgentCheck):
             self.warning("Error while running %s\n%s", query, traceback.format_exc())
             self.log.exception("Error while running %s", query)
 
-    def _get_runtime_tags(self, db):
-        """
-        Collects the tags which are determined at runtime by queries (separate from the tags
-        defined by config).
-        """
+    def _get_runtime_aurora_tags(self, db):
         runtime_tags = []
 
         try:
             with closing(db.cursor()) as cursor:
-                try:
-                    cursor.execute(SQL_REPLICATION_ROLE_AWS_AURORA)
-                    replication_role = cursor.fetchone()[0]
+                cursor.execute(SQL_REPLICATION_ROLE_AWS_AURORA)
+                replication_role = cursor.fetchone()[0]
 
-                    if replication_role in {'writer', 'reader'}:
-                        runtime_tags.append('replication_role:' + replication_role)
-                except pymysql.err.InternalError as e:
-                    # Non-AWS Aurora databases will not have the tables required for
-                    # the query so this is an expected error.
-                    if e.args[0] != pymysql.constants.ER.UNKNOWN_TABLE:
-                        raise
+                if replication_role in {'writer', 'reader'}:
+                    runtime_tags.append('replication_role:' + replication_role)
         except Exception:
-            self.log.warning("Error occurred while fetching runtime tags: %s", traceback.format_exc())
+            self.log.warning("Error occurred while fetching Aurora runtime tags: %s", traceback.format_exc())
 
         return runtime_tags
 
@@ -558,6 +559,24 @@ class MySql(AgentCheck):
                     self.log.exception("Error while fetching mysql pid from psutil")
 
         return pid
+
+    def _get_is_aurora(self, db):
+        """
+        Tests if the instance is an AWS Aurora database.
+        """
+        try:
+            with closing(db.cursor()) as cursor:
+                cursor.execute(SQL_SERVER_ID_AWS_AURORA)
+                if len(cursor.fetchall()) > 0:
+                    return True
+        except Exception:
+            self.warning(
+                "Unable to determine if server is Aurora. If this is an Aurora database, some "
+                "information may be unavailable: %s",
+                traceback.format_exc(),
+            )
+
+        return False
 
     @classmethod
     def _get_stats_from_status(cls, db):

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -211,7 +211,7 @@ class MySql(AgentCheck):
             if db:
                 db.close()
 
-    def _collect_metrics(self, db):
+    def _collect_metrics(self, db, tags):
 
         # Get aggregate of all VARS we want to collect
         metrics = STATUS_VARS
@@ -305,13 +305,13 @@ class MySql(AgentCheck):
             if src in results:
                 results[dst] = results[src]
 
-        self._submit_metrics(metrics, results, self._config.tags)
+        self._submit_metrics(metrics, results, tags)
 
         # Collect custom query metrics
         # Max of 20 queries allowed
         if isinstance(self._config.queries, list):
             for check in self._config.queries[: self._config.max_custom_queries]:
-                total_tags = self._config.tags + check.get('tags', [])
+                total_tags = tags + check.get('tags', [])
                 self._collect_dict(
                     check['type'], {check['field']: check['metric']}, check['query'], db, tags=total_tags
                 )

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -73,7 +73,8 @@ class MySql(AgentCheck):
         super(MySql, self).__init__(name, init_config, instances)
         self.qcache_stats = {}
         self.version = None
-        self._config = MySQLConfig(self.instance)
+        self._is_aurora = None
+        self.config = MySQLConfig(self.instance)
 
         # Create a new connection on every check run
         self._conn = None
@@ -101,34 +102,27 @@ class MySql(AgentCheck):
     def get_library_versions(cls):
         return {'pymysql': pymysql.__version__}
 
-    def init_with_connection(self):
-        """
-        Run one-time check initialization tasks which require a connection to the DB.
-        """
-        tags = []
-
-        with self._connect() as db:
-            if self._get_is_aurora(db):
-                tags.extend(self._get_runtime_aurora_tags(db))
-
-        self.config.tags = list(set(self.config.tags) | set(tags))
-
     def check(self, _):
+        tags = list(self.config.tags)
         self._set_qcache_stats()
         with self._connect() as db:
             try:
                 self._conn = db
+
+                if self._get_is_aurora(db):
+                    tags.extend(self._get_runtime_aurora_tags(db))
+                    tags = list(set(tags))
 
                 # version collection
                 self.version = get_version(db)
                 self._send_metadata()
 
                 # Metric collection
-                self._collect_metrics(db)
-                self._collect_system_metrics(self._config.host, db, self._config.tags)
+                self._collect_metrics(db, tags)
+                self._collect_system_metrics(self._config.host, db, tags)
                 if self._config.deep_database_monitoring:
-                    self._collect_statement_metrics(db, self._config.tags)
-                    self._statement_samples.run_sampler(self.service_check_tags)
+                    self._collect_statement_metrics(db, tags)
+                    self._statement_samples.run_sampler(tags)
 
                 # keeping track of these:
                 self._put_qcache_stats()
@@ -562,13 +556,19 @@ class MySql(AgentCheck):
 
     def _get_is_aurora(self, db):
         """
-        Tests if the instance is an AWS Aurora database.
+        Tests if the instance is an AWS Aurora database and caches the result.
         """
+        if self._is_aurora is not None:
+            return self._is_aurora
+
         try:
             with closing(db.cursor()) as cursor:
                 cursor.execute(SQL_SERVER_ID_AWS_AURORA)
                 if len(cursor.fetchall()) > 0:
-                    return True
+                    self._is_aurora = True
+                else:
+                    self._is_aurora = False
+
         except Exception:
             self.warning(
                 "Unable to determine if server is Aurora. If this is an Aurora database, some "
@@ -576,7 +576,7 @@ class MySql(AgentCheck):
                 traceback.format_exc(),
             )
 
-        return False
+        return self._is_aurora
 
     @classmethod
     def _get_stats_from_status(cls, db):

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -83,7 +83,6 @@ class MySql(AgentCheck):
         self.check_initializations.append(self._query_manager.compile_queries)
         self.innodb_stats = InnoDBMetrics()
         self.check_initializations.append(self._config.configuration_checks)
-        self.check_initializations.append(self.init_with_connection)
         self._statement_metrics = MySQLStatementMetrics(self._config)
         self._statement_samples = MySQLStatementSamples(self, self._config, self._get_connection_args())
 

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -575,6 +575,7 @@ class MySql(AgentCheck):
                 "information may be unavailable: %s",
                 traceback.format_exc(),
             )
+            return False
 
         return self._is_aurora
 

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -118,7 +118,7 @@ class MySql(AgentCheck):
                 self._send_metadata()
 
                 # Metric collection
-                self._collect_metrics(db, tags)
+                self._collect_metrics(db, tags=tags)
                 self._collect_system_metrics(self._config.host, db, tags)
                 if self._config.deep_database_monitoring:
                     self._collect_statement_metrics(db, tags)

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -79,7 +79,7 @@ class MySql(AgentCheck):
         # Create a new connection on every check run
         self._conn = None
 
-        self._query_manager = QueryManager(self, self.execute_query_raw, queries=[], tags=self._config.tags)
+        self._query_manager = QueryManager(self, self.execute_query_raw, queries=[])
         self.check_initializations.append(self._query_manager.compile_queries)
         self.innodb_stats = InnoDBMetrics()
         self.check_initializations.append(self._config.configuration_checks)

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -482,10 +482,10 @@ class MySql(AgentCheck):
 
                     if replication_role in {'writer', 'reader'}:
                         runtime_tags.append('replication_role:' + replication_role)
-                except pymysql.err.ProgrammingError as e:
+                except pymysql.err.InternalError as e:
                     # Non-AWS Aurora databases will not have the tables required for
                     # the query so this is an expected error.
-                    if e.args[0] != pymysql.constants.ER.NO_SUCH_TABLE:
+                    if e.args[0] != pymysql.constants.ER.UNKNOWN_TABLE:
                         raise
         except Exception:
             self.log.warning("Error occurred while fetching runtime tags: %s", traceback.format_exc())

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -33,7 +33,6 @@ FROM information_schema.ENGINES
 WHERE engine='InnoDB' and support != 'no' and support != 'disabled'"""
 
 SQL_REPLICATION_ROLE_AWS_AURORA = """\
-SET sql_notes = 0;  -- Show no warnings if not running on AWS Aurora
 SELECT IF(session_id = 'MASTER_SESSION_ID','writer', 'reader') AS replication_role
 FROM information_schema.replica_host_status
 WHERE server_id = @@aurora_server_id;

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -33,7 +33,7 @@ FROM information_schema.ENGINES
 WHERE engine='InnoDB' and support != 'no' and support != 'disabled'"""
 
 SQL_SERVER_ID_AWS_AURORA = """\
-SHOW VARIABLES LIKE 'aurora_server_id' LIMIT 1"""
+SHOW VARIABLES LIKE 'aurora_server_id'"""
 
 SQL_REPLICATION_ROLE_AWS_AURORA = """\
 SELECT IF(session_id = 'MASTER_SESSION_ID','writer', 'reader') AS replication_role

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -32,11 +32,13 @@ SELECT engine
 FROM information_schema.ENGINES
 WHERE engine='InnoDB' and support != 'no' and support != 'disabled'"""
 
+SQL_SERVER_ID_AWS_AURORA = """\
+SHOW VARIABLES LIKE 'aurora_server_id' LIMIT 1"""
+
 SQL_REPLICATION_ROLE_AWS_AURORA = """\
 SELECT IF(session_id = 'MASTER_SESSION_ID','writer', 'reader') AS replication_role
 FROM information_schema.replica_host_status
-WHERE server_id = @@aurora_server_id;
-"""
+WHERE server_id = @@aurora_server_id"""
 
 def show_replica_status_query(version, is_mariadb, channel=''):
     if version.version_compatible((10, 5, 1)) or not is_mariadb and version.version_compatible((8, 0, 22)):

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -32,6 +32,12 @@ SELECT engine
 FROM information_schema.ENGINES
 WHERE engine='InnoDB' and support != 'no' and support != 'disabled'"""
 
+SQL_REPLICATION_ROLE_AWS_AURORA = """\
+SET sql_notes = 0;  -- Show no warnings if not running on AWS Aurora
+SELECT IF(session_id = 'MASTER_SESSION_ID','writer', 'reader') AS replication_role
+FROM information_schema.replica_host_status
+WHERE server_id = @@aurora_server_id;
+"""
 
 def show_replica_status_query(version, is_mariadb, channel=''):
     if version.version_compatible((10, 5, 1)) or not is_mariadb and version.version_compatible((8, 0, 22)):

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -40,6 +40,7 @@ SELECT IF(session_id = 'MASTER_SESSION_ID','writer', 'reader') AS replication_ro
 FROM information_schema.replica_host_status
 WHERE server_id = @@aurora_server_id"""
 
+
 def show_replica_status_query(version, is_mariadb, channel=''):
     if version.version_compatible((10, 5, 1)) or not is_mariadb and version.version_compatible((8, 0, 22)):
         base_query = "SHOW REPLICA STATUS"

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -769,7 +769,7 @@ def test_replication_check_status(
     assert len(aggregator.service_checks('mysql.replication.slave_running')) == expected_service_check_len
 
 
-def test__get_runtime_tags():
+def test__get_runtime_aurora_tags():
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[{'server': 'localhost', 'user': 'datadog'}])
 
     class MockCursor:
@@ -805,25 +805,25 @@ def test__get_runtime_tags():
     reader_row = ('reader',)
     writer_row = ('writer',)
 
-    tags = mysql_check._get_runtime_tags(MockDatabase(MockCursor(reader_row)))
+    tags = mysql_check._get_runtime_aurora_tags(MockDatabase(MockCursor(reader_row)))
     assert tags == ['replication_role:reader']
 
-    tags = mysql_check._get_runtime_tags(MockDatabase(MockCursor(writer_row)))
+    tags = mysql_check._get_runtime_aurora_tags(MockDatabase(MockCursor(writer_row)))
     assert tags == ['replication_role:writer']
 
-    tags = mysql_check._get_runtime_tags(MockDatabase(MockCursor((1, 'reader'))))
+    tags = mysql_check._get_runtime_aurora_tags(MockDatabase(MockCursor((1, 'reader'))))
     assert tags == []
 
     # Error cases for non-aurora databases; any error should be caught and not fail the check
 
-    tags = mysql_check._get_runtime_tags(
+    tags = mysql_check._get_runtime_aurora_tags(
         MockDatabase(
             MockCursorWithError(pymysql.err.InternalError(pymysql.constants.ER.UNKNOWN_TABLE, 'Unknown Table'))
         )
     )
     assert tags == []
 
-    tags = mysql_check._get_runtime_tags(
+    tags = mysql_check._get_runtime_aurora_tags(
         MockDatabase(
             MockCursorWithError(
                 pymysql.err.ProgrammingError(pymysql.constants.ER.DBACCESS_DENIED_ERROR, 'Access Denied')

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -823,9 +823,9 @@ def test__get_is_aurora():
     assert False is check._is_aurora
 
     check = new_check()
-    assert None is check._get_is_aurora(MockDatabase(MockCursor(rows=None, side_effect=ValueError())))
+    assert False is check._get_is_aurora(MockDatabase(MockCursor(rows=None, side_effect=ValueError())))
     assert None is check._is_aurora
-    assert None is check._get_is_aurora(None)
+    assert False is check._get_is_aurora(None)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What does this PR do?

This adds the tag `replication_role` if the check runs against a database running in AWS Aurora. If the database is a "reader" then the tag `replication_role:reader` will be added, and if the database is the writer then the tag `replication_role:writer` will be added.

In a future PR, I can expand this to include non-AWS Aurora databases as well.

### Motivation

This feature was specifically requested by Zendesk so they can filter queries to queries running on a read-only or read-write database. The primary use case is to identify read queries on the primary which could instead be issued on one of the replicas.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
