### PR TITLE
Add HOME env var

### DIFF
--- a/vault/tox.ini
+++ b/vault/tox.ini
@@ -21,6 +21,7 @@ deps =
 passenv =
     DOCKER*
     COMPOSE*
+    HOME
 setenv =
     AUTH_TYPE=token-auth
     noauth: AUTH_TYPE=noauth


### PR DESCRIPTION
Avoid:
```
tests/conftest.py:66: in dd_environment
    with docker_run(
/opt/hostedtoolcache/Python/3.8.7/x64/lib/python3.8/contextlib.py:113: in __enter__
    return next(self.gen)
../datadog_checks_dev/datadog_checks/dev/docker.py:208: in docker_run
    with environment_run(
/opt/hostedtoolcache/Python/3.8.7/x64/lib/python3.8/contextlib.py:113: in __enter__
    return next(self.gen)
../datadog_checks_dev/datadog_checks/dev/env.py:73: in environment_run
    condition()
tests/conftest.py:105: in __call__
    raise Exception(result.stderr)
E   Exception: WARNING: Error loading config file: .dockercfg: $HOME is not defined
- generated xml file: /home/vsts/work/1/s/vault/.junit/test-unit-py38-noauth.xml
```