### PR TITLE
Add config spec support for options with multiple types

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/example.py
@@ -37,19 +37,22 @@ def construct_yaml(obj, **kwargs):
 
 
 def value_type_string(value):
-    value_type = value['type']
-    if value_type == 'object':
-        return 'mapping'
-    elif value_type == 'array':
-        item_type = value['items']['type']
-        if item_type == 'object':
-            return 'list of mappings'
-        elif item_type == 'array':
-            return 'list of lists'
-        else:
-            return f'list of {item_type}s'
+    if 'oneOf' in value:
+        return ' or '.join(value_type_string(type_data) for type_data in value['oneOf'])
     else:
-        return value_type
+        value_type = value['type']
+        if value_type == 'object':
+            return 'mapping'
+        elif value_type == 'array':
+            item_type = value['items']['type']
+            if item_type == 'object':
+                return 'list of mappings'
+            elif item_type == 'array':
+                return 'list of lists'
+            else:
+                return f'list of {item_type}s'
+        else:
+            return value_type
 
 
 def option_enabled(option):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/spec.py
@@ -366,7 +366,47 @@ VALID_TYPES = {
 
 
 def value_validator(value, loader, file_name, sections_display, option_name, depth=0):
-    if 'type' not in value:
+    if 'oneOf' in value:
+        if 'type' in value:
+            loader.errors.append(
+                '{}, {}, {}{}: Values must contain either a `type` or `oneOf` attribute, not both'.format(
+                    loader.source, file_name, sections_display, option_name
+                )
+            )
+            return
+
+        one_of = value['oneOf']
+        if not isinstance(one_of, list):
+            loader.errors.append(
+                '{}, {}, {}{}: Attribute `oneOf` must be an array'.format(
+                    loader.source, file_name, sections_display, option_name
+                )
+            )
+            return
+        elif len(one_of) == 1:
+            loader.errors.append(
+                '{}, {}, {}{}: Attribute `oneOf` contains a single type, use the `type` attribute instead'.format(
+                    loader.source, file_name, sections_display, option_name
+                )
+            )
+            return
+
+        for i, type_data in enumerate(one_of, 1):
+            if not isinstance(type_data, dict):
+                loader.errors.append(
+                    '{}, {}, {}{}: Type #{} of attribute `oneOf` must be a mapping'.format(
+                        loader.source, file_name, sections_display, option_name, i
+                    )
+                )
+                return
+
+            value_validator(type_data, loader, file_name, sections_display, option_name)
+
+        if not depth:
+            value['example'] = default_option_example(option_name)
+
+        return
+    elif 'type' not in value:
         loader.errors.append(
             '{}, {}, {}{}: Every value must contain a `type` attribute'.format(
                 loader.source, file_name, sections_display, option_name
@@ -607,7 +647,7 @@ def value_validator(value, loader, file_name, sections_display, option_name, dep
         if required and set(required).difference(property_names):
             loader.errors.append(
                 '{}, {}, {}{}: All entries in attribute `required` for `type` '
-                '{} must be defined in the`properties` attribute'.format(
+                '{} must be defined in the `properties` attribute'.format(
                     loader.source, file_name, sections_display, option_name, value_type
                 )
             )

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -1427,3 +1427,43 @@ def test_enabled_override_required():
             # bar: <BAR>
         """
     )
+
+
+def test_option_multiple_types():
+    consumer = get_example_consumer(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - template: instances
+            options:
+            - name: foo
+              description: words
+              value:
+                oneOf:
+                - type: string
+                - type: array
+                  items:
+                    type: string
+        """
+    )
+
+    files = consumer.render()
+    contents, errors = files['test.yaml.example']
+    assert not errors
+    assert contents == normalize_yaml(
+        """
+        ## Every instance is scheduled independent of the others.
+        #
+        instances:
+
+          -
+            ## @param foo - string or list of strings - optional
+            ## words
+            #
+            # foo: <FOO>
+        """
+    )

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -2509,7 +2509,7 @@ def test_value_type_object_properties_required_not_met():
 
     assert (
         'test, test.yaml, instances, foo: All entries in attribute `required` '
-        'for `type` object must be defined in the`properties` attribute'
+        'for `type` object must be defined in the `properties` attribute'
     ) in spec.errors
 
 
@@ -2859,6 +2859,199 @@ def test_template_hide_duplicate():
             - template: instances/jmx
               overrides:
                 password.hidden: true
+        """
+    )
+    spec.load()
+
+    assert not spec.errors
+
+
+def test_value_one_of_with_type():
+    spec = get_spec(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - name: instances
+            description: words
+            options:
+            - name: foo
+              description: words
+              value:
+                type: number
+                oneOf: []
+        """
+    )
+    spec.load()
+
+    assert (
+        'test, test.yaml, instances, foo: Values must contain either a `type` or `oneOf` attribute, not both'
+        in spec.errors
+    )
+
+
+def test_value_one_of_not_array():
+    spec = get_spec(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - name: instances
+            description: words
+            options:
+            - name: foo
+              description: words
+              value:
+                oneOf: bar
+        """
+    )
+    spec.load()
+
+    assert 'test, test.yaml, instances, foo: Attribute `oneOf` must be an array' in spec.errors
+
+
+def test_value_one_of_single_type():
+    spec = get_spec(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - name: instances
+            description: words
+            options:
+            - name: foo
+              description: words
+              value:
+                oneOf:
+                - type: string
+        """
+    )
+    spec.load()
+
+    assert (
+        'test, test.yaml, instances, foo: Attribute `oneOf` contains a single type, use the `type` attribute instead'
+        in spec.errors
+    )
+
+
+def test_value_one_of_type_not_mapping():
+    spec = get_spec(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - name: instances
+            description: words
+            options:
+            - name: foo
+              description: words
+              value:
+                oneOf:
+                - bar
+                - {}
+        """
+    )
+    spec.load()
+
+    assert 'test, test.yaml, instances, foo: Type #1 of attribute `oneOf` must be a mapping' in spec.errors
+
+
+def test_value_one_of_type_recursive_validation_error():
+    spec = get_spec(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - name: instances
+            description: words
+            options:
+            - name: foo
+              description: words
+              value:
+                oneOf:
+                - type: string
+                - type: object
+                  required:
+                  - foo
+                  - foo
+        """
+    )
+    spec.load()
+
+    assert (
+        'test, test.yaml, instances, foo: All entries in attribute `required` for `type` object must be unique'
+    ) in spec.errors
+
+
+def test_value_one_of_type_super_recursive_validation_error():
+    spec = get_spec(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - name: instances
+            description: words
+            options:
+            - name: foo
+              description: words
+              value:
+                oneOf:
+                - type: string
+                - type: array
+                  items:
+                    oneOf:
+                    - type: string
+                    - type: object
+                      required:
+                      - foo
+                      - foo
+        """
+    )
+    spec.load()
+
+    assert (
+        'test, test.yaml, instances, foo: All entries in attribute `required` for `type` object must be unique'
+    ) in spec.errors
+
+
+def test_value_one_of_type_recursive_validation_success():
+    spec = get_spec(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - name: instances
+            description: words
+            options:
+            - name: foo
+              description: words
+              value:
+                oneOf:
+                - type: string
+                - type: array
+                  items:
+                    type: string
         """
     )
     spec.load()

--- a/docs/developer/meta/config-specs.md
+++ b/docs/developer/meta/config-specs.md
@@ -87,7 +87,6 @@ The type system is based on a loose subset of OpenAPI 3 [data types][openapi-dat
 
 The differences are:
 
-- Types cannot be mixed e.g. `oneOf` is invalid in all cases
 - Only the `minimum` and `maximum` numeric modifiers are supported
 - Only the `pattern` string modifier is supported
 - The `properties` object modifier is not a map, but rather a list of maps with a required `name`
@@ -126,7 +125,7 @@ are shipped with every Agent and individual Integration release.
 
 It respects a few extra [option](#options)-level attributes:
 
-- `example` - A complete example of a option in lieu of a strictly typed `value` attribute
+- `example` - A complete example of an option in lieu of a strictly typed `value` attribute
 - `enabled` - Whether or not to un-comment the option, overriding the behavior of `required`
 
 It also respects a few extra fields under the `value` attribute of each option:


### PR DESCRIPTION
### What does this PR do?

https://swagger.io/docs/specification/data-models/data-types/#mixed-type

### Motivation

Many integrations need this