### PR TITLE
Provide error message on subprocess output

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/_util.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/_util.py
@@ -30,7 +30,7 @@ def subprocess_output(command, raise_on_empty_output, env=None):
     if not output and raise_on_empty_output:
         msg = "expected subprocess output but had none."
         if err:
-            msg += " Error: %s".format(err)
+            msg += " Error: {}".format(str(err))
         raise SubprocessOutputEmptyError(msg)
 
     return output, err, proc.returncode

--- a/datadog_checks_base/datadog_checks/base/stubs/_util.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/_util.py
@@ -28,6 +28,9 @@ def subprocess_output(command, raise_on_empty_output, env=None):
         output = stdout_f.read()
 
     if not output and raise_on_empty_output:
-        raise SubprocessOutputEmptyError("get_subprocess_output expected output but had none.")
+        msg = "expected subprocess output but had none."
+        if err:
+            msg += " Error: %s".format(err)
+        raise SubprocessOutputEmptyError(msg)
 
     return output, err, proc.returncode


### PR DESCRIPTION
Provide error message, if any, when there is no subprocess output to better diagnose the issue