### PR TITLE
Increase indentation of log snippets

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/default.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/default.yaml
@@ -85,13 +85,13 @@
 
     1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-      ```yaml
-      logs_enabled: true
-      ```
+        ```yaml
+        logs_enabled: true
+        ```
 
     2. Add this configuration block to your `{check_conf_path}` file to start collecting your {display_name} logs:
 
-      {check_log_conf_snippet}
+    {check_log_conf_snippet:4i}
 
       Change the `path` and `service` parameter values based on your environment. See the {check_conf_link} for all available configuration options.
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/setup/configuration/log_collection.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/setup/configuration/log_collection.yaml
@@ -5,13 +5,13 @@ description: |
 
   1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-    ```yaml
-    logs_enabled: true
-    ```
+      ```yaml
+      logs_enabled: true
+      ```
 
   2. Add this configuration block to your `{check_conf_path}` file to start collecting your {display_name} logs:
 
-    {check_log_conf_snippet}
+      {check_log_conf_snippet}
 
     Change the `path` and `service` parameter values based on your environment. See the {check_conf_link} for all available configuration options.
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/setup/configuration/log_collection.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/setup/configuration/log_collection.yaml
@@ -11,7 +11,7 @@ description: |
 
   2. Add this configuration block to your `{check_conf_path}` file to start collecting your {display_name} logs:
 
-      {check_log_conf_snippet}
+  {check_log_conf_snippet:4i}
 
     Change the `path` and `service` parameter values based on your environment. See the {check_conf_link} for all available configuration options.
 

--- a/rethinkdb/README.md
+++ b/rethinkdb/README.md
@@ -58,19 +58,19 @@ _Available for Agent versions >6.0_
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
-  ```yaml
-  logs_enabled: true
-  ```
+    ```yaml
+    logs_enabled: true
+    ```
 
 2. Add this configuration block to your `rethinkdb.d/conf.yaml` file to start collecting your RethinkDB logs:
 
-  ```yaml
-logs:
-  - type: file
-    path: "<LOG_FILE_PATH>"
-    source: rethinkdb
-    service: "<SERVICE_NAME>"
-```
+    ```yaml
+    logs:
+      - type: file
+        path: "<LOG_FILE_PATH>"
+        source: rethinkdb
+        service: "<SERVICE_NAME>"
+    ```
 
 
   Change the `path` and `service` parameter values based on your environment. See the https://github.com/DataDog/integrations-core/blob/master/rethinkdb/datadog_checks/rethinkdb/data/conf.yaml.example for all available configuration options.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix indentation of YAML snippets in `log_configuration.yaml`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Prompted by https://github.com/DataDog/integrations-core/pull/7891/files#r557275622

Goal is to have these snippets align with the `1.` and `2.` items, instead of being at the regular left-hand side of the content area.

Take a look at the RethinkDB readme in prod: https://docs.datadoghq.com/integrations/rethinkdb

The logs snippets were dedented when adding docs specs: https://github.com/DataDog/integrations-core/pull/8355/files#diff-cc5366001ead2c6612aa8bc99ee3be2594b38d422259ae6e434a245788508c17L52-R63

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
