### PR TITLE
Update logs template with docs feedback

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/setup/configuration/log_collection.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/docs/setup/configuration/log_collection.yaml
@@ -1,4 +1,4 @@
-name: Log Collection
+name: Log collection
 header_level: 4
 description: |
 
@@ -8,11 +8,11 @@ description: |
       logs_enabled: true
       ```
 
-  2. Add this configuration block to your `{check_conf_path}` file to start collecting your {display_name} logs:
+  2. Edit this configuration block in your `{check_conf_path}` file to start collecting your {display_name} logs:
 
   {check_log_conf_snippet:4i}
 
-    Change the `path` parameter value based on your environment. See the {check_conf_link} for all available configuration options.
+    Change the `path` parameter value based on your environment. See the [sample conf.yaml]({check_conf_link}) for all available configuration options.
 
     3. [Restart the Agent][1].
 

--- a/rethinkdb/README.md
+++ b/rethinkdb/README.md
@@ -52,7 +52,7 @@ configuration options.
 
 **Note**: this integration collects metrics from all servers in the cluster, so you only need a single Agent.
 
-#### Log Collection
+#### Log collection
 
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
@@ -61,7 +61,7 @@ configuration options.
     logs_enabled: true
     ```
 
-2. Add this configuration block to your `rethinkdb.d/conf.yaml` file to start collecting your RethinkDB logs:
+2. Edit this configuration block in your `rethinkdb.d/conf.yaml` file to start collecting your RethinkDB logs:
 
     ```yaml
     logs:
@@ -72,7 +72,7 @@ configuration options.
     ```
 
 
-  Change the `path` parameter value based on your environment. See the https://github.com/DataDog/integrations-core/blob/master/rethinkdb/datadog_checks/rethinkdb/data/conf.yaml.example for all available configuration options.
+  Change the `path` parameter value based on your environment. See the [sample conf.yaml][7] for all available configuration options.
 
   3. [Restart the Agent][8].
 


### PR DESCRIPTION
### What does this PR do?
I based the logs docs off of rethinkdb for another integration(which uses the readme specs). this PR updates the wording/links to conf.yaml.example

Before, the following line contained long link:
```
  Change the `path` parameter value based on your environment. See the https://github.com/DataDog/integrations-core/blob/master/rethinkdb/datadog_checks/rethinkdb/data/conf.yaml.example for all available configuration options.

```

Now, it is appropriately linked with text `sample conf.yaml`:

```
  Change the `path` parameter value based on your environment. See the [sample conf.yaml][7] for all available configuration options.

```
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
