### PR TITLE
Minor error message fix

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/spec.py
@@ -213,11 +213,11 @@ def section_validator(sections, loader, file_name, *prev_sections):
 
         MISSING = (
             f'{loader.source}, {file_name}, {sections_display}section #{section_index}: '
-            'Every section must contain a `{{key}}` attribute'
+            f'Every section must contain a `{{key}}` attribute'
         )
         INVALID = (
             f'{loader.source}, {file_name}, {sections_display}section #{section_index}: '
-            'Attribute `{{key}}` must be a {{type}}'
+            f'Attribute `{{key}}` must be a {{type}}'
         )
 
         # now validate the expanded section object


### PR DESCRIPTION
### What does this PR do?
The second part of the string didn't pass through the `f` processor leaving the double-`{` still in the resulting `MISSING` template string.

