### PR TITLE
Avoid double periods at the end of PR titles

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -121,7 +121,8 @@ def changelog(
             thanks_note = ''
             if entry.from_contributor:
                 thanks_note = f' Thanks [{entry.author}]({entry.author_url}).'
-            new_entry.write(f'* {entry.title}. See [#{entry.number}]({entry.url}).{thanks_note}\n')
+            title_period = "." if not entry.title.endswith(".") else ""
+            new_entry.write(f'* {entry.title}{title_period} See [#{entry.number}]({entry.url}).{thanks_note}\n')
     new_entry.write('\n')
 
     # read the old contents


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Avoid changelog entries like "`* Some sentence..`" (double stop) when PR title is "`Some sentence.`".

### Motivation
<!-- What inspired you to submit this pull request? -->
Prompted by https://github.com/DataDog/integrations-core/pull/8441#discussion_r563543391
Prevent unnecessary work when reviewing changelogs, esp during Agent releases.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
