### PR TITLE
Reflect new metric types in haproxy metadata

### DIFF
--- a/haproxy/metadata.csv
+++ b/haproxy/metadata.csv
@@ -1,8 +1,8 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 haproxy.backend.active.servers,gauge,,,,Current number of active servers.,0,haproxy,
 haproxy.backend.backup.servers,gauge,,,,Current number of backup servers.,0,haproxy,
-haproxy.backend.bytes.in.total,gauge,,byte,,Current total of incoming bytes. By default submitted as count if using prometheus,0,haproxy,
-haproxy.backend.bytes.out.total,gauge,,byte,,Current total of outgoing bytes. By default submitted as count if using prometheus,0,haproxy,
+haproxy.backend.bytes.in.total,count,,byte,,Current total of incoming bytes. By default submitted as count if using prometheus,0,haproxy,
+haproxy.backend.bytes.out.total,count,,byte,,Current total of outgoing bytes. By default submitted as count if using prometheus,0,haproxy,
 haproxy.backend.check.last.change.seconds,gauge,,,,Number of seconds since the last UP<->DOWN transition.,0,haproxy,
 haproxy.backend.check.up.down.total,count,,,,Total number of UP->DOWN transitions.,0,haproxy,
 haproxy.backend.client.aborts.total,count,,,,Total number of data transfers aborted by the client.,0,haproxy,
@@ -73,8 +73,8 @@ haproxy.backend.uptime,gauge,,second,,Number of seconds since the last UP<->DOWN
 haproxy.backend.warnings.redis_rate,gauge,,error,second,Number of times a request was redispatched to another server (legacy check only).,-1,haproxy,backend warn redis rate
 haproxy.backend.warnings.retr_rate,gauge,,error,second,Number of times a connection to a server was retried (legacy check only).,-1,haproxy,backend warn retry rate
 haproxy.count_per_status,gauge,,host,,Number of hosts by status (UP/DOWN/NOLB/MAINT) (legacy check only).,0,haproxy,hosts status
-haproxy.frontend.bytes.in.total,gauge,,byte,,Current total of incoming bytes. By default submitted as count if using prometheus,0,haproxy,
-haproxy.frontend.bytes.out.total,gauge,,byte,,Current total of outgoing bytes. By default submitted as count if using prometheus,0,haproxy,
+haproxy.frontend.bytes.in.total,count,,byte,,Current total of incoming bytes. By default submitted as count if using prometheus,0,haproxy,
+haproxy.frontend.bytes.out.total,count,,byte,,Current total of outgoing bytes. By default submitted as count if using prometheus,0,haproxy,
 haproxy.frontend.connections.rate.max,gauge,,,,Maximum observed number of connections per second.,0,haproxy,
 haproxy.frontend.connections.total,count,,,,Total number of connections.,0,haproxy,
 haproxy.frontend.current.sessions,gauge,,,,Current number of active sessions.,0,haproxy,

--- a/haproxy/tests/legacy/test_haproxy.py
+++ b/haproxy/tests/legacy/test_haproxy.py
@@ -7,7 +7,7 @@ import copy
 import pytest
 from packaging import version
 
-# from datadog_checks.dev.utils import get_metadata_metrics
+from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.haproxy import HAProxyCheck
 
 from ..common import HAPROXY_VERSION
@@ -132,8 +132,16 @@ def test_check(aggregator, check, instance):
 
     aggregator.assert_all_metrics_covered()
     # The assertion below fails due to difference between new and legacy metric types in metadata.
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True,
-      exclude=['haproxy.frontend.bytes.in.total', 'haproxy.frontend.bytes.out.total', 'haproxy.backend.bytes.in.total', 'haproxy.backend.bytes.out.total'])
+    aggregator.assert_metrics_using_metadata(
+        get_metadata_metrics(),
+        check_submission_type=True,
+        exclude=[
+            'haproxy.frontend.bytes.in.total',
+            'haproxy.frontend.bytes.out.total',
+            'haproxy.backend.bytes.in.total',
+            'haproxy.backend.bytes.out.total',
+        ],
+    )
 
 
 @requires_socket_support

--- a/haproxy/tests/legacy/test_haproxy.py
+++ b/haproxy/tests/legacy/test_haproxy.py
@@ -132,7 +132,8 @@ def test_check(aggregator, check, instance):
 
     aggregator.assert_all_metrics_covered()
     # The assertion below fails due to difference between new and legacy metric types in metadata.
-    # aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True,
+      exclude=['haproxy.frontend.bytes.in.total', 'haproxy.frontend.bytes.out.total', 'haproxy.backend.bytes.in.total', 'haproxy.backend.bytes.out.total'])
 
 
 @requires_socket_support

--- a/haproxy/tests/legacy/test_haproxy.py
+++ b/haproxy/tests/legacy/test_haproxy.py
@@ -7,7 +7,7 @@ import copy
 import pytest
 from packaging import version
 
-from datadog_checks.dev.utils import get_metadata_metrics
+# from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.haproxy import HAProxyCheck
 
 from ..common import HAPROXY_VERSION
@@ -131,7 +131,8 @@ def test_check(aggregator, check, instance):
     _test_service_checks(aggregator, count=0)
 
     aggregator.assert_all_metrics_covered()
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
+    # The assertion below fails due to difference between new and legacy metric types in metadata.
+    # aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 
 
 @requires_socket_support


### PR DESCRIPTION
### What does this PR do?
Edits haproxy metric metadata to correctly reflect metric types 
### Motivation
https://datadoghq.atlassian.net/browse/AI-1311

### Additional Notes
- Edited tests/legacy/test_haproxy.py as metadata will reflect new metrics types over legacy ones, thus causing legacy test to fail 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
