### PR TITLE
Add --export-csv option

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/stats.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/stats.py
@@ -54,6 +54,9 @@ def export_changes_as_csv(changes, filename):
                     change['teams'],
                     change['next_tag'].split('-')[-1] if '-' in change['next_tag'] else change['next_tag'],
                     change['title'],
+                    '',
+                    '',
+                    '',
                 ]
             )
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/stats.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/stats.py
@@ -1,9 +1,11 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import csv
+
 import click
 
-from ...console import CONTEXT_SETTINGS
+from ...console import CONTEXT_SETTINGS, echo_info
 from .common import Release
 
 
@@ -28,6 +30,34 @@ def parse_commit(commit):
     return {'sha': commit.sha, 'title': title, 'url': url, 'teams': ' & '.join(teams), 'next_tag': next_tag}
 
 
+def export_changes_as_csv(changes, filename):
+    with open(filename, "w") as release_csv:
+        echo_info("Exporting csv as {}".format(filename))
+        writer = csv.writer(release_csv)
+
+        # Header
+        writer.writerow(
+            [
+                'PR',
+                'Team',
+                'What RC was it included in?',
+                'Short description',
+                'Severity',
+                'Was this a bug or something else?',
+                'What could we have done differently or what could we do differently to find this bug earlier',
+            ]
+        )
+        for change in changes:
+            writer.writerow(
+                [
+                    change['url'],
+                    change['teams'],
+                    change['next_tag'].split('-')[-1] if '-' in change['next_tag'] else change['next_tag'],
+                    change['title'],
+                ]
+            )
+
+
 @click.command(
     context_settings=CONTEXT_SETTINGS,
     short_help="Prints the PRs merged between the first RC and the current RC/final build",
@@ -38,9 +68,9 @@ def parse_commit(commit):
 @click.option(
     '--exclude-releases', '-e', help="Flag to exclude the release PRs from the list", required=False, is_flag=True
 )
+@click.option('--export-csv', help="CSV file where the list will be exported", required=False)
 @click.pass_context
-def merged_prs(ctx, from_ref, to_ref, release_milestone, exclude_releases):
-
+def merged_prs(ctx, from_ref, to_ref, release_milestone, exclude_releases, export_csv):
     agent_release = Release.from_github(ctx, 'datadog-agent', release_milestone, from_ref=from_ref, to_ref=to_ref)
     integrations_release = Release.from_github(
         ctx, 'integrations-core', release_milestone, from_ref=from_ref, to_ref=to_ref
@@ -57,6 +87,10 @@ def merged_prs(ctx, from_ref, to_ref, release_milestone, exclude_releases):
         changes = filtered_changes
 
     changes = sorted(changes, key=lambda x: x['next_tag'])  # sort by RC
+
+    if export_csv:
+        export_changes_as_csv(changes, export_csv)
+
     for change in changes:
         print(','.join([change[field] for field in ['url', 'teams', 'next_tag', 'title']]))
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add option to export the list of merged PRs between 2 references as a CSV.

Command example:
```
ddev release stats merged-prs --from-ref 7.23.0-rc.1 --to-ref 7.23.0 --release-milestone 7.23.0 --export-csv ./changes_7_23.csv
```
Export all the changes (`datadog-agent` and `integrations-core`) made for 7.23.0 after the first rc in `changes_7_23.csv`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Help release manager to keep track of all the changes.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Related PR to remove the release PRs from this list (#8351)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
