### PR TITLE
Rename cluster_name tag to yarn_cluster

### DIFF
--- a/yarn/assets/configuration/spec.yaml
+++ b/yarn/assets/configuration/spec.yaml
@@ -91,7 +91,11 @@ files:
             value:
               example: false
               type: boolean
-
+          - name: disable_legacy_cluster_tag
+            description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `yarn_cluster`.
+            value:
+              type: boolean
+              example: false
           - template: instances/http
           - template: instances/default
 

--- a/yarn/datadog_checks/yarn/data/conf.yaml.example
+++ b/yarn/datadog_checks/yarn/data/conf.yaml.example
@@ -119,6 +119,11 @@ instances:
     #
     # split_yarn_application_tags: false
 
+    ## @param disable_legacy_cluster_tag - boolean - optional - default: false
+    ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `yarn_cluster`.
+    #
+    # disable_legacy_cluster_tag: false
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/yarn/datadog_checks/yarn/yarn.py
+++ b/yarn/datadog_checks/yarn/yarn.py
@@ -163,6 +163,7 @@ class YarnCheck(AgentCheck):
     def __init__(self, *args, **kwargs):
         super(YarnCheck, self).__init__(*args, **kwargs)
         application_status_mapping = self.instance.get('application_status_mapping', DEFAULT_APPLICATION_STATUS_MAPPING)
+        self._disable_legacy_cluster_tag = is_affirmative(self.instance.get('disable_legacy_cluster_tag', False))
         try:
             self.application_status_mapping = {
                 k.upper(): getattr(AgentCheck, v.upper()) for k, v in application_status_mapping.items()
@@ -203,7 +204,9 @@ class YarnCheck(AgentCheck):
             )
             cluster_name = DEFAULT_CLUSTER_NAME
 
-        tags.append('cluster_name:{}'.format(cluster_name))
+        tags.append('yarn_cluster:{}'.format(cluster_name))
+        if not self._disable_legacy_cluster_tag:
+            tags.append('cluster_name:{}'.format(cluster_name))
 
         # Get metrics from the Resource Manager
         self._yarn_cluster_metrics(rm_address, tags)

--- a/yarn/datadog_checks/yarn/yarn.py
+++ b/yarn/datadog_checks/yarn/yarn.py
@@ -163,7 +163,6 @@ class YarnCheck(AgentCheck):
     def __init__(self, *args, **kwargs):
         super(YarnCheck, self).__init__(*args, **kwargs)
         application_status_mapping = self.instance.get('application_status_mapping', DEFAULT_APPLICATION_STATUS_MAPPING)
-        self._disable_legacy_cluster_tag = is_affirmative(self.instance.get('disable_legacy_cluster_tag', False))
         try:
             self.application_status_mapping = {
                 k.upper(): getattr(AgentCheck, v.upper()) for k, v in application_status_mapping.items()
@@ -205,7 +204,7 @@ class YarnCheck(AgentCheck):
             cluster_name = DEFAULT_CLUSTER_NAME
 
         tags.append('yarn_cluster:{}'.format(cluster_name))
-        if not self._disable_legacy_cluster_tag:
+        if not is_affirmative(self.instance.get('disable_legacy_cluster_tag', False)):
             tags.append('cluster_name:{}'.format(cluster_name))
 
         # Get metrics from the Resource Manager

--- a/yarn/tests/common.py
+++ b/yarn/tests/common.py
@@ -31,7 +31,8 @@ INSTANCE_INTEGRATION = {
     "cluster_name": CLUSTER_NAME,
 }
 
-CLUSTER_TAG = "cluster_name:{}".format(CLUSTER_NAME)
+LEGACY_CLUSTER_TAG = "cluster_name:{}".format(CLUSTER_NAME)
+YARN_CLUSTER_TAG = "yarn_cluster:{}".format(CLUSTER_NAME)
 
 EXPECTED_METRICS = [
     "yarn.metrics.apps_submitted",
@@ -90,7 +91,7 @@ EXPECTED_METRICS = [
     "yarn.node.num_containers",
 ]
 
-EXPECTED_TAGS = ['cluster_name:test']
+EXPECTED_TAGS = ['cluster_name:test', 'yarn_cluster:test']
 
 YARN_CONFIG = {
     'instances': [
@@ -225,7 +226,7 @@ YARN_CLUSTER_METRICS_VALUES = {
     'yarn.metrics.rebooted_nodes': 0,
 }
 
-YARN_CLUSTER_METRICS_TAGS = ['cluster_name:{}'.format(CLUSTER_NAME)]
+YARN_CLUSTER_METRICS_TAGS = [LEGACY_CLUSTER_TAG, YARN_CLUSTER_TAG]
 
 DEPRECATED_YARN_APP_METRICS_VALUES = {
     'yarn.apps.progress': 100,
@@ -251,7 +252,7 @@ YARN_APP_METRICS_VALUES = {
     'yarn.apps.vcore_seconds_gauge': 103,
 }
 
-YARN_APP_METRICS_TAGS = ['cluster_name:{}'.format(CLUSTER_NAME), 'app_name:word count', 'app_queue:default']
+YARN_APP_METRICS_TAGS = ['app_name:word count', 'app_queue:default'] + YARN_CLUSTER_METRICS_TAGS
 
 YARN_NODE_METRICS_VALUES = {
     'yarn.node.last_health_update': 1324056895432,
@@ -262,7 +263,7 @@ YARN_NODE_METRICS_VALUES = {
     'yarn.node.num_containers': 0,
 }
 
-YARN_NODE_METRICS_TAGS = ['cluster_name:{}'.format(CLUSTER_NAME), 'node_id:h2:1235']
+YARN_NODE_METRICS_TAGS = ['node_id:h2:1235'] + YARN_CLUSTER_METRICS_TAGS
 
 YARN_ROOT_QUEUE_METRICS_VALUES = {
     'yarn.queue.root.max_capacity': 100,
@@ -270,7 +271,7 @@ YARN_ROOT_QUEUE_METRICS_VALUES = {
     'yarn.queue.root.capacity': 100,
 }
 
-YARN_ROOT_QUEUE_METRICS_TAGS = ['cluster_name:{}'.format(CLUSTER_NAME), 'queue_name:root']
+YARN_ROOT_QUEUE_METRICS_TAGS = ['queue_name:root'] + YARN_CLUSTER_METRICS_TAGS
 
 YARN_QUEUE_METRICS_VALUES = {
     'yarn.queue.num_pending_applications': 0,
@@ -297,6 +298,6 @@ YARN_QUEUE_METRICS_VALUES = {
     'yarn.queue.max_applications_per_user': 5212,
 }
 
-YARN_QUEUE_METRICS_TAGS = ['cluster_name:{}'.format(CLUSTER_NAME), 'queue_name:clientqueue']
+YARN_QUEUE_METRICS_TAGS = ['queue_name:clientqueue'] + YARN_CLUSTER_METRICS_TAGS
 
-YARN_QUEUE_NOFOLLOW_METRICS_TAGS = ['cluster_name:{}'.format(CLUSTER_NAME), 'queue_name:nofollowqueue']
+YARN_QUEUE_NOFOLLOW_METRICS_TAGS = ['queue_name:nofollowqueue'] + YARN_CLUSTER_METRICS_TAGS

--- a/yarn/tests/test_integration.py
+++ b/yarn/tests/test_integration.py
@@ -26,6 +26,7 @@ def test_check_e2e(dd_agent_check, instance):
 def assert_check(aggregator):
     aggregator.assert_service_check('yarn.can_connect', AgentCheck.OK)
     for metric in common.EXPECTED_METRICS:
-        aggregator.assert_metric_has_tag(metric, common.CLUSTER_TAG)
+        aggregator.assert_metric_has_tag(metric, common.YARN_CLUSTER_TAG)
+        aggregator.assert_metric_has_tag(metric, common.LEGACY_CLUSTER_TAG)
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
This PR introduces a backwards compatible config option disable_legacy_cluster_tag which will stop sending cluster_name tag.

### Motivation
cluster_name tag is also emitted at the hostlevel. Using a service specific tag key will prevent conflicts/confusion.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
