### PR TITLE
Simplify replication status check

### DIFF
--- a/mysql/assets/SERVICE_CHECK_CLARIFICATION.md
+++ b/mysql/assets/SERVICE_CHECK_CLARIFICATION.md
@@ -1,17 +1,14 @@
 ## On a slave host:
-* For MySQL >= 5.7.0
-  * If the SQL and the IO threads are running, returns OK
-  * If one of them is down, returns WARNING
-  * If both are down, returns CRITICAL
-* For MySQL < 5.7.0
-  * If both threads are running, returns OK
-  * If at least one of them is down, returns CRITICAL
+
+* If the SQL and the IO threads are running, returns OK
+* If one of them is down, returns WARNING
+* If both are down, returns CRITICAL
 * Else, if none of the condition above was satisfied
   * If the IO and the SQL threads are healthy, returns OK
   * Else, returns CRITICAL
 
 ## On a master host:
-* If `Slave_Running`, `Slave_IO_Running` and `Slave_SQL_Running` are present, but the IO and the SQL thread is not healthy, returns CRTITICAL
+* If `Slave_IO_Running` and `Slave_SQL_Running` are present, but the IO and the SQL thread is not healthy, returns CRTITICAL
 * If binary log is enabled and at least 1 binlog_dump is running, returns OK
 * If binary log and `nonblocking` option are enabled, MySQL >= 5.6.0 and one worker thread running, returns OK
 * Else, returns WARNING

--- a/mysql/assets/service_checks.json
+++ b/mysql/assets/service_checks.json
@@ -20,6 +20,7 @@
         "check": "mysql.replication.slave_running",
         "statuses": [
             "ok",
+            "warning",
             "critical"
         ],
         "groups": [
@@ -27,6 +28,6 @@
             "channel"
         ],
         "name": "Replication Running",
-        "description": "Returns CRITICAL for a slave that's not running. Returns `OK` otherwise."
+        "description": "Returns CRITICAL for a slave that's not running Slave_IO_Running or Slave_SQL_Running, WARNING if one of the two is not running. Returns `OK` otherwise."
     }
 ]

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -315,9 +315,6 @@ class MySql(AgentCheck):
     def _check_replication_status(self, results):
         # get slave running form global status page
         slave_running_status = AgentCheck.UNKNOWN
-        # This is ON if this server is a replica that is connected to a replication source,
-        # and both the I/O and SQL threads are running; otherwise, it is OFF.
-        slave_running = collect_string('Slave_running', results)
         # Slave_IO_Running: Whether the I/O thread for reading the source's binary log is running.
         # You want this to be Yes unless you have not yet started replication or have explicitly stopped it.
         slave_io_running = collect_type('Slave_IO_Running', results, dict)


### PR DESCRIPTION
`Slave_running` was not present in 5.7, is removed in 8.0 and it is redundant in any case so lets get rid of it
https://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html#statvar_Slave_running