### PR TITLE
Fix nested section validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/spec.py
@@ -131,7 +131,7 @@ def section_validator(sections, loader, file_name, *prev_sections):
         Validation(key='append_text', type=str, required=False),
         Validation(key='processor', type=str, required=False),
         Validation(key='hidden', type=bool, required=False),
-        Validation(key='sections', type=list, required=False, children='self'),
+        Validation(key='sections', type=list, required=False),
         Validation(key='overrides', type=list, required=False),
     ]
 


### PR DESCRIPTION
### What does this PR do?
Nested sections already get processed recursively, no need to have it done within the `_validate` function.
