### PR TITLE
Rename config spec example consumer option `default` to `display_default`

### DIFF
--- a/cilium/assets/configuration/spec.yaml
+++ b/cilium/assets/configuration/spec.yaml
@@ -16,7 +16,7 @@ files:
       value:
         type: string
         example: http://localhost:9090/metrics
-        default: None
+        display_default: None
     - name: operator_endpoint
       description: |
         Provide instead of `agent_endpoint` to collect `cilium-operator` metrics.
@@ -24,7 +24,7 @@ files:
       value:
         type: string
         example: http://localhost:6942/metrics
-        default: None
+        display_default: None
     - template: instances/openmetrics_legacy
       overrides:
         prometheus_url.hidden: true

--- a/cisco_aci/assets/configuration/spec.yaml
+++ b/cisco_aci/assets/configuration/spec.yaml
@@ -109,5 +109,5 @@ files:
         aws_service.hidden: true
     - template: instances/default
       overrides:
-        min_collection_interval.value.default: 15
+        min_collection_interval.value.display_default: 15
         min_collection_interval.value.example: 180

--- a/clickhouse/assets/configuration/spec.yaml
+++ b/clickhouse/assets/configuration/spec.yaml
@@ -37,7 +37,7 @@ files:
       description: The database to connect to.
       value:
         type: string
-        default: default
+        display_default: default
     - name: connect_timeout
       description: The timeout for connecting to the `server`.
       value:

--- a/cloud_foundry_api/assets/configuration/spec.yaml
+++ b/cloud_foundry_api/assets/configuration/spec.yaml
@@ -43,7 +43,7 @@ files:
       value:
         type: integer
         maximum: 5000
-        default: 100
+        display_default: 100
     - template: instances/default
     - template: instances/http
       overrides:
@@ -65,4 +65,3 @@ files:
     options:
     - template: init_config/default
     - template: init_config/http
-

--- a/couch/assets/configuration/spec.yaml
+++ b/couch/assets/configuration/spec.yaml
@@ -30,7 +30,7 @@ files:
         example:
           - <DATABASE_1>
           - <DATABASE_2>
-        default: all
+        display_default: all
     - name: db_exclude
       description: |
         The `db_exclude` should contain the names of any databases meant to be excluded
@@ -43,7 +43,7 @@ files:
         example:
           - <DATABASE_1>
           - <DATABASE_2>
-        default: None
+        display_default: None
     - name: max_dbs_per_check
       description: Number of databases to scan per check.
       value:
@@ -54,13 +54,13 @@ files:
       value:
         type: string
         example: <ERLANG_NAME>
-        default: None
+        display_default: None
     - name: max_nodes_per_check
       description: CouchDB 2.x only. How many nodes each check reports if no name is provided.
       value:
         type: integer
         example: 10
-        default: 20
+        display_default: 20
     - template: instances/default
     - template: instances/http
       overrides:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/example.py
@@ -119,8 +119,8 @@ def write_option(option, writer, indent='', start_list=False):
         example = value.get('example')
         example_type = type(example)
         if not required:
-            if 'default' in value:
-                default = value['default']
+            if 'display_default' in value:
+                default = value['display_default']
                 default_type = type(default)
                 if default is not None and str(default).lower() != 'none':
                     if default_type is str:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/db.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/db.yaml
@@ -8,7 +8,7 @@
     type: array
     items:
       type: object
-    default: null
+    display_default: null
     example:
       - query: <QUERY>
         columns: <COLUMNS>

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
@@ -21,7 +21,7 @@
   value:
     type: boolean
     example: false
-    default: false
+    display_default: false
 - name: service_check_prefix
   description: |
     Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -18,7 +18,7 @@
   value:
     type: string
     example: <PREFIX>_
-    default: null
+    display_default: null
 - name: metrics  # Only shown for the `openmetrics` provider integration
   hidden: true
   description: |

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy.yaml
@@ -29,7 +29,7 @@
   value:
     type: string
     example: <PREFIX>_
-    default: null
+    display_default: null
 - name: health_service_check
   description: |
     Send a service check reporting about the health of the Prometheus endpoint.

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -809,7 +809,7 @@ def test_option_string_type_not_default_example_default_value_none():
             value:
               type: string
               example: something
-              default: None
+              display_default: None
         """
     )
 
@@ -840,7 +840,7 @@ def test_option_string_type_not_default_example_default_value_null():
             value:
               type: string
               example: something
-              default: null
+              display_default: null
         """
     )
 
@@ -1294,7 +1294,7 @@ def test_option_default_example_override_null():
             value:
               type: string
               example: something
-              default: null
+              display_default: null
         """
     )
 
@@ -1325,7 +1325,7 @@ def test_option_default_example_override_string():
             value:
               type: string
               example: something
-              default: bar
+              display_default: bar
         """
     )
 
@@ -1356,7 +1356,7 @@ def test_option_default_example_override_non_string():
             value:
               type: string
               example: something
-              default:
+              display_default:
                 foo: [bar, baz]
         """
     )

--- a/disk/assets/configuration/spec.yaml
+++ b/disk/assets/configuration/spec.yaml
@@ -190,7 +190,7 @@ files:
               Works on Linux only.
             value:
               example: /run/blkid/blkid.tab
-              default: null
+              display_default: null
               type: string
           - name: device_tag_re
             description: |
@@ -215,7 +215,7 @@ files:
             description: Timeout of the disk query in seconds
             value:
               example: 5
-              default: 5
+              display_default: 5
               type: integer
           - name: create_mounts
             description: |

--- a/docs/developer/meta/config-specs.md
+++ b/docs/developer/meta/config-specs.md
@@ -127,10 +127,12 @@ It respects a few extra [option](#options)-level attributes:
 
 - `example` - A complete example of an option in lieu of a strictly typed `value` attribute
 - `enabled` - Whether or not to un-comment the option, overriding the behavior of `required`
+- `display_priority` - This is an integer affecting the order in which options are displayed, with higher values indicating higher priority.
+  The default is `0`.
 
 It also respects a few extra fields under the `value` attribute of each option:
 
-- `default` - This is the default value that will be shown in the header of each option, useful if it differs from the `example`.
+- `display_default` - This is the default value that will be shown in the header of each option, useful if it differs from the `example`.
   You may set it to `null` explicitly to disable showing this part of the header.
 - `compact_example` - Whether or not to display complex types like arrays in their most compact representation. It defaults to `false`.
 

--- a/go_expvar/assets/configuration/spec.yaml
+++ b/go_expvar/assets/configuration/spec.yaml
@@ -18,7 +18,7 @@ files:
       description: Define your namespace that is prefixed to all metrics collected by this check.
       value:
         type: string
-        default: go_expvar
+        display_default: go_expvar
     - name: metrics
       description: |
         These metrics are just here as examples.

--- a/istio/assets/configuration/spec.yaml
+++ b/istio/assets/configuration/spec.yaml
@@ -12,7 +12,7 @@ files:
             Collect mixer, galley, pilot, and citadel metrics available from the istiod deployment.
             Only available for Istio >= v1.5.
           value:
-            default: null
+            display_default: null
             example: http://istiod.istio-system:15014/metrics
             type: string
         - name: istio_mesh_endpoint
@@ -25,7 +25,7 @@ files:
             When collecting mesh metrics in Istio < v1.5, use
             istio_mesh_endpoint: http://istio-telemetry.istio-system:42422/metrics
           value:
-            default: null
+            display_default: null
             example: http://istio-proxy.istio-system:15090/stats/prometheus
             type: string
         - name: mixer_endpoint
@@ -35,7 +35,7 @@ files:
             If using Istio < v1.1, replace port 15014 with port 9093. See the changes here:
             https://istio.io/about/notes/1.1/#configuration-management
           value:
-            default: null
+            display_default: null
             example: http://istio-telemetry.istio-system:15014/metrics
             type: string
         - name: pilot_endpoint
@@ -43,7 +43,7 @@ files:
             Define the pilot endpoint in order to collect all Prometheus metrics on the Pilot process.
             Only available for Istio >= v1.1.
           value:
-            default: null
+            display_default: null
             example: http://istio-pilot.istio-system:15014/metrics
             type: string
         - name: galley_endpoint
@@ -51,7 +51,7 @@ files:
             Define the galley endpoint in order to collect all Prometheus metrics on the Galley process.
             Only available for Istio >= v1.1.
           value:
-            default: null
+            display_default: null
             example: http://istio-galley.istio-system:15014/metrics
             type: string
         - name: citadel_endpoint
@@ -59,7 +59,7 @@ files:
             Define the citadel endpoint in order to collect all Prometheus metrics on the Citadel process.
             Only available for Istio >= v1.1.
           value:
-            default: null
+            display_default: null
             example: http://istio-citadel.istio-system:15014/metrics
             type: string
         - template: instances/openmetrics_legacy

--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -21,21 +21,21 @@ files:
       value:
         type: integer
         example: 5
-      default: 5
+      display_default: 5
     - name: zk_timeout
       description: |
         DEPRECATED: Customizes the ZooKeeper connection timeout.
       value:
         type: integer
         example: 5
-      default: 5
+      display_default: 5
     - template: init_config/default
   - template: instances
     options:
       - name: kafka_connect_str
         description: |
           Kafka endpoints and port to connect to.
-          
+
           In a production environment, it's often useful to specify multiple
           Kafka nodes for a single check instance. This way you
           only generate a single check process, but if one host goes down,
@@ -46,12 +46,12 @@ files:
           type: array
           items:
             type: string
-          example: 
+          example:
             - localhost:9092
       - name: kafka_client_api_version
         description: |
           Specify the highest client protocol version supported by all brokers in the cluster.
-          
+
           This is a performance optimization. If this is not set, then the check automatically probes
           the cluster for broker version during the connection bootstrapping process. Explicitly setting
           this bypasses that probe, saving 3-5 network calls depending on the broker version. Note that
@@ -60,7 +60,7 @@ files:
         value:
           type: string
           example: "2.3.0"
-          default: null
+          display_default: null
       - name: consumer_groups
         description: |
           Each level is optional. Any empty values are fetched from the Kafka cluster.
@@ -69,7 +69,7 @@ files:
 
           Deprecation notice: Omitting various levels works for zookeeper-based consumers. However, all
           functionality related to fetching offsets from Zookeeper is deprecated.
-        value: 
+        value:
           type: object
           example:
             <CONSUMER_NAME_1>:
@@ -107,7 +107,7 @@ files:
           Protocol used to communicate with brokers.
           Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
           Default: PLAINTEXT.
-        default: PLAINTEXT
+        display_default: PLAINTEXT
         value:
           type: string
           example: PLAINTEXT
@@ -118,7 +118,7 @@ files:
         value:
           type: string
           example: PLAIN
-          default: null
+          display_default: null
       - name: sasl_plain_username
         description: Username for sasl PLAIN or SCRAM authentication.
         value:
@@ -139,7 +139,7 @@ files:
         value:
           type: string
           example: localhost
-          default: null
+          display_default: null
       - name: ssl_context
         description: |
           Pre-configured SSLContext for wrapping socket connections.
@@ -151,7 +151,7 @@ files:
         description: |
           Flag to configure whether SSL handshake should verify that the
           certificate matches the broker’s hostname.
-        default: true
+        display_default: true
         value:
           type: boolean
           example: true
@@ -172,7 +172,7 @@ files:
         value:
           type: string
           example: <KEY_FILE_PATH>
-      - name: ssl_password 
+      - name: ssl_password
         description: Password to be used when loading the certificate chain.
         value:
           type: string
@@ -188,17 +188,17 @@ files:
       - name: broker_requests_batch_size
         description: |
           The OffsetRequests sent to each broker are batched by the kafka_consumer check in groups of 30 by default.
-          If the batch size is too big, you may see KafkaTimeoutError exceptions in the logs while 
+          If the batch size is too big, you may see KafkaTimeoutError exceptions in the logs while
           running the wakeup calls.
           If the batch size is too small, the check will take longer to run.
-        default: 30
+        display_default: 30
         value:
           type: integer
           example: 30
       - name: zk_connect_str
         description: |
-          DEPRECATION NOTICE: This option is only used for fetching consumer offsets 
-          from Zookeeper and is deprecated.  
+          DEPRECATION NOTICE: This option is only used for fetching consumer offsets
+          from Zookeeper and is deprecated.
           Zookeeper endpoints and port to connect to.
           In a production environment, it's often useful to specify multiple
           Zookeeper nodes for a single check instance. This way you
@@ -214,8 +214,8 @@ files:
             - <ZOOKEEPER_ENDPOINT>:2181
       - name: zk_prefix
         description: |
-          DEPRECATION NOTICE: This option is only used for fetching consumer offsets 
-          from Zookeeper and is deprecated. 
+          DEPRECATION NOTICE: This option is only used for fetching consumer offsets
+          from Zookeeper and is deprecated.
           Zookeeper chroot prefix under which kafka data is living in zookeeper.
           If kafka is connecting to `my-zookeeper:2181/kafka` then the `zk_prefix` is `/kafka`.
         value:
@@ -223,12 +223,12 @@ files:
           example: <ZK_PREFIX>
       - name: kafka_consumer_offsets
         description: |
-          DEPRECATION NOTICE: This option is only used for fetching consumer offsets 
-          from Zookeeper and is deprecated. 
+          DEPRECATION NOTICE: This option is only used for fetching consumer offsets
+          from Zookeeper and is deprecated.
           This setting only applies if zk_connect_str is set
           Set to true to fetch consumer offsets from both Zookeeper and Kafka
           Set to false to fetch consumer offsets only from Zookeeper.
         value:
           type: boolean
           example: false
-        default: false
+        display_default: false

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -200,15 +200,15 @@ instances:
 
     ## @param broker_requests_batch_size - integer - optional - default: 30
     ## The OffsetRequests sent to each broker are batched by the kafka_consumer check in groups of 30 by default.
-    ## If the batch size is too big, you may see KafkaTimeoutError exceptions in the logs while 
+    ## If the batch size is too big, you may see KafkaTimeoutError exceptions in the logs while
     ## running the wakeup calls.
     ## If the batch size is too small, the check will take longer to run.
     #
     # broker_requests_batch_size: 30
 
     ## @param zk_connect_str - list of mappings - optional
-    ## DEPRECATION NOTICE: This option is only used for fetching consumer offsets 
-    ## from Zookeeper and is deprecated.  
+    ## DEPRECATION NOTICE: This option is only used for fetching consumer offsets
+    ## from Zookeeper and is deprecated.
     ## Zookeeper endpoints and port to connect to.
     ## In a production environment, it's often useful to specify multiple
     ## Zookeeper nodes for a single check instance. This way you
@@ -221,16 +221,16 @@ instances:
     #   - <ZOOKEEPER_ENDPOINT>:2181
 
     ## @param zk_prefix - string - optional
-    ## DEPRECATION NOTICE: This option is only used for fetching consumer offsets 
-    ## from Zookeeper and is deprecated. 
+    ## DEPRECATION NOTICE: This option is only used for fetching consumer offsets
+    ## from Zookeeper and is deprecated.
     ## Zookeeper chroot prefix under which kafka data is living in zookeeper.
     ## If kafka is connecting to `my-zookeeper:2181/kafka` then the `zk_prefix` is `/kafka`.
     #
     # zk_prefix: <ZK_PREFIX>
 
     ## @param kafka_consumer_offsets - boolean - optional - default: false
-    ## DEPRECATION NOTICE: This option is only used for fetching consumer offsets 
-    ## from Zookeeper and is deprecated. 
+    ## DEPRECATION NOTICE: This option is only used for fetching consumer offsets
+    ## from Zookeeper and is deprecated.
     ## This setting only applies if zk_connect_str is set
     ## Set to true to fetch consumer offsets from both Zookeeper and Kafka
     ## Set to false to fetch consumer offsets only from Zookeeper.

--- a/marathon/assets/configuration/spec.yaml
+++ b/marathon/assets/configuration/spec.yaml
@@ -18,13 +18,13 @@ files:
           - name: acs_url
             description: The base ACS endpoint url if an ACS token is required to access the marathon API.
             value:
-              default: 
+              display_default: null
               example: https://<SERVER>:<PORT>
               type: string
           - name: group
             description: Enter a Specific Application group name to get only it's related metrics.
             value:
-              default: 
+              display_default: null
               example: product
               type: string
           - name: label_tags

--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -195,7 +195,7 @@ files:
         E.g. mongodb://datadog:LnCbkX4uhpuLHSUrcayEoAZA@localhost:27016/admin
       value:
         example: mongodb://<USER>:<PASSWORD>@<HOST>:<PORT>/<DB_NAME>
-        default: null
+        display_default: null
         type: string
     - template: instances/default
   - template: logs

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -24,7 +24,7 @@ files:
             value:
               type: string
               example: localhost
-              default: null
+              display_default: null
 
           - name: user
             description: |
@@ -33,7 +33,7 @@ files:
             value:
               type: string
               example: datadog
-              default: null
+              display_default: null
 
           - name: pass
             description: |
@@ -61,7 +61,7 @@ files:
             value:
               type: string
               example: utf8
-              default: None
+              display_default: None
           - name: defaults_file
             description: |
               Path to an alternative configuration mechanism file.
@@ -245,7 +245,7 @@ files:
             value:
               type: boolean
               example: false
-              default: false
+              display_default: false
 
           - template: instances/default
 

--- a/network/assets/configuration/spec.yaml
+++ b/network/assets/configuration/spec.yaml
@@ -45,7 +45,7 @@ files:
           - name: excluded_interface_re
             description: Completely ignore any network interface matching the given regex.
             value:
-              default:
+              display_default: null
               example: <NETWORK_INTERFACE_NAME>.*
               type: string
           - name: combine_connection_states
@@ -82,7 +82,7 @@ files:
               It will be run with sudo by default, so an entry needs to be added to the sudoers file.
               By default, these metrics will not be sent.
             value:
-              default:
+              display_default: null
               example: /usr/sbin/conntrack
               type: string
           - name: use_sudo_conntrack
@@ -104,11 +104,11 @@ files:
               example:
                 - <METRIC_NAME>
                 - <METRIC_PREFIX>.*
-              default:
+              display_default:
                 - max
                 - count
               type: array
-              items: 
+              items:
                 type: string
           - name: blacklist_conntrack_metrics
             description: |
@@ -119,12 +119,12 @@ files:
               Regex expressions for the project names are supported.
               Blacklist takes precedence over whitelist in case of overlap.
             value:
-              default: []
+              display_default: []
               example:
                 - <METRIC_NAME>
                 - <METRIC_PREFIX>.*
               type: array
-              items: 
+              items:
                 type: string
           - name: collect_aws_ena_metrics
             description: |
@@ -137,7 +137,7 @@ files:
               network interfaces. To get host-level ENA metrics from a container, it needs to be executed
               with `CAP_NET_ADMIN` capability and use the `host` network mode.
             value:
-              default: false
+              display_default: false
               example: false
               type: boolean
           - template: instances/default

--- a/nfsstat/assets/configuration/spec.yaml
+++ b/nfsstat/assets/configuration/spec.yaml
@@ -12,7 +12,7 @@ files:
       value:
         type: string
         example: /usr/local/sbin/nfsiostat
-        default: null
+        display_default: null
     - name: autofs_enabled
       description: |
         If your environment uses AutoFS, enable this option to only log DEBUG-level messages when there are no mounts.

--- a/nginx/assets/configuration/spec.yaml
+++ b/nginx/assets/configuration/spec.yaml
@@ -44,12 +44,12 @@ files:
       value:
         type: boolean
         example: false
-        default: true
+        display_default: true
     - name: plus_api_version
       description: Specify the version of the Plus API to use. The check supports versions 1-3.
       value:
         type: integer
-        default: 2
+        display_default: 2
     - name: use_vts
       description: |
         Set this option to true if you are using the nginx vhost_traffic_status module.

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -37,7 +37,7 @@ files:
         Note: If omitted, the default system Postgres database is queried.
       value:
         type: string
-        default: postgres
+        display_default: postgres
     - name: ssl
       description: |
         This option determines whether or not and with what priority a secure SSL TCP/IP connection
@@ -57,7 +57,7 @@ files:
         Note: `true` is an alias for `require`, and `false` is an alias for `disable`.
       value:
         type: string
-        default: false
+        display_default: false
         example: "false"
     - name: query_timeout
       description: |
@@ -68,7 +68,7 @@ files:
       value:
         type: integer
         example: 1000
-        default: null
+        display_default: null
     - name: relations
       description: |
         The list of relations/tables must be specified here to track per-relation (table) metrics.
@@ -147,7 +147,7 @@ files:
       description: The maximum number of tables to collect metrics from.
       value:
         type: integer
-        default: 200
+        display_default: 200
         example: 200
     - name: custom_queries
       description: |
@@ -186,7 +186,7 @@ files:
       value:
         type: boolean
         example: false
-        default: false
+        display_default: false
     - name: pg_stat_statements_view
       description: |
         Set this value if you want to define a custom view or function to allow the datadog user to query the

--- a/process/assets/configuration/spec.yaml
+++ b/process/assets/configuration/spec.yaml
@@ -34,7 +34,7 @@ files:
         value:
           type: string
           example: /proc
-          default: null
+          display_default: null
       - template: init_config/default
     - template: instances
       options:

--- a/redisdb/assets/configuration/spec.yaml
+++ b/redisdb/assets/configuration/spec.yaml
@@ -25,7 +25,7 @@ files:
       value:
         type: string
         example: /var/run/redis/redis.sock
-        default: null
+        display_default: null
     - name: db
       description: |
         The index of the database (keyspace) to use.
@@ -109,7 +109,7 @@ files:
       description: |
         Set the maximum number of entries to fetch from the slow query log.
         By default, the check reads this value from the redis config, but is limited to 128.
-        
+
         Set a custom value here if you need to get more than 128 slowlog entries every 15 seconds.
         Warning: Higher values may impact the performance of your Redis instance.
       value:

--- a/riakcs/assets/configuration/spec.yaml
+++ b/riakcs/assets/configuration/spec.yaml
@@ -26,22 +26,22 @@ files:
       description: Hostname or IP address of your RiakCS node.
       value:
         type: string
-        default: localhost
+        display_default: localhost
     - name: port
       description: Port used by your RiakCS node.
       value:
         type: integer
-        default: 8080
+        display_default: 8080
     - name: s3_root
       description: The S3 hostname.
       value:
         type: string
-        default: s3.amazonaws.com
+        display_default: s3.amazonaws.com
     - name: metrics
       description: |
-        For RiackCS v2.1+, the default metrics collected by this integration includes S3 API metrics and memory stats, 
+        For RiackCS v2.1+, the default metrics collected by this integration includes S3 API metrics and memory stats,
         except for the following:
-      
+
           * bucket_acl_get
           * bucket_acl_put
           * object_acl_get
@@ -53,7 +53,7 @@ files:
           * _in_total
           * _time_error_*
           * _time_100
-      
+
         Include these metrics in the following list if you would like to collect them for your Datadog account.
         See the complete list of metrics available: https://github.com/basho/riak_cs/wiki/Riak-cs-and-stanchion-metrics
       value:

--- a/riakcs/datadog_checks/riakcs/data/conf.yaml.example
+++ b/riakcs/datadog_checks/riakcs/data/conf.yaml.example
@@ -44,7 +44,7 @@ instances:
     # s3_root: <S3_ROOT>
 
     ## @param metrics - list of strings - optional
-    ## For RiackCS v2.1+, the default metrics collected by this integration includes S3 API metrics and memory stats, 
+    ## For RiackCS v2.1+, the default metrics collected by this integration includes S3 API metrics and memory stats,
     ## except for the following:
     ##
     ##   * bucket_acl_get

--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -17,7 +17,7 @@ files:
         description: The port used to connect to the system.
         value:
           type: integer
-          default: 30015
+          display_default: 30015
       - name: username
         description: The database user to authenticate as.
         required: true
@@ -39,12 +39,12 @@ files:
         description: The number of rows to return with each query result.
         value:
           type: integer
-          default: 1000
+          display_default: 1000
       - name: timeout
         description: The timeout in seconds for connecting to `server`.
         value:
           type: integer
-          default: 10
+          display_default: 10
       - template: instances/db
       - name: use_tls
         description: |

--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -102,7 +102,7 @@ files:
           Use `oauth` to authenticate with OAuth, be sure to set the `token` option as well.
         value:
           type: string
-          default: snowflake
+          display_default: snowflake
       - name: token
         description: Token used for OAuth connection to Snowflake.
         value:
@@ -162,6 +162,6 @@ files:
             so to minimize unnecessary queries the `min_collection_interval` defaults to 1 hour.
 
             Most metrics are aggregated by day, you can increase the interval to reduce the number of queries.
-          min_collection_interval.default: 3600
+          min_collection_interval.display_default: 3600
           min_collection_interval.value.example: 3600
           min_collection_interval.enabled: 3600

--- a/varnish/assets/configuration/spec.yaml
+++ b/varnish/assets/configuration/spec.yaml
@@ -53,7 +53,7 @@ files:
             value:
               type: string
               example: /usr/bin/varnishadm
-              default: None
+              display_default: None
           - name: secretfile
             description: The path to the varnish secretfile used in the varnishadm command, if enabled.
             value:

--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -1,7 +1,7 @@
 name: vSphere
 files:
 - name: vsphere.yaml
-  options:  
+  options:
   - template: init_config
     options:
     - template: init_config/default
@@ -17,16 +17,16 @@ files:
       - name: username
         required: true
         display_priority: 1
-        description: | 
+        description: |
           The username of the read-only credentials to connect to vCenter
           see https://app.datadoghq.com/account/settings#integrations/vsphere
         value:
           type: string
           example: <USERNAME>
-      - name: password 
+      - name: password
         required: true
         display_priority: 1
-        description: | 
+        description: |
           The password of the read-only credentials to connect to vCenter.
           see https://app.datadoghq.com/account/settings#integrations/vsphere
         value:
@@ -35,8 +35,8 @@ files:
       - name: use_legacy_check_version
         required: true
         display_priority: 1
-        description: | 
-          For backward compatibility reasons, it is possible to use a deprecated version of the vSphere 
+        description: |
+          For backward compatibility reasons, it is possible to use a deprecated version of the vSphere
           integration by setting this field to "true".
         value:
             type: boolean
@@ -70,11 +70,11 @@ files:
           realtime and historical metrics), you usually want to collect events only once.
           By default this parameter will be 'true' if `collection_type: realtime` and 'false' if
           `collection_type: historical`
-          If `collect_events_only: true`, this option has no effect and events will be collected. 
+          If `collect_events_only: true`, this option has no effect and events will be collected.
         value:
           type: boolean
-          default: depends on collection_type value
-          example: true 
+          display_default: depends on collection_type value
+          example: true
       - name: use_collect_events_fallback
         description: |
           Some events might contain invalid types.
@@ -95,7 +95,7 @@ files:
           example: true
       - name: ssl_capath
         description: |
-          Set to the absolute file path of a directory containing CA certificates 
+          Set to the absolute file path of a directory containing CA certificates
           in PEM format
         value:
           type: string
@@ -104,8 +104,8 @@ files:
         description: |
           If `ssl_verify ` is disabled, security warnings are logged by the check when making http requests.
           Disable those by setting `tls_ignore_warning` to true.
-          
-          Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration. 
+
+          Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration.
           If enabled for multiple instances, spurious warnings might still appear even if `tls_ignore_warning` is set
           to true.
         value:
@@ -137,7 +137,7 @@ files:
                   historical metrics
 
         value:
-          default: no filter
+          display_default: no filter
           example:
             - resource: vm
               property: name
@@ -190,9 +190,9 @@ files:
           Note1: 'datastore', 'datacenter' and 'cluster' filters are ignored when collecting realtime metrics as those
                   resources do not have realtime metrics. They will work only with "collection_type: historical".
           Note2: 'vm' and 'host' filters are ignored when collecting historical metrics as those resources do no
-                  have historical metrics. They will work only with "collection_type: realtime".     
+                  have historical metrics. They will work only with "collection_type: realtime".
         value:
-          default: all metrics
+          display_default: all metrics
           example:
             vm:
               - <VM_REGEX>                 # Only possible with "collection_type: realtime"
@@ -227,7 +227,7 @@ files:
               items:
                 type: string
       - name: collect_per_instance_filters
-        description: | 
+        description: |
           Some vSphere metrics can be tagged with instance values.
           For each resource type (vm, host, datastore, cluster) to collect,
           you can choose which metrics you want to collect the instance value as tags using a list of regex.
@@ -237,7 +237,7 @@ files:
           Note2: 'vm' and 'host' are possible only with "collection_type: realtime"
           /!\ Use with parsimony, collecting per-instance metrics might be very expensive for big environments.
         value:
-          default: none
+          display_default: none
           example:
             vm:
               - <VM_REGEX>                 # Only possible with "collection_type: realtime"
@@ -264,9 +264,9 @@ files:
             - name: cluster
               type: array
               items:
-                type: string            
+                type: string
       - name: collect_tags
-        description: | 
+        description: |
           If true, the vSphere Tags will be collected.
           The final tag sent to Datadog is composed of the vSphere tags prefix + vSphere tag category as key and
           vSphere tag name as value:
@@ -292,7 +292,7 @@ files:
         value:
           type: string
           example: ''
-      - name: collect_attributes 
+      - name: collect_attributes
         description: |
           If true, the vSphere attributes will be collected and submitted as Datadog tags.
           The final tag sent to Datadog is composed of 'attribute_prefix' + vSphere attribute category as key and
@@ -350,10 +350,10 @@ files:
           change often and it is usually helpful to be informed quickly of this change.
         value:
           type: array
-          items: 
+          items:
             type: string
-          default: []
-          example: 
+          display_default: []
+          example:
             - <HOST_TAG>
       - name: metrics_per_query
         description: |
@@ -363,7 +363,7 @@ files:
           A value <= 0 means unlimited: it makes one query for all the monitored objects
         value:
           type: integer
-          default: 500
+          display_default: 500
           example: 50
       - name: max_historical_metrics
         description: |

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -31,7 +31,7 @@ instances:
     password: <PASSWORD>
 
     ## @param use_legacy_check_version - boolean - required
-    ## For backward compatibility reasons, it is possible to use a deprecated version of the vSphere 
+    ## For backward compatibility reasons, it is possible to use a deprecated version of the vSphere
     ## integration by setting this field to "true".
     #
     use_legacy_check_version: false
@@ -70,7 +70,7 @@ instances:
     ## realtime and historical metrics), you usually want to collect events only once.
     ## By default this parameter will be 'true' if `collection_type: realtime` and 'false' if
     ## `collection_type: historical`
-    ## If `collect_events_only: true`, this option has no effect and events will be collected. 
+    ## If `collect_events_only: true`, this option has no effect and events will be collected.
     #
     # collect_events: true
 
@@ -92,7 +92,7 @@ instances:
     # ssl_verify: true
 
     ## @param ssl_capath - string - optional
-    ## Set to the absolute file path of a directory containing CA certificates 
+    ## Set to the absolute file path of a directory containing CA certificates
     ## in PEM format
     #
     # ssl_capath: <DIRECTORY_PATH>
@@ -101,7 +101,7 @@ instances:
     ## If `ssl_verify ` is disabled, security warnings are logged by the check when making http requests.
     ## Disable those by setting `tls_ignore_warning` to true.
     ##
-    ## Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration. 
+    ## Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration.
     ## If enabled for multiple instances, spurious warnings might still appear even if `tls_ignore_warning` is set
     ## to true.
     #
@@ -169,7 +169,7 @@ instances:
     ## Note1: 'datastore', 'datacenter' and 'cluster' filters are ignored when collecting realtime metrics as those
     ##         resources do not have realtime metrics. They will work only with "collection_type: historical".
     ## Note2: 'vm' and 'host' filters are ignored when collecting historical metrics as those resources do no
-    ##         have historical metrics. They will work only with "collection_type: realtime".     
+    ##         have historical metrics. They will work only with "collection_type: realtime".
     #
     # metric_filters:
     #   vm:

--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -236,7 +236,7 @@ files:
         This is useful for preventing duplicate events being sent as a consequence of Agent restarts.
       value:
         type: integer
-        default: <PAYLOAD_SIZE>
+        display_default: <PAYLOAD_SIZE>
     - name: legacy_mode
       description: |
         Whether or not to use a mode of operation that is now unmaintained and will be removed in a future version.
@@ -248,7 +248,7 @@ files:
       enabled: true
       value:
         type: boolean
-        default: true
+        display_default: true
         example: false
     - name: host
       description: |
@@ -260,7 +260,7 @@ files:
       value:
         type: string
         example: <REMOTE_HOSNAME>
-        default: localhost
+        display_default: localhost
     - name: log_file
       description: |
         The `log_file` filter instructs the check to only capture events
@@ -295,7 +295,7 @@ files:
           type: string
         example:
           - information
-        default: information
+        display_default: information
     - name: event_id
       description: |
         The `event_id` filter instructs the check to only capture events
@@ -336,7 +336,7 @@ files:
         type: array
         items:
           type: string
-        default: Message
+        display_default: Message
         example:
           - Message
     - template: instances/default

--- a/wmi_check/assets/configuration/spec.yaml
+++ b/wmi_check/assets/configuration/spec.yaml
@@ -102,7 +102,7 @@ files:
         Comma-separated list of property names
       value:
         type: string
-        default: null
+        display_default: null
         example: Name,Label
     - name: tag_queries
       description: |


### PR DESCRIPTION
### Motivation

The upcoming data model consumer will use the option `default` as the default value at runtime, which despite the name, currently does not mean that (see for example the `vsphere` change)