### PR TITLE
Manually release tls to 2.1.1

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -129,7 +129,7 @@ datadog-system-swap==1.10.0
 datadog-tcp-check==2.6.0
 datadog-teamcity==1.12.0
 datadog-tenable==1.3.0
-datadog-tls==2.1.0
+datadog-tls==2.1.1
 datadog-tokumx==2.3.2
 datadog-tomcat==1.6.0
 datadog-twemproxy==1.8.0

--- a/tls/CHANGELOG.md
+++ b/tls/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - TLS
 
+## 2.1.1 / 2021-02-05
+
+* [Fixed] Include validate_cert in backwards compatibility remapper. See [#8543](https://github.com/DataDog/integrations-core/pull/8543).
+
 ## 2.1.0 / 2021-01-28
 
 * [Security] Upgrade cryptography python package. See [#8476](https://github.com/DataDog/integrations-core/pull/8476).

--- a/tls/datadog_checks/tls/__about__.py
+++ b/tls/datadog_checks/tls/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '2.1.0'
+__version__ = '2.1.1'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Manually release TLS check.

### Motivation
<!-- What inspired you to submit this pull request? -->
* Prepare 7.26.0-rc.4
* Manual release bc other unrelated `Added` changes were added in `master` since last 7.26.0 bug fix.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
