### PR TITLE
Fix queries for audit success/failure

### DIFF
--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -111,6 +111,9 @@ files:
           type:
            - Error
            - Warning
+           - Information
+           - Success Audit
+           - Failure Audit
           id:
            - 9000
     - name: included_messages

--- a/win32_event_log/datadog_checks/win32_event_log/constants.py
+++ b/win32_event_log/datadog_checks/win32_event_log/constants.py
@@ -14,4 +14,10 @@ EVENT_TYPES_TO_LEVEL = {'success': 4, 'error': 2, 'warning': 3, 'information': 4
 # Audit success and audit failures event do not correspond to a specific level but can instead be queries
 # by using specific keywords.
 # https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.eventing.reader.standardeventkeywords?view=netframework-4.8
-EVENT_TYPES_TO_KEYWORD = {'failure audit': '0x8010000000000000', 'success audit': '0x8020000000000000'}
+EVENT_TYPES_TO_KEYWORD = {
+    'failure audit': '0x8010000000000000',
+    'success audit': '0x8020000000000000',
+    # Aliases for legacy version
+    'audit failure': '0x8010000000000000',
+    'audit success': '0x8020000000000000',
+}

--- a/win32_event_log/datadog_checks/win32_event_log/constants.py
+++ b/win32_event_log/datadog_checks/win32_event_log/constants.py
@@ -9,11 +9,6 @@
 #
 # However, event viewer & the C api do not show the constants from above, but rather return these:
 # https://docs.microsoft.com/en-us/windows/win32/wes/eventmanifestschema-leveltype-complextype#remarks
-EVENT_TYPES = {
-    'success': 4,
-    'error': 2,
-    'warning': 3,
-    'information': 4,
-    'success audit': 4,
-    'failure audit': 2,
-}
+EVENT_TYPES_TO_LEVEL = {'success': 4, 'error': 2, 'warning': 3, 'information': 4}
+
+EVENT_TYPES_TO_KEYWORD = {'failure audit': '0x8010000000000000', 'success audit': '0x8020000000000000'}

--- a/win32_event_log/datadog_checks/win32_event_log/constants.py
+++ b/win32_event_log/datadog_checks/win32_event_log/constants.py
@@ -11,4 +11,7 @@
 # https://docs.microsoft.com/en-us/windows/win32/wes/eventmanifestschema-leveltype-complextype#remarks
 EVENT_TYPES_TO_LEVEL = {'success': 4, 'error': 2, 'warning': 3, 'information': 4}
 
+# Audit success and audit failures event do not correspond to a specific level but can instead be queries
+# by using specific keywords.
+# https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.eventing.reader.standardeventkeywords?view=netframework-4.8
 EVENT_TYPES_TO_KEYWORD = {'failure audit': '0x8010000000000000', 'success audit': '0x8020000000000000'}

--- a/win32_event_log/datadog_checks/win32_event_log/constants.py
+++ b/win32_event_log/datadog_checks/win32_event_log/constants.py
@@ -14,10 +14,4 @@ EVENT_TYPES_TO_LEVEL = {'success': 4, 'error': 2, 'warning': 3, 'information': 4
 # Audit success and audit failure events do not correspond to a specific level but can instead be queried
 # by using specific keywords.
 # https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.eventing.reader.standardeventkeywords?view=netframework-4.8
-EVENT_TYPES_TO_KEYWORD = {
-    'failure audit': '0x8010000000000000',
-    'success audit': '0x8020000000000000',
-    # Aliases for legacy version
-    'audit failure': '0x8010000000000000',
-    'audit success': '0x8020000000000000',
-}
+EVENT_TYPES_TO_KEYWORD = {'failure audit': '0x8010000000000000', 'success audit': '0x8020000000000000'}

--- a/win32_event_log/datadog_checks/win32_event_log/constants.py
+++ b/win32_event_log/datadog_checks/win32_event_log/constants.py
@@ -11,7 +11,7 @@
 # https://docs.microsoft.com/en-us/windows/win32/wes/eventmanifestschema-leveltype-complextype#remarks
 EVENT_TYPES_TO_LEVEL = {'success': 4, 'error': 2, 'warning': 3, 'information': 4}
 
-# Audit success and audit failures event do not correspond to a specific level but can instead be queries
+# Audit success and audit failure events do not correspond to a specific level but can instead be queried
 # by using specific keywords.
 # https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.eventing.reader.standardeventkeywords?view=netframework-4.8
 EVENT_TYPES_TO_KEYWORD = {

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -111,6 +111,9 @@ instances:
     #   type:
     #   - Error
     #   - Warning
+    #   - Information
+    #   - Success Audit
+    #   - Failure Audit
     #   id:
     #   - 9000
 

--- a/win32_event_log/datadog_checks/win32_event_log/filters.py
+++ b/win32_event_log/datadog_checks/win32_event_log/filters.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from datadog_checks.base import ConfigurationError
 
-from .constants import EVENT_TYPES
+from .constants import EVENT_TYPES_TO_KEYWORD, EVENT_TYPES_TO_LEVEL
 
 
 def construct_xpath_query(filters):
@@ -42,19 +42,25 @@ def construct_sources(sources):
 
 
 def construct_types(types):
-    event_types = set()
+    event_levels = set()
+    event_keywords = set()
 
     for event_type in types:
         if not isinstance(event_type, str):
             raise ConfigurationError('Values for event filter `type` must be strings.')
 
         event_type = event_type.lower()
-        if event_type not in EVENT_TYPES:
+
+        if event_type in EVENT_TYPES_TO_LEVEL:
+            event_levels.add(EVENT_TYPES_TO_LEVEL[event_type])
+        elif event_type in EVENT_TYPES_TO_KEYWORD:
+            event_keywords.add(EVENT_TYPES_TO_KEYWORD[event_type])
+        else:
             raise ConfigurationError('Unknown value for event filter `type`: {}'.format(event_type))
 
-        event_types.add(EVENT_TYPES[event_type])
-
-    parts = ['Level={}'.format(value_to_xpath_string(value)) for value in sorted(event_types)]
+    parts = ['Level={}'.format(value_to_xpath_string(value)) for value in sorted(event_levels)] + [
+        'Keywords={}'.format(value_to_xpath_string(value)) for value in sorted(event_keywords)
+    ]
     return combine_value_parts(parts)
 
 

--- a/win32_event_log/datadog_checks/win32_event_log/filters.py
+++ b/win32_event_log/datadog_checks/win32_event_log/filters.py
@@ -58,9 +58,8 @@ def construct_types(types):
         else:
             raise ConfigurationError('Unknown value for event filter `type`: {}'.format(event_type))
 
-    parts = ['Level={}'.format(value_to_xpath_string(value)) for value in sorted(event_levels)] + [
-        'Keywords={}'.format(value_to_xpath_string(value)) for value in sorted(event_keywords)
-    ]
+    parts = ['Level={}'.format(value_to_xpath_string(value)) for value in sorted(event_levels)]
+    parts.extend('Keywords={}'.format(value_to_xpath_string(value)) for value in sorted(event_keywords))
     return combine_value_parts(parts)
 
 

--- a/win32_event_log/tests/test_filters.py
+++ b/win32_event_log/tests/test_filters.py
@@ -21,10 +21,11 @@ pytestmark = [pytest.mark.unit]
         pytest.param({'type': ['Warning']}, '*[System[Level=3]]', id='type Warning'),
         pytest.param({'type': ['Information']}, '*[System[Level=4]]', id='type Information'),
         pytest.param({'type': ['Success Audit']}, "*[System[Keywords='0x8020000000000000']]", id='type Success Audit'),
+        pytest.param({'type': ['Audit Success']}, "*[System[Keywords='0x8020000000000000']]", id='type Success Audit'),
         pytest.param({'type': ['Failure Audit']}, "*[System[Keywords='0x8010000000000000']]", id='type Failure Audit'),
-        pytest.param({'type': ['Failure Audit']}, "*[System[Keywords='0x8010000000000000']]", id='type Failure Audit'),
+        pytest.param({'type': ['Audit Failure']}, "*[System[Keywords='0x8010000000000000']]", id='type Failure Audit'),
         pytest.param(
-            {'type': ['Information', 'Error', 'Warning', 'Success Audit', 'Failure Audit']},
+            {'type': ['Information', 'Error', 'Warning', 'Success Audit', 'Audit failure']},
             "*[System[(Level=2 or Level=3 or Level=4 or "
             "Keywords='0x8010000000000000' or Keywords='0x8020000000000000')]]",
             id='type multiple',

--- a/win32_event_log/tests/test_filters.py
+++ b/win32_event_log/tests/test_filters.py
@@ -20,11 +20,13 @@ pytestmark = [pytest.mark.unit]
         pytest.param({'type': ['Error']}, '*[System[Level=2]]', id='type Error'),
         pytest.param({'type': ['Warning']}, '*[System[Level=3]]', id='type Warning'),
         pytest.param({'type': ['Information']}, '*[System[Level=4]]', id='type Information'),
-        pytest.param({'type': ['Success Audit']}, '*[System[Level=4]]', id='type Success Audit'),
-        pytest.param({'type': ['Failure Audit']}, '*[System[Level=2]]', id='type Failure Audit'),
+        pytest.param({'type': ['Success Audit']}, "*[System[Keywords='0x8020000000000000']]", id='type Success Audit'),
+        pytest.param({'type': ['Failure Audit']}, "*[System[Keywords='0x8010000000000000']]", id='type Failure Audit'),
+        pytest.param({'type': ['Failure Audit']}, "*[System[Keywords='0x8010000000000000']]", id='type Failure Audit'),
         pytest.param(
-            {'type': ['Information', 'Error', 'Warning']},
-            '*[System[(Level=2 or Level=3 or Level=4)]]',
+            {'type': ['Information', 'Error', 'Warning', 'Success Audit', 'Failure Audit']},
+            "*[System[(Level=2 or Level=3 or Level=4 or "
+            "Keywords='0x8010000000000000' or Keywords='0x8020000000000000')]]",
             id='type multiple',
         ),
         pytest.param({'id': [5678]}, '*[System[EventID=5678]]', id='id single'),

--- a/win32_event_log/tests/test_filters.py
+++ b/win32_event_log/tests/test_filters.py
@@ -21,11 +21,9 @@ pytestmark = [pytest.mark.unit]
         pytest.param({'type': ['Warning']}, '*[System[Level=3]]', id='type Warning'),
         pytest.param({'type': ['Information']}, '*[System[Level=4]]', id='type Information'),
         pytest.param({'type': ['Success Audit']}, "*[System[Keywords='0x8020000000000000']]", id='type Success Audit'),
-        pytest.param({'type': ['Audit Success']}, "*[System[Keywords='0x8020000000000000']]", id='type Success Audit'),
         pytest.param({'type': ['Failure Audit']}, "*[System[Keywords='0x8010000000000000']]", id='type Failure Audit'),
-        pytest.param({'type': ['Audit Failure']}, "*[System[Keywords='0x8010000000000000']]", id='type Failure Audit'),
         pytest.param(
-            {'type': ['Information', 'Error', 'Warning', 'Success Audit', 'Audit failure']},
+            {'type': ['Information', 'Error', 'Warning', 'Success Audit', 'Failure audit']},
             "*[System[(Level=2 or Level=3 or Level=4 or "
             "Keywords='0x8010000000000000' or Keywords='0x8020000000000000')]]",
             id='type multiple',


### PR DESCRIPTION
`audit success` and `audit failures` event types cannot be queried using Levels, they have to be queried with "Keywords"
