### PR TITLE
Add missing Envoy HTTP router filter vhost metrics

### DIFF
--- a/envoy/datadog_checks/envoy/metrics.py
+++ b/envoy/datadog_checks/envoy/metrics.py
@@ -374,6 +374,38 @@ METRICS = {
         ),
         'method': 'monotonic_count',
     },
+    'vhost.vcluster.upstream_rq_retry': {
+        'tags': (
+            ('virtual_host_name', ),
+            ('virtual_cluster_name', ),
+            (),
+        ),
+        'method': 'monotonic_count',
+    },
+    'vhost.vcluster.upstream_rq_retry_limit_exceeded': {
+        'tags': (
+            ('virtual_host_name', ),
+            ('virtual_cluster_name', ),
+            (),
+        ),
+        'method': 'monotonic_count',
+    },
+    'vhost.vcluster.upstream_rq_retry_overflow': {
+        'tags': (
+            ('virtual_host_name', ),
+            ('virtual_cluster_name', ),
+            (),
+        ),
+        'method': 'monotonic_count',
+    },
+    'vhost.vcluster.upstream_rq_retry_success': {
+        'tags': (
+            ('virtual_host_name', ),
+            ('virtual_cluster_name', ),
+            (),
+        ),
+        'method': 'monotonic_count',
+    },
     'vhost.vcluster.upstream_rq_time': {
         'tags': (
             ('virtual_host_name', ),
@@ -381,6 +413,22 @@ METRICS = {
             (),
         ),
         'method': 'histogram',
+    },
+    'vhost.vcluster.upstream_rq_timeout': {
+        'tags': (
+            ('virtual_host_name', ),
+            ('virtual_cluster_name', ),
+            (),
+        ),
+        'method': 'monotonic_count',
+    },
+    'vhost.vcluster.upstream_rq_total': {
+        'tags': (
+            ('virtual_host_name', ),
+            ('virtual_cluster_name', ),
+            (),
+        ),
+        'method': 'monotonic_count',
     },
     'cluster.ratelimit.ok': {
         'tags': (

--- a/envoy/metadata.csv
+++ b/envoy/metadata.csv
@@ -28,6 +28,12 @@ envoy.vhost.vcluster.upstream_rq_2xx,count,,response,,Aggregate HTTP 2xx respons
 envoy.vhost.vcluster.upstream_rq_3xx,count,,response,,Aggregate HTTP 3xx response codes,0,envoy,vhost 3xx response codes
 envoy.vhost.vcluster.upstream_rq_4xx,count,,response,,Aggregate HTTP 4xx response codes,-1,envoy,vhost 4xx response codes
 envoy.vhost.vcluster.upstream_rq_5xx,count,,response,,Aggregate HTTP 5xx response codes,-1,envoy,vhost 5xx response codes
+envoy.vhost.vcluster.upstream_rq_retry,count,,request,,Total request retries,-1,envoy,vhost request retries
+envoy.vhost.vcluster.upstream_rq_retry_limit_exceeded,count,,request,,Total requests not retried due to exceeding the configured number of maximum retries,-1,envoy,vhost request retries exceeded
+envoy.vhost.vcluster.upstream_rq_retry_overflow,count,,request,,Total requests not retried due to circuit breaking or exceeding the retry budgets,-1,envoy,vhost request retries over budget
+envoy.vhost.vcluster.upstream_rq_retry_success,count,,request,,Total request retry successes,0,envoy,vhost request retries succeeded
+envoy.vhost.vcluster.upstream_rq_timeout,count,,request,,Total requests that timed out waiting for a response,-1,envoy,vhost requests timed out
+envoy.vhost.vcluster.upstream_rq_total,count,,request,,Total requests initiated by the router to the upstream,0,envoy,vhost requests total
 envoy.cluster.ratelimit.ok,count,,response,,Total under limit responses from the rate limit service,1,envoy,
 envoy.cluster.ratelimit.error,count,,response,,Total errors contacting the rate limit service,-1,envoy,
 envoy.cluster.ratelimit.over_limit,count,,response,,Total over limit responses from the rate limit service,-1,envoy,


### PR DESCRIPTION
### What does this PR do?

Add a handful of missing Envoy metrics from the HTTP router filter. (https://www.envoyproxy.io/docs/envoy/v1.17.0/configuration/http/http_filters/router_filter.html?highlight=vhost#virtual-clusters)

### Motivation

Using those metrics.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
