### PR TITLE
Fix automatic discovery of metrics from web API and improve example config documentation

### DIFF
--- a/sonarqube/assets/configuration/spec.yaml
+++ b/sonarqube/assets/configuration/spec.yaml
@@ -12,9 +12,20 @@ files:
     options:
     - name: web_endpoint
       description: |
-        The SonarQube web endpoint which should expose its API at `/api`.
+<<<<<<< HEAD
+<<<<<<< HEAD
+        The SonarQube web endpoint which should expose its API at `/api`. For example:
+=======
+        The SonarQube web endpoint which should expose its API at `/api`. example:
+>>>>>>> b3e744f1f... editing the conf.yaml.example properly by generating via spec.yaml and ddev
+=======
+        The SonarQube web endpoint which should expose its API at `/api`. For example:
+>>>>>>> da7fa8be3... making requested changes
 
-        NOTE: This only takes effect when `is_jmx` is set to `false`.
+          web_endpoint: http://<WEB_ENDPOINT>:<PORT>
+
+        NOTE: This only takes effect when `is_jmx` is set to `false` and is required for all
+        API metrics.
       value:
         type: string
     - name: default_tag
@@ -51,13 +62,14 @@ files:
           type: string
     - name: components
       description: |
-        The components for which metrics should be collected. Each object may override the default options.
-        For example:
-
+        The components for which metrics should be collected. Each object may override the default
+        options. For example, the following will gather all default metrics for "some-project",
+        and only what is included/excluded for "another-project":
+          
           components:
-            default-component:
             some-project:
-              tag: project
+            another-project:
+              tag: project-2
               include:
                 - issues.
                 - maintainability.
@@ -65,7 +77,8 @@ files:
               exclude:
                 - issues.(false_positive_issues|reopened_issues)
 
-        NOTE: This only takes effect when `is_jmx` is set to `false`.
+        NOTE: This is required for all project checks, regardless of `is_jmx` being set to `true` 
+        or `false.
       value:
         type: object
         properties:
@@ -81,8 +94,10 @@ files:
             type: string
     - template: instances/jmx
       overrides:
+        user.description: |
+          User name to use when connecting to JMX (or HTTP if `is_jmx = false`).
         password.description: |
-          Password to use when connecting to JMX or HTTP (depending on the value of `is_jmx`).
+          Password to use when connecting to JMX (or HTTP if `is_jmx = false`).
     - template: instances/http
       overrides:
         password.hidden: true

--- a/sonarqube/assets/configuration/spec.yaml
+++ b/sonarqube/assets/configuration/spec.yaml
@@ -12,15 +12,7 @@ files:
     options:
     - name: web_endpoint
       description: |
-<<<<<<< HEAD
-<<<<<<< HEAD
         The SonarQube web endpoint which should expose its API at `/api`. For example:
-=======
-        The SonarQube web endpoint which should expose its API at `/api`. example:
->>>>>>> b3e744f1f... editing the conf.yaml.example properly by generating via spec.yaml and ddev
-=======
-        The SonarQube web endpoint which should expose its API at `/api`. For example:
->>>>>>> da7fa8be3... making requested changes
 
           web_endpoint: http://<WEB_ENDPOINT>:<PORT>
 

--- a/sonarqube/datadog_checks/sonarqube/check.py
+++ b/sonarqube/datadog_checks/sonarqube/check.py
@@ -198,4 +198,38 @@ class SonarqubeCheck(AgentCheck):
 
     @staticmethod
     def is_valid_metric(metric):
-        return not metric['hidden'] and metric['type'] in NUMERIC_TYPES
+<<<<<<< HEAD
+<<<<<<< HEAD
+        return (
+            not metric['hidden']
+            and metric['type'] in NUMERIC_TYPES
+            # https://github.com/DataDog/integrations-core/pull/8552
+            and not metric['key'].startswith('new_')
+        )
+=======
+        metric_re = '^(% s)' % '|'.join(BLOCKED_METRICS)
+<<<<<<< HEAD
+        
+        return not metric['hidden'] and metric['type'] in NUMERIC_TYPES and not re.match(metric_re, metric['key'])
+>>>>>>> da7fa8be3... making requested changes
+=======
+
+<<<<<<< HEAD
+            return (
+                not metric['hidden']
+                and metric['type'] in NUMERIC_TYPES
+                # https://github.com/DataDog/integrations-core/pull/8552
+                and not metric['key'].startswith('new_')
+            )
+            
+>>>>>>> 57df81d5f... restructuring return staticmethod
+=======
+=======
+>>>>>>> 3926bda10... removing regex list match for performance, may include later if required
+        return (
+            not metric['hidden']
+            and metric['type'] in NUMERIC_TYPES
+            # https://github.com/DataDog/integrations-core/pull/8552
+            and not metric['key'].startswith('new_')
+        )
+>>>>>>> e934e2df2... making requested changes

--- a/sonarqube/datadog_checks/sonarqube/check.py
+++ b/sonarqube/datadog_checks/sonarqube/check.py
@@ -198,38 +198,9 @@ class SonarqubeCheck(AgentCheck):
 
     @staticmethod
     def is_valid_metric(metric):
-<<<<<<< HEAD
-<<<<<<< HEAD
         return (
             not metric['hidden']
             and metric['type'] in NUMERIC_TYPES
             # https://github.com/DataDog/integrations-core/pull/8552
             and not metric['key'].startswith('new_')
         )
-=======
-        metric_re = '^(% s)' % '|'.join(BLOCKED_METRICS)
-<<<<<<< HEAD
-        
-        return not metric['hidden'] and metric['type'] in NUMERIC_TYPES and not re.match(metric_re, metric['key'])
->>>>>>> da7fa8be3... making requested changes
-=======
-
-<<<<<<< HEAD
-            return (
-                not metric['hidden']
-                and metric['type'] in NUMERIC_TYPES
-                # https://github.com/DataDog/integrations-core/pull/8552
-                and not metric['key'].startswith('new_')
-            )
-            
->>>>>>> 57df81d5f... restructuring return staticmethod
-=======
-=======
->>>>>>> 3926bda10... removing regex list match for performance, may include later if required
-        return (
-            not metric['hidden']
-            and metric['type'] in NUMERIC_TYPES
-            # https://github.com/DataDog/integrations-core/pull/8552
-            and not metric['key'].startswith('new_')
-        )
->>>>>>> e934e2df2... making requested changes

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -87,15 +87,7 @@ instances:
 
   -
     ## @param web_endpoint - string - optional
-<<<<<<< HEAD
-<<<<<<< HEAD
     ## The SonarQube web endpoint which should expose its API at `/api`. For example:
-=======
-    ## The SonarQube web endpoint which should expose its API at `/api`. example:
->>>>>>> b3e744f1f... editing the conf.yaml.example properly by generating via spec.yaml and ddev
-=======
-    ## The SonarQube web endpoint which should expose its API at `/api`. For example:
->>>>>>> da7fa8be3... making requested changes
     ##
     ##   web_endpoint: http://<WEB_ENDPOINT>:<PORT>
     ##

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -87,9 +87,20 @@ instances:
 
   -
     ## @param web_endpoint - string - optional
-    ## The SonarQube web endpoint which should expose its API at `/api`.
+<<<<<<< HEAD
+<<<<<<< HEAD
+    ## The SonarQube web endpoint which should expose its API at `/api`. For example:
+=======
+    ## The SonarQube web endpoint which should expose its API at `/api`. example:
+>>>>>>> b3e744f1f... editing the conf.yaml.example properly by generating via spec.yaml and ddev
+=======
+    ## The SonarQube web endpoint which should expose its API at `/api`. For example:
+>>>>>>> da7fa8be3... making requested changes
     ##
-    ## NOTE: This only takes effect when `is_jmx` is set to `false`.
+    ##   web_endpoint: http://<WEB_ENDPOINT>:<PORT>
+    ##
+    ## NOTE: This only takes effect when `is_jmx` is set to `false` and is required for all
+    ## API metrics.
     #
     # web_endpoint: <WEB_ENDPOINT>
 
@@ -121,13 +132,14 @@ instances:
     # default_exclude: []
 
     ## @param components - mapping - optional
-    ## The components for which metrics should be collected. Each object may override the default options.
-    ## For example:
-    ##
+    ## The components for which metrics should be collected. Each object may override the default
+    ## options. For example, the following will gather all default metrics for "some-project",
+    ## and only what is included/excluded for "another-project":
+    ##   
     ##   components:
-    ##     default-component:
     ##     some-project:
-    ##       tag: project
+    ##     another-project:
+    ##       tag: project-2
     ##       include:
     ##         - issues.
     ##         - maintainability.
@@ -135,7 +147,8 @@ instances:
     ##       exclude:
     ##         - issues.(false_positive_issues|reopened_issues)
     ##
-    ## NOTE: This only takes effect when `is_jmx` is set to `false`.
+    ## NOTE: This is required for all project checks, regardless of `is_jmx` being set to `true` 
+    ## or `false.
     #
     # components: {}
 
@@ -150,12 +163,12 @@ instances:
     port: <PORT>
 
     ## @param user - string - optional
-    ## User to use when connecting to JMX.
+    ## User name to use when connecting to JMX (or HTTP if `is_jmx = false`).
     #
     # user: <USER>
 
     ## @param password - string - optional
-    ## Password to use when connecting to JMX or HTTP (depending on the value of `is_jmx`).
+    ## Password to use when connecting to JMX (or HTTP if `is_jmx = false`).
     #
     # password: <PASSWORD>
 

--- a/sonarqube/datadog_checks/sonarqube/data/metrics.yaml
+++ b/sonarqube/datadog_checks/sonarqube/data/metrics.yaml
@@ -1,4 +1,5 @@
 # https://docs.sonarqube.org/latest/instance-administration/monitoring/
+# If `is_jmx: true` is not defined in any instance, this file can be safely renamed or removed to reduce log chattiness
 jmx_metrics:
   - include:
       domain: SonarQube


### PR DESCRIPTION
Signed-off-by: Daniel Bright <daniel.bright@datadoghq.com>

### What does this PR do?
This PR updates the SonarQube check to exclude specific, problematic metrics that are identified by the `key` of `new_.*`, these metrics are used in the SonarQube dashboard to indicate "new" items between the most current scan and the last scan, they also break metric collection due to their format, example `new_blocker_violations`:

```json
{
  "metric": "new_blocker_violations",
  "periods": [
    {
      "index": 1,
      "value": "0",
      "bestValue": true
    }
  ],
  "period": {
    "index": 1,
    "value": "0",
    "bestValue": true
  }
},
```
Versus a valid metric, `blocker_violations`: 
```json
{
  "metric": "blocker_violations",
  "value": "0",
  "bestValue": true
},
```

### Motivation
Zendesk request

### Additional Notes
I cannot see why these metrics would be valid other than use on the SonarQube interface, however, there may be reason in the future to integrate them. Currently, the format of these metrics breaks ingestion of the standard metrics. 

Another interesting point is that these `new_*` metrics don't seem to generate until after a subsequent code scan is run in SonarQube, thus an initial deployment/test scan would result in the Datadog Agent showing successful, however after a subsequent code scan is run, you would see an error such as this:

```sh
Error: 'value'
Traceback (most recent call last):
   File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 878, in run
      self.check(instance)
   File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sonarqube/check.py", line 31, in check
      self.collect_metrics()
   File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sonarqube/check.py", line 61, in collect_metrics
      self.gauge(available_metrics[measure['metric']], measure['value'], tags=tags)
KeyError: 'value'
```

Also, I went the route of updating the `constants.py` with a new `BLOCKED_METRICS` list so in the future we can add more static blocked metrics if required.

Finally, I also took the time to update the example `conf.yaml.example` with some notes on using this integration when `is_jmx: false` is set, this will help with some confusion surrounding how to configure this integration to get metrics from the SonarQube API only and not from JMX.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
