### PR TITLE
Add index.health.reverse metric

### DIFF
--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -154,6 +154,7 @@ class ESCheck(AgentCheck):
         index_resp = self._get_data(index_url)
         index_stats_metrics = index_stats_for_version(version)
         health_stat = {'green': 0, 'yellow': 1, 'red': 2}
+        reversed_health_stat = {'red': 0, 'yellow': 1, 'green': 2}
         for idx in index_resp:
             tags = base_tags + ['index_name:' + idx['index']]
             # we need to remap metric names because the ones from elastic
@@ -170,7 +171,9 @@ class ESCheck(AgentCheck):
 
             # Convert the health status value
             if index_data['health'] is not None:
-                index_data['health'] = health_stat[index_data['health'].lower()]
+                status = index_data['health'].lower()
+                index_data['health'] = health_stat[status]
+                index_data['health_reverse'] = reversed_health_stat[status]
 
             # Ensure that index_data does not contain None values
             for key, value in list(iteritems(index_data)):

--- a/elastic/datadog_checks/elastic/metrics.py
+++ b/elastic/datadog_checks/elastic/metrics.py
@@ -235,6 +235,7 @@ ADDITIONAL_METRICS_PRE_5_0_0 = {
 # Metrics for index level
 INDEX_STATS_METRICS = {
     'elasticsearch.index.health': ('gauge', 'health'),
+    'elasticsearch.index.health.reverse': ('gauge', 'health_reverse'),
     'elasticsearch.index.docs.count': ('gauge', 'docs_count'),
     'elasticsearch.index.docs.deleted': ('gauge', 'docs_deleted'),
     'elasticsearch.index.primary_shards': ('gauge', 'primary_shards'),

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -249,7 +249,8 @@ jvm.mem.pools.survivor.used,gauge,,byte,,The amount of memory in bytes currently
 jvm.mem.pools.survivor.max,gauge,,byte,,The maximum amount of memory that can be used by the Survivor Space.,0,elasticsearch,jvm survivor max
 jvm.threads.count,gauge,,thread,,The number of active threads in the JVM.,0,elasticsearch,jvm threads
 jvm.threads.peak_count,gauge,,thread,,The peak number of threads used by the JVM.,0,elasticsearch,jvm peak threads
-elasticsearch.index.health,gauge,,,,The status of the index,0,elasticsearch,index health
+elasticsearch.index.health,gauge,,,,"The status of the index as a number: green = 0, yellow = 1, red = 2",0,elasticsearch,index health
+elasticsearch.index.health.reverse,gauge,,,,"The status of the index as a number: red = 0, yellow = 1, green = 2",0,elasticsearch,index health r
 elasticsearch.index.docs.count,gauge,,document,,The number of documents in the index,0,elasticsearch,index doc count
 elasticsearch.index.docs.deleted,gauge,,document,,The number of deleted documents in the index,0,elasticsearch,index doc deleted count
 elasticsearch.index.primary_shards,gauge,,shard,,The number of primary shards in the index,0,elasticsearch,index primary shards count


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add a new `elasticsearch.index.health.reverse` that gives the same information as `elasticsearch.index.health` but with values aligned with `elasticsearch.cluster_status`

### Motivation
<!-- What inspired you to submit this pull request? -->
Resolve #8310 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Open to naming suggestions

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
