### PR TITLE
Fix logging

### DIFF
--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -253,7 +253,7 @@ class AerospikeCheck(AgentCheck):
                 data,
             )
         except Exception as e:
-            self.log.warning("Command `%s` was unsuccessful: %s"(command, str(e)))
+            self.log.warning("Command `%s` was unsuccessful: %s", command, str(e))
             return
         # Get rid of command and whitespace
         data = data[len(command) :].strip()


### PR DESCRIPTION
fixes
```
During handling of the above exception, another exception occurred:
tests/test_aerospike.py:22: in test_check
    check.check(None)
datadog_checks/aerospike/aerospike.py:116: in check
    self.collect_info('statistics', CLUSTER_METRIC_TYPE, required_keys=self._metrics, tags=self._tags)
datadog_checks/aerospike/aerospike.py:189: in collect_info
    entries = self.get_info(command, separator=separator)
datadog_checks/aerospike/aerospike.py:256: in get_info
    self.log.warning("Command `%s` was unsuccessful: %s"(command, str(e)))
E   TypeError: 'str' object is not callable
```