### PR TITLE
Add support for Kubernetes leader election based on Lease objects

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/__init__.py
@@ -4,6 +4,6 @@
 
 from .base_check import KubeLeaderElectionBaseCheck
 from .mixins import KubeLeaderElectionMixin
-from .record import ElectionRecord
+from .record import ElectionRecordAnnotation, ElectionRecordLease
 
-__all__ = ['KubeLeaderElectionMixin', 'ElectionRecord', 'KubeLeaderElectionBaseCheck']
+__all__ = ['KubeLeaderElectionMixin', 'ElectionRecordAnnotation', 'ElectionRecordLease', 'KubeLeaderElectionBaseCheck']

--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/record.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/record.py
@@ -42,8 +42,9 @@ REQUIRED_FIELDS = [
 
 
 class ElectionRecordAnnotation(ElectionRecord):
-    def __init__(self, record_string):
+    def __init__(self, record_kind, record_string):
         super(ElectionRecordAnnotation, self).__init__()
+        self._kind = record_kind
         self._record = json.loads(record_string)
 
     def validate(self):
@@ -95,6 +96,10 @@ class ElectionRecordAnnotation(ElectionRecord):
     def transitions(self):
         return self._record.get("leaderTransitions", 0)
 
+    @property
+    def kind(self):
+        return self._kind
+
 
 class ElectionRecordLease(ElectionRecord):
     def __init__(self, lease):
@@ -123,3 +128,7 @@ class ElectionRecordLease(ElectionRecord):
     @property
     def transitions(self):
         return self._lease.lease_transitions
+
+    @property
+    def kind(self):
+        return "lease"

--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/record.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/record.py
@@ -5,6 +5,28 @@
 import json
 from datetime import datetime
 
+from kubernetes.client.models.v1_lease_spec import V1LeaseSpec
+
+
+class ElectionRecord(object):
+    def __init__(self):
+        super(ElectionRecord, self).__init__()
+
+    @property
+    def seconds_until_renew(self):
+        """
+        Returns the number of seconds between the current time
+        and the set renew time. It can be negative if the
+        leader election is running late.
+        """
+        delta = self.renew_time - datetime.now(self.renew_time.tzinfo)
+        return delta.total_seconds()
+
+    @property
+    def summary(self):
+        return "Leader: {} since {}, next renew {}".format(self.leader_name, self.acquire_time, self.renew_time)
+
+
 # Import lazily to reduce memory footprint
 parse_rfc3339 = None
 
@@ -19,8 +41,9 @@ REQUIRED_FIELDS = [
 ]
 
 
-class ElectionRecord(object):
+class ElectionRecordAnnotation(ElectionRecord):
     def __init__(self, record_string):
+        super(ElectionRecordAnnotation, self).__init__()
         self._record = json.loads(record_string)
 
     def validate(self):
@@ -72,16 +95,31 @@ class ElectionRecord(object):
     def transitions(self):
         return self._record.get("leaderTransitions", 0)
 
-    @property
-    def seconds_until_renew(self):
-        """
-        Returns the number of seconds between the current time
-        and the set renew time. It can be negative if the
-        leader election is running late.
-        """
-        delta = self.renew_time - datetime.now(self.renew_time.tzinfo)
-        return delta.total_seconds()
+
+class ElectionRecordLease(ElectionRecord):
+    def __init__(self, lease):
+        super(ElectionRecordLease, self).__init__()
+        self._lease = lease.spec
+
+    def validate(self):
+        return isinstance(self._lease, V1LeaseSpec), None
 
     @property
-    def summary(self):
-        return "Leader: {} since {}, next renew {}".format(self.leader_name, self.acquire_time, self.renew_time)
+    def leader_name(self):
+        return self._lease.holder_identity
+
+    @property
+    def lease_duration(self):
+        return self._lease.lease_duration_seconds
+
+    @property
+    def renew_time(self):
+        return self._lease.renew_time
+
+    @property
+    def acquire_time(self):
+        return self._lease.acquire_time
+
+    @property
+    def transitions(self):
+        return self._lease.lease_transitions

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -26,7 +26,7 @@ jpype1==0.7.1; python_version <= "2.7"
 jpype1==1.2.1; python_version > "3"
 kafka-python==2.0.2
 kazoo==2.6.1
-kubernetes==8.0.1
+kubernetes==12.0.1
 ldap3==2.5
 lxml==4.6.2
 lz4==2.2.1

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -6,7 +6,7 @@ cryptography==3.3.1
 ddtrace==0.32.2
 enum34==1.1.6; python_version < '3.0'
 ipaddress==1.0.22; python_version < '3.0'
-kubernetes==8.0.1
+kubernetes==12.0.1
 mmh3==2.5.1
 orjson==2.6.1; python_version > '3.0'
 prometheus-client==0.9.0

--- a/datadog_checks_base/tests/test_kube_leader.py
+++ b/datadog_checks_base/tests/test_kube_leader.py
@@ -7,11 +7,13 @@ from datetime import datetime, timedelta
 
 import mock
 import pytest
+from kubernetes.client.models.v1_lease import V1Lease
+from kubernetes.client.models.v1_lease_spec import V1LeaseSpec
 from kubernetes.config.dateutil import format_rfc3339
 from six import iteritems, string_types
 
 from datadog_checks.base import AgentCheck, KubeLeaderElectionBaseCheck
-from datadog_checks.base.checks.kube_leader import ElectionRecord
+from datadog_checks.base.checks.kube_leader import ElectionRecordAnnotation, ElectionRecordLease
 
 # Trigger lazy imports
 try:
@@ -26,6 +28,18 @@ RAW_VALID_RECORD = (
     '"acquireTime":"2018-12-17T11:53:07Z",'
     '"renewTime":"2018-12-18T12:32:22Z",'
     '"leaderTransitions":7}'
+)
+
+LEASE_OBJECT = V1Lease(
+    api_version="coordination.k8s.io/v1",
+    kind="Lease",
+    spec=V1LeaseSpec(
+        acquire_time=datetime(2021, 2, 4, 8, 23, 33),
+        holder_identity="ip-172-20-76-27_fa8a18f2-9c8a-42e8-99ff-2e759d623d0e",
+        lease_duration_seconds=15,
+        lease_transitions=42,
+        renew_time=datetime(2021, 2, 4, 15, 51, 10),
+    ),
 )
 
 EP_INSTANCE = {
@@ -103,8 +117,8 @@ def make_fake_object(record=None):
 
 
 class TestElectionRecord:
-    def test_parse_raw(self):
-        record = ElectionRecord(RAW_VALID_RECORD)
+    def test_parse_annotation(self):
+        record = ElectionRecordAnnotation(RAW_VALID_RECORD)
 
         valid, reason = record.validate()
         assert valid is True
@@ -119,6 +133,24 @@ class TestElectionRecord:
             "Leader: dd-cluster-agent-568f458dd6-kj6vt "
             "since 2018-12-17 11:53:07+00:00, "
             "next renew 2018-12-18 12:32:22+00:00"
+        )
+
+    def test_parse_lease(self):
+        record = ElectionRecordLease(LEASE_OBJECT)
+
+        valid, reason = record.validate()
+        assert valid is True
+        assert reason is None
+
+        assert record.leader_name == "ip-172-20-76-27_fa8a18f2-9c8a-42e8-99ff-2e759d623d0e"
+        assert record.lease_duration == 15
+        assert record.transitions == 42
+        assert record.renew_time > record.acquire_time
+        assert record.seconds_until_renew < 0
+        assert record.summary == (
+            "Leader: ip-172-20-76-27_fa8a18f2-9c8a-42e8-99ff-2e759d623d0e "
+            "since 2021-02-04 08:23:33, "
+            "next renew 2021-02-04 15:51:10"
         )
 
     def test_validation(self):
@@ -139,7 +171,7 @@ class TestElectionRecord:
         }
 
         for raw, expected_reason in iteritems(cases):
-            valid, reason = ElectionRecord(raw).validate()
+            valid, reason = ElectionRecordAnnotation(raw).validate()
             assert reason == expected_reason
             if expected_reason is None:
                 assert valid is True
@@ -151,7 +183,7 @@ class TestElectionRecord:
             holder="me", duration=30, acquire="2018-12-18T12:32:22Z", renew=datetime.utcnow() + timedelta(seconds=20)
         )
 
-        record = ElectionRecord(raw)
+        record = ElectionRecordAnnotation(raw)
         assert record.seconds_until_renew > 19
         assert record.seconds_until_renew < 21
 
@@ -159,7 +191,7 @@ class TestElectionRecord:
             holder="me", duration=30, acquire="2018-12-18T12:32:22Z", renew=datetime.utcnow() - timedelta(seconds=5)
         )
 
-        record = ElectionRecord(raw)
+        record = ElectionRecordAnnotation(raw)
         assert record.seconds_until_renew > -6
         assert record.seconds_until_renew < -4
 

--- a/datadog_checks_base/tests/test_kube_leader.py
+++ b/datadog_checks_base/tests/test_kube_leader.py
@@ -118,7 +118,7 @@ def make_fake_object(record=None):
 
 class TestElectionRecord:
     def test_parse_annotation(self):
-        record = ElectionRecordAnnotation(RAW_VALID_RECORD)
+        record = ElectionRecordAnnotation("endpoints", RAW_VALID_RECORD)
 
         valid, reason = record.validate()
         assert valid is True
@@ -171,7 +171,7 @@ class TestElectionRecord:
         }
 
         for raw, expected_reason in iteritems(cases):
-            valid, reason = ElectionRecordAnnotation(raw).validate()
+            valid, reason = ElectionRecordAnnotation("endpoints", raw).validate()
             assert reason == expected_reason
             if expected_reason is None:
                 assert valid is True
@@ -183,7 +183,7 @@ class TestElectionRecord:
             holder="me", duration=30, acquire="2018-12-18T12:32:22Z", renew=datetime.utcnow() + timedelta(seconds=20)
         )
 
-        record = ElectionRecordAnnotation(raw)
+        record = ElectionRecordAnnotation("endpoints", raw)
         assert record.seconds_until_renew > 19
         assert record.seconds_until_renew < 21
 
@@ -191,7 +191,7 @@ class TestElectionRecord:
             holder="me", duration=30, acquire="2018-12-18T12:32:22Z", renew=datetime.utcnow() - timedelta(seconds=5)
         )
 
-        record = ElectionRecordAnnotation(raw)
+        record = ElectionRecordAnnotation("endpoints", raw)
         assert record.seconds_until_renew > -6
         assert record.seconds_until_renew < -4
 

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
@@ -16,9 +16,18 @@ instances:
     #   - <KEY_2>:<VALUE_2>
 
     ## @param leader_election - boolean - optional - default: true
-    ## Monitor the leader-election process on the kube-system:kube-controller-manager endpoints
+    ## Monitor the leader-election process on the kube-system:kube-controller-manager.
     #
     # leader_election: true
+
+    ## @param leader_election_kind - string - optional - default: endpoints
+    ## Kind of object to look at for the leader election.
+    ## Can be:
+    ##   * lease
+    ##   * endpoints
+    ##   * configmap
+    #
+    # leader_election_kind: endpoints
 
     ## @param prometheus_timeout - integer - optional - default: 10
     ## Overrides the default timeout value in second

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
@@ -20,14 +20,16 @@ instances:
     #
     # leader_election: true
 
-    ## @param leader_election_kind - string - optional - default: endpoints
+    ## @param leader_election_kind - string - optional - default: auto
     ## Kind of object to look at for the leader election.
     ## Can be:
+    ##   * auto
     ##   * lease
     ##   * endpoints
     ##   * configmap
+    ## auto makes the check try lease first and fallback to endpoints if lease isn't available
     #
-    # leader_election_kind: endpoints
+    # leader_election_kind: auto
 
     ## @param prometheus_timeout - integer - optional - default: 10
     ## Overrides the default timeout value in second

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
@@ -151,6 +151,7 @@ class KubeControllerManagerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
         if is_affirmative(instance.get('leader_election', True)):
             leader_config = self.LEADER_ELECTION_CONFIG
             leader_config["tags"] = instance.get("tags", [])
+            leader_config["record_kind"] = instance.get('leader_election_kind', 'endpoints')
             self.check_election_status(leader_config)
 
     def _ignore_deprecated_metric(self, metric, scraper_config):

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
@@ -151,7 +151,7 @@ class KubeControllerManagerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
         if is_affirmative(instance.get('leader_election', True)):
             leader_config = self.LEADER_ELECTION_CONFIG
             leader_config["tags"] = instance.get("tags", [])
-            leader_config["record_kind"] = instance.get('leader_election_kind', 'endpoints')
+            leader_config["record_kind"] = instance.get('leader_election_kind', 'auto')
             self.check_election_status(leader_config)
 
     def _ignore_deprecated_metric(self, metric, scraper_config):

--- a/kube_controller_manager/tests/test_kube_controller_manager.py
+++ b/kube_controller_manager/tests/test_kube_controller_manager.py
@@ -7,7 +7,7 @@ import os
 import mock
 import pytest
 
-from datadog_checks.base.checks.kube_leader import ElectionRecord
+from datadog_checks.base.checks.kube_leader import ElectionRecordAnnotation
 from datadog_checks.kube_controller_manager import KubeControllerManagerCheck
 
 instance = {
@@ -48,7 +48,7 @@ def mock_leader():
     # Inject a fake object in the leader-election monitoring logic
     with mock.patch(
         'datadog_checks.kube_controller_manager.KubeControllerManagerCheck._get_record',
-        return_value=ElectionRecord(
+        return_value=ElectionRecordAnnotation(
             '{"holderIdentity":"pod1","leaseDurationSeconds":15,"leaderTransitions":3,'
             + '"acquireTime":"2018-12-19T18:23:24Z","renewTime":"2019-01-02T16:30:07Z"}'
         ),

--- a/kube_controller_manager/tests/test_kube_controller_manager.py
+++ b/kube_controller_manager/tests/test_kube_controller_manager.py
@@ -49,8 +49,9 @@ def mock_leader():
     with mock.patch(
         'datadog_checks.kube_controller_manager.KubeControllerManagerCheck._get_record',
         return_value=ElectionRecordAnnotation(
+            "endpoints",
             '{"holderIdentity":"pod1","leaseDurationSeconds":15,"leaderTransitions":3,'
-            + '"acquireTime":"2018-12-19T18:23:24Z","renewTime":"2019-01-02T16:30:07Z"}'
+            + '"acquireTime":"2018-12-19T18:23:24Z","renewTime":"2019-01-02T16:30:07Z"}',
         ),
     ):
         yield

--- a/kube_scheduler/assets/configuration/spec.yaml
+++ b/kube_scheduler/assets/configuration/spec.yaml
@@ -9,10 +9,20 @@ files:
     options:
     - name: leader_election
       description: |
-        Monitor the leader-election process on the kube-system:kube-scheduler endpoints.
+        Monitor the leader-election process on the kube-system:kube-scheduler.
       value:
         type: boolean
         example: true
+    - name: leader_election_kind
+      description: |
+        Kind of object to look at for the leader election.
+        Can be:
+          * lease
+          * endpoints
+          * configmap
+      value:
+        type: string
+        example: endpoints
     - template: instances/openmetrics_legacy
       overrides:
         prometheus_url.value.example: http://localhost:10251/metrics

--- a/kube_scheduler/assets/configuration/spec.yaml
+++ b/kube_scheduler/assets/configuration/spec.yaml
@@ -17,12 +17,14 @@ files:
       description: |
         Kind of object to look at for the leader election.
         Can be:
+          * auto
           * lease
           * endpoints
           * configmap
+        auto makes the check try lease first and fallback to endpoints if lease isn't available
       value:
         type: string
-        example: endpoints
+        example: auto
     - template: instances/openmetrics_legacy
       overrides:
         prometheus_url.value.example: http://localhost:10251/metrics

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -51,9 +51,18 @@ instances:
   - prometheus_url: http://localhost:10251/metrics
 
     ## @param leader_election - boolean - optional - default: true
-    ## Monitor the leader-election process on the kube-system:kube-scheduler endpoints.
+    ## Monitor the leader-election process on the kube-system:kube-scheduler.
     #
     # leader_election: true
+
+    ## @param leader_election_kind - string - optional - default: endpoints
+    ## Kind of object to look at for the leader election.
+    ## Can be:
+    ##   * lease
+    ##   * endpoints
+    ##   * configmap
+    #
+    # leader_election_kind: endpoints
 
     ## @param prometheus_metrics_prefix - string - optional
     ## Removes a given <PREFIX> from exposed Prometheus metrics.

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -55,14 +55,16 @@ instances:
     #
     # leader_election: true
 
-    ## @param leader_election_kind - string - optional - default: endpoints
+    ## @param leader_election_kind - string - optional - default: auto
     ## Kind of object to look at for the leader election.
     ## Can be:
+    ##   * auto
     ##   * lease
     ##   * endpoints
     ##   * configmap
+    ## auto makes the check try lease first and fallback to endpoints if lease isn't available
     #
-    # leader_election_kind: endpoints
+    # leader_election_kind: auto
 
     ## @param prometheus_metrics_prefix - string - optional
     ## Removes a given <PREFIX> from exposed Prometheus metrics.

--- a/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
@@ -141,4 +141,5 @@ class KubeSchedulerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
         if is_affirmative(instance.get('leader_election', True)):
             leader_config = self.LEADER_ELECTION_CONFIG
             leader_config["tags"] = instance.get("tags", [])
+            leader_config["record_kind"] = instance.get('leader_election_kind', 'endpoints')
             self.check_election_status(leader_config)

--- a/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
@@ -141,5 +141,5 @@ class KubeSchedulerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
         if is_affirmative(instance.get('leader_election', True)):
             leader_config = self.LEADER_ELECTION_CONFIG
             leader_config["tags"] = instance.get("tags", [])
-            leader_config["record_kind"] = instance.get('leader_election_kind', 'endpoints')
+            leader_config["record_kind"] = instance.get('leader_election_kind', 'auto')
             self.check_election_status(leader_config)

--- a/kube_scheduler/tests/test_kube_scheduler_1_13.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_13.py
@@ -7,7 +7,7 @@ import os
 import mock
 import pytest
 
-from datadog_checks.base.checks.kube_leader import ElectionRecord
+from datadog_checks.base.checks.kube_leader import ElectionRecordAnnotation
 from datadog_checks.kube_scheduler import KubeSchedulerCheck
 
 instance = {'prometheus_url': 'http://localhost:10251/metrics', 'send_histograms_buckets': True}
@@ -37,7 +37,7 @@ def mock_leader():
     # don't forget to update the [testenv] in tox.ini with the 'kube' dependency
     with mock.patch(
         'datadog_checks.kube_scheduler.KubeSchedulerCheck._get_record',
-        return_value=ElectionRecord(
+        return_value=ElectionRecordAnnotation(
             '{"holderIdentity":"pod1","leaseDurationSeconds":15,"leaderTransitions":3,'
             + '"acquireTime":"2018-12-19T18:23:24Z","renewTime":"2019-01-02T16:30:07Z"}'
         ),

--- a/kube_scheduler/tests/test_kube_scheduler_1_13.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_13.py
@@ -38,8 +38,9 @@ def mock_leader():
     with mock.patch(
         'datadog_checks.kube_scheduler.KubeSchedulerCheck._get_record',
         return_value=ElectionRecordAnnotation(
+            "endpoints",
             '{"holderIdentity":"pod1","leaseDurationSeconds":15,"leaderTransitions":3,'
-            + '"acquireTime":"2018-12-19T18:23:24Z","renewTime":"2019-01-02T16:30:07Z"}'
+            + '"acquireTime":"2018-12-19T18:23:24Z","renewTime":"2019-01-02T16:30:07Z"}',
         ),
     ):
         yield

--- a/kube_scheduler/tests/test_kube_scheduler_1_14.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_14.py
@@ -7,7 +7,7 @@ import os
 import mock
 import pytest
 
-from datadog_checks.base.checks.kube_leader import ElectionRecord
+from datadog_checks.base.checks.kube_leader import ElectionRecordAnnotation
 from datadog_checks.kube_scheduler import KubeSchedulerCheck
 
 instance = {'prometheus_url': 'http://localhost:10251/metrics', 'send_histograms_buckets': True}
@@ -37,7 +37,7 @@ def mock_leader():
     # don't forget to update the [testenv] in tox.ini with the 'kube' dependency
     with mock.patch(
         'datadog_checks.kube_scheduler.KubeSchedulerCheck._get_record',
-        return_value=ElectionRecord(
+        return_value=ElectionRecordAnnotation(
             '{"holderIdentity":"pod1","leaseDurationSeconds":15,"leaderTransitions":3,'
             + '"acquireTime":"2018-12-19T18:23:24Z","renewTime":"2019-01-02T16:30:07Z"}'
         ),

--- a/kube_scheduler/tests/test_kube_scheduler_1_14.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_14.py
@@ -38,8 +38,9 @@ def mock_leader():
     with mock.patch(
         'datadog_checks.kube_scheduler.KubeSchedulerCheck._get_record',
         return_value=ElectionRecordAnnotation(
+            "endpoints",
             '{"holderIdentity":"pod1","leaseDurationSeconds":15,"leaderTransitions":3,'
-            + '"acquireTime":"2018-12-19T18:23:24Z","renewTime":"2019-01-02T16:30:07Z"}'
+            + '"acquireTime":"2018-12-19T18:23:24Z","renewTime":"2019-01-02T16:30:07Z"}',
         ),
     ):
         yield


### PR DESCRIPTION
### What does this PR do?

Add support for Kubernetes leader election based on Lease objects.

### Motivation

Historically, the Kubernetes control plane components were coordinating themselves to elect a leader via annotations on an `EndPoints` object.
There is now a dedicated object for that purpose: the `Lease` object.

The checks that are detecting which pod is a leader need to be adapted accordingly.

### Additional Notes

This change requires new permissions for the agent:
* DataDog/helm-charts#160
* DataDog/datadog-operator#219

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
