### PR TITLE
Handle overflow error for certain sql queries

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -375,8 +375,8 @@ class SqlOsTasks(BaseSqlServerMetric):
     DEFAULT_METRIC_TYPE = 'gauge'
     QUERY_BASE = """
     select scheduler_id,
-           SUM(context_switches_count) as context_switches_count,
-           SUM(pending_io_count) as pending_io_count,
+           SUM(CAST(context_switches_count AS BIGINT)) as context_switches_count,
+           SUM(CAST(pending_io_count AS BIGINT)) as pending_io_count,
            SUM(pending_io_byte_count) as pending_io_byte_count,
            AVG(pending_io_byte_average) as pending_io_byte_average
     from {table} group by scheduler_id;

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -453,7 +453,12 @@ class SQLServer(AgentCheck):
                     if not metric_names:
                         instance_results[cls] = None, None
                     else:
-                        rows, cols = getattr(metrics, cls).fetch_all_values(cursor, metric_names, self.log)
+                        try:
+                            rows, cols = getattr(metrics, cls).fetch_all_values(cursor, metric_names, self.log)
+                        except Exception as e:
+                            self.log.error("Error running `fetch_all` for metrics %s - skipping.  Error: %s", cls, e)
+                            continue
+
                         instance_results[cls] = rows, cols
 
                 # Using the cached data, extract and report individual metrics


### PR DESCRIPTION
### What does this PR do?
In `sqlserver` check we have one query that aggregates data via `SUM` operation for the [`sys.dm_os_tasks`](https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-tasks-transact-sql?view=sql-server-ver15) table.  The columns are defined as `int`s, but we have reports of this overflowing when the sum gets applied.  This fix casts the results into a `bigint` data type instead.

It also adds a try/except block around the sql query operations to guard against errors of this type in the future while still allowing the rest of the check to continue.  

### Motivation
Bug fix.
