### PR TITLE
Better arbiter support

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -21,6 +21,9 @@ files:
           - For a sharded cluster, specify the hostname(s) of the mongos instance(s).
 
         If the port number is not specified, the default port 27017 is used.
+
+        Even if the host is an arbiter node, you still need to provide authentication credentials
+        as the check will create an additional connection to the primary in this specific case.
       value:
         example:
         - <HOST_1>

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -25,6 +25,9 @@ instances:
     ##   - For a sharded cluster, specify the hostname(s) of the mongos instance(s).
     ##
     ## If the port number is not specified, the default port 27017 is used.
+    ##
+    ## Even if the host is an arbiter node, you still need to provide authentication credentials
+    ## as the check will create an additional connection to the primary in this specific case.
     #
   - hosts:
       - <HOST_1>

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -193,8 +193,11 @@ class MongoDb(AgentCheck):
         elif isinstance(deployment, MongosDeployment):
             tags.append('sharding_cluster_role:mongos')
 
-        dbnames = api.list_database_names()
-        self.gauge('mongodb.dbs', len(dbnames), tags=tags)
+        if isinstance(deployment, ReplicaSetDeployment) and deployment.is_arbiter:
+            dbnames = []
+        else:
+            dbnames = api.list_database_names()
+            self.gauge('mongodb.dbs', len(dbnames), tags=tags)
 
         self.refresh_collectors(api.deployment_type, mongo_version, dbnames, tags)
         for collector in self.collectors:

--- a/mongo/tests/common.py
+++ b/mongo/tests/common.py
@@ -9,6 +9,7 @@ HERE = get_here()
 HOST = get_docker_hostname()
 PORT1 = 27017
 PORT2 = 27018
+PORT_ARBITER = 27020
 MAX_WAIT = 150
 
 MONGODB_SERVER = "mongodb://%s:%s/test" % (HOST, PORT1)
@@ -47,3 +48,5 @@ INSTANCE_USER = {
     'password': 'testPass2',
 }
 INSTANCE_USER_LEGACY_CONFIG = {'server': 'mongodb://testUser2:testPass2@{}:{}/test'.format(HOST, PORT1)}
+
+INSTANCE_ARBITER = {'hosts': ['{}:{}'.format(HOST, PORT_ARBITER)], 'username': 'testUser', 'password': 'testPass'}

--- a/mongo/tests/compose/docker-compose.yml
+++ b/mongo/tests/compose/docker-compose.yml
@@ -30,16 +30,16 @@ services:
       - ./scripts:/scripts
   shard01b:
     image: mongo:$MONGO_VERSION
-    command: mongod --port 27018 --bind_ip=0.0.0.0 --shardsvr --replSet shard01 --oplogSize 16
+    command: mongod --port 27019 --bind_ip=0.0.0.0 --shardsvr --replSet shard01 --oplogSize 16
     ports:
-    - "27019:27018"
+    - "27019:27019"
     volumes:
       - ./scripts:/scripts
   shard01c:
     image: mongo:$MONGO_VERSION
-    command: mongod --port 27018 --bind_ip=0.0.0.0 --shardsvr --replSet shard01 --oplogSize 16
+    command: mongod --port 27020 --bind_ip=0.0.0.0 --shardsvr --replSet shard01 --oplogSize 16
     ports:
-    - "27020:27018"
+    - "27020:27020"
     volumes:
     - ./scripts:/scripts
   shard02a:

--- a/mongo/tests/compose/scripts/init-router.js
+++ b/mongo/tests/compose/scripts/init-router.js
@@ -1,6 +1,6 @@
 sh.addShard("shard01/shard01a:27018")
-sh.addShard("shard01/shard01b:27018")
-sh.addShard("shard01/shard01c:27018")
+sh.addShard("shard01/shard01b:27019")
+sh.addShard("shard01/shard01c:27020")
 
 sh.addShard("shard02/shard02a:27019")
 sh.addShard("shard02/shard02b:27019")

--- a/mongo/tests/compose/scripts/init-shard01.js
+++ b/mongo/tests/compose/scripts/init-shard01.js
@@ -4,8 +4,8 @@ rs.initiate(
       version: 1,
       members: [
          { _id: 0, host : "shard01a:27018", priority: 1},
-         { _id: 1, host : "shard01b:27018", priority: 0.5 },
-         { _id: 2, host : "shard01c:27018", arbiterOnly: true},
+         { _id: 1, host : "shard01b:27019", priority: 0.5 },
+         { _id: 2, host : "shard01c:27020", arbiterOnly: true},
       ]
    }
 )

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -9,7 +9,6 @@ from contextlib import contextmanager
 import mock
 import pymongo
 import pytest
-
 from datadog_test_libs.utils.mock_dns import mock_local
 from tests.mocked_api import MockedPyMongoClient
 
@@ -17,7 +16,6 @@ from datadog_checks.dev import LazyFunction, WaitFor, docker_run, run_command
 from datadog_checks.mongo import MongoDb
 
 from . import common
-
 
 HOSTNAME_TO_PORT_MAPPING = {
     "shard01a": (

--- a/mongo/tests/conftest.py
+++ b/mongo/tests/conftest.py
@@ -9,12 +9,30 @@ from contextlib import contextmanager
 import mock
 import pymongo
 import pytest
+
+from datadog_test_libs.utils.mock_dns import mock_local
 from tests.mocked_api import MockedPyMongoClient
 
 from datadog_checks.dev import LazyFunction, WaitFor, docker_run, run_command
 from datadog_checks.mongo import MongoDb
 
 from . import common
+
+
+HOSTNAME_TO_PORT_MAPPING = {
+    "shard01a": (
+        '127.0.0.1',
+        27018,
+    ),
+    "shard01b": (
+        '127.0.0.1',
+        27019,
+    ),
+    "shard01c": (
+        '127.0.0.1',
+        27020,
+    ),
+}
 
 
 @pytest.fixture(scope='session')
@@ -29,7 +47,12 @@ def dd_environment():
             WaitFor(create_shard_user, attempts=60, wait=5),
         ],
     ):
-        yield common.INSTANCE_BASIC
+        yield common.INSTANCE_BASIC, {'custom_hosts': get_custom_hosts()}
+
+
+def get_custom_hosts():
+    custom_hosts = [(host, '127.0.0.1') for host in HOSTNAME_TO_PORT_MAPPING]
+    return custom_hosts
 
 
 @pytest.fixture
@@ -106,6 +129,12 @@ def instance_integration(instance_custom_queries):
     return instance
 
 
+@pytest.fixture(scope='session', autouse=True)
+def mock_local_tls_dns():
+    with mock_local(HOSTNAME_TO_PORT_MAPPING):
+        yield
+
+
 @contextmanager
 def mock_pymongo(deployment):
     mocked_client = MockedPyMongoClient(deployment=deployment)
@@ -133,6 +162,11 @@ def instance_1valid_and_1invalid_custom_queries():
     ]
 
     return instance
+
+
+@pytest.fixture
+def instance_arbiter():
+    return common.INSTANCE_ARBITER.copy()
 
 
 @pytest.fixture

--- a/mongo/tests/fixtures/getCmdLineOpts-replica-arbiter
+++ b/mongo/tests/fixtures/getCmdLineOpts-replica-arbiter
@@ -1,0 +1,49 @@
+{
+    "argv": [
+        "/opt/bitnami/mongodb/bin/mongod",
+        "--config=/opt/bitnami/mongodb/conf/mongodb.conf"
+    ],
+    "parsed": {
+        "config": "/opt/bitnami/mongodb/conf/mongodb.conf",
+        "net": {
+            "bindIp": "*",
+            "ipv6": false,
+            "port": 27017,
+            "unixDomainSocket": {
+                "enabled": true,
+                "pathPrefix": "/opt/bitnami/mongodb/tmp"
+            }
+        },
+        "processManagement": {
+            "fork": false,
+            "pidFilePath": "/opt/bitnami/mongodb/tmp/mongodb.pid"
+        },
+        "replication": {
+            "enableMajorityReadConcern": true,
+            "replSetName": "replset"
+        },
+        "security": {
+            "authorization": "disabled",
+            "keyFile": "/opt/bitnami/mongodb/conf/keyfile"
+        },
+        "setParameter": {
+            "enableLocalhostAuthBypass": "true"
+        },
+        "storage": {
+            "dbPath": "/bitnami/mongodb/data/db",
+            "directoryPerDB": false,
+            "journal": {
+                "enabled": true
+            }
+        },
+        "systemLog": {
+            "destination": "file",
+            "logAppend": true,
+            "logRotate": "reopen",
+            "path": "/opt/bitnami/mongodb/logs/mongodb.log",
+            "quiet": false,
+            "verbosity": 0
+        }
+    },
+    "ok": 1.0
+}

--- a/mongo/tests/fixtures/getCmdLineOpts-replica-arbiter-in-shard
+++ b/mongo/tests/fixtures/getCmdLineOpts-replica-arbiter-in-shard
@@ -1,0 +1,52 @@
+{
+    "argv": [
+        "/opt/bitnami/mongodb/bin/mongod",
+        "--config=/opt/bitnami/mongodb/conf/mongodb.conf"
+    ],
+    "parsed": {
+        "config": "/opt/bitnami/mongodb/conf/mongodb.conf",
+        "net": {
+            "bindIp": "*",
+            "ipv6": false,
+            "port": 27017,
+            "unixDomainSocket": {
+                "enabled": true,
+                "pathPrefix": "/opt/bitnami/mongodb/tmp"
+            }
+        },
+        "processManagement": {
+            "fork": false,
+            "pidFilePath": "/opt/bitnami/mongodb/tmp/mongodb.pid"
+        },
+        "replication": {
+            "enableMajorityReadConcern": true,
+            "replSetName": "mongo-mongodb-sharded-shard-0"
+        },
+        "security": {
+            "authorization": "disabled",
+            "keyFile": "/opt/bitnami/mongodb/conf/keyfile"
+        },
+        "setParameter": {
+            "enableLocalhostAuthBypass": "true"
+        },
+        "sharding": {
+            "clusterRole": "shardsvr"
+        },
+        "storage": {
+            "dbPath": "/bitnami/mongodb/data/db",
+            "directoryPerDB": false,
+            "journal": {
+                "enabled": true
+            }
+        },
+        "systemLog": {
+            "destination": "file",
+            "logAppend": true,
+            "logRotate": "reopen",
+            "path": "/opt/bitnami/mongodb/logs/mongodb.log",
+            "quiet": false,
+            "verbosity": 0
+        }
+    },
+    "ok": 1.0
+}

--- a/mongo/tests/fixtures/replSetGetStatus-replica-arbiter
+++ b/mongo/tests/fixtures/replSetGetStatus-replica-arbiter
@@ -1,0 +1,311 @@
+{
+    "set": "replset",
+    "date": {
+        "$date": 1601626042162
+    },
+    "myState": 7,
+    "term": 24,
+    "syncingTo": "",
+    "syncSourceHost": "",
+    "syncSourceId": -1,
+    "heartbeatIntervalMillis": 2000,
+    "majorityVoteCount": 3,
+    "writeMajorityCount": 3,
+    "optimes": {
+        "lastCommittedOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1601384207,
+                    "i": 1
+                }
+            },
+            "t": 24
+        },
+        "lastCommittedWallTime": {
+            "$date": 1601384207410
+        },
+        "readConcernMajorityOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1601384207,
+                    "i": 1
+                }
+            },
+            "t": 24
+        },
+        "readConcernMajorityWallTime": {
+            "$date": 1601384207410
+        },
+        "appliedOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1601384207,
+                    "i": 1
+                }
+            },
+            "t": 24
+        },
+        "durableOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1601384207,
+                    "i": 1
+                }
+            },
+            "t": 24
+        },
+        "lastAppliedWallTime": {
+            "$date": 1601384207410
+        },
+        "lastDurableWallTime": {
+            "$date": 1601384207410
+        }
+    },
+    "lastStableRecoveryTimestamp": {
+        "$timestamp": {
+            "t": 1601384207,
+            "i": 1
+        }
+    },
+    "lastStableCheckpointTimestamp": {
+        "$timestamp": {
+            "t": 1601384207,
+            "i": 1
+        }
+    },
+    "electionCandidateMetrics": {
+        "lastElectionReason": "priorityTakeover",
+        "lastElectionDate": {
+            "$date": 1596803917118
+        },
+        "electionTerm": 24,
+        "lastCommittedOpTimeAtElection": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1596803912,
+                    "i": 1
+                }
+            },
+            "t": 23
+        },
+        "lastSeenOpTimeAtElection": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1596803912,
+                    "i": 1
+                }
+            },
+            "t": 23
+        },
+        "numVotesNeeded": 3,
+        "priorityAtElection": 5.0,
+        "electionTimeoutMillis": 10000,
+        "priorPrimaryMemberId": 2,
+        "numCatchUpOps": 0,
+        "newTermStartDate": {
+            "$date": 1596803917125
+        },
+        "wMajorityWriteAvailabilityDate": {
+            "$date": 1596803919128
+        }
+    },
+    "members": [
+        {
+            "_id": 0,
+            "name": "replset-data-0.mongo.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 1,
+            "stateStr": "PRIMARY",
+            "uptime": 4822189,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1601384207,
+                        "i": 1
+                    }
+                },
+                "t": 24
+            },
+            "optimeDate": {
+                "$date": 1601384207000
+            },
+            "syncingTo": "",
+            "syncSourceHost": "",
+            "syncSourceId": -1,
+            "infoMessage": "",
+            "electionTime": {
+                "$timestamp": {
+                    "t": 1596803917,
+                    "i": 1
+                }
+            },
+            "electionDate": {
+                "$date": 1596803917000
+            },
+            "configVersion": 4,
+            "lastHeartbeatMessage": ""
+        },
+        {
+            "_id": 1,
+            "name": "replset-arbiter-0.mongo.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 7,
+            "stateStr": "ARBITER",
+            "uptime": 4822185,
+            "lastHeartbeat": {
+                "$date": 1601626040978
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1601626041204
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "",
+            "syncSourceHost": "",
+            "syncSourceId": -1,
+            "infoMessage": "",
+            "configVersion": 4,
+            "self": true
+        },
+        {
+            "_id": 2,
+            "name": "replset-data-1.mongo.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 2,
+            "stateStr": "SECONDARY",
+            "uptime": 4822185,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1601384207,
+                        "i": 1
+                    }
+                },
+                "t": 24
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1601384207,
+                        "i": 1
+                    }
+                },
+                "t": 24
+            },
+            "optimeDate": {
+                "$date": 1601384107000
+            },
+            "optimeDurableDate": {
+                "$date": 1601384207000
+            },
+            "lastHeartbeat": {
+                "$date": 1601626040980
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1601626041076
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceHost": "mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceId": 3,
+            "infoMessage": "",
+            "configVersion": 4
+        },
+        {
+            "_id": 3,
+            "name": "replset-data-2.mongo.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 2,
+            "stateStr": "SECONDARY",
+            "uptime": 4822185,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1601384207,
+                        "i": 1
+                    }
+                },
+                "t": 24
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1601384207,
+                        "i": 1
+                    }
+                },
+                "t": 24
+            },
+            "optimeDate": {
+                "$date": 1601384202000
+            },
+            "optimeDurableDate": {
+                "$date": 1601384207000
+            },
+            "lastHeartbeat": {
+                "$date": 1601626041190
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1601626040934
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceHost": "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceId": 0,
+            "infoMessage": "",
+            "configVersion": 4
+        }
+    ],
+    "ok": 1.0,
+    "$gleStats": {
+        "lastOpTime": {
+            "$timestamp": {
+                "t": 0,
+                "i": 0
+            }
+        },
+        "electionId": {
+            "$oid": "7fffffff0000000000000018"
+        }
+    },
+    "lastCommittedOpTime": {
+        "$timestamp": {
+            "t": 1601384207,
+            "i": 1
+        }
+    },
+    "$configServerState": {
+        "opTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1601626035,
+                    "i": 1
+                }
+            },
+            "t": 2
+        }
+    },
+    "$clusterTime": {
+        "clusterTime": {
+            "$timestamp": {
+                "t": 1601626035,
+                "i": 1
+            }
+        },
+        "signature": {
+            "hash": {
+                "$binary": "GDIYxUuFam0+pL9BpjPXgskjojA=",
+                "$type": "00"
+            },
+            "keyId": 6857852638906548233
+        }
+    },
+    "operationTime": {
+        "$timestamp": {
+            "t": 1601384207,
+            "i": 1
+        }
+    }
+}

--- a/mongo/tests/fixtures/replSetGetStatus-replica-arbiter-in-shard
+++ b/mongo/tests/fixtures/replSetGetStatus-replica-arbiter-in-shard
@@ -1,0 +1,266 @@
+{
+    "set": "mongo-mongodb-sharded-shard-0",
+    "date": {
+        "$date": 1607692721343
+    },
+    "myState": 7,
+    "term": 20,
+    "syncingTo": "",
+    "syncSourceHost": "",
+    "syncSourceId": -1,
+    "heartbeatIntervalMillis": 2000,
+    "majorityVoteCount": 3,
+    "writeMajorityCount": 3,
+    "optimes": {
+        "lastCommittedOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1607692716,
+                    "i": 1
+                }
+            },
+            "t": 20
+        },
+        "lastCommittedWallTime": {
+            "$date": 1607692716969
+        },
+        "readConcernMajorityOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1607692716,
+                    "i": 1
+                }
+            },
+            "t": 20
+        },
+        "readConcernMajorityWallTime": {
+            "$date": 1607692716969
+        },
+        "appliedOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1607692716,
+                    "i": 1
+                }
+            },
+            "t": 20
+        },
+        "durableOpTime": {
+            "ts": {
+                "$timestamp": {
+                    "t": 0,
+                    "i": 0
+                }
+            },
+            "t": -1
+        },
+        "lastAppliedWallTime": {
+            "$date": 1607692716969
+        },
+        "lastDurableWallTime": {
+            "$date": 0
+        }
+    },
+    "lastStableRecoveryTimestamp": {
+        "$timestamp": {
+            "t": 1607692716,
+            "i": 1
+        }
+    },
+    "lastStableCheckpointTimestamp": {
+        "$timestamp": {
+            "t": 1607692716,
+            "i": 1
+        }
+    },
+    "electionParticipantMetrics": {
+        "votedForCandidate": true,
+        "electionTerm": 20,
+        "lastVoteDate": {
+            "$date": 1607612714163
+        },
+        "electionCandidateMemberId": 0,
+        "voteReason": "",
+        "lastAppliedOpTimeAtElection": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1607612709,
+                    "i": 1
+                }
+            },
+            "t": 19
+        },
+        "maxAppliedOpTimeInSet": {
+            "ts": {
+                "$timestamp": {
+                    "t": 1607612709,
+                    "i": 1
+                }
+            },
+            "t": 19
+        },
+        "priorityAtElection": 0.0
+    },
+    "members": [
+        {
+            "_id": 0,
+            "name": "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 1,
+            "stateStr": "PRIMARY",
+            "uptime": 80007,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1607692716,
+                        "i": 1
+                    }
+                },
+                "t": 20
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1607692716,
+                        "i": 1
+                    }
+                },
+                "t": 20
+            },
+            "optimeDate": {
+                "$date": 1607692716000
+            },
+            "optimeDurableDate": {
+                "$date": 1607692716000
+            },
+            "lastHeartbeat": {
+                "$date": 1607692721326
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1607692720831
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "",
+            "syncSourceHost": "",
+            "syncSourceId": -1,
+            "infoMessage": "",
+            "electionTime": {
+                "$timestamp": {
+                    "t": 1607612714,
+                    "i": 2
+                }
+            },
+            "electionDate": {
+                "$date": 1607612714000
+            },
+            "configVersion": 4
+        },
+        {
+            "_id": 1,
+            "name": "mongo-mongodb-sharded-shard0-arbiter-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 7,
+            "stateStr": "ARBITER",
+            "uptime": 80180,
+            "syncingTo": "",
+            "syncSourceHost": "",
+            "syncSourceId": -1,
+            "infoMessage": "",
+            "configVersion": 4,
+            "self": true,
+            "lastHeartbeatMessage": ""
+        },
+        {
+            "_id": 2,
+            "name": "mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 2,
+            "stateStr": "SECONDARY",
+            "uptime": 80102,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1607692716,
+                        "i": 1
+                    }
+                },
+                "t": 20
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1607692716,
+                        "i": 1
+                    }
+                },
+                "t": 20
+            },
+            "optimeDate": {
+                "$date": 1607692716000
+            },
+            "optimeDurableDate": {
+                "$date": 1607692716000
+            },
+            "lastHeartbeat": {
+                "$date": 1607692720386
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1607692719877
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceHost": "mongo-mongodb-sharded-shard0-data-0.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceId": 0,
+            "infoMessage": "",
+            "configVersion": 4
+        },
+        {
+            "_id": 3,
+            "name": "mongo-mongodb-sharded-shard0-data-2.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "health": 1.0,
+            "state": 2,
+            "stateStr": "SECONDARY",
+            "uptime": 80177,
+            "optime": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1607692716,
+                        "i": 1
+                    }
+                },
+                "t": 20
+            },
+            "optimeDurable": {
+                "ts": {
+                    "$timestamp": {
+                        "t": 1607692716,
+                        "i": 1
+                    }
+                },
+                "t": 20
+            },
+            "optimeDate": {
+                "$date": 1607692716000
+            },
+            "optimeDurableDate": {
+                "$date": 1607692716000
+            },
+            "lastHeartbeat": {
+                "$date": 1607692721325
+            },
+            "lastHeartbeatRecv": {
+                "$date": 1607692719550
+            },
+            "pingMs": 0,
+            "lastHeartbeatMessage": "",
+            "syncingTo": "mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceHost": "mongo-mongodb-sharded-shard0-data-1.mongo-mongodb-sharded-headless.default.svc.cluster.local:27017",
+            "syncSourceId": 2,
+            "infoMessage": "",
+            "configVersion": 4
+        }
+    ],
+    "ok": 1.0
+}

--- a/mongo/tests/results/metrics-replset-arbiter.json
+++ b/mongo/tests/results/metrics-replset-arbiter.json
@@ -1,0 +1,34 @@
+[
+    {
+        "name": "mongodb.replset.health",
+        "type": 0,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test"
+        ]
+    },
+    {
+        "name": "mongodb.replset.state",
+        "type": 0,
+        "value": 7.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test"
+        ]
+    },
+    {
+        "name": "mongodb.replset.votes",
+        "type": 0,
+        "value": 1.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test"
+        ]
+    },
+    {
+        "name": "mongodb.replset.votefraction",
+        "type": 0,
+        "value": 0.25,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test"
+        ]
+    }
+]

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -175,6 +175,39 @@ def test_integration_replicaset_secondary_in_shard(instance_integration, aggrega
     assert len(aggregator._events) == 0
 
 
+def test_integration_replicaset_arbiter_in_shard(instance_integration, aggregator, check):
+    for query in instance_integration['custom_queries']:
+        query['run_on_secondary'] = True
+    instance_integration['is_arbiter'] = True
+    mongo_check = check(instance_integration)
+    mongo_check.last_states_by_server = {0: 2, 1: 1, 2: 7, 3: 2}
+
+    with mock_pymongo("replica-arbiter-in-shard"):
+        mongo_check.check(None)
+
+    replica_tags = [
+        'replset_name:mongo-mongodb-sharded-shard-0',
+        'replset_state:arbiter',
+        'sharding_cluster_role:shardsvr',
+    ]
+    metrics_categories = ['serverStatus', 'replset-arbiter']
+
+    _assert_metrics(aggregator, metrics_categories, replica_tags)
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(
+        get_metadata_metrics(),
+        exclude=[
+            'dd.custom.mongo.aggregate.total',
+            'dd.custom.mongo.count',
+            'dd.custom.mongo.query_a.amount',
+            'dd.custom.mongo.query_a.el',
+        ],
+        check_submission_type=True,
+    )
+    assert len(aggregator._events) == 0
+
+
 def test_integration_configsvr_primary(instance_integration, aggregator, check):
     mongo_check = check(instance_integration)
     mongo_check.last_states_by_server = {0: 2, 1: 1, 2: 7, 3: 2}
@@ -387,6 +420,35 @@ def test_integration_replicaset_secondary(instance_integration, aggregator, chec
     ]
     if collect_custom_queries:
         metrics_categories.append('custom-queries')
+
+    _assert_metrics(aggregator, metrics_categories, replica_tags)
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(
+        get_metadata_metrics(),
+        exclude=[
+            'dd.custom.mongo.aggregate.total',
+            'dd.custom.mongo.count',
+            'dd.custom.mongo.query_a.amount',
+            'dd.custom.mongo.query_a.el',
+        ],
+        check_submission_type=True,
+    )
+    assert len(aggregator._events) == 0
+
+
+def test_integration_replicaset_arbiter(instance_integration, aggregator, check):
+    for query in instance_integration['custom_queries']:
+        query['run_on_secondary'] = True
+    instance_integration['is_arbiter'] = True
+    mongo_check = check(instance_integration)
+    mongo_check.last_states_by_server = {0: 2, 1: 1, 2: 7, 3: 2}
+
+    with mock_pymongo("replica-arbiter"):
+        mongo_check.check(None)
+
+    replica_tags = ['replset_name:replset', 'replset_state:arbiter']
+    metrics_categories = ['serverStatus', 'replset-arbiter']
 
     _assert_metrics(aggregator, metrics_categories, replica_tags)
 

--- a/mongo/tests/test_mongo.py
+++ b/mongo/tests/test_mongo.py
@@ -246,7 +246,7 @@ def test_mongo_replset(instance_shard, aggregator, check):
         'mongodb.replset.optime_lag', tags=replset_common_tags + ['replset_state:primary', 'member:shard01a:27018']
     )
     aggregator.assert_metric(
-        'mongodb.replset.optime_lag', tags=replset_common_tags + ['replset_state:secondary', 'member:shard01b:27018']
+        'mongodb.replset.optime_lag', tags=replset_common_tags + ['replset_state:secondary', 'member:shard01b:27019']
     )
     aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 

--- a/mongo/tests/test_mongo.py
+++ b/mongo/tests/test_mongo.py
@@ -4,10 +4,9 @@
 import logging
 
 import pytest
-
-from datadog_checks.dev.utils import get_metadata_metrics
 from six import iteritems
 
+from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.mongo import MongoDb
 
 from . import common
@@ -114,13 +113,13 @@ def test_mongo_arbiter(aggregator, check, instance_arbiter):
         'mongodb.replset.health': 1.0,
         'mongodb.replset.votefraction': None,
         'mongodb.replset.votes': 1,
-        'mongodb.replset.state': 7
+        'mongodb.replset.state': 7,
     }
     expected_tags = [
         'server:mongodb://testUser:*****@localhost:27020/',
         'replset_name:shard01',
         'replset_state:arbiter',
-        'sharding_cluster_role:shardsvr'
+        'sharding_cluster_role:shardsvr',
     ]
     for metric, value in iteritems(expected_metrics):
         aggregator.assert_metric(metric, value, expected_tags, count=1)

--- a/mongo/tox.ini
+++ b/mongo/tox.ini
@@ -20,6 +20,7 @@ passenv =
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
+    -e../datadog_checks_tests_helper
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
Better support for arbiter nodes:
- For collecting replica metrics, an additional connection is made to the primary in order to run the replSetGetConfig command
- Running `list_databases` on arbiters is forbidden, so skip it.
- Adds extensive fixture-based tests.