### PR TITLE
Fix dev docs home tabs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,10 +29,11 @@ theme:
   logo: assets/images/logo.svg
 
 nav:
-  - Home: index.md
-  - Setup: setup.md
-  - Testing: testing.md
-  - E2E: e2e.md
+  - Home:
+    - About: index.md
+    - Setup: setup.md
+    - Testing: testing.md
+    - E2E: e2e.md
   - Base Package:
     - About: base/about.md
     - Basics: base/basics.md


### PR DESCRIPTION
### Motivation

A recent dependency release made it so that consecutive pages are no longer implicitly grouped