### PR TITLE
fix nested sections in docs validator

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/spec.py
@@ -38,6 +38,14 @@ def _validate(obj, items, loader, MISSING, INVALID):
                 # initialize as empty builtin type
                 obj[v.key] = v.type()
 
+        if v.children and obj[v.key]:
+            # handle recursive elements which may be passed as strings
+            if v.children == 'self':
+                children = items
+            else:
+                children = v.children
+            _validate(obj[v.key], children, loader, MISSING, INVALID)
+
 
 def spec_validator(spec, loader):
     if not isinstance(spec, dict):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/spec.py
@@ -9,6 +9,8 @@ from collections import namedtuple
 
 from ...utils import load_manifest, load_service_checks
 
+CLASS_REMAP = {str: 'a string', list: 'an array', dict: 'a mapping object', int: 'an int'}
+
 # Simple validation tuple, with some interesting caveats:
 #
 # `key` - name of value in the object
@@ -23,7 +25,7 @@ Validation = namedtuple('Validation', 'key, type, required, default, children', 
 
 def _validate(obj, items, loader, MISSING, INVALID):
     for v in items:
-        type_name = v.type.__name__
+        type_name = CLASS_REMAP.get(v.type, v.type.__name__)
         if v.required and v.key not in obj:
             loader.errors.append(MISSING.format(loader=loader, key=v.key, type=type_name))
             return
@@ -49,11 +51,11 @@ def _validate(obj, items, loader, MISSING, INVALID):
 
 def spec_validator(spec, loader):
     if not isinstance(spec, dict):
-        loader.errors.append(f'{loader.source}: {loader.spec_type} specifications must be a mapping object')
+        loader.errors.append(f'{loader.source}: {loader.spec_type} specifications must be {CLASS_REMAP[dict]}')
         return
 
     MISSING = '{loader.source}: {loader.spec_type} specifications must include a top-level `{key}` attribute'
-    INVALID = '{loader.source}: The top-level `{key}` attribute must be a {type}'
+    INVALID = '{loader.source}: The top-level `{key}` attribute must be {type}'
 
     valid_options = [Validation(key='autodiscovery', type=bool, required=False)]
     validations = [
@@ -84,10 +86,10 @@ def files_validator(files, loader):
 
     for file_index, doc_file in enumerate(files, 1):
         MISSING = f'{loader.source}: {loader.spec_type} file #{file_index}: Must include a `{{key}}` attribute.'
-        INVALID = f'{loader.source}: {loader.spec_type} file #{file_index}: Attribute `{{key}}` must be a {{type}}'
+        INVALID = f'{loader.source}: {loader.spec_type} file #{file_index}: Attribute `{{key}}` must be {{type}}'
 
         if not isinstance(doc_file, dict):
-            loader.errors.append(f'{loader.source}, file #{file_index}: File attribute must be a mapping object')
+            loader.errors.append(f'{loader.source}, file #{file_index}: File attribute must be {CLASS_REMAP[dict]}')
             continue
 
         _validate(doc_file, validations, loader, MISSING, INVALID)
@@ -150,8 +152,8 @@ def section_validator(sections, loader, file_name, *prev_sections):
     for section_index, section in enumerate(sections, 1):
         if not isinstance(section, dict):
             loader.errors.append(
-                '{}, {}, {}section #{}: section attribute must be a mapping object'.format(
-                    loader.source, file_name, sections_display, section_index
+                '{}, {}, {}section #{}: section attribute must be {}'.format(
+                    loader.source, file_name, sections_display, section_index, CLASS_REMAP[dict]
                 )
             )
             continue
@@ -187,8 +189,8 @@ def section_validator(sections, loader, file_name, *prev_sections):
                     # Perform this check once again
                     if not isinstance(section, dict):
                         loader.errors.append(
-                            '{}, {}, {}section #{}: Template section must be a mapping object'.format(
-                                loader.source, file_name, sections_display, section_index
+                            '{}, {}, {}section #{}: Template section must be {}'.format(
+                                loader.source, file_name, sections_display, section_index, CLASS_REMAP[dict]
                             )
                         )
                         break
@@ -220,7 +222,7 @@ def section_validator(sections, loader, file_name, *prev_sections):
         )
         INVALID = (
             f'{loader.source}, {file_name}, {sections_display}section #{section_index}: '
-            f'Attribute `{{key}}` must be a {{type}}'
+            f'Attribute `{{key}}` must be {{type}}'
         )
 
         # now validate the expanded section object
@@ -280,8 +282,8 @@ def section_validator(sections, loader, file_name, *prev_sections):
             nested_sections = section['sections']
             if not isinstance(nested_sections, list):
                 loader.errors.append(
-                    '{}, {}, {}{}: Attribute `sections` must be a list'.format(
-                        loader.source, file_name, sections_display, section_name
+                    '{}, {}, {}{}: Attribute `sections` must be {}'.format(
+                        loader.source, file_name, sections_display, section_name, CLASS_REMAP[list]
                     )
                 )
                 continue

--- a/datadog_checks_dev/tests/tooling/docs/test_load.py
+++ b/datadog_checks_dev/tests/tooling/docs/test_load.py
@@ -59,7 +59,7 @@ def test_name_not_string():
     )
     doc.load()
 
-    assert 'test: The top-level `name` attribute must be a str' in doc.errors
+    assert 'test: The top-level `name` attribute must be a string' in doc.errors
 
 
 def test_no_files():
@@ -83,7 +83,7 @@ def test_files_not_array():
     )
     doc.load()
 
-    assert 'test: The top-level `files` attribute must be a list' in doc.errors
+    assert 'test: The top-level `files` attribute must be an array' in doc.errors
 
 
 def test_file_not_map():
@@ -162,7 +162,7 @@ def test_file_name_not_string():
     )
     doc.load()
 
-    assert 'test: Docs file #1: Attribute `name` must be a str' in doc.errors
+    assert 'test: Docs file #1: Attribute `name` must be a string' in doc.errors
 
 
 def test_section_not_array():
@@ -177,7 +177,7 @@ def test_section_not_array():
     )
     doc.load()
 
-    assert 'test: Docs file #1: Attribute `sections` must be a list' in doc.errors
+    assert 'test: Docs file #1: Attribute `sections` must be an array' in doc.errors
 
 
 @mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
@@ -211,7 +211,7 @@ def test_section_name_not_string(_):
     )
     doc.load()
 
-    assert 'test, README.md, section #1: Attribute `name` must be a str' in doc.errors
+    assert 'test, README.md, section #1: Attribute `name` must be a string' in doc.errors
 
 
 @mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
@@ -281,7 +281,7 @@ def test_section_header_level_not_int(_):
     )
     doc.load()
 
-    assert 'test, README.md, section #1: Attribute `header_level` must be a int' in doc.errors
+    assert 'test, README.md, section #1: Attribute `header_level` must be an int' in doc.errors
 
 
 @mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
@@ -318,7 +318,7 @@ def test_nested_section_not_array(_):
     )
     doc.load()
     # nested section names don't get carried on to the validator
-    assert 'test, README.md, instances: Attribute `sections` must be a list' in doc.errors
+    assert 'test, README.md, instances: Attribute `sections` must be an array' in doc.errors
 
 
 @mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
@@ -382,7 +382,7 @@ def test_nested_section_name_not_string(_):
     )
     doc.load()
 
-    assert 'test, README.md, instances, section #1: Attribute `name` must be a str' in doc.errors
+    assert 'test, README.md, instances, section #1: Attribute `name` must be a string' in doc.errors
 
 
 @mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
@@ -453,7 +453,7 @@ def test_nested_section_header_level_not_int(_):
     )
     doc.load()
 
-    assert 'test, README.md, instances, section #1: Attribute `header_level` must be a int' in doc.errors
+    assert 'test, README.md, instances, section #1: Attribute `header_level` must be an int' in doc.errors
 
 
 @mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add more tests for docs validator. New tests check for functionality of nested sections. There was a fix provided for the name of nested sections not being included in the error messages. 
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
