### PR TITLE
Fix handling of multiple nested types for the example config spec consumer

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/example.py
@@ -44,13 +44,17 @@ def value_type_string(value):
         if value_type == 'object':
             return 'mapping'
         elif value_type == 'array':
-            item_type = value['items']['type']
-            if item_type == 'object':
-                return 'list of mappings'
-            elif item_type == 'array':
-                return 'list of lists'
+            items = value['items']
+            if 'oneOf' in items:
+                return f'(list of {value_type_string(items)})'
             else:
-                return f'list of {item_type}s'
+                item_type = items['type']
+                if item_type == 'object':
+                    return 'list of mappings'
+                elif item_type == 'array':
+                    return 'list of lists'
+                else:
+                    return f'list of {item_type}s'
         else:
             return value_type
 

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -1467,3 +1467,47 @@ def test_option_multiple_types():
             # foo: <FOO>
         """
     )
+
+
+def test_option_multiple_types_nested():
+    consumer = get_example_consumer(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - template: instances
+            options:
+            - name: foo
+              description: words
+              value:
+                oneOf:
+                - type: string
+                - type: array
+                  items:
+                    oneOf:
+                    - type: string
+                    - type: object
+                      required:
+                      - foo
+        """
+    )
+
+    files = consumer.render()
+    contents, errors = files['test.yaml.example']
+    assert not errors
+    assert contents == normalize_yaml(
+        """
+        ## Every instance is scheduled independent of the others.
+        #
+        instances:
+
+          -
+            ## @param foo - string or (list of string or mapping) - optional
+            ## words
+            #
+            # foo: <FOO>
+        """
+    )


### PR DESCRIPTION
### Motivation

```
Traceback (most recent call last):
  File "C:\Users\ofek\AppData\Local\Programs\Python\Python38\Scripts\ddev-script.py", line 30, in <module>
    sys.exit(load_entry_point('datadog-checks-dev', 'console_scripts', 'ddev')())
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 782, in main
    rv = self.invoke(ctx)
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "c:\users\ofek\desktop\code\integrations-core\datadog_checks_dev\datadog_checks\dev\tooling\commands\validate\config.py", line 100, in config
    for example_file, (contents, errors) in example_consumer.render().items():
  File "c:\users\ofek\desktop\code\integrations-core\datadog_checks_dev\datadog_checks\dev\tooling\specs\configuration\consumers\example.py", line 231, in render
    write_option(option, writer)
  File "c:\users\ofek\desktop\code\integrations-core\datadog_checks_dev\datadog_checks\dev\tooling\specs\configuration\consumers\example.py", line 196, in write_option
    write_option(opt, writer, next_indent)
  File "c:\users\ofek\desktop\code\integrations-core\datadog_checks_dev\datadog_checks\dev\tooling\specs\configuration\consumers\example.py", line 110, in write_option
    value_type_string(value),
  File "c:\users\ofek\desktop\code\integrations-core\datadog_checks_dev\datadog_checks\dev\tooling\specs\configuration\consumers\example.py", line 47, in value_type_string
    item_type = value['items']['type']
KeyError: 'type'
```