### PR TITLE
Fix error handling when Agent has no sudo access

### DIFF
--- a/glusterfs/datadog_checks/glusterfs/check.py
+++ b/glusterfs/datadog_checks/glusterfs/check.py
@@ -53,9 +53,11 @@ class GlusterfsCheck(AgentCheck):
 
     def check(self, _):
         if self.use_sudo:
-            test_sudo, err, rcode = get_subprocess_output(['sudo', '-ln', self.gstatus_cmd], self.log)
-            if rcode != 0:
-                raise Exception('The dd-agent user does not have sudo access: %s', err or test_sudo)
+            test_sudo, err, rcode = get_subprocess_output(
+                ['sudo', '-ln', self.gstatus_cmd], self.log, raise_on_empty_output=False
+            )
+            if rcode != 0 or not test_sudo:
+                raise Exception('The dd-agent user does not have sudo access: {!r}'.format(err or test_sudo))
             gluster_args = 'sudo {}'.format(self.gstatus_cmd)
         else:
             gluster_args = self.gstatus_cmd


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Properly handle sudo access error.

### Motivation
<!-- What inspired you to submit this pull request? -->
Found while testing #8159 during QA

To test for sudo access we run:

```console
$ sudo -ln <cmd>
```

This should output the command path on stdout if sudo access is available, eg:

```console
$ sudo -s
# Enter password...
(root) $ sudo -ln test
/usr/local/opt/coreutils/libexec/gnubin/test
```

If sudo access is not available, we either get a non-0 error code and/or empty output. Eg on macOS we get both:

```console
$ sudo -ln test
sudo: a password is required
```

So right now we get an unhelpful "output empty" error:

```console
      Error: get_subprocess_output expected output but had none.
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 901, in run
          self.check(instance)
        File "/home/glusterfs/datadog_checks/glusterfs/check.py", line 56, in check
          test_sudo, err, rcode = get_subprocess_output(['sudo', '-ln', self.gstatus_cmd], self.log)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/utils/subprocess_output.py", line 56, in get_subprocess_output
          out, err, returncode = subprocess_output(cmd_args, raise_on_empty_output, env=env)
      _util.SubprocessOutputEmptyError: get_subprocess_output expected output but had none.
```

This PR moves things around so we check for either status code _or_ empty output, and raise the proper error message we meant to raise in the first place:

```console
      Error: The dd-agent user does not have sudo access: ''
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 901, in run
          self.check(instance)
        File "/home/glusterfs/datadog_checks/glusterfs/check.py", line 60, in check
          raise Exception('The dd-agent user does not have sudo access: {!r}'.format(err or test_sudo))
      Exception: The dd-agent user does not have sudo access: ''
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
