### PR TITLE
Migrate cisco_aci, consul, kubernetes dashboards

### DIFF
--- a/cisco_aci/assets/dashboards/cisco_aci_dashboard.json
+++ b/cisco_aci/assets/dashboards/cisco_aci_dashboard.json
@@ -1,0 +1,562 @@
+{
+    "title": "Cisco ACI - Overview",
+    "description": "",
+    "widgets": [
+        {
+            "id": 0,
+            "definition": {
+                "type": "image",
+                "url": "/static/images/logos/cisco-aci_large.svg",
+                "sizing": "zoom"
+            },
+            "layout": {
+                "x": 1,
+                "y": 2,
+                "width": 36,
+                "height": 27
+            }
+        },
+        {
+            "id": 1,
+            "definition": {
+                "type": "note",
+                "content": "APIC controller",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 2,
+                "y": 31,
+                "width": 18,
+                "height": 6
+            }
+        },
+        {
+            "id": 2,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:cisco_aci.capacity.apic.tenant.utilized{*}/avg:cisco_aci.capacity.apic.tenant.limit{*}*100",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Tenant Utilization",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                },
+                "autoscale": true,
+                "custom_unit": "%",
+                "precision": 2
+            },
+            "layout": {
+                "x": 2,
+                "y": 39,
+                "width": 18,
+                "height": 10
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:cisco_aci.capacity.apic.fabric_node.utilized{*}/avg:cisco_aci.capacity.apic.fabric_node.limit{*}*100",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Switch Utilization",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                },
+                "autoscale": true,
+                "custom_unit": "%",
+                "precision": 2
+            },
+            "layout": {
+                "x": 2,
+                "y": 51,
+                "width": 18,
+                "height": 10
+            }
+        },
+        {
+            "id": 4,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "avg:cisco_aci.capacity.apic.endpoint_group.utilized{*}/avg:cisco_aci.capacity.apic.endpoint_group.limit{*}*100",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "EPG Utilization",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                },
+                "autoscale": true,
+                "custom_unit": "%",
+                "precision": 2
+            },
+            "layout": {
+                "x": 2,
+                "y": 63,
+                "width": 18,
+                "height": 10
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "note",
+                "content": "Tenants (Logical Infrastructure)\n",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 39,
+                "y": 2,
+                "width": 64,
+                "height": 5
+            }
+        },
+        {
+            "id": 6,
+            "definition": {
+                "type": "note",
+                "content": "Fabric (Physical Infrastructure)",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 105,
+                "y": 2,
+                "width": 64,
+                "height": 5
+            }
+        },
+        {
+            "id": 7,
+            "definition": {
+                "type": "hostmap",
+                "requests": {
+                    "fill": {
+                        "q": "avg:cisco_aci.fabric.node.health.cur{*} by {host}"
+                    }
+                },
+                "custom_links": [],
+                "title": "Fabric Switch Health (by role)",
+                "title_size": "16",
+                "title_align": "left",
+                "no_metric_hosts": false,
+                "no_group_hosts": true,
+                "group": ["apic_role"],
+                "style": {
+                    "palette": "green_to_orange",
+                    "palette_flip": false
+                }
+            },
+            "layout": {
+                "x": 105,
+                "y": 9,
+                "width": 64,
+                "height": 20
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(avg:cisco_aci.tenant.health{*} by {tenant}, 10, 'mean', 'desc')",
+                        "style": {
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Tenant Health",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                }
+            },
+            "layout": {
+                "x": 39,
+                "y": 9,
+                "width": 64,
+                "height": 20
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cisco_aci.tenant.egress_bytes.unicast.rate{*} by {tenant}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "sum:cisco_aci.tenant.ingress_bytes.unicast.rate{*} by {tenant}*-1",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "dotted",
+                            "line_width": "thick"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "include_zero": false
+                },
+                "title": "Bandwidth by Tenant (ingress is negative)",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 39,
+                "y": 30,
+                "width": 64,
+                "height": 14
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cisco_aci.fabric.port.egr_total.bytes.rate{*} by {node_id}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "sum:cisco_aci.fabric.port.ingr_total.bytes.rate{*} by {node_id}*-1",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "cool",
+                            "line_type": "dotted",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Bandwidth by Switch (ingress is negative)",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 105,
+                "y": 30,
+                "width": 64,
+                "height": 14
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "note",
+                "content": "Network",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 24,
+                "y": 30,
+                "width": 12,
+                "height": 14
+            }
+        },
+        {
+            "id": 12,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cisco_aci.tenant.fault_counter{*} by {tenant}",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Tenant Faults",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 39,
+                "y": 45,
+                "width": 64,
+                "height": 14
+            }
+        },
+        {
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:cisco_aci.fabric.port.fault_counter.warn{*} by {node_id}+sum:cisco_aci.fabric.port.fault_counter.crit{*} by {node_id}",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "purple",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Faults by switch",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 105,
+                "y": 45,
+                "width": 64,
+                "height": 14
+            }
+        },
+        {
+            "id": 14,
+            "definition": {
+                "type": "note",
+                "content": "Faults",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 24,
+                "y": 45,
+                "width": 12,
+                "height": 14
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "note",
+                "content": "Endpoint Group Information",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "right"
+            },
+            "layout": {
+                "x": 24,
+                "y": 64,
+                "width": 12,
+                "height": 21
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "count_not_null(avg:cisco_aci.tenant.egress_pkts.unicast.rate{*} by {endpoint_group})",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Total EPGs",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                },
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 39,
+                "y": 64,
+                "width": 16,
+                "height": 10
+            }
+        },
+        {
+            "id": 17,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:cisco_aci.tenant.egress_bytes.unicast.rate{*} by {endpoint_group,tenant}, 10, 'mean', 'desc')+top(sum:cisco_aci.tenant.ingress_bytes.unicast.rate{*} by {endpoint_group,tenant}, 10, 'mean', 'desc')",
+                        "style": {
+                            "palette": "purple"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Top 10 EPGs by traffic",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                }
+            },
+            "layout": {
+                "x": 57,
+                "y": 64,
+                "width": 38,
+                "height": 21
+            }
+        },
+        {
+            "id": 18,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "count_not_null(avg:cisco_aci.tenant.ingress_pkts.flood.cum{*} by {application})",
+                        "aggregator": "last"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Applications",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                },
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 39,
+                "y": 75,
+                "width": 16,
+                "height": 10
+            }
+        },
+        {
+            "id": 19,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(exclude_null(avg:cisco_aci.fabric.port.egr_bytes.unicast{*} by {node_id,port,endpoint_group}) + exclude_null(avg:cisco_aci.fabric.port.ingr_bytes.unicast{*} by {node_id,port,endpoint_group}),10,'mean','desc')",
+                        "style": {
+                            "palette": "orange"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Top 10 EPG Ports by traffic",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                }
+            },
+            "layout": {
+                "x": 133,
+                "y": 64,
+                "width": 36,
+                "height": 21
+            }
+        },
+        {
+            "id": 20,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(avg:cisco_aci.tenant.egress_bytes.unicast.rate{*} by {ip,application,endpoint_group}, 10, 'mean', 'desc')",
+                        "style": {
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Top 10 EPGs by IP",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                }
+            },
+            "layout": {
+                "x": 96,
+                "y": 64,
+                "width": 36,
+                "height": 21
+            }
+        }
+    ],
+    "template_variables": [],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 242
+}

--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -28,7 +28,7 @@
     },
     "monitors": {},
     "dashboards": {
-      "cisco-aci": "assets/dashboards/cisco_aci_dashboard.json"
+      "cisco_aci": "assets/dashboards/cisco_aci_dashboard.json"
     },
     "service_checks": "assets/service_checks.json",
     "logs": {},

--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -27,7 +27,9 @@
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {},
-    "dashboards": {},
+    "dashboards": {
+      "cisco-aci": "assets/dashboards/cisco_aci_dashboard.json"
+    },
     "service_checks": "assets/service_checks.json",
     "logs": {},
     "metrics_metadata": "metadata.csv"

--- a/consul/assets/dashboards/consul_dashboard.json
+++ b/consul/assets/dashboards/consul_dashboard.json
@@ -1,0 +1,437 @@
+{
+    "title": "Consul - Overview",
+    "description": "This dashboard displays key metrics from your Consul integration, displaying the size of your deployment and performance over time. Further reading on Consul monitoring:\n\n- [Datadog's Consul integration docs](https://docs.datadoghq.com/integrations/consul/)\n\n- [Monitor Consul health and performance with Datadog](https://www.datadoghq.com/blog/monitor-consul-health-and-performance-with-datadog/)\n\n- [Consul at Datadog](https://www.datadoghq.com/blog/engineering/consul-at-datadog/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
+    "widgets": [
+        {
+            "id": 0,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "max:consul.catalog.nodes_up{$consul_datacenter} by {consul_service_id}",
+                        "display_type": "area"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Number of Consul Nodes by Service",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1d"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 0,
+                "y": 15,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 1,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "max:consul.peers{$consul_datacenter}",
+                        "display_type": "line"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Number of Consul Servers by Datacenter",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1d"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 2,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "max:consul.catalog.nodes_up{$consul_datacenter,$consul_service_id}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "grey"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Number of Consul Nodes",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1d"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 47,
+                "y": 15,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:consul.peers{mode:leader,$consul_datacenter}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "max:consul.serf.events.consul_new_leader{$consul_datacenter}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "warm"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Number of Consul Leaders (Leadership Transition Event Overlay)",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1d"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 0,
+                "y": 30,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 4,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:consul.serf.member.join{*}.as_count()",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic"
+                        }
+                    },
+                    {
+                        "q": "sum:consul.serf.member.failed{*}.as_count()",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "orange",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Consul Cluster Join and Failure",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1d"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 47,
+                "y": 30,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:consul.raft.rpc.appendEntries.max{*}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "purple",
+                            "line_type": "solid"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Leader Time to Append Entries",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1d"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 94,
+                "y": 15,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 6,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:consul.raft.leader.lastContact.max{*}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:consul.raft.leader.lastContact.avg{*}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:consul.raft.leader.lastContact.95percentile{*}",
+                        "display_type": "line"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Leader Last Contact with Followers (in ms)",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1d"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 94,
+                "y": 0,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:consul.raft.leader.dispatchLog.max{*}",
+                        "display_type": "line",
+                        "style": {
+                            "line_type": "dotted"
+                        }
+                    },
+                    {
+                        "q": "sum:consul.raft.leader.dispatchLog.avg{*}",
+                        "display_type": "line"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Latency of Leader Commit to Disk",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1d"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 94,
+                "y": 30,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:consul.raft.commitTime.avg{*}",
+                        "display_type": "line"
+                    },
+                    {
+                        "q": "sum:consul.raft.commitTime.median{*}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "warm"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Consul Raft Commit Time",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1d"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 0,
+                "y": 45,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "avg:consul.consul.leader.reconcileMember.max{*}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "cool"
+                        }
+                    },
+                    {
+                        "q": "avg:consul.consul.leader.reconcile.95percentile{*}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "warm"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Time to Reconcile Members (in ms)",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1d"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 47,
+                "y": 45,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "max:consul.serf.events{*}.as_count()",
+                        "display_type": "bars"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Consul Events",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1d"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 47,
+                "y": 60,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:consul.serf.queue.Event.avg{*}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "warm"
+                        }
+                    },
+                    {
+                        "q": "sum:consul.serf.queue.Event.max{*}",
+                        "display_type": "line"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Consul Event Queue",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1d"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 0,
+                "y": 60,
+                "width": 47,
+                "height": 15
+            }
+        },
+        {
+            "id": 12,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(max:consul.catalog.nodes_up{$consul_datacenter} by {consul_service_id}, 20, 'mean', 'desc')",
+                        "style": {
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Consul Nodes by Service Top List",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                }
+            },
+            "layout": {
+                "x": 47,
+                "y": 0,
+                "width": 47,
+                "height": 15
+            }
+        }
+    ],
+    "template_variables": [
+        {
+            "name": "consul_service_id",
+            "default": "*",
+            "prefix": "consul_service_id"
+        },
+        {
+            "name": "consul_datacenter",
+            "default": "*",
+            "prefix": "consul_datacenter"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 83
+}

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -36,7 +36,9 @@
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {},
-    "dashboards": {},
+    "dashboards": {
+      "consul": "assets/dashboards/consul_dashboard.json"
+    },
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "consul"

--- a/kubernetes/assets/dashboards/kubernetes_dashboard.json
+++ b/kubernetes/assets/dashboards/kubernetes_dashboard.json
@@ -1,0 +1,1678 @@
+{
+    "title": "Kubernetes - Overview",
+    "description": "Our Kubernetes dashboard gives you broad visibility into the scale, status, and resource usage of your cluster and its containers. Further reading for Kubernetes monitoring:\n\n- [Autoscale Kubernetes workloads with any Datadog metric](https://www.datadoghq.com/blog/autoscale-kubernetes-datadog/)\n\n- [How to monitor Kubernetes + Docker with Datadog](https://www.datadoghq.com/blog/monitor-kubernetes-docker/)\n\n- [Monitoring in the Kubernetes era](https://www.datadoghq.com/blog/monitoring-kubernetes-era/)\n\n- [Monitoring Kubernetes performance metrics](https://www.datadoghq.com/blog/monitoring-kubernetes-performance-metrics/)\n\n- [Collecting metrics with built-in Kubernetes monitoring tools](https://www.datadoghq.com/blog/how-to-collect-and-graph-kubernetes-metrics/)\n\n- [Monitoring Kubernetes with Datadog](https://www.datadoghq.com/blog/monitoring-kubernetes-with-datadog/)\n\n- [Datadog's Kubernetes integration docs](https://docs.datadoghq.com/integrations/kubernetes/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
+    "widgets": [
+        {
+            "id": 0,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:kubernetes.memory.usage{$scope,$deployment,$daemonset,$cluster,$namespace,!pod_name:no_pod,$label,$service,$node} by {pod_name}, 10, 'mean', 'desc')",
+                        "style": {
+                            "palette": "cool"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Most memory-intensive pods",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                }
+            },
+            "layout": {
+                "x": 151,
+                "y": 57,
+                "width": 43,
+                "height": 24
+            }
+        },
+        {
+            "id": 1,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:kubernetes.cpu.usage.total{$scope,$deployment,$daemonset,$cluster,$namespace,!pod_name:no_pod,$label,$service,$node} by {pod_name}, 10, 'mean', 'desc')",
+                        "style": {
+                            "palette": "warm"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Most CPU-intensive pods",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                }
+            },
+            "layout": {
+                "x": 107,
+                "y": 57,
+                "width": 43,
+                "height": 24
+            }
+        },
+        {
+            "id": 2,
+            "definition": {
+                "type": "image",
+                "url": "/static/images/screenboard/integrations/kubernetes.jpg",
+                "sizing": "zoom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 23,
+                "height": 15
+            }
+        },
+        {
+            "id": 3,
+            "definition": {
+                "type": "check_status",
+                "title": "Kubelets up",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "kubernetes.kubelet.check",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": ["$scope", "$node", "$label"],
+                "time": {
+                    "live_span": "10m"
+                }
+            },
+            "layout": {
+                "x": 80,
+                "y": 0,
+                "width": 13,
+                "height": 7
+            }
+        },
+        {
+            "id": 4,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas_available{$scope,$deployment,$daemonset,$cluster,$label,$namespace,$service,$node}",
+                        "aggregator": "avg",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "green_on_white"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods Available",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "5m"
+                },
+                "autoscale": true,
+                "precision": 0
+            },
+            "layout": {
+                "x": 50,
+                "y": 91,
+                "width": 16,
+                "height": 14
+            }
+        },
+        {
+            "id": 5,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas_available{$scope,$deployment,$daemonset,$service,$label,$cluster,$namespace,$node} by {deployment}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "green",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods available",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 67,
+                "y": 91,
+                "width": 37,
+                "height": 14
+            }
+        },
+        {
+            "id": 6,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$deployment,$daemonset,$cluster,$label,$namespace,$service,$node}",
+                        "aggregator": "avg",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "custom_text",
+                                "custom_fg_color": "#6a53a1"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods desired",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "5m"
+                },
+                "autoscale": true,
+                "precision": 0
+            },
+            "layout": {
+                "x": 50,
+                "y": 76,
+                "width": 16,
+                "height": 14
+            }
+        },
+        {
+            "id": 7,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$deployment,$daemonset,$cluster,$label,$namespace,$service,$node} by {deployment}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "purple",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods desired",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 67,
+                "y": 76,
+                "width": 37,
+                "height": 14
+            }
+        },
+        {
+            "id": 8,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas_unavailable{$scope,$deployment,$daemonset,$cluster,$label,$namespace,$service,$node}",
+                        "aggregator": "avg",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "yellow_on_white"
+                            },
+                            {
+                                "comparator": "<=",
+                                "value": 0,
+                                "palette": "green_on_white"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods unavailable",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "5m"
+                },
+                "autoscale": true,
+                "precision": 0
+            },
+            "layout": {
+                "x": 50,
+                "y": 106,
+                "width": 16,
+                "height": 14
+            }
+        },
+        {
+            "id": 9,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.deployment.replicas_unavailable{$scope,$deployment,$daemonset,$service,$label,$cluster,$namespace,$node} by {deployment}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "orange",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods unavailable",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 67,
+                "y": 106,
+                "width": 37,
+                "height": 14
+            }
+        },
+        {
+            "id": 10,
+            "definition": {
+                "type": "note",
+                "content": "Pods",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 37,
+                "y": 16,
+                "width": 67,
+                "height": 5
+            }
+        },
+        {
+            "id": 11,
+            "definition": {
+                "type": "note",
+                "content": "[Resource utilization](https://www.datadoghq.com/blog/monitoring-kubernetes-performance-metrics/#toc-resource-utilization6)",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 107,
+                "y": 16,
+                "width": 87,
+                "height": 5
+            }
+        },
+        {
+            "id": 12,
+            "definition": {
+                "type": "event_stream",
+                "query": "sources:kubernetes $node",
+                "tags_execution": "and",
+                "event_size": "s",
+                "time": {
+                    "live_span": "1w"
+                }
+            },
+            "layout": {
+                "x": 0,
+                "y": 34,
+                "width": 36,
+                "height": 37
+            }
+        },
+        {
+            "id": 13,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.pods.running{$scope,$deployment,$daemonset,$label,$cluster,$namespace,$service,$node} by {host}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Running pods per node",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false
+            },
+            "layout": {
+                "x": 37,
+                "y": 38,
+                "width": 33,
+                "height": 15
+            }
+        },
+        {
+            "id": 14,
+            "definition": {
+                "type": "hostmap",
+                "requests": {
+                    "fill": {
+                        "q": "sum:kubernetes.memory.usage{$scope,$deployment,$daemonset,$namespace,$cluster,$label,$service,$node} by {host}"
+                    }
+                },
+                "custom_links": [],
+                "title": "Memory usage per node",
+                "title_size": "16",
+                "title_align": "left",
+                "no_metric_hosts": false,
+                "no_group_hosts": true,
+                "scope": [
+                    "$scope",
+                    "$node",
+                    "$label",
+                    "$kube_deployment",
+                    "$kube_namespace"
+                ],
+                "style": {
+                    "palette": "hostmap_blues",
+                    "palette_flip": false
+                }
+            },
+            "layout": {
+                "x": 151,
+                "y": 22,
+                "width": 43,
+                "height": 18
+            }
+        },
+        {
+            "id": 15,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.network.rx_errors{$scope,$deployment,$daemonset,$namespace,$cluster,$label,$service,$node} by {host}",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "warm"
+                        }
+                    },
+                    {
+                        "q": "sum:kubernetes.network.tx_errors{$scope,$deployment,$daemonset,$namespace,$cluster,$label,$service,$node} by {host}",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "warm"
+                        }
+                    },
+                    {
+                        "q": "sum:kubernetes.network_errors{$scope,$deployment,$daemonset,$namespace,$cluster,$label,$service,$node} by {host}",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Network errors per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 107,
+                "y": 121,
+                "width": 43,
+                "height": 16
+            }
+        },
+        {
+            "id": 16,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.cpu.requests{$scope,$deployment,$daemonset,$cluster,$namespace,$label,$service,$node} by {host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "warm"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Sum Kubernetes CPU requests per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 107,
+                "y": 41,
+                "width": 43,
+                "height": 15
+            }
+        },
+        {
+            "id": 17,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.memory.requests{$scope,$deployment,$daemonset,$cluster,$namespace,$label,$service,$node} by {host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "cool"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Sum Kubernetes memory requests per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 151,
+                "y": 41,
+                "width": 43,
+                "height": 15
+            }
+        },
+        {
+            "id": 18,
+            "definition": {
+                "type": "note",
+                "content": "Disk I/O & Network",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 107,
+                "y": 82,
+                "width": 87,
+                "height": 5
+            }
+        },
+        {
+            "id": 19,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.network.rx_bytes{$scope,$deployment,$daemonset,$cluster,$namespace,$label,$service,$node} by {host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "purple"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Network in per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 107,
+                "y": 88,
+                "width": 43,
+                "height": 16
+            }
+        },
+        {
+            "id": 20,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.network.tx_bytes{$scope,$deployment,$daemonset,$namespace,$cluster,$label,$service,$node} by {host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "green"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Network out per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 107,
+                "y": 105,
+                "width": 43,
+                "height": 15
+            }
+        },
+        {
+            "id": 21,
+            "definition": {
+                "type": "note",
+                "content": "[Events](https://www.datadoghq.com/blog/monitoring-kubernetes-performance-metrics/#toc-correlate-with-events10)",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 16,
+                "width": 36,
+                "height": 5
+            }
+        },
+        {
+            "id": 22,
+            "definition": {
+                "type": "event_timeline",
+                "query": "sources:kubernetes $node",
+                "tags_execution": "and",
+                "title": "Number of Kubernetes events per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1d"
+                }
+            },
+            "layout": {
+                "x": 0,
+                "y": 22,
+                "width": 36,
+                "height": 9
+            }
+        },
+        {
+            "id": 23,
+            "definition": {
+                "type": "hostmap",
+                "requests": {
+                    "fill": {
+                        "q": "sum:kubernetes.cpu.usage.total{$scope,$deployment,$daemonset,$namespace,$cluster,$label,$service,$node} by {host}"
+                    }
+                },
+                "custom_links": [],
+                "title": "CPU utilization per node",
+                "title_size": "16",
+                "title_align": "left",
+                "no_metric_hosts": false,
+                "no_group_hosts": true,
+                "scope": [
+                    "$scope",
+                    "$node",
+                    "$label",
+                    "$kube_deployment",
+                    "$kube_namespace"
+                ],
+                "style": {
+                    "palette": "YlOrRd",
+                    "palette_flip": false
+                }
+            },
+            "layout": {
+                "x": 107,
+                "y": 22,
+                "width": 43,
+                "height": 18
+            }
+        },
+        {
+            "id": 24,
+            "definition": {
+                "type": "note",
+                "content": "Read our\n[Monitoring guide for Kubernetes](https://www.datadoghq.com/blog/monitoring-kubernetes-era/).\n \nCheck [the agent documentation](https://docs.datadoghq.com/agent/kubernetes/) if some of the graphs are empty.",
+                "background_color": "yellow",
+                "font_size": "14",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "left"
+            },
+            "layout": {
+                "x": 95,
+                "y": 0,
+                "width": 16,
+                "height": 15
+            }
+        },
+        {
+            "id": 25,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.daemonset.desired{$scope,$deployment,$daemonset,$cluster,$label,$namespace,$service,$node}",
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "custom_text",
+                                "custom_fg_color": "#6a53a1"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Desired",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "5m"
+                },
+                "autoscale": true,
+                "precision": 0
+            },
+            "layout": {
+                "x": 0,
+                "y": 76,
+                "width": 16,
+                "height": 14
+            }
+        },
+        {
+            "id": 26,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.daemonset.desired{$scope,$deployment,$daemonset,$service,$namespace,$label,$cluster,$node} by {daemonset}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "purple",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods desired",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 17,
+                "y": 76,
+                "width": 32,
+                "height": 14
+            }
+        },
+        {
+            "id": 27,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.daemonset.ready{$scope,$deployment,$daemonset,$cluster,$label,$namespace,$service,$node}",
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "green_on_white"
+                            },
+                            {
+                                "comparator": "<=",
+                                "value": 0,
+                                "palette": "red_on_white"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Ready",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "5m"
+                },
+                "autoscale": true,
+                "precision": 0
+            },
+            "layout": {
+                "x": 0,
+                "y": 91,
+                "width": 16,
+                "height": 14
+            }
+        },
+        {
+            "id": 28,
+            "definition": {
+                "type": "check_status",
+                "title": "Kubelet Ping",
+                "title_size": "16",
+                "title_align": "center",
+                "check": "kubernetes.kubelet.check.ping",
+                "grouping": "cluster",
+                "group_by": [],
+                "tags": ["*", "$node", "$label", "$scope"],
+                "time": {
+                    "live_span": "10m"
+                }
+            },
+            "layout": {
+                "x": 80,
+                "y": 8,
+                "width": 13,
+                "height": 7
+            }
+        },
+        {
+            "id": 29,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.container.running{$scope,$deployment,$daemonset,$service,$namespace,$label,$cluster,$node}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "sum:kubernetes_state.container.waiting{$scope,$deployment,$daemonset,$service,$namespace,$label,$cluster,$node}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "sum:kubernetes_state.container.terminated{$scope,$deployment,$daemonset,$service,$namespace,$label,$cluster,$node}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "grey",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "sum:kubernetes_state.container.ready{$scope,$deployment,$daemonset,$service,$namespace,$label,$cluster,$node}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "grey",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Container states",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 50,
+                "y": 127,
+                "width": 54,
+                "height": 14
+            }
+        },
+        {
+            "id": 30,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.replicaset.replicas_ready{$scope,$daemonset,$service,$namespace,$deployment,$label,$cluster,$node} by {replicaset}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "purple",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Ready",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 17,
+                "y": 112,
+                "width": 32,
+                "height": 14
+            }
+        },
+        {
+            "id": 31,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.replicaset.replicas_desired{$scope,$daemonset,$service,$namespace,$deployment,$label,$cluster,$node} by {replicaset}-sum:kubernetes_state.replicaset.replicas_ready{$scope,$daemonset,$service,$namespace,$deployment,$label,$cluster,$node} by {replicaset}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "orange",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Not ready",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "1h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 17,
+                "y": 127,
+                "width": 32,
+                "height": 14
+            }
+        },
+        {
+            "id": 32,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.io.read_bytes{$scope,$daemonset,$service,$namespace,$label,$cluster,$deployment,$node} by {replicaset,host}-avg:kubernetes_state.replicaset.replicas_ready{$scope,$daemonset,$service,$namespace,$label,$cluster,$deployment,$node} by {host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "grey",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Disk reads per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 151,
+                "y": 105,
+                "width": 43,
+                "height": 15
+            }
+        },
+        {
+            "id": 33,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.io.write_bytes{$scope,$daemonset,$service,$namespace,$label,$cluster,$deployment,$node} by {replicaset,host}-avg:kubernetes_state.replicaset.replicas_ready{$scope,$daemonset,$service,$namespace,$label,$cluster,$deployment,$node} by {host}",
+                        "display_type": "line",
+                        "style": {
+                            "palette": "grey",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Disk writes per node",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 151,
+                "y": 88,
+                "width": 43,
+                "height": 16
+            }
+        },
+        {
+            "id": 34,
+            "definition": {
+                "type": "note",
+                "content": "DaemonSets",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 70,
+                "width": 49,
+                "height": 5
+            }
+        },
+        {
+            "id": 35,
+            "definition": {
+                "type": "note",
+                "content": "Deployments",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 50,
+                "y": 70,
+                "width": 54,
+                "height": 5
+            }
+        },
+        {
+            "id": 36,
+            "definition": {
+                "type": "note",
+                "content": "ReplicaSets",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 0,
+                "y": 106,
+                "width": 49,
+                "height": 5
+            }
+        },
+        {
+            "id": 37,
+            "definition": {
+                "type": "note",
+                "content": "Containers",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "bottom"
+            },
+            "layout": {
+                "x": 50,
+                "y": 121,
+                "width": 54,
+                "height": 5
+            }
+        },
+        {
+            "id": 38,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.replicaset.replicas_ready{$scope,$deployment,$daemonset,$cluster,$label,$namespace,$service,$node}",
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "custom_text",
+                                "custom_fg_color": "#6a53a1"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Ready",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "5m"
+                },
+                "autoscale": true,
+                "precision": 0
+            },
+            "layout": {
+                "x": 0,
+                "y": 112,
+                "width": 16,
+                "height": 14
+            }
+        },
+        {
+            "id": 39,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.replicaset.replicas_desired{$scope,$daemonset,$service,$namespace,$deployment,$label,$cluster,$node}-sum:kubernetes_state.replicaset.replicas_ready{$scope,$daemonset,$service,$namespace,$deployment,$label,$cluster,$node}",
+                        "aggregator": "last",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "yellow_on_white",
+                                "custom_fg_color": "#6a53a1"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Not ready",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "5m"
+                },
+                "autoscale": true,
+                "precision": 0
+            },
+            "layout": {
+                "x": 0,
+                "y": 127,
+                "width": 16,
+                "height": 14
+            }
+        },
+        {
+            "id": 40,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.daemonset.ready{$scope,$deployment,$daemonset,$service,$namespace,$label,$cluster,$node} by {daemonset}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "green",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods ready",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 17,
+                "y": 91,
+                "width": 32,
+                "height": 14
+            }
+        },
+        {
+            "id": 41,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.pods.running{$scope,$cluster,$namespace,$deployment,$daemonset,$label,$node,$service} by {cluster_name,kube_namespace}",
+                        "display_type": "area",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [
+                    {
+                        "link": "https://www.google.com?search={{kube_namespace.value}}",
+                        "label": "Search Namespace on Google"
+                    }
+                ],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Running pods per namespace",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 37,
+                "y": 22,
+                "width": 33,
+                "height": 15
+            }
+        },
+        {
+            "id": 42,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:kubernetes_state.pod.status_phase{$scope,$cluster,$namespace,$deployment,$daemonset,!phase:running,!phase:succeeded,$label,$node,$service} by {cluster_name,kube_namespace,phase}, 100, 'last', 'desc')",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 0,
+                                "palette": "white_on_red"
+                            },
+                            {
+                                "comparator": "<=",
+                                "value": 0,
+                                "palette": "white_on_green"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods in bad phase by namespaces",
+                "title_size": "16",
+                "title_align": "left"
+            },
+            "layout": {
+                "x": 37,
+                "y": 54,
+                "width": 33,
+                "height": 15
+            }
+        },
+        {
+            "id": 43,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.container.waiting{$cluster,$namespace,$deployment,reason:crashloopbackoff,$scope,$daemonset,$label,$node,$service} by {pod_name}",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "markers": [
+                    {
+                        "value": "y = 0",
+                        "display_type": "ok dashed",
+                        "label": "y = 0"
+                    }
+                ],
+                "title": "CrashloopBackOff by Pod",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 71,
+                "y": 54,
+                "width": 33,
+                "height": 15
+            }
+        },
+        {
+            "id": 44,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:kubernetes.pods.running{$scope,$namespace,$deployment,$cluster,$daemonset,$label,$node,$service} by {cluster_name,kube_namespace}, 100, 'max', 'desc')",
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "value": 2000,
+                                "palette": "white_on_red"
+                            },
+                            {
+                                "comparator": ">",
+                                "value": 1500,
+                                "palette": "white_on_yellow"
+                            },
+                            {
+                                "comparator": "<=",
+                                "value": 3000,
+                                "palette": "white_on_green"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods running by namespace",
+                "title_size": "16",
+                "title_align": "left"
+            },
+            "layout": {
+                "x": 71,
+                "y": 22,
+                "width": 33,
+                "height": 15
+            }
+        },
+        {
+            "id": 45,
+            "definition": {
+                "type": "toplist",
+                "requests": [
+                    {
+                        "q": "top(sum:kubernetes_state.pod.ready{$scope,$cluster,$namespace,$deployment,condition:true,$daemonset,$label,$node,$service} by {kubernetes_cluster,host,nodepool}, 10, 'last', 'desc')",
+                        "conditional_formats": [
+                            {
+                                "comparator": "<=",
+                                "value": 24,
+                                "palette": "white_on_green"
+                            },
+                            {
+                                "comparator": ">",
+                                "value": 32,
+                                "palette": "white_on_red"
+                            },
+                            {
+                                "comparator": ">",
+                                "value": 24,
+                                "palette": "white_on_yellow"
+                            }
+                        ]
+                    }
+                ],
+                "custom_links": [],
+                "title": "Pods in ready state by node",
+                "title_size": "16",
+                "title_align": "left"
+            },
+            "layout": {
+                "x": 71,
+                "y": 38,
+                "width": 33,
+                "height": 15
+            }
+        },
+        {
+            "id": 46,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "count_nonzero(avg:kubernetes.pods.running{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster} by {cluster_name})",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Clusters",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 24,
+                "y": 0,
+                "width": 13,
+                "height": 7
+            }
+        },
+        {
+            "id": 47,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "count_nonzero(avg:kubernetes.pods.running{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster} by {cluster_name,kube_namespace})",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Namespaces",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 38,
+                "y": 0,
+                "width": 13,
+                "height": 7
+            }
+        },
+        {
+            "id": 48,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "count_nonzero(avg:kubernetes_state.deployment.replicas{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster} by {cluster_name,kube_namespace,kube_deployment})",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Deployments",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 52,
+                "y": 8,
+                "width": 13,
+                "height": 7
+            }
+        },
+        {
+            "id": 49,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.service.count{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster}",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Services",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 52,
+                "y": 0,
+                "width": 13,
+                "height": 7
+            }
+        },
+        {
+            "id": 50,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "count_nonzero(avg:kubernetes_state.daemonset.desired{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster} by {cluster_name,kube_namespace,kube_daemon_set})",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "DaemonSets",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 38,
+                "y": 8,
+                "width": 13,
+                "height": 7
+            }
+        },
+        {
+            "id": 51,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes_state.node.count{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster}",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Nodes",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 24,
+                "y": 8,
+                "width": 13,
+                "height": 7
+            }
+        },
+        {
+            "id": 52,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.pods.running{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster}",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [
+                    {
+                        "link": "https://app.datadoghq.com/screen/integration/30322/kubernetes-pods-overview",
+                        "label": "View Pods overview"
+                    }
+                ],
+                "title": "Pods",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 66,
+                "y": 0,
+                "width": 13,
+                "height": 7
+            }
+        },
+        {
+            "id": 53,
+            "definition": {
+                "type": "query_value",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.containers.running{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster}",
+                        "aggregator": "avg"
+                    }
+                ],
+                "custom_links": [],
+                "title": "Containers",
+                "title_size": "16",
+                "title_align": "left",
+                "precision": 0
+            },
+            "layout": {
+                "x": 66,
+                "y": 8,
+                "width": 13,
+                "height": 7
+            }
+        },
+        {
+            "id": 54,
+            "definition": {
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "q": "sum:kubernetes.network.rx_errors{$scope,$deployment,$daemonset,$namespace,$cluster,$label,$service,$node} by {pod_name}",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    },
+                    {
+                        "q": "sum:kubernetes.network.tx_errors{$scope,$deployment,$daemonset,$namespace,$cluster,$label,$service,$node} by {pod_name}",
+                        "display_type": "bars",
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        }
+                    }
+                ],
+                "custom_links": [],
+                "yaxis": {
+                    "label": "",
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto",
+                    "include_zero": true
+                },
+                "title": "Network errors per pod",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                    "live_span": "4h"
+                },
+                "show_legend": false,
+                "legend_size": "0"
+            },
+            "layout": {
+                "x": 151,
+                "y": 121,
+                "width": 43,
+                "height": 16
+            }
+        }
+    ],
+    "template_variables": [
+        {
+            "name": "scope",
+            "default": "*",
+            "prefix": null
+        },
+        {
+            "name": "cluster",
+            "default": "*",
+            "prefix": "cluster_name"
+        },
+        {
+            "name": "namespace",
+            "default": "*",
+            "prefix": "kube_namespace"
+        },
+        {
+            "name": "deployment",
+            "default": "*",
+            "prefix": "kube_deployment"
+        },
+        {
+            "name": "daemonset",
+            "default": "*",
+            "prefix": "kube_daemon_set"
+        },
+        {
+            "name": "service",
+            "default": "*",
+            "prefix": "kube_service"
+        },
+        {
+            "name": "node",
+            "default": "*",
+            "prefix": "node"
+        },
+        {
+            "name": "label",
+            "default": "*",
+            "prefix": "label"
+        }
+    ],
+    "layout_type": "free",
+    "is_read_only": true,
+    "notify_list": [],
+    "id": 86
+}

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -33,6 +33,7 @@
       "[kubernetes] Monitor Kubernetes Statefulset Replicas": "assets/monitors/monitor_statefulset_replicas.json"
     },
     "dashboards": {
+      "kubernetes": "assets/dashboards/kubernetes_dashboard.json",
       "Kubernetes - Pods": "assets/dashboards/kubernetes_pods.json",
       "Kubernetes Nodes Overview": "assets/dashboards/kubernetes_nodes.json",
       "Kubernetes Deployments Overview": "assets/dashboards/kubernetes_deployments.json",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Migrates the following dashboards from dogweb:
- cisco_aci [Staging Link](https://dd.datad0g.com/screen/integration/129/cisco-aci-overview?from_ts=1613078418227&to_ts=1613082018227&live=true)
- consul [Staging Link](https://dd.datad0g.com/screen/integration/83/consul---overview?from_ts=1613078015516&to_ts=1613081615516&live=true)
- kubernetes [Staging Link](https://dd.datad0g.com/screen/integration/86/kubernetes-overview?from_ts=1613078403380&live=true&to_ts=1613082003380)


[Dogweb PR](https://github.com/DataDog/dogweb/pull/56445)

### Motivation
<!-- What inspired you to submit this pull request? -->
Compatibility
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
