### PR TITLE
Do not run replication metrics on newer aurora versions either

### DIFF
--- a/postgres/datadog_checks/postgres/metrics_cache.py
+++ b/postgres/datadog_checks/postgres/metrics_cache.py
@@ -152,22 +152,21 @@ class PostgresMetricsCache:
         """Use either REPLICATION_METRICS_10, REPLICATION_METRICS_9_1, or
         REPLICATION_METRICS_9_1 + REPLICATION_METRICS_9_2, depending on the
         postgres version.
-        Uses a dictionary to save the result for each instance
+        Caches the result on a dictionary
         """
-        metrics = self.replication_metrics
-        if version >= V10 and metrics is None:
+        if self.replication_metrics is not None:
+            return self.replication_metrics
+
+        if is_aurora:
+            logger.debug("Detected Aurora {}. Won't collect replication metrics", version)
+            self.replication_metrics = {}
+        elif version >= V10:
             self.replication_metrics = dict(REPLICATION_METRICS_10)
-            metrics = self.replication_metrics
-        elif version >= V9_1 and metrics is None:
-            if is_aurora:
-                logger.debug("Detected Aurora {}. Won't collect replication metrics", version)
-                self.replication_metrics = {}
-            else:
-                self.replication_metrics = dict(REPLICATION_METRICS_9_1)
-                if version >= V9_2:
-                    self.replication_metrics.update(REPLICATION_METRICS_9_2)
-            metrics = self.replication_metrics
-        return metrics
+        elif version >= V9_1:
+            self.replication_metrics = dict(REPLICATION_METRICS_9_1)
+            if version >= V9_2:
+                self.replication_metrics.update(REPLICATION_METRICS_9_2)
+        return self.replication_metrics
 
     def get_replication_stats_metrics(self, version):
         if version >= V10 and self.replication_stats_metrics is None:

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -126,10 +126,10 @@ class PostgreSql(AgentCheck):
             if is_relations:
                 schema_field = get_schema_field(descriptors)
                 relations_filter = build_relations_filter(relations_config, schema_field)
-                self.log.debug("Running query: %s with relations matching: %s", query, relations_filter)
+                self.log.debug("Running query: %s with relations matching: %s", str(query), relations_filter)
                 cursor.execute(query.format(relations=relations_filter))
             else:
-                self.log.debug("Running query: %s", query)
+                self.log.debug("Running query: %s", str(query))
                 cursor.execute(query.replace(r'%', r'%%'))
 
             results = cursor.fetchall()
@@ -431,7 +431,7 @@ class PostgreSql(AgentCheck):
             self._connect()
             if self.config.tag_replication_role:
                 tags.extend(["replication_role:{}".format(self._get_replication_role())])
-            self.log.debug("Running check against version %s", str(self.version))
+            self.log.debug("Running check against version %s: is_aurora: %s", str(self.version), str(self._is_aurora))
             self._collect_stats(tags)
             self._collect_custom_queries(tags)
             if self.config.deep_database_monitoring:

--- a/postgres/tests/test_metrics_cache.py
+++ b/postgres/tests/test_metrics_cache.py
@@ -14,7 +14,7 @@ from datadog_checks.postgres.version_utils import V9_1, V9_2, V10
     'version, is_aurora, expected_metrics',
     [
         pytest.param(V10, False, REPLICATION_METRICS_10),
-        pytest.param(V10, True, REPLICATION_METRICS_10),
+        pytest.param(V10, True, {}),
         pytest.param(V9_1, False, REPLICATION_METRICS_9_1),
         pytest.param(V9_2, True, {}),
     ],


### PR DESCRIPTION
Previously we were only skipping replication metrics in Aurora < 10, they should be skipped in all versions