### PR TITLE
Add `no_op` utility

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/common.py
+++ b/datadog_checks_base/datadog_checks/base/utils/common.py
@@ -38,6 +38,10 @@ else:
 to_string = to_native_string
 
 
+def no_op(*args, **kwargs):
+    pass
+
+
 def compute_percent(part, total):
     if total:
         return part / total * 100


### PR DESCRIPTION
### Motivation

Often you'll want to cache a unit of work like a function based on conditions. However, if nothing needs to be done you must either check if the reference is `None` or create an anonymous function which can be costly.