### PR TITLE
datadog_checks_dev: add env management debug logging

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/conditions.py
+++ b/datadog_checks_dev/datadog_checks/dev/conditions.py
@@ -1,10 +1,10 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
 import re
 import socket
 import time
-import logging
 from contextlib import closing
 
 from six import string_types
@@ -16,6 +16,7 @@ from .subprocess import run_command
 from .utils import file_exists
 
 logger = logging.getLogger(__name__)
+
 
 class WaitFor(LazyFunction):
     def __init__(self, func, attempts=60, wait=1, args=(), kwargs=None):

--- a/datadog_checks_dev/datadog_checks/dev/conditions.py
+++ b/datadog_checks_dev/datadog_checks/dev/conditions.py
@@ -4,6 +4,7 @@
 import re
 import socket
 import time
+import logging
 from contextlib import closing
 
 from six import string_types
@@ -14,6 +15,7 @@ from .structures import LazyFunction
 from .subprocess import run_command
 from .utils import file_exists
 
+logger = logging.getLogger(__name__)
 
 class WaitFor(LazyFunction):
     def __init__(self, func, attempts=60, wait=1, args=(), kwargs=None):
@@ -34,6 +36,7 @@ class WaitFor(LazyFunction):
             try:
                 result = self.func(*self.args, **self.kwargs)
             except Exception as e:
+                logger.debug("WaitFor error func=%s", self.func.__name__, exc_info=1)
                 last_error = str(e)
                 time.sleep(self.wait)
                 continue

--- a/datadog_checks_dev/datadog_checks/dev/structures.py
+++ b/datadog_checks_dev/datadog_checks/dev/structures.py
@@ -2,8 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import abc
-import os
 import logging
+import os
 from shutil import rmtree
 from tempfile import mkdtemp
 
@@ -13,6 +13,7 @@ from ._env import e2e_active, get_env_vars, remove_env_vars, set_env_vars, tear_
 from .warn import warning
 
 logger = logging.getLogger(__name__)
+
 
 @six.add_metaclass(abc.ABCMeta)
 class LazyFunction(object):

--- a/datadog_checks_dev/datadog_checks/dev/structures.py
+++ b/datadog_checks_dev/datadog_checks/dev/structures.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import abc
 import os
+import logging
 from shutil import rmtree
 from tempfile import mkdtemp
 
@@ -11,6 +12,7 @@ import six
 from ._env import e2e_active, get_env_vars, remove_env_vars, set_env_vars, tear_down_env
 from .warn import warning
 
+logger = logging.getLogger(__name__)
 
 @six.add_metaclass(abc.ABCMeta)
 class LazyFunction(object):
@@ -36,6 +38,7 @@ class EnvVars(dict):
     def __enter__(self):
         os.environ.clear()
         os.environ.update(self)
+        logger.debug("EnvVars: %s", " ".join('{}="{}"'.format(k, v) for k, v in self.items()))
 
     def __exit__(self, exc_type, exc_value, traceback):
         os.environ.clear()

--- a/datadog_checks_dev/datadog_checks/dev/subprocess.py
+++ b/datadog_checks_dev/datadog_checks/dev/subprocess.py
@@ -3,8 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import absolute_import
 
-import shlex
 import logging
+import shlex
 from collections import namedtuple
 from subprocess import Popen
 from tempfile import TemporaryFile

--- a/datadog_checks_dev/datadog_checks/dev/subprocess.py
+++ b/datadog_checks_dev/datadog_checks/dev/subprocess.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 import shlex
+import logging
 from collections import namedtuple
 from subprocess import Popen
 from tempfile import TemporaryFile
@@ -12,6 +13,8 @@ from six import string_types
 
 from .errors import SubprocessError
 from .utils import NEED_SHELL, ON_WINDOWS, mock_context_manager
+
+logger = logging.getLogger(__name__)
 
 SubprocessResult = namedtuple('SubprocessResult', ('stdout', 'stderr', 'code'))
 
@@ -58,6 +61,7 @@ def run_command(command, capture=None, check=False, encoding='utf-8', shell=Fals
         stdout, stderr = mock_context_manager, mock_context_manager
 
     with stdout() as stdout, stderr() as stderr:
+        logger.debug("run_command: %s", " ".join(command))
         process = Popen(command, stdout=stdout, stderr=stderr, shell=shell, env=env)
         process.wait()
 


### PR DESCRIPTION
### What does this PR do?

Add debug logging to make it easier to debug problems with the docker-based dev/test environment. 

### Motivation
When a container is failing to start due to a problem in its startup (i.e. postgres container startup scripts) it's difficult to figure out what's happening because the logs don't appear anywhere. In this case it's easiest to manually run docker-compose but you may not know the exact set of environment variables or other args used by the test framework to start it up. To fix, add the following logging to make it easy to run the docker-compose command manually if necessary:
* add debug logging to `dev/subprocess:run_command` so we can see the full command being run
* add debug logging to `dev/structurs:EnvVars` to log out the full environment being used

If `dev/conditions:WaitFor` is failing it causes the test to be stuck in an extended retry loop. Add debug logging to make it easier to see what the problem is quickly.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
