### PR TITLE
Added enabling Prometheus monitoring

### DIFF
--- a/amazon_msk/README.md
+++ b/amazon_msk/README.md
@@ -12,7 +12,8 @@ Follow the instructions below to install and configure this check for an Agent r
 
 1. [Create a client machine][3] if one does not already exist
 2. Ensure the client machine has been [granted][4] the permission policy [arn:aws:iam::aws:policy/AmazonMSKReadOnlyAccess][5] or equivalent [credentials][6] are available
-3. Install the [Datadog Agent][7]
+3. Enable [open monitoring with Prometheus][13] on the MSK side to enable the JmxExporter and the NodeExporter.
+4. Install the [Datadog Agent][7]
 
 ### Configuration
 
@@ -58,3 +59,4 @@ Need help? Contact [Datadog support][12].
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [11]: https://github.com/DataDog/integrations-core/blob/master/amazon_msk/metadata.csv
 [12]: https://docs.datadoghq.com/help/
+[13]: https://docs.aws.amazon.com/msk/latest/developerguide/open-monitoring.html


### PR DESCRIPTION
### What does this PR do?
PR added a line in Installation -> Set up to include, enabling prometheus monitoring on the MSK side for the integration to work.

### Motivation
Ticket #443176

### Additional Notes
Please review the steps, and the ticket #443176 has more details

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
