### PR TITLE
Rename cluster_name tag to vault_cluster

### DIFF
--- a/vault/assets/configuration/spec.yaml
+++ b/vault/assets/configuration/spec.yaml
@@ -36,6 +36,11 @@ files:
       value:
         example: false
         type: boolean
+    - name: disable_legacy_cluster_tag
+      description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `vault_cluster`.
+      value:
+        type: boolean
+        example: false
     - template: instances/http
     - template: instances/default
   - template: logs

--- a/vault/datadog_checks/vault/data/conf.yaml.example
+++ b/vault/datadog_checks/vault/data/conf.yaml.example
@@ -71,6 +71,11 @@ instances:
     #
     # no_token: false
 
+    ## @param disable_legacy_cluster_tag - boolean - optional - default: false
+    ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `vault_cluster`.
+    #
+    # disable_legacy_cluster_tag: false
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -66,6 +66,7 @@ class Vault(OpenMetricsBaseCheck):
         self._no_token = is_affirmative(self.instance.get('no_token', False))
         self._tags = list(self.instance.get('tags', []))
         self._tags.append('api_url:{}'.format(self._api_url))
+        self._disable_legacy_cluster_tag = is_affirmative(self.instance.get('disable_legacy_cluster_tag', False))
 
         # Keep track of the previous cluster leader to detect changes
         self._previous_leader = None
@@ -196,7 +197,9 @@ class Vault(OpenMetricsBaseCheck):
         health_data = self.access_api(url, ignore_status_codes=self.SYS_HEALTH_DEFAULT_CODES)
         cluster_name = health_data.get('cluster_name')
         if cluster_name:
-            dynamic_tags.append('cluster_name:{}'.format(cluster_name))
+            dynamic_tags.append('vault_cluster:{}'.format(cluster_name))
+            if not self._disable_legacy_cluster_tag:
+                dynamic_tags.append('cluster_name:{}'.format(cluster_name))
 
         replication_mode = health_data.get('replication_dr_mode', '').lower()
         if replication_mode == 'secondary':

--- a/vault/tests/test_integration.py
+++ b/vault/tests/test_integration.py
@@ -90,6 +90,7 @@ def assert_collection(aggregator, tags, runs=1):
                     raise
             else:
                 aggregator.assert_metric_has_tag_prefix(metric, 'is_leader:')
+                aggregator.assert_metric_has_tag_prefix(metric, 'vault_cluster:')
                 aggregator.assert_metric_has_tag_prefix(metric, 'cluster_name:')
                 aggregator.assert_metric_has_tag_prefix(metric, 'vault_version:')
 


### PR DESCRIPTION
### What does this PR do?
This PR introduces a backwards compatible config option `disable_legacy_cluster_tag` which will stop sending `cluster_name` tag.

### Motivation
`cluster_name` tag is also emitted at the hostlevel. Using a service specific tag key will prevent conflicts/confusion.
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
