### PR TITLE
Avoid redundant queries

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -410,11 +410,11 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
     QUERY_BASE = "select * from {table}".format(table=TABLE)
 
     DB_TYPE_MAP = {0: 'data', 1: 'transaction_log', 2: 'filestream', 3: 'unknown', 4: 'full_text'}
-    _DATABASES = []
+    _DATABASES = set()
 
     def __init__(self, cfg_instance, base_name, report_function, column, logger):
         super(SqlDatabaseFileStats, self).__init__(cfg_instance, base_name, report_function, column, logger)
-        self._DATABASES.append(self.instance)
+        self._DATABASES.add(self.instance)
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger):


### PR DESCRIPTION
### What does this PR do?
Observed via log files that the fix from #8329 would add the same database for each metric in the table, resulting in duplicate queries.  Changing class collection to a set will avoid duplicates.
