### PR TITLE
Fix dep validation to work on single checks for PRs

### DIFF
--- a/.azure-pipelines/templates/run-validations.yml
+++ b/.azure-pipelines/templates/run-validations.yml
@@ -1,4 +1,5 @@
 parameters:
+  check: null
   repo: 'core'
   ispr: false
 
@@ -26,7 +27,7 @@ steps:
   displayName: 'Validate dashboard definition files'
 
 - ${{ if and(eq(parameters.repo, 'core'), eq(parameters.ispr, 'true')) }}:
-  - script: ddev validate dep --require-base-check-version
+  - script: ddev validate dep --require-base-check-version ${{ parameters.check }}
     displayName: 'Validate dependencies'
 
 - ${{ if and(eq(parameters.repo, 'core'), eq(parameters.ispr, 'false')) }}:

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -41,6 +41,7 @@ jobs:
   - ${{ if eq(parameters.validate, 'true') }}:
     - template: './run-validations.yml'
       parameters:
+        check: ${{ parameters.check }}
         repo: ${{ parameters.repo }}
         ispr: ${{ parameters.ispr }}
 

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -43,6 +43,7 @@ jobs:
   - ${{ if eq(parameters.validate, 'true') }}:
     - template: './run-validations.yml'
       parameters:
+        check: ${{ parameters.check }}
         repo: ${{ parameters.repo }}
         ispr: ${{ parameters.ispr }}
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
@@ -3,9 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import click
 
-from ...utils import complete_valid_checks
 from ....utils import get_next
 from ...dependencies import read_agent_dependencies, read_check_base_dependencies, read_check_dependencies
+from ...utils import complete_valid_checks
 from ..console import CONTEXT_SETTINGS, abort, echo_failure
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import click
 
+from ...utils import complete_valid_checks
 from ....utils import get_next
 from ...dependencies import read_agent_dependencies, read_check_base_dependencies, read_check_dependencies
 from ..console import CONTEXT_SETTINGS, abort, echo_failure
@@ -117,17 +118,18 @@ def verify_dependency(source, name, versions):
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Verify dependencies across all checks')
+@click.argument('check', autocompletion=complete_valid_checks, required=False)
 @click.option(
     '--require-base-check-version', is_flag=True, help='Require specific version for datadog-checks-base requirement'
 )
 @click.option(
     '--min-base-check-version', help='Specify minimum version for datadog-checks-base requirement, e.g. `11.0.0`'
 )
-def dep(require_base_check_version, min_base_check_version):
+def dep(check, require_base_check_version, min_base_check_version):
     """
     This command will:
 
-    * Verify the uniqueness of dependency versions across all checks.
+    * Verify the uniqueness of dependency versions across all checks, or optionally a single check
     * Verify all the dependencies are pinned.
     * Verify the embedded Python environment defined in the base check and requirements
       listed in every integration are compatible.
@@ -136,7 +138,7 @@ def dep(require_base_check_version, min_base_check_version):
     * Optionally verify that the `datadog-checks-base` requirement satisfies specific version
     """
     failed = False
-    check_dependencies, check_errors = read_check_dependencies()
+    check_dependencies, check_errors = read_check_dependencies(check)
 
     if check_errors:
         for check_error in check_errors:
@@ -144,7 +146,7 @@ def dep(require_base_check_version, min_base_check_version):
 
         abort()
 
-    check_base_dependencies, check_base_errors = read_check_base_dependencies()
+    check_base_dependencies, check_base_errors = read_check_base_dependencies(check)
 
     if check_base_errors:
         for check_error in check_base_errors:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
@@ -63,24 +63,28 @@ def load_base_check(req_file, dependencies, errors, check_name=None):
     errors.append(f'File `{req_file}` missing base check dependency `CHECKS_BASE_REQ`')
 
 
-def read_check_dependencies():
+def read_check_dependencies(check=None):
     root = get_root()
     dependencies = create_dependency_data()
     errors = []
 
-    for check_name in sorted(get_valid_checks()):
+    checks = sorted(get_valid_checks()) if check is None else [check]
+
+    for check_name in checks:
         req_file = os.path.join(root, check_name, 'requirements.in')
         load_dependency_data(req_file, dependencies, errors, check_name)
 
     return dependencies, errors
 
 
-def read_check_base_dependencies():
+def read_check_base_dependencies(check=None):
     root = get_root()
     dependencies = create_dependency_data()
     errors = []
 
-    for check_name in sorted(get_valid_checks()):
+    checks = sorted(get_valid_checks()) if check is None else [check]
+
+    for check_name in checks:
         if check_name.startswith('datadog_checks_'):
             continue
         req_file = os.path.join(root, check_name, 'setup.py')


### PR DESCRIPTION
### What does this PR do?
PR https://github.com/DataDog/integrations-core/pull/8293 added support to perform stricter dependency validation on PRs to gradually force updates to checks, but this validation runs across the whole repo.

This fixes it so the validation can run against a single check which should limit the scope in PR CI runs.
