### PR TITLE
Fix metadata short name for coredns request_duration.seconds.sum

### DIFF
--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -15,7 +15,7 @@ coredns.dnssec.cache_hits,count,,hit,,"Counter of cache hits.",0,coredns,dnssec 
 coredns.dnssec.cache_misses,count,,miss,,"Counter of cache misses.",0,coredns,dnssec cache miss
 coredns.request_count,count,,request,,total query count.,1,coredns,request count
 coredns.request_type_count,count,,,,counter of queries per zone and type,1,coredns,request type
-coredns.request_duration.seconds.sum,gauge,,second,,duration to process each query,-1,coredns,proxy request duration
+coredns.request_duration.seconds.sum,gauge,,second,,duration to process each query,-1,coredns,request duration
 coredns.request_duration.seconds.count,gauge,,second,,duration to process each query,-1,coredns,request duration
 coredns.proxy_request_duration.seconds.sum,gauge,,second,,duration per upstream interaction,-1,coredns,proxy request duration
 coredns.proxy_request_duration.seconds.count,gauge,,second,,duration per upstream interaction,-1,coredns,proxy request duration


### PR DESCRIPTION
### What does this PR do?

Fixes (hopefully) the metadata short name for coredns request duration; it is currently specified as proxy request duration.


### Motivation

Spelunking whilst trying to understand why `send_distribution_buckets` is causing my coredns prom check to fail.

### Additional Notes

I'm unsure how this is used, but based on the patterns in the file, I think this looks correct. Please feel free to disregard it if it is not. If that's the case, happy to be enlightened why :)


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
