### PR TITLE
Fix validation of Agent deps when using single check

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
@@ -177,9 +177,10 @@ def dep(check, require_base_check_version, min_base_check_version):
             failed = True
 
     # If validating a single check, whether all Agent dependencies are included in check dependencies is irrelevant.
-    agent_dependencies_to_compare = (agent_dependencies if check is None else {})
+    if check is not None:
+        agent_dependencies = {}
 
-    for name, versions in sorted(agent_dependencies_to_compare.items()):
+    for name, versions in sorted(agent_dependencies.items()):
         if not verify_dependency('Agent', name, versions):
             failed = True
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
@@ -176,12 +176,8 @@ def dep(check, require_base_check_version, min_base_check_version):
         ):
             failed = True
 
-    agent_dependencies_to_compare = (
-        agent_dependencies
-        if check is None
-        # If validating a single check, whether all Agent dependencies are included in check dependencies is irrelevant.
-        else {}
-    )
+    # If validating a single check, whether all Agent dependencies are included in check dependencies is irrelevant.
+    agent_dependencies_to_compare = (agent_dependencies if check is None else {})
 
     for name, versions in sorted(agent_dependencies_to_compare.items()):
         if not verify_dependency('Agent', name, versions):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
@@ -176,7 +176,14 @@ def dep(check, require_base_check_version, min_base_check_version):
         ):
             failed = True
 
-    for name, versions in sorted(agent_dependencies.items()):
+    agent_dependencies_to_compare = (
+        agent_dependencies
+        if check is None
+        # If validating a single check, whether all Agent dependencies are included in check dependencies is irrelevant.
+        else {}
+    )
+
+    for name, versions in sorted(agent_dependencies_to_compare.items()):
         if not verify_dependency('Agent', name, versions):
             failed = True
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix behavior of `ddev validate dep <check>`

### Motivation
<!-- What inspired you to submit this pull request? -->
Found during QA for #8297 

Currently `$ ddev validate dep nginx` fails with a large list of errors:

```console
$ ddev validate dep nginx
Stale dependency needs to be removed by syncing: adodbapi
Stale dependency needs to be removed by syncing: aerospike
Stale dependency needs to be removed by syncing: aws-requests-auth
[...]
Stale dependency needs to be removed by syncing: uptime
Stale dependency needs to be removed by syncing: vertica-python
Stale dependency needs to be removed by syncing: win-inet-pton
```

This is because when passing a `<check>`, we currently still validate `check_dependencies` (which only contains the deps for `<check>`, rather than the set of all deps for all checks) against `agent_dependencies` (which contains all dependencies shipped in the Agent).

Instead, I think we should just skip this verification when passing a `<check>`. If the dependencies for `<check>` does contain an out-of-sync dependency compared to Agent deps, then we'll notice during the "all checks" run of this job anyway.

With this PR, the validation passes.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
