### PR TITLE
Remove EOLed elastic version

### DIFF
--- a/elastic/tox.ini
+++ b/elastic/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 basepython = py38
 skip_missing_interpreters = true
 envlist =
-    py{27,38}-{7.0rc1,7.2,7.7}
+    py{27,38}-{7.2,7.7}
     bench
 
 [testenv]


### PR DESCRIPTION
Elastic 7.0 ended life in October 2020 https://www.elastic.co/support/eol