### PR TITLE
Fix unit from gibibyte to mebibyte

### DIFF
--- a/openstack/metadata.csv
+++ b/openstack/metadata.csv
@@ -29,8 +29,8 @@ openstack.nova.server.hdd_write_req,gauge,,,,The number of write requests made t
 openstack.nova.server.vda_errors,gauge,,,,The number of errors seen by the server when accessing a VDA device,-1,openstack,total vda errors
 openstack.nova.server.vda_read_req,gauge,,,,The number of read requests made to a VDA device by this server,0,openstack,vda read reqs
 openstack.nova.server.vda_write_req,gauge,,,,The number of write requests made to a VDA device by this server,0,openstack,vda write reqs
-openstack.nova.limits.max_total_ram_size,gauge,,gibibyte,,The max allowed RAM size for this tenant,0,openstack,max ram size
-openstack.nova.limits.total_ram_used,gauge,,gibibyte,,The current RAM used by this tenant,-1,openstack,ram used
+openstack.nova.limits.max_total_ram_size,gauge,,mebibyte,,The max allowed RAM size for this tenant in megabytes (MB),0,openstack,max ram size
+openstack.nova.limits.total_ram_used,gauge,,mebibyte,,The current RAM used by this tenant in megabytes (MB),-1,openstack,ram used
 openstack.nova.local_gb,gauge,,gibibyte,,The size in GB of the ephemeral disk present on this hypervisor host,0,openstack,local gb
 openstack.nova.local_gb_used,gauge,,gibibyte,,The size in GB of disk used on this hypervisor host,-1,openstack,local gb used
 openstack.nova.memory_mb,gauge,,mebibyte,,The size in MB of RAM present on this hypervisor host,0,openstack,memory mb

--- a/openstack_controller/metadata.csv
+++ b/openstack_controller/metadata.csv
@@ -19,9 +19,9 @@ openstack.nova.limits.max_total_keypairs,gauge,,,,The maximum allowed keypairs a
 openstack.nova.limits.total_cores_used,gauge,,,,The total cores used by this tenant,-1,openstack_controller,total cores used
 openstack.nova.limits.total_floating_ips_used,gauge,,,,The total floating IPs used by this tenant,-1,openstack_controller,floating IPs used
 openstack.nova.limits.total_instances_used,gauge,,,,The total instances used by this tenant,-1,openstack_controller,total instances used
-openstack.nova.limits.total_ram_used,gauge,,gibibyte,,The current RAM used by this tenant,-1,openstack_controller,ram used
+openstack.nova.limits.total_ram_used,gauge,,mebibyte,,The current RAM used by this tenant in megabytes (MB),-1,openstack_controller,ram used
 openstack.nova.limits.total_security_groups_used,gauge,,,,The total number of security groups used by this tenant,-1,openstack_controller,total security groups used
-openstack.nova.limits.max_total_ram_size,gauge,,gibibyte,,The max allowed RAM size for this tenant,0,openstack_controller,max ram size
+openstack.nova.limits.max_total_ram_size,gauge,,mebibyte,,The max allowed RAM size for this tenant in megabytes (MB),0,openstack_controller,max ram size
 openstack.nova.local_gb,gauge,,gibibyte,,The size in GB of the ephemeral disk present on this hypervisor host,0,openstack_controller,local gb
 openstack.nova.local_gb_used,gauge,,gibibyte,,The size in GB of disk used on this hypervisor host,-1,openstack_controller,local gb used
 openstack.nova.memory_mb,gauge,,mebibyte,,The size in MB of RAM present on this hypervisor host,0,openstack_controller,memory mb


### PR DESCRIPTION
### What does this PR do?

Fix unit from gibibyte to mebibyte

### Motivation

The ram units are in MB, not GB:

https://github.com/gophercloud/gophercloud/blob/v0.15.0/openstack/compute/v2/extensions/limits/results.go#L54-L56

https://github.com/gophercloud/gophercloud/blob/v0.15.0/openstack/compute/v2/extensions/limits/results.go#L67-L68


https://docs.openstack.org/api-guide/compute/limits.html
