### PR TITLE
Do not use master by default if database is not provided

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -29,10 +29,11 @@ instances:
   #
     password: <PASSWORD>
 
-  ## @param database - string - optional - default: master
-  ## Database name to query
+  ## @param database - string - optional - default: none
+  ## Database name to query. You can comment this and then the connection will be made to the configured
+  ## default database of the login that's connecting to SQL Server.
   #
-  #  database: master
+    database: master
 
   ## @param adoprovider - string - optional - default: SQLOLEDB
   ## Choose the ADO provider.  Note that the (default) provider

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -382,7 +382,7 @@ class SQLServer(AgentCheck):
             conn_str = 'DSN={};'.format(dsn)
 
         if driver:
-            conn_str += 'Driver={};'.format(driver)
+            conn_str += 'DRIVER={};'.format(driver)
         if host:
             conn_str += 'Server={};'.format(host)
         if database:
@@ -392,7 +392,7 @@ class SQLServer(AgentCheck):
             conn_str += 'UID={};'.format(username)
         self.log.debug("Connection string (before password) {}".format(conn_str))
         if password:
-            conn_str += 'Password={};'.format(password)
+            conn_str += 'PWD={};'.format(password)
         return conn_str
 
     def _conn_string_adodbapi(self, db_key, instance=None, conn_key=None, db_name=None):
@@ -640,10 +640,9 @@ class SQLServer(AgentCheck):
         custom_tags = instance.get("tags", [])
         if custom_tags is None:
             custom_tags = []
-        service_check_tags = [
-            'host:{}'.format(host),
-            'db:{}'.format(database)
-        ]
+        service_check_tags = ['host:{}'.format(host)]
+        if database:
+            service_check_tags.append('db:{}'.format(database))
         service_check_tags.extend(custom_tags)
         service_check_tags = list(set(service_check_tags))
 

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -16,6 +16,7 @@
   "support": "core",
   "supported_os": [
     "linux",
+    "mac_os",
     "windows"
   ],
   "type": "check",

--- a/sqlserver/requirements.in
+++ b/sqlserver/requirements.in
@@ -1,5 +1,5 @@
 adodbapi==2.6.0.7; sys_platform == 'win32'
-pyodbc==4.0.22; sys_platform != 'darwin'
+pyodbc==4.0.22;
 pyro4==4.73; sys_platform == 'win32'
 pywin32==224; sys_platform == 'win32'
 selectors34==1.2.0; sys_platform == 'win32' and python_version < '3.4'

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -33,6 +33,7 @@ INSTANCE_DOCKER = {
     'driver': lib_tds_path(),
     'username': 'sa',
     'password': 'Password123',
+    'database': 'master',
     'tags': ['optional:tag1'],
 }
 
@@ -40,6 +41,7 @@ INSTANCE_SQL2017 = {
     'host': r'(local)\SQL2017',
     'username': 'sa',
     'password': 'Password12!',
+    'database': 'master',
 }
 
 INIT_CONFIG = {


### PR DESCRIPTION
SQLServer integration defaults to connecting to the `master` database if no database is provided. However not providing a database is possible and may be the source of a customer issue