### PR TITLE
Hide auto-populated prometheus_url from config spec

### DIFF
--- a/amazon_msk/assets/configuration/spec.yaml
+++ b/amazon_msk/assets/configuration/spec.yaml
@@ -37,3 +37,5 @@ files:
         type: integer
         example: 11002
     - template: instances/openmetrics
+      overrides:
+        prometheus_url.hidden: true

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -74,11 +74,6 @@ instances:
     #
     # node_exporter_port: 11002
 
-    ## @param prometheus_url - string - required
-    ## The URL where your application metrics are exposed by Prometheus.
-    #
-    prometheus_url: <PROMETHEUS_URL>
-
     ## @param prometheus_metrics_prefix - string - optional
     ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Hide the `prometheus_url` option from Amazon MSK example config.

### Motivation
<!-- What inspired you to submit this pull request? -->
Customer and SE were confused about this option being present and marked as "required", but they didn't know what to put there.

Turns out the option is irrelevant to the MSK check:

https://github.com/DataDog/integrations-core/blob/2fdc311b8bfae5a4bc0a12e03b45934764dbff31/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py#L33-L34

The check iterates through MSK nodes returned by the AWS API, and auto-fills the `prometheus_url` for each:

https://github.com/DataDog/integrations-core/blob/2fdc311b8bfae5a4bc0a12e03b45934764dbff31/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py#L78-L82

As our test setup confirms, only `cluster_arn` is really required:

https://github.com/DataDog/integrations-core/blob/1bf1bcf5f4af4a54f16bf45ad76d55c4f364ce05/amazon_msk/tests/conftest.py#L34-L39

So we should drop `prometheus_url` from the docs.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
