### PR TITLE
Support tags set at runtime on the DB QueryManager

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -80,10 +80,10 @@ class QueryManager(object):
         for query in self.queries:
             query.compile(column_transformers, EXTRA_TRANSFORMERS.copy())
 
-    def execute(self):
+    def execute(self, tags=None):
         """This method is what you call every check run."""
         logger = self.check.log
-        global_tags = self.tags
+        global_tags = list(set(self.tags + (tags or [])))
 
         for query in self.queries:
             query_name = query.name

--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -80,10 +80,10 @@ class QueryManager(object):
         for query in self.queries:
             query.compile(column_transformers, EXTRA_TRANSFORMERS.copy())
 
-    def execute(self, tags=None):
+    def execute(self, extra_tags=None):
         """This method is what you call every check run."""
         logger = self.check.log
-        global_tags = list(set(self.tags + (tags or [])))
+        global_tags = list(set(self.tags + (extra_tags or [])))
 
         for query in self.queries:
             query_name = query.name

--- a/datadog_checks_base/tests/test_db.py
+++ b/datadog_checks_base/tests/test_db.py
@@ -995,6 +995,27 @@ class TestSubmission:
         aggregator.assert_metric('test.foo', 7, metric_type=aggregator.COUNT, tags=['test:foo', 'tag:tag2'])
         aggregator.assert_all_metrics_covered()
 
+    def test_runtime_tags(self, aggregator):
+        query_manager = create_query_manager(
+            {
+                'name': 'test query',
+                'query': 'foo',
+                'columns': [{'name': 'test.foo', 'type': 'count'}, {'name': 'tag', 'type': 'tag'}],
+            },
+            executor=mock_executor([[3, 'tag1'], [7, 'tag2'], [5, 'tag1']]),
+            tags=['test:init'],
+        )
+        query_manager.compile_queries()
+        query_manager.execute(['test:runtime', 'test:init'])
+
+        aggregator.assert_metric(
+            'test.foo', 8, metric_type=aggregator.COUNT, tags=['test:init', 'test:runtime', 'tag:tag1']
+        )
+        aggregator.assert_metric(
+            'test.foo', 7, metric_type=aggregator.COUNT, tags=['test:init', 'test:runtime', 'tag:tag2']
+        )
+        aggregator.assert_all_metrics_covered()
+
     def test_kwarg_passing(self, aggregator):
         class MyCheck(AgentCheck):
             __NAMESPACE__ = 'test_check'

--- a/datadog_checks_base/tests/test_db.py
+++ b/datadog_checks_base/tests/test_db.py
@@ -1006,7 +1006,7 @@ class TestSubmission:
             tags=['test:init'],
         )
         query_manager.compile_queries()
-        query_manager.execute(['test:runtime', 'test:init'])
+        query_manager.execute(extra_tags=['test:runtime', 'test:init'])
 
         aggregator.assert_metric(
             'test.foo', 8, metric_type=aggregator.COUNT, tags=['test:init', 'test:runtime', 'tag:tag1']


### PR DESCRIPTION
### What does this PR do?

This PR adds the functionality to pass additional tags to the QueryManager after initialization.

### Motivation

In https://github.com/DataDog/integrations-core/pull/8282, I want to set the `replication_role` tag based on whether the instance is a reader or a writer. This has to be queried after a connection is made to the database.

It seems like the database integration classes are growing quite large and there is mixed access to instance-level state and function-level locals. Since my change requires tags to be mutable, I want to keep tags a function local variable and I don't see any cases where tags need to be stateful. I thought that this PR was the best way to go about making that change, but let me know if I'm heading in the wrong direction.

If we agree on this approach, I will update the QueryManager in the MySQL integration so that tags are only passed to the `execute` function and not the `__init__`.

### Additional Notes

Please review with https://github.com/DataDog/integrations-core/pull/8282

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
