### PR TITLE
Update agent version and config requirements for tcp_queue_length

### DIFF
--- a/tcp_queue_length/README.md
+++ b/tcp_queue_length/README.md
@@ -8,7 +8,7 @@ This check monitors the usage of the Linux TCP receive and send queues, and can 
 
 ### Installation
 
-`tcp_queue_length` is a core Agent 6/7 check that relies on an eBPF part implemented in `system-probe`.
+`tcp_queue_length` is a core Agent 6/7 check that relies on an eBPF part implemented in `system-probe`. Agent version 7.24.1/6.24.1 or above is required.
 
 The eBPF program used by `system-probe` is compiled at runtime and requires you to have access to the proper kernel headers.
 
@@ -32,7 +32,6 @@ Enabling the `tcp_queue_length` integration requires both the `system-probe` and
 Inside the `system-probe.yaml` configuration file, the following parameters must be set:
 ```yaml
 system_probe_config:
-  enabled: true
   enable_tcp_queue_length: true
 ```
 


### PR DESCRIPTION
### What does this PR do?

Setting system_probe_config.enabled=true can cause network performance monitoring to get inadvertently enabled.  Our docs should not require this! 


### Motivation


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
