### PR TITLE
Skip apps which have the UI disabled

### DIFF
--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -4,7 +4,7 @@
 import re
 
 from bs4 import BeautifulSoup
-from requests.exceptions import ConnectionError, HTTPError, InvalidURL, RequestException, Timeout
+from requests.exceptions import ConnectionError, HTTPError, InvalidURL, Timeout
 from simplejson import JSONDecodeError
 from six import iteritems, itervalues
 from six.moves.urllib.parse import urljoin, urlparse, urlsplit, urlunsplit
@@ -475,7 +475,7 @@ class SparkCheck(AgentCheck):
                 if not version_set:
                     version_set = self._collect_version(tracking_url, tags)
                 response = self._rest_request_to_json(tracking_url, SPARK_APPS_PATH, SPARK_SERVICE_CHECK, tags)
-            except RequestException as e:
+            except Exception as e:
                 self.log.warning("Exception happened when fetching app ids for %s: %s", tracking_url, e)
                 continue
 

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -1192,7 +1192,7 @@ def test_ssl_cert():
 def test_do_not_crash_on_single_app_failure():
     running_apps = {'foo': ('bar', 'http://foo.bar/'), 'foo2': ('bar', 'http://foo.bar/')}
     results = []
-    rest_requests_to_json = mock.MagicMock(side_effect=[RequestException, results])
+    rest_requests_to_json = mock.MagicMock(side_effect=[Exception, results])
     c = SparkCheck('spark', {}, [INSTANCE_STANDALONE])
 
     with mock.patch.object(c, '_rest_request_to_json', rest_requests_to_json), mock.patch.object(c, '_collect_version'):


### PR DESCRIPTION
Extending https://github.com/DataDog/integrations-core/pull/5552/

Some spark applications can disable the UI explicitly (by setting spark.ui.enabled=false). In such a case, api request for that particular apps are redirected to the master (which doesn't provide the required information).

This PR skips any apps that raises any exception, in order to continue monitoring of valid applications.