### PR TITLE
Clear process cache if cached PIDs not found

### DIFF
--- a/process/datadog_checks/process/cache.py
+++ b/process/datadog_checks/process/cache.py
@@ -42,3 +42,7 @@ class ProcessListCache(object):
                 return True
             else:
                 return False
+
+    def reset(self):
+        """Resets the cache."""
+        self.last_ts = 0

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -279,8 +279,9 @@ class ProcessCheck(AgentCheck):
                 # Skip processes dead in the meantime
                 except psutil.NoSuchProcess:
                     self.warning('Process %s disappeared while scanning', pid)
-                    # reset the PID cache now, something changed
+                    # reset the process caches now, something changed
                     self.last_pid_cache_ts[name] = 0
+                    self.process_list_cache.reset()
                     continue
 
             p = self.process_cache[name][pid]
@@ -452,8 +453,9 @@ class ProcessCheck(AgentCheck):
 
         if len(pids) == 0:
             self.warning("No matching process '%s' was found", name)
-            # reset the PID cache now, something changed
+            # reset the process caches now, something changed
             self.last_pid_cache_ts[name] = 0
+            self.process_list_cache.reset()
 
         for attr, mname in iteritems(ATTR_TO_METRIC):
             vals = [x for x in proc_state[attr] if x is not None]

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -32,7 +32,7 @@ except Exception:
 @pytest.fixture(autouse=True)
 def reset_process_list_cache():
     # Force process list cache flush in the next test
-    ProcessCheck.process_list_cache.last_ts = -ProcessCheck.process_list_cache.cache_duration - 1
+    ProcessCheck.process_list_cache.reset()
 
 
 class MockProcess(object):
@@ -105,8 +105,9 @@ def test_process_list_cache(aggregator):
     process1 = ProcessCheck(common.CHECK_NAME, {}, [config['instances'][0]])
     process2 = ProcessCheck(common.CHECK_NAME, {}, [config['instances'][1]])
 
-    process1.check(config['instances'][0])
-    process2.check(config['instances'][1])
+    with patch('datadog_checks.process.cache.ProcessListCache.reset'):
+        process1.check(config['instances'][0])
+        process2.check(config['instances'][1])
 
     # Should always succeed
     assert process1.process_list_cache.elements[0].name() == "Process 1"


### PR DESCRIPTION
### What does this PR do?
* follow-up from #8263
* adding a `reset` method to ProcessListCache
* also resetting this cache when pids cannot be found

### Motivation
see above and #8057

### Additional Notes
is caching even needed in Linux?
perhaps it will be better to skip it completely and only use it in Windows?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
