### PR TITLE
Add support for legacy config to OpenMetricsCompatibilityScraper

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -347,8 +347,6 @@ class OpenMetricsCompatibilityScraper(OpenMetricsScraper):
         return OpenMetricsCompatibilityScraper(self, self.get_config_with_defaults(config))
     """
 
-    SERVICE_CHECK_HEALTH = 'prometheus.health'
-
     def __init__(self, check, config):
         new_config = deepcopy(config)
         new_config.setdefault('enable_health_service_check', new_config.pop('health_service_check', True))

--- a/datadog_checks_base/tests/openmetrics/test_compat_scraper.py
+++ b/datadog_checks_base/tests/openmetrics/test_compat_scraper.py
@@ -1,0 +1,184 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from ..utils import requires_py3
+from .utils import get_legacy_check
+
+pytestmark = [requires_py3, pytest.mark.openmetrics, pytest.mark.openmetrics_compat_scraper]
+
+
+class TestRawMetricPrefix:
+    def test_not_string(self, dd_run_check):
+        check = get_legacy_check({'prometheus_metrics_prefix': 9000})
+
+        with pytest.raises(Exception, match='^Setting `raw_metric_prefix` must be a string$'):
+            dd_run_check(check, extract_message=True)
+
+
+class TestHostnameLabel:
+    def test_not_string(self, dd_run_check):
+        check = get_legacy_check({'label_to_hostname': 9000})
+
+        with pytest.raises(Exception, match='^Setting `hostname_label` must be a string$'):
+            dd_run_check(check, extract_message=True)
+
+
+class TestRenameLabels:
+    def test_not_mapping(self, dd_run_check):
+        check = get_legacy_check({'labels_mapper': 9000})
+
+        with pytest.raises(Exception, match='^Setting `rename_labels` must be a mapping$'):
+            dd_run_check(check, extract_message=True)
+
+    def test_value_not_string(self, dd_run_check):
+        check = get_legacy_check({'labels_mapper': {'foo': 9000}})
+
+        with pytest.raises(Exception, match='^Value for label `foo` of setting `rename_labels` must be a string$'):
+            dd_run_check(check, extract_message=True)
+
+
+class TestExcludeMetrics:
+    def test_entry_invalid_type(self, dd_run_check):
+        check = get_legacy_check({'exclude_metrics': [9000]})
+
+        with pytest.raises(Exception, match='^Entry #1 of setting `exclude_metrics` must be a string$'):
+            dd_run_check(check, extract_message=True)
+
+
+class TestExcludeMetricsByLabels:
+    def test_value_not_string(self, dd_run_check):
+        check = get_legacy_check({'ignore_metrics_by_labels': {'foo': [9000]}})
+
+        with pytest.raises(
+            Exception, match='^Value #1 for label `foo` of setting `exclude_metrics_by_labels` must be a string$'
+        ):
+            dd_run_check(check, extract_message=True)
+
+
+class TestShareLabels:
+    def test_not_mapping(self, dd_run_check):
+        check = get_legacy_check({'share_labels': 9000})
+
+        with pytest.raises(Exception, match='^Setting `share_labels` must be a mapping$'):
+            dd_run_check(check, extract_message=True)
+
+    def test_invalid_type(self, dd_run_check):
+        check = get_legacy_check({'share_labels': {'foo': 9000}})
+
+        with pytest.raises(
+            Exception, match='^Metric `foo` of setting `share_labels` must be a mapping or set to `true`$'
+        ):
+            dd_run_check(check, extract_message=True)
+
+    def test_values_not_array(self, dd_run_check):
+        check = get_legacy_check({'share_labels': {'foo': {'values': 9000}}})
+
+        with pytest.raises(
+            Exception, match='^Option `values` for metric `foo` of setting `share_labels` must be an array$'
+        ):
+            dd_run_check(check, extract_message=True)
+
+    def test_values_entry_not_integer(self, dd_run_check):
+        check = get_legacy_check({'share_labels': {'foo': {'values': [1.0]}}})
+
+        with pytest.raises(
+            Exception,
+            match=(
+                '^Entry #1 of option `values` for metric `foo` of setting `share_labels` must represent an integer$'
+            ),
+        ):
+            dd_run_check(check, extract_message=True)
+
+    @pytest.mark.parametrize('option', ['labels', 'match'])
+    def test_option_not_array(self, dd_run_check, option):
+        check = get_legacy_check({'share_labels': {'foo': {option: 9000}}})
+
+        with pytest.raises(
+            Exception, match='^Option `{}` for metric `foo` of setting `share_labels` must be an array$'.format(option)
+        ):
+            dd_run_check(check, extract_message=True)
+
+    @pytest.mark.parametrize('option', ['labels', 'match'])
+    def test_option_entry_not_string(self, dd_run_check, option):
+        check = get_legacy_check({'share_labels': {'foo': {option: [9000]}}})
+
+        with pytest.raises(
+            Exception,
+            match=(
+                '^Entry #1 of option `{}` for metric `foo` of setting `share_labels` must be a string$'.format(option)
+            ),
+        ):
+            dd_run_check(check, extract_message=True)
+
+    def test_share_labels(self, aggregator, dd_run_check, mock_http_response):
+        mock_http_response(
+            """
+            # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+            # TYPE go_memstats_alloc_bytes gauge
+            go_memstats_alloc_bytes{foo="bar",baz="foo",pod="test"} 1
+            # HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+            # TYPE go_memstats_gc_sys_bytes gauge
+            go_memstats_gc_sys_bytes{bar="foo",baz="foo"} 901120
+            # HELP go_memstats_free_bytes Number of bytes free and available for use.
+            # TYPE go_memstats_free_bytes gauge
+            go_memstats_free_bytes{bar="baz",baz="bar"} 6.396288e+06
+            """
+        )
+        check = get_legacy_check(
+            {
+                'metrics': ['*'],
+                'label_joins': {'go_memstats_alloc_bytes': {'labels_to_match': ['baz'], 'labels_to_get': ['pod']}},
+            }
+        )
+        dd_run_check(check)
+
+        aggregator.assert_metric(
+            'test.go_memstats_alloc_bytes',
+            1,
+            metric_type=aggregator.GAUGE,
+            tags=['endpoint:test', 'foo:bar', 'baz:foo', 'pod:test'],
+        )
+        aggregator.assert_metric(
+            'test.go_memstats_gc_sys_bytes',
+            901120,
+            metric_type=aggregator.GAUGE,
+            tags=['endpoint:test', 'bar:foo', 'baz:foo', 'pod:test'],
+        )
+        aggregator.assert_metric(
+            'test.go_memstats_free_bytes',
+            6396288,
+            metric_type=aggregator.GAUGE,
+            tags=['endpoint:test', 'bar:baz', 'baz:bar'],
+        )
+
+        aggregator.assert_all_metrics_covered()
+
+    def test_metadata(self, aggregator, datadog_agent, dd_run_check, mock_http_response):
+        mock_http_response(
+            """
+            # HELP kubernetes_build_info A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.
+            # TYPE kubernetes_build_info gauge
+            kubernetes_build_info{buildDate="2016-11-18T23:57:26Z",compiler="gc",gitCommit="3872cb93abf9482d770e651b5fe14667a6fca7e0",gitTreeState="dirty",gitVersion="v1.6.0-alpha.0.680+3872cb93abf948-dirty",goVersion="go1.7.3",major="1",minor="6+",platform="linux/amd64"} 1
+            """  # noqa: E501
+        )
+        check = get_legacy_check(
+            {'metadata_metric_name': 'kubernetes_build_info', 'metadata_label_map': {'version': 'gitVersion'}}
+        )
+        check.check_id = 'test:instance'
+        dd_run_check(check)
+
+        version_metadata = {
+            'version.major': '1',
+            'version.minor': '6',
+            'version.patch': '0',
+            'version.release': 'alpha.0.680',
+            'version.build': '3872cb93abf948-dirty',
+            'version.raw': 'v1.6.0-alpha.0.680+3872cb93abf948-dirty',
+            'version.scheme': 'semver',
+        }
+
+        datadog_agent.assert_metadata('test:instance', version_metadata)
+        datadog_agent.assert_metadata_count(len(version_metadata))
+        aggregator.assert_all_metrics_covered()

--- a/datadog_checks_base/tests/openmetrics/test_interface.py
+++ b/datadog_checks_base/tests/openmetrics/test_interface.py
@@ -7,7 +7,7 @@ from datadog_checks.base import OpenMetricsBaseCheckV2
 from datadog_checks.base.constants import ServiceCheck
 
 from ..utils import requires_py3
-from .utils import get_check
+from .utils import get_check, get_legacy_check
 
 pytestmark = [requires_py3, pytest.mark.openmetrics, pytest.mark.openmetrics_interface]
 
@@ -82,15 +82,6 @@ def test_service_check_dynamic_tags(aggregator, dd_run_check, mock_http_response
 
 
 def test_scraper_override(aggregator, dd_run_check, mock_http_response):
-    # TODO: when we drop Python 2 move this up top
-    from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
-
-    class Check(OpenMetricsBaseCheckV2):
-        __NAMESPACE__ = 'test'
-
-        def create_scraper(self, config):
-            return OpenMetricsCompatibilityScraper(self, self.get_config_with_defaults(config))
-
     mock_http_response(
         """
         # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
@@ -98,7 +89,7 @@ def test_scraper_override(aggregator, dd_run_check, mock_http_response):
         go_memstats_alloc_bytes{foo="baz"} 6.396288e+06
         """
     )
-    check = Check('test', {}, [{'openmetrics_endpoint': 'test', 'metrics': ['.+']}])
+    check = get_legacy_check()
     dd_run_check(check)
 
     aggregator.assert_service_check('test.prometheus.health', ServiceCheck.OK, tags=['endpoint:test'])

--- a/datadog_checks_base/tests/openmetrics/test_interface.py
+++ b/datadog_checks_base/tests/openmetrics/test_interface.py
@@ -7,7 +7,7 @@ from datadog_checks.base import OpenMetricsBaseCheckV2
 from datadog_checks.base.constants import ServiceCheck
 
 from ..utils import requires_py3
-from .utils import get_check, get_legacy_check
+from .utils import get_check
 
 pytestmark = [requires_py3, pytest.mark.openmetrics, pytest.mark.openmetrics_interface]
 
@@ -79,17 +79,3 @@ def test_service_check_dynamic_tags(aggregator, dd_run_check, mock_http_response
 
     aggregator.assert_all_metrics_covered()
     assert len(aggregator.service_check_names) == 2
-
-
-def test_scraper_override(aggregator, dd_run_check, mock_http_response):
-    mock_http_response(
-        """
-        # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
-        # TYPE go_memstats_alloc_bytes gauge
-        go_memstats_alloc_bytes{foo="baz"} 6.396288e+06
-        """
-    )
-    check = get_legacy_check()
-    dd_run_check(check)
-
-    aggregator.assert_service_check('test.prometheus.health', ServiceCheck.OK, tags=['endpoint:test'])

--- a/datadog_checks_base/tests/openmetrics/utils.py
+++ b/datadog_checks_base/tests/openmetrics/utils.py
@@ -3,15 +3,35 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from datadog_checks.base import OpenMetricsBaseCheckV2
 
+# TODO: remove `try` when we drop Python 2
+try:
+    from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
+
+    class LegacyCheck(OpenMetricsBaseCheckV2):
+        def create_scraper(self, config):
+            return OpenMetricsCompatibilityScraper(self, self.get_config_with_defaults(config))
+
+
+except Exception:
+    pass
+
 
 def get_check(instance=None, init_config=None):
+    return _get_check(OpenMetricsBaseCheckV2, instance, init_config)
+
+
+def get_legacy_check(instance=None, init_config=None):
+    return _get_check(LegacyCheck, instance, init_config)
+
+
+def _get_check(cls, instance, init_config):
     if instance is None:
         instance = {}
     if init_config is None:
         init_config = {}
 
     instance.setdefault('openmetrics_endpoint', 'test')
-    check = OpenMetricsBaseCheckV2('test', init_config, [instance])
+    check = cls('test', init_config, [instance])
     check.__NAMESPACE__ = 'test'
 
     return check

--- a/linkerd/tests/common.py
+++ b/linkerd/tests/common.py
@@ -553,7 +553,9 @@ EXPECTED_METRICS_V2_E2E = {
 EXPECTED_METRICS_V2_NEW = {}
 
 for metric_name, metric_type in list(EXPECTED_METRICS_V2.items()):
-    if metric_name.endswith('_total'):
+    if metric_name == 'linkerd.prometheus.health':
+        EXPECTED_METRICS_V2_NEW['linkerd.openmetrics.health'] = metric_type
+    elif metric_name.endswith('_total'):
         EXPECTED_METRICS_V2_NEW['{}.count'.format(metric_name[:-6])] = aggregator.MONOTONIC_COUNT
     elif metric_name.endswith('.sum'):
         EXPECTED_METRICS_V2_NEW[metric_name] = aggregator.MONOTONIC_COUNT

--- a/linkerd/tests/test_linkerd.py
+++ b/linkerd/tests/test_linkerd.py
@@ -80,7 +80,7 @@ def test_linkerd_v2_new(aggregator, dd_run_check, mock_http_response):
     aggregator.assert_all_metrics_covered()
 
     aggregator.assert_service_check(
-        'linkerd.prometheus.health', status=LinkerdCheck.OK, tags=['endpoint:http://fake.tld/prometheus'], count=1
+        'linkerd.openmetrics.health', status=LinkerdCheck.OK, tags=['endpoint:http://fake.tld/prometheus'], count=1
     )
 
 


### PR DESCRIPTION
### What does this PR do?

This makes it so that users of existing OpenMetrics checks can enable the new implementation (when supported) by only setting `openmetrics_endpoint`

### Motivation

Avoid displaying both configs; only `openmetrics_endpoint` will be documented until full deprecation