### PR TITLE
Update step 2 of configuration to include localhost/agent container address for containerized deployment

### DIFF
--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -21,7 +21,7 @@ No additional installation is needed on your server.
     gem install dogstatsd-ruby
    ```
 
-2. Enable Sidekiq Pro metric collection by including this in your initializer (For a containerized deployment, update localhost to your Agent container address):
+2. Enable Sidekiq Pro metric collection by including this in your initializer; for a containerized deployment, update `localhost` to your Agent container address:
 
    ```ruby
         require 'datadog/statsd' # gem 'dogstatsd-ruby'

--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -21,12 +21,12 @@ No additional installation is needed on your server.
     gem install dogstatsd-ruby
    ```
 
-2. Enable Sidekiq Pro metric collection by including this in your initializer:
+2. Enable Sidekiq Pro metric collection by including this in your initializer (For a containerized deployment, update localhost to your Agent container address):
 
    ```ruby
         require 'datadog/statsd' # gem 'dogstatsd-ruby'
 
-        Sidekiq::Pro.dogstatsd = ->{ Datadog::Statsd.new('metrics.example.com', 8125, namespace:'sidekiq') }
+        Sidekiq::Pro.dogstatsd = ->{ Datadog::Statsd.new('localhost', 8125, namespace:'sidekiq') }
 
         Sidekiq.configure_server do |config|
           config.server_middleware do |chain|
@@ -35,7 +35,7 @@ No additional installation is needed on your server.
           end
         end
    ```
-
+   
     If you are using Sidekiq Enterprise and would like to collect historical metrics, include this line as well:
 
    ```ruby


### PR DESCRIPTION
### What does this PR do?
Updates code snippet of configuration step 2 (https://docs.datadoghq.com/integrations/sidekiq/#configuration) to include localhost instead of metrics.example.com and a note to add agent container address for containerized deployments

### Motivation
Customer Ticket: https://datadog.zendesk.com/agent/tickets/391292 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
