### PR TITLE
Change example configs for databases to default to deep_database_monitoring: false

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -244,7 +244,7 @@ files:
             enabled: false
             value:
               type: boolean
-              example: true
+              example: false
               default: false
 
           - template: instances/default

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -230,7 +230,7 @@ instances:
     ## If you would like to hear more about Deep Database Monitoring, please reach out to your customer
     ## success manager or Datadog support.
     #
-    # deep_database_monitoring: true
+    # deep_database_monitoring: false
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -185,7 +185,7 @@ files:
         success manager or Datadog support.
       value:
         type: boolean
-        example: true
+        example: false
         default: false
     - name: pg_stat_statements_view
       description: |

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -159,7 +159,7 @@ instances:
     ## If you would like to hear more about Deep Database Monitoring, please reach out to your customer
     ## success manager or Datadog support.
     #
-    # deep_database_monitoring: true
+    # deep_database_monitoring: false
 
     ## @param pg_stat_statements_view - string - optional - default: show_pg_stat_statements()
     ## Set this value if you want to define a custom view or function to allow the datadog user to query the


### PR DESCRIPTION
### What does this PR do?

Changes the example config for integrations to default to `false`. This is to avoid customers copying the default config and accidentally opting into beta features. While the "default" value was false, the "example" value was true.

Since this is only a documentation change, I grouped both mysql and postgres integrations together.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
