### PR TITLE
Fix postqueue defer counting

### DIFF
--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -125,7 +125,6 @@ class PostfixCheck(AgentCheck):
             self.log.debug('authorized_mailq_users : %s', authorized_mailq_users)
 
         output, _, _ = get_subprocess_output(['postqueue', '-c', postfix_config_dir, '-p'], self.log, False)
-
         active_count = 0
         hold_count = 0
         deferred_count = 0
@@ -144,15 +143,13 @@ class PostfixCheck(AgentCheck):
 
         -- 1 Kbytes in 2 Requests.
         '''
-
         for line in output.splitlines():
             if '*' in line:
                 active_count += 1
-                continue
-            if '!' in line:
+            elif '!' in line:
                 hold_count += 1
-                continue
-            if line[0:1].isdigit():
+            # Check the line starts with an ID
+            elif line[0:1].isalnum():
                 deferred_count += 1
 
         self.gauge(

--- a/postfix/tests/fixtures/postqueue_p.txt
+++ b/postfix/tests/fixtures/postqueue_p.txt
@@ -1,0 +1,18 @@
+----Queue ID----- --Size-- ---Arrival Time---- --Sender/Recipient------
+3xWyLP6Nmfz23fk        367 Tue Aug 15 16:17:33 root@postfix.devnull.home
+                                                    (deferred transport)
+                                                    alice@crypto.io
+
+3xWyD86NwZz23ff!       358 Tue Aug 15 16:12:08 root@postfix.devnull.home
+                                                    (deferred transport)
+                                                    bob@crypto.io
+
+TxWyD86NwZz23ff*       358 Tue Aug 15 16:11:08 root@postfix.devnull.home
+                                                    (deferred transport)
+                                                    bob@crypto.io
+
+TxWyD86NwZz23ff        358 Tue Aug 15 16:01:08 root@postfix.devnull.home
+                                                    (deferred transport)
+                                                    bob@crypto.io
+
+-- 1 Kbytes in 4 Requests.

--- a/postfix/tests/test_unit.py
+++ b/postfix/tests/test_unit.py
@@ -1,11 +1,31 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+
 import mock
 
+from datadog_checks.dev import get_here
 from datadog_checks.postfix import PostfixCheck
 
 MOCK_VERSION = '1.3.1'
+
+
+def test__get_postqueue_stats(aggregator):
+    check = PostfixCheck('postfix', {}, [])
+    common_tags = ['instance:/etc/postfix', 'foo:bar']
+
+    filepath = os.path.join(get_here(), 'fixtures', 'postqueue_p.txt')
+    with open(filepath, 'r') as f:
+        mocked_output = f.read()
+
+    with mock.patch('datadog_checks.postfix.postfix.get_subprocess_output') as s:
+        s.side_effect = [(False, None, None), (mocked_output, None, None)]
+        check._get_postqueue_stats('/etc/postfix', ['foo:bar'])
+
+        aggregator.assert_metric('postfix.queue.size', 1, tags=common_tags + ['queue:active'])
+        aggregator.assert_metric('postfix.queue.size', 1, tags=common_tags + ['queue:hold'])
+        aggregator.assert_metric('postfix.queue.size', 2, tags=common_tags + ['queue:deferred'])
 
 
 @mock.patch(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix how we count defer messages using `postqueue -p`
The queue id can start with any alphanumerical char

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->
http://www.postfix.org/postqueue.1.html

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
