### PR TITLE
Disable SLM metrics by default

### DIFF
--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -52,6 +52,13 @@ files:
       value:
         type: boolean
         example: false
+    - name: slm_stats
+      description: | 
+        Set "slm_stats" to true to collect statistics about Snapshot Lifcycle Management.
+        The user must have `manage_slm` cluster priviege to get these metrics.
+      value:
+        type: boolean
+        example: false
     - name: pshard_graceful_timeout
       description: Continue gracefully if pshard stats TO
       value:

--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -55,7 +55,7 @@ files:
     - name: slm_stats
       description: | 
         Set "slm_stats" to true to collect statistics about Snapshot Lifcycle Management.
-        The user must have `manage_slm` cluster priviege to get these metrics.
+        The user must have `manage_slm` cluster privilege to get these metrics.
       value:
         type: boolean
         example: false

--- a/elastic/datadog_checks/elastic/config.py
+++ b/elastic/datadog_checks/elastic/config.py
@@ -15,6 +15,7 @@ ESInstanceConfig = namedtuple(
         'pshard_graceful_to',
         'node_name_as_host',
         'cluster_stats',
+        'slm_stats',
         'index_stats',
         'service_check_tags',
         'tags',
@@ -37,6 +38,7 @@ def from_instance(instance):
     node_name_as_host = is_affirmative(instance.get('node_name_as_host', False))
     index_stats = is_affirmative(instance.get('index_stats', False))
     cluster_stats = is_affirmative(instance.get('cluster_stats', False))
+    slm_stats = is_affirmative(instance.get('slm_stats', False))
     if 'is_external' in instance:
         cluster_stats = is_affirmative(instance.get('is_external', False))
     pending_task_stats = is_affirmative(instance.get('pending_task_stats', True))
@@ -65,6 +67,7 @@ def from_instance(instance):
         pshard_graceful_to=pshard_graceful_to,
         node_name_as_host=node_name_as_host,
         cluster_stats=cluster_stats,
+        slm_stats=slm_stats,
         index_stats=index_stats,
         service_check_tags=service_check_tags,
         tags=tags,

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -86,7 +86,7 @@ instances:
 
     ## @param slm_stats - boolean - optional - default: false
     ## Set "slm_stats" to true to collect statistics about Snapshot Lifcycle Management.
-    ## The user must have `manage_slm` cluster priviege to get these metrics.
+    ## The user must have `manage_slm` cluster privilege to get these metrics.
     #
     # slm_stats: false
 

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -84,6 +84,12 @@ instances:
     #
     # pshard_stats: false
 
+    ## @param slm_stats - boolean - optional - default: false
+    ## Set "slm_stats" to true to collect statistics about Snapshot Lifcycle Management.
+    ## The user must have `manage_slm` cluster priviege to get these metrics.
+    #
+    # slm_stats: false
+
     ## @param pshard_graceful_timeout - boolean - optional - default: false
     ## Continue gracefully if pshard stats TO
     #

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -207,7 +207,7 @@ class ESCheck(AgentCheck):
             if version < [5, 0, 0]:
                 # version 5 errors out if the `all` parameter is set
                 stats_url += "?all=true"
-            if version >= [7, 4, 0]:
+            if version >= [7, 4, 0] and self.config.slm_stats:
                 slm_url = "/_slm/policy"
         else:
             # legacy


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix #8335 and disable SLM metrics by default.
`manage_slm` seems not to be part of the `manage` permission, which causes 403 error when trying to get slm metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
