### PR TITLE
Add cancel method to the AgentCheck base class, allowing cleanup of resources when checks are unscheduled.

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -853,6 +853,16 @@ class AgentCheck(object):
         # type: (InstanceType) -> None
         raise NotImplementedError
 
+    def cancel(self):
+        # type: () -> None
+        """
+        This method is called when the check in unscheduled by the agent. This
+        is SIGNAL that the check is being unscheduled and can be called while
+        the check is running. It's up to the python implementation to make sure
+        cancel is thread safe and won't block.
+        """
+        pass
+
     def run(self):
         # type: () -> str
         try:


### PR DESCRIPTION
### What does this PR do?

This is called by the agent when a check is unscheduled

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This is linked to https://github.com/DataDog/datadog-agent/pull/7279

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
