### PR TITLE
Normalize links in docs validator for nested sections

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/core.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/core.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import re
+from collections import deque
 
 import markdown
 from markdown.blockprocessors import ReferenceProcessor
@@ -39,8 +40,16 @@ class DocsSpec(BaseSpec):
         # Markdown doc reference: https://www.markdownguide.org/basic-syntax/#links
 
         for fidx, file in enumerate(self.data['files'], 1):
-            for sidx, section in enumerate(file['sections'], 1):
+            sections = deque(enumerate(file['sections'], 1))
+            while sections:
+                sidx, section = sections.popleft()
                 section['description'] = self._normalize(section['description'], fidx, sidx)
+                if 'sections' in section:
+                    nested_sections = [
+                        (f'{sidx}.{subidx}', subsection) for subidx, subsection in enumerate(section['sections'], 1)
+                    ]
+                    # extend left backwards for correct order of sections
+                    sections.extendleft(nested_sections[::-1])
 
     def _normalize(self, text, fidx, sidx):
         # use the markdown internal processor class to extract all references into a dict

--- a/datadog_checks_dev/tests/tooling/docs/test_load.py
+++ b/datadog_checks_dev/tests/tooling/docs/test_load.py
@@ -562,12 +562,12 @@ def test_sections_link(_):
             description: |
                 [link][1]
 
-                [1]: google.com
+                [1]: datadoghq.com
         """
     )
     doc.load()
-    expected_description = '[link](google.com)'
-    assert doc.data['files'][0]['sections'][0]['description'] == '[link](google.com)'
+    expected_description = '[link](datadoghq.com)'
+    assert doc.data['files'][0]['sections'][0]['description'] == expected_description
 
 
 @mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
@@ -584,16 +584,16 @@ def test_nested_sections_link(_):
             description: |
                 [link][1]
 
-                [1]: google.com
+                [1]: datadoghq.com
             sections:
             - name: bar
               header_level: 1
               description: |
                 [link][1]
 
-                [1]: google.com
+                [1]: datadoghq.com
         """
     )
     doc.load()
-    expected_description = '[link](google.com)'
-    assert doc.data['files'][0]['sections'][0]['sections'][0]['description'] == '[link](google.com)'
+    expected_description = '[link](datadoghq.com)'
+    assert doc.data['files'][0]['sections'][0]['sections'][0]['description'] == expected_description

--- a/datadog_checks_dev/tests/tooling/docs/test_load.py
+++ b/datadog_checks_dev/tests/tooling/docs/test_load.py
@@ -546,3 +546,54 @@ def test_bar_valid(_):
     doc.load()
 
     assert not doc.errors
+
+
+@mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
+def test_sections_link(_):
+
+    doc = get_doc(
+        """
+        name: foo
+        files:
+        - name: README.md
+          sections:
+          - name: foo
+            header_level: 1
+            description: |
+                [link][1]
+
+                [1]: google.com
+        """
+    )
+    doc.load()
+    expected_description = '[link](google.com)'
+    assert doc.data['files'][0]['sections'][0]['description'] == '[link](google.com)'
+
+
+@mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
+def test_nested_sections_link(_):
+
+    doc = get_doc(
+        """
+        name: foo
+        files:
+        - name: README.md
+          sections:
+          - name: foo
+            header_level: 1
+            description: |
+                [link][1]
+
+                [1]: google.com
+            sections:
+            - name: bar
+              header_level: 1
+              description: |
+                [link][1]
+
+                [1]: google.com
+        """
+    )
+    doc.load()
+    expected_description = '[link](google.com)'
+    assert doc.data['files'][0]['sections'][0]['sections'][0]['description'] == '[link](google.com)'

--- a/datadog_checks_dev/tests/tooling/docs/test_load.py
+++ b/datadog_checks_dev/tests/tooling/docs/test_load.py
@@ -589,11 +589,13 @@ def test_nested_sections_link(_):
             - name: bar
               header_level: 1
               description: |
-                [link][1]
+                [foo][1]
 
-                [1]: datadoghq.com
+                [1]: foo.bar
         """
     )
     doc.load()
     expected_description = '[link](datadoghq.com)'
-    assert doc.data['files'][0]['sections'][0]['sections'][0]['description'] == expected_description
+    expected_nested_description = '[foo](foo.bar)'
+    assert doc.data['files'][0]['sections'][0]['description'] == expected_description
+    assert doc.data['files'][0]['sections'][0]['sections'][0]['description'] == expected_nested_description


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Handles the case when there are nested sections with links in the `description` tab.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
