### PR TITLE
Convert monitor to query alert

### DIFF
--- a/scylla/assets/monitors/instance_down.json
+++ b/scylla/assets/monitors/instance_down.json
@@ -1,6 +1,6 @@
 {
 	"name": "[Scylla] Server is shutting down",
-	"type": "metric alert",
+	"type": "query alert",
 	"query": "avg(last_1m):max:scylla.node.operation_mode{*} by {server} > 3",
 	"message": "{{server.name}} is shutting down. Current value of {{value}} \n\nThe operation mode of the current nodes can have values of UNKNOWN = 0; STARTING = 1; JOINING = 2; NORMAL = 3; LEAVING = 4; DECOMMISSIONED = 5; DRAINING = 6; DRAINED = 7; MOVING = 8",
 	"tags": [

--- a/sonarqube/assets/recommended_monitors/vulnerabilities.json
+++ b/sonarqube/assets/recommended_monitors/vulnerabilities.json
@@ -1,6 +1,6 @@
 {
 	"name": "[SonarQube] Vulnerabilities",
-	"type": "metric alert",
+	"type": "query alert",
 	"query": "max(last_5m):avg:sonarqube.security.vulnerabilities{*} > 0",
 	"message": "At least one vulnerability has been detected.",
 	"tags": [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Monitor teams are working on making `metric alert` and `query alert` be the same, they advise us to only keep `query alert`. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
