### PR TITLE
Update broken link to Airflow Apache Page - 442208

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -337,7 +337,7 @@ Need help? Contact [Datadog support][7].
 [8]: https://docs.datadoghq.com/developers/dogstatsd/
 [9]: https://docs.datadoghq.com/agent/
 [10]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/
-[11]: https://airflow.apache.org/docs/stable/_modules/airflow/contrib/hooks/datadog_hook.html
+[11]: https://airflow.apache.org/docs/apache-airflow-providers-datadog/stable/_modules/airflow/providers/datadog/hooks/datadog.html
 [12]: https://docs.datadoghq.com/agent/kubernetes/integrations/
 [13]: https://docs.datadoghq.com/agent/kubernetes/log/?tab=containerinstallation#setup
 [14]: https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes#configuration


### PR DESCRIPTION
### What does this PR do?
Update broken hyperlink in our Airflow Integration public document: https://docs.datadoghq.com/integrations/airflow/?tab=host#airflow-datadoghook 

### Motivation
Broken hyperlink was reported via Zendesk ticket: https://datadog.zendesk.com/agent/tickets/442208
I want to ensure other customers don't come across this problem so that's why I want this fixed.

### Additional Notes
None.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
