### PR TITLE
Remove class substitution logic for new OpenMetrics base class

### DIFF
--- a/datadog_checks_base/datadog_checks/base/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/__init__.py
@@ -8,6 +8,12 @@ from .config import is_affirmative
 from .errors import ConfigurationError
 from .utils.common import ensure_bytes, ensure_unicode, to_native_string, to_string
 
+# Python 3+
+try:
+    from .checks.openmetrics.v2.base import OpenMetricsBaseCheckV2
+except ImportError:
+    OpenMetricsBaseCheckV2 = None
+
 # Windows-only
 try:
     from .checks.win import PDHBaseCheck
@@ -25,6 +31,7 @@ __all__ = [
     'AgentCheck',
     'KubeLeaderElectionBaseCheck',
     'OpenMetricsBaseCheck',
+    'OpenMetricsBaseCheckV2',
     'PDHBaseCheck',
     'ConfigurationError',
     'ensure_bytes',

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -7,9 +7,6 @@ from ...errors import CheckException
 from .. import AgentCheck
 from .mixins import OpenMetricsScraperMixin
 
-if not PY2:
-    from .v2.base import OpenMetricsBaseCheckV2
-
 STANDARD_FIELDS = [
     'prometheus_url',
     'namespace',
@@ -62,17 +59,6 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
         'ssl_ca_cert': {'name': 'tls_ca_cert'},
         'prometheus_timeout': {'name': 'timeout'},
     }
-
-    def __new__(cls, *args, **kwargs):
-        # Legacy signature
-        if kwargs or len(args) != 3 or not isinstance(args[2], list):
-            return super(OpenMetricsBaseCheck, cls).__new__(cls)
-
-        instance = args[2][0]
-        if not PY2 and 'openmetrics_endpoint' in instance:
-            return OpenMetricsBaseCheckV2(*args, **kwargs)
-        else:
-            return super(OpenMetricsBaseCheck, cls).__new__(cls)
 
     def __init__(self, *args, **kwargs):
         """

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+# TODO: remove ignore when we stop invoking Mypy with --py2
+# type: ignore
 from collections import ChainMap
 from contextlib import contextmanager
 

--- a/datadog_checks_base/tests/openmetrics/test_bench.py
+++ b/datadog_checks_base/tests/openmetrics/test_bench.py
@@ -5,7 +5,7 @@ import os
 
 import pytest
 
-from datadog_checks.base import OpenMetricsBaseCheck
+from datadog_checks.base import OpenMetricsBaseCheck, OpenMetricsBaseCheckV2
 from datadog_checks.dev import get_here
 
 from ..utils import requires_py3
@@ -28,7 +28,7 @@ def fixture_amazon_msk_jmx_metrics():
 
 def test_ksm_new(benchmark, dd_run_check, mock_http_response, fixture_ksm):
     mock_http_response(file_path=fixture_ksm)
-    c = OpenMetricsBaseCheck('test', {}, [{'openmetrics_endpoint': 'foo', 'namespace': 'bar', 'metrics': ['.+']}])
+    c = OpenMetricsBaseCheckV2('test', {}, [{'openmetrics_endpoint': 'foo', 'namespace': 'bar', 'metrics': ['.+']}])
 
     # Run once to get initialization steps out of the way.
     dd_run_check(c)
@@ -58,7 +58,7 @@ def test_amazon_msk_jmx_metrics_new(benchmark, dd_run_check, mock_http_response,
 
         metrics.append(config)
 
-    c = OpenMetricsBaseCheck('test', {}, [{'openmetrics_endpoint': 'foo', 'namespace': 'bar', 'metrics': metrics}])
+    c = OpenMetricsBaseCheckV2('test', {}, [{'openmetrics_endpoint': 'foo', 'namespace': 'bar', 'metrics': metrics}])
 
     # Run once to get initialization steps out of the way.
     dd_run_check(c)
@@ -102,7 +102,7 @@ def test_label_joins_new(benchmark, dd_run_check, mock_http_response, fixture_ks
             '9': {'match': ['pod', 'namespace'], 'labels': ['node'], 'values': [1]},
         },
     }
-    c = OpenMetricsBaseCheck('test', {}, [instance])
+    c = OpenMetricsBaseCheckV2('test', {}, [instance])
 
     # Run once to get initialization steps out of the way.
     dd_run_check(c)

--- a/datadog_checks_base/tests/openmetrics/test_interface.py
+++ b/datadog_checks_base/tests/openmetrics/test_interface.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
+from datadog_checks.base import OpenMetricsBaseCheckV2
 from datadog_checks.base.constants import ServiceCheck
 
 from ..utils import requires_py3
@@ -12,9 +13,9 @@ pytestmark = [requires_py3, pytest.mark.openmetrics, pytest.mark.openmetrics_int
 
 
 def test_default_config(aggregator, dd_run_check, mock_http_response):
-    from datadog_checks.base import OpenMetricsBaseCheck
+    class Check(OpenMetricsBaseCheckV2):
+        __NAMESPACE__ = 'test'
 
-    class Check(OpenMetricsBaseCheck):
         def get_default_config(self):
             return {'metrics': ['.+'], 'rename_labels': {'foo': 'bar'}}
 
@@ -82,10 +83,11 @@ def test_service_check_dynamic_tags(aggregator, dd_run_check, mock_http_response
 
 def test_scraper_override(aggregator, dd_run_check, mock_http_response):
     # TODO: when we drop Python 2 move this up top
-    from datadog_checks.base import OpenMetricsBaseCheck
     from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
 
-    class Check(OpenMetricsBaseCheck):
+    class Check(OpenMetricsBaseCheckV2):
+        __NAMESPACE__ = 'test'
+
         def create_scraper(self, config):
             return OpenMetricsCompatibilityScraper(self, self.get_config_with_defaults(config))
 

--- a/datadog_checks_base/tests/openmetrics/utils.py
+++ b/datadog_checks_base/tests/openmetrics/utils.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.base import OpenMetricsBaseCheck
+from datadog_checks.base import OpenMetricsBaseCheckV2
 
 
 def get_check(instance=None, init_config=None):
@@ -11,7 +11,7 @@ def get_check(instance=None, init_config=None):
         init_config = {}
 
     instance.setdefault('openmetrics_endpoint', 'test')
-    check = OpenMetricsBaseCheck('test', init_config, [instance])
+    check = OpenMetricsBaseCheckV2('test', init_config, [instance])
     check.__NAMESPACE__ = 'test'
 
     return check

--- a/haproxy/datadog_checks/haproxy/check.py
+++ b/haproxy/datadog_checks/haproxy/check.py
@@ -14,7 +14,7 @@ class HAProxyCheck(OpenMetricsBaseCheck):
         instance = instances[0]
 
         if is_affirmative(instance.get('use_prometheus', False)):
-            return super(HAProxyCheck, cls).__new__(cls, name, init_config, instances)
+            return super(HAProxyCheck, cls).__new__(cls)
         else:
             return HAProxyCheckLegacy(name, init_config, instances)
 

--- a/istio/datadog_checks/istio/istio.py
+++ b/istio/datadog_checks/istio/istio.py
@@ -40,6 +40,6 @@ class Istio(OpenMetricsBaseCheck):
     def __new__(cls, name, init_config, instances):
         instance = instances[0]
         if instance.get('istiod_endpoint'):
-            return super(Istio, cls).__new__(cls, name, init_config, instances)
+            return super(Istio, cls).__new__(cls)
         else:
             return LegacyIstioCheck_1_4(name, init_config, instances)


### PR DESCRIPTION
### What does this PR do?

This makes it so that checks must explicitly opt-in to the conditional use of the latest implementation with their own `__new__` method like so:

```python
class Check(OpenMetricsBaseCheck):

    def __new__(cls, name, init_config, instances):
        instance = instances[0]

        if not PY2 and 'openmetrics_endpoint' in instance:
            # This will inherit from `datadog_checks.base.OpenMetricsBaseCheckV2`
            return NewCheck(name, init_config, instances)
        else:
            return super(Check, cls).__new__(cls)
```

### Motivation

As shown when running tests on the first commit of this PR, checks that enable the new functionality did not have their class data available to `OpenMetricsBaseCheckV2`. This makes sense of course since there is no intrinsic relationship, but was an oversight in the test cases.

As a workaround, I tried:

```python
def __new__(cls, *args, **kwargs):
    # Legacy signature
    if kwargs or len(args) != 3 or not isinstance(args[2], list):
        return super(OpenMetricsBaseCheck, cls).__new__(cls)

    instance = args[2][0]
    if not PY2 and 'openmetrics_endpoint' in instance:
        from types import MethodType
        check = OpenMetricsBaseCheckV2(*args, **kwargs)

        check_source_file = inspect.getsourcefile(cls)
        for name, member in inspect.getmembers(cls):
            try:
                source_file = inspect.getsourcefile(member)
            except TypeError:
                continue
            else:
                if source_file != check_source_file:
                    continue

                # Bind any methods
                if inspect.isfunction(member):
                    setattr(check, name, MethodType(member, check))
                else:
                    setattr(check, name, member)

        return check
    else:
        return super(OpenMetricsBaseCheck, cls).__new__(cls)
```

This works, but then the problem arises that you can override `__init__`, in which case it likely applies differently based on the class. Also, it's too hacky...