### PR TITLE
Implement append and prepend options for docs validator

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
@@ -62,12 +62,19 @@ def process_links(section, links):
 
 def write_section(section, writer):
     header = '{} {}'.format('#' * section['header_level'], section['name'])
-
+    prepend_text = section['prepend_text']
     description = section['description']
+    append_text = section['append_text']
 
     writer.write(header)
     writer.write('\n\n')
+    if prepend_text:
+        writer.write(prepend_text)
+        writer.write('\n\n')
     writer.write(description)
+    if append_text:
+        writer.write('\n\n')
+        writer.write(append_text)
     writer.write('\n')
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/core.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/core.py
@@ -43,7 +43,9 @@ class DocsSpec(BaseSpec):
             sections = deque(enumerate(file['sections'], 1))
             while sections:
                 sidx, section = sections.popleft()
+                section['prepend_text'] = self._normalize(section['prepend_text'], fidx, sidx)
                 section['description'] = self._normalize(section['description'], fidx, sidx)
+                section['append_text'] = self._normalize(section['append_text'], fidx, sidx)
                 if 'sections' in section:
                     nested_sections = [
                         (f'{sidx}.{subidx}', subsection) for subidx, subsection in enumerate(section['sections'], 1)

--- a/datadog_checks_dev/tests/tooling/docs/test_load.py
+++ b/datadog_checks_dev/tests/tooling/docs/test_load.py
@@ -640,6 +640,82 @@ def test_sections_prepend(_):
 
 
 @mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
+def test_sections_append_link(_):
+
+    doc = get_doc(
+        """
+        name: foo
+        files:
+        - name: README.md
+          sections:
+          - name: foo
+            header_level: 1
+            description: words
+            append_text: |
+                [link][1]
+
+                [1]: datadoghq.com
+        """
+    )
+    doc.load()
+    assert doc.data['files'][0]['sections'][0]['append_text'] == '[link](datadoghq.com)'
+
+
+@mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
+def test_sections_append_link(_):
+
+    doc = get_doc(
+        """
+        name: foo
+        files:
+        - name: README.md
+          sections:
+          - name: foo
+            header_level: 1
+            description: words
+            prepend_text: |
+                [link][1]
+
+                [1]: datadoghq.com
+        """
+    )
+    doc.load()
+    assert doc.data['files'][0]['sections'][0]['prepend_text'] == '[link](datadoghq.com)'
+
+
+@mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
+def test_sections_append_prepend_links(_):
+
+    doc = get_doc(
+        """
+        name: foo
+        files:
+        - name: README.md
+          sections:
+          - name: foo
+            header_level: 1
+            description: |
+                [description][1]
+
+                [1]: foo.com
+            prepend_text: |
+                [prepend][1]
+
+                [1]: bar.com
+            append_text: |
+                [append][1]
+
+                [1]: baz.com
+
+        """
+    )
+    doc.load()
+    assert doc.data['files'][0]['sections'][0]['prepend_text'] == '[prepend](bar.com)'
+    assert doc.data['files'][0]['sections'][0]['description'] == '[description](foo.com)'
+    assert doc.data['files'][0]['sections'][0]['append_text'] == '[append](baz.com)'
+
+
+@mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
 def test_sections_prepend_append_empty(_):
 
     doc = get_doc(

--- a/datadog_checks_dev/tests/tooling/docs/test_load.py
+++ b/datadog_checks_dev/tests/tooling/docs/test_load.py
@@ -637,3 +637,22 @@ def test_sections_prepend(_):
     )
     doc.load()
     assert doc.data['files'][0]['sections'][0]['prepend_text'] == "prepend"
+
+
+@mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
+def test_sections_prepend_append_empty(_):
+
+    doc = get_doc(
+        """
+        name: foo
+        files:
+        - name: README.md
+          sections:
+          - name: foo
+            header_level: 1
+            description: words
+        """
+    )
+    doc.load()
+    assert doc.data['files'][0]['sections'][0]['prepend_text'] == ""
+    assert doc.data['files'][0]['sections'][0]['append_text'] == ""

--- a/datadog_checks_dev/tests/tooling/docs/test_load.py
+++ b/datadog_checks_dev/tests/tooling/docs/test_load.py
@@ -662,7 +662,7 @@ def test_sections_append_link(_):
 
 
 @mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
-def test_sections_append_link(_):
+def test_sections_prepend_link(_):
 
     doc = get_doc(
         """

--- a/datadog_checks_dev/tests/tooling/docs/test_load.py
+++ b/datadog_checks_dev/tests/tooling/docs/test_load.py
@@ -599,3 +599,41 @@ def test_nested_sections_link(_):
     expected_nested_description = '[foo](foo.bar)'
     assert doc.data['files'][0]['sections'][0]['description'] == expected_description
     assert doc.data['files'][0]['sections'][0]['sections'][0]['description'] == expected_nested_description
+
+
+@mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
+def test_sections_append(_):
+
+    doc = get_doc(
+        """
+        name: foo
+        files:
+        - name: README.md
+          sections:
+          - name: foo
+            header_level: 1
+            description: words
+            append_text: append
+        """
+    )
+    doc.load()
+    assert doc.data['files'][0]['sections'][0]['append_text'] == "append"
+
+
+@mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
+def test_sections_prepend(_):
+
+    doc = get_doc(
+        """
+        name: foo
+        files:
+        - name: README.md
+          sections:
+          - name: foo
+            header_level: 1
+            prepend_text: prepend
+            description: words
+        """
+    )
+    doc.load()
+    assert doc.data['files'][0]['sections'][0]['prepend_text'] == "prepend"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Implements the functionality for the `prepend_section` and `append_section` options in docs validator. Validates these sections as well as adds them to the output document. 
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
These two options are useful for overrides in templates. It allows you to use a commonly used template for different sections of our integrations docs but allows you to add specific remarks before and after the template without having to override the description. Additionally, if we modify the way we do something (eg. installation) the template for installation can be modified and would be reflected on all integrations that use the template, making it more scalable.

#### Example
`spec.yaml`
```
name: Nginx
files:
  - name: README.md
    sections:
      - template: overview
        overrides:
          prepend_text: This is prepended text.
          append_text: This is appended text.
```
`README.md`

![image](https://user-images.githubusercontent.com/39505100/107055846-53e26280-6797-11eb-9d2f-0065b704ba4e.png)


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
