### PR TITLE
[HAProxy] Adding recommended monitors

### DIFF
--- a/haproxy/assets/monitors/backend_dreq.json
+++ b/haproxy/assets/monitors/backend_dreq.json
@@ -1,0 +1,30 @@
+{
+  "name": "[HAProxy] High number of backend denied responses for host: {{host.name}}",
+  "type": "metric alert",
+  "query": "avg(last_4h):anomalies(avg:haproxy.backend.denied.resp_rate{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+  "message": "The number of backend denied responses due to security restrictions for host: {{host.name}} is above normal.\n\nA malicious attacker or misconfigured application could be to blame. More information on designing ACLs for HAProxy can be found in the [Introduction to HAProxy ACLs blog post](https://www.haproxy.com/blog/introduction-to-haproxy-acls/).",
+  "tags": ["integration:haproxy"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": "0",
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 1,
+      "critical_recovery": 0
+    },
+    "threshold_windows": {
+      "trigger_window": "last_15m",
+      "recovery_window": "last_15m"
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when HAProxy denined backend responses are higher than usual for a specific host."
+  }
+}

--- a/haproxy/assets/monitors/backend_dreq.json
+++ b/haproxy/assets/monitors/backend_dreq.json
@@ -1,6 +1,6 @@
 {
   "name": "[HAProxy] High number of backend denied responses for host: {{host.name}}",
-  "type": "metric alert",
+  "type": "query alert",
   "query": "avg(last_4h):anomalies(avg:haproxy.backend.denied.resp_rate{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
   "message": "The number of backend denied responses due to security restrictions for host: {{host.name}} is above normal.\n\nA malicious attacker or misconfigured application could be to blame. More information on designing ACLs for HAProxy can be found in the [Introduction to HAProxy ACLs blog post](https://www.haproxy.com/blog/introduction-to-haproxy-acls/).",
   "tags": ["integration:haproxy"],

--- a/haproxy/assets/monitors/backend_dreq.json
+++ b/haproxy/assets/monitors/backend_dreq.json
@@ -11,7 +11,7 @@
     "new_host_delay": 300,
     "require_full_window": true,
     "notify_no_data": false,
-    "renotify_interval": "0",
+    "renotify_interval": 0,
     "escalation_message": "",
     "no_data_timeframe": null,
     "include_tags": true,

--- a/haproxy/assets/monitors/backend_econ.json
+++ b/haproxy/assets/monitors/backend_econ.json
@@ -1,6 +1,6 @@
 {
   "name": "[HAProxy] Number of backend connection failures for host: {{host.name}} is above normal.",
-  "type": "metric alert",
+  "type": "query alert",
   "query": "avg(last_4h):anomalies(avg:haproxy.backend.errors.con_rate{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
   "message": "There is a higher number of backend connection failures for host: {{host.name}}\n\nNote: This monitored metric doesn't only includes failed backend requests but additionally includes general backend errors, like a backend without an active frontend. Correlating this metric with `haproxy.backend.errors.resp_rate` and response codes from both your frontend and backend servers will give you a better idea of the causes of an increase in backend connection errors.",
   "tags": ["integration:haproxy"],

--- a/haproxy/assets/monitors/backend_econ.json
+++ b/haproxy/assets/monitors/backend_econ.json
@@ -1,0 +1,30 @@
+{
+  "name": "[HAProxy] Number of backend connection failures for host: {{host.name}} is above normal.",
+  "type": "metric alert",
+  "query": "avg(last_4h):anomalies(avg:haproxy.backend.errors.con_rate{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+  "message": "There is a higher number of backend connection failures for host: {{host.name}}\n\nNote: This monitored metric doesn't only includes failed backend requests but additionally includes general backend errors, like a backend without an active frontend. Correlating this metric with `haproxy.backend.errors.resp_rate` and response codes from both your frontend and backend servers will give you a better idea of the causes of an increase in backend connection errors.",
+  "tags": ["integration:haproxy"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 1,
+      "critical_recovery": 0
+    },
+    "threshold_windows": {
+      "trigger_window": "last_15m",
+      "recovery_window": "last_15m"
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when HAProxy the number of backend connection errors is above normal for a specific host."
+  }
+}

--- a/haproxy/assets/monitors/backend_queue_time.json
+++ b/haproxy/assets/monitors/backend_queue_time.json
@@ -1,0 +1,25 @@
+{
+  "name": "[HAProxy] Backend queue time went above 500ms for host: {{host.name}}",
+  "type": "metric alert",
+  "query": "max(last_5m):avg:haproxy.backend.queue.time{*} by {host} > 500",
+  "message": "The average queue time for host: {{host.name}} just reached: {{value}}.\n",
+  "tags": ["integration:haproxy"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 500
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when the HAProxy backend queue time went above 500ms for a specific host."
+  }
+}

--- a/haproxy/assets/monitors/backend_queue_time.json
+++ b/haproxy/assets/monitors/backend_queue_time.json
@@ -1,6 +1,6 @@
 {
   "name": "[HAProxy] Backend queue time went above 500ms for host: {{host.name}}",
-  "type": "metric alert",
+  "type": "query alert",
   "query": "max(last_5m):avg:haproxy.backend.queue.time{*} by {host} > 500",
   "message": "The average queue time for host: {{host.name}} just reached: {{value}}.\n",
   "tags": ["integration:haproxy"],

--- a/haproxy/assets/monitors/backend_rtime.json
+++ b/haproxy/assets/monitors/backend_rtime.json
@@ -1,6 +1,6 @@
 {
   "name": "[HAProxy] Backend response time is above 500ms for host: {{host.name}}",
-  "type": "metric alert",
+  "type": "query alert",
   "query": "avg(last_5m):avg:haproxy.backend.response.time{*} by {host} > 500",
   "message": "The average backend response time for host: {{host.name}} is on average at: {{value}} over the last 5min.\n",
   "tags": ["integration:haproxy"],

--- a/haproxy/assets/monitors/backend_rtime.json
+++ b/haproxy/assets/monitors/backend_rtime.json
@@ -1,0 +1,25 @@
+{
+  "name": "[HAProxy] Backend response time is above 500ms for host: {{host.name}}",
+  "type": "metric alert",
+  "query": "avg(last_5m):avg:haproxy.backend.response.time{*} by {host} > 500",
+  "message": "The average backend response time for host: {{host.name}} is on average at: {{value}} over the last 5min.\n",
+  "tags": ["integration:haproxy"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 500
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when the HAProxy backend response time is above 500ms for a specific host."
+  }
+}

--- a/haproxy/assets/monitors/backend_sessions.json
+++ b/haproxy/assets/monitors/backend_sessions.json
@@ -1,0 +1,26 @@
+{
+  "name": "[HAProxy] High amount of backend session usage for host: {{host.name}}",
+  "type": "metric alert",
+  "query": "avg(last_5m):avg:haproxy.backend.session.pct{*} by {host} > 80",
+  "message": "{{#is_alert}}\n\nALERT: The amount of backend sessions in use for host: {{host.name}} reached {{value}} for a detection threshold of {{threshold}} %\n\nWhen reaching the session limit HAProxy will deny additional clients until resource consumption drops. It could be time to either modify HAProxy’s configuration to allow more sessions, or migrate your HAProxy server to a bigger box.\n\n{{/is_alert}} \n\n{{#is_warning}}\n\nWARNING: The amount of backend sessions in use for host: {{host.name}} reached {{value}} for a detection threshold of {{threshold}} %\n\n{{/is_warning}} ",
+  "tags": ["integration:haproxy"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": false,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 80,
+      "warning": 60
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when HAProxy backend sessions usage is approaching the maximum defined for a specific host."
+  }
+}

--- a/haproxy/assets/monitors/backend_sessions.json
+++ b/haproxy/assets/monitors/backend_sessions.json
@@ -1,6 +1,6 @@
 {
   "name": "[HAProxy] High amount of backend session usage for host: {{host.name}}",
-  "type": "metric alert",
+  "type": "query alert",
   "query": "avg(last_5m):avg:haproxy.backend.session.pct{*} by {host} > 80",
   "message": "{{#is_alert}}\n\nALERT: The amount of backend sessions in use for host: {{host.name}} reached {{value}} for a detection threshold of {{threshold}} %\n\nWhen reaching the session limit HAProxy will deny additional clients until resource consumption drops. It could be time to either modify HAProxy’s configuration to allow more sessions, or migrate your HAProxy server to a bigger box.\n\n{{/is_alert}} \n\n{{#is_warning}}\n\nWARNING: The amount of backend sessions in use for host: {{host.name}} reached {{value}} for a detection threshold of {{threshold}} %\n\n{{/is_warning}} ",
   "tags": ["integration:haproxy"],

--- a/haproxy/assets/monitors/frontend_4xx.json
+++ b/haproxy/assets/monitors/frontend_4xx.json
@@ -1,6 +1,6 @@
 {
   "name": "[HAProxy] Anomalous number of frontend 4xx HTTP responses for host: {{host.name}}",
-  "type": "metric alert",
+  "type": "query alert",
   "query": "avg(last_4h):anomalies(avg:haproxy.frontend.response.4xx{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
   "message": "An anomalous number of HAProxy frontend 4xx HTTP responses for host: {{host.name}}  has been detected over the last 15mins.",
   "tags": ["integration:haproxy"],

--- a/haproxy/assets/monitors/frontend_4xx.json
+++ b/haproxy/assets/monitors/frontend_4xx.json
@@ -1,0 +1,30 @@
+{
+  "name": "[HAProxy] Anomalous number of frontend 4xx HTTP responses for host: {{host.name}}",
+  "type": "metric alert",
+  "query": "avg(last_4h):anomalies(avg:haproxy.frontend.response.4xx{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+  "message": "An anomalous number of HAProxy frontend 4xx HTTP responses for host: {{host.name}}  has been detected over the last 15mins.",
+  "tags": ["integration:haproxy"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": false,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 1,
+      "critical_recovery": 0
+    },
+    "threshold_windows": {
+      "trigger_window": "last_15m",
+      "recovery_window": "last_15m"
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when HAProxy frontend 4xx errors are higher than usual for a specific host."
+  }
+}

--- a/haproxy/assets/monitors/frontend_5xx.json
+++ b/haproxy/assets/monitors/frontend_5xx.json
@@ -1,0 +1,30 @@
+{
+  "name": "[HAProxy] Anomalous number of frontend 5xx HTTP responses for host: {{host.name}}",
+  "type": "metric alert",
+  "query": "avg(last_4h):anomalies(avg:haproxy.frontend.response.5xx{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+  "message": "An anomalous number of HAProxy frontend 5xx HTTP responses for host: {{host.name}}  has been detected over the last 15mins.",
+  "tags": ["integration:haproxy"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": false,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 1,
+      "critical_recovery": 0
+    },
+    "threshold_windows": {
+      "trigger_window": "last_15m",
+      "recovery_window": "last_15m"
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when HAProxy frontend 5xx errors are higher than usual for a specific host."
+  }
+}

--- a/haproxy/assets/monitors/frontend_5xx.json
+++ b/haproxy/assets/monitors/frontend_5xx.json
@@ -1,6 +1,6 @@
 {
   "name": "[HAProxy] Anomalous number of frontend 5xx HTTP responses for host: {{host.name}}",
-  "type": "metric alert",
+  "type": "query alert",
   "query": "avg(last_4h):anomalies(avg:haproxy.frontend.response.5xx{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
   "message": "An anomalous number of HAProxy frontend 5xx HTTP responses for host: {{host.name}}  has been detected over the last 15mins.",
   "tags": ["integration:haproxy"],

--- a/haproxy/assets/monitors/frontend_dreq.json
+++ b/haproxy/assets/monitors/frontend_dreq.json
@@ -1,0 +1,30 @@
+{
+  "name": "[HAProxy] High number of frontend denied requests for host: {{host.name}}",
+  "type": "metric alert",
+  "query": "avg(last_4h):anomalies(avg:haproxy.frontend.denied.req_rate{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+  "message": "The number of frontend denied requests due to security restrictions for host: {{host.name}} is above normal.\n\nA malicious attacker or misconfigured application could be to blame. More information on designing ACLs for HAProxy can be found in the [Introduction to HAProxy ACLs blog post](https://www.haproxy.com/blog/introduction-to-haproxy-acls/).",
+  "tags": ["integration:haproxy"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 1,
+      "critical_recovery": 0
+    },
+    "threshold_windows": {
+      "trigger_window": "last_15m",
+      "recovery_window": "last_15m"
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when HAProxy denined frontend requests are higher than usual for a specific host."
+  }
+}

--- a/haproxy/assets/monitors/frontend_dreq.json
+++ b/haproxy/assets/monitors/frontend_dreq.json
@@ -1,6 +1,6 @@
 {
   "name": "[HAProxy] High number of frontend denied requests for host: {{host.name}}",
-  "type": "metric alert",
+  "type": "query alert",
   "query": "avg(last_4h):anomalies(avg:haproxy.frontend.denied.req_rate{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
   "message": "The number of frontend denied requests due to security restrictions for host: {{host.name}} is above normal.\n\nA malicious attacker or misconfigured application could be to blame. More information on designing ACLs for HAProxy can be found in the [Introduction to HAProxy ACLs blog post](https://www.haproxy.com/blog/introduction-to-haproxy-acls/).",
   "tags": ["integration:haproxy"],

--- a/haproxy/assets/monitors/frontend_ereq.json
+++ b/haproxy/assets/monitors/frontend_ereq.json
@@ -1,0 +1,30 @@
+{
+  "name": "[HAProxy] Number of client-side request error for {{host.name}} is above normal.",
+  "type": "metric alert",
+  "query": "avg(last_4h):anomalies(avg:haproxy.frontend.errors.req_rate{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+  "message": "There is a higher number of client-side request error for host: {{host.name}}\n\nClient-side request errors could have a number of causes:\n\n- Client terminates before sending request\n- Read error from client\n- Client timeout\n- Client terminated connection\n- Request was tarpitted/subject to ACL",
+  "tags": ["integration:haproxy"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 1,
+      "critical_recovery": 0
+    },
+    "threshold_windows": {
+      "trigger_window": "last_15m",
+      "recovery_window": "last_15m"
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when HAProxy frontend error request rate is above normal for a specific host."
+  }
+}

--- a/haproxy/assets/monitors/frontend_ereq.json
+++ b/haproxy/assets/monitors/frontend_ereq.json
@@ -1,6 +1,6 @@
 {
   "name": "[HAProxy] Number of client-side request error for {{host.name}} is above normal.",
-  "type": "metric alert",
+  "type": "query alert",
   "query": "avg(last_4h):anomalies(avg:haproxy.frontend.errors.req_rate{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
   "message": "There is a higher number of client-side request error for host: {{host.name}}\n\nClient-side request errors could have a number of causes:\n\n- Client terminates before sending request\n- Read error from client\n- Client timeout\n- Client terminated connection\n- Request was tarpitted/subject to ACL",
   "tags": ["integration:haproxy"],

--- a/haproxy/assets/monitors/frontend_sessions.json
+++ b/haproxy/assets/monitors/frontend_sessions.json
@@ -1,6 +1,6 @@
 {
   "name": "[HAProxy] High amount of frontend session usage for host: {{host.name}}",
-  "type": "metric alert",
+  "type": "query alert",
   "query": "avg(last_5m):avg:haproxy.frontend.session.pct{*} by {host} > 80",
   "message": "{{#is_alert}}\n\nALERT: The amount of frontend sessions in use for host: {{host.name}} reached {{value}} for a detection threshold of {{threshold}} %\n\nWhen reaching the session limit HAProxy will deny additional clients until resource consumption drops. It could be time to either modify HAProxy’s configuration to allow more sessions, or migrate your HAProxy server to a bigger box.\n\n{{/is_alert}} \n\n{{#is_warning}}\n\nWARNING: The amount of frontend sessions in use for host: {{host.name}} reached {{value}} for a detection threshold of {{threshold}} %\n\n{{/is_warning}} ",
   "tags": ["integration:haproxy"],

--- a/haproxy/assets/monitors/frontend_sessions.json
+++ b/haproxy/assets/monitors/frontend_sessions.json
@@ -1,0 +1,26 @@
+{
+  "name": "[HAProxy] High amount of frontend session usage for host: {{host.name}}",
+  "type": "metric alert",
+  "query": "avg(last_5m):avg:haproxy.frontend.session.pct{*} by {host} > 80",
+  "message": "{{#is_alert}}\n\nALERT: The amount of frontend sessions in use for host: {{host.name}} reached {{value}} for a detection threshold of {{threshold}} %\n\nWhen reaching the session limit HAProxy will deny additional clients until resource consumption drops. It could be time to either modify HAProxy’s configuration to allow more sessions, or migrate your HAProxy server to a bigger box.\n\n{{/is_alert}} \n\n{{#is_warning}}\n\nWARNING: The amount of frontend sessions in use for host: {{host.name}} reached {{value}} for a detection threshold of {{threshold}} %\n\n{{/is_warning}} ",
+  "tags": ["integration:haproxy"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": false,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 80,
+      "warning": 60
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when HAProxy frontend sessions usage is approaching the maximum defined for a specific host."
+  }
+}

--- a/haproxy/assets/monitors/request_rate.json
+++ b/haproxy/assets/monitors/request_rate.json
@@ -1,0 +1,31 @@
+{
+  "name": "[HAProxy] Anomalous frontend request rate for host {{host.name}}",
+  "type": "metric alert",
+  "query": "avg(last_4h):anomalies(avg:haproxy.frontend.requests.rate{*} by {host}, 'agile', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+  "message": "There is an anomaly in the amount of frontend requests handled by HAProxy on host: {{host.name}} ",
+  "tags": ["integration:haproxy"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 1,
+      "critical_recovery": 0
+    },
+    "threshold_windows": {
+      "trigger_window": "last_15m",
+      "recovery_window": "last_15m"
+    }
+  },
+
+  "recommended_monitor_metadata": {
+    "description": "Notifies when HAProxy experiences an anomalous number of frontend request rate for a specific host."
+  }
+}

--- a/haproxy/assets/monitors/request_rate.json
+++ b/haproxy/assets/monitors/request_rate.json
@@ -1,6 +1,6 @@
 {
   "name": "[HAProxy] Anomalous frontend request rate for host {{host.name}}",
-  "type": "metric alert",
+  "type": "query alert",
   "query": "avg(last_4h):anomalies(avg:haproxy.frontend.requests.rate{*} by {host}, 'agile', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
   "message": "There is an anomaly in the amount of frontend requests handled by HAProxy on host: {{host.name}} ",
   "tags": ["integration:haproxy"],

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -36,7 +36,19 @@
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
-    "monitors": {},
+    "monitors": {
+      "[HAProxy] Anomalous number of frontend 4xx HTTP responses for host: {{host.name}}": "assets/monitors/frontend_5xx.json",
+      "[HAProxy] Anomalous number of frontend 5xx HTTP responses for host: {{host.name}}": "assets/monitors/frontend_4xx.json",
+      "[HAProxy] High amount of frontend session usage for host: {{host.name}}": "assets/monitors/frontend_sessions.json",
+      "[HAProxy] High amount of backend session usage for host: {{host.name}}": "assets/monitors/backend_sessions.json",
+      "[HAProxy] High number of frontend denied requests for host: {{host.name}}": "assets/monitors/frontend_dreq.json",
+      "[HAProxy] High number of backend denied responses for host: {{host.name}}": "assets/monitors/backend_dreq.json",
+      "[HAProxy] Anomalous frontend request rate for host {{host.name}}": "assets/monitors/request_rate.json",
+      "[HAProxy] Number of client-side request error for {{host.name}} is above normal.": "assets/monitors/frontend_ereq.json",
+      "[HAProxy] Number of backend connection failures for host: {{host.name}} is above normal.": "assets/monitors/backend_econ.json",
+      "[HAProxy] Backend queue time went above 500ms for host: {{host.name}}": "assets/monitors/backend_queue_time.json",
+      "[HAProxy] Backend response time is above 500ms for host: {{host.name}}": "assets/monitors/backend_rtime.json"
+    },
     "dashboards": {
       "haproxy": "assets/dashboards/overview.json",
       "HAProxy - Overview (Prometheus)": "assets/dashboards/prometheus_overview.json"


### PR DESCRIPTION
### What does this PR do?

Adds a set of recommended monitors for HAProxy, following the recommendation of the blog post:

https://www.datadoghq.com/blog/monitoring-haproxy-performance-metrics/

Since in order to get backend/frontend tagging of those metrics a user should either:

* Use prometheus
* Set manually an option to true in the conf

Those monitors are vanilla in a sense that they only do a break down by host.

Monitors added leverage mostly anomaly monitors:

* [HAProxy] Anomalous number of frontend 4xx HTTP responses for host: {{host.name}}
* [HAProxy] Anomalous number of frontend 5xx HTTP responses for host: {{host.name}}
* [HAProxy] High amount of frontend session usage for host: {{host.name}}
* [HAProxy] High amount of backend session usage for host: {{host.name}}
* [HAProxy] High number of frontend denied requests for host: {{host.name}}
* [HAProxy] High number of backend denied responses for host: {{host.name}}
* [HAProxy] Anomalous frontend request rate for host {{host.name}}
* [HAProxy] Number of client-side request error for {{host.name}} is above normal.
* [HAProxy] Number of backend connection failures for host: {{host.name}} is above normal.
* [HAProxy] Backend queue time went above 500ms for host: {{host.name}}
* [HAProxy] Backend response time is above 500ms for host: {{host.name}}

### Motivation

Push more OOTB recommended monitors.

