### PR TITLE
Fix misleading debug message

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -316,7 +316,7 @@ class HTTPCheck(AgentCheck):
                 self.log.debug("The hostname on the SSL certificate does not match the given host: %s", e)
                 return AgentCheck.UNKNOWN, None, None, msg
             else:
-                self.log.debug("Site is down, unable to connect to get cert expiration: %s", e)
+                self.log.debug("Unable to connect to site to get cert expiration: %s", e)
                 return AgentCheck.UNKNOWN, None, None, msg
 
         exp_date = datetime.strptime(cert['notAfter'], "%b %d %H:%M:%S %Y %Z")


### PR DESCRIPTION
This error is misleading and is causing some confusion. We don't know if the site is down, just that we cannot connect