### PR TITLE
Adds new metric unit `span`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -204,6 +204,7 @@ VALID_UNIT_NAMES = {
     'millivolt',
     'deciwatt',
     'decidegree celsius',
+    'span',
 }
 
 PROVIDER_INTEGRATIONS = {'openmetrics', 'prometheus'}


### PR DESCRIPTION
### What does this PR do?
Adds new metric units `span`.

### Motivation
New metric unit `span` is used for APM estimation metrics.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
