### PR TITLE
Avoid ZeroDivisionError for hdfs.namenode.capacity_in_use 

### DIFF
--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -119,7 +119,7 @@ class HDFSNameNode(AgentCheck):
             if metric_value is not None:
                 self._set_metric(metric_name, metric_type, metric_value, tags)
 
-        if 'CapacityUsed' in bean and 'CapacityTotal' in bean:
+        if 'CapacityUsed' in bean and 'CapacityTotal' in bean and float(bean['CapacityTotal']) > 0:
             self._set_metric(
                 'hdfs.namenode.capacity_in_use',
                 self.GAUGE,

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -119,13 +119,15 @@ class HDFSNameNode(AgentCheck):
             if metric_value is not None:
                 self._set_metric(metric_name, metric_type, metric_value, tags)
 
-        if 'CapacityUsed' in bean and 'CapacityTotal' in bean and float(bean['CapacityTotal']) > 0:
-            self._set_metric(
-                'hdfs.namenode.capacity_in_use',
-                self.GAUGE,
-                float(bean['CapacityUsed']) / float(bean['CapacityTotal']),
-                tags,
-            )
+        if 'CapacityUsed' in bean and 'CapacityTotal' in bean:
+            capacity_total = float(bean.get('CapacityTotal', 0))
+            if capacity_total > 0:
+                self._set_metric(
+                    'hdfs.namenode.capacity_in_use',
+                    self.GAUGE,
+                    float(bean['CapacityUsed']) / capacity_total,
+                    tags,
+                )
 
     def _set_metric(self, metric_name, metric_type, value, tags=None):
         """

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -9,6 +9,7 @@ from six import iteritems
 from six.moves.urllib.parse import urljoin
 
 from datadog_checks.base import AgentCheck
+from datadog_checks.base.utils.common import compute_percent
 
 
 class HDFSNameNode(AgentCheck):
@@ -120,14 +121,13 @@ class HDFSNameNode(AgentCheck):
                 self._set_metric(metric_name, metric_type, metric_value, tags)
 
         if 'CapacityUsed' in bean and 'CapacityTotal' in bean:
-            capacity_total = float(bean.get('CapacityTotal', 0))
-            if capacity_total > 0:
-                self._set_metric(
-                    'hdfs.namenode.capacity_in_use',
-                    self.GAUGE,
-                    float(bean['CapacityUsed']) / capacity_total,
-                    tags,
-                )
+            capacity_in_use = compute_percent(float(bean['CapacityUsed']), float(bean.get('CapacityTotal', 0)))
+            self._set_metric(
+                'hdfs.namenode.capacity_in_use',
+                self.GAUGE,
+                capacity_in_use,
+                tags,
+            )
 
     def _set_metric(self, metric_name, metric_type, value, tags=None):
         """


### PR DESCRIPTION
### What does this PR do?
Do not submit `hdfs.namenode.capacity_in_use` if CapacityTotal is 0.

### Motivation
Resolves https://github.com/DataDog/integrations-core/issues/8564

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
