### PR TITLE
Fix cacti e2e

### DIFF
--- a/cacti/README.md
+++ b/cacti/README.md
@@ -16,7 +16,7 @@ The Cacti check is included in the [Datadog Agent][1] package, to start gatherin
 1. Install `librrd` headers and libraries.
 2. Install python bindings to `rrdtool`.
 
-#### librrd headers and librairies
+#### librrd headers and libraries
 
 On Debian/Ubuntu:
 

--- a/cacti/tests/compose/Dockerfile
+++ b/cacti/tests/compose/Dockerfile
@@ -2,7 +2,9 @@ FROM quantumobject/docker-cacti:latest
 
 # username and password is admin/Admin23@
 COPY alldb_backup.sql /var/backups/
+COPY restore.sh /sbin/restore
 COPY rra.tar.gz /var/backups/
 
+RUN chmod +x /sbin/restore
 RUN chown www-data:www-data /var/www/html/cacti/rra
 RUN chown -R www-data:www-data /var/www/html/cacti/rra

--- a/cacti/tests/compose/Dockerfile
+++ b/cacti/tests/compose/Dockerfile
@@ -1,4 +1,4 @@
-FROM quantumobject/docker-cacti:1.2.8
+FROM quantumobject/docker-cacti:latest
 
 # username and password is admin/Admin23@
 COPY alldb_backup.sql /var/backups/

--- a/cacti/tests/compose/restore.sh
+++ b/cacti/tests/compose/restore.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+mysql -u root -pmysqlpsswd < /var/backups/alldb_backup.sql


### PR DESCRIPTION
Cacti tests are failing
```
---------------------------- Captured stderr setup -----------------------------
Creating network "compose_default" with the default driver
Building cacti
Service 'cacti' failed to build : manifest for quantumobject/docker-cacti:1.2.8 not found: manifest unknown: manifest unknown
=========================== 1 error in 7.59 seconds ============================
```
It seems that since 2 days ago the only tag for that docker image is `latest` https://hub.docker.com/r/quantumobject/docker-cacti/tags
The restore script has been deleted https://github.com/QuantumObject/docker-cacti/commit/5ab073d64e1a6d5626ddc6a8d767e1bb189d66f2