### PR TITLE
Add MySQL recommended monitors

### DIFF
--- a/mysql/assets/monitors/replica_running.json
+++ b/mysql/assets/monitors/replica_running.json
@@ -1,0 +1,25 @@
+{
+	"name": "[MySQL] Replica {{host.name}} is not running properly",
+	"type": "service check",
+	"query": "\"mysql.replication.replica_running\".over(\"*\").last(2).count_by_status()",
+	"message": "Replica_IO_Running and/or Replica_SQL_Running is not running on replica {{host.name}}. Consider investigating to restore full data replication.",
+	"tags": [
+        "integration:mysql"
+    ],
+	"options": {
+        "notify_audit": false,
+		"renotify_interval": 0,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+        "notify_no_data": false,
+        "no_data_timeframe": 2,
+		"thresholds": {
+			"critical": 1,
+			"warning": 1,
+			"ok": 1
+		}
+	},
+    "recommended_monitor_metadata": {
+		"description": "Notify your team when a replica is not running properly."
+    }
+}

--- a/mysql/assets/monitors/select_query_rate.json
+++ b/mysql/assets/monitors/select_query_rate.json
@@ -1,0 +1,33 @@
+{
+	"name": "[MySQL] Unusual drop in SELECT query rate on server {{host.name}}",
+	"type": "query alert",
+	"query": "avg(last_1h):anomalies(avg:mysql.performance.com_select{*}, 'basic', 2, direction='below', alert_window='last_15m', interval=20, count_default_zero='true') >= 1",
+	"message": "Get notified of drastic and prolonged drops in SELECT query throughput.",
+	"tags": [
+      "integration:mysql"
+    ],
+	"options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+		"require_full_window": true,
+		"notify_no_data": false,
+		"renotify_interval": "0",
+		"escalation_message": "",
+		"no_data_timeframe": null,
+		"include_tags": true,
+		"thresholds": {
+			"critical": 1,
+			"critical_recovery": 0
+		},
+		"threshold_windows": {
+			"trigger_window": "last_15m",
+			"recovery_window": "last_15m"
+		}
+	},
+	"priority": null,
+	"recommended_monitor_metadata": {
+		"description": "Notify your team when a drastic drop in SELECT queries occurs."
+	}
+}

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -31,12 +31,12 @@
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {
-      "select query rate": "assets/monitors/select_query_rate.json"
+      "select query rate": "assets/monitors/select_query_rate.json",
+      "replica running": "assets/monitors/replica_running.json"
     },
     "dashboards": {
       "mysql": "assets/dashboards/overview.json",
       "mysql-screenboard": "assets/dashboards/overview-screenboard.json"
-
     },
     "saved_views": {
       "operations": "assets/saved_views/operations.json",

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -30,7 +30,9 @@
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
-    "monitors": {},
+    "monitors": {
+      "select query rate": "assets/monitors/select_query_rate.json"
+    },
     "dashboards": {
       "mysql": "assets/dashboards/overview.json",
       "mysql-screenboard": "assets/dashboards/overview-screenboard.json"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Added recommended monitors for MySQL

[Staging link](https://dd.datad0g.com/monitors#create/integration?recommendedMonitorID=mysql_select_query_rate)

![Screenshot 2021-02-16 at 12 15 14](https://user-images.githubusercontent.com/15911462/108055773-b7e70f80-7050-11eb-93ee-ff66324e838d.png)

### Motivation
<!-- What inspired you to submit this pull request? -->
Recommended monitor coverage

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This monitor ("alert in case of SELECT query rate below usual bounds") is inspired by the MySQL blog post and dashboard:

> The current rate of queries will naturally rise and fall, and as such it’s not always an actionable metric based on fixed thresholds. But it is worthwhile to alert on sudden changes in query volume—drastic drops in throughput, especially, can indicate a serious problem.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
