### PR TITLE
Fix GlusterFS dashboard logo path

### DIFF
--- a/glusterfs/assets/dashboards/red_hat_gluster_storage.json
+++ b/glusterfs/assets/dashboards/red_hat_gluster_storage.json
@@ -20,7 +20,7 @@
             "definition": {
                 "sizing": "zoom",
                 "type": "image",
-                "url": "/static/images/saas_logos/bot/red_hat_gluster_storage@2x.png"
+                "url": "/static/images/saas_logos/bot/glusterfs@2x.png"
             },
             "id": 4299518788960180,
             "layout": {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix path to logo image in GlusterFS dashboard

### Motivation
<!-- What inspired you to submit this pull request? -->
Current path does not exist and results in a "blank" image widget (error in browser console):

```console
GET https://static.datadoghq.com/static/images/saas_logos/bot/red_hat_gluster_storage@2x.png 403
```

Fixed path to point to correct path in `web-ui`: https://github.com/DataDog/web-ui/blob/prod/public/static/images/saas_logos/bot/glusterfs@2x.png

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
