### PR TITLE
Rename tests

### DIFF
--- a/activemq_xml/tests/test_activemq_xml.py
+++ b/activemq_xml/tests/test_activemq_xml.py
@@ -13,7 +13,7 @@ from .common import CHECK_NAME, CONFIG, GENERAL_METRICS, QUEUE_METRICS, SUBSCRIB
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
-def test_integration(aggregator):
+def test_activemq_integration(aggregator):
     """
     Collect ActiveMQ metrics
     """
@@ -24,7 +24,7 @@ def test_integration(aggregator):
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check):
+def test_activemq_e2e(dd_agent_check):
     aggregator = dd_agent_check(CONFIG)
 
     _test_check(aggregator)

--- a/aerospike/tests/test_aerospike.py
+++ b/aerospike/tests/test_aerospike.py
@@ -24,7 +24,7 @@ def test_aerospike(aggregator, instance):
     _test_check(aggregator)
 
 
-def test_version_metadata(aggregator, instance, datadog_agent):
+def test_aerospike_version_metadata(aggregator, instance, datadog_agent):
 
     check = AerospikeCheck('aerospike', {}, [instance])
     check.check_id = 'test:123'

--- a/aerospike/tests/test_aerospike.py
+++ b/aerospike/tests/test_aerospike.py
@@ -14,7 +14,7 @@ from .common import LATENCIES_METRICS, LAZY_METRICS, NAMESPACE_METRICS, SET_METR
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_check(aggregator, instance):
+def test_aerospike(aggregator, instance):
     check = AerospikeCheck('aerospike', {}, [instance])
     # sleep to make sure client is available
     time.sleep(30)

--- a/ambari/tests/manual_test.py
+++ b/ambari/tests/manual_test.py
@@ -7,7 +7,7 @@ from datadog_checks.ambari import AmbariCheck
 
 
 @pytest.mark.skip(reason="Cannot be automated due to network restrictions")
-def test_check(aggregator):
+def test_ambari(aggregator):
     ambari_ip = "localhost"
     init_config = {"collect_host_metrics": True, "collect_service_metrics": True, "collect_service_status": True}
     instances = [

--- a/apache/tests/test_apache.py
+++ b/apache/tests/test_apache.py
@@ -46,7 +46,7 @@ def test_no_metrics_failure(aggregator, check):
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, check):
+def test_apache(aggregator, check):
     """
     This test will try and fail with `/server-status` url first then fallback on `/server-status??auto`
     """

--- a/azure_iot_edge/tests/test_check.py
+++ b/azure_iot_edge/tests/test_check.py
@@ -56,7 +56,7 @@ def test_azure_iot(aggregator, mock_instance):
 
 
 @pytest.mark.usefixtures("mock_server")
-def test_version_metadata(datadog_agent, mock_instance):
+def test_azure_iot_version_metadata(datadog_agent, mock_instance):
     # type: (DatadogAgentStub, dict) -> None
     check = AzureIoTEdgeCheck('azure_iot_edge', {}, [mock_instance])
     check.check_id = 'test:123'

--- a/azure_iot_edge/tests/test_check.py
+++ b/azure_iot_edge/tests/test_check.py
@@ -15,7 +15,7 @@ from . import common
 
 
 @pytest.mark.usefixtures("mock_server")
-def test_check(aggregator, mock_instance):
+def test_azure_iot(aggregator, mock_instance):
     # type: (AggregatorStub, dict) -> None
     """
     Under normal conditions, metrics and service checks are collected as expected.

--- a/btrfs/tests/test_btrfs.py
+++ b/btrfs/tests/test_btrfs.py
@@ -33,7 +33,7 @@ def get_mock_devices():
 
 @mock.patch('datadog_checks.btrfs.btrfs.psutil.disk_partitions', return_value=get_mock_devices())
 @mock.patch('datadog_checks.btrfs.btrfs.BTRFS.get_usage', return_value=mock_get_usage())
-def test_check(mock_get_usage, mock_device_list, aggregator):
+def test_btrfs(mock_get_usage, mock_device_list, aggregator):
     """
     Testing Btrfs check.
     """

--- a/cacti/tests/test_cacti.py
+++ b/cacti/tests/test_cacti.py
@@ -115,7 +115,7 @@ def check():
 pytestmark = pytest.mark.unit
 
 
-def test_check(aggregator, check):
+def test_cacti(aggregator, check):
     mocks = _setup_mocks()
 
     # Run the check twice to set the timestamps and capture metrics on the second run

--- a/cassandra_nodetool/tests/test_integration.py
+++ b/cassandra_nodetool/tests/test_integration.py
@@ -12,7 +12,7 @@ from . import common
 
 
 @pytest.mark.integration
-def test_integration(aggregator, dd_environment):
+def test_cassandra_nodetool_integration(aggregator, dd_environment):
     """
     Testing Cassandra Nodetool Integration
     """

--- a/cassandra_nodetool/tests/test_unit.py
+++ b/cassandra_nodetool/tests/test_unit.py
@@ -26,7 +26,7 @@ def mock_output_old_format(*args, **kwargs):
 
 
 @patch('datadog_checks.cassandra_nodetool.cassandra_nodetool.get_subprocess_output', side_effect=mock_output)
-def test_check(mock_output, aggregator):
+def test_cassandra_nodetool(mock_output, aggregator):
     _check(mock_output, aggregator)
 
 

--- a/ceph/tests/test_e2e.py
+++ b/ceph/tests/test_e2e.py
@@ -10,7 +10,7 @@ from .common import BASIC_CONFIG, EXPECTED_METRICS, EXPECTED_SERVICE_CHECKS, EXP
 
 
 @pytest.mark.e2e
-def test_check(dd_agent_check):
+def test_ceph_e2e(dd_agent_check):
     aggregator = dd_agent_check(BASIC_CONFIG, rate=True)
 
     for metric in EXPECTED_METRICS:

--- a/ceph/tests/test_integration.py
+++ b/ceph/tests/test_integration.py
@@ -13,7 +13,7 @@ from .common import BASIC_CONFIG, CHECK_NAME, EXPECTED_METRICS, EXPECTED_SERVICE
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator):
+def test_ceph(aggregator):
     ceph_check = Ceph(CHECK_NAME, {}, {})
     ceph_check.check(copy.deepcopy(BASIC_CONFIG))
 

--- a/cilium/tests/test_cilium.py
+++ b/cilium/tests/test_cilium.py
@@ -24,7 +24,7 @@ def test_operator_check(aggregator, operator_instance, mock_operator_data):
     aggregator.assert_all_metrics_covered()
 
 
-def test_version_metadata(datadog_agent, agent_instance, mock_agent_data):
+def test_cilium_version_metadata(datadog_agent, agent_instance, mock_agent_data):
     check = CiliumCheck('cilium', {}, [agent_instance])
     check.check_id = 'test:123'
     check.check(agent_instance)

--- a/clickhouse/tests/test_clickhouse.py
+++ b/clickhouse/tests/test_clickhouse.py
@@ -93,7 +93,7 @@ def test_custom_queries(aggregator, instance):
 
 
 @pytest.mark.skipif(CLICKHOUSE_VERSION == 'latest', reason='Version `latest` is ever-changing, skipping')
-def test_version_metadata(instance, datadog_agent):
+def test_clickhouse_version_metadata(instance, datadog_agent):
     check = ClickhouseCheck('clickhouse', {}, [instance])
     check.check_id = 'test:123'
     check.run()

--- a/clickhouse/tests/test_clickhouse.py
+++ b/clickhouse/tests/test_clickhouse.py
@@ -13,7 +13,7 @@ from .metrics import ALL_METRICS
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
 
 
-def test_check(aggregator, instance):
+def test_clickhouse(aggregator, instance):
     # We do not do aggregator.assert_all_metrics_covered() because depending on timing, some other metrics may appear
     check = ClickhouseCheck('clickhouse', {}, [instance])
     check.run()

--- a/clickhouse/tests/test_e2e.py
+++ b/clickhouse/tests/test_e2e.py
@@ -8,7 +8,7 @@ from .metrics import ALL_METRICS
 pytestmark = pytest.mark.e2e
 
 
-def test_check(dd_agent_check, instance):
+def test_clickhouse_e2e(dd_agent_check, instance):
     # We do not do aggregator.assert_all_metrics_covered() because depending on timing, some other metrics may appear
     aggregator = dd_agent_check(instance, rate=True)
 

--- a/cloud_foundry_api/tests/test_cloud_foundry_api.py
+++ b/cloud_foundry_api/tests/test_cloud_foundry_api.py
@@ -75,7 +75,7 @@ def test_init_bad_instance(_):
 @mock.patch.object(CloudFoundryApiCheck, "discover_api", return_value=("v3", "uaa_url"))
 @mock.patch.object(CloudFoundryApiCheck, "get_orgs", return_value={"org_id": "org_name"})
 @mock.patch.object(CloudFoundryApiCheck, "get_spaces", return_value={"space_id": "space_name"})
-def test_check(_, __, ___, aggregator, instance, dd_events):
+def test_cloudfoundry(_, __, ___, aggregator, instance, dd_events):
     with mock.patch.object(CloudFoundryApiCheck, "get_events", return_value=dd_events):
         check = CloudFoundryApiCheck('cloud_foundry_api', {}, [instance])
         check.check({})

--- a/cockroachdb/tests/test_cockroachdb.py
+++ b/cockroachdb/tests/test_cockroachdb.py
@@ -34,7 +34,7 @@ def _test_check(aggregator):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
-def test_version_metadata(aggregator, instance, datadog_agent):
+def test_cockroach_version_metadata(aggregator, instance, datadog_agent):
 
     check_instance = CockroachdbCheck('cockroachdb', {}, [instance])
     check_instance.check_id = 'test:123'

--- a/cockroachdb/tests/test_cockroachdb.py
+++ b/cockroachdb/tests/test_cockroachdb.py
@@ -12,7 +12,7 @@ from .common import COCKROACHDB_VERSION
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
-def test_integration(aggregator, instance):
+def test_cockroachdb_integration(aggregator, instance):
     check = CockroachdbCheck('cockroachdb', {}, [instance])
     check.check(instance)
 
@@ -20,7 +20,7 @@ def test_integration(aggregator, instance):
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, instance):
+def test_cockroachdb_e2e(dd_agent_check, instance):
     aggregator = dd_agent_check(instance, rate=True)
     _test_check(aggregator)
 

--- a/consul/tests/test_integration.py
+++ b/consul/tests/test_integration.py
@@ -132,7 +132,7 @@ def test_prometheus_endpoint(aggregator, dd_environment, instance_prometheus, ca
 
 
 @pytest.mark.integration
-def test_version_metadata(aggregator, instance, dd_environment, datadog_agent):
+def test_consul_version_metadata(aggregator, instance, dd_environment, datadog_agent):
     consul_check = ConsulCheck(common.CHECK_NAME, {}, [instance])
     consul_check.check_id = 'test:123'
     consul_check.check(instance)

--- a/consul/tests/test_integration.py
+++ b/consul/tests/test_integration.py
@@ -35,7 +35,7 @@ METRICS = [
 
 
 @pytest.mark.integration
-def test_check(aggregator, instance, dd_environment):
+def test_consul(aggregator, instance, dd_environment):
     """
     Testing Consul Integration
     """

--- a/coredns/tests/test_check.py
+++ b/coredns/tests/test_check.py
@@ -12,7 +12,7 @@ from .common import CHECK_NAME, METRICS, NAMESPACE
 class TestCoreDNS:
     """Basic Test for CoreDNS integration."""
 
-    def test_check(self, aggregator, mock_get, instance):
+    def test_coredns(self, aggregator, mock_get, instance):
         """
         Testing CoreDNS check.
         """
@@ -30,7 +30,7 @@ class TestCoreDNS:
         aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 
     @pytest.mark.skipif(ON_WINDOWS, reason='No `dig` utility on Windows')
-    def test_docker(self, aggregator, dd_environment, dockerinstance):
+    def test_coredns_docker(self, aggregator, dd_environment, dockerinstance):
         """
         Testing metrics emitted from docker container.
         """

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -72,7 +72,7 @@ def gauges():
 
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_check(aggregator, gauges):
+def test_couch(aggregator, gauges):
     for config in deepcopy(INSTANCES):
         check = CouchDb(common.CHECK_NAME, {}, [config])
         check.check(config)
@@ -80,7 +80,7 @@ def test_check(aggregator, gauges):
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, gauges):
+def test_couch_e2e(dd_agent_check, gauges):
     aggregator = dd_agent_check({'init_config': {}, 'instances': deepcopy(INSTANCES)})
     _assert_check(aggregator, gauges)
 

--- a/datadog_checks_base/tests/test_prometheus.py
+++ b/datadog_checks_base/tests/test_prometheus.py
@@ -117,7 +117,7 @@ def test_parse_metric_family():
         assert messages[-1].name == 'process_virtual_memory_bytes'
 
 
-def test_check(mocked_prometheus_check):
+def test_prometheus(mocked_prometheus_check):
     """ Should not be implemented as it is the mother class """
     with pytest.raises(NotImplementedError):
         mocked_prometheus_check.check(None)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tests/test_{check_name}.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/tests/test_{check_name}.py
@@ -6,7 +6,7 @@ from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.{check_name} import {check_class}
 
 
-def test_check(aggregator, instance):
+def test_{check_class}(aggregator, instance):
     # type: (AggregatorStub, Dict[str, Any]) -> None
     check = {check_class}('{check_name}', {{}}, [instance])
     check.check(instance)

--- a/directory/tests/test_e2e.py
+++ b/directory/tests/test_e2e.py
@@ -8,7 +8,7 @@ from . import common
 
 
 @pytest.mark.e2e
-def test_check(dd_agent_check):
+def test_directory_e2e(dd_agent_check):
     aggregator = dd_agent_check(common.get_config_stubs(".")[0], rate=True)
     for metric in common.DIR_METRICS:
         aggregator.assert_metric(metric, tags=common.EXPECTED_TAGS)

--- a/directory/tests/test_integration.py
+++ b/directory/tests/test_integration.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator):
+def test_disk(aggregator):
     config = common.get_config_stubs(".")[0]
     check = DirectoryCheck(common.CHECK_NAME, {}, [config])
     check.check(config)

--- a/disk/tests/test_check.py
+++ b/disk/tests/test_check.py
@@ -6,7 +6,7 @@ from itertools import chain
 from datadog_checks.disk import Disk
 
 
-def test_check(aggregator, instance_basic_volume, gauge_metrics, rate_metrics):
+def test_disk(aggregator, instance_basic_volume, gauge_metrics, rate_metrics):
     """
     Basic check to see if all metrics are there
     """

--- a/disk/tests/test_e2e.py
+++ b/disk/tests/test_e2e.py
@@ -10,7 +10,7 @@ from . import common
 
 
 @pytest.mark.e2e
-def test_check(dd_agent_check):
+def test_disk_e2e(dd_agent_check):
     aggregator = dd_agent_check()
     for metric in common.EXPECTED_METRICS:
         for device in common.EXPECTED_DEVICES:

--- a/dns_check/tests/test_dns_check.py
+++ b/dns_check/tests/test_dns_check.py
@@ -15,7 +15,7 @@ RESULTS_TIMEOUT = 10
 
 @mock.patch('datadog_checks.dns_check.dns_check.time_func', side_effect=MockTime.time)
 @mock.patch.object(Resolver, 'query', side_effect=success_query_mock)
-def test_success(mocked_query, mocked_time, aggregator):
+def test_dns_success(mocked_query, mocked_time, aggregator):
     integration = DNSCheck('dns_check', {}, common.CONFIG_SUCCESS['instances'])
 
     integration.check(common.CONFIG_SUCCESS['instances'][0])

--- a/dns_check/tests/test_e2e.py
+++ b/dns_check/tests/test_e2e.py
@@ -9,6 +9,6 @@ from . import common
 
 
 @pytest.mark.e2e
-def test_check(dd_agent_check):
+def test_dns_e2e(dd_agent_check):
     aggregator = dd_agent_check(deepcopy(common.INSTANCE_INTEGRATION))
     common._test_check(aggregator)

--- a/dns_check/tests/test_integration.py
+++ b/dns_check/tests/test_integration.py
@@ -11,6 +11,6 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, check):
+def test_dns(aggregator, check):
     check.check(deepcopy(common.INSTANCE_INTEGRATION))
     common._test_check(aggregator)

--- a/elastic/tests/test_bench.py
+++ b/elastic/tests/test_bench.py
@@ -8,7 +8,7 @@ from datadog_checks.elastic import ESCheck
 from .common import PASSWORD, URL, USER
 
 
-def test_check(benchmark, dd_environment, elastic_check, instance):
+def test_elastic_bench(benchmark, dd_environment, elastic_check, instance):
     for _ in range(3):
         try:
             elastic_check.check(instance)

--- a/elastic/tests/test_elastic.py
+++ b/elastic/tests/test_elastic.py
@@ -83,7 +83,7 @@ def test__get_urls(instance, url_fix):
 
 
 @pytest.mark.integration
-def test_check(dd_environment, elastic_check, instance, aggregator, cluster_tags, node_tags):
+def test_elastic(dd_environment, elastic_check, instance, aggregator, cluster_tags, node_tags):
     elastic_check.check(None)
     _test_check(elastic_check, instance, aggregator, cluster_tags, node_tags)
 

--- a/envoy/tests/test_envoy.py
+++ b/envoy/tests/test_envoy.py
@@ -17,7 +17,7 @@ CHECK_NAME = 'envoy'
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_success(aggregator):
+def test_envoy_success(aggregator):
     instance = INSTANCES['main']
     c = Envoy(CHECK_NAME, {}, [instance])
     c.check(instance)

--- a/etcd/tests/test_integration.py
+++ b/etcd/tests/test_integration.py
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')
 
 
 @preview
-def test_check(aggregator, instance, openmetrics_metrics):
+def test_etcd(aggregator, instance, openmetrics_metrics):
     check = Etcd('etcd', {}, [instance])
     check.check(instance)
 

--- a/etcd/tests/test_integration.py
+++ b/etcd/tests/test_integration.py
@@ -193,7 +193,7 @@ def test_config(instance, test_case, extra_config, expected_http_kwargs):
 
 
 @pytest.mark.integration
-def test_version_metadata(aggregator, instance, dd_environment, datadog_agent):
+def test_etcd_version_metadata(aggregator, instance, dd_environment, datadog_agent):
     check_instance = Etcd(CHECK_NAME, {}, [instance])
     check_instance.check_id = 'test:123'
     check_instance.check(instance)

--- a/gearmand/tests/test_integration.py
+++ b/gearmand/tests/test_integration.py
@@ -21,7 +21,7 @@ def test_service_check_broken(check, aggregator):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
-def test_version_metadata(check, aggregator, datadog_agent):
+def test_gearmand_version_metadata(check, aggregator, datadog_agent):
     check.check_id = 'test:123'
     check.check(common.INSTANCE)
 

--- a/gitlab_runner/tests/test_integration.py
+++ b/gitlab_runner/tests/test_integration.py
@@ -35,7 +35,7 @@ def test_connection_failure(aggregator):
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_version_metadata(aggregator, datadog_agent):
+def test_gitlabl_runner_version_metadata(aggregator, datadog_agent):
     check_instance = GitlabRunnerCheck('gitlab_runner', CONFIG['init_config'], instances=CONFIG['instances'])
     check_instance.check_id = 'test:123'
     check_instance.check(CONFIG['instances'][0])

--- a/gitlab_runner/tests/test_integration_e2e.py
+++ b/gitlab_runner/tests/test_integration_e2e.py
@@ -31,7 +31,7 @@ def assert_check(aggregator):
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator):
+def test_gitlab_runner(aggregator):
     gitlab_runner = GitlabRunnerCheck('gitlab_runner', CONFIG['init_config'], instances=CONFIG['instances'])
 
     gitlab_runner.check(CONFIG['instances'][0])
@@ -41,7 +41,7 @@ def test_check(aggregator):
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check):
+def test_gitlab_runner_e2e(dd_agent_check):
     aggregator = dd_agent_check(CONFIG, rate=True)
 
     assert_check(aggregator)

--- a/glusterfs/tests/test_glusterfs.py
+++ b/glusterfs/tests/test_glusterfs.py
@@ -13,7 +13,7 @@ from .common import CHECK, E2E_INIT_CONFIG, EXPECTED_METRICS, GLUSTER_VERSION
 
 
 @pytest.mark.unit
-def test_check(aggregator, instance, mock_gstatus_data):
+def test_glusterfs(aggregator, instance, mock_gstatus_data):
     # type: (AggregatorStub, Dict[str, Any]) -> None
     check = GlusterfsCheck(CHECK, E2E_INIT_CONFIG, [instance])
     check.check(instance)

--- a/glusterfs/tests/test_glusterfs.py
+++ b/glusterfs/tests/test_glusterfs.py
@@ -26,7 +26,7 @@ def test_glusterfs(aggregator, instance, mock_gstatus_data):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
-def test_version_metadata(aggregator, datadog_agent, instance):
+def test_glusterfs_version_metadata(aggregator, datadog_agent, instance):
     c = GlusterfsCheck(CHECK, E2E_INIT_CONFIG, [instance])
     c.check_id = 'test:123'
     c.check(instance)

--- a/haproxy/tests/legacy/test_haproxy.py
+++ b/haproxy/tests/legacy/test_haproxy.py
@@ -119,7 +119,7 @@ def _test_sticktable_metrics(aggregator, services=None, count=1):
 @requires_socket_support
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_check(aggregator, check, instance):
+def test_haproxy_legacy(aggregator, check, instance):
     check = check(instance)
     check.check(instance)
 

--- a/haproxy/tests/test_check.py
+++ b/haproxy/tests/test_check.py
@@ -8,7 +8,7 @@ from . import common
 pytestmark = [common.requires_new_environment, pytest.mark.usefixtures('dd_environment')]
 
 
-def test_check(aggregator, dd_run_check, check, prometheus_metrics):
+def test_haproxy(aggregator, dd_run_check, check, prometheus_metrics):
     dd_run_check(check(common.INSTANCE))
 
     for metric in prometheus_metrics:

--- a/haproxy/tests/test_e2e.py
+++ b/haproxy/tests/test_e2e.py
@@ -8,7 +8,7 @@ from . import common
 pytestmark = [common.requires_new_environment, pytest.mark.e2e]
 
 
-def test_check(dd_agent_check, prometheus_metrics):
+def test_haproxy_e2e(dd_agent_check, prometheus_metrics):
     aggregator = dd_agent_check(common.INSTANCE, rate=True)
 
     for metric in prometheus_metrics:

--- a/hdfs_datanode/tests/test_hdfs_datanode.py
+++ b/hdfs_datanode/tests/test_hdfs_datanode.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.unit
 CHECK_ID = 'test:123'
 
 
-def test_check(aggregator, mocked_request):
+def test_hdfs_datanode(aggregator, mocked_request):
     """
     Test that we get all the metrics we're supposed to get
     """

--- a/hdfs_datanode/tests/test_integration.py
+++ b/hdfs_datanode/tests/test_integration.py
@@ -12,7 +12,7 @@ CHECK_ID = 'test:123'
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, check, instance):
+def test_hdfs_datanode(aggregator, check, instance):
     check = check(instance)
     check.check(instance)
 

--- a/hdfs_namenode/tests/test_hdfs_namenode.py
+++ b/hdfs_namenode/tests/test_hdfs_namenode.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.unit
 CHECK_ID = 'test:123'
 
 
-def test_check(aggregator, mocked_request):
+def test_hdfs_namenode(aggregator, mocked_request):
     instance = HDFS_NAMENODE_CONFIG['instances'][0]
     hdfs_namenode = HDFSNameNode('hdfs_namenode', {}, [instance])
 

--- a/hdfs_namenode/tests/test_integration.py
+++ b/hdfs_namenode/tests/test_integration.py
@@ -12,7 +12,7 @@ CHECK_ID = 'test:123'
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, check, instance):
+def test_hdfs_namenode(aggregator, check, instance):
     check = check(instance)
     check.check(instance)
 

--- a/hyperv/tests/test_hyperv.py
+++ b/hyperv/tests/test_hyperv.py
@@ -7,7 +7,7 @@ from datadog_checks.hyperv import HypervCheck
 from datadog_checks.hyperv.metrics import DEFAULT_COUNTERS
 
 
-def test_check(aggregator, instance_refresh):
+def test_hyperv(aggregator, instance_refresh):
     check = HypervCheck('hyperv', {}, [instance_refresh])
     check.check(instance_refresh)
 
@@ -16,7 +16,7 @@ def test_check(aggregator, instance_refresh):
 
 
 @pytest.mark.e2e
-def test_check_e2e(dd_agent_check, instance_refresh):
+def test_hyperv_e2e(dd_agent_check, instance_refresh):
     aggregator = dd_agent_check(instance_refresh)
 
     for counter_data in DEFAULT_COUNTERS:

--- a/ibm_was/tests/test_integration.py
+++ b/ibm_was/tests/test_integration.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixtures('dd_environment')
-def test_check(aggregator, instance, check):
+def test_ibm_was(aggregator, instance, check):
     check = check(instance)
     check.check(instance)
 

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -86,7 +86,7 @@ def test_service_check_with_invalid_host(aggregator):
 
 
 @pytest.mark.usefixtures('pdh_mocks_fixture')
-def test_check(aggregator):
+def test_iis(aggregator):
     """
     Returns the right metrics and service checks
     """

--- a/istio/tests/test_istio_1_5.py
+++ b/istio/tests/test_istio_1_5.py
@@ -54,7 +54,7 @@ def test_istio_proxy_mesh_exclude(aggregator, istio_proxy_mesh_fixture):
     aggregator.assert_all_metrics_covered()
 
 
-def test_version_metadata(datadog_agent, istiod_mixture_fixture):
+def test_istio_version_metadata(datadog_agent, istiod_mixture_fixture):
     check = Istio(common.CHECK_NAME, {}, [common.MOCK_ISTIOD_INSTANCE])
     check.check_id = 'test:123'
     check.check(common.MOCK_ISTIOD_INSTANCE)

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -102,7 +102,7 @@ def test_no_partitions(aggregator, kafka_instance):
 @pytest.mark.skipif(os.environ.get('KAFKA_VERSION', '').startswith('0.9'), reason='Old Kafka version')
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_version_metadata(datadog_agent, kafka_instance):
+def test_kafka_consumer_version_metadata(datadog_agent, kafka_instance):
     kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
     kafka_consumer_check.check_id = 'test:123'
 

--- a/kong/tests/test_integration_e2e.py
+++ b/kong/tests/test_integration_e2e.py
@@ -25,7 +25,7 @@ def check():
 
 
 @pytest.mark.usefixtures('dd_environment')
-def test_check(aggregator, check):
+def test_kong(aggregator, check):
     for stub in common.CONFIG_STUBS:
         check.check(stub)
 

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -92,7 +92,7 @@ class TestKubeAPIServerMetrics:
         NAMESPACE + '.authenticated_user_requests.count',
     ]
 
-    def test_check(self, aggregator, mock_get):
+    def test_kube_api_server(self, aggregator, mock_get):
         """
         Testing kube_apiserver_metrics metrics collection.
         """

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_15.py
@@ -74,7 +74,7 @@ class TestKubeAPIServerMetrics:
         NAMESPACE + '.apiserver_request_total.count',
     ]
 
-    def test_check(self, aggregator, mock_get):
+    def test_kube_api_server(self, aggregator, mock_get):
         """
         Testing kube_apiserver_metrics metrics collection.
         """

--- a/kube_dns/tests/test_kube_dns.py
+++ b/kube_dns/tests/test_kube_dns.py
@@ -58,7 +58,7 @@ class TestKubeDNS:
         NAMESPACE + '.cachemiss_count.count',
     ]
 
-    def test_check(self, aggregator, mock_get):
+    def test_kube_dns(self, aggregator, mock_get):
         """
         Testing kube_dns check.
         """

--- a/kyototycoon/tests/test_kyototycoon.py
+++ b/kyototycoon/tests/test_kyototycoon.py
@@ -18,7 +18,7 @@ RATES = list(KyotoTycoonCheck.RATES.values())
 ALL_RATES = TOTALS + RATES
 
 
-def test_check(aggregator, dd_environment):
+def test_kyototycoon(aggregator, dd_environment):
     kt = KyotoTycoonCheck('kyototycoon', {}, {})
     kt.check(deepcopy(DEFAULT_INSTANCE))
     kt.check(deepcopy(DEFAULT_INSTANCE))
@@ -27,7 +27,7 @@ def test_check(aggregator, dd_environment):
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check):
+def test_kyototycoon_e2e(dd_agent_check):
     aggregator = dd_agent_check(DEFAULT_INSTANCE, rate=True)
 
     _assert_check(aggregator, rate_metric_count=1)

--- a/lighttpd/tests/test_check.py
+++ b/lighttpd/tests/test_check.py
@@ -34,7 +34,7 @@ def test_lighttpd(aggregator, check, instance):
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_version_metadata(check, instance, datadog_agent):
+def test_lighthttpd_version_metadata(check, instance, datadog_agent):
     check.check_id = 'test:123'
 
     check.check(instance)

--- a/linux_proc_extras/tests/test_integration.py
+++ b/linux_proc_extras/tests/test_integration.py
@@ -10,7 +10,7 @@ from . import common
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, check):
+def test_linux_proc_extras(aggregator, check):
     check.check(deepcopy(common.INSTANCE))
 
     for metric in common.EXPECTED_METRICS:
@@ -27,7 +27,7 @@ def test_check_no_irq(aggregator, check):
 
 
 @pytest.mark.e2e
-def test_check_e2e(dd_agent_check):
+def test_linux_proc_extras_e2e(dd_agent_check):
     aggregator = dd_agent_check(deepcopy(common.INSTANCE), rate=True)
     expected_metrics = deepcopy(common.EXPECTED_METRICS)
     # metric removed from list because env does not emit

--- a/linux_proc_extras/tests/test_linux_proc_extras.py
+++ b/linux_proc_extras/tests/test_linux_proc_extras.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.unit
 
 
 # Really a basic check to see if all metrics are there
-def test_check(aggregator, check):
+def test_linux_proc_extras(aggregator, check):
 
     check.tags = []
     check.set_paths()

--- a/mapr/tests/test_unit.py
+++ b/mapr/tests/test_unit.py
@@ -104,7 +104,7 @@ def test_submit_bucket(instance, aggregator):
 
 @pytest.mark.usefixtures("mock_getconnection")
 @pytest.mark.usefixtures("mock_fqdn", "mock_ticket_file_readable")
-def test_check(aggregator, instance):
+def test_mapr(aggregator, instance):
     check = MaprCheck('mapr', {}, [instance])
     check.check(instance)
 

--- a/mapreduce/tests/test_mapreduce.py
+++ b/mapreduce/tests/test_mapreduce.py
@@ -27,7 +27,7 @@ from .common import (
 pytestmark = pytest.mark.unit
 
 
-def test_check(aggregator, mocked_request):
+def test_mapreduce(aggregator, mocked_request):
     """
     Test that we get all the metrics we're supposed to get
     """

--- a/marathon/tests/test_e2e.py
+++ b/marathon/tests/test_e2e.py
@@ -8,7 +8,7 @@ from . import common
 
 
 @pytest.mark.e2e
-def test_check(dd_agent_check, instance):
+def test_marathon_e2e(dd_agent_check, instance):
     aggregator = dd_agent_check(instance)
 
     for metric in common.EXPECTED_METRICS:

--- a/marathon/tests/test_integration.py
+++ b/marathon/tests/test_integration.py
@@ -8,7 +8,7 @@ from . import common
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, check, instance):
+def test_marathon(aggregator, check, instance):
     check.check(instance)
 
     for metric in common.EXPECTED_METRICS:

--- a/marklogic/tests/test_marklogic.py
+++ b/marklogic/tests/test_marklogic.py
@@ -69,7 +69,7 @@ def _assert_service_checks(aggregator, tags, count=1, include_health_checks=True
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator):
+def test_marklogic(aggregator):
     # type: (AggregatorStub) -> None
     check = MarklogicCheck('marklogic', {}, [INSTANCE])
 

--- a/mesos_master/tests/test_check.py
+++ b/mesos_master/tests/test_check.py
@@ -11,7 +11,7 @@ from datadog_checks.base.errors import CheckException
 from datadog_checks.mesos_master import MesosMaster
 
 
-def test_check(check, instance, aggregator):
+def test_mesos_master(check, instance, aggregator):
     check = check({}, instance)
     check.check(instance)
     metrics = {}

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -363,7 +363,7 @@ def test_replication_check_status(replica_io_running, replica_sql_running, check
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_version_metadata(instance_basic, datadog_agent, version_metadata):
+def test_mysql_version_metadata(instance_basic, datadog_agent, version_metadata):
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[instance_basic])
     mysql_check.check_id = 'test:123'
 

--- a/network/tests/test_integration.py
+++ b/network/tests/test_integration.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, check, instance):
+def test_network(aggregator, check, instance):
     check.check(instance)
 
     for metric in common.EXPECTED_METRICS:
@@ -20,7 +20,7 @@ def test_check(aggregator, check, instance):
 
 @pytest.mark.skipif(platform.system() != 'Linux', reason="Only runs on Unix systems")
 @pytest.mark.usefixtures("dd_environment")
-def test_check_linux(aggregator, check, instance_blacklist):
+def test_network_linux(aggregator, check, instance_blacklist):
     check.check(instance_blacklist)
 
     for metric in common.CONNTRACK_METRICS:

--- a/nfsstat/tests/test_nfsstat.py
+++ b/nfsstat/tests/test_nfsstat.py
@@ -49,7 +49,7 @@ class TestNfsstat:
             c.check(instance)
         c.log.debug.assert_called_once_with("AutoFS enabled: no mount points currently.")
 
-    def test_check(self, aggregator):
+    def test_nfsstat(self, aggregator):
         instance = self.INSTANCES['main']
         c = NfsStatCheck(self.CHECK_NAME, self.INIT_CONFIG, [instance])
 

--- a/openldap/tests/test_check.py
+++ b/openldap/tests/test_check.py
@@ -14,14 +14,14 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixtures('dd_environment')
-def test_check(aggregator, check, instance):
+def test_openldap(aggregator, check, instance):
     tags = ["url:{}".format(instance["url"]), "test:integration"]
     check.check(instance)
     _check(aggregator, check, tags)
 
 
 @pytest.mark.usefixtures('dd_environment')
-def test_check_ssl(aggregator, check, instance_ssl):
+def test_openldsp_ssl(aggregator, check, instance_ssl):
     tags = ["url:{}".format(instance_ssl["url"]), "test:integration"]
     # Should fail certificate verification
     with pytest.raises(ldap3.core.exceptions.LDAPExceptionError):
@@ -34,7 +34,7 @@ def test_check_ssl(aggregator, check, instance_ssl):
 
 
 @pytest.mark.usefixtures('dd_environment')
-def test_check_connection_failure(aggregator, check, instance):
+def test_openldap_connection_failure(aggregator, check, instance):
     instance["url"] = "bad_url"
     tags = ["url:{}".format(instance["url"]), "test:integration"]
     # Should fail certificate verification
@@ -45,7 +45,7 @@ def test_check_connection_failure(aggregator, check, instance):
 
 @pytest.mark.skipif(not Platform.is_linux(), reason='Windows sockets are not file handles')
 @pytest.mark.usefixtures('dd_environment')
-def test_check_socket(aggregator, check, instance):
+def test_openldap_socket(aggregator, check, instance):
     host_socket_path = os.path.join(os.environ['HOST_SOCKET_DIR'], 'ldapi')
     instance["url"] = "ldapi://{}".format(host_socket_path)
     tags = ["url:{}".format(instance["url"]), "test:integration"]

--- a/openldap/tests/test_e2e.py
+++ b/openldap/tests/test_e2e.py
@@ -8,7 +8,7 @@ from .common import _check
 
 
 @pytest.mark.e2e
-def test_check(dd_agent_check, check, instance):
+def test_openldap_e2e(dd_agent_check, check, instance):
     tags = ["url:{}".format(instance["url"]), "test:integration"]
     aggregator = dd_agent_check(instance, rate=True)
     _check(aggregator, check, tags)

--- a/openldap/tests/test_unit.py
+++ b/openldap/tests/test_unit.py
@@ -12,7 +12,7 @@ from datadog_checks.base.errors import CheckException
 from .common import HERE
 
 
-def test_check(check, aggregator, mocker):
+def test_openldap(check, aggregator, mocker):
     server_mock = ldap3.Server("fake_server")
     conn_mock = ldap3.Connection(server_mock, client_strategy=ldap3.MOCK_SYNC, collect_usage=True)
     # usage.last_received_time is not populated when using mock connection, let's set a value

--- a/openmetrics/tests/test_integration.py
+++ b/openmetrics/tests/test_integration.py
@@ -6,7 +6,7 @@ from .common import CHECK_NAME, INSTANCE
 
 
 @pytest.mark.integration
-def test_integration(aggregator, dd_environment):
+def test_openmetrics_integration(aggregator, dd_environment):
     c = OpenMetricsCheck('openmetrics', {}, [dd_environment])
     c.check(dd_environment)
     aggregator.assert_metric(CHECK_NAME + '.go_memstats_mallocs_total', metric_type=aggregator.MONOTONIC_COUNT)
@@ -14,7 +14,7 @@ def test_integration(aggregator, dd_environment):
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check):
+def test_openmetrics_e2e(dd_agent_check):
     aggregator = dd_agent_check(INSTANCE, rate=True)
     aggregator.assert_metric(CHECK_NAME + '.go_memstats_mallocs_total', metric_type=aggregator.COUNT)
     assert_metrics_covered(aggregator)

--- a/openstack_controller/tests/test_e2e.py
+++ b/openstack_controller/tests/test_e2e.py
@@ -8,7 +8,7 @@ from . import common
 
 
 @pytest.mark.e2e
-def test_check(dd_agent_check):
+def test_openstack_controller_e2e(dd_agent_check):
     aggregator = dd_agent_check()
     for metric in common.DEFAULT_METRICS:
         aggregator.assert_metric(metric)

--- a/openstack_controller/tests/test_openstack.py
+++ b/openstack_controller/tests/test_openstack.py
@@ -86,7 +86,7 @@ def test_populate_servers_cache_with_project_name_none(servers_detail, aggregato
 
 
 @mock.patch('datadog_checks.openstack_controller.api.ApiFactory.create', return_value=mock.MagicMock(AbstractApi))
-def test_check(mock_api, aggregator):
+def test_openstack(mock_api, aggregator):
     check = OpenStackControllerCheck("test", {'ssl_verify': False}, [common.KEYSTONE_INSTANCE])
 
     check.check(common.KEYSTONE_INSTANCE)

--- a/oracle/tests/test_e2e.py
+++ b/oracle/tests/test_e2e.py
@@ -44,7 +44,7 @@ METRICS = [
 
 
 @pytest.mark.e2e
-def test_check(dd_agent_check):
+def test_oracle_e2e(dd_agent_check):
     aggregator = dd_agent_check()
     for metric in METRICS:
         aggregator.assert_metric(metric)

--- a/pgbouncer/tests/test_pgbouncer_integration_e2e.py
+++ b/pgbouncer/tests/test_pgbouncer_integration_e2e.py
@@ -13,7 +13,7 @@ from . import common
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
-def test_check(instance, aggregator, datadog_agent):
+def test_pgbouncer(instance, aggregator, datadog_agent):
     # add some stats
     connection = psycopg2.connect(
         host=common.HOST,

--- a/postfix/tests/test_integration.py
+++ b/postfix/tests/test_integration.py
@@ -10,7 +10,7 @@ from .common import get_instance, get_queue_counts
 
 
 @pytest.mark.usefixtures('dd_environment')
-def test_check(aggregator):
+def test_postfix(aggregator):
     instance = get_instance()
     check = PostfixCheck('postfix', {}, [instance])
     check.check(instance)

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -176,7 +176,7 @@ def test_wrong_version(aggregator, integration_check, pg_instance):
     assert_state_set(check)
 
 
-def test_version_metadata(integration_check, pg_instance, datadog_agent):
+def test_pg_version_metadata(integration_check, pg_instance, datadog_agent):
     check = integration_check(pg_instance)
     check.check_id = 'test:123'
     # Enforce to cache wrong version

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -203,7 +203,7 @@ def test_malformed_get_custom_queries(check):
         ),
     ],
 )
-def test_version_metadata(check, test_case, params):
+def test_pg_version_metadata(check, test_case, params):
     check.check_id = 'test:123'
     with mock.patch('datadog_checks.base.stubs.datadog_agent.set_check_metadata') as m:
         check.set_metadata('version', test_case)

--- a/powerdns_recursor/tests/test_e2e.py
+++ b/powerdns_recursor/tests/test_e2e.py
@@ -11,7 +11,7 @@ from . import common, metrics
 pytestmark = [pytest.mark.e2e]
 
 
-def test_check(dd_agent_check):
+def test_powerdns_e2e(dd_agent_check):
     # get version and test v3 first.
     version = common._get_pdns_version()
     if version == 3:

--- a/powerdns_recursor/tests/test_powerdns.py
+++ b/powerdns_recursor/tests/test_powerdns.py
@@ -11,7 +11,7 @@ from . import common, metrics
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("dd_environment")]
 
 
-def test_check(aggregator):
+def test_powerdns(aggregator):
     # get version and test v3 first.
     version = common._get_pdns_version()
     if version == 3:

--- a/process/tests/test_integration.py
+++ b/process/tests/test_integration.py
@@ -12,14 +12,14 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, check):
+def test_process(aggregator, check):
     check.check(deepcopy(common.INSTANCE))
     for metric in common.EXPECTED_METRICS:
         aggregator.assert_metric(metric, tags=common.EXPECTED_TAGS)
 
 
 @pytest.mark.e2e
-def test_check_e2e(dd_agent_check):
+def test_process_e2e(dd_agent_check):
     aggregator = dd_agent_check(deepcopy(common.INSTANCE))
     for metric in common.EXPECTED_METRICS:
         aggregator.assert_metric(metric, tags=common.EXPECTED_TAGS)

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -168,7 +168,7 @@ def generate_expected_tags(instance):
 
 
 @patch('psutil.Process', return_value=MockProcess())
-def test_check(mock_process, reset_process_list_cache, aggregator):
+def test_process(mock_process, reset_process_list_cache, aggregator):
     (minflt, cminflt, majflt, cmajflt) = [1, 2, 3, 4]
 
     def mock_get_pagefault_stats(pid):

--- a/prometheus/tests/test_prometheus.py
+++ b/prometheus/tests/test_prometheus.py
@@ -179,7 +179,7 @@ def test_prometheus_mixed_instance(aggregator, poll_mock):
     assert aggregator.metrics_asserted_pct == 100.0
 
 
-def test_integration(aggregator, dd_environment):
+def test_prometheus_integration(aggregator, dd_environment):
     c = PrometheusCheck('prometheus', None, {}, [dd_environment])
     c.check(dd_environment)
     aggregator.assert_metric(CHECK_NAME + '.target_interval_seconds.sum', metric_type=aggregator.GAUGE)
@@ -191,7 +191,7 @@ def test_integration(aggregator, dd_environment):
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, e2e_instance):
+def test_prometheus_e2e(dd_agent_check, e2e_instance):
     aggregator = dd_agent_check(e2e_instance, rate=True)
     aggregator.assert_metric(CHECK_NAME + '.target_interval_seconds.sum', metric_type=aggregator.GAUGE)
     aggregator.assert_metric(CHECK_NAME + '.target_interval_seconds.count', metric_type=aggregator.GAUGE)

--- a/riak/tests/test_e2e.py
+++ b/riak/tests/test_e2e.py
@@ -10,7 +10,7 @@ from . import common
 
 
 @pytest.mark.e2e
-def test_check(dd_agent_check, instance):
+def test_riak_e2e(dd_agent_check, instance):
     aggregator = dd_agent_check(instance, rate=True)
     tags = ['my_tag']
     sc_tags = tags + ['url:' + instance['url']]

--- a/riak/tests/test_riak.py
+++ b/riak/tests/test_riak.py
@@ -12,7 +12,7 @@ from . import common
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_check(aggregator, check, instance):
+def test_riak(aggregator, check, instance):
     check.check(instance)
     check.check(instance)
     tags = ['my_tag']

--- a/riakcs/tests/test_e2e.py
+++ b/riakcs/tests/test_e2e.py
@@ -8,7 +8,7 @@ from . import common
 
 
 @pytest.mark.e2e
-def test_check(dd_agent_check, check):
+def test_riacks_e2e(dd_agent_check, check):
     aggregator = dd_agent_check(common.generate_config_with_creds(), rate=True)
     aggregator.assert_service_check(common.SERVICE_CHECK_NAME, check.OK, tags=common.EXPECTED_TAGS)
     for metric in common.EXPECTED_METRICS_21:

--- a/riakcs/tests/test_integration.py
+++ b/riakcs/tests/test_integration.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, check):
+def test_riacks(aggregator, check):
     check.check(common.generate_config_with_creds())
     aggregator.assert_service_check(common.SERVICE_CHECK_NAME, check.OK, tags=common.EXPECTED_TAGS)
     for metric in common.EXPECTED_METRICS_21:

--- a/sap_hana/tests/test_e2e.py
+++ b/sap_hana/tests/test_e2e.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.e2e
 
 
 @pytest.mark.e2e
-def test_check(dd_agent_check, instance):
+def test_sap_hana_e2e(dd_agent_check, instance):
     aggregator = dd_agent_check(instance, rate=True)
 
     for metric in metrics.STANDARD:

--- a/sap_hana/tests/test_integration.py
+++ b/sap_hana/tests/test_integration.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixtures('dd_environment')
-def test_check(aggregator, instance):
+def test_sap_hana(aggregator, instance):
     check = SapHanaCheck('sap_hana', {}, [instance])
     check.check(instance)
 

--- a/snowflake/tests/test_snowflake.py
+++ b/snowflake/tests/test_snowflake.py
@@ -178,7 +178,7 @@ def test_query_metrics(dd_run_check, aggregator, instance):
     aggregator.assert_metric('snowflake.query.bytes_spilled.remote', value=0, count=1, tags=expected_tags)
 
 
-def test_version_metadata(dd_run_check, instance, datadog_agent):
+def test_snowflake_version_metadata(dd_run_check, instance, datadog_agent):
     expected_version = [('4.30.2',)]
     version_metadata = {
         'version.major': '4',

--- a/sonarqube/tests/test_check.py
+++ b/sonarqube/tests/test_check.py
@@ -11,7 +11,7 @@ from .metrics import WEB_METRICS
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
 
 
-def test_check(aggregator, dd_run_check, sonarqube_check, web_instance):
+def test_sonarqube(aggregator, dd_run_check, sonarqube_check, web_instance):
     check = sonarqube_check(web_instance)
     dd_run_check(check)
 

--- a/sonarqube/tests/test_check.py
+++ b/sonarqube/tests/test_check.py
@@ -27,7 +27,7 @@ def test_sonarqube(aggregator, dd_run_check, sonarqube_check, web_instance):
     aggregator.assert_service_check('sonarqube.api_access', status=check.OK, tags=global_tags)
 
 
-def test_version_metadata(datadog_agent, dd_run_check, sonarqube_check, web_instance):
+def test_sonarqube_version_metadata(datadog_agent, dd_run_check, sonarqube_check, web_instance):
     check = sonarqube_check(web_instance)
     check.check_id = 'test:123'
 

--- a/squid/tests/test_squid.py
+++ b/squid/tests/test_squid.py
@@ -78,7 +78,7 @@ def test_check_ok(aggregator, check, instance):
     ],
 )
 @pytest.mark.usefixtures("dd_environment")
-def test_version_metadata(check, instance, datadog_agent, raw_version, version_metadata, count):
+def test_squid_version_metadata(check, instance, datadog_agent, raw_version, version_metadata, count):
     with mock.patch('datadog_checks.base.utils.http.requests.get') as g:
         g.return_value.headers = {'Server': raw_version}
 

--- a/ssh_check/tests/test_integration.py
+++ b/ssh_check/tests/test_integration.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, instance):
+def test_ssh(aggregator, instance):
     check = CheckSSH('ssh_check', {}, [instance])
     check.check(instance)
     common._test_check(aggregator, instance)

--- a/supervisord/tests/test_supervisord_integration.py
+++ b/supervisord/tests/test_supervisord_integration.py
@@ -55,7 +55,7 @@ def test_connection_failure(aggregator, check, bad_instance):
         aggregator.assert_service_check("supervisord.can_connect", status=check.CRITICAL, tags=instance_tags, count=1)
 
 
-def test_version_metadata(aggregator, check, instance, datadog_agent):
+def test_supervisord_version_metadata(aggregator, check, instance, datadog_agent):
     check.check_id = 'test:123'
     check.check(instance)
 

--- a/supervisord/tests/test_supervisord_integration.py
+++ b/supervisord/tests/test_supervisord_integration.py
@@ -12,7 +12,7 @@ from .common import PROCESSES, PROCESSES_BY_STATE_BY_ITERATION, STATUSES, SUPERV
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("dd_environment")]
 
 
-def test_check(aggregator, check, instance):
+def test_supervisord(aggregator, check, instance):
     """
     Run Supervisord check and assess coverage
     """

--- a/supervisord/tests/test_supervisord_unit.py
+++ b/supervisord/tests/test_supervisord_unit.py
@@ -21,7 +21,7 @@ def mock_server(url, transport=None):
     return MockXmlRcpServer(url, transport)
 
 
-def test_check(aggregator, check):
+def test_supervisord(aggregator, check):
     """Integration test for supervisord check. Using a mocked supervisord."""
 
     with patch.object(xmlrpclib, 'Server', side_effect=mock_server), patch.object(

--- a/system_core/tests/test_integration.py
+++ b/system_core/tests/test_integration.py
@@ -9,6 +9,6 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, check, instance):
+def test_system_core(aggregator, check, instance):
     check.check(instance)
     common._test_check(aggregator, instance)

--- a/system_swap/tests/test_integration.py
+++ b/system_swap/tests/test_integration.py
@@ -9,6 +9,6 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixture("dd_environment")
-def test_check(aggregator, check, instance):
+def test_system_swap(aggregator, check, instance):
     check.check(instance)
     common._test_check(aggregator, instance)

--- a/tcp_check/tests/test_integration.py
+++ b/tcp_check/tests/test_integration.py
@@ -9,6 +9,6 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, check, instance):
+def test_tcp(aggregator, check, instance):
     check.check(instance)
     common._test_check(aggregator)

--- a/tokumx/tests/test_check.py
+++ b/tokumx/tests/test_check.py
@@ -11,7 +11,7 @@ from . import common, metrics
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
-def test_integration(aggregator, check):
+def test_tokumx_integration(aggregator, check):
     check.check(common.INSTANCE)
 
     server_tag = 'server:{}'.format(common.TOKUMX_SERVER)

--- a/twemproxy/tests/test_twemproxy.py
+++ b/twemproxy/tests/test_twemproxy.py
@@ -13,7 +13,7 @@ SC_TAGS = ['host:{}'.format(common.HOST), 'port:{}'.format(common.PORT), 'option
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_integration(check, dd_environment, setup_request, aggregator):
+def test_twemproxy_integration(check, dd_environment, setup_request, aggregator):
     check.check(common.INSTANCE)
 
     for stat in metrics.POOL_STATS:

--- a/twistlock/tests/test_twistlock.py
+++ b/twistlock/tests/test_twistlock.py
@@ -70,7 +70,7 @@ def mock_get_factory(fixture_group):
 
 
 @pytest.mark.parametrize('fixture_group', ['twistlock', 'prisma_cloud'])
-def test_check(aggregator, fixture_group):
+def test_twistlock(aggregator, fixture_group):
 
     check = TwistlockCheck('twistlock', {}, [instance])
 

--- a/varnish/tests/test_e2e.py
+++ b/varnish/tests/test_e2e.py
@@ -8,7 +8,7 @@ from . import common
 
 
 @pytest.mark.e2e
-def test_check(dd_agent_check, instance):
+def test_varnish_e2e(dd_agent_check, instance):
     aggregator = dd_agent_check(instance, rate=True)
     for mname in common.COMMON_METRICS:
         aggregator.assert_metric(mname, tags=['cluster:webs', 'varnish_name:default'])

--- a/varnish/tests/test_varnish.py
+++ b/varnish/tests/test_varnish.py
@@ -49,7 +49,7 @@ def test_exclusion_filter(aggregator, check, instance):
             aggregator.assert_metric(mname, count=1, tags=['cluster:webs', 'varnish_name:default'])
 
 
-def test_version_metadata(aggregator, check, instance, datadog_agent):
+def test_varnish_version_metadata(aggregator, check, instance, datadog_agent):
     check.check_id = 'test:123'
     check.check(instance)
 

--- a/varnish/tests/test_varnish.py
+++ b/varnish/tests/test_varnish.py
@@ -11,7 +11,7 @@ from . import common
 pytestmark = [pytest.mark.usefixtures('dd_environment'), pytest.mark.integration]
 
 
-def test_check(aggregator, check, instance):
+def test_varnish(aggregator, check, instance):
     check.check(instance)
 
     if common.VARNISH_VERSION.startswith("5"):

--- a/vault/tests/test_integration.py
+++ b/vault/tests/test_integration.py
@@ -16,7 +16,7 @@ from .utils import run_check
 @auth_required
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_integration(aggregator, check, instance, global_tags):
+def test_valut_integration(aggregator, check, instance, global_tags):
     instance = instance()
     check = check(instance)
     run_check(check)

--- a/vertica/tests/test_vertica.py
+++ b/vertica/tests/test_vertica.py
@@ -24,7 +24,7 @@ def test_check_e2e(dd_agent_check, instance):
 
 
 @pytest.mark.usefixtures('dd_environment')
-def test_check(aggregator, datadog_agent, instance, dd_run_check):
+def test_vertica(aggregator, datadog_agent, instance, dd_run_check):
 
     check = VerticaCheck('vertica', {}, [instance])
     check.check_id = 'test:123'

--- a/voltdb/tests/test_integration.py
+++ b/voltdb/tests/test_integration.py
@@ -20,7 +20,7 @@ from . import assertions, common
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 class TestCheck:
-    def test_check(self, aggregator, instance):
+    def test_voltdb(self, aggregator, instance):
         # type: (AggregatorStub, Instance) -> None
         check = VoltDBCheck('voltdb', {}, [instance])
         check.run()

--- a/vsphere/tests/legacy/test_vsphere.py
+++ b/vsphere/tests/legacy/test_vsphere.py
@@ -551,7 +551,7 @@ def test__collect_metrics_async_hostname(vsphere, instance, aggregator):
     aggregator.assert_metric('vsphere.mymetric', value=23.4, hostname="foo")
 
 
-def test_check(vsphere, instance):
+def test_vsphere(vsphere, instance):
     """
     Test the check() method
     """

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -397,7 +397,7 @@ def test_attributes_filters(aggregator, dd_run_check, realtime_instance):
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api', 'mock_rest_api')
-def test_version_metadata(aggregator, dd_run_check, realtime_instance, datadog_agent):
+def test_vsphere_version_metadata(aggregator, dd_run_check, realtime_instance, datadog_agent):
     check = VSphereCheck('vsphere', {}, [realtime_instance])
     check.check_id = 'test:123'
     dd_run_check(check)

--- a/win32_event_log/tests/legacy/test_check.py
+++ b/win32_event_log/tests/legacy/test_check.py
@@ -73,7 +73,7 @@ def check():
     return check
 
 
-def test_check(mock_from_time, mock_to_time, check, mock_get_wmi_sampler, aggregator):
+def test_win32_event_log(mock_from_time, mock_to_time, check, mock_get_wmi_sampler, aggregator):
     check.check(INSTANCE)
     check.check(INSTANCE)
 

--- a/wmi_check/tests/test_wmi_check.py
+++ b/wmi_check/tests/test_wmi_check.py
@@ -58,7 +58,7 @@ def test_invalid_metrics(aggregator, check):
     aggregator.assert_all_metrics_covered()
 
 
-def test_check(mock_disk_sampler, aggregator, check):
+def test_wmi(mock_disk_sampler, aggregator, check):
     c = check(common.WMI_CONFIG)
     c.check(common.WMI_CONFIG)
 

--- a/yarn/tests/test_integration.py
+++ b/yarn/tests/test_integration.py
@@ -11,7 +11,7 @@ from . import common
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, check, instance):
+def test_yarn(aggregator, check, instance):
     check = check(instance)
     check.check(instance)
     assert_check(aggregator)

--- a/yarn/tests/test_yarn.py
+++ b/yarn/tests/test_yarn.py
@@ -43,7 +43,7 @@ from .common import (
 EXPECTED_TAGS = YARN_CLUSTER_METRICS_TAGS + CUSTOM_TAGS
 
 
-def test_check(aggregator, mocked_request):
+def test_yarn(aggregator, mocked_request):
     instance = YARN_CONFIG['instances'][0]
 
     # Instantiate YarnCheck

--- a/zk/tests/test_zk.py
+++ b/zk/tests/test_zk.py
@@ -26,7 +26,7 @@ def extract_nan_metrics(text):
     return metrics
 
 
-def test_check(aggregator, dd_environment, get_test_instance, caplog):
+def test_zk(aggregator, dd_environment, get_test_instance, caplog):
     """
     Collect ZooKeeper metrics.
     """


### PR DESCRIPTION
We have a report to see tests that fail most frequently, however it does not namespace test names and it is not very useful if all tests are named the same

![image](https://user-images.githubusercontent.com/611228/107973942-26c35a80-6fb6-11eb-9a38-968d9e17a440.png)

https://dev.azure.com/datadoghq/integrations-core/_test/analytics?definitionId=29&contextType=build