### PR TITLE
Add the `host` tag to RDS instances' parsed tags

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/aws.py
+++ b/datadog_checks_base/datadog_checks/base/utils/aws.py
@@ -10,8 +10,10 @@ def rds_parse_tags_from_endpoint(endpoint):
 
     * `dbinstanceidentifier` - The instance's unique identifier for RDS and Aurora clusters
     * `dbclusteridentifier` - The cluster identifier in the case of Aurora cluster endpoints and serverless
-    * `hostname` - The full endpoint if the endpoint points to a specific instance
-    * `host` - The full endpoint if the endpoint points to a specific instance
+    * `hostname` - The full endpoint if the endpoint points to a specific instance. This tag should match
+        the RDS integration tag of the same name.
+    * `host` - Same value as the hostname tag, but intended to supplement the agent `host` tag since RDS
+        instance checks are always run on different hosts from where the actual managed DB is run.
     * `region` - The AWS region of the endpoint
 
     Examples:
@@ -41,8 +43,6 @@ def rds_parse_tags_from_endpoint(endpoint):
     else:
         tags.append('dbinstanceidentifier:' + identifier)
         tags.append('hostname:' + endpoint)
-        # Add the `host` tag as the instance endpoint. This is a more useful tag for metrics
-        # because the agent's hostname is not the actual host being monitored.
         tags.append('host:' + endpoint)
     tags.append('region:' + region)
     return tags

--- a/datadog_checks_base/datadog_checks/base/utils/aws.py
+++ b/datadog_checks_base/datadog_checks/base/utils/aws.py
@@ -40,5 +40,8 @@ def rds_parse_tags_from_endpoint(endpoint):
     else:
         tags.append('dbinstanceidentifier:' + identifier)
         tags.append('hostname:' + endpoint)
+        # Add the `host` tag as the instance endpoint. This is a more useful tag for metrics
+        # because the agent's hostname is not the actual host being monitored.
+        tags.append('host:' + endpoint)
     tags.append('region:' + region)
     return tags

--- a/datadog_checks_base/datadog_checks/base/utils/aws.py
+++ b/datadog_checks_base/datadog_checks/base/utils/aws.py
@@ -11,13 +11,14 @@ def rds_parse_tags_from_endpoint(endpoint):
     * `dbinstanceidentifier` - The instance's unique identifier for RDS and Aurora clusters
     * `dbclusteridentifier` - The cluster identifier in the case of Aurora cluster endpoints and serverless
     * `hostname` - The full endpoint if the endpoint points to a specific instance
+    * `host` - The full endpoint if the endpoint points to a specific instance
     * `region` - The AWS region of the endpoint
 
     Examples:
 
     >>> rds_parse_tags_from_endpoint('customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com')
     ['dbinstanceidentifier:customers-04', 'hostname:customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com',
-     'region:us-west-2']
+     'host:customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com', 'region:us-west-2']
 
     >>> rds_parse_tags_from_endpoint('dd-metrics.cluster-ro-cfxdfe8cpixl.ap-east-1.rds.amazonaws.com')
     ['dbclusteridentifier:dd-metrics', 'region:ap-east-1']

--- a/datadog_checks_base/tests/test_aws.py
+++ b/datadog_checks_base/tests/test_aws.py
@@ -21,6 +21,7 @@ class TestRDS:
                 [
                     'dbinstanceidentifier:my_db',
                     'hostname:my_db.cfxdfe8cpixl.us-east-2.rds.amazonaws.com',
+                    'host:my_db.cfxdfe8cpixl.us-east-2.rds.amazonaws.com',
                     'region:us-east-2',
                 ],
             ),
@@ -29,6 +30,7 @@ class TestRDS:
                 [
                     'dbinstanceidentifier:customers-04',
                     'hostname:customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com',
+                    'host:customers-04.cfxdfe8cpixl.us-west-2.rds.amazonaws.com',
                     'region:us-west-2',
                 ],
             ),


### PR DESCRIPTION
### What does this PR do?

This is a follow-up to: https://github.com/DataDog/integrations-core/pull/7353. A previous conversation on that PR (now removed due to a force push) suggested there may be a billing impact to adding the `host` tag to metrics. At the time, it was removed for investigation. I confirmed that host tags on metrics are not used for metering and will not impact host counts, so it is safe to add this tag back.

### Motivation

This tag will allow customers monitoring RDS instances to filter by `host:{rds_instance}` and group by `host`. Currently the tag set sent with metrics are:

```
["host:agent_hostname", ...other tags]
```

With this change, the tag set will be:

```
["host:agent_hostname", "host:rds_hostname", ...other tags]
```

### Additional Notes

If approved/merged, I will need help to cut a new release so postgres/mysql integrations can leverage this new functionality.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
