### PR TITLE
Support installing minimum and unpinned datadog_checks_base dependencies for tests

### DIFF
--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -22,8 +22,8 @@ steps:
 
 # Nightly base package check
 - ${{ if and(eq(parameters.test, 'true'), eq(parameters.force_base_package, 'true')) }}:
-    - script: ddev test --force-base-package --force-env-rebuild --junit ${{ parameters.check }}
-      displayName: 'Run Unit/Integration tests (no coverage, forced datadog_checks_base package)'
+    - script: ddev test --force-base-min --force-env-rebuild --junit ${{ parameters.check }}
+      displayName: 'Run Unit/Integration tests (forced install of minimum datadog_checks_base package)'
 
 - ${{ if eq(parameters.test_e2e, 'true') }}:
   - script: |

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -55,3 +55,4 @@ jobs:
       latest_metrics: ${{ parameters.latest_metrics }}
       repo: ${{ parameters.repo }}
       coverage: ${{ parameters.coverage }}
+      force_base_package: ${{ parameters.force_base_package }}

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -70,11 +70,35 @@ def tox_configure(config):
             if E2E_READY_CONDITION in cfg.description:
                 cfg.description = description
 
-    # Workaround for tox's `--force-dep` having limited functionality when package already installed.
+    # Next two sections hack the sequencing of Tox's package installation.
+    #
+    # Tox package installation order:
+    #   1. Install `deps`, which typically looks like:
+    #        deps =
+    #            -e../datadog_checks_base[deps]
+    #            -rrequirements-dev.txt
+    #   2. Install check package, editable mode
+    #   3. Execute `commands` which typically looks like:
+    #        commands =
+    #            pip install -r requirements.in
+    #            pytest -v {posargs} --benchmark-skip
+
+    # Forcibly remove any dependencies from the `tox.ini` deps that are meant to be unpinned
+    # This should have the effect of relying on a package's setup.py for installation
+    # We manually pip install `datadog_checks_base[deps]` to ensure that test dependencies are installed,
+    # but this should have no effect on the version of the base package.
+    force_unpinned = os.getenv('TOX_FORCE_UNPINNED', None)
+    if force_unpinned:
+        for env in config.envlist:
+            deps = [d for d in config.envconfigs[env].deps if force_unpinned not in d.name]
+            config.envconfigs[env].deps = deps
+            config.envconfigs[env].commands.insert(0, 'pip install datadog_checks_base[deps]'.split())
+
+    # Workaround for tox's `--force-dep` having limited functionality when package is already installed.
     # Primarily meant for pinning datadog-checks-base to a specific version, but could be
     # applied to other packages in the future. Since we typically install checks base via
     # editable mode, we need to force the reinstall to ensure that the PyPI package installs.
-    force_install = os.getenv('TOX_FORCE_INSTALL', [])
+    force_install = os.getenv('TOX_FORCE_INSTALL', None)
     if force_install:
         command = f'pip install --force-reinstall {force_install}'.split()
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -6,9 +6,10 @@ import sys
 
 import click
 
+from ..dependencies import read_check_base_dependencies
 from ..._env import E2E_PARENT_PYTHON, SKIP_ENVIRONMENT
 from ...subprocess import run_command
-from ...utils import chdir, file_exists, get_ci_env_vars, remove_path, running_on_ci
+from ...utils import chdir, file_exists, get_ci_env_vars, remove_path, running_on_ci, get_next
 from ..constants import get_root
 from ..testing import construct_pytest_options, fix_coverage_report, get_tox_envs, pytest_coverage_sources
 from ..utils import complete_testable_checks, get_version_string
@@ -43,7 +44,8 @@ def display_envs(check_envs):
 @click.option('--cov-keep', is_flag=True, help='Keep coverage reports')
 @click.option('--skip-env', is_flag=True, help='Skip environment creation and assume it is already running')
 @click.option('--pytest-args', '-pa', help='Additional arguments to pytest')
-@click.option('--force-base-package', is_flag=True, help='Force using latest released version of datadog-checks-base')
+@click.option('--force-base-unpinned', is_flag=True, help='Force using datadog-checks-base as specified by check dep')
+@click.option('--force-base-min', is_flag=True, help='Force using lowest viable release version of datadog-checks-base')
 @click.option('--force-env-rebuild', is_flag=True, help='Force creating a new env')
 @click.pass_context
 def test(
@@ -68,7 +70,8 @@ def test(
     cov_keep,
     skip_env,
     pytest_args,
-    force_base_package,
+    force_base_unpinned,
+    force_base_min,
     force_env_rebuild,
 ):
     """Run tests for Agent-based checks.
@@ -202,9 +205,21 @@ def test(
 
             env = os.environ.copy()
 
-            if force_base_package:
-                version = get_version_string('datadog_checks_base', '')
+            if force_base_min:
+                check_base_dependencies, errors = read_check_base_dependencies(check)
+                if errors:
+                    abort(f'\nError collecting base package dependencies: {errors}')
+
+                spec_set = list(check_base_dependencies['datadog-checks-base'].keys())[0]
+
+                spec = get_next(spec_set) if spec_set else None
+                if spec is None or spec.operator != '>=':
+                    abort(f'\nFailed to determine minimum version of package `datadog_checks_base`: {spec}')
+
+                version = spec.version
                 env['TOX_FORCE_INSTALL'] = f"datadog_checks_base[deps]=={version}"
+            elif force_base_unpinned:
+                env['TOX_FORCE_UNPINNED'] = "datadog_checks_base"
 
             if force_env_rebuild:
                 command.append('--recreate')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -6,13 +6,13 @@ import sys
 
 import click
 
-from ..dependencies import read_check_base_dependencies
 from ..._env import E2E_PARENT_PYTHON, SKIP_ENVIRONMENT
 from ...subprocess import run_command
-from ...utils import chdir, file_exists, get_ci_env_vars, remove_path, running_on_ci, get_next
+from ...utils import chdir, file_exists, get_ci_env_vars, get_next, remove_path, running_on_ci
 from ..constants import get_root
+from ..dependencies import read_check_base_dependencies
 from ..testing import construct_pytest_options, fix_coverage_report, get_tox_envs, pytest_coverage_sources
-from ..utils import complete_testable_checks, get_version_string
+from ..utils import complete_testable_checks
 from .console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, echo_success, echo_waiting, echo_warning
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
@@ -50,7 +50,7 @@ def load_base_check(req_file, dependencies, errors, check_name=None):
             try:
                 dep = line.split(' = ')[1]
                 req = Requirement(dep.strip("'"))
-            except InvalidRequirement as e:
+            except (IndexError, InvalidRequirement) as e:
                 errors.append(f'File `{req_file}` has an invalid base check dependency: `{line}`\n{e}')
                 return
 


### PR DESCRIPTION
### What does this PR do?
Updates `ddev test` command with two options:

- `--force-base-min` (renamed from `--force-base-package`) to detect the minimum specified version of `datadog-checks-base` that a check specifies, then attempt to install that version and run tests with it.  
- `--force-base-unpinned` which handles the use case of installing an unpinned version of `datadog-checks-base`. This has the effect of ensuring the latest released version of the package is tested, versus the editable development version.

### Additional Notes
The `force-base-min` option will have quite a few failures which may not be material, but would highlight opportunities to bump the requirement spec.  For example, when the exact minimum version doesn't exist:

```
❯ ddev test --force-base-min --force-env-rebuild redisdb:py38-latest
Running tests for `redisdb`
---------------------------
py38-latest recreate: /Users/mike.garabedian/src/integrations-core/redisdb/.tox/py38
py38-latest installdeps: -e../datadog_checks_base[deps], -rrequirements-dev.txt
py38-latest develop-inst: /Users/mike.garabedian/src/integrations-core/redisdb
py38-latest installed: attrs==20.3.0,aws-requests-auth==0.4.2,binary==1.0.0,botocore==1.13.42,certifi==2020.12.5,chardet==3.0.4,coverage==5.3.1,-e git+https://github.com/DataDog/integrations-core@7cb83e9b0b2d9cbbcbbf80dee77de54e404d795c#egg=datadog_checks_base&subdirectory=datadog_checks_base,-e git+https://github.com/DataDog/integrations-core@7cb83e9b0b2d9cbbcbbf80dee77de54e404d795c#egg=datadog_checks_dev&subdirectory=datadog_checks_dev,-e git+https://github.com/DataDog/integrations-core@7cb83e9b0b2d9cbbcbbf80dee77de54e404d795c#egg=datadog_redisdb&subdirectory=redisdb,ddtrace==0.32.2,docutils==0.15.2,idna==2.8,iniconfig==1.1.1,jmespath==0.10.0,mock==4.0.3,packaging==20.8,pluggy==0.13.1,prometheus-client==0.7.1,protobuf==3.7.0,psutil==5.8.0,py==1.10.0,py-cpuinfo==7.0.0,pygal==2.4.0,pygaljs==1.0.2,pyparsing==2.4.7,pytest==6.2.1,pytest-benchmark==3.2.3,pytest-cov==2.10.1,pytest-mock==3.5.0,python-dateutil==2.8.0,pytz==2019.3,PyYAML==5.3.1,requests==2.22.0,requests-toolbelt==0.9.1,requests-unixsocket==0.2.0,simplejson==3.6.5,six==1.14.0,tenacity==6.3.1,toml==0.10.2,uptime==3.0.1,urllib3==1.25.11
py38-latest run-test-pre: PYTHONHASHSEED='622516632'
py38-latest run-test: commands[0] | pip install --force-reinstall 'datadog_checks_base[deps]==5.1.0'
ERROR: Could not find a version that satisfies the requirement datadog_checks_base[deps]==5.1.0 (from versions: 1.4.0, 1.5.0, 3.0.0, 4.0.0, 4.1.0, 4.2.0, 4.3.0, 4.6.0, 5.0.1, 6.2.0, 6.6.0, 7.0.0, 8.2.0, 8.5.0, 8.6.0, 9.0.0, 9.1.0, 9.2.0, 9.2.1, 9.3.0, 9.5.0, 9.6.0, 10.0.0, 10.0.1, 10.0.2, 10.1.0, 10.2.0, 10.2.1, 10.3.0, 11.0.0, 11.2.0, 11.3.0, 11.8.0, 11.9.0, 11.10.0, 11.11.0, 11.11.1, 13.1.0, 14.0.0, 15.0.0, 15.3.0, 15.4.0, 15.6.0, 15.7.0, 15.7.1, 15.7.2)
ERROR: No matching distribution found for datadog_checks_base[deps]==5.1.0
WARNING: You are using pip version 20.0.2; however, version 20.3.3 is available.
You should consider upgrading via the '/Users/mike.garabedian/src/integrations-core/redisdb/.tox/py38/bin/python -m pip install --upgrade pip' command.
ERROR: InvocationError for command /Users/mike.garabedian/src/integrations-core/redisdb/.tox/py38/bin/pip install --force-reinstall 'datadog_checks_base[deps]==5.1.0' (exited with code 1)
____________________________________________________________________________________________________________________________________ summary _____________________________________________________________________________________________________________________________________
ERROR:   py38-latest: commands failed

Failed!
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
