### PR TITLE
Fix conflicting link references in tile readme template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/README.md
@@ -34,6 +34,7 @@ This check monitors [{integration_name}][1].
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][1].
+Need help? Contact [Datadog support][2].
 
-[1]: https://docs.datadoghq.com/help/
+[1]: **LINK_TO_INTEGRATION_SITE**
+[2]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?
Fix conflicting links in template

### Motivation
First link should be a placeholder for integration site.
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
