### PR TITLE
Update README.md

### DIFF
--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -34,7 +34,7 @@ Create an Agent user for your default vhost with the following commands:
 
 ```text
 rabbitmqctl add_user datadog <SECRET>
-rabbitmqctl set_permissions  -p / datadog "^aliveness-test$" "^amq\.default$" ".*"
+rabbitmqctl set_permissions  -p / datadog "^aliveness-test$" "^amq.default$" ".*"
 rabbitmqctl set_user_tags datadog monitoring
 ```
 


### PR DESCRIPTION
Using the permissions in the docs gives errors in RabbitMQ, we need to add the permissions without the backslash

### What does this PR do?
RabbitMQ gives this error if we follow the `amq\.default` write permission

```
=ERROR EVENT==== Fri, 15 Jan 2021 10:50:26 GMT ===
2021-01-15 10:50:26.651 [error] <0.5896.269> Channel error on connection <0.6023.269> (<rabbit@REDACTED-01.1606815935.6023.269>, vhost: '/', user: 'datadog'), channel 1:
operation basic.publish caused a channel exception access_refused: access to exchange 'amq.default' in vhost '/' refused for user 'datadog'
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
