### PR TITLE
More Kubernetes API server metrics

### DIFF
--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -16,6 +16,13 @@ METRICS = {
     'go_goroutines': 'go_goroutines',
     'APIServiceRegistrationController_depth': 'APIServiceRegistrationController_depth',
     'etcd_object_counts': 'etcd_object_counts',
+    'etcd_request_duration_seconds': 'etcd_request_duration_seconds',
+    'apiserver_registered_watchers': 'registered_watchers',
+    'apiserver_request_duration_seconds': 'request_duration_seconds',
+    'grpc_client_started_total': 'grpc_client_started_total',
+    'grpc_client_handled_total': 'grpc_client_handled_total',
+    'grpc_client_msg_sent_total': 'grpc_client_msg_sent_total',
+    'grpc_client_msg_received_total': 'grpc_client_msg_received_total',
     # For Kubernetes < 1.14
     'rest_client_request_latency_seconds': 'rest_client_request_latency_seconds',
     'apiserver_admission_webhook_admission_latencies_seconds': 'admission_webhook_admission_latencies_seconds',
@@ -35,6 +42,15 @@ METRICS = {
     'apiserver_admission_step_admission_duration_seconds_summary':
         'admission_step_admission_latencies_seconds_summary',
     # fmt: on
+    # For Kubernetes >= 1.16
+    # https://v1-16.docs.kubernetes.io/docs/setup/release/#added-metrics
+    'authentication_attempts': 'authentication_attempts',
+    'apiserver_watch_events_sizes': 'watch_events_sizes',
+    # For Kubernetes >= 1.17
+    # https://github.com/kubernetes/kubernetes/pull/82409
+    'authentication_duration_seconds': 'authentication_duration_seconds',
+    # https://github.com/kubernetes/kubernetes/pull/83427
+    'apiserver_request_terminations_total': 'request_terminations_total',
 }
 
 
@@ -58,6 +74,7 @@ class KubeAPIServerMetricsCheck(OpenMetricsBaseCheck):
             'rest_client_requests_total': self.rest_client_requests_total,
             'apiserver_request_count': self.apiserver_request_count,
             'apiserver_dropped_requests_total': self.apiserver_dropped_requests_total,
+            'apiserver_request_terminations_total': self.apiserver_request_terminations_total,
             'http_requests_total': self.http_requests_total,
             'authenticated_user_requests': self.authenticated_user_requests,
             # metric added in kubernetes 1.15
@@ -149,3 +166,6 @@ class KubeAPIServerMetricsCheck(OpenMetricsBaseCheck):
 
     def apiserver_request_total(self, metric, scraper_config):
         self.submit_as_gauge_and_monotonic_count('.apiserver_request_total', metric, scraper_config)
+
+    def apiserver_request_terminations_total(self, metric, scraper_config):
+        self.submit_as_gauge_and_monotonic_count('.request_terminations_total', metric, scraper_config)

--- a/kube_apiserver_metrics/metadata.csv
+++ b/kube_apiserver_metrics/metadata.csv
@@ -30,3 +30,18 @@ kube_apiserver.admission_step_admission_latencies_seconds_summary.count,count,,,
 kube_apiserver.admission_step_admission_latencies_seconds_summary.quantile,gauge,,second,,Admission sub-step latency summary broken out for each operation and API resource and step type (validate or admit) quantile,0,kube_apiserver,admission step admission latencies summary
 kube_apiserver.admission_controller_admission_duration_seconds.sum,gauge,,second,,Admission controller latency histogram in seconds identified by name and broken out for each operation and API resource and type (validate or admit),0,kube_apiserver,duration of admission controller admission
 kube_apiserver.admission_controller_admission_duration_seconds.count,count,,,,Admission controller latency histogram in seconds identified by name and broken out for each operation and API resource and type (validate or admit) count,0,kube_apiserver,duration of admission controller admission
+kube_apiserver.etcd_request_duration_seconds.sum,gauge,,second,,Etcd request latencies for each operation and object type,0,kube_apiserver,etcd latency
+kube_apiserver.etcd_request_duration_seconds.count,count,,,,Etcd request latencies count for each operation and object type,0,kube_apiserver,etcd latency
+kube_apiserver.registered_watchers,gauge,,object,,Number of currently registered for a given resource,0,kube_apiserver,watchers
+kube_apiserver.request_duration_seconds.sum,gauge,,second,,Response latency distribution for each verb/group/version/resource/subresource/scope/component and dry run value,0,kube_apiserver,response latency
+kube_apiserver.request_duration_seconds.count,count,,,,Response latency distribution for each verb/group/version/resource/subresource/scope/component and dry run value,0,kube_apiserver,response latency
+kube_apiserver.watch_events_sizes.sum,gauge,,byte,,Watch event size distribution (Kubernetes 1.16+),0,kube_apiserver,distribution of watch event sizes
+kube_apiserver.watch_events_sizes.count,count,,,,Watch event size distribution (Kubernetes 1.16+),0,kube_apiserver,distribution of watch event sizes
+kube_apiserver.authentication_duration_seconds.sum,gauge,,second,,Authentication duration histogram broken out by result (Kubernetes 1.17+),0,kube_apiserver,authentication latencies
+kube_apiserver.authentication_duration_seconds.count,count,,,,Authentication duration histogram broken out by result (Kubernetes 1.17+),0,kube_apiserver,authentication latencies
+kube_apiserver.authentication_attempts.count,count,,request,,Counter of authenticated attempts (Kubernetes 1.16+),0,kube_apiserver,count of authenticated attempts
+kube_apiserver.apiserver_request_terminations_total.count,count,,request,,Number of requests which apiserver terminated in self-defense (Kubernetes 1.17+),0,kube_apiserver,count of requests dropped in self-defense
+kube_apiserver.grpc_client_handled_total,count,,request,,Total number of RPCs completed by the client regardless of success or failure,1,kube_apiserver,gRPC client requests completed
+kube_apiserver.grpc_client_msg_received_total,count,,message,,Total number of gRPC stream messages received by the client,1,kube_apiserver,gRPC client messages received
+kube_apiserver.grpc_client_msg_sent_total,count,,message,, Total number of gRPC stream messages sent by the client,1,kube_apiserver,gRPC client messages sent
+kube_apiserver.grpc_client_started_total,count,,request,,Total number of RPCs started on the client,1,kube_apiserver,gRPC client requests started

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
@@ -54,6 +54,10 @@ class TestKubeAPIServerMetrics:
         NAMESPACE + '.http_requests_total',
         NAMESPACE + '.authenticated_user_requests',
         NAMESPACE + '.apiserver_request_total',
+        NAMESPACE + '.grpc_client_handled_total',
+        NAMESPACE + '.grpc_client_msg_received_total',
+        NAMESPACE + '.grpc_client_msg_sent_total',
+        NAMESPACE + '.grpc_client_started_total',
         NAMESPACE + '.rest_client_request_latency_seconds.sum',
         NAMESPACE + '.rest_client_request_latency_seconds.count',
         NAMESPACE + '.admission_step_admission_latencies_seconds.sum',
@@ -63,6 +67,19 @@ class TestKubeAPIServerMetrics:
         NAMESPACE + '.admission_step_admission_latencies_seconds_summary.quantile',
         NAMESPACE + '.admission_controller_admission_duration_seconds.sum',
         NAMESPACE + '.admission_controller_admission_duration_seconds.count',
+        NAMESPACE + '.registered_watchers',
+        NAMESPACE + '.etcd_request_duration_seconds.sum',
+        NAMESPACE + '.etcd_request_duration_seconds.count',
+        NAMESPACE + '.request_duration_seconds.sum',
+        NAMESPACE + '.request_duration_seconds.count',
+        # v1.16+
+        # https://v1-16.docs.kubernetes.io/docs/setup/release/#added-metrics
+        # NAMESPACE + '.watch_events_sizes.sum',
+        # NAMESPACE + '.watch_events_sizes.count',
+        # v1.17+
+        # https://github.com/kubernetes/kubernetes/pull/82409
+        # NAMESPACE + '.authentication_duration_seconds.sum',
+        # NAMESPACE + '.authentication_duration_seconds.count',
     ]
     COUNT_METRICS = [
         NAMESPACE + '.audit_event.count',
@@ -72,6 +89,12 @@ class TestKubeAPIServerMetrics:
         NAMESPACE + '.http_requests_total.count',
         NAMESPACE + '.authenticated_user_requests.count',
         NAMESPACE + '.apiserver_request_total.count',
+        # v1.16+
+        # https://v1-16.docs.kubernetes.io/docs/setup/release/#added-metrics
+        # NAMESPACE + '.authentication_attempts.count',
+        # v1.17+
+        # https://github.com/kubernetes/kubernetes/pull/83427
+        # NAMESPACE + '.apiserver_request_terminations_total.count',
     ]
 
     def test_check(self, aggregator, mock_get):


### PR DESCRIPTION
### What does this PR do?
It adds new metrics scraped from API servers:

* registered_watchers
* request_duration_seconds
* request_terminations_total
* watch_events_sizes
* authentication_attempts
* authentication_duration_seconds
* etcd_request_duration_seconds
* grpc_client_handled_total
* grpc_client_msg_received_total
* grpc_client_msg_sent_total
* grpc_client_started_total

### Motivation
Fixes #8522

We had trouble investigating poor performance of the control plane

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
