### PR TITLE
Rename cluster_name tag to mapreduce_cluster

### DIFF
--- a/mapreduce/assets/configuration/spec.yaml
+++ b/mapreduce/assets/configuration/spec.yaml
@@ -85,7 +85,9 @@ files:
             description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `mapreduce_cluster`.
             value:
               type: boolean
-              example: false
+              default: false
+              example: true
+            enabled: true
           - template: instances/http
           - template: instances/default
 

--- a/mapreduce/assets/configuration/spec.yaml
+++ b/mapreduce/assets/configuration/spec.yaml
@@ -81,6 +81,11 @@ files:
             value:
               example: "<MAPREDUCE_CLUSTER_NAME>"
               type: string
+          - name: disable_legacy_cluster_tag
+            description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `mapreduce_cluster`.
+            value:
+              type: boolean
+              example: false
           - template: instances/http
           - template: instances/default
 

--- a/mapreduce/assets/configuration/spec.yaml
+++ b/mapreduce/assets/configuration/spec.yaml
@@ -85,7 +85,7 @@ files:
             description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `mapreduce_cluster`.
             value:
               type: boolean
-              default: false
+              display_default: false
               example: true
             enabled: true
           - template: instances/http

--- a/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
+++ b/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
@@ -110,7 +110,7 @@ instances:
     ## @param disable_legacy_cluster_tag - boolean - optional - default: false
     ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `mapreduce_cluster`.
     #
-    # disable_legacy_cluster_tag: false
+    disable_legacy_cluster_tag: true
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
+++ b/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
@@ -107,6 +107,11 @@ instances:
     #
     cluster_name: <MAPREDUCE_CLUSTER_NAME>
 
+    ## @param disable_legacy_cluster_tag - boolean - optional - default: false
+    ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `mapreduce_cluster`.
+    #
+    # disable_legacy_cluster_tag: false
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/mapreduce/datadog_checks/mapreduce/mapreduce.py
+++ b/mapreduce/datadog_checks/mapreduce/mapreduce.py
@@ -65,7 +65,11 @@ class MapReduceCheck(AgentCheck):
                 self.DEFAULT_CLUSTER_NAME,
             )
             cluster_name = self.DEFAULT_CLUSTER_NAME
-        self.metric_tags = self.custom_tags + ['cluster_name:{}'.format(cluster_name)]
+
+        self.metric_tags = self.custom_tags + ['mapreduce_cluster:{}'.format(cluster_name)]
+        if not is_affirmative(self.instance.get('disable_legacy_cluster_tag', False)):
+            self.metric_tags.append('cluster_name:{}'.format(cluster_name))
+
 
     def check(self, instance):
         # Get the running MR applications from YARN

--- a/mapreduce/datadog_checks/mapreduce/mapreduce.py
+++ b/mapreduce/datadog_checks/mapreduce/mapreduce.py
@@ -70,7 +70,6 @@ class MapReduceCheck(AgentCheck):
         if not is_affirmative(self.instance.get('disable_legacy_cluster_tag', False)):
             self.metric_tags.append('cluster_name:{}'.format(cluster_name))
 
-
     def check(self, instance):
         # Get the running MR applications from YARN
         running_apps = self._get_running_app_ids()

--- a/mapreduce/tests/common.py
+++ b/mapreduce/tests/common.py
@@ -29,6 +29,16 @@ RM_URI = 'http://{}:8088'.format(HOST)
 
 # Custom tags
 CUSTOM_TAGS = ['optional:tag1']
+MAPREDUCE_CLUSTER_TAG = 'mapreduce_cluster:{}'.format(CLUSTER_NAME)
+LEGACY_CLUSTER_TAG = 'cluster_name:{}'.format(CLUSTER_NAME)
+
+CLUSTER_TAGS = [MAPREDUCE_CLUSTER_TAG, LEGACY_CLUSTER_TAG]
+
+COMMON_TAGS = [
+    'app_name:{}'.format(APP_NAME),
+    'job_name:{}'.format(JOB_NAME),
+    'user_name:{}'.format(USER_NAME),
+] + CUSTOM_TAGS
 
 YARN_APPS_URL_BASE = '{}/{}'.format(RM_URI, MapReduceCheck.YARN_APPS_PATH)
 MR_JOBS_URL = '{}/proxy/{}/{}'.format(RM_URI, APP_ID, MapReduceCheck.MAPREDUCE_JOBS_PATH)
@@ -76,8 +86,6 @@ def mock_local_mapreduce_dns():
     with mock_local(mapping):
         yield
 
-
-CLUSTER_TAG = ['cluster_name:{}'.format(CLUSTER_NAME)]
 
 MR_CONFIG = {
     'instances': [
@@ -194,30 +202,15 @@ MAPREDUCE_JOB_METRIC_VALUES = {
     'mapreduce.job.successful_map_attempts': 0,
 }
 
-MAPREDUCE_JOB_METRIC_TAGS = [
-    'cluster_name:{}'.format(CLUSTER_NAME),
-    'app_name:{}'.format(APP_NAME),
-    'job_name:{}'.format(JOB_NAME),
-    'user_name:{}'.format(USER_NAME),
-]
-
 MAPREDUCE_MAP_TASK_METRIC_VALUES = {'mapreduce.job.map.task.elapsed_time': 99869037}
 
 MAPREDUCE_MAP_TASK_METRIC_TAGS = [
-    'cluster_name:{}'.format(CLUSTER_NAME),
-    'app_name:{}'.format(APP_NAME),
-    'job_name:{}'.format(JOB_NAME),
-    'user_name:{}'.format(USER_NAME),
     'task_type:map',
 ]
 
 MAPREDUCE_REDUCE_TASK_METRIC_VALUES = {'mapreduce.job.reduce.task.elapsed_time': 123456}
 
 MAPREDUCE_REDUCE_TASK_METRIC_TAGS = [
-    'cluster_name:{}'.format(CLUSTER_NAME),
-    'app_name:{}'.format(APP_NAME),
-    'job_name:{}'.format(JOB_NAME),
-    'user_name:{}'.format(USER_NAME),
     'task_type:reduce',
 ]
 
@@ -238,10 +231,3 @@ MAPREDUCE_JOB_COUNTER_METRIC_VALUES_RECORDS = {
     'mapreduce.job.counter.map_counter_value': {'value': 10, 'tags': ['counter_name:map_output_records']},
     'mapreduce.job.counter.reduce_counter_value': {'value': 11, 'tags': ['counter_name:map_output_records']},
 }
-
-MAPREDUCE_JOB_COUNTER_METRIC_TAGS = [
-    'cluster_name:{}'.format(CLUSTER_NAME),
-    'app_name:{}'.format(APP_NAME),
-    'job_name:{}'.format(JOB_NAME),
-    'user_name:{}'.format(USER_NAME),
-]

--- a/mapreduce/tests/test_mapreduce.py
+++ b/mapreduce/tests/test_mapreduce.py
@@ -7,13 +7,14 @@ from six import iteritems
 from datadog_checks.mapreduce import MapReduceCheck
 
 from .common import (
+    CLUSTER_TAGS,
+    COMMON_TAGS,
     CUSTOM_TAGS,
     INIT_CONFIG,
-    MAPREDUCE_JOB_COUNTER_METRIC_TAGS,
+    MAPREDUCE_CLUSTER_TAG,
     MAPREDUCE_JOB_COUNTER_METRIC_VALUES_READ,
     MAPREDUCE_JOB_COUNTER_METRIC_VALUES_RECORDS,
     MAPREDUCE_JOB_COUNTER_METRIC_VALUES_WRITTEN,
-    MAPREDUCE_JOB_METRIC_TAGS,
     MAPREDUCE_JOB_METRIC_VALUES,
     MAPREDUCE_MAP_TASK_METRIC_TAGS,
     MAPREDUCE_MAP_TASK_METRIC_VALUES,
@@ -39,24 +40,27 @@ def test_check(aggregator, mocked_request):
     # Run the check once
     mapreduce.check(instance)
 
+    # expected tags contains both mapreduce_cluster and cluster_name tags
+    expected_tags = COMMON_TAGS + CLUSTER_TAGS
+
     # Check the MapReduce job metrics
     for metric, value in iteritems(MAPREDUCE_JOB_METRIC_VALUES):
-        aggregator.assert_metric(metric, value=value, tags=MAPREDUCE_JOB_METRIC_TAGS + CUSTOM_TAGS, count=1)
+        aggregator.assert_metric(metric, value=value, tags=expected_tags, count=1)
 
     # Check the map task metrics
     for metric, value in iteritems(MAPREDUCE_MAP_TASK_METRIC_VALUES):
-        aggregator.assert_metric(metric, value=value, tags=MAPREDUCE_MAP_TASK_METRIC_TAGS + CUSTOM_TAGS, count=1)
+        aggregator.assert_metric(metric, value=value, tags=MAPREDUCE_MAP_TASK_METRIC_TAGS + expected_tags, count=1)
 
     # Check the reduce task metrics
     for metric, value in iteritems(MAPREDUCE_REDUCE_TASK_METRIC_VALUES):
-        aggregator.assert_metric(metric, value=value, tags=MAPREDUCE_REDUCE_TASK_METRIC_TAGS + CUSTOM_TAGS, count=1)
+        aggregator.assert_metric(metric, value=value, tags=MAPREDUCE_REDUCE_TASK_METRIC_TAGS + expected_tags, count=1)
 
     # Check the MapReduce job counter metrics
     for metric, attributes in iteritems(MAPREDUCE_JOB_COUNTER_METRIC_VALUES_READ):
         aggregator.assert_metric(
             metric,
             value=attributes["value"],
-            tags=attributes["tags"] + MAPREDUCE_JOB_COUNTER_METRIC_TAGS + CUSTOM_TAGS,
+            tags=attributes["tags"] + expected_tags,
             count=1,
         )
 
@@ -65,7 +69,7 @@ def test_check(aggregator, mocked_request):
         aggregator.assert_metric(
             metric,
             value=attributes["value"],
-            tags=attributes["tags"] + MAPREDUCE_JOB_COUNTER_METRIC_TAGS + CUSTOM_TAGS,
+            tags=attributes["tags"] + expected_tags,
             count=1,
         )
 
@@ -74,7 +78,7 @@ def test_check(aggregator, mocked_request):
         aggregator.assert_metric(
             metric,
             value=attributes["value"],
-            tags=attributes["tags"] + MAPREDUCE_JOB_COUNTER_METRIC_TAGS + CUSTOM_TAGS,
+            tags=attributes["tags"] + expected_tags,
             count=1,
         )
 
@@ -110,3 +114,60 @@ def test_auth(aggregator, mocked_auth_request):
     aggregator.assert_service_check(
         MapReduceCheck.MAPREDUCE_SERVICE_CHECK, status=MapReduceCheck.OK, tags=service_check_tags, count=1
     )
+
+
+def test_disable_legacy_cluster_tag(aggregator, mocked_request):
+    """
+    Test that we get all the metrics we're supposed to get
+    """
+    instance = MR_CONFIG['instances'][0]
+    instance['disable_legacy_cluster_tag'] = True
+
+    # Instantiate the check
+    mapreduce = MapReduceCheck('mapreduce', INIT_CONFIG, [instance])
+
+    # Run the check once
+    mapreduce.check(instance)
+
+    # Only mapreduce_cluster tag
+    expected_tags = COMMON_TAGS
+    expected_tags.append(MAPREDUCE_CLUSTER_TAG)
+
+    # Check the MapReduce job metrics
+    for metric, value in iteritems(MAPREDUCE_JOB_METRIC_VALUES):
+        aggregator.assert_metric(metric, value=value, tags=expected_tags, count=1)
+
+    # Check the map task metrics
+    for metric, value in iteritems(MAPREDUCE_MAP_TASK_METRIC_VALUES):
+        aggregator.assert_metric(metric, value=value, tags=MAPREDUCE_MAP_TASK_METRIC_TAGS + expected_tags, count=1)
+
+    # Check the reduce task metrics
+    for metric, value in iteritems(MAPREDUCE_REDUCE_TASK_METRIC_VALUES):
+        aggregator.assert_metric(metric, value=value, tags=MAPREDUCE_REDUCE_TASK_METRIC_TAGS + expected_tags, count=1)
+
+    # Check the MapReduce job counter metrics
+    for metric, attributes in iteritems(MAPREDUCE_JOB_COUNTER_METRIC_VALUES_READ):
+        aggregator.assert_metric(
+            metric,
+            value=attributes["value"],
+            tags=attributes["tags"] + expected_tags,
+            count=1,
+        )
+
+    # Check the MapReduce job counter metrics
+    for metric, attributes in iteritems(MAPREDUCE_JOB_COUNTER_METRIC_VALUES_WRITTEN):
+        aggregator.assert_metric(
+            metric,
+            value=attributes["value"],
+            tags=attributes["tags"] + expected_tags,
+            count=1,
+        )
+
+    # Check the MapReduce job counter metrics
+    for metric, attributes in iteritems(MAPREDUCE_JOB_COUNTER_METRIC_VALUES_RECORDS):
+        aggregator.assert_metric(
+            metric,
+            value=attributes["value"],
+            tags=attributes["tags"] + expected_tags,
+            count=1,
+        )


### PR DESCRIPTION
### What does this PR do?
This PR introduces a backwards compatible config option disable_legacy_cluster_tag which will stop sending cluster_name tag.

### Motivation
cluster_name tag is also emitted at the hostlevel. Using a service specific tag key will prevent conflicts/confusion.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
