### PR TITLE
Replace `oneOf` with `anyOf` for multi-type support

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/example.py
@@ -37,15 +37,15 @@ def construct_yaml(obj, **kwargs):
 
 
 def value_type_string(value):
-    if 'oneOf' in value:
-        return ' or '.join(value_type_string(type_data) for type_data in value['oneOf'])
+    if 'anyOf' in value:
+        return ' or '.join(value_type_string(type_data) for type_data in value['anyOf'])
     else:
         value_type = value['type']
         if value_type == 'object':
             return 'mapping'
         elif value_type == 'array':
             items = value['items']
-            if 'oneOf' in items:
+            if 'anyOf' in items:
                 return f'(list of {value_type_string(items)})'
             else:
                 item_type = items['type']

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/spec.py
@@ -366,26 +366,26 @@ VALID_TYPES = {
 
 
 def value_validator(value, loader, file_name, sections_display, option_name, depth=0):
-    if 'oneOf' in value:
+    if 'anyOf' in value:
         if 'type' in value:
             loader.errors.append(
-                '{}, {}, {}{}: Values must contain either a `type` or `oneOf` attribute, not both'.format(
+                '{}, {}, {}{}: Values must contain either a `type` or `anyOf` attribute, not both'.format(
                     loader.source, file_name, sections_display, option_name
                 )
             )
             return
 
-        one_of = value['oneOf']
+        one_of = value['anyOf']
         if not isinstance(one_of, list):
             loader.errors.append(
-                '{}, {}, {}{}: Attribute `oneOf` must be an array'.format(
+                '{}, {}, {}{}: Attribute `anyOf` must be an array'.format(
                     loader.source, file_name, sections_display, option_name
                 )
             )
             return
         elif len(one_of) == 1:
             loader.errors.append(
-                '{}, {}, {}{}: Attribute `oneOf` contains a single type, use the `type` attribute instead'.format(
+                '{}, {}, {}{}: Attribute `anyOf` contains a single type, use the `type` attribute instead'.format(
                     loader.source, file_name, sections_display, option_name
                 )
             )
@@ -394,7 +394,7 @@ def value_validator(value, loader, file_name, sections_display, option_name, dep
         for i, type_data in enumerate(one_of, 1):
             if not isinstance(type_data, dict):
                 loader.errors.append(
-                    '{}, {}, {}{}: Type #{} of attribute `oneOf` must be a mapping'.format(
+                    '{}, {}, {}{}: Type #{} of attribute `anyOf` must be a mapping'.format(
                         loader.source, file_name, sections_display, option_name, i
                     )
                 )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -62,11 +62,11 @@
   value:
     type: array
     items:
-      oneOf:
+      anyOf:
       - type: string
       - type: object
         additionalProperties:
-          oneOf:
+          anyOf:
           - type: string
           - type: object
             properties:
@@ -118,11 +118,11 @@
   value:
     type: array
     items:
-      oneOf:
+      anyOf:
       - type: string
       - type: object
         additionalProperties:
-          oneOf:
+          anyOf:
           - type: string
           - type: object
             properties:
@@ -155,7 +155,7 @@
   value:
     type: object
     additionalProperties:
-      oneOf:
+      anyOf:
       - type: boolean
       - type: array
         items:
@@ -247,7 +247,7 @@
   value:
     type: object
     additionalProperties:
-      oneOf:
+      anyOf:
       - type: boolean
       - type: object
         properties:

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -1443,7 +1443,7 @@ def test_option_multiple_types():
             - name: foo
               description: words
               value:
-                oneOf:
+                anyOf:
                 - type: string
                 - type: array
                   items:
@@ -1483,11 +1483,11 @@ def test_option_multiple_types_nested():
             - name: foo
               description: words
               value:
-                oneOf:
+                anyOf:
                 - type: string
                 - type: array
                   items:
-                    oneOf:
+                    anyOf:
                     - type: string
                     - type: object
                       required:

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -3000,13 +3000,13 @@ def test_value_one_of_with_type():
               description: words
               value:
                 type: number
-                oneOf: []
+                anyOf: []
         """
     )
     spec.load()
 
     assert (
-        'test, test.yaml, instances, foo: Values must contain either a `type` or `oneOf` attribute, not both'
+        'test, test.yaml, instances, foo: Values must contain either a `type` or `anyOf` attribute, not both'
         in spec.errors
     )
 
@@ -3026,12 +3026,12 @@ def test_value_one_of_not_array():
             - name: foo
               description: words
               value:
-                oneOf: bar
+                anyOf: bar
         """
     )
     spec.load()
 
-    assert 'test, test.yaml, instances, foo: Attribute `oneOf` must be an array' in spec.errors
+    assert 'test, test.yaml, instances, foo: Attribute `anyOf` must be an array' in spec.errors
 
 
 def test_value_one_of_single_type():
@@ -3049,14 +3049,14 @@ def test_value_one_of_single_type():
             - name: foo
               description: words
               value:
-                oneOf:
+                anyOf:
                 - type: string
         """
     )
     spec.load()
 
     assert (
-        'test, test.yaml, instances, foo: Attribute `oneOf` contains a single type, use the `type` attribute instead'
+        'test, test.yaml, instances, foo: Attribute `anyOf` contains a single type, use the `type` attribute instead'
         in spec.errors
     )
 
@@ -3076,14 +3076,14 @@ def test_value_one_of_type_not_mapping():
             - name: foo
               description: words
               value:
-                oneOf:
+                anyOf:
                 - bar
                 - {}
         """
     )
     spec.load()
 
-    assert 'test, test.yaml, instances, foo: Type #1 of attribute `oneOf` must be a mapping' in spec.errors
+    assert 'test, test.yaml, instances, foo: Type #1 of attribute `anyOf` must be a mapping' in spec.errors
 
 
 def test_value_one_of_type_recursive_validation_error():
@@ -3101,7 +3101,7 @@ def test_value_one_of_type_recursive_validation_error():
             - name: foo
               description: words
               value:
-                oneOf:
+                anyOf:
                 - type: string
                 - type: object
                   required:
@@ -3131,11 +3131,11 @@ def test_value_one_of_type_super_recursive_validation_error():
             - name: foo
               description: words
               value:
-                oneOf:
+                anyOf:
                 - type: string
                 - type: array
                   items:
-                    oneOf:
+                    anyOf:
                     - type: string
                     - type: object
                       required:
@@ -3165,7 +3165,7 @@ def test_value_one_of_type_recursive_validation_success():
             - name: foo
               description: words
               value:
-                oneOf:
+                anyOf:
                 - type: string
                 - type: array
                   items:


### PR DESCRIPTION
### Motivation

- Semantically, we already use it as `anyOf`. See: https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/
- Overcome https://github.com/koxudaxi/datamodel-code-generator/issues/333