### PR TITLE
Ensure network check doesn't fail on importing fcntl on Windows

### DIFF
--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -27,7 +27,7 @@ jobs:
 - template: './templates/test-single-windows.yml'
   parameters:
     job_name: Changed
-    check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet azure_iot_edge disk dns_check dotnetclr exchange_server iis pdh_check sqlserver tcp_check win32_event_log windows_service wmi_check'
+    check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet azure_iot_edge disk dns_check dotnetclr exchange_server iis network pdh_check sqlserver tcp_check win32_event_log windows_service wmi_check'
     display: Windows
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'

--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -290,9 +290,12 @@ jobs:
     - checkName: nagios
       displayName: Nagios
       os: linux
-    - checkName: network
+    - checkName: network (Linux)
       displayName: Network
       os: linux
+    - checkName: network (Windows)
+      displayName: Network
+      os: windows
     - checkName: nfsstat
       displayName: NFSstat
       os: linux

--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -290,11 +290,11 @@ jobs:
     - checkName: nagios
       displayName: Nagios
       os: linux
-    - checkName: network (Linux)
-      displayName: Network
+    - checkName: network
+      displayName: Network (Linux)
       os: linux
-    - checkName: network (Windows)
-      displayName: Network
+    - checkName: network
+      displayName: Network (Windows)
       os: windows
     - checkName: nfsstat
       displayName: NFSstat

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -98,6 +98,7 @@ class Network(AgentCheck):
         # along with a few other things
         self._setup_metrics(instance)
 
+
         self._exclude_iface_re = None
         exclude_re = instance.get('excluded_interface_re', None)
         if exclude_re:

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -92,7 +92,7 @@ class Network(AgentCheck):
         self._collect_count_metrics = instance.get('collect_count_metrics', False)
         self._collect_ena_metrics = instance.get('collect_aws_ena_metrics', False)
         if fcntl is None and self._collect_ena_metrics:
-            raise ConfigurationError("fcntl not importable, deactivating collection of AWS ENA metrics")
+            raise ConfigurationError("fcntl not importable, collect_aws_ena_metrics should be disabled")
 
         # This decides whether we should split or combine connection states,
         # along with a few other things

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -98,7 +98,6 @@ class Network(AgentCheck):
         # along with a few other things
         self._setup_metrics(instance)
 
-
         self._exclude_iface_re = None
         exclude_re = instance.get('excluded_interface_re', None)
         if exclude_re:

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -8,7 +8,6 @@ Collects network metrics.
 
 import array
 import distutils.spawn
-import fcntl
 import os
 import re
 import socket
@@ -27,6 +26,11 @@ try:
     import datadog_agent
 except ImportError:
     from datadog_checks.base.stubs import datadog_agent
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 
 if PY3:
     long = int
@@ -87,6 +91,8 @@ class Network(AgentCheck):
         self._collect_rate_metrics = instance.get('collect_rate_metrics', True)
         self._collect_count_metrics = instance.get('collect_count_metrics', False)
         self._collect_ena_metrics = instance.get('collect_aws_ena_metrics', False)
+        if fcntl is None and self._collect_ena_metrics:
+            raise ConfigurationError("fcntl not importable, deactivating collection of AWS ENA metrics")
 
         # This decides whether we should split or combine connection states,
         # along with a few other things

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -386,6 +386,7 @@ def send_ethtool_ioctl_mock(iface, sckt, data):
     raise ValueError("Couldn't match any iface/data combination in the test data")
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('datadog_checks.network.network.Network._send_ethtool_ioctl')
 def test_collect_ena(send_ethtool_ioctl, check):
     send_ethtool_ioctl.side_effect = send_ethtool_ioctl_mock
@@ -398,6 +399,7 @@ def test_collect_ena(send_ethtool_ioctl, check):
     }
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('datadog_checks.network.network.Network._send_ethtool_ioctl')
 def test_submit_ena(send_ethtool_ioctl, check, aggregator):
     send_ethtool_ioctl.side_effect = send_ethtool_ioctl_mock
@@ -418,12 +420,14 @@ def test_submit_ena(send_ethtool_ioctl, check, aggregator):
         aggregator.assert_metric(m, count=1, value=0, tags=['device:eth0'])
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('datadog_checks.network.network.Network._send_ethtool_ioctl')
 def test_collect_ena_values_not_present(send_ethtool_ioctl, check):
     send_ethtool_ioctl.side_effect = send_ethtool_ioctl_mock
     assert check._collect_ena('enp0s3') == {}
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('fcntl.ioctl')
 def test_collect_ena_unsupported_on_iface(ioctl_mock, check, caplog):
     caplog.set_level(logging.DEBUG)


### PR DESCRIPTION
### What does this PR do?
`fcntl` is not importable on Windows, so we have to create a try/except clause for its import so that the check itself is importable on Windows.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
