### PR TITLE
Fix condition for replication status

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -332,7 +332,7 @@ class MySql(AgentCheck):
             if not slave_io_running and not slave_sql_running:
                 self.log.debug("Slave_IO_Running and Slave_SQL_Running are not ok")
                 slave_running_status = AgentCheck.CRITICAL
-            if not slave_io_running or not slave_sql_running:
+            elif not slave_io_running or not slave_sql_running:
                 self.log.debug("Either Slave_IO_Running or Slave_SQL_Running are not ok")
                 slave_running_status = AgentCheck.WARNING
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Having `slave_io_running=False` and `slave_sql_running=False` set the service check as WARNING, but it should be CRITICAL.

### Motivation
<!-- What inspired you to submit this pull request? -->
QA

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
