### PR TITLE
Return empty array instead of None

### DIFF
--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -258,7 +258,7 @@ class AerospikeCheck(AgentCheck):
             self.log.warning("Command `%s` was unsuccessful: %s", command, str(e))
             return []
         # Get rid of command and whitespace
-        data = data[len(command):].strip()
+        data = data[len(command) :].strip()
 
         if not separator:
             return data

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -169,18 +169,16 @@ class AerospikeCheck(AgentCheck):
         self.service_check(SERVICE_CHECK_UP, self.OK, tags=self._tags)
 
     def collect_version(self):
-        raw_version = self.get_info("build")[0]
-        self.submit_version_metadata(raw_version)
-
         try:
+            raw_version = self.get_info("build")[0]
+            self.submit_version_metadata(raw_version)
             parse_version = raw_version.split('.')
             version = tuple(int(p) for p in parse_version)
+            self.log.debug("Found Aerospike version: %s", version)
+            return version
         except Exception as e:
             self.log.debug("Unable to parse version: %s", str(e))
             return None
-
-        self.log.debug("Found Aerospike version: %s", version)
-        return version
 
     @AgentCheck.metadata_entrypoint
     def submit_version_metadata(self, version):

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 
 import re
 from collections import defaultdict
+from typing import List
 
 from six import iteritems
 
@@ -241,6 +242,7 @@ class AerospikeCheck(AgentCheck):
             return client
 
     def get_info(self, command, separator=';'):
+        # type: (str, str) -> List[str]
         # See https://www.aerospike.com/docs/reference/info/
         # Example output: command\tKEY=VALUE;KEY=VALUE;...
         try:
@@ -254,9 +256,9 @@ class AerospikeCheck(AgentCheck):
             )
         except Exception as e:
             self.log.warning("Command `%s` was unsuccessful: %s", command, str(e))
-            return
+            return []
         # Get rid of command and whitespace
-        data = data[len(command) :].strip()
+        data = data[len(command):].strip()
 
         if not separator:
             return data

--- a/aerospike/tox.ini
+++ b/aerospike/tox.ini
@@ -13,6 +13,11 @@ envdir =
 description =
     py{27,38}: e2e ready
 dd_check_style = true
+dd_check_types = true
+dd_mypy_args =
+    --py2
+    --follow-imports silent
+    datadog_checks/aerospike
 usedevelop = true
 platform = linux|darwin
 deps =


### PR DESCRIPTION
Fixes:
```
tests/test_aerospike.py:35: in test_version_metadata
    check.check(None)
datadog_checks/aerospike/aerospike.py:116: in check
    self.collect_info('statistics', CLUSTER_METRIC_TYPE, required_keys=self._metrics, tags=self._tags)
datadog_checks/aerospike/aerospike.py:193: in collect_info
    for entry in entries:
E   TypeError: 'NoneType' object is not iterable
```
And
```
tests/test_aerospike.py:35: in test_version_metadata
    check.check(None)
datadog_checks/aerospike/aerospike.py:148: in check
    version = self.collect_version()
datadog_checks/aerospike/aerospike.py:172: in collect_version
    raw_version = self.get_info("build")[0]
E   IndexError: list index out of range
```

Raised an internal issue to fix the underlying flakeyness