### PR TITLE
Try to reduce cassandra flakeyness

### DIFF
--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -29,7 +29,9 @@ def dd_environment():
     env['CONTAINER_PORT'] = common.PORT
 
     with docker_run(
-        compose_file, service_name=common.CASSANDRA_CONTAINER_NAME, log_patterns=['Listening for thrift clients']
+            compose_file,
+            service_name=common.CASSANDRA_CONTAINER_NAME,
+            log_patterns=['Listening for thrift clients', 'Handshaking version', 'All sessions completed']
     ):
         cassandra_seed = get_container_ip("{}".format(common.CASSANDRA_CONTAINER_NAME))
         env['CASSANDRA_SEEDS'] = cassandra_seed


### PR DESCRIPTION
Starting with recent Cassandra versions, replication takes some time to warm up so we are already retrying in the test but seems it's not enough.