### PR TITLE
Fix link referencing for append and prepend

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
@@ -45,19 +45,22 @@ def update_links(link, links):
 
 def process_links(section, links):
     """Extract inline links and replace with references."""
+    # these are the attributes in each section that can contain links
+    text_attributes = ['prepend_text', 'description', 'append_text']
 
-    text = section['description']
+    for attribute in text_attributes:
+        text = section[attribute]
 
-    matches = INLINE_REF.findall(text)
+        matches = INLINE_REF.findall(text)
 
-    for m in matches:
-        lnk = m[1]
-        if lnk not in links:
-            update_links(lnk, links)
+        for m in matches:
+            lnk = m[1]
+            if lnk not in links:
+                update_links(lnk, links)
 
-    # replace (link) with [ref]
-    newtext = INLINE_REF.sub(lambda x: '{}[{}]'.format(x.group(1), links[x.group(2)]), text)
-    section['description'] = newtext
+        # replace (link) with [ref]
+        newtext = INLINE_REF.sub(lambda x: '{}[{}]'.format(x.group(1), links[x.group(2)]), text)
+        section[attribute] = newtext
 
 
 def write_section(section, writer):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixed an issue where links in `prepend_text` and `append_text` were not being converted into references. This meant that something like this:

```
name: integration_id
  files:
    - name: README.md
    sections:
      - name: cool section
        header_level: 1
        prepend_text: |
          [cool link][1]

          [1]: link.com
        description: |
          [another cool link][1]

          [1]: foo.com

```

would generate a `README.md` as such

```

...

# cool section

[cool link][link.com]

[another cool link][1]

[1]: foo.com

```

The fix will process links in `prepend_text` and `append_text` and generate a `README.md` as such.

```

...

# cool section

[cool link][1]

[another cool link][2]

[1]: link.com

[2]: foo.com

```


- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
