### PR TITLE
Fix `oneOf` in config specs

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/spec.py
@@ -400,7 +400,7 @@ def value_validator(value, loader, file_name, sections_display, option_name, dep
                 )
                 return
 
-            value_validator(type_data, loader, file_name, sections_display, option_name)
+            value_validator(type_data, loader, file_name, sections_display, option_name, depth=depth + 1)
 
         if not depth:
             value['example'] = default_option_example(option_name)


### PR DESCRIPTION
### What does this PR do?

Properly require `example` only at the top level