### PR TITLE
Remove outdated description of `local_cert_path` option

### DIFF
--- a/tls/assets/configuration/spec.yaml
+++ b/tls/assets/configuration/spec.yaml
@@ -40,8 +40,7 @@ files:
       description: |
         The path to a local certificate in lieu of a server/port. In this mode, the
         service checks `tls.can_connect` and `tls.version` are unavailable. The
-        certificate can be in PEM or DER format. If in DER format, the file
-        extension must be either `.cer`, `.crt`, or `.der`.
+        certificate can be in PEM or DER format.
       value:
         type: string
     - name: server_hostname

--- a/tls/datadog_checks/tls/data/conf.yaml.example
+++ b/tls/datadog_checks/tls/data/conf.yaml.example
@@ -41,8 +41,7 @@ instances:
     ## @param local_cert_path - string - optional
     ## The path to a local certificate in lieu of a server/port. In this mode, the
     ## service checks `tls.can_connect` and `tls.version` are unavailable. The
-    ## certificate can be in PEM or DER format. If in DER format, the file
-    ## extension must be either `.cer`, `.crt`, or `.der`.
+    ## certificate can be in PEM or DER format.
     #
     # local_cert_path: <LOCAL_CERT_PATH>
 


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/integrations-core/pull/5694