### PR TITLE
Manually release integrations following cryptography bump

### DIFF
--- a/cisco_aci/CHANGELOG.md
+++ b/cisco_aci/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - cisco_aci
 
+## 1.14.0 / 2021-02-12
+
+* [Security] Upgrade cryptography python package. See [#8611](https://github.com/DataDog/integrations-core/pull/8611).
+
 ## 1.13.0 / 2021-01-28
 
 * [Security] Upgrade cryptography python package. See [#8476](https://github.com/DataDog/integrations-core/pull/8476).

--- a/cisco_aci/datadog_checks/cisco_aci/__about__.py
+++ b/cisco_aci/datadog_checks/cisco_aci/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "1.13.0"
+__version__ = "1.14.0"

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - datadog_checks_base
 
+## 16.4.0 / 2021-02-12
+
+* [Security] Upgrade cryptography python package. See [#8611](https://github.com/DataDog/integrations-core/pull/8611).
+
 ## 16.3.2 / 2021-02-01
 
 * [Fixed] Fix histogram upper bound label name for new OpenMetrics implementation. See [#8505](https://github.com/DataDog/integrations-core/pull/8505).

--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = "16.3.2"
+__version__ = "16.4.0"

--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - http_check
 
+## 5.2.0 / 2021-02-12
+
+* [Security] Upgrade cryptography python package. See [#8611](https://github.com/DataDog/integrations-core/pull/8611).
+
 ## 5.1.0 / 2021-01-28
 
 * [Security] Upgrade cryptography python package. See [#8476](https://github.com/DataDog/integrations-core/pull/8476).

--- a/http_check/datadog_checks/http_check/__about__.py
+++ b/http_check/datadog_checks/http_check/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = "5.1.0"
+__version__ = "5.2.0"

--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - mysql
 
+## 2.3.0 / 2021-02-12
+
+* [Security] Upgrade cryptography python package. See [#8611](https://github.com/DataDog/integrations-core/pull/8611).
+
 ## 2.2.1 / 2021-01-29
 
 * [Fixed] Fix condition for replication status. See [#8475](https://github.com/DataDog/integrations-core/pull/8475).

--- a/mysql/datadog_checks/mysql/__about__.py
+++ b/mysql/datadog_checks/mysql/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "2.2.1"
+__version__ = "2.3.0"

--- a/tls/CHANGELOG.md
+++ b/tls/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - TLS
 
+## 2.2.0 / 2021-02-12
+
+* [Security] Upgrade cryptography python package. See [#8611](https://github.com/DataDog/integrations-core/pull/8611).
+
 ## 2.1.1 / 2021-02-05
 
 * [Fixed] Include validate_cert in backwards compatibility remapper. See [#8543](https://github.com/DataDog/integrations-core/pull/8543).

--- a/tls/datadog_checks/tls/__about__.py
+++ b/tls/datadog_checks/tls/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '2.1.1'
+__version__ = '2.2.0'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Manual release of

* `datadog_checks_base`
* `tls`
* `mysql`
* `http_check`
* `cisco_aci`

### Motivation
<!-- What inspired you to submit this pull request? -->
Release #8611 for 7.26.0

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Note: no further step required after this gets merged (no push to PyPI for `base`, no tagging), since this is a manual release only for the purpose of 7.26.0. See also similar PRs: #8544, #8514 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
