### PR TITLE
Fail more gracefully

### DIFF
--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -72,7 +72,7 @@ class Ceph(AgentCheck):
 
         mon_map = raw.get('status', {}).get('monmap')
         if mon_map is None:
-            raise RuntimeError("Could not detect if ceph is an octopus release or not")
+            raise RuntimeError("Could not detect Ceph release series")
         if 'min_mon_release_name' in mon_map and mon_map['min_mon_release_name'] == 'octopus':
             self.log.debug("Detected octopus version of ceph...")
             self._octopus = True

--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -70,7 +70,9 @@ class Ceph(AgentCheck):
             name = cmd.replace(' ', '_')
             raw[name] = res
 
-        mon_map = raw['status']['monmap']
+        mon_map = raw.get('status', {}).get('monmap')
+        if mon_map is None:
+            raise RuntimeError("Could not detect if ceph is an octopus release or not")
         if 'min_mon_release_name' in mon_map and mon_map['min_mon_release_name'] == 'octopus':
             self.log.debug("Detected octopus version of ceph...")
             self._octopus = True


### PR DESCRIPTION
Ceph is flaking on CI with following errors:

```
=================================== FAILURES ===================================
__________________________________ test_check __________________________________
tests/test_integration.py:18: in test_check
    ceph_check.check(copy.deepcopy(BASIC_CONFIG))
datadog_checks/ceph/ceph.py:319: in check
    raw = self._collect_raw(ceph_cmd, ceph_cluster, instance)
datadog_checks/ceph/ceph.py:73: in _collect_raw
    mon_map = raw['status']['monmap']
E   KeyError: 'status'
---------------------------- Captured stderr setup -----------------------------
Building with native build. Learn about native build in Compose here: https://docs.docker.com/go/compose-native-build/
Creating network "compose_default" with the default driver
Creating dd-test-ceph ... 
Creating dd-test-ceph ... done
Error response from daemon: Container 1a0fce237e6376b91628fcf97c0a251f89842a752199eb1c64a75cef6c8b3fa8 is not running
------------------------------ Captured log call -------------------------------
WARNING  datadog_checks.base.checks.base.ceph:ceph.py:67 Unable to parse data from cmd=mon_status: get_subprocess_output expected output but had none.
WARNING  datadog_checks.base.checks.base.ceph:ceph.py:67 Unable to parse data from cmd=status: get_subprocess_output expected output but had none.
WARNING  datadog_checks.base.checks.base.ceph:ceph.py:67 Unable to parse data from cmd=df detail: get_subprocess_output expected output but had none.
WARNING  datadog_checks.base.checks.base.ceph:ceph.py:67 Unable to parse data from cmd=osd pool stats: get_subprocess_output expected output but had none.
WARNING  datadog_checks.base.checks.base.ceph:ceph.py:67 Unable to parse data from cmd=osd perf: get_subprocess_output expected output but had none.
WARNING  datadog_checks.base.checks.base.ceph:ceph.py:67 Unable to parse data from cmd=health detail: get_subprocess_output expected output but had none.
```
Created https://github.com/DataDog/integrations-core/pull/8455/files to see if we can better diagnose why there is no output in the subprocess while this PR attempts to make it fail more gracefully