### PR TITLE
fix nested sections for readme rendering

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
@@ -2,8 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
-from io import StringIO
 from collections import deque
+from io import StringIO
 
 DESCRIPTION_LINE_LENGTH_LIMIT = 120
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
 from io import StringIO
+from collections import deque
 
 DESCRIPTION_LINE_LENGTH_LIMIT = 120
 
@@ -92,9 +93,10 @@ class ReadmeConsumer(object):
                 writer.write('# Agent Check: {}'.format(self.spec['name']))
                 writer.write('\n\n')
 
-                sections = file['sections']
+                sections = deque(file['sections'])
                 tab = None
-                for section in sections:
+                while sections:
+                    section = sections.popleft()
                     if section['hidden']:
                         continue
 
@@ -117,6 +119,9 @@ class ReadmeConsumer(object):
                     write_section(section, writer)
 
                     writer.write('\n')
+
+                    if 'sections' in section:
+                        sections.extendleft(section['sections'][::-1])
 
                 # add link references to the end of document
                 refs = get_references(links)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
@@ -122,6 +122,8 @@ class ReadmeConsumer(object):
 
                     if 'sections' in section:
                         # extend left backwards for correct order of sections
+                        # eg sections.extendleft([s2.1, s2.2]) updates section to [s2.2, s2.1, s3]
+                        # so we need to reverse it for correctness
                         sections.extendleft(section['sections'][::-1])
 
                 # add link references to the end of document

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
@@ -121,6 +121,7 @@ class ReadmeConsumer(object):
                     writer.write('\n')
 
                     if 'sections' in section:
+                        # extend left backwards for correct order of sections
                         sections.extendleft(section['sections'][::-1])
 
                 # add link references to the end of document


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Handles the case where a section contains subsections in the readme rendering. 
### Motivation
<!-- What inspired you to submit this pull request? -->
READMEs were not rendering properly. 
### Additional Notes
<!-- Anything else we should know when reviewing? -->
Example of fix:
Say we have:
`section = [s1, s2, s3]` and `s2` has subsections `s2.1, s2.2`
we would want to process the list as follows: 
`section = [s1, s2, s2.1, s2.2, s3]`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
