### PR TITLE
Rename cluster_name tag to elastic_cluster

### DIFF
--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -89,7 +89,7 @@ files:
         type: boolean
         example: false
     - name: disable_legacy_cluster_tag
-      description: Enable to stop submitting the tag `cluster_name` that has been renamed to `elastic_cluster`.
+      description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `elastic_cluster`.
       value:
         type: boolean
         example: false

--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -88,6 +88,11 @@ files:
       value:
         type: boolean
         example: false
+    - name: disable_legacy_cluster_tag
+      description: Enable to stop submitting the tag `cluster_name` that has been renamed to `elastic_cluster`.
+      value:
+        type: boolean
+        example: false
     - template: instances/default
     - template: instances/http
   - template: logs

--- a/elastic/assets/dashboards/overview.json
+++ b/elastic/assets/dashboards/overview.json
@@ -5,8 +5,8 @@
     "template_variables": [
         {
             "default": "*",
-            "name": "cluster_name",
-            "prefix": "cluster_name"
+            "name": "elastic_cluster",
+            "prefix": "elastic_cluster"
         },
         {
             "default": "*",
@@ -112,7 +112,7 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "(sum:elasticsearch.search.query.time{$cluster_name}/sum:elasticsearch.search.query.total{$cluster_name})",
+                        "q": "(sum:elasticsearch.search.query.time{$elastic_cluster}/sum:elasticsearch.search.query.total{$elastic_cluster})",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -121,7 +121,7 @@
                     },
                     {
                         "display_type": "line",
-                        "q": "(sum:elasticsearch.search.fetch.time{$cluster_name}/sum:elasticsearch.search.fetch.total{$cluster_name})",
+                        "q": "(sum:elasticsearch.search.fetch.time{$elastic_cluster}/sum:elasticsearch.search.fetch.total{$elastic_cluster})",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -130,7 +130,7 @@
                     }
                 ],
                 "show_legend": false,
-                "title": "Avg query and fetch latency over $cluster_name",
+                "title": "Avg query and fetch latency over $elastic_cluster",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "timeseries",
@@ -175,7 +175,7 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "sum:elasticsearch.docs.count{$cluster_name}",
+                        "q": "sum:elasticsearch.docs.count{$elastic_cluster}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -184,7 +184,7 @@
                     }
                 ],
                 "show_legend": false,
-                "title": "Number of documents in $cluster_name",
+                "title": "Number of documents in $elastic_cluster",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "timeseries",
@@ -211,10 +211,10 @@
                 "requests": [
                     {
                         "aggregator": "max",
-                        "q": "max:elasticsearch.active_shards{$cluster_name}"
+                        "q": "max:elasticsearch.active_shards{$elastic_cluster}"
                     }
                 ],
-                "title": "Active shards over $cluster_name",
+                "title": "Active shards over $elastic_cluster",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "query_value"
@@ -247,7 +247,7 @@
                                 "value": 0
                             }
                         ],
-                        "q": "max:elasticsearch.initializing_shards{$cluster_name}"
+                        "q": "max:elasticsearch.initializing_shards{$elastic_cluster}"
                     }
                 ],
                 "title": "Initializing shards",
@@ -282,7 +282,7 @@
                                 "value": 0
                             }
                         ],
-                        "q": "max:elasticsearch.relocating_shards{$cluster_name}"
+                        "q": "max:elasticsearch.relocating_shards{$elastic_cluster}"
                     }
                 ],
                 "title": "Relocating shards",
@@ -317,7 +317,7 @@
                                 "value": 0
                             }
                         ],
-                        "q": "max:elasticsearch.unassigned_shards{$cluster_name}"
+                        "q": "max:elasticsearch.unassigned_shards{$elastic_cluster}"
                     }
                 ],
                 "title": "Unassigned shards",
@@ -339,7 +339,7 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "max:elasticsearch.active_shards{$cluster_name}",
+                        "q": "max:elasticsearch.active_shards{$elastic_cluster}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -348,7 +348,7 @@
                     },
                     {
                         "display_type": "line",
-                        "q": "max:elasticsearch.active_primary_shards{$cluster_name}",
+                        "q": "max:elasticsearch.active_primary_shards{$elastic_cluster}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -357,7 +357,7 @@
                     }
                 ],
                 "show_legend": false,
-                "title": "Active shards (total and primary) over $cluster_name",
+                "title": "Active shards (total and primary) over $elastic_cluster",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "timeseries",
@@ -402,7 +402,7 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "max:elasticsearch.initializing_shards{$cluster_name}",
+                        "q": "max:elasticsearch.initializing_shards{$elastic_cluster}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -411,7 +411,7 @@
                     },
                     {
                         "display_type": "line",
-                        "q": "max:elasticsearch.unassigned_shards{$cluster_name}",
+                        "q": "max:elasticsearch.unassigned_shards{$elastic_cluster}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -420,7 +420,7 @@
                     },
                     {
                         "display_type": "line",
-                        "q": "max:elasticsearch.relocating_shards{$cluster_name}",
+                        "q": "max:elasticsearch.relocating_shards{$elastic_cluster}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -429,7 +429,7 @@
                     }
                 ],
                 "show_legend": false,
-                "title": "Shards initializing, relocating, unassigned over $cluster_name",
+                "title": "Shards initializing, relocating, unassigned over $elastic_cluster",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "timeseries",
@@ -453,10 +453,10 @@
             "definition": {
                 "requests": [
                     {
-                        "q": "top(diff(avg:elasticsearch.indexing.index.total{$cluster_name} by {host}), 10, 'sum', 'desc')"
+                        "q": "top(diff(avg:elasticsearch.indexing.index.total{$elastic_cluster} by {host}), 10, 'sum', 'desc')"
                     }
                 ],
-                "title": "Nodes of $cluster_name with most indexing activity (top 10 hosts)",
+                "title": "Nodes of $elastic_cluster with most indexing activity (top 10 hosts)",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "toplist"
@@ -477,7 +477,7 @@
                 ],
                 "indexes": [],
                 "message_display": "expanded-lg",
-                "query": "source:elasticsearch $cluster_name",
+                "query": "source:elasticsearch $elastic_cluster",
                 "show_date_column": true,
                 "show_message_column": true,
                 "sort": {
@@ -500,7 +500,7 @@
                 "requests": [
                     {
                         "display_type": "area",
-                        "q": "per_second(avg:elasticsearch.transport.rx_count{$cluster_name,$node_name} by {host})",
+                        "q": "per_second(avg:elasticsearch.transport.rx_count{$elastic_cluster,$node_name} by {host})",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -509,7 +509,7 @@
                     }
                 ],
                 "show_legend": false,
-                "title": "Bytes received over $cluster_name,$node_name",
+                "title": "Bytes received over $elastic_cluster,$node_name",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "timeseries",
@@ -535,7 +535,7 @@
                 "requests": [
                     {
                         "display_type": "area",
-                        "q": "per_second(sum:elasticsearch.http.total_opened{$cluster_name})",
+                        "q": "per_second(sum:elasticsearch.http.total_opened{$elastic_cluster})",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -544,7 +544,7 @@
                     }
                 ],
                 "show_legend": false,
-                "title": "Rate of opened HTTP connections over $cluster_name",
+                "title": "Rate of opened HTTP connections over $elastic_cluster",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "timeseries",
@@ -570,7 +570,7 @@
                 "requests": [
                     {
                         "display_type": "area",
-                        "q": "per_second(avg:elasticsearch.transport.tx_count{$cluster_name,$node_name} by {host})",
+                        "q": "per_second(avg:elasticsearch.transport.tx_count{$elastic_cluster,$node_name} by {host})",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -579,7 +579,7 @@
                     }
                 ],
                 "show_legend": false,
-                "title": "Bytes sent over $cluster_name,$node_name",
+                "title": "Bytes sent over $elastic_cluster,$node_name",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "timeseries",
@@ -622,10 +622,10 @@
             "definition": {
                 "requests": [
                     {
-                        "q": "top(diff(avg:elasticsearch.search.query.total{$cluster_name} by {host}), 10, 'sum', 'desc')"
+                        "q": "top(diff(avg:elasticsearch.search.query.total{$elastic_cluster} by {host}), 10, 'sum', 'desc')"
                     }
                 ],
-                "title": "Nodes of $cluster_name with most queries (top 10 hosts)",
+                "title": "Nodes of $elastic_cluster with most queries (top 10 hosts)",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "toplist"
@@ -662,7 +662,7 @@
                                 "value": 90
                             }
                         ],
-                        "q": "(1-(sum:elasticsearch.fs.total.available_in_bytes{$cluster_name} by {host}/sum:elasticsearch.fs.total.total_in_bytes{$cluster_name} by {host}))*100"
+                        "q": "(1-(sum:elasticsearch.fs.total.available_in_bytes{$elastic_cluster} by {host}/sum:elasticsearch.fs.total.total_in_bytes{$elastic_cluster} by {host}))*100"
                     }
                 ],
                 "title": "Disk space used",
@@ -684,7 +684,7 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "sum:elasticsearch.pending_tasks_total{$cluster_name}",
+                        "q": "sum:elasticsearch.pending_tasks_total{$elastic_cluster}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -693,7 +693,7 @@
                     }
                 ],
                 "show_legend": false,
-                "title": "Total number of pending task in $cluster_name",
+                "title": "Total number of pending task in $elastic_cluster",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "timeseries",
@@ -719,7 +719,7 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "sum:elasticsearch.get.missing.total{$cluster_name,$node_name}",
+                        "q": "sum:elasticsearch.get.missing.total{$elastic_cluster,$node_name}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -728,7 +728,7 @@
                     }
                 ],
                 "show_legend": false,
-                "title": "Total number of unsuccessful GETs over $cluster_name,$node_name",
+                "title": "Total number of unsuccessful GETs over $elastic_cluster,$node_name",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "timeseries",
@@ -754,7 +754,7 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "avg:elasticsearch.indexing.index.time{$cluster_name}",
+                        "q": "avg:elasticsearch.indexing.index.time{$elastic_cluster}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -763,7 +763,7 @@
                     }
                 ],
                 "show_legend": false,
-                "title": "Avg indexing latency over $cluster_name",
+                "title": "Avg indexing latency over $elastic_cluster",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "timeseries",
@@ -790,10 +790,10 @@
                 "requests": [
                     {
                         "aggregator": "last",
-                        "q": "sum:elasticsearch.store.size{$cluster_name}"
+                        "q": "sum:elasticsearch.store.size{$elastic_cluster}"
                     }
                 ],
-                "title": "Sum of elasticsearch.store.size over $cluster_name",
+                "title": "Sum of elasticsearch.store.size over $elastic_cluster",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "query_value"
@@ -927,10 +927,10 @@
                 "requests": [
                     {
                         "aggregator": "avg",
-                        "q": "avg:elasticsearch.process.open_fd{$cluster_name,$node_name}"
+                        "q": "avg:elasticsearch.process.open_fd{$elastic_cluster,$node_name}"
                     }
                 ],
-                "title": "Average number of file descriptors opened over $cluster_name,$node_name",
+                "title": "Average number of file descriptors opened over $elastic_cluster,$node_name",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "query_value"

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -117,7 +117,7 @@ instances:
     # gc_collectors_as_rate: false
 
     ## @param disable_legacy_cluster_tag - boolean - optional - default: false
-    ## Enable to stop submitting the tag `cluster_name` that has been renamed to `elastic_cluster`.
+    ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `elastic_cluster`.
     #
     # disable_legacy_cluster_tag: false
 

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -116,6 +116,11 @@ instances:
     #
     # gc_collectors_as_rate: false
 
+    ## @param disable_legacy_cluster_tag - boolean - optional - default: false
+    ## Enable to stop submitting the tag `cluster_name` that has been renamed to `elastic_cluster`.
+    #
+    # disable_legacy_cluster_tag: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -81,7 +81,7 @@ class ESCheck(AgentCheck):
             # retrieve the cluster name from the data, and append it to the
             # master tag list.
             cluster_tags = ["elastic_cluster:{}".format(stats_data['cluster_name'])]
-            if is_affirmative(self.instance.get('disable_legacy_cluster_tag', False)):
+            if not is_affirmative(self.instance.get('disable_legacy_cluster_tag', False)):
                 cluster_tags.append("cluster_name:{}".format(stats_data['cluster_name']))
             base_tags.extend(cluster_tags)
             service_check_tags.extend(cluster_tags)

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -8,7 +8,7 @@ import requests
 from six import iteritems, itervalues
 from six.moves.urllib.parse import urljoin, urlparse
 
-from datadog_checks.base import AgentCheck, to_string
+from datadog_checks.base import AgentCheck, is_affirmative, to_string
 
 from .config import from_instance
 from .metrics import (
@@ -80,9 +80,11 @@ class ESCheck(AgentCheck):
         if stats_data.get('cluster_name'):
             # retrieve the cluster name from the data, and append it to the
             # master tag list.
-            cluster_name_tag = "cluster_name:{}".format(stats_data['cluster_name'])
-            base_tags.append(cluster_name_tag)
-            service_check_tags.append(cluster_name_tag)
+            cluster_tags = ["elastic_cluster:{}".format(stats_data['cluster_name'])]
+            if is_affirmative(self.instance.get('disable_legacy_cluster_tag', False)):
+                cluster_tags.append("cluster_name:{}".format(stats_data['cluster_name']))
+            base_tags.append(cluster_tags)
+            service_check_tags.append(cluster_tags)
         self._process_stats_data(stats_data, stats_metrics, base_tags)
 
         # Load cluster-wise data

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -83,8 +83,8 @@ class ESCheck(AgentCheck):
             cluster_tags = ["elastic_cluster:{}".format(stats_data['cluster_name'])]
             if is_affirmative(self.instance.get('disable_legacy_cluster_tag', False)):
                 cluster_tags.append("cluster_name:{}".format(stats_data['cluster_name']))
-            base_tags.append(cluster_tags)
-            service_check_tags.append(cluster_tags)
+            base_tags.extend(cluster_tags)
+            service_check_tags.extend(cluster_tags)
         self._process_stats_data(stats_data, stats_metrics, base_tags)
 
         # Load cluster-wise data

--- a/elastic/tests/common.py
+++ b/elastic/tests/common.py
@@ -10,7 +10,8 @@ USER = "elastic"
 PASSWORD = "changeme"
 HOST = get_docker_hostname()
 PORT = '9200'
-CLUSTER_TAG = ["cluster_name:test-cluster", "elastic_cluster:test-cluster"]
+CLUSTER_TAG = ["cluster_name:test-cluster"]
+ELASTIC_CLUSTER_TAG = ["elastic_cluster:test-cluster"]
 URL = 'http://{}:{}'.format(HOST, PORT)
 ELASTIC_VERSION = os.getenv('ELASTIC_VERSION', os.environ['ELASTIC_IMAGE'])
 

--- a/elastic/tests/common.py
+++ b/elastic/tests/common.py
@@ -10,7 +10,7 @@ USER = "elastic"
 PASSWORD = "changeme"
 HOST = get_docker_hostname()
 PORT = '9200'
-CLUSTER_TAG = ["cluster_name:test-cluster"]
+CLUSTER_TAG = ["cluster_name:test-cluster", "elastic_cluster:test-cluster"]
 URL = 'http://{}:{}'.format(HOST, PORT)
 ELASTIC_VERSION = os.getenv('ELASTIC_VERSION', os.environ['ELASTIC_IMAGE'])
 

--- a/elastic/tests/conftest.py
+++ b/elastic/tests/conftest.py
@@ -13,7 +13,7 @@ from datadog_checks.base.utils.common import exclude_undefined_keys
 from datadog_checks.dev import WaitFor, docker_run
 from datadog_checks.elastic import ESCheck
 
-from .common import CLUSTER_TAG, ELASTIC_VERSION, HERE, PASSWORD, URL, USER
+from .common import CLUSTER_TAG, ELASTIC_CLUSTER_TAG, ELASTIC_VERSION, HERE, PASSWORD, URL, USER
 
 CUSTOM_TAGS = ['foo:bar', 'baz']
 COMPOSE_FILES_MAP = {
@@ -112,7 +112,7 @@ def version_metadata():
 
 
 def _cluster_tags():
-    tags = ['url:{}'.format(URL)] + CLUSTER_TAG
+    tags = ['url:{}'.format(URL)] + ELASTIC_CLUSTER_TAG + CLUSTER_TAG
     tags.extend(CUSTOM_TAGS)
 
     return tags

--- a/elastic/tests/conftest.py
+++ b/elastic/tests/conftest.py
@@ -119,6 +119,14 @@ def _cluster_tags():
 
 
 @pytest.fixture
+def new_cluster_tags():
+    tags = ['url:{}'.format(URL)] + ELASTIC_CLUSTER_TAG
+    tags.extend(CUSTOM_TAGS)
+
+    return tags
+
+
+@pytest.fixture
 def cluster_tags():
     return _cluster_tags()
 

--- a/elastic/tests/conftest.py
+++ b/elastic/tests/conftest.py
@@ -13,7 +13,7 @@ from datadog_checks.base.utils.common import exclude_undefined_keys
 from datadog_checks.dev import WaitFor, docker_run
 from datadog_checks.elastic import ESCheck
 
-from .common import ELASTIC_VERSION, HERE, PASSWORD, URL, USER
+from .common import CLUSTER_TAG, ELASTIC_VERSION, HERE, PASSWORD, URL, USER
 
 CUSTOM_TAGS = ['foo:bar', 'baz']
 COMPOSE_FILES_MAP = {
@@ -112,7 +112,7 @@ def version_metadata():
 
 
 def _cluster_tags():
-    tags = ['url:{}'.format(URL), 'cluster_name:test-cluster']
+    tags = ['url:{}'.format(URL)] + CLUSTER_TAG
     tags.extend(CUSTOM_TAGS)
 
     return tags

--- a/elastic/tests/test_elastic.py
+++ b/elastic/tests/test_elastic.py
@@ -104,6 +104,21 @@ def test_check_slm_stats(dd_environment, instance, aggregator, cluster_tags, nod
 
 
 @pytest.mark.integration
+def test_disable_cluster_tag(dd_environment, instance, aggregator, new_cluster_tags):
+    disable_instance = deepcopy(instance)
+    disable_instance['disable_legacy_cluster_tag'] = True
+    elastic_check = ESCheck('elastic', {}, instances=[disable_instance])
+    elastic_check.check(None)
+    es_version = elastic_check._get_es_version()
+
+    # cluster stats
+    expected_metrics = health_stats_for_version(es_version)
+    expected_metrics.update(CLUSTER_PENDING_TASKS)
+    for m_name in expected_metrics:
+        aggregator.assert_metric(m_name, at_least=1, tags=new_cluster_tags)
+
+
+@pytest.mark.integration
 def test_jvm_gc_rate_metrics(dd_environment, instance, aggregator, cluster_tags, node_tags):
     instance['gc_collectors_as_rate'] = True
     check = ESCheck('elastic', {}, instances=[instance])


### PR DESCRIPTION
### What does this PR do?
The `cluster_name` tag is submitted for container environments. This PR introduces an option to disable the commonly used tag and renames the cluster tag to `elastic_cluster`.

This PR also updates the template var used in the OOTB dashboard to use new tag.

### Motivation
Customer support

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
