### PR TITLE
Clean up cases where `display_default` should be null

### DIFF
--- a/cilium/assets/configuration/spec.yaml
+++ b/cilium/assets/configuration/spec.yaml
@@ -16,7 +16,7 @@ files:
       value:
         type: string
         example: http://localhost:9090/metrics
-        display_default: None
+        display_default: null
     - name: operator_endpoint
       description: |
         Provide instead of `agent_endpoint` to collect `cilium-operator` metrics.
@@ -24,7 +24,7 @@ files:
       value:
         type: string
         example: http://localhost:6942/metrics
-        display_default: None
+        display_default: null
     - template: instances/openmetrics_legacy
       overrides:
         prometheus_url.hidden: true

--- a/couch/assets/configuration/spec.yaml
+++ b/couch/assets/configuration/spec.yaml
@@ -43,7 +43,7 @@ files:
         example:
           - <DATABASE_1>
           - <DATABASE_2>
-        display_default: None
+        display_default: null
     - name: max_dbs_per_check
       description: Number of databases to scan per check.
       value:
@@ -54,7 +54,7 @@ files:
       value:
         type: string
         example: <ERLANG_NAME>
-        display_default: None
+        display_default: null
     - name: max_nodes_per_check
       description: CouchDB 2.x only. How many nodes each check reports if no name is provided.
       value:

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -809,7 +809,7 @@ def test_option_string_type_not_default_example_default_value_none():
             value:
               type: string
               example: something
-              display_default: None
+              display_default: null
         """
     )
 

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -61,7 +61,7 @@ files:
             value:
               type: string
               example: utf8
-              display_default: None
+              display_default: null
           - name: defaults_file
             description: |
               Path to an alternative configuration mechanism file.

--- a/varnish/assets/configuration/spec.yaml
+++ b/varnish/assets/configuration/spec.yaml
@@ -53,7 +53,7 @@ files:
             value:
               type: string
               example: /usr/bin/varnishadm
-              display_default: None
+              display_default: null
           - name: secretfile
             description: The path to the varnish secretfile used in the varnishadm command, if enabled.
             value:


### PR DESCRIPTION
### Motivation

Adhere to https://datadoghq.dev/integrations-core/meta/config-specs/#example-file-consumer

Encountered while working on the upcoming data model consumer