### PR TITLE
Properly support check namespacing for the `submit_histogram_bucket` method

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -406,8 +406,8 @@ class AgentCheck(object):
         # type: (int, str, Sequence[str], str) -> str
         return '{}-{}-{}-{}'.format(mtype, name, tags if tags is None else hash(frozenset(tags)), hostname)
 
-    def submit_histogram_bucket(self, name, value, lower_bound, upper_bound, monotonic, hostname, tags):
-        # type: (str, float, int, int, bool, str, Sequence[str]) -> None
+    def submit_histogram_bucket(self, name, value, lower_bound, upper_bound, monotonic, hostname, tags, raw=False):
+        # type: (str, float, int, int, bool, str, Sequence[str], bool) -> None
         if value is None:
             # ignore metric sample
             return
@@ -429,7 +429,15 @@ class AgentCheck(object):
             hostname = ''
 
         aggregator.submit_histogram_bucket(
-            self, self.check_id, name, value, lower_bound, upper_bound, monotonic, hostname, tags
+            self,
+            self.check_id,
+            self._format_namespace(name, raw),
+            value,
+            lower_bound,
+            upper_bound,
+            monotonic,
+            hostname,
+            tags,
         )
 
     def _submit_metric(


### PR DESCRIPTION
### What does this PR do?

Correct the behavior to match the other submission methods

### Motivation

Noticed bug while working on the OpenMetrics rewrite

### Additional Notes

Integrations using `submit_histogram_bucket`:

- `mapr` - will not be affected b/c no `__NAMESPACE__`
- `azure_iot_edge` - defines a `__NAMESPACE__`, but was only just made public in 7.25.x and if any users have happened to enable `send_distribution_buckets` they likely are struggling to find the metrics in the UI