### PR TITLE
[kubelet] Fix TypeError when retrieved pod_list is occasionally None

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -240,7 +240,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         )
         return kubelet_instance
 
-    def _create_pod_tags_by_pvc(self, pods):
+    def _create_pod_tags_by_pvc(self, pod_list):
         """
         Return a map, e.g.
             {
@@ -250,7 +250,10 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         that can be used to add pod tags to associated volume metrics
         """
         pod_tags_by_pvc = defaultdict(set)
-        for pod in pods['items']:
+        if pod_list is None:
+            return pod_tags_by_pvc
+        pods = pod_list.get('items', [])
+        for pod in pods:
             # get kubernetes namespace of PVC
             kube_ns = pod.get('metadata', {}).get('namespace')
             if not kube_ns:

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import sys
+from collections import defaultdict
 from datetime import datetime
 
 import mock
@@ -1114,3 +1115,8 @@ def test_create_pod_tags_by_pvc(monkeypatch, tagger):
         },
     }
     assert pod_tags_by_pvc == expected_result
+
+    # Test None case
+    empty = defaultdict(set)
+    pod_tags_by_pvc = check._create_pod_tags_by_pvc(None)
+    assert pod_tags_by_pvc == empty


### PR DESCRIPTION
### What does this PR do?
Fix issue where retrieved pod_list is occasionally `None`, leading to a `TypeError` when attempting to loop through the variable.

### Motivation
Prevent an ERROR log

### Additional Notes

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have `changelog/` and `integration/` labels attached
