### PR TITLE
Update minimum mongo version requirement

### DIFF
--- a/mongo/README.md
+++ b/mongo/README.md
@@ -11,7 +11,7 @@ Connect MongoDB to Datadog in order to:
 
 You can also create your own metrics using custom `find`, `count` and `aggregate` queries.
 
-**Note**: MongoDB v2.6+ is required for this integration.
+**Note**: MongoDB v3.0+ is required for this integration.
 
 ## Setup
 


### PR DESCRIPTION
The 2.6+ version requirement in the ReadMe comes from a limitation of the pymongo library.
Besides pymongo, we also rely on specific commands including `replSetGetConfig` that requries v3.0+ of mongo.

Mongo 2.6 is EOL since October 2016, the next version is 3.0 which is EOL since Feb 2018: https://www.mongodb.com/support-policy