### PR TITLE
Handle offline databases for existence check

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -209,7 +209,8 @@ class Connection(object):
                 self.existing_databases = {}
                 cursor.execute(DATABASE_EXISTS_QUERY)
                 for row in cursor:
-                    case_insensitive = 'CI' in row.collation_name
+                    # collation_name can be NULL if db offline, in that case assume its case_insensitive
+                    case_insensitive = not row.collation_name or 'CI' in row.collation_name
                     self.existing_databases[row.name.lower()] = case_insensitive, row.name
 
             except Exception as e:

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -57,6 +57,7 @@ def test_db_exists(get_cursor, mock_connect, instance_sql2017, dd_run_check):
         Row('tempdb', 'SQL_Latin1_General_CP1_CI_AS'),
         Row('AdventureWorks2017', 'SQL_Latin1_General_CP1_CI_AS'),
         Row('CaseSensitive2018', 'SQL_Latin1_General_CP1_CS_AS'),
+        Row('OfflineDB', None),
     ]
 
     mock_connect.__enter__ = mock.Mock(return_value='foo')
@@ -97,6 +98,12 @@ def test_db_exists(get_cursor, mock_connect, instance_sql2017, dd_run_check):
     check = SQLServer(CHECK_NAME, {}, [instance])
     with pytest.raises(ConfigurationError):
         check.initialize_connection()
+
+    # check offline but exists db
+    instance['database'] = 'Offlinedb'
+    check = SQLServer(CHECK_NAME, {}, [instance])
+    check.initialize_connection()
+    assert check.do_check is True
 
 
 def test_autodiscovery_matches_all_by_default(instance_autodiscovery):


### PR DESCRIPTION
### What does this PR do?
According to the [`sys.databases`](https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-databases-transact-sql?redirectedfrom=MSDN&view=sql-server-ver15) documentation, if a database is offline then the value of `collation_name` will be NULL.  This PR guards against that condition and just assumes the database is case-insensitive (which is the default).  



