### PR TITLE
Fix cursor execution returning None

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -422,7 +422,8 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
         rows = []
         columns = []
 
-        data = cursor.execute('select DB_NAME()').fetchall()
+        cursor.execute('select DB_NAME()')
+        data = cursor.fetchall()
         current_db = data[0][0]
         logger.debug("%s: current db is %s", cls.__name__, current_db)
 


### PR DESCRIPTION
### What does this PR do?
In some implementations, the `cursor.execute()` call will return None, and cannot be chained with a `fetchall()` method.
This breaks it into the more common approach of separate method calls.

### Additional Notes
Noted specifically on Windows using the default connection library.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
