### PR TITLE
Do not throw configuration error for missing password when using OAuth

### DIFF
--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -47,12 +47,16 @@ class Config(object):
         if account is None:
             raise ConfigurationError('Must specify an account')
 
-        if authenticator == 'snowflake':
-            if user is None or password is None:
-                raise ConfigurationError('Must specify a user and password')
+        if user is None:
+            raise ConfigurationError('Must specify a user')
 
+        if authenticator == 'snowflake':
             if is_affirmative(passcode_in_password) and passcode is None:
                 raise ConfigurationError('MFA enabled, please specify a passcode')
+
+            if password is None:
+                raise ConfigurationError('Must specify a password if using snowflake authentication')
+
         else:
             if authenticator == 'oauth' and token is None:
                 raise ConfigurationError('If using OAuth, you must specify a token')

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -47,20 +47,21 @@ class Config(object):
         if account is None:
             raise ConfigurationError('Must specify an account')
 
-        if user is None or password is None:
-            raise ConfigurationError('Must specify a user and password')
+        if authenticator == 'snowflake':
+            if user is None or password is None:
+                raise ConfigurationError('Must specify a user and password')
+
+            if is_affirmative(passcode_in_password) and passcode is None:
+                raise ConfigurationError('MFA enabled, please specify a passcode')
+        else:
+            if authenticator == 'oauth' and token is None:
+                raise ConfigurationError('If using OAuth, you must specify a token')
+
+            if authenticator not in self.AUTHENTICATION_MODES:
+                raise ConfigurationError('The Authenticator method set is invalid: {}'.format(authenticator))
 
         if not isinstance(tags, list):
             raise ConfigurationError('tags {!r} must be a list (got {!r})'.format(tags, type(tags)))
-
-        if is_affirmative(passcode_in_password) and passcode is None:
-            raise ConfigurationError('MFA enabled, please specify a passcode')
-
-        if authenticator not in self.AUTHENTICATION_MODES:
-            raise ConfigurationError('The Authenticator method set is invalid: {}'.format(authenticator))
-
-        if authenticator == 'oauth' and token is None:
-            raise ConfigurationError('If using OAuth, you must specify a token')
 
         if role is None:
             raise ConfigurationError('Must specify a role')

--- a/snowflake/tests/conftest.py
+++ b/snowflake/tests/conftest.py
@@ -12,6 +12,16 @@ INSTANCE = {
     'role': "ACCOUNTADMIN",
 }
 
+OAUTH_INSTANCE = {
+    "user": "testuser",
+    "account": "test_acct.us-central1.gcp",
+    "database": "SNOWFLAKE",
+    "schema": "ACCOUNT_USAGE",
+    'role': "ACCOUNTADMIN",
+    "authenticator": "oauth",
+    "token": "testtoken",
+}
+
 CHECK_NAME = 'snowflake'
 
 
@@ -23,3 +33,8 @@ def dd_environment(instance):
 @pytest.fixture(scope='session')
 def instance():
     return INSTANCE
+
+
+@pytest.fixture(scope='session')
+def oauth_instance():
+    return OAUTH_INSTANCE

--- a/snowflake/tests/test_unit.py
+++ b/snowflake/tests/test_unit.py
@@ -12,6 +12,13 @@ from .conftest import CHECK_NAME
 
 PROXY_CONFIG = {'http': 'http_host', 'https': 'https_host', 'no_proxy': 'uri1,uri2;uri3,uri4'}
 INVALID_PROXY = {'http': 'unused', 'https': 'unused', 'no_proxy': 'unused'}
+INVALID_CONFIG = {
+    "account": "test_acct.us-central1.gcp",
+    "database": "SNOWFLAKE",
+    "schema": "ACCOUNT_USAGE",
+    'role': "ACCOUNTADMIN",
+    "authenticator": "oauth",
+}
 
 
 def test_config():
@@ -25,7 +32,7 @@ def test_config():
 
     # Test missing user and pass
     account_config = {'account': 'TEST123'}
-    with pytest.raises(Exception, match='Must specify a user and password'):
+    with pytest.raises(Exception, match='Must specify a user'):
         SnowflakeCheck(CHECK_NAME, {}, [account_config])
 
 
@@ -35,13 +42,18 @@ def test_default_authentication(instance):
     assert check.config.authenticator == 'snowflake'
 
 
-def test_invalid_auth(instance):
-    # Test oauth
-    oauth_inst = copy.deepcopy(instance)
-    oauth_inst['authenticator'] = 'oauth'
-    with pytest.raises(Exception, match='If using OAuth, you must specify a token'):
-        SnowflakeCheck(CHECK_NAME, {}, [oauth_inst])
+def test_invalid_oauth(oauth_instance):
+    # Test oauth without user
+    with pytest.raises(Exception, match='Must specify a user'):
+        SnowflakeCheck(CHECK_NAME, {}, [INVALID_CONFIG])
 
+    # Test oauth without token
+    no_token_config = copy.deepcopy(INVALID_CONFIG)
+    no_token_config['user'] = "test_user"
+    with pytest.raises(Exception, match='If using OAuth, you must specify a token'):
+        SnowflakeCheck(CHECK_NAME, {}, [no_token_config])
+
+    oauth_inst = copy.deepcopy(oauth_instance)
     oauth_inst['authenticator'] = 'testauth'
     with pytest.raises(Exception, match='The Authenticator method set is invalid: testauth'):
         SnowflakeCheck(CHECK_NAME, {}, [oauth_inst])
@@ -77,11 +89,9 @@ def test_default_auth(instance):
         )
 
 
-def test_oauth_auth(instance):
+def test_oauth_auth(oauth_instance):
     # Test oauth
-    oauth_inst = copy.deepcopy(instance)
-    oauth_inst['authenticator'] = 'oauth'
-    oauth_inst['token'] = 'testtoken'
+    oauth_inst = copy.deepcopy(oauth_instance)
 
     with mock.patch('datadog_checks.snowflake.check.sf') as sf:
         check = SnowflakeCheck(CHECK_NAME, {}, [oauth_inst])
@@ -90,7 +100,7 @@ def test_oauth_auth(instance):
         check.check(oauth_inst)
         sf.connect.assert_called_with(
             user='testuser',
-            password='pass',
+            password=None,
             account='test_acct.us-central1.gcp',
             database='SNOWFLAKE',
             schema='ACCOUNT_USAGE',


### PR DESCRIPTION
### What does this PR do?
The config validation would throw a configuration error if password is not configured. This PR ensures that password is only checked when using `snowflake` authenticator.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
