### PR TITLE
Fix Prometheus summary quantile metrics

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transformers/summary.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transformers/summary.py
@@ -35,7 +35,7 @@ def get_summary(check, metric_name, modifiers, global_options):
                     hostname=hostname,
                     flush_first_value=has_successfully_executed,
                 )
-            elif sample_name == metric_name:
+            elif sample_name == metric.name:
                 gauge_method(quantile_metric, sample.value, tags=tags, hostname=hostname)
 
     del check

--- a/datadog_checks_base/tests/openmetrics/test_transformers/test_summary.py
+++ b/datadog_checks_base/tests/openmetrics/test_transformers/test_summary.py
@@ -110,3 +110,40 @@ def test_no_quantiles(aggregator, dd_run_check, mock_http_response):
     )
 
     aggregator.assert_all_metrics_covered()
+
+def test_quantiles_remapped_metric_name(aggregator, dd_run_check, mock_http_response):
+    payload = """
+        # HELP prometheus_target_interval_length_seconds Actual intervals between scrapes.
+        # TYPE prometheus_target_interval_length_seconds summary
+        prometheus_target_interval_length_seconds{interval="1s",quantile="0.01"} 0.9950473
+        prometheus_target_interval_length_seconds{interval="1s",quantile="0.05"} 0.9970795
+        prometheus_target_interval_length_seconds{interval="1s",quantile="0.5"} 0.9999885
+        prometheus_target_interval_length_seconds{interval="1s",quantile="0.9"} 1.0020113
+        prometheus_target_interval_length_seconds{interval="1s",quantile="0.99"} 1.0046735
+        prometheus_target_interval_length_seconds_sum{interval="1s"} 26649.83516454906
+        prometheus_target_interval_length_seconds_count{interval="1s"} 26032
+        """
+    mock_http_response(payload)
+    check = get_check({'metrics': [{'prometheus_target_interval_length_seconds': 'target_interval_seconds'}]})
+    dd_run_check(check)
+
+    aggregator.assert_metric(
+        'test.target_interval_seconds.sum',
+        26649.83516454906,
+        metric_type=aggregator.MONOTONIC_COUNT,
+        tags=['endpoint:test', 'handler:prometheus'],
+    )
+    aggregator.assert_metric(
+        'test.target_interval_seconds.count',
+        26032,
+        metric_type=aggregator.MONOTONIC_COUNT,
+        tags=['endpoint:test', 'handler:prometheus'],
+    )
+
+    aggregator.assert_metric(
+        'test.target_interval_seconds.quantile',
+        metric_type=aggregator.GAUGE,
+        count=5,
+    )
+
+    aggregator.assert_all_metrics_covered()

--- a/datadog_checks_base/tests/openmetrics/test_transformers/test_summary.py
+++ b/datadog_checks_base/tests/openmetrics/test_transformers/test_summary.py
@@ -131,13 +131,13 @@ def test_quantiles_remapped_metric_name(aggregator, dd_run_check, mock_http_resp
         'test.target_interval_seconds.sum',
         26649.83516454906,
         metric_type=aggregator.MONOTONIC_COUNT,
-        tags=['endpoint:test', 'handler:prometheus'],
+        tags=['endpoint:test', 'interval:1s'],
     )
     aggregator.assert_metric(
         'test.target_interval_seconds.count',
         26032,
         metric_type=aggregator.MONOTONIC_COUNT,
-        tags=['endpoint:test', 'handler:prometheus'],
+        tags=['endpoint:test', 'interval:1s'],
     )
 
     aggregator.assert_metric(

--- a/datadog_checks_base/tests/openmetrics/test_transformers/test_summary.py
+++ b/datadog_checks_base/tests/openmetrics/test_transformers/test_summary.py
@@ -111,6 +111,7 @@ def test_no_quantiles(aggregator, dd_run_check, mock_http_response):
 
     aggregator.assert_all_metrics_covered()
 
+
 def test_quantiles_remapped_metric_name(aggregator, dd_run_check, mock_http_response):
     payload = """
         # HELP prometheus_target_interval_length_seconds Actual intervals between scrapes.


### PR DESCRIPTION
### What does this PR do?
Found bug during QA. Remapped summary metrics are not submitting quantile metrics.

In V2, the following config only yields 15 metrics because `openmetrics.target_interval_seconds.quantile` were not being submitted.

```
init_config: {}
instances:
- metrics:
  - prometheus_target_interval_length_seconds: target_interval_seconds
  - prometheus_http_request_duration_seconds: http_req_duration_seconds
  - go_memstats_mallocs_total
  - go_memstats_alloc_bytes
  namespace: openmetrics
  openmetrics_endpoint: http://localhost:9090/metrics
```
