### PR TITLE
add SCC instructions for Helm for OpenShift

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -13,7 +13,7 @@ To install the Agent, refer to the [Agent installation instructions][2] for kube
 ### Configuration
 
 
-If deploying the Datadog agent using any of the methods linked in the installation instructions above, you must include an SCC (Security Context Constraints) in order for the agent to be able collect data. Please follow the instructions below as they relate to your deployment. 
+If you are deploying the Datadog Agent using any of the methods linked in the installation instructions above, you must include SCC (Security Context Constraints) for the Agent to collect data. Follow the instructions below as they relate to your deployment. 
 
 {{ < tabs > }}
 {{% tab "Helm" %}}

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -18,7 +18,7 @@ If you are deploying the Datadog Agent using any of the methods linked in the in
 {{ < tabs > }}
 {{% tab "Helm" %}}
 
-The SCC can be applied directly within your Datadog agent's `values.yaml`. Simply add the following block underneath the `agents:` section in the file. 
+The SCC can be applied directly within your Datadog agent's `values.yaml`. Add the following block underneath the `agents:` section in the file. 
 
 ```yaml
 ...

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -30,7 +30,7 @@ agents:
 ...
 ```
 
-You can either apply this when you initially deploy the agent, or alternatively you can execute a `helm upgrade` after making this change to apply the SCC. 
+You can apply this when you initially deploy the Agent. Or, you can execute a `helm upgrade` after making this change to apply the SCC. 
 
 {{% /tab %}}
 {{% tab "Daemonset" %}}

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -12,7 +12,31 @@ To install the Agent, refer to the [Agent installation instructions][2] for kube
 
 ### Configuration
 
-Starting with version 6.1, the Datadog Agent supports monitoring OpenShift Origin and Enterprise clusters. Depending on your needs and the [security constraints][3] of your cluster, three deployment scenarios are supported:
+
+If deploying the Datadog agent using any of the methods linked in the installation instructions above, you must include an SCC (Security Context Constraints) in order for the agent to be able collect data. Please follow the instructions below as they relate to your deployment. 
+
+{{ < tabs > }}
+{{% tab "Helm" %}}
+
+The SCC can be applied directly within your Datadog agent's `values.yaml`. Simply add the following block underneath the `agents:` section in the file. 
+
+```yaml
+...
+agents:
+...
+  podSecurity:
+    securityContextConstraints:
+      create: true
+...
+```
+
+You can either apply this when you initially deploy the agent, or alternatively you can execute a `helm upgrade` after making this change to apply the SCC. 
+
+{{% /tab %}}
+{{% tab "Daemonset" %}}
+
+
+Depending on your needs and the [security constraints][3] of your cluster, three deployment scenarios are supported:
 
 - [Restricted SCC operations](#restricted-scc-operations)
 - [Host network SCC operations](#host)
@@ -34,7 +58,8 @@ Starting with version 6.1, the Datadog Agent supports monitoring OpenShift Origi
 <div class="alert alert-warning">
 <bold>OpenShift 4.0+</bold>: If you used the OpenShift installer on a supported cloud provider, you must deploy the Agent with <code>hostNetwork: true</code> in the <code>datadog.yaml</code> configuration file to get host tags and aliases. Access to metadata servers from the PODs network is otherwise restricted.
 </div>
-
+{{% /tab % }}
+{{< /tabs >}}
 #### Log collection
 
 Refer to the [Kubernetes Log Collection][12] documentation for further information.


### PR DESCRIPTION
### What does this PR do?
Added additional instructions for applying the SCC using helm.  

Removed old "starting with version 6.1" message (don't believe this is necessary at this point). 

### Motivation
Customers aren't aware that the Helm chart can deploy the SCC automatically, so most folks are deploying the SCC directly. The SCC separate from the helm chart can occassionally be out of sync. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
