### PR TITLE
Add metrics_metadata to templates

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/manifest.json
@@ -29,6 +29,7 @@
     "monitors": {{}},
     "saved_views": {{}},
     "service_checks": "assets/service_checks.json",
-    "logs": {{}}
+    "logs": {{}},
+    "metrics_metadata": "metadata.csv"
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/manifest.json
@@ -29,6 +29,7 @@
     "monitors": {{}},
     "saved_views": {{}},
     "service_checks": "assets/service_checks.json",
-    "logs": {{}}
+    "logs": {{}},
+    "metrics_metadata": "metadata.csv"
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/manifest.json
@@ -29,6 +29,7 @@
     "saved_views": {{}},
     "monitors": {{}},
     "service_checks": "assets/service_checks.json",
-    "logs": {{}}
+    "logs": {{}},
+    "metrics_metadata": "metadata.csv"
   }}
 }}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/manifest.json
@@ -26,6 +26,7 @@
     "saved_views": {{}},
     "monitors": {{}},
     "service_checks": "assets/service_checks.json",
-    "logs": {{}}
+    "logs": {{}},
+    "metrics_metadata": "metadata.csv"
   }}
 }}


### PR DESCRIPTION
### What does this PR do?
metrics_metadata is a field required if the integration contains a `metadata.csv`. This PR ensures that templates contain so they don't fail CI

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
