### PR TITLE
Adding support for v2.3

### DIFF
--- a/haproxy/datadog_checks/haproxy/metrics.py
+++ b/haproxy/datadog_checks/haproxy/metrics.py
@@ -162,7 +162,9 @@ METRIC_MAP = {
     'haproxy_server_retry_warnings_total': 'server.retry.warnings.total',
     'haproxy_server_server_aborts_total': 'server.server.aborts.total',
     'haproxy_server_server_idle_connections_current': 'server.server.idle.connections.current',
+    'haproxy_server_idle_connections_current': 'server.idle.connections.current',  # rename since >= v2.3
     'haproxy_server_server_idle_connections_limit': 'server.server.idle.connections.limit',
+    'haproxy_server_idle_connections_limit': 'server.idle.connections.limit',  # rename since >= 2.3
     'haproxy_server_sessions_total': 'server.sessions.total',
     'haproxy_server_status': 'server.status',
     'haproxy_server_total_time_average_seconds': 'server.total.time.average.seconds',

--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -4,12 +4,15 @@
 import os
 
 import pytest
+from packaging import version
 
 from datadog_checks.dev import get_docker_hostname, get_here
 
 HERE = get_here()
 HOST = get_docker_hostname()
 HAPROXY_LEGACY = os.getenv('HAPROXY_LEGACY')
+HAPROXY_VERSION_RAW = os.getenv('HAPROXY_VERSION')
+HAPROXY_VERSION = version.parse(HAPROXY_VERSION_RAW)
 ENDPOINT_PROMETHEUS = 'http://{}:8404/metrics'.format(HOST)
 
 INSTANCE = {'use_prometheus': True, 'prometheus_url': ENDPOINT_PROMETHEUS}

--- a/haproxy/tests/conftest.py
+++ b/haproxy/tests/conftest.py
@@ -44,8 +44,16 @@ def dd_environment():
 
 @pytest.fixture(scope='session')
 def prometheus_metrics():
-    metrics = list(METRIC_MAP.values())
+    metrics = deepcopy(METRIC_MAP)
+    if HAPROXY_VERSION >= version.parse('2.3'):
+        # the two following metrics were renamed in >= v2.3
+        metrics.pop('haproxy_server_server_idle_connections_current')
+        metrics.pop('haproxy_server_server_idle_connections_limit')
+    else:
+        metrics.pop('haproxy_server_idle_connections_current')
+        metrics.pop('haproxy_server_idle_connections_limit')
 
+    metrics = list(metrics.values())
     return metrics
 
 

--- a/haproxy/tests/legacy/common.py
+++ b/haproxy/tests/legacy/common.py
@@ -1,9 +1,12 @@
 import os
 
 import pytest
+from packaging import version
 
 from datadog_checks.base.utils.common import get_docker_hostname
 from datadog_checks.dev.utils import ON_LINUX, ON_MACOS
+
+from ..common import HAPROXY_LEGACY, HAPROXY_VERSION
 
 AGG_STATUSES_BY_SERVICE = (
     (['status:available', 'service:a', 'haproxy_service:a'], 1),
@@ -51,8 +54,6 @@ STATS_URL_OPEN = "{0}/stats".format(BASE_URL_OPEN)
 STATS_SOCKET = "tcp://{0}:{1}".format(HOST, SOCKET_PORT)
 USERNAME = 'datadog'
 PASSWORD = 'isdevops'
-HAPROXY_VERSION = os.getenv('HAPROXY_VERSION')
-HAPROXY_LEGACY = os.getenv('HAPROXY_LEGACY')
 
 platform_supports_sockets = ON_LINUX or ON_MACOS
 platform_supports_sharing_unix_sockets_through_docker = ON_LINUX
@@ -63,7 +64,7 @@ requires_shareable_unix_socket = pytest.mark.skipif(
     not platform_supports_sharing_unix_sockets_through_docker,
     reason='AF_UNIX sockets cannot be bind-mounted between a macOS host and a linux guest in docker',
 )
-haproxy_less_than_1_6 = os.environ.get('HAPROXY_VERSION', '1.5.11').split('.')[:2] < ['1', '6']
+haproxy_less_than_1_6 = HAPROXY_VERSION < version.parse('1.6')
 requires_haproxy_tcp_stats = pytest.mark.skipif(
     haproxy_less_than_1_6 or not platform_supports_sockets,
     reason="Multiple `stats socket` definitions aren't supported in 1.4",
@@ -113,67 +114,67 @@ BACKEND_STATUS_METRIC = 'haproxy.count_per_status'
 
 FRONTEND_CHECK = [
     # gauges
-    ('haproxy.frontend.session.current', ['1', '0']),
-    ('haproxy.frontend.session.limit', ['1', '0']),
-    ('haproxy.frontend.session.pct', ['1', '0']),
-    ('haproxy.frontend.requests.rate', ['1', '4']),
-    ('haproxy.frontend.connections.rate', ['1', '7']),
-    ('haproxy.frontend.bytes.in.total', ['1', '0']),
-    ('haproxy.frontend.bytes.out.total', ['1', '0']),
+    ('haproxy.frontend.session.current', '1.0'),
+    ('haproxy.frontend.session.limit', '1.0'),
+    ('haproxy.frontend.session.pct', '1.0'),
+    ('haproxy.frontend.requests.rate', '1.4'),
+    ('haproxy.frontend.connections.rate', '1.7'),
+    ('haproxy.frontend.bytes.in.total', '1.0'),
+    ('haproxy.frontend.bytes.out.total', '1.0'),
     # rates
-    ('haproxy.frontend.bytes.in_rate', ['1', '0']),
-    ('haproxy.frontend.bytes.out_rate', ['1', '0']),
-    ('haproxy.frontend.denied.req_rate', ['1', '0']),
-    ('haproxy.frontend.denied.resp_rate', ['1', '0']),
-    ('haproxy.frontend.errors.req_rate', ['1', '0']),
-    ('haproxy.frontend.session.rate', ['1', '0']),
-    ('haproxy.frontend.response.1xx', ['1', '4']),
-    ('haproxy.frontend.response.2xx', ['1', '4']),
-    ('haproxy.frontend.response.3xx', ['1', '4']),
-    ('haproxy.frontend.response.4xx', ['1', '4']),
-    ('haproxy.frontend.response.5xx', ['1', '4']),
-    ('haproxy.frontend.response.other', ['1', '4']),
-    ('haproxy.frontend.requests.tot_rate', ['1', '4']),
-    ('haproxy.frontend.connections.tot_rate', ['1', '7']),
-    ('haproxy.frontend.requests.intercepted', ['1', '7']),
+    ('haproxy.frontend.bytes.in_rate', '1.0'),
+    ('haproxy.frontend.bytes.out_rate', '1.0'),
+    ('haproxy.frontend.denied.req_rate', '1.0'),
+    ('haproxy.frontend.denied.resp_rate', '1.0'),
+    ('haproxy.frontend.errors.req_rate', '1.0'),
+    ('haproxy.frontend.session.rate', '1.0'),
+    ('haproxy.frontend.response.1xx', '1.4'),
+    ('haproxy.frontend.response.2xx', '1.4'),
+    ('haproxy.frontend.response.3xx', '1.4'),
+    ('haproxy.frontend.response.4xx', '1.4'),
+    ('haproxy.frontend.response.5xx', '1.4'),
+    ('haproxy.frontend.response.other', '1.4'),
+    ('haproxy.frontend.requests.tot_rate', '1.4'),
+    ('haproxy.frontend.connections.tot_rate', '1.7'),
+    ('haproxy.frontend.requests.intercepted', '1.7'),
 ]
 
 BACKEND_CHECK = [
     # gauges
-    ('haproxy.backend.queue.current', ['1', '0']),
-    ('haproxy.backend.session.current', ['1', '0']),
-    ('haproxy.backend.queue.time', ['1', '5']),
-    ('haproxy.backend.connect.time', ['1', '5']),
-    ('haproxy.backend.response.time', ['1', '5']),
-    ('haproxy.backend.session.time', ['1', '5']),
-    ('haproxy.backend.uptime', ['1', '7']),
-    ('haproxy.backend.bytes.in.total', ['1', '0']),
-    ('haproxy.backend.bytes.out.total', ['1', '0']),
+    ('haproxy.backend.queue.current', '1.0'),
+    ('haproxy.backend.session.current', '1.0'),
+    ('haproxy.backend.queue.time', '1.5'),
+    ('haproxy.backend.connect.time', '1.5'),
+    ('haproxy.backend.response.time', '1.5'),
+    ('haproxy.backend.session.time', '1.5'),
+    ('haproxy.backend.uptime', '1.7'),
+    ('haproxy.backend.bytes.in.total', '1.0'),
+    ('haproxy.backend.bytes.out.total', '1.0'),
     # rates
-    ('haproxy.backend.bytes.in_rate', ['1', '0']),
-    ('haproxy.backend.bytes.out_rate', ['1', '0']),
-    ('haproxy.backend.denied.resp_rate', ['1', '0']),
-    ('haproxy.backend.errors.con_rate', ['1', '0']),
-    ('haproxy.backend.errors.resp_rate', ['1', '0']),
-    ('haproxy.backend.session.rate', ['1', '0']),
-    ('haproxy.backend.warnings.redis_rate', ['1', '0']),
-    ('haproxy.backend.warnings.retr_rate', ['1', '0']),
-    ('haproxy.backend.response.1xx', ['1', '4']),
-    ('haproxy.backend.response.2xx', ['1', '4']),
-    ('haproxy.backend.response.3xx', ['1', '4']),
-    ('haproxy.backend.response.4xx', ['1', '4']),
-    ('haproxy.backend.response.5xx', ['1', '4']),
-    ('haproxy.backend.response.other', ['1', '4']),
+    ('haproxy.backend.bytes.in_rate', '1.0'),
+    ('haproxy.backend.bytes.out_rate', '1.0'),
+    ('haproxy.backend.denied.resp_rate', '1.0'),
+    ('haproxy.backend.errors.con_rate', '1.0'),
+    ('haproxy.backend.errors.resp_rate', '1.0'),
+    ('haproxy.backend.session.rate', '1.0'),
+    ('haproxy.backend.warnings.redis_rate', '1.0'),
+    ('haproxy.backend.warnings.retr_rate', '1.0'),
+    ('haproxy.backend.response.1xx', '1.4'),
+    ('haproxy.backend.response.2xx', '1.4'),
+    ('haproxy.backend.response.3xx', '1.4'),
+    ('haproxy.backend.response.4xx', '1.4'),
+    ('haproxy.backend.response.5xx', '1.4'),
+    ('haproxy.backend.response.other', '1.4'),
 ]
 
 BACKEND_AGGREGATE_ONLY_CHECK = [
     # gauges
-    ('haproxy.backend.uptime', ['1', '0']),
-    ('haproxy.backend.session.limit', ['1', '0']),
-    ('haproxy.backend.session.pct', ['1', '5']),
+    ('haproxy.backend.uptime', '1.0'),
+    ('haproxy.backend.session.limit', '1.0'),
+    ('haproxy.backend.session.pct', '1.5'),
     # rates
-    ('haproxy.backend.denied.req_rate', ['1', '0']),
-    ('haproxy.backend.requests.tot_rate', ['1', '7']),
+    ('haproxy.backend.denied.req_rate', '1.0'),
+    ('haproxy.backend.requests.tot_rate', '1.7'),
 ]
 
 SERVICE_CHECK_NAME = 'haproxy.backend_up'

--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 basepython = py38
 envlist =
     py{27,38}-{16,17,18,20,21}-legacy
-    py{27,38}-{20,21,22}
+    py{27,38}-{20,21,22,23}
 
 [testenv]
 ensure_default_envdir = true
@@ -30,6 +30,7 @@ setenv =
   20: HAPROXY_VERSION=2.0.20
   21: HAPROXY_VERSION=2.1.11
   22: HAPROXY_VERSION=2.2.7
+  23: HAPROXY_VERSION=2.3.3
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?

    haproxy: adding support for 2.3.x

    in v2.3 two metrics are being renamed, so imply add them to the list,
    but update tests to exclude them depending on versions

    haproxy: sanitize the way we handle version

    - use packaging.version
    - move from table to string in metrics to check
    - remove redundancy of legacy vs common

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
