### PR TITLE
Pin cassandra test version

### DIFF
--- a/cassandra_nodetool/tox.ini
+++ b/cassandra_nodetool/tox.ini
@@ -19,7 +19,7 @@ deps =
     -rrequirements-dev.txt
 setenv =
     2.1: CASSANDRA_VERSION=2.1.14
-    3.0: CASSANDRA_VERSION=3.0
+    3.0: CASSANDRA_VERSION=3.0.22
     CONTAINER_PORT=7199
 passenv =
     DOCKER*

--- a/cassandra_nodetool/tox.ini
+++ b/cassandra_nodetool/tox.ini
@@ -19,7 +19,7 @@ deps =
     -rrequirements-dev.txt
 setenv =
     2.1: CASSANDRA_VERSION=2.1.14
-    3.0: CASSANDRA_VERSION=3.0.22
+    3.0: CASSANDRA_VERSION=3.0.23
     CONTAINER_PORT=7199
 passenv =
     DOCKER*


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Image tag `3.0` recently changed to `3.0.23` and it broke integration tests, because the nodes in the cluster test didn't have the same version. Pinning the image patch version solves this.

Error: `There are nodes in the cluster with a different schema version than us we did not merged schemas from, our version`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
