### PR TITLE
Fix tabs in readme consumer

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
@@ -105,25 +105,31 @@ class ReadmeConsumer(object):
 
                 sections = deque(file['sections'])
                 tab = None
+                tab_section_end = None
                 while sections:
                     section = sections.popleft()
                     if section['hidden']:
                         continue
 
                     if section['tab']:
-                        if tab is None:
-                            tab = section['tab']
+                        tab = section['tab']
+                        if tab_section_end is None:
+                            # find which section stops having 'tab'
+                            for s in sections:
+                                if not s['tab']:
+                                    tab_section_end = s
+                                    break
                             writer.write(TAB_SECTION_START + '\n')
                         else:
                             writer.write(TAB_END + '\n')
                         writer.write(TAB_START.format(tab) + '\n')
                         writer.write('\n')
 
-                    elif tab is not None:
+                    elif section == tab_section_end:
                         writer.write(TAB_END + '\n')
                         writer.write(TAB_SECTION_END + '\n')
                         writer.write('\n')
-                        tab = None
+                        tab_section_end = None
 
                     process_links(section, links)
                     write_section(section, writer)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/docs/consumers/readme.py
@@ -104,7 +104,6 @@ class ReadmeConsumer(object):
                 writer.write('\n\n')
 
                 sections = deque(file['sections'])
-                tab = None
                 tab_section_end = None
                 while sections:
                     section = sections.popleft()
@@ -119,6 +118,10 @@ class ReadmeConsumer(object):
                                 if not s['tab']:
                                     tab_section_end = s
                                     break
+                            else:
+                                # tabs continue until end of sections
+                                # add a flag to close at end of all sections
+                                tab_section_end = 'EOL'
                             writer.write(TAB_SECTION_START + '\n')
                         else:
                             writer.write(TAB_END + '\n')
@@ -141,6 +144,13 @@ class ReadmeConsumer(object):
                         # eg sections.extendleft([s2.1, s2.2]) updates section to [s2.2, s2.1, s3]
                         # so we need to reverse it for correctness
                         sections.extendleft(section['sections'][::-1])
+
+                # close tabs section if never got closed
+                if tab_section_end:
+                    writer.write(TAB_END + '\n')
+                    writer.write(TAB_SECTION_END + '\n')
+                    writer.write('\n')
+                    tab_section_end = None
 
                 # add link references to the end of document
                 refs = get_references(links)

--- a/datadog_checks_dev/tests/tooling/docs/consumers/__init__.py
+++ b/datadog_checks_dev/tests/tooling/docs/consumers/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/datadog_checks_dev/tests/tooling/docs/consumers/test_readme.py
+++ b/datadog_checks_dev/tests/tooling/docs/consumers/test_readme.py
@@ -4,7 +4,7 @@
 import mock
 import pytest
 
-from ..utils import get_readme_consumer, normalize_yaml, MOCK_RESPONSE
+from ..utils import get_readme_consumer, normalize_readme, MOCK_RESPONSE
 
 pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer]
 
@@ -27,7 +27,7 @@ def test_tab_valid(_):
     files = consumer.render()
     contents, errors = files['README.md']
     assert not errors
-    assert contents == normalize_yaml(
+    assert contents == normalize_readme(
         """
         # Agent Check: foo
 
@@ -67,7 +67,7 @@ def test_tab_multiple(_):
     files = consumer.render()
     contents, errors = files['README.md']
     assert not errors
-    assert contents == normalize_yaml(
+    assert contents == normalize_readme(
         """
         # Agent Check: foo
 
@@ -122,7 +122,7 @@ def test_tab_multiple_nested(_):
     files = consumer.render()
     contents, errors = files['README.md']
     assert not errors
-    assert contents == normalize_yaml(
+    assert contents == normalize_readme(
         """
         # Agent Check: foo
 

--- a/datadog_checks_dev/tests/tooling/docs/consumers/test_readme.py
+++ b/datadog_checks_dev/tests/tooling/docs/consumers/test_readme.py
@@ -1,0 +1,92 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
+import pytest
+
+from ..utils import get_readme_consumer, normalize_yaml, MOCK_RESPONSE
+
+pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer]
+
+
+@mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
+def test_tab_valid(_):
+
+    consumer = get_readme_consumer(
+        """
+        name: foo
+        files:
+        - name: README.md
+          sections:
+          - name: foo
+            header_level: 1
+            description: words
+            tab: bar
+        """
+    )
+    files = consumer.render()
+    contents, errors = files['README.md']
+    assert not errors
+    assert contents == normalize_yaml(
+        """
+        # Agent Check: foo
+
+        <!-- xxx tabs xxx -->
+        <!-- xxx tab "bar" xxx -->
+
+        # foo
+
+        words
+
+        <!-- xxz tab xxx -->
+        <!-- xxz tabs xxx -->
+
+        """
+    )
+
+
+@mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
+def test_tab_multiple(_):
+
+    consumer = get_readme_consumer(
+        """
+        name: foo
+        files:
+        - name: README.md
+          sections:
+          - name: foo
+            header_level: 1
+            description: words
+            tab: bar
+          - name: bar
+            header_level: 1
+            description: words
+            tab: baz
+        """
+    )
+    files = consumer.render()
+    contents, errors = files['README.md']
+    assert not errors
+    assert contents == normalize_yaml(
+        """
+        # Agent Check: foo
+
+        <!-- xxx tabs xxx -->
+        <!-- xxx tab "bar" xxx -->
+
+        # foo
+
+        words
+
+        <!-- xxz tab xxx -->
+        <!-- xxx tab "baz" xxx -->
+
+        # bar
+
+        words
+
+        <!-- xxz tab xxx -->
+        <!-- xxz tabs xxx -->
+
+        """
+    )

--- a/datadog_checks_dev/tests/tooling/docs/consumers/test_readme.py
+++ b/datadog_checks_dev/tests/tooling/docs/consumers/test_readme.py
@@ -4,7 +4,7 @@
 import mock
 import pytest
 
-from ..utils import get_readme_consumer, normalize_readme, MOCK_RESPONSE
+from ..utils import MOCK_RESPONSE, get_readme_consumer, normalize_readme
 
 pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer]
 

--- a/datadog_checks_dev/tests/tooling/docs/consumers/test_readme.py
+++ b/datadog_checks_dev/tests/tooling/docs/consumers/test_readme.py
@@ -90,3 +90,66 @@ def test_tab_multiple(_):
 
         """
     )
+
+
+@mock.patch('datadog_checks.dev.tooling.specs.docs.spec.load_manifest', return_value=MOCK_RESPONSE)
+def test_tab_multiple_nested(_):
+
+    consumer = get_readme_consumer(
+        """
+        name: foo
+        files:
+        - name: README.md
+          sections:
+          - name: foo
+            header_level: 1
+            description: words
+            tab: bar
+            sections:
+            - name: nested
+              header_level: 1
+              description: words
+          - name: bar
+            header_level: 1
+            description: words
+            tab: baz
+            sections:
+            - name: nested
+              header_level: 1
+              description: words
+        """
+    )
+    files = consumer.render()
+    contents, errors = files['README.md']
+    assert not errors
+    assert contents == normalize_yaml(
+        """
+        # Agent Check: foo
+
+        <!-- xxx tabs xxx -->
+        <!-- xxx tab "bar" xxx -->
+
+        # foo
+
+        words
+
+        # nested
+
+        words
+
+        <!-- xxz tab xxx -->
+        <!-- xxx tab "baz" xxx -->
+
+        # bar
+
+        words
+
+        # nested
+
+        words
+
+        <!-- xxz tab xxx -->
+        <!-- xxz tabs xxx -->
+
+        """
+    )

--- a/datadog_checks_dev/tests/tooling/docs/test_load.py
+++ b/datadog_checks_dev/tests/tooling/docs/test_load.py
@@ -4,7 +4,7 @@
 import mock
 import pytest
 
-from .utils import get_doc, MOCK_RESPONSE
+from .utils import MOCK_RESPONSE, get_doc
 
 pytestmark = pytest.mark.conf
 

--- a/datadog_checks_dev/tests/tooling/docs/test_load.py
+++ b/datadog_checks_dev/tests/tooling/docs/test_load.py
@@ -4,10 +4,9 @@
 import mock
 import pytest
 
-from .utils import get_doc
+from .utils import get_doc, MOCK_RESPONSE
 
 pytestmark = pytest.mark.conf
-MOCK_RESPONSE = {'integration_id': 'foo'}
 
 
 def test_cache():

--- a/datadog_checks_dev/tests/tooling/docs/utils.py
+++ b/datadog_checks_dev/tests/tooling/docs/utils.py
@@ -4,11 +4,20 @@
 from textwrap import dedent
 
 from datadog_checks.dev.tooling.specs.docs import DocsSpec
+from datadog_checks.dev.tooling.specs.docs.consumers import ReadmeConsumer
+
+MOCK_RESPONSE = {'integration_id': 'foo'}
 
 
 def get_doc(text, **kwargs):
     kwargs.setdefault('source', 'test')
     return DocsSpec(normalize_yaml(text), **kwargs)
+
+
+def get_readme_consumer(text, **kwargs):
+    doc = get_doc(text, **kwargs)
+    doc.load()
+    return ReadmeConsumer(doc.data)
 
 
 def normalize_yaml(text):

--- a/datadog_checks_dev/tests/tooling/docs/utils.py
+++ b/datadog_checks_dev/tests/tooling/docs/utils.py
@@ -11,7 +11,7 @@ MOCK_RESPONSE = {'integration_id': 'foo'}
 
 def get_doc(text, **kwargs):
     kwargs.setdefault('source', 'test')
-    return DocsSpec(normalize_yaml(text), **kwargs)
+    return DocsSpec(normalize_readme(text), **kwargs)
 
 
 def get_readme_consumer(text, **kwargs):
@@ -20,5 +20,5 @@ def get_readme_consumer(text, **kwargs):
     return ReadmeConsumer(doc.data)
 
 
-def normalize_yaml(text):
+def normalize_readme(text):
     return dedent(text).lstrip()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes an issue where the readme consumer was not parsing sections with `tab` attributes correctly. It would assume each section was its own `tab` rather than grouping multiple tabs together, as we would want to display in our [docs](https://docs.datadoghq.com/integrations/nginx/?tab=host#configuration)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
For better understanding of this issue, check out this PR for nginx docs spec using the current readme consumer (https://github.com/DataDog/integrations-core/pull/8549). This [comment](https://github.com/DataDog/integrations-core/pull/8549#discussion_r571228833) plus the diff might be useful to understand the issue.  

This solution was developed with two assumptions:
- All `tab` attributes exist as top level sections. 
- Adjacent sections with a `tab` attribute are to be grouped together. 

These two assumptions seem to be respected throughout our repo's use of `tab` in `README.md` files as we only use them for host/containarized configuration [(as shown here)](https://docs.datadoghq.com/integrations/nginx/?tab=containerized#configuration)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
