### PR TITLE
Add note hinting to rebuild Kerberos images

### DIFF
--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -504,6 +504,9 @@ class TestAuth:
            via `docker exec -it compose_agent_1 /bin/bash`
         5. Execute check via `agent check nginx` and verify successful result.
         6. Exit test via Ctrl-C (test will show as failed, but that's okay)
+
+        NOTE: if encountering issues (GSS auth error, nginx 403 error, ...), delete the images for the Agent, KDC
+        and nginx containers, and try again to start off from fresh images.
         """
         import time
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Cleanup for #8234 

Add note that in case of errors while using the Kerberos setup, developer might have to rebuild fresh images.

### Motivation
<!-- What inspired you to submit this pull request? -->
Found while testing #8234 

Spent a fair amount of time figuring out why the Kerberos wouldn't work on my machine. @mgarabed and I eventually figured out I had older versions of the custom-built images, and `ddev test` doesn't rebuild those automatically.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
