### PR TITLE
Include validate_cert in backwards compatibility remapper

### DIFF
--- a/tls/datadog_checks/tls/tls.py
+++ b/tls/datadog_checks/tls/tls.py
@@ -40,6 +40,7 @@ class TLSCheck(AgentCheck):
         'private_key': {'name': 'tls_private_key'},
         'ca_cert': {'name': 'tls_ca_cert'},
         'validate_hostname': {'name': 'tls_validate_hostname'},
+        'validate_cert': {'name': 'tls_verify'},
     }
 
     def __init__(self, name, init_config, instances):

--- a/tls/tests/test_config.py
+++ b/tls/tests/test_config.py
@@ -74,6 +74,7 @@ def test_validation_data():
         pytest.param(
             {'validate_hostname': False}, {'tls_validate_hostname': False}, id='legacy validate_hostname param'
         ),
+        pytest.param({'validate_cert': False}, {'tls_verify': False}, id='legacy validate_cert param'),
     ],
 )
 def test_config(extra_config, expected_http_kwargs):


### PR DESCRIPTION
### What does this PR do?
The `validate_cert` option is not backwards compatible with the tls context remapper.

https://github.com/DataDog/integrations-core/blob/7.23.x/tls/datadog_checks/tls/data/conf.yaml.example#L62-L71

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
