### PR TITLE
Remove any OpenMetrics metric prefixes immediately during parsing

### DIFF
--- a/datadog_checks_base/tests/openmetrics/test_options.py
+++ b/datadog_checks_base/tests/openmetrics/test_options.py
@@ -40,7 +40,7 @@ class TestRawMetricPrefix:
             foo_go_memstats_alloc_bytes 6.396288e+06
             """
         )
-        check = get_check({'metrics': ['.+'], 'raw_metric_prefix': 'foo_'})
+        check = get_check({'metrics': ['go_memstats_alloc_bytes'], 'raw_metric_prefix': 'foo_'})
         dd_run_check(check)
 
         aggregator.assert_metric(
@@ -509,6 +509,44 @@ class TestShareLabels:
         )
         aggregator.assert_metric(
             'test.go_memstats_free_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['endpoint:test', 'bar:baz']
+        )
+
+        aggregator.assert_all_metrics_covered()
+
+    def test_excluded_metric(self, aggregator, dd_run_check, mock_http_response):
+        mock_http_response(
+            """
+            # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+            # TYPE go_memstats_alloc_bytes gauge
+            go_memstats_alloc_bytes{foo="bar"} 6.396288e+06
+            # HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+            # TYPE go_memstats_gc_sys_bytes gauge
+            go_memstats_gc_sys_bytes{bar="foo"} 901120
+            # HELP go_memstats_free_bytes Number of bytes free and available for use.
+            # TYPE go_memstats_free_bytes gauge
+            go_memstats_free_bytes{bar="baz"} 6.396288e+06
+            """
+        )
+        check = get_check(
+            {
+                'metrics': ['.+'],
+                'share_labels': {'go_memstats_alloc_bytes': True},
+                'exclude_metrics': ['go_memstats_alloc_bytes'],
+            }
+        )
+        dd_run_check(check)
+
+        aggregator.assert_metric(
+            'test.go_memstats_gc_sys_bytes',
+            901120,
+            metric_type=aggregator.GAUGE,
+            tags=['endpoint:test', 'bar:foo', 'foo:bar'],
+        )
+        aggregator.assert_metric(
+            'test.go_memstats_free_bytes',
+            6396288,
+            metric_type=aggregator.GAUGE,
+            tags=['endpoint:test', 'bar:baz', 'foo:bar'],
         )
 
         aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### Motivation

So that all other configuration may reference the trimmed metric name, thus eliminating much confusion for users

### Additional Notes

I made this `Added` rather than `Fixed` since the legacy version did not do this:

https://github.com/DataDog/integrations-core/blob/45274b9e3657ed66a570f927393d925df3c2c353/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L422-L432