### PR TITLE
Clarify windows user and validate connection options

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -181,7 +181,7 @@ files:
       description: |
         Specify a custom connection string to be used
         Ex: "ApplicationIntent=ReadWrite" or "MultiSubnetFailover=True"
-        "Trusted_Connection=yes" to use Windows Authentication (note that in this case the connection will be perfomed
+        "Trusted_Connection=yes" to use Windows Authentication (note that in this case the connection will be performed
         with the `ddagentuser` user, you can find more information about this user
         in https://docs.datadoghq.com/agent/faq/windows-agent-ddagent-user/)
       value:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -181,7 +181,9 @@ files:
       description: |
         Specify a custom connection string to be used
         Ex: "ApplicationIntent=ReadWrite" or "MultiSubnetFailover=True"
-        "Trusted_Connection=yes" to use Windows Authentication
+        "Trusted_Connection=yes" to use Windows Authentication (note that in this case the connection will be perfomed
+        with the `ddagentuser` user, you can find more information about this user
+        in https://docs.datadoghq.com/agent/faq/windows-agent-ddagent-user/)
       value:
         type: string
         example: "<CONNECTION_STRING>"

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -307,26 +307,23 @@ class Connection(object):
         }
 
         if self.connector == 'adodbapi':
-            for key, value in adodbapi_options.items():
-                if key in cs:
-                    raise ConfigurationError("%s has been provided both in the connection string and as a "
-                                             "configuration option, please specify it only one".format(key))
-            for key, value in odbc_options.items():
-                if key in cs or value is not None:
-                    raise ConfigurationError("%s has been provided in the connection string. "
-                                             "This option is only available for odbc connections,"
-                                             " however adodbapi has been selected" % key)
+            other_connector = 'odbc'
+            connector_options = adodbapi_options
+            other_connector_options = odbc_options
         else:
-            for key, value in odbc_options.items():
-                if key in cs:
-                    raise ConfigurationError("%s has been provided both in the connection string and as a "
-                                             "configuration option, please specify it only one".format(key))
-            for key, value in adodbapi_options.items():
-                if key in cs or value is not None:
-                    raise ConfigurationError("%s has been provided in the connection string. "
-                                             "This option is only available for adodbapi connections,"
-                                             " however odbc has been selected" % key)
+            other_connector = 'adodbapi'
+            connector_options = odbc_options
+            other_connector_options = adodbapi_options
 
+        for key, value in connector_options.items():
+            if key in cs:
+                raise ConfigurationError("%s has been provided both in the connection string and as a "
+                                         "configuration option, please specify it only one".format(key))
+        for key, value in other_connector_options.items():
+            if key in cs or value is not None:
+                raise ConfigurationError("%s has been provided in the connection string. "
+                                         "This option is only available for %s connections,"
+                                         " however %s has been selected" % (key, other_connector, self.connector))
 
     def _conn_string_odbc(self, db_key, conn_key=None, db_name=None):
         """Return a connection string to use with odbc"""

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -325,7 +325,7 @@ class Connection(object):
         for key, value in connector_options.items():
             if key in cs:
                 raise ConfigurationError("%s has been provided both in the connection string and as a "
-                                         "configuration option, please specify it only one".format(key))
+                                         "configuration option, please specify it only once".format(key))
         for key, value in other_connector_options.items():
             if key in cs or value is not None:
                 raise ConfigurationError("%s has been provided in the connection string. "

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -325,7 +325,7 @@ class Connection(object):
                     "%s has been provided both in the connection string and as a "
                     "configuration option (%s), please specify it only once" % (key, value)
                 )
-        for key, value in other_connector_options.items():
+        for key in other_connector_options.keys():
             if key.upper() in cs:
                 raise ConfigurationError(
                     "%s has been provided in the connection string. "

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -310,10 +310,17 @@ class Connection(object):
             other_connector = 'odbc'
             connector_options = adodbapi_options
             other_connector_options = odbc_options
+            if provider:
+                self.log.warning("Provider option will be ignored since adodbapi connection is used")
+
         else:
             other_connector = 'adodbapi'
             connector_options = odbc_options
             other_connector_options = adodbapi_options
+            if dsn:
+                self.log.warning("DSN option will be ignored since odbc connection is used")
+            if driver:
+                self.log.warning("Driver option will be ignored since odbc connection is used")
 
         for key, value in connector_options.items():
             if key in cs:

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -176,7 +176,9 @@ instances:
     ## @param connection_string - string - optional
     ## Specify a custom connection string to be used
     ## Ex: "ApplicationIntent=ReadWrite" or "MultiSubnetFailover=True"
-    ## "Trusted_Connection=yes" to use Windows Authentication
+    ## "Trusted_Connection=yes" to use Windows Authentication (note that in this case the connection will be performed
+    ## with the `ddagentuser` user, you can find more information about this user
+    ## in https://docs.datadoghq.com/agent/faq/windows-agent-ddagent-user/)
     #
     # connection_string: <CONNECTION_STRING>
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -99,7 +99,7 @@ class SQLServer(AgentCheck):
             )
 
     def initialize_connection(self):
-        self.connection = Connection(self.init_config, self.instance, self.handle_service_check, self.log)
+        self.connection = Connection(self.init_config, self.instance, self.handle_service_check)
 
         # Pre-process the list of metrics to collect
         try:

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -1,0 +1,83 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
+import pytest
+from datadog_checks.base import ConfigurationError
+
+from datadog_checks.sqlserver.connection import Connection
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    'connector, param',
+     [
+         pytest.param('adodbapi', 'adoprovider', id='Provider is ignored when using adodbapi'),
+         pytest.param('odbc', 'dsn', id='DSN is ignored when using odbc'),
+         pytest.param('odbc', 'driver', id='Driver is ignored when using odbc'),
+     ]
+)
+def test_will_warn_parameters_for_the_wrong_connection(instance_sql2017_defaults, connector, param):
+    instance_sql2017_defaults.update({
+        'connector': connector,
+        param: 'foo'
+    })
+    connection = Connection({}, instance_sql2017_defaults, None)
+    connection.log = mock.MagicMock()
+    connection._connection_options_validation('somekey', 'somedb')
+    connection.log.warning.assert_called_once_with(
+        "%s option will be ignored since %s connection is used", param, connector)
+
+
+@pytest.mark.parametrize(
+    'connector, cs, param',
+     [
+         pytest.param('adodbapi', 'DSN', 'dsn', id='Cannot define DSN twice'),
+         pytest.param('adodbapi', 'DRIVER', 'driver', id='Cannot define DRIVER twice'),
+         pytest.param('adodbapi', 'SERVER', 'host', id='Cannot define DRIVER twice'),
+         pytest.param('adodbapi', 'UID', 'username', id='Cannot define UID twice'),
+         pytest.param('adodbapi', 'PWD', 'password', id='Cannot define PWD twice'),
+         pytest.param('odbc', 'PROVIDER', 'adoprovider', id='Cannot define PROVIDER twice'),
+         pytest.param('odbc', 'Data Source', 'host', id='Cannot define Data source twice'),
+         pytest.param('odbc', 'User ID', 'username', id='Cannot define User ID twice'),
+         pytest.param('odbc', 'Password', 'password', id='Cannot define Password twice'),
+     ]
+)
+def will_fail_for_duplicate_parameters(instance_sql2017_defaults, connector, cs, param):
+    instance_sql2017_defaults.update({
+        'connector': connector,
+        param: 'foo',
+        'connection_string': cs + "=foo"
+    })
+    connection = Connection({}, instance_sql2017_defaults, None)
+    match = "%s has been provided both in the connection string and as a configuration option (%s), please specify it only once".format(cs, param)
+    with pytest.raises(ConfigurationError, match=match):
+        connection._connection_options_validation('somekey', 'somedb')
+
+
+@pytest.mark.parametrize(
+    'connector, cs, param',
+     [
+         pytest.param('odbc', 'DSN=foo', id='Cannot define DSN for odbc'),
+         pytest.param('odbc', 'DRIVER=foo', id='Cannot define DRIVER for odbc'),
+         pytest.param('odbc', 'SERVER=foo', id='Cannot define DRIVER for odbc'),
+         pytest.param('odbc', 'UID=foo', id='Cannot define UID for odbc'),
+         pytest.param('odbc', 'PWD=foo', id='Cannot define PWD for odbc'),
+         pytest.param('adodbapi', 'PROVIDER=foo', id='Cannot define PROVIDER for adodbapi'),
+         pytest.param('adodbapi', 'Data Source=foo', id='Cannot define Data source for adodbapi'),
+         pytest.param('adodbapi', 'User ID=foo', id='Cannot define User ID for adodbapi'),
+         pytest.param('adodbapi', 'Password=foo', id='Cannot define Password for adodbapi'),
+     ]
+)
+def will_fail_for_wrong_parameters_in_the_connection_string(instance_sql2017_defaults, connector, cs):
+    instance_sql2017_defaults.update({
+        'connector': connector,
+        'connection_string': cs
+    })
+    other_connector = 'odbc' if connector != 'odbc' else 'adodbapi'
+    connection = Connection({}, instance_sql2017_defaults, None)
+    match = "%s has been provided in the connection string. This option is only available for %s connections, however %s has been selected" % (cs, other_connector, connector)
+    with pytest.raises(ConfigurationError, match=match):
+        connection._connection_options_validation('somekey', 'somedb')

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -1,83 +1,84 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import re
+
 import mock
 import pytest
+
 from datadog_checks.base import ConfigurationError
-
 from datadog_checks.sqlserver.connection import Connection
-
 
 pytestmark = pytest.mark.unit
 
 
 @pytest.mark.parametrize(
     'connector, param',
-     [
-         pytest.param('adodbapi', 'adoprovider', id='Provider is ignored when using adodbapi'),
-         pytest.param('odbc', 'dsn', id='DSN is ignored when using odbc'),
-         pytest.param('odbc', 'driver', id='Driver is ignored when using odbc'),
-     ]
+    [
+        pytest.param('adodbapi', 'adoprovider', id='Provider is ignored when using adodbapi'),
+        pytest.param('odbc', 'dsn', id='DSN is ignored when using odbc'),
+        pytest.param('odbc', 'driver', id='Driver is ignored when using odbc'),
+    ],
 )
 def test_will_warn_parameters_for_the_wrong_connection(instance_sql2017_defaults, connector, param):
-    instance_sql2017_defaults.update({
-        'connector': connector,
-        param: 'foo'
-    })
+    instance_sql2017_defaults.update({'connector': connector, param: 'foo'})
     connection = Connection({}, instance_sql2017_defaults, None)
     connection.log = mock.MagicMock()
     connection._connection_options_validation('somekey', 'somedb')
     connection.log.warning.assert_called_once_with(
-        "%s option will be ignored since %s connection is used", param, connector)
+        "%s option will be ignored since %s connection is used", param, connector
+    )
 
 
 @pytest.mark.parametrize(
     'connector, cs, param',
-     [
-         pytest.param('adodbapi', 'DSN', 'dsn', id='Cannot define DSN twice'),
-         pytest.param('adodbapi', 'DRIVER', 'driver', id='Cannot define DRIVER twice'),
-         pytest.param('adodbapi', 'SERVER', 'host', id='Cannot define DRIVER twice'),
-         pytest.param('adodbapi', 'UID', 'username', id='Cannot define UID twice'),
-         pytest.param('adodbapi', 'PWD', 'password', id='Cannot define PWD twice'),
-         pytest.param('odbc', 'PROVIDER', 'adoprovider', id='Cannot define PROVIDER twice'),
-         pytest.param('odbc', 'Data Source', 'host', id='Cannot define Data source twice'),
-         pytest.param('odbc', 'User ID', 'username', id='Cannot define User ID twice'),
-         pytest.param('odbc', 'Password', 'password', id='Cannot define Password twice'),
-     ]
+    [
+        pytest.param('adodbapi', 'DSN', 'dsn', id='Cannot define DSN twice'),
+        pytest.param('adodbapi', 'DRIVER', 'driver', id='Cannot define DRIVER twice'),
+        pytest.param('adodbapi', 'SERVER', 'host', id='Cannot define DRIVER twice'),
+        pytest.param('adodbapi', 'UID', 'username', id='Cannot define UID twice'),
+        pytest.param('adodbapi', 'PWD', 'password', id='Cannot define PWD twice'),
+        pytest.param('odbc', 'PROVIDER', 'adoprovider', id='Cannot define PROVIDER twice'),
+        pytest.param('odbc', 'Data Source', 'host', id='Cannot define Data Source twice'),
+        pytest.param('odbc', 'User ID', 'username', id='Cannot define User ID twice'),
+        pytest.param('odbc', 'Password', 'password', id='Cannot define Password twice'),
+    ],
 )
-def will_fail_for_duplicate_parameters(instance_sql2017_defaults, connector, cs, param):
-    instance_sql2017_defaults.update({
-        'connector': connector,
-        param: 'foo',
-        'connection_string': cs + "=foo"
-    })
+def test_will_fail_for_duplicate_parameters(instance_sql2017_defaults, connector, cs, param):
+    instance_sql2017_defaults.update({'connector': connector, param: 'foo', 'connection_string': cs + "=foo"})
     connection = Connection({}, instance_sql2017_defaults, None)
-    match = "%s has been provided both in the connection string and as a configuration option (%s), please specify it only once".format(cs, param)
-    with pytest.raises(ConfigurationError, match=match):
+    match = (
+        "%s has been provided both in the connection string and as a configuration option (%s), "
+        "please specify it only once" % (cs, param)
+    )
+
+    with pytest.raises(ConfigurationError, match=re.escape(match)):
         connection._connection_options_validation('somekey', 'somedb')
 
 
 @pytest.mark.parametrize(
-    'connector, cs, param',
-     [
-         pytest.param('odbc', 'DSN=foo', id='Cannot define DSN for odbc'),
-         pytest.param('odbc', 'DRIVER=foo', id='Cannot define DRIVER for odbc'),
-         pytest.param('odbc', 'SERVER=foo', id='Cannot define DRIVER for odbc'),
-         pytest.param('odbc', 'UID=foo', id='Cannot define UID for odbc'),
-         pytest.param('odbc', 'PWD=foo', id='Cannot define PWD for odbc'),
-         pytest.param('adodbapi', 'PROVIDER=foo', id='Cannot define PROVIDER for adodbapi'),
-         pytest.param('adodbapi', 'Data Source=foo', id='Cannot define Data source for adodbapi'),
-         pytest.param('adodbapi', 'User ID=foo', id='Cannot define User ID for adodbapi'),
-         pytest.param('adodbapi', 'Password=foo', id='Cannot define Password for adodbapi'),
-     ]
+    'connector, cs',
+    [
+        pytest.param('odbc', 'DSN', id='Cannot define DSN for odbc'),
+        pytest.param('odbc', 'DRIVER', id='Cannot define DRIVER for odbc'),
+        pytest.param('odbc', 'SERVER', id='Cannot define DRIVER for odbc'),
+        pytest.param('odbc', 'UID', id='Cannot define UID for odbc'),
+        pytest.param('odbc', 'PWD', id='Cannot define PWD for odbc'),
+        pytest.param('adodbapi', 'PROVIDER', id='Cannot define PROVIDER for adodbapi'),
+        pytest.param('adodbapi', 'Data Source', id='Cannot define Data source for adodbapi'),
+        pytest.param('adodbapi', 'User ID', id='Cannot define User ID for adodbapi'),
+        pytest.param('adodbapi', 'Password', id='Cannot define Password for adodbapi'),
+    ],
 )
-def will_fail_for_wrong_parameters_in_the_connection_string(instance_sql2017_defaults, connector, cs):
-    instance_sql2017_defaults.update({
-        'connector': connector,
-        'connection_string': cs
-    })
+def test_will_fail_for_wrong_parameters_in_the_connection_string(instance_sql2017_defaults, connector, cs):
+    instance_sql2017_defaults.update({'connector': connector, 'connection_string': cs + '=foo'})
     other_connector = 'odbc' if connector != 'odbc' else 'adodbapi'
     connection = Connection({}, instance_sql2017_defaults, None)
-    match = "%s has been provided in the connection string. This option is only available for %s connections, however %s has been selected" % (cs, other_connector, connector)
-    with pytest.raises(ConfigurationError, match=match):
+    match = (
+        "%s has been provided in the connection string. "
+        "This option is only available for %s connections, however %s has been selected"
+        % (cs, other_connector, connector)
+    )
+
+    with pytest.raises(ConfigurationError, match=re.escape(match)):
         connection._connection_options_validation('somekey', 'somedb')


### PR DESCRIPTION
We add config options to the connection string even if they are already there. This change prevents options to be added twice the connection string