### PR TITLE
Support nightly datadog_checks_base package checks

### DIFF
--- a/.azure-pipelines/all_master.yml
+++ b/.azure-pipelines/all_master.yml
@@ -18,3 +18,4 @@ jobs:
       restoreKeys: |
         pip | $(Agent.OS)
       path: $(PIP_CACHE_DIR)
+      ispr: false

--- a/.azure-pipelines/all_pr.yml
+++ b/.azure-pipelines/all_pr.yml
@@ -22,3 +22,4 @@ jobs:
       restoreKeys: |
         pip | $(Agent.OS)
       path: $(PIP_CACHE_DIR)
+      ispr: true

--- a/.azure-pipelines/nightly_latest_base.yml
+++ b/.azure-pipelines/nightly_latest_base.yml
@@ -1,0 +1,29 @@
+# Nightly run on the master branch.
+# This pipeline tests using the latest released version of `datadog_checks_base` rather than the dev version.
+
+schedules:
+- cron: "0 5 * * *"
+  displayName: Nightly (5am UTC)
+  always: true
+  branches:
+    include:
+    - master
+
+pr: none
+
+trigger: none
+
+variables:
+  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
+  DDEV_COLOR: 1
+
+jobs:
+- template: './templates/test-all-checks.yml'
+  parameters:
+    run_py2_tests: false  # Handled via separate nightly
+    force_base_package: true
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -7,6 +7,7 @@ parameters:
   latest_metrics: false
   repo: ''
   coverage: true
+  force_base_package: false
 
 steps:
 - ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true')) }}:
@@ -18,6 +19,11 @@ steps:
 - ${{ if and(eq(parameters.test, 'true'), not(eq(parameters.coverage, 'true'))) }}:
     - script: ddev test --junit ${{ parameters.check }}
       displayName: 'Run Unit/Integration tests (no coverage)'
+
+# Nightly base package check
+- ${{ if and(eq(parameters.test, 'true'), eq(parameters.force_base_package, 'true')) }}:
+    - script: ddev test --force-base-package --force-env-rebuild --junit ${{ parameters.check }}
+      displayName: 'Run Unit/Integration tests (no coverage, forced datadog_checks_base package)'
 
 - ${{ if eq(parameters.test_e2e, 'true') }}:
   - script: |

--- a/.azure-pipelines/templates/run-validations.yml
+++ b/.azure-pipelines/templates/run-validations.yml
@@ -1,5 +1,6 @@
 parameters:
   repo: 'core'
+  ispr: false
 
 steps:
 - ${{ if in(parameters.repo, 'core', 'extras', 'internal') }}:
@@ -24,9 +25,13 @@ steps:
 - script: ddev validate dashboards
   displayName: 'Validate dashboard definition files'
 
-- ${{ if eq(parameters.repo, 'core') }}:
-  - script: ddev validate dep
+- ${{ if and(eq(parameters.repo, 'core'), eq(parameters.ispr, 'true')) }}:
+  - script: ddev validate dep --require-base-check-version
     displayName: 'Validate dependencies'
+
+- ${{ if and(eq(parameters.repo, 'core'), eq(parameters.ispr, 'false')) }}:
+    - script: ddev validate dep
+      displayName: 'Validate dependencies'
 
 - script: ddev validate manifest
   displayName: 'Validate manifest files'

--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -1,11 +1,15 @@
 parameters:
+  ispr: false
   pip_cache_config: null
   run_py2_tests: true
+  force_base_package: false
 jobs:
 - template: ./test-all.yml
   parameters:
+    ispr: ${{ parameters.ispr }}
     pip_cache_config: ${{ parameters.pip_cache_config }}
     run_py2_tests: ${{ parameters.run_py2_tests }}
+    force_base_package: ${{ parameters.force_base_package }}
     checks:
     - checkName: datadog_checks_base
       displayName: Datadog Checks Base (Linux)

--- a/.azure-pipelines/templates/test-all.yml
+++ b/.azure-pipelines/templates/test-all.yml
@@ -1,8 +1,10 @@
 parameters:
   checks: []
   repo: 'core'
+  ispr: false
   pip_cache_config: null
   run_py2_tests: true
+  force_base_package: false
   coverage: true
 
 jobs:
@@ -13,8 +15,10 @@ jobs:
       coverage: ${{ parameters.coverage }}
       display: ${{ check.displayName }}
       repo: ${{ parameters.repo }}
+      ispr: ${{ parameters.ispr }}
       pip_cache_config: ${{ parameters.pip_cache_config }}
       run_py2_tests: ${{ parameters.run_py2_tests }}
+      force_base_package: ${{ parameters.force_base_package }}
 
       # Avoid max step limits
       ${{ if eq(check.checkName, 'datadog_checks_base') }}:

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -8,7 +8,9 @@ parameters:
   latest_metrics: false
   validate: false
   repo: 'core'
+  ispr: false
   run_py2_tests: true  # Whether or not to run python2 tests.
+  force_base_package: false
   pip_cache_config: null
   coverage: true
 
@@ -40,6 +42,7 @@ jobs:
     - template: './run-validations.yml'
       parameters:
         repo: ${{ parameters.repo }}
+        ispr: ${{ parameters.ispr }}
 
   - template: './run-tests.yml'
     parameters:

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -8,8 +8,10 @@ parameters:
   latest_metrics: false
   validate: false
   repo: 'core'
-  pip_cache_config: null
+  ispr: false
   run_py2_tests: true  # Whether or not to run python2 tests
+  force_base_package: false
+  pip_cache_config: null
   coverage: true
 
 jobs:
@@ -42,6 +44,7 @@ jobs:
     - template: './run-validations.yml'
       parameters:
         repo: ${{ parameters.repo }}
+        ispr: ${{ parameters.ispr }}
 
   - template: './run-tests.yml'
     parameters:
@@ -53,3 +56,4 @@ jobs:
       latest_metrics: ${{ parameters.latest_metrics }}
       repo: ${{ parameters.repo }}
       coverage: ${{ parameters.coverage }}
+      force_base_package: ${{ parameters.force_base_package }}

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -70,6 +70,17 @@ def tox_configure(config):
             if E2E_READY_CONDITION in cfg.description:
                 cfg.description = description
 
+    # Workaround for tox's `--force-dep` having limited functionality when package already installed.
+    # Primarily meant for pinning datadog-checks-base to a specific version, but could be
+    # applied to other packages in the future. Since we typically install checks base via
+    # editable mode, we need to force the reinstall to ensure that the PyPI package installs.
+    force_install = os.getenv('TOX_FORCE_INSTALL', [])
+    if force_install:
+        command = f'pip install --force-reinstall {force_install}'.split()
+
+        for env in config.envlist:
+            config.envconfigs[env].commands.insert(0, command)
+
 
 def add_style_checker(config, sections, make_envconfig, reader):
     # testenv:style


### PR DESCRIPTION
### What does this PR do?
Adds support to test against the latest released version of `datadog_checks_base` as part of `ddev test` command.

Includes a few related features:
- New `ddev test` options: `--force-base-package` and `--force-env-rebuild`
- Nightly CI tests with those options enabled
- Add `ispr` parameter to CI to limit certain tests/validations to PRs-only
- Add PR validation for `ddev validate dep --require-base-check-version`

### Motivation
Avoid surprises when a check depends on unreleased `datadog_checks_base` functionality.

### Additional Notes
While not needed for CI, the `--force-env-rebuild` is helpful for local testing since `tox` will just reuse an existing env.
