### PR TITLE
Rename cluster_name tag to spark_cluster

### DIFF
--- a/spark/assets/configuration/spec.yaml
+++ b/spark/assets/configuration/spec.yaml
@@ -104,6 +104,11 @@ files:
         value:
           type: boolean
           example: false
+      - name: disable_legacy_cluster_tag
+        description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `spark_cluster`.
+        value:
+          type: boolean
+          example: false
       - template: instances/http
         overrides:
           auth_token.description: |

--- a/spark/assets/configuration/spec.yaml
+++ b/spark/assets/configuration/spec.yaml
@@ -108,7 +108,9 @@ files:
         description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `spark_cluster`.
         value:
           type: boolean
-          example: false
+          default: false
+          example: true
+        enabled: true
       - template: instances/http
         overrides:
           auth_token.description: |

--- a/spark/assets/configuration/spec.yaml
+++ b/spark/assets/configuration/spec.yaml
@@ -108,7 +108,7 @@ files:
         description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `spark_cluster`.
         value:
           type: boolean
-          default: false
+          display_default: false
           example: true
         enabled: true
       - template: instances/http

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -135,7 +135,7 @@ instances:
     ## @param disable_legacy_cluster_tag - boolean - optional - default: false
     ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `spark_cluster`.
     #
-    # disable_legacy_cluster_tag: false
+    disable_legacy_cluster_tag: true
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -132,6 +132,11 @@ instances:
     #
     # executor_level_metrics: false
 
+    ## @param disable_legacy_cluster_tag - boolean - optional - default: false
+    ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `spark_cluster`.
+    #
+    # disable_legacy_cluster_tag: false
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -175,7 +175,7 @@ class SparkCheck(AgentCheck):
                 SPARK_YARN_MODE,
             )
             self.cluster_mode = SPARK_YARN_MODE
-
+        self._disable_legacy_cluster_tag = is_affirmative(self.instance.get('disable_legacy_cluster_tag', False))
         self.metricsservlet_path = self.instance.get('metricsservlet_path', '/metrics/json')
 
         # Get the cluster name from the instance configuration
@@ -187,7 +187,10 @@ class SparkCheck(AgentCheck):
 
     def check(self, _):
         tags = list(self.tags)
-        tags.append('cluster_name:%s' % self.cluster_name)
+
+        tags.append('spark_cluster:%s' % self.cluster_name)
+        if not self._disable_legacy_cluster_tag:
+            tags.append('cluster_name:%s' % self.cluster_name)
 
         spark_apps = self._get_running_apps()
 
@@ -261,7 +264,7 @@ class SparkCheck(AgentCheck):
         tags = list(self.tags)
 
         tags.append('spark_cluster:%s' % self.cluster_name)
-        if is_affirmative(self.instance.get('disable_legacy_cluster_tag', False)):
+        if not self._disable_legacy_cluster_tag:
             tags.append('cluster_name:%s' % self.cluster_name)
 
         if self.cluster_mode == SPARK_STANDALONE_MODE:

--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -259,7 +259,10 @@ class SparkCheck(AgentCheck):
         Determine what mode was specified
         """
         tags = list(self.tags)
-        tags.append('cluster_name:%s' % self.cluster_name)
+
+        tags.append('spark_cluster:%s' % self.cluster_name)
+        if is_affirmative(self.instance.get('disable_legacy_cluster_tag', False)):
+            tags.append('cluster_name:%s' % self.cluster_name)
 
         if self.cluster_mode == SPARK_STANDALONE_MODE:
             # check for PRE-20

--- a/spark/tests/common.py
+++ b/spark/tests/common.py
@@ -5,6 +5,14 @@ from datadog_checks.dev import get_docker_hostname, get_here
 
 HERE = get_here()
 HOST = get_docker_hostname()
+
+CLUSTER_NAME = 'SparkCluster'
+
+CLUSTER_TAGS = [
+    'spark_cluster:' + CLUSTER_NAME,
+    'cluster_name:' + CLUSTER_NAME,
+]
+
 EXPECTED_E2E_METRICS = [
     'spark.driver.total_shuffle_read',
     'spark.stage.num_active_tasks',

--- a/spark/tests/common.py
+++ b/spark/tests/common.py
@@ -5,7 +5,6 @@ from datadog_checks.dev import get_docker_hostname, get_here
 
 HERE = get_here()
 HOST = get_docker_hostname()
-
 EXPECTED_E2E_METRICS = [
     'spark.driver.total_shuffle_read',
     'spark.stage.num_active_tasks',

--- a/spark/tests/test_e2e.py
+++ b/spark/tests/test_e2e.py
@@ -5,7 +5,7 @@ import pytest
 
 from datadog_checks.spark import SparkCheck
 
-from . import common, conftest
+from . import common
 
 
 @pytest.mark.e2e
@@ -27,5 +27,5 @@ def test_e2e(dd_agent_check):
     aggregator.assert_service_check(
         'spark.standalone_master.can_connect',
         status=SparkCheck.OK,
-        tags=['url:http://spark-master:8080'] + conftest.CLUSTER_TAGS,
+        tags=['url:http://spark-master:8080'] + common.CLUSTER_TAGS,
     )

--- a/spark/tests/test_e2e.py
+++ b/spark/tests/test_e2e.py
@@ -5,7 +5,7 @@ import pytest
 
 from datadog_checks.spark import SparkCheck
 
-from . import common
+from . import common, conftest
 
 
 @pytest.mark.e2e
@@ -27,5 +27,5 @@ def test_e2e(dd_agent_check):
     aggregator.assert_service_check(
         'spark.standalone_master.can_connect',
         status=SparkCheck.OK,
-        tags=['cluster_name:SparkCluster', 'url:http://spark-master:8080'],
+        tags=['url:http://spark-master:8080'] + conftest.CLUSTER_TAGS,
     )

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -19,12 +19,12 @@ from six.moves.urllib.parse import parse_qsl, unquote_plus, urlencode, urljoin, 
 from datadog_checks.base import ensure_unicode
 from datadog_checks.spark import SparkCheck
 
-from .common import INSTANCE_DRIVER_1, INSTANCE_DRIVER_2, INSTANCE_STANDALONE
+from .common import CLUSTER_NAME, CLUSTER_TAGS, INSTANCE_DRIVER_1, INSTANCE_DRIVER_2, INSTANCE_STANDALONE
 
 # IDs
 YARN_APP_ID = 'application_1459362484344_0011'
 SPARK_APP_ID = 'app_001'
-CLUSTER_NAME = 'SparkCluster'
+
 APP_NAME = 'PySparkShell'
 
 # URLs for cluster managers
@@ -57,11 +57,6 @@ TEST_USERNAME = 'admin'
 TEST_PASSWORD = 'password'
 
 CUSTOM_TAGS = ['optional:tag1']
-CLUSTER_TAGS = [
-    'spark_cluster:' + CLUSTER_NAME,
-    'cluster_name:' + CLUSTER_NAME,
-]
-
 COMMON_TAGS = [
     'app_name:' + APP_NAME,
 ] + CLUSTER_TAGS

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -57,6 +57,14 @@ TEST_USERNAME = 'admin'
 TEST_PASSWORD = 'password'
 
 CUSTOM_TAGS = ['optional:tag1']
+CLUSTER_TAGS = [
+    'spark_cluster:' + CLUSTER_NAME,
+    'cluster_name:' + CLUSTER_NAME,
+]
+
+COMMON_TAGS = [
+    'app_name:' + APP_NAME,
+] + CLUSTER_TAGS
 
 
 def join_url_dir(url, *args):
@@ -551,13 +559,11 @@ SPARK_JOB_RUNNING_METRIC_VALUES = {
 }
 
 SPARK_JOB_RUNNING_METRIC_TAGS = [
-    'cluster_name:' + CLUSTER_NAME,
-    'app_name:' + APP_NAME,
     'status:running',
     'job_id:0',
     'stage_id:0',
     'stage_id:1',
-]
+] + COMMON_TAGS
 
 SPARK_JOB_SUCCEEDED_METRIC_VALUES = {
     'spark.job.count': 3,
@@ -573,13 +579,11 @@ SPARK_JOB_SUCCEEDED_METRIC_VALUES = {
 }
 
 SPARK_JOB_SUCCEEDED_METRIC_TAGS = [
-    'cluster_name:' + CLUSTER_NAME,
-    'app_name:' + APP_NAME,
     'status:succeeded',
     'job_id:0',
     'stage_id:0',
     'stage_id:1',
-]
+] + COMMON_TAGS
 
 SPARK_STAGE_RUNNING_METRIC_VALUES = {
     'spark.stage.count': 3,
@@ -600,11 +604,9 @@ SPARK_STAGE_RUNNING_METRIC_VALUES = {
 }
 
 SPARK_STAGE_RUNNING_METRIC_TAGS = [
-    'cluster_name:' + CLUSTER_NAME,
-    'app_name:' + APP_NAME,
     'status:running',
     'stage_id:1',
-]
+] + COMMON_TAGS
 
 SPARK_STAGE_COMPLETE_METRIC_VALUES = {
     'spark.stage.count': 2,
@@ -625,11 +627,9 @@ SPARK_STAGE_COMPLETE_METRIC_VALUES = {
 }
 
 SPARK_STAGE_COMPLETE_METRIC_TAGS = [
-    'cluster_name:' + CLUSTER_NAME,
-    'app_name:' + APP_NAME,
     'status:complete',
     'stage_id:0',
-]
+] + COMMON_TAGS
 
 SPARK_DRIVER_METRIC_VALUES = {
     'spark.driver.rdd_blocks': 99,
@@ -678,10 +678,8 @@ SPARK_EXECUTOR_LEVEL_METRIC_VALUES = {
 }
 
 SPARK_EXECUTOR_LEVEL_METRIC_TAGS = [
-    'cluster_name:' + CLUSTER_NAME,
-    'app_name:' + APP_NAME,
     'executor_id:1',
-]
+] + COMMON_TAGS
 
 SPARK_RDD_METRIC_VALUES = {
     'spark.rdd.count': 1,
@@ -715,8 +713,6 @@ SPARK_STRUCTURED_STREAMING_METRIC_VALUES = {
     'spark.structured_streaming.used_bytes': 12,
 }
 
-SPARK_METRIC_TAGS = ['cluster_name:' + CLUSTER_NAME, 'app_name:' + APP_NAME]
-
 
 @pytest.mark.unit
 def test_yarn(aggregator):
@@ -738,7 +734,7 @@ def test_yarn(aggregator):
 
         # Check the driver metrics
         for metric, value in iteritems(SPARK_DRIVER_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the executor level metrics
         for metric, value in iteritems(SPARK_EXECUTOR_LEVEL_METRIC_VALUES):
@@ -746,21 +742,21 @@ def test_yarn(aggregator):
 
         # Check the summary executor metrics
         for metric, value in iteritems(SPARK_EXECUTOR_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the RDD metrics
         for metric, value in iteritems(SPARK_RDD_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the streaming statistics metrics
         for metric, value in iteritems(SPARK_STREAMING_STATISTICS_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the structured streaming metrics
         for metric, value in iteritems(SPARK_STRUCTURED_STREAMING_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
-        tags = ['url:http://localhost:8088', 'cluster_name:SparkCluster'] + CUSTOM_TAGS
+        tags = ['url:http://localhost:8088'] + CLUSTER_TAGS + CUSTOM_TAGS
         tags.sort()
 
         for sc in aggregator.service_checks(YARN_SERVICE_CHECK):
@@ -782,7 +778,7 @@ def test_auth_yarn(aggregator):
         c = SparkCheck('spark', {}, [YARN_AUTH_CONFIG])
         c.check(YARN_AUTH_CONFIG)
 
-        tags = ['url:http://localhost:8088', 'cluster_name:SparkCluster'] + CUSTOM_TAGS
+        tags = ['url:http://localhost:8088'] + CUSTOM_TAGS + CLUSTER_TAGS
         tags.sort()
 
         for sc in aggregator.service_checks(YARN_SERVICE_CHECK):
@@ -820,7 +816,7 @@ def test_mesos(aggregator):
 
         # Check the driver metrics
         for metric, value in iteritems(SPARK_DRIVER_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the executor level metrics
         for metric, value in iteritems(SPARK_EXECUTOR_LEVEL_METRIC_VALUES):
@@ -828,31 +824,31 @@ def test_mesos(aggregator):
 
         # Check the summary executor metrics
         for metric, value in iteritems(SPARK_EXECUTOR_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the RDD metrics
         for metric, value in iteritems(SPARK_RDD_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the streaming statistics metrics
         for metric, value in iteritems(SPARK_STREAMING_STATISTICS_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the structured streaming metrics
         for metric, value in iteritems(SPARK_STRUCTURED_STREAMING_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the service tests
 
         for sc in aggregator.service_checks(MESOS_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            tags = ['url:http://localhost:5050', 'cluster_name:SparkCluster'] + CUSTOM_TAGS
+            tags = ['url:http://localhost:5050'] + CLUSTER_TAGS + CUSTOM_TAGS
             tags.sort()
             sc.tags.sort()
             assert sc.tags == tags
         for sc in aggregator.service_checks(SPARK_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            tags = ['url:http://localhost:4040', 'cluster_name:SparkCluster'] + CUSTOM_TAGS
+            tags = ['url:http://localhost:4040'] + CLUSTER_TAGS + CUSTOM_TAGS
             tags.sort()
             sc.tags.sort()
             assert sc.tags == tags
@@ -869,7 +865,7 @@ def test_mesos_filter(aggregator):
 
         for sc in aggregator.service_checks(MESOS_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            assert sc.tags == ['url:http://localhost:5050', 'cluster_name:SparkCluster']
+            assert sc.tags == ['url:http://localhost:5050'] + CLUSTER_TAGS
 
         assert aggregator.metrics_asserted_pct == 100.0
 
@@ -898,7 +894,7 @@ def test_driver_unit(aggregator):
 
         # Check the driver metrics
         for metric, value in iteritems(SPARK_DRIVER_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the executor level metrics
         for metric, value in iteritems(SPARK_EXECUTOR_LEVEL_METRIC_VALUES):
@@ -906,31 +902,31 @@ def test_driver_unit(aggregator):
 
         # Check the summary executor metrics
         for metric, value in iteritems(SPARK_EXECUTOR_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the RDD metrics
         for metric, value in iteritems(SPARK_RDD_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the streaming statistics metrics
         for metric, value in iteritems(SPARK_STREAMING_STATISTICS_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the structured streaming metrics
         for metric, value in iteritems(SPARK_STRUCTURED_STREAMING_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
 
         # Check the service tests
 
         for sc in aggregator.service_checks(SPARK_DRIVER_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            tags = ['url:http://localhost:4040', 'cluster_name:SparkCluster'] + CUSTOM_TAGS
+            tags = ['url:http://localhost:4040'] + CLUSTER_TAGS + CUSTOM_TAGS
             tags.sort()
             sc.tags.sort()
             assert sc.tags == tags
         for sc in aggregator.service_checks(SPARK_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            tags = ['url:http://localhost:4040', 'cluster_name:SparkCluster'] + CUSTOM_TAGS
+            tags = ['url:http://localhost:4040'] + CLUSTER_TAGS + CUSTOM_TAGS
             tags.sort()
             sc.tags.sort()
             assert sc.tags == tags
@@ -967,7 +963,7 @@ def test_standalone_unit(aggregator):
 
         # Check the driver metrics
         for metric, value in iteritems(SPARK_DRIVER_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the executor level metrics
         for metric, value in iteritems(SPARK_EXECUTOR_LEVEL_METRIC_VALUES):
@@ -975,27 +971,27 @@ def test_standalone_unit(aggregator):
 
         # Check the executor metrics
         for metric, value in iteritems(SPARK_EXECUTOR_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the RDD metrics
         for metric, value in iteritems(SPARK_RDD_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the streaming statistics metrics
         for metric, value in iteritems(SPARK_STREAMING_STATISTICS_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the structured streaming metrics
         for metric, value in iteritems(SPARK_STRUCTURED_STREAMING_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the service tests
         for sc in aggregator.service_checks(STANDALONE_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            assert sc.tags == ['url:http://localhost:8080', 'cluster_name:SparkCluster']
+            assert sc.tags == ['url:http://localhost:8080'] + CLUSTER_TAGS
         for sc in aggregator.service_checks(SPARK_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            assert sc.tags == ['url:http://localhost:4040', 'cluster_name:SparkCluster']
+            assert sc.tags == ['url:http://localhost:4040'] + CLUSTER_TAGS
 
         # Assert coverage for this check on this instance
         aggregator.assert_all_metrics_covered()
@@ -1029,7 +1025,7 @@ def test_standalone_unit_with_proxy_warning_page(aggregator):
 
         # Check the driver metrics
         for metric, value in iteritems(SPARK_DRIVER_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the executor level metrics
         for metric, value in iteritems(SPARK_EXECUTOR_LEVEL_METRIC_VALUES):
@@ -1037,27 +1033,27 @@ def test_standalone_unit_with_proxy_warning_page(aggregator):
 
         # Check the summary executor metrics
         for metric, value in iteritems(SPARK_EXECUTOR_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the RDD metrics
         for metric, value in iteritems(SPARK_RDD_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the streaming statistics metrics
         for metric, value in iteritems(SPARK_STREAMING_STATISTICS_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the structured streaming metrics
         for metric, value in iteritems(SPARK_STRUCTURED_STREAMING_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the service tests
         for sc in aggregator.service_checks(STANDALONE_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            assert sc.tags == ['url:http://localhost:8080', 'cluster_name:SparkCluster']
+            assert sc.tags == ['url:http://localhost:8080'] + CLUSTER_TAGS
         for sc in aggregator.service_checks(SPARK_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            assert sc.tags == ['url:http://localhost:4040', 'cluster_name:SparkCluster']
+            assert sc.tags == ['url:http://localhost:4040'] + CLUSTER_TAGS
 
         # Assert coverage for this check on this instance
         aggregator.assert_all_metrics_covered()
@@ -1091,7 +1087,7 @@ def test_standalone_pre20(aggregator):
 
         # Check the driver metrics
         for metric, value in iteritems(SPARK_DRIVER_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the executor level metrics
         for metric, value in iteritems(SPARK_EXECUTOR_LEVEL_METRIC_VALUES):
@@ -1099,27 +1095,27 @@ def test_standalone_pre20(aggregator):
 
         # Check the summary executor metrics
         for metric, value in iteritems(SPARK_EXECUTOR_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the RDD metrics
         for metric, value in iteritems(SPARK_RDD_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the streaming statistics metrics
         for metric, value in iteritems(SPARK_STREAMING_STATISTICS_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the structured streaming metrics
         for metric, value in iteritems(SPARK_STRUCTURED_STREAMING_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=SPARK_METRIC_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
 
         # Check the service tests
         for sc in aggregator.service_checks(STANDALONE_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            assert sc.tags == ['url:http://localhost:8080', 'cluster_name:SparkCluster']
+            assert sc.tags == ['url:http://localhost:8080'] + CLUSTER_TAGS
         for sc in aggregator.service_checks(SPARK_SERVICE_CHECK):
             assert sc.status == SparkCheck.OK
-            assert sc.tags == ['url:http://localhost:4040', 'cluster_name:SparkCluster']
+            assert sc.tags == ['url:http://localhost:4040'] + CLUSTER_TAGS
 
         # Assert coverage for this check on this instance
         aggregator.assert_all_metrics_covered()
@@ -1221,6 +1217,9 @@ def run_ssl_server():
     return httpd
 
 
+SPARK_DRIVER_CLUSTER_TAGS = ['spark_cluster:{}'.format('SparkDriver'), 'cluster_name:{}'.format('SparkDriver')]
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_integration_standalone(aggregator):
@@ -1247,7 +1246,7 @@ def test_integration_standalone(aggregator):
     aggregator.assert_service_check(
         'spark.standalone_master.can_connect',
         status=SparkCheck.OK,
-        tags=['cluster_name:{}'.format('SparkCluster'), 'url:{}'.format('http://spark-master:8080')],
+        tags=['url:{}'.format('http://spark-master:8080')] + CLUSTER_TAGS,
     )
     aggregator.assert_all_metrics_covered()
 
@@ -1280,7 +1279,7 @@ def test_integration_driver_1(aggregator):
     aggregator.assert_service_check(
         'spark.driver.can_connect',
         status=SparkCheck.OK,
-        tags=['cluster_name:{}'.format('SparkDriver'), 'url:{}'.format('http://spark-app-1:4040')],
+        tags=['url:{}'.format('http://spark-app-1:4040')] + SPARK_DRIVER_CLUSTER_TAGS,
     )
     aggregator.assert_all_metrics_covered()
 
@@ -1314,6 +1313,6 @@ def test_integration_driver_2(aggregator):
     aggregator.assert_service_check(
         'spark.driver.can_connect',
         status=SparkCheck.OK,
-        tags=['cluster_name:{}'.format('SparkDriver'), 'url:{}'.format('http://spark-app-2:4050')],
+        tags=['url:{}'.format('http://spark-app-2:4050')] + SPARK_DRIVER_CLUSTER_TAGS,
     )
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
This PR introduces a backwards compatible config option disable_legacy_cluster_tag which will stop sending cluster_name tag.


### Motivation
cluster_name tag is also emitted at the hostlevel. Using a service specific tag key will prevent conflicts/confusion.


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
