### PR TITLE
Handle database specific queries for autodiscovery

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -410,12 +410,57 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
     QUERY_BASE = "select * from {table}".format(table=TABLE)
 
     DB_TYPE_MAP = {0: 'data', 1: 'transaction_log', 2: 'filestream', 3: 'unknown', 4: 'full_text'}
+    _DATABASES = []
+
+    def __init__(self, cfg_instance, base_name, report_function, column, logger):
+        super(SqlDatabaseFileStats, self).__init__(cfg_instance, base_name, report_function, column, logger)
+        self._DATABASES.append(self.instance)
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger):
-        return cls._fetch_generic_values(cursor, None, logger)
+        # special case since this table is specific to databases, need to run query for each database instance
+        rows = []
+        columns = []
+
+        logger.debug("%s: finding current db", cls.__name__)
+        data = cursor.execute('select DB_NAME()').fetchall()
+        current_db = data[0][0]
+        logger.debug("%s: current db is %s", cls.__name__, current_db)
+
+        for db in cls._DATABASES:
+            # use statements need to be executed separate from select queries
+            ctx = 'use {}'.format(db)
+            logger.debug("%s: changing cursor context via use statement: %s", cls.__name__, ctx)
+            cursor.execute(ctx)
+            logger.debug("%s: fetch_all executing query: %s", cls.__name__, cls.QUERY_BASE)
+            cursor.execute(cls.QUERY_BASE)
+
+            data = cursor.fetchall()
+            query_columns = ['database'] + [i[0] for i in cursor.description]
+            if columns:
+                assert columns == query_columns
+            else:
+                columns = query_columns
+
+            results = []
+            # insert database name as new column for each row
+            for row in data:
+                r = list(row)
+                r.insert(0, db)
+                results.append(r)
+
+            rows.extend(results)
+
+            logger.debug("%s: received %d rows and %d columns for db %s", cls.__name__, len(data), len(columns), db)
+
+        # reset back to previous db
+        logger.debug("%s: reverting cursor context via use statement to %s", cls.__name__, current_db)
+        cursor.execute('use {}'.format(str(current_db)))
+
+        return rows, columns
 
     def fetch_metric(self, rows, columns):
+        db_name = columns.index('database')
         file_id = columns.index("file_id")
         file_type = columns.index("type")
         file_location = columns.index("physical_name")
@@ -423,6 +468,8 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
         value_column_index = columns.index(self.column)
 
         for row in rows:
+            if row[db_name] != self.instance:
+                continue
             column_val = row[value_column_index]
             if self.column in ('size', 'max_size'):
                 column_val *= 8  # size reported in 8 KB pages

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -422,7 +422,6 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
         rows = []
         columns = []
 
-        logger.debug("%s: finding current db", cls.__name__)
         data = cursor.execute('select DB_NAME()').fetchall()
         current_db = data[0][0]
         logger.debug("%s: current db is %s", cls.__name__, current_db)

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -174,6 +174,35 @@ def test_custom_metrics_alt_tables(aggregator, dd_run_check, init_config_alt_tab
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
+def test_autodiscovery_database_metrics(aggregator, dd_run_check, instance_autodiscovery):
+    instance_autodiscovery['autodiscovery_include'] = ['master', 'msdb']
+    check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
+    dd_run_check(check)
+
+    master_tags = [
+        'database:master',
+        'database_files_state_desc:ONLINE',
+        'file_id:1',
+        'file_location:/var/opt/mssql/data/master.mdf',
+        'file_type:data',
+        'optional:tag1',
+    ]
+    msdb_tags = [
+        'database:msdb',
+        'database_files_state_desc:ONLINE',
+        'file_id:1',
+        'file_location:/var/opt/mssql/data/MSDBData.mdf',
+        'file_type:data',
+        'optional:tag1',
+    ]
+    aggregator.assert_metric('sqlserver.database.files.size', tags=master_tags)
+    aggregator.assert_metric('sqlserver.database.files.size', tags=msdb_tags)
+    aggregator.assert_metric('sqlserver.database.files.state', tags=master_tags)
+    aggregator.assert_metric('sqlserver.database.files.state', tags=msdb_tags)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 def test_custom_queries(aggregator, dd_run_check, instance_docker):
     instance = copy(instance_docker)
     querya = copy(CUSTOM_QUERY_A)


### PR DESCRIPTION
### What does this PR do?
With autodiscovery option enabled for `sqlserver`, certain tables will only provide data relative to the current database context.  [`sys.database_files`](https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-database-files-transact-sql?view=sql-server-ver15) is one of those tables and we query it to extract two metrics: `sqlserver.database.files.size` and `sqlserver.database.files.state`.

### Motivation
Without this change we will report incorrect database statistics, all relative to the initial database.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
