### PR TITLE
Add prefix to manifest fields and update link list in readme in snmp_tile template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/README.md
@@ -1,9 +1,9 @@
-# Agent Check: snmp_{integration_name}
+# Agent Check: snmp_{check_name}
 
 ## Overview
 
-This check monitors [{integration_name}][1].
-For details of monitored metrics see the [SNMP Data Collected][4] section.
+This check monitors {integration_name}.
+For details of monitored metrics see the [SNMP Data Collected][1] section.
 
 ## Setup
 
@@ -13,7 +13,7 @@ To install and configure the SNMP integration, see the [Network Device Monitorin
 
 ### Metrics
 
-For details of monitored metrics see the [SNMP Data Collected][4] section.
+For details of monitored metrics see the [SNMP Data Collected][1] section.
 
 ### Service Checks
 
@@ -29,7 +29,6 @@ Additional helpful documentation, links, and articles:
 
 * [Monitor SNMP with Datadog][3]
 
-[1]: https://app.datadoghq.com/account/settings#integrations/snmp
+[1]: https://docs.datadoghq.com/network_performance_monitoring/devices/data
 [2]: https://docs.datadoghq.com/network_performance_monitoring/devices/setup
 [3]: https://www.datadoghq.com/blog/monitor-snmp-with-datadog/
-[4]: https://docs.datadoghq.com/network_performance_monitoring/devices/data/

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/manifest.json
@@ -2,7 +2,7 @@
   "display_name": "{integration_name}",
   "maintainer": "{email}",
   "manifest_version": "1.0.0",
-  "name": "{check_name}",
+  "name": "snmp_{check_name}",
   "metric_prefix": "snmp.",
   "metric_to_check": "",
   "creates_events": false,
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "{integration_name}",
+  "public_title": "Datadog-{integration_name}",
   "categories": [ 
     "monitoring", 
     "notification", 
@@ -24,7 +24,7 @@
   ],
   "type": "check",
   "is_public": false,
-  "integration_id": "{integration_id}",
+  "integration_id": "snmp-{integration_id}",
   "assets": {{
     "dashboards": {{}},
     "saved_views": {{}},


### PR DESCRIPTION
### What does this PR do?
Minor fixes in snmp_tile template files:

* cleanup link list in `readme`
* add `snmp` prefix to `integration-id` and `name` in `manifest.json`
* add `Datadog-` prefix to `public-title` field in `manifest.json`

### Motivation
Changes required to be consistent with other integration tiles

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
