### PR TITLE
Collect mysql statement samples & execution plans 

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -301,7 +301,7 @@ files:
                   example: 5000
               - name: seen_samples_cache_maxsize
                 description: |
-                  Set the max size of the cache used for the samples_per_hour_per_query rate limit. This should be
+                  Sets the max size of the cache used for the samples_per_hour_per_query rate limit. This should be
                   increased for databases with a very large number of unique normalized execution plans which exceed the
                   cache's limit.
                 value:

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -309,7 +309,7 @@ files:
                   example: 10000
               - name: events_statements_row_limit
                 description: |
-                  The maximum number of rows to read out from a `performance_schema.events_statements_*` table during
+                  Sets the maximum number of rows to read out from a `performance_schema.events_statements_*` table during
                   a single collection.
                 value:
                   type: integer

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -266,7 +266,7 @@ files:
             options:
               - name: enabled
                 description: |
-                  Enable collection of statement samples. Requires `deep_database_monitoring: true`.
+                  Enables collection of statement samples. Requires `deep_database_monitoring: true`.
                 value:
                   type: boolean
                   example: false

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -286,7 +286,7 @@ files:
                   example: 60
               - name: samples_per_hour_per_query
                 description: |
-                  Set the rate limit for how many statement sample events will be ingested per hour per normalized
+                  Sets the rate limit for how many statement sample events will be ingested per hour per normalized
                   execution plan.
                 value:
                   type: integer

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -272,7 +272,7 @@ files:
                   example: false
               - name: collections_per_second
                 description: |
-                  Set the maximum statement sample collection rate. Each collection involves a single query to one
+                  Sets the maximum statement sample collection rate. Each collection involves a single query to one
                   of the `performance_schema.events_statements_*` tables, followed by at most one `EXPLAIN` query per
                   unique statement seen.
                 value:

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -352,7 +352,7 @@ files:
                   example: datadog.temp_events
               - name: collection_strategy_cache_maxsize
                 description: |
-                  Set the max size of the cache used for caching collection strategies. This value should be increased
+                  Sets the max size of the cache used for caching collection strategies. This value should be increased
                   to be at least as much as the number of unique schemas that are being monitored.
                 value:
                   type: integer

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -332,7 +332,7 @@ files:
                   example: explain_statement
               - name: fully_qualified_explain_procedure
                 description: |
-                  Override the default fully qualified explain procedure used for collecting execution plans for
+                  Overrides the default fully qualified explain procedure used for collecting execution plans for
                   statements sent from connections that do not have a default schema configured.
                 value:
                   type: string

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -293,7 +293,7 @@ files:
                   example: 15
               - name: explained_statements_cache_maxsize
                 description: |
-                  Set the max size of the cache used for the explained_statements_per_hour_per_query rate limit. This
+                  Sets the max size of the cache used for the explained_statements_per_hour_per_query rate limit. This
                   should be increased for databases with a very large number of unique normalized queries which exceed the
                   cache's limit.
                 value:

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -345,7 +345,7 @@ files:
                   example: datadog.enable_events_statements_consumers
               - name: events_statements_temp_table_name
                 description: |
-                  Override the default fully qualified name for the temp table the agent creates while collecting
+                  Overrides the default fully qualified name for the temp table the agent creates while collecting
                   samples.
                 value:
                   type: string

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -261,7 +261,110 @@ files:
                 time: [100, 0]
                 <METRIC_COLUMN>: [<TOP_K_LIMIT>, <BOTTOM_K_LIMIT>]
               display_default: false
-
+          - name: statement_samples
+            description: Configure collection of statement samples
+            options:
+              - name: enabled
+                description: |
+                  Enable collection of statement samples. Requires `deep_database_monitoring: true`.
+                value:
+                  type: boolean
+                  example: false
+              - name: collections_per_second
+                description: |
+                  Set the maximum statement sample collection rate. Each collection involves a single query to one
+                  of the `performance_schema.events_statements_*` tables, followed by at most one `EXPLAIN` query per
+                  unique statement seen.
+                value:
+                  type: number
+                  example: 1
+              - name: explained_statements_per_hour_per_query
+                description: |
+                  Set the rate limit for how many execution plans will be collected per hour per normalized statement.
+                value:
+                  type: integer
+                  example: 60
+              - name: samples_per_hour_per_query
+                description: |
+                  Set the rate limit for how many statement sample events will be ingested per hour per normalized
+                  execution plan.
+                value:
+                  type: integer
+                  example: 15
+              - name: explained_statements_cache_maxsize
+                description: |
+                  Set the max size of the cache used for the explained_statements_per_hour_per_query rate limit. This
+                  should be increased for databases with a very large number unique normalized queries which exceed the
+                  cache's limit.
+                value:
+                  type: integer
+                  example: 5000
+              - name: seen_samples_cache_maxsize
+                description: |
+                  Set the max size of the cache used for the samples_per_hour_per_query rate limit. This should be
+                  increased for databases with a very large number of unique normalized execution plans which exceed the
+                  cache's limit.
+                value:
+                  type: integer
+                  example: 10000
+              - name: events_statements_row_limit
+                description: |
+                  The maximum number of rows to read out from a `performance_schema.events_statements_*` table during
+                  a single collection.
+                value:
+                  type: integer
+                  example: 5000
+              - name: events_statements_table
+                description: |
+                  Force a specific events statements table. Must be one of events_statements_current,
+                  events_statements_history, events_statements_history_long. If not set then the agent will choose
+                  the best available table that is enabled and not empty.
+                value:
+                  type: string
+                  example: events_statements_history_long
+                  display_default: null
+              - name: explain_procedure
+                description: |
+                  Override the default procedure used for collecting execution plans. The agent will use this
+                  procedure in each schema where it exists: `{schema}.explain_statement({statement})`.
+                value:
+                  type: string
+                  example: explain_statement
+              - name: fully_qualified_explain_procedure
+                description: |
+                  Override the default fully qualified explain procedure used for collecting execution plans for
+                  statements sent from connections that do not have a default schema configured.
+                value:
+                  type: string
+                  example: datadog.explain_statement
+              - name: events_statements_enable_procedure
+                description: |
+                  Override the default procedure used for enabling events statements consumers.
+                value:
+                  type: string
+                  example: datadog.enable_events_statements_consumers
+              - name: events_statements_temp_table_name
+                description: |
+                  Override the default fully qualified name for the temp table the agent creates while collecting
+                  samples.
+                value:
+                  type: string
+                  example: datadog.temp_events
+              - name: collection_strategy_cache_maxsize
+                description: |
+                  Set the max size of the cache used for caching collection strategies. This value should be increased
+                  to be at least as much as the number of unique schemas that are being monitored.
+                value:
+                  type: integer
+                  example: 1000
+              - name: collection_strategy_cache_ttl
+                description: |
+                  Set how long we cache collection strategies. This should only be decreased if the set of enabled
+                  `events_statements_*` tables changes frequently enough to cause stale strategies to return empty
+                  results for an extended period of time.
+                value:
+                  type: integer
+                  example: 300
           - template: instances/default
 
       - template: logs

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -339,7 +339,7 @@ files:
                   example: datadog.explain_statement
               - name: events_statements_enable_procedure
                 description: |
-                  Override the default procedure used for enabling events statements consumers.
+                  Overrides the default procedure used for enabling events statements consumers.
                 value:
                   type: string
                   example: datadog.enable_events_statements_consumers

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -280,7 +280,7 @@ files:
                   example: 1
               - name: explained_statements_per_hour_per_query
                 description: |
-                  Set the rate limit for how many execution plans will be collected per hour per normalized statement.
+                  Sets the rate limit for how many execution plans will be collected per hour per normalized statement.
                 value:
                   type: integer
                   example: 60

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -359,7 +359,7 @@ files:
                   example: 1000
               - name: collection_strategy_cache_ttl
                 description: |
-                  Set how long we cache collection strategies. This should only be decreased if the set of enabled
+                  Sets how long to cache collection strategies. This should only be decreased if the set of enabled
                   `events_statements_*` tables changes frequently enough to cause stale strategies to return empty
                   results for an extended period of time.
                 value:

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -353,7 +353,7 @@ files:
               - name: collection_strategy_cache_maxsize
                 description: |
                   Sets the max size of the cache used for caching collection strategies. This value should be increased
-                  to be at least as much as the number of unique schemas that are being monitored.
+                  to be at least as many as the number of unique schemas that are being monitored.
                 value:
                   type: integer
                   example: 1000

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -294,7 +294,7 @@ files:
               - name: explained_statements_cache_maxsize
                 description: |
                   Set the max size of the cache used for the explained_statements_per_hour_per_query rate limit. This
-                  should be increased for databases with a very large number unique normalized queries which exceed the
+                  should be increased for databases with a very large number of unique normalized queries which exceed the
                   cache's limit.
                 value:
                   type: integer

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -325,7 +325,7 @@ files:
                   display_default: null
               - name: explain_procedure
                 description: |
-                  Override the default procedure used for collecting execution plans. The agent will use this
+                  Overrides the default procedure used for collecting execution plans. The agent will use this
                   procedure in each schema where it exists: `{schema}.explain_statement({statement})`.
                 value:
                   type: string

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -316,7 +316,7 @@ files:
                   example: 5000
               - name: events_statements_table
                 description: |
-                  Force a specific events statements table. Must be one of events_statements_current,
+                  Forces a specific events statements table. Must be one of events_statements_current,
                   events_statements_history, events_statements_history_long. If not set then the agent will choose
                   the best available table that is enabled and not empty.
                 value:

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -30,6 +30,8 @@ class MySQLConfig(object):
         self.charset = instance.get('charset')
         self.deep_database_monitoring = is_affirmative(instance.get('deep_database_monitoring', False))
         self.statement_metrics_limits = instance.get('statement_metrics_limits', None)
+        self.statement_samples_config = instance.get('statement_samples', {}) or {}
+        self.min_collection_interval = instance.get('min_collection_interval', 15)
         self.configuration_checks()
 
     def _build_tags(self, custom_tags):

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -251,6 +251,96 @@ instances:
     #   - <TOP_K_LIMIT>
     #   - <BOTTOM_K_LIMIT>
 
+    ## Configure collection of statement samples
+    #
+    statement_samples:
+
+        ## @param enabled - boolean - optional - default: false
+        ## Enable collection of statement samples. Requires `deep_database_monitoring: true`.
+        #
+        # enabled: false
+
+        ## @param collections_per_second - number - optional - default: 1
+        ## Set the maximum statement sample collection rate. Each collection involves a single query to one
+        ## of the `performance_schema.events_statements_*` tables, followed by at most one `EXPLAIN` query per
+        ## unique statement seen.
+        #
+        # collections_per_second: 1
+
+        ## @param explained_statements_per_hour_per_query - integer - optional - default: 60
+        ## Set the rate limit for how many execution plans will be collected per hour per normalized statement.
+        #
+        # explained_statements_per_hour_per_query: 60
+
+        ## @param samples_per_hour_per_query - integer - optional - default: 15
+        ## Set the rate limit for how many statement sample events will be ingested per hour per normalized
+        ## execution plan.
+        #
+        # samples_per_hour_per_query: 15
+
+        ## @param explained_statements_cache_maxsize - integer - optional - default: 5000
+        ## Set the max size of the cache used for the explained_statements_per_hour_per_query rate limit. This
+        ## should be increased for databases with a very large number unique normalized queries which exceed the
+        ## cache's limit.
+        #
+        # explained_statements_cache_maxsize: 5000
+
+        ## @param seen_samples_cache_maxsize - integer - optional - default: 10000
+        ## Set the max size of the cache used for the samples_per_hour_per_query rate limit. This should be
+        ## increased for databases with a very large number of unique normalized execution plans which exceed the
+        ## cache's limit.
+        #
+        # seen_samples_cache_maxsize: 10000
+
+        ## @param events_statements_row_limit - integer - optional - default: 5000
+        ## The maximum number of rows to read out from a `performance_schema.events_statements_*` table during
+        ## a single collection.
+        #
+        # events_statements_row_limit: 5000
+
+        ## @param events_statements_table - string - optional
+        ## Force a specific events statements table. Must be one of events_statements_current,
+        ## events_statements_history, events_statements_history_long. If not set then the agent will choose
+        ## the best available table that is enabled and not empty.
+        #
+        # events_statements_table: events_statements_history_long
+
+        ## @param explain_procedure - string - optional - default: explain_statement
+        ## Override the default procedure used for collecting execution plans. The agent will use this
+        ## procedure in each schema where it exists: `{schema}.explain_statement({statement})`.
+        #
+        # explain_procedure: explain_statement
+
+        ## @param fully_qualified_explain_procedure - string - optional - default: datadog.explain_statement
+        ## Override the default fully qualified explain procedure used for collecting execution plans for
+        ## statements sent from connections that do not have a default schema configured.
+        #
+        # fully_qualified_explain_procedure: datadog.explain_statement
+
+        ## @param events_statements_enable_procedure - string - optional - default: datadog.enable_events_statements_consumers
+        ## Override the default procedure used for enabling events statements consumers.
+        #
+        # events_statements_enable_procedure: datadog.enable_events_statements_consumers
+
+        ## @param events_statements_temp_table_name - string - optional - default: datadog.temp_events
+        ## Override the default fully qualified name for the temp table the agent creates while collecting
+        ## samples.
+        #
+        # events_statements_temp_table_name: datadog.temp_events
+
+        ## @param collection_strategy_cache_maxsize - integer - optional - default: 1000
+        ## Set the max size of the cache used for caching collection strategies. This value should be increased
+        ## to be at least as much as the number of unique schemas that are being monitored.
+        #
+        # collection_strategy_cache_maxsize: 1000
+
+        ## @param collection_strategy_cache_ttl - integer - optional - default: 300
+        ## Set how long we cache collection strategies. This should only be decreased if the set of enabled
+        ## `events_statements_*` tables changes frequently enough to cause stale strategies to return empty
+        ## results for an extended period of time.
+        #
+        # collection_strategy_cache_ttl: 300
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -256,12 +256,12 @@ instances:
     statement_samples:
 
         ## @param enabled - boolean - optional - default: false
-        ## Enable collection of statement samples. Requires `deep_database_monitoring: true`.
+        ## Enables collection of statement samples. Requires `deep_database_monitoring: true`.
         #
         # enabled: false
 
         ## @param collections_per_second - number - optional - default: 1
-        ## Set the maximum statement sample collection rate. Each collection involves a single query to one
+        ## Sets the maximum statement sample collection rate. Each collection involves a single query to one
         ## of the `performance_schema.events_statements_*` tables, followed by at most one `EXPLAIN` query per
         ## unique statement seen.
         #
@@ -330,12 +330,12 @@ instances:
 
         ## @param collection_strategy_cache_maxsize - integer - optional - default: 1000
         ## Sets the max size of the cache used for caching collection strategies. This value should be increased
-        ## to be at least as much as the number of unique schemas that are being monitored.
+        ## to be at least as many as the number of unique schemas that are being monitored.
         #
         # collection_strategy_cache_maxsize: 1000
 
         ## @param collection_strategy_cache_ttl - integer - optional - default: 300
-        ## Set how long we cache collection strategies. This should only be decreased if the set of enabled
+        ## Sets how long to cache collection strategies. This should only be decreased if the set of enabled
         ## `events_statements_*` tables changes frequently enough to cause stale strategies to return empty
         ## results for an extended period of time.
         #

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -268,68 +268,68 @@ instances:
         # collections_per_second: 1
 
         ## @param explained_statements_per_hour_per_query - integer - optional - default: 60
-        ## Set the rate limit for how many execution plans will be collected per hour per normalized statement.
+        ## Sets the rate limit for how many execution plans will be collected per hour per normalized statement.
         #
         # explained_statements_per_hour_per_query: 60
 
         ## @param samples_per_hour_per_query - integer - optional - default: 15
-        ## Set the rate limit for how many statement sample events will be ingested per hour per normalized
+        ## Sets the rate limit for how many statement sample events will be ingested per hour per normalized
         ## execution plan.
         #
         # samples_per_hour_per_query: 15
 
         ## @param explained_statements_cache_maxsize - integer - optional - default: 5000
-        ## Set the max size of the cache used for the explained_statements_per_hour_per_query rate limit. This
-        ## should be increased for databases with a very large number unique normalized queries which exceed the
+        ## Sets the max size of the cache used for the explained_statements_per_hour_per_query rate limit. This
+        ## should be increased for databases with a very large number of unique normalized queries which exceed the
         ## cache's limit.
         #
         # explained_statements_cache_maxsize: 5000
 
         ## @param seen_samples_cache_maxsize - integer - optional - default: 10000
-        ## Set the max size of the cache used for the samples_per_hour_per_query rate limit. This should be
+        ## Sets the max size of the cache used for the samples_per_hour_per_query rate limit. This should be
         ## increased for databases with a very large number of unique normalized execution plans which exceed the
         ## cache's limit.
         #
         # seen_samples_cache_maxsize: 10000
 
         ## @param events_statements_row_limit - integer - optional - default: 5000
-        ## The maximum number of rows to read out from a `performance_schema.events_statements_*` table during
+        ## Sets the maximum number of rows to read out from a `performance_schema.events_statements_*` table during
         ## a single collection.
         #
         # events_statements_row_limit: 5000
 
         ## @param events_statements_table - string - optional
-        ## Force a specific events statements table. Must be one of events_statements_current,
+        ## Forces a specific events statements table. Must be one of events_statements_current,
         ## events_statements_history, events_statements_history_long. If not set then the agent will choose
         ## the best available table that is enabled and not empty.
         #
         # events_statements_table: events_statements_history_long
 
         ## @param explain_procedure - string - optional - default: explain_statement
-        ## Override the default procedure used for collecting execution plans. The agent will use this
+        ## Overrides the default procedure used for collecting execution plans. The agent will use this
         ## procedure in each schema where it exists: `{schema}.explain_statement({statement})`.
         #
         # explain_procedure: explain_statement
 
         ## @param fully_qualified_explain_procedure - string - optional - default: datadog.explain_statement
-        ## Override the default fully qualified explain procedure used for collecting execution plans for
+        ## Overrides the default fully qualified explain procedure used for collecting execution plans for
         ## statements sent from connections that do not have a default schema configured.
         #
         # fully_qualified_explain_procedure: datadog.explain_statement
 
         ## @param events_statements_enable_procedure - string - optional - default: datadog.enable_events_statements_consumers
-        ## Override the default procedure used for enabling events statements consumers.
+        ## Overrides the default procedure used for enabling events statements consumers.
         #
         # events_statements_enable_procedure: datadog.enable_events_statements_consumers
 
         ## @param events_statements_temp_table_name - string - optional - default: datadog.temp_events
-        ## Override the default fully qualified name for the temp table the agent creates while collecting
+        ## Overrides the default fully qualified name for the temp table the agent creates while collecting
         ## samples.
         #
         # events_statements_temp_table_name: datadog.temp_events
 
         ## @param collection_strategy_cache_maxsize - integer - optional - default: 1000
-        ## Set the max size of the cache used for caching collection strategies. This value should be increased
+        ## Sets the max size of the cache used for caching collection strategies. This value should be increased
         ## to be at least as much as the number of unique schemas that are being monitored.
         #
         # collection_strategy_cache_maxsize: 1000

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -127,6 +127,9 @@ class MySql(AgentCheck):
             finally:
                 self._conn = None
 
+    def cancel(self):
+        self._statement_samples.cancel()
+
     def _set_qcache_stats(self):
         host_key = self._get_host_key()
         qcache_st = self.qcache_stats.get(host_key, (None, None, None))

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -45,6 +45,7 @@ from .queries import (
     SQL_WORKER_THREADS,
     show_replica_status_query,
 )
+from .statement_samples import MySQLStatementSamples
 from .statements import MySQLStatementMetrics
 from .version_utils import get_version
 
@@ -76,10 +77,11 @@ class MySql(AgentCheck):
         self._conn = None
 
         self._query_manager = QueryManager(self, self.execute_query_raw, queries=[], tags=self._config.tags)
-        self._statement_metrics = MySQLStatementMetrics(self._config)
         self.check_initializations.append(self._query_manager.compile_queries)
         self.innodb_stats = InnoDBMetrics()
         self.check_initializations.append(self._config.configuration_checks)
+        self._statement_metrics = MySQLStatementMetrics(self._config)
+        self._statement_samples = MySQLStatementSamples(self, self._config, self._get_connection_args())
 
     def execute_query_raw(self, query):
         with closing(self._conn.cursor(pymysql.cursors.SSCursor)) as cursor:
@@ -111,6 +113,7 @@ class MySql(AgentCheck):
                 self._collect_system_metrics(self._config.host, db, self._config.tags)
                 if self._config.deep_database_monitoring:
                     self._collect_statement_metrics(db, self._config.tags)
+                    self._statement_samples.run_sampler(self.service_check_tags)
 
                 # keeping track of these:
                 self._put_qcache_stats()

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -17,7 +17,11 @@ except ImportError:
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.log import get_check_logger
 from datadog_checks.base.utils.db.sql import compute_exec_plan_signature, compute_sql_signature
-from datadog_checks.base.utils.db.statement_samples import statement_samples_client
+from datadog_checks.base.utils.db.statement_samples import (
+    StatementSamplesClient,
+    StubStatementSamplesClient,
+    using_stub_datadog_agent,
+)
 from datadog_checks.base.utils.db.utils import ConstantRateLimiter, resolve_db_host
 from datadog_checks.base.utils.serialization import json
 
@@ -199,6 +203,10 @@ PYMYSQL_NON_RETRYABLE_ERRORS = frozenset(
 )
 
 
+def _new_statement_samples_client():
+    return StubStatementSamplesClient() if using_stub_datadog_agent else StatementSamplesClient()
+
+
 class MySQLStatementSamples(object):
     """
     Collects statement samples and execution plans.
@@ -259,6 +267,7 @@ class MySQLStatementSamples(object):
         }
         self._preferred_explain_strategies = ['PROCEDURE', 'FQ_PROCEDURE', 'STATEMENT']
         self._init_caches()
+        self._statement_samples_client = _new_statement_samples_client()
 
     def _init_caches(self):
         self._collection_strategy_cache = TTLCache(
@@ -637,7 +646,7 @@ class MySQLStatementSamples(object):
         rows = self._get_new_events_statements(events_statements_table, self._events_statements_row_limit)
         rows = self._filter_valid_statement_rows(rows)
         events = self._collect_plans_for_statements(rows)
-        submitted_count, failed_count = statement_samples_client.submit_events(events)
+        submitted_count, failed_count = self._statement_samples_client.submit_events(events)
         self._check.count("dd.mysql.statement_samples.error", failed_count, tags=self._tags + ["error:submit-events"])
         self._check.histogram("dd.mysql.collect_statement_samples.time", (time.time() - start_time) * 1000, tags=tags)
         self._check.count("dd.mysql.collect_statement_samples.events_submitted.count", submitted_count, tags=tags)

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -1,0 +1,773 @@
+import json
+import logging
+import os
+import re
+import time
+from concurrent.futures.thread import ThreadPoolExecutor
+from contextlib import closing
+
+import pymysql
+from cachetools import TTLCache
+
+try:
+    import datadog_agent
+except ImportError:
+    from ..stubs import datadog_agent
+
+from datadog_checks.base import is_affirmative
+from datadog_checks.base.log import get_check_logger
+from datadog_checks.base.utils.db.sql import compute_exec_plan_signature, compute_sql_signature
+from datadog_checks.base.utils.db.statement_samples import statement_samples_client
+from datadog_checks.base.utils.db.utils import ConstantRateLimiter, resolve_db_host
+
+VALID_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update'})
+
+# unless a specific table is configured, we try all of the events_statements tables in descending order of
+# preference
+EVENTS_STATEMENTS_PREFERRED_TABLES = [
+    'events_statements_history_long',
+    'events_statements_current',
+    # events_statements_history is the lowest in preference because it keeps the history only as long as the thread
+    # exists, which means if an application uses only short-lived connections that execute a single query then we
+    # won't be able to catch any samples of it. By querying events_statements_current we at least guarantee we'll
+    # be able to catch queries from short-lived connections.
+    'events_statements_history',
+]
+
+# default sampling settings for events_statements_* tables
+# rate limit is in samples/second
+# {table -> rate-limit}
+DEFAULT_EVENTS_STATEMENTS_COLLECTIONS_PER_SECOND = {
+    'events_statements_history_long': 0.1,
+    'events_statements_history': 0.1,
+    'events_statements_current': 1,
+}
+
+# columns from events_statements_summary tables which correspond to attributes common to all databases and are
+# therefore stored under other standard keys
+EVENTS_STATEMENTS_SAMPLE_EXCLUDE_KEYS = {
+    # gets obfuscated
+    'sql_text',
+    # stored as "instance"
+    'current_schema',
+    # used for signature
+    'digest_text',
+    'timer_end_time_s',
+    'max_timer_wait_ns',
+    'timer_start',
+    # included as network.client.ip
+    'processlist_host',
+}
+
+CREATE_TEMP_TABLE = re.sub(
+    r'\s+',
+    ' ',
+    """
+    CREATE TEMPORARY TABLE {temp_table} SELECT
+        current_schema,
+        sql_text,
+        digest,
+        digest_text,
+        timer_start,
+        timer_end,
+        timer_wait,
+        lock_time,
+        rows_affected,
+        rows_sent,
+        rows_examined,
+        select_full_join,
+        select_full_range_join,
+        select_range,
+        select_range_check,
+        select_scan,
+        sort_merge_passes,
+        sort_range,
+        sort_rows,
+        sort_scan,
+        no_index_used,
+        no_good_index_used,
+        event_name,
+        thread_id
+     FROM {statements_table}
+        WHERE sql_text IS NOT NULL
+        AND event_name like 'statement/%%'
+        AND digest_text is NOT NULL
+        AND digest_text NOT LIKE 'EXPLAIN %%'
+        AND timer_start > %s
+    LIMIT %s
+""",
+).strip()
+
+# neither window functions nor this variable-based window function emulation can be used directly on performance_schema
+# tables due to some underlying issue regarding how the performance_schema storage engine works (for some reason
+# many of the rows end up making it past the WHERE clause when they should have been filtered out)
+SUB_SELECT_EVENTS_NUMBERED = re.sub(
+    r'\s+',
+    ' ',
+    """
+    (SELECT
+        *,
+        @row_num := IF(@current_digest = digest, @row_num + 1, 1) AS row_num,
+        @current_digest := digest
+    FROM {statements_table}
+    ORDER BY digest, timer_wait)
+""",
+).strip()
+
+SUB_SELECT_EVENTS_WINDOW = re.sub(
+    r'\s+',
+    ' ',
+    """
+    (SELECT
+        *,
+        row_number() over (partition by digest order by timer_wait desc) as row_num
+    FROM {statements_table})
+""",
+).strip()
+
+STARTUP_TIME_SUBQUERY = re.sub(
+    r'\s+',
+    ' ',
+    """
+    (SELECT UNIX_TIMESTAMP()-VARIABLE_VALUE
+    FROM {global_status_table}
+    WHERE VARIABLE_NAME='UPTIME')
+""",
+).strip()
+
+EVENTS_STATEMENTS_QUERY = re.sub(
+    r'\s+',
+    ' ',
+    """
+    SELECT
+        current_schema,
+        sql_text,
+        digest,
+        digest_text,
+        timer_start,
+        @startup_time_s+timer_end*1e-12 as timer_end_time_s,
+        timer_wait / 1000 AS timer_wait_ns,
+        lock_time / 1000 AS lock_time_ns,
+        rows_affected,
+        rows_sent,
+        rows_examined,
+        select_full_join,
+        select_full_range_join,
+        select_range,
+        select_range_check,
+        select_scan,
+        sort_merge_passes,
+        sort_range,
+        sort_rows,
+        sort_scan,
+        no_index_used,
+        no_good_index_used,
+        processlist_user,
+        processlist_host,
+        processlist_db
+    FROM {statements_numbered} as E
+    LEFT JOIN performance_schema.threads as T
+        ON E.thread_id = T.thread_id
+    WHERE sql_text IS NOT NULL
+        AND timer_start > %s
+        AND row_num = 1
+    ORDER BY timer_wait DESC
+    LIMIT %s
+""",
+).strip()
+
+ENABLED_STATEMENTS_CONSUMERS_QUERY = re.sub(
+    r'\s+',
+    ' ',
+    """
+    SELECT name
+    FROM performance_schema.setup_consumers
+    WHERE enabled = 'YES'
+    AND name LIKE 'events_statements_%'
+""",
+).strip()
+
+PYMYSQL_NON_RETRYABLE_ERRORS = frozenset(
+    {
+        1044,  # access denied on database
+        1046,  # no permission on statement
+        1049,  # unknown database
+        1305,  # procedure does not exist
+        1370,  # no execute on procedure
+    }
+)
+
+
+class MySQLStatementSamples(object):
+    """
+    Collects statement samples and execution plans.
+    """
+
+    executor = ThreadPoolExecutor()
+
+    def __init__(self, check, config, connection_args):
+        self._check = check
+        self._version_processed = False
+        self._connection_args = connection_args
+        # checkpoint at zero so we pull the whole history table on the first run
+        self._checkpoint = 0
+        self._log = get_check_logger()
+        self._last_check_run = 0
+        self._db = None
+        self._tags = None
+        self._tags_str = None
+        self._service = "mysql"
+        self._collection_loop_future = None
+        self._rate_limiter = ConstantRateLimiter(1)
+        self._config = config
+        self._db_hostname = resolve_db_host(self._config.host)
+        self._enabled = is_affirmative(self._config.statement_samples_config.get('enabled', False))
+        self._run_sync = is_affirmative(self._config.statement_samples_config.get('run_sync', False))
+        self._collections_per_second = self._config.statement_samples_config.get('collections_per_second', -1)
+        self._events_statements_row_limit = self._config.statement_samples_config.get(
+            'events_statements_row_limit', 5000
+        )
+        self._explain_procedure = self._config.statement_samples_config.get('explain_procedure', 'explain_statement')
+        self._fully_qualified_explain_procedure = self._config.statement_samples_config.get(
+            'fully_qualified_explain_procedure', 'datadog.explain_statement'
+        )
+        self._events_statements_temp_table = self._config.statement_samples_config.get(
+            'events_statements_temp_table_name', 'datadog.temp_events'
+        )
+        self._events_statements_enable_procedure = self._config.statement_samples_config.get(
+            'events_statements_enable_procedure', 'datadog.enable_events_statements_consumers'
+        )
+        self._preferred_events_statements_tables = EVENTS_STATEMENTS_PREFERRED_TABLES
+        self._has_window_functions = False
+        events_statements_table = self._config.statement_samples_config.get('events_statements_table', None)
+        if events_statements_table:
+            if events_statements_table in DEFAULT_EVENTS_STATEMENTS_COLLECTIONS_PER_SECOND:
+                self._log.debug("Configured preferred events_statements_table: %s", events_statements_table)
+                self._preferred_events_statements_tables = [events_statements_table]
+            else:
+                self._log.warning(
+                    "Invalid events_statements_table: %s. Must be one of %s. Falling back to trying all tables.",
+                    events_statements_table,
+                    ', '.join(DEFAULT_EVENTS_STATEMENTS_COLLECTIONS_PER_SECOND.keys()),
+                )
+        self._explain_strategies = {
+            'PROCEDURE': self._run_explain_procedure,
+            'FQ_PROCEDURE': self._run_fully_qualified_explain_procedure,
+            'STATEMENT': self._run_explain,
+        }
+        self._preferred_explain_strategies = ['PROCEDURE', 'FQ_PROCEDURE', 'STATEMENT']
+        self._init_caches()
+
+    def _init_caches(self):
+        self._collection_strategy_cache = TTLCache(
+            maxsize=self._config.statement_samples_config.get('collection_strategy_cache_maxsize', 1000),
+            ttl=self._config.statement_samples_config.get('collection_strategy_cache_ttl', 300),
+        )
+
+        # explained_statements_cache: limit how often we try to re-explain the same query
+        self._explained_statements_cache = TTLCache(
+            maxsize=self._config.statement_samples_config.get('explained_statements_cache_maxsize', 5000),
+            ttl=60 * 60 / self._config.statement_samples_config.get('explained_statements_per_hour_per_query', 60),
+        )
+
+        # seen_samples_cache: limit the ingestion rate per (query_signature, plan_signature)
+        self._seen_samples_cache = TTLCache(
+            # assuming ~100 bytes per entry (query & plan signature, key hash, 4 pointers (ordered dict), expiry time)
+            # total size: 10k * 100 = 1 Mb
+            maxsize=self._config.statement_samples_config.get('seen_samples_cache_maxsize', 10000),
+            ttl=60 * 60 / self._config.statement_samples_config.get('samples_per_hour_per_query', 15),
+        )
+
+    def run_sampler(self, tags):
+        """
+        start the sampler thread if not already running & update tag metadata
+        :param tags:
+        :return:
+        """
+        if not self._enabled:
+            self._log.debug("Statement sampler not enabled")
+            return
+        self._tags = tags
+        self._tags_str = ','.join(tags)
+        for t in self._tags:
+            if t.startswith('service:'):
+                self._service = t[len('service:'):]
+        if not self._version_processed and self._check.version:
+            self._has_window_functions = self._check.version.version_compatible((8, 0, 0))
+            if self._check.version.flavor == "MariaDB" or not self._check.version.version_compatible((5, 7, 0)):
+                self._global_status_table = "information_schema.global_status"
+            else:
+                self._global_status_table = "performance_schema.global_status"
+            self._version_processed = True
+        self._last_check_run = time.time()
+        if self._run_sync or is_affirmative(os.environ.get('DBM_STATEMENT_SAMPLER_RUN_SYNC', "false")):
+            self._log.debug("Running statement sampler synchronously")
+            self._collect_statement_samples()
+        elif self._collection_loop_future is None or not self._collection_loop_future.running():
+            self._collection_loop_future = MySQLStatementSamples.executor.submit(self.collection_loop)
+        else:
+            self._log.debug("Statement sampler collection loop already running")
+
+    def _get_db_connection(self):
+        """
+        lazy reconnect db
+        pymysql connections are not thread safe so we can't reuse the same connection from the main check
+        :return:
+        """
+        if not self._db:
+            self._db = pymysql.connect(**self._connection_args)
+        return self._db
+
+    def close(self):
+        if self._db:
+            try:
+                self._db.close()
+            except Exception:
+                self._log.debug("Failed to close db connection", exc_info=1)
+            finally:
+                self._db = None
+
+    def collection_loop(self):
+        try:
+            self._log.info("Starting statement sampler collection loop")
+            while True:
+                if time.time() - self._last_check_run > self._config.min_collection_interval * 2:
+                    self._log.info("Stopping statement sampler collection loop due to check inactivity")
+                    self._check.count("dd.mysql.statement_samples.collection_loop_inactive_stop", 1, tags=self._tags)
+                    break
+                self._collect_statement_samples()
+        except pymysql.err.DatabaseError as e:
+            self._log.warning(
+                "Statement sampler database error: %s", e, exc_info=self._log.getEffectiveLevel() == logging.DEBUG
+            )
+            self._check.count(
+                "dd.mysql.statement_samples.error",
+                1,
+                tags=self._tags + ["error:collection-loop-database-error-{}".format(type(e))],
+            )
+        except Exception as e:
+            self._log.exception("Statement sampler collection loop crash")
+            self._check.count(
+                "dd.mysql.statement_samples.error",
+                1,
+                tags=self._tags + ["error:collection-loop-crash-{}".format(type(e))],
+            )
+        finally:
+            self._log.info("Shutting down statement sampler collection loop")
+            self.close()
+
+    def _cursor_run(self, cursor, query, params=None, obfuscated_params=None):
+        """
+        Run and log the query. If provided, obfuscated params are logged in place of the regular params.
+        """
+        self._log.debug("Running query [%s] %s", query, obfuscated_params if obfuscated_params else params)
+        cursor.execute(query, params)
+
+    def _get_new_events_statements(self, events_statements_table, row_limit):
+        # Select the most recent events with a bias towards events which have higher wait times
+        start = time.time()
+        drop_temp_table_query = "DROP TEMPORARY TABLE IF EXISTS {}".format(self._events_statements_temp_table)
+        params = (self._checkpoint, row_limit)
+        with closing(self._get_db_connection().cursor(pymysql.cursors.DictCursor)) as cursor:
+            # silence expected warnings to avoid spam
+            cursor.execute('SET @@SESSION.sql_notes = 0')
+            try:
+                self._cursor_run(cursor, drop_temp_table_query)
+                self._cursor_run(
+                    cursor,
+                    CREATE_TEMP_TABLE.format(
+                        temp_table=self._events_statements_temp_table,
+                        statements_table="performance_schema." + events_statements_table,
+                    ),
+                    params,
+                )
+            except pymysql.err.DatabaseError as e:
+                self._check.count(
+                    "dd.mysql.statement_samples.error",
+                    1,
+                    tags=self._tags + ["error:create-temp-table-{}".format(type(e))],
+                )
+                raise
+            if self._has_window_functions:
+                sub_select = SUB_SELECT_EVENTS_WINDOW
+            else:
+                self._cursor_run(cursor, "set @row_num = 0")
+                self._cursor_run(cursor, "set @current_digest = ''")
+                sub_select = SUB_SELECT_EVENTS_NUMBERED
+            self._cursor_run(
+                cursor,
+                "set @startup_time_s = {}".format(
+                    STARTUP_TIME_SUBQUERY.format(global_status_table=self._global_status_table)
+                ),
+            )
+            self._cursor_run(
+                cursor,
+                EVENTS_STATEMENTS_QUERY.format(
+                    statements_numbered=sub_select.format(statements_table=self._events_statements_temp_table)
+                ),
+                params,
+            )
+            rows = cursor.fetchall()
+            self._cursor_run(cursor, drop_temp_table_query)
+            tags = self._tags + ["events_statements_table:{}".format(events_statements_table)]
+            self._check.histogram("dd.mysql.get_new_events_statements.time", (time.time() - start) * 1000, tags=tags)
+            self._check.histogram("dd.mysql.get_new_events_statements.rows", len(rows), tags=tags)
+            self._log.debug("Read %s rows from %s", len(rows), events_statements_table)
+            return rows
+
+    def _filter_valid_statement_rows(self, rows):
+        num_sent = 0
+        num_truncated = 0
+
+        for row in rows:
+            if not row or not all(row):
+                self._log.debug('Row was unexpectedly truncated or the events_statements table is not enabled')
+                continue
+            sql_text = row['sql_text']
+            if not sql_text:
+                continue
+            # The SQL_TEXT column will store 1024 chars by default. Plans cannot be captured on truncated
+            # queries, so the `performance_schema_max_sql_text_length` variable must be raised.
+            if sql_text[-3:] == '...':
+                num_truncated += 1
+                continue
+            yield row
+            # only save the checkpoint for rows that we have successfully processed
+            # else rows that we ignore can push the checkpoint forward causing us to miss some on the next run
+            if row['timer_start'] > self._checkpoint:
+                self._checkpoint = row['timer_start']
+            num_sent += 1
+
+        if num_truncated > 0:
+            self._log.warning(
+                'Unable to collect %d/%d statement samples due to truncated SQL text. Consider raising '
+                '`performance_schema_max_sql_text_length` to capture these queries.',
+                num_truncated,
+                num_truncated + num_sent,
+            )
+            self._check.count("dd.mysql.statement_samples.error", 1, tags=self._tags + ["error:truncated-sql-text"])
+
+    def _collect_plan_for_statement(self, row):
+        # Plans have several important signatures to tag events with:
+        # - `plan_signature` - hash computed from the normalized JSON plan to group identical plan trees
+        # - `resource_hash` - hash computed off the raw sql text to match apm resources
+        # - `query_signature` - hash computed from the digest text to match query metrics
+
+        try:
+            obfuscated_statement = datadog_agent.obfuscate_sql(row['sql_text'])
+            obfuscated_digest_text = datadog_agent.obfuscate_sql(row['digest_text'])
+        except Exception:
+            # do not log the raw sql_text to avoid leaking sensitive data into logs. digest_text is safe as parameters
+            # are obfuscated by the database
+            self._log.debug("Failed to obfuscate statement: %s", row['digest_text'])
+            self._check.count("dd.mysql.statement_samples.error", 1, tags=self._tags + ["error:sql-obfuscate"])
+            return None
+
+        apm_resource_hash = compute_sql_signature(obfuscated_statement)
+        query_signature = compute_sql_signature(obfuscated_digest_text)
+
+        query_cache_key = (row['current_schema'], query_signature)
+        if query_cache_key in self._explained_statements_cache:
+            return None
+        self._explained_statements_cache[query_cache_key] = True
+
+        plan = None
+        with closing(self._get_db_connection().cursor()) as cursor:
+            try:
+                plan = self._explain_statement(cursor, row['sql_text'], row['current_schema'], obfuscated_statement)
+            except Exception as e:
+                self._check.count(
+                    "dd.mysql.statement_samples.error", 1, tags=self._tags + ["error:explain-{}".format(type(e))]
+                )
+                self._log.exception("Failed to explain statement: %s", obfuscated_statement)
+
+        normalized_plan, obfuscated_plan, plan_signature, plan_cost = None, None, None, None
+        if plan:
+            normalized_plan = datadog_agent.obfuscate_sql_exec_plan(plan, normalize=True) if plan else None
+            obfuscated_plan = datadog_agent.obfuscate_sql_exec_plan(plan)
+            plan_signature = compute_exec_plan_signature(normalized_plan)
+            plan_cost = self._parse_execution_plan_cost(plan)
+
+        query_plan_cache_key = (query_cache_key, plan_signature)
+        if query_plan_cache_key not in self._seen_samples_cache:
+            self._seen_samples_cache[query_plan_cache_key] = True
+            return {
+                "timestamp": row["timer_end_time_s"] * 1000,
+                "host": self._db_hostname,
+                "service": self._service,
+                "ddsource": "mysql",
+                "ddtags": self._tags_str,
+                "duration": row['timer_wait_ns'],
+                "network": {
+                    "client": {
+                        "ip": row.get('processlist_host', None),
+                    }
+                },
+                "db": {
+                    "instance": row['current_schema'],
+                    "plan": {"definition": obfuscated_plan, "cost": plan_cost, "signature": plan_signature},
+                    "query_signature": query_signature,
+                    "resource_hash": apm_resource_hash,
+                    "statement": obfuscated_statement,
+                },
+                'mysql': {k: v for k, v in row.items() if k not in EVENTS_STATEMENTS_SAMPLE_EXCLUDE_KEYS},
+            }
+
+    def _collect_plans_for_statements(self, rows):
+        for row in rows:
+            try:
+                event = self._collect_plan_for_statement(row)
+                if event:
+                    yield event
+            except Exception:
+                self._log.debug("Failed to collect plan for statement", exc_info=1)
+
+    def _get_enabled_performance_schema_consumers(self):
+        """
+        Returns the list of available performance schema consumers
+        I.e. (events_statements_current, events_statements_history)
+        :return:
+        """
+        with closing(self._get_db_connection().cursor()) as cursor:
+            self._cursor_run(cursor, ENABLED_STATEMENTS_CONSUMERS_QUERY)
+            return set([r[0] for r in cursor.fetchall()])
+
+    def _enable_events_statements_consumers(self):
+        """
+        Enable events statements consumers
+        :return:
+        """
+        try:
+            with closing(self._get_db_connection().cursor()) as cursor:
+                self._cursor_run(cursor, 'CALL {}()'.format(self._events_statements_enable_procedure))
+        except pymysql.err.DatabaseError as e:
+            self._log.debug("failed to enable events_statements consumers using procedure=%s: %s",
+                            self._events_statements_enable_procedure, e)
+
+    def _get_sample_collection_strategy(self):
+        """
+        Decides on the plan collection strategy:
+        - which events_statement_history-* table are we using
+        - how long should the rate and time limits be
+        :return: (table, rate_limit)
+        """
+        cached_strategy = self._collection_strategy_cache.get("plan_collection_strategy")
+        if cached_strategy:
+            self._log.debug("Using cached plan_collection_strategy: %s", cached_strategy)
+            return cached_strategy
+
+        enabled_consumers = self._get_enabled_performance_schema_consumers()
+        if len(enabled_consumers) < 3:
+            self._enable_events_statements_consumers()
+            enabled_consumers = self._get_enabled_performance_schema_consumers()
+
+        if not enabled_consumers:
+            self._log.warning(
+                "Cannot collect statement samples as there are no enabled performance_schema.events_statements_* "
+                "consumers. Enable performance_schema and at least one events_statements consumer in order to collect "
+                "statement samples."
+            )
+            self._check.count(
+                "dd.mysql.statement_samples.error",
+                1,
+                tags=self._tags + ["error:no-enabled-events-statements-consumers"],
+            )
+            return None, None
+        self._log.debug("Found enabled performance_schema statements consumers: %s", enabled_consumers)
+
+        events_statements_table = None
+        for table in self._preferred_events_statements_tables:
+            if table not in enabled_consumers:
+                continue
+            rows = self._get_new_events_statements(table, 1)
+            if not rows:
+                self._log.debug("No statements found in %s table. checking next one.", table)
+                continue
+            events_statements_table = table
+            break
+        if not events_statements_table:
+            self._log.warning(
+                "Cannot collect statement samples as all enabled events_statements_consumers %s are empty.",
+                enabled_consumers,
+            )
+            return None, None
+
+        rate_limit = self._collections_per_second
+        if rate_limit < 0:
+            rate_limit = DEFAULT_EVENTS_STATEMENTS_COLLECTIONS_PER_SECOND[events_statements_table]
+
+        # cache only successful strategies
+        # should be short enough that we'll reflect updates relatively quickly
+        # i.e., an aurora replica becomes a master (or vice versa).
+        strategy = (events_statements_table, rate_limit)
+        self._log.debug(
+            "Chose plan collection strategy: events_statements_table=%s, collections_per_second=%s",
+            events_statements_table,
+            rate_limit,
+        )
+        self._collection_strategy_cache["plan_collection_strategy"] = strategy
+        return strategy
+
+    def _collect_statement_samples(self):
+        self._rate_limiter.sleep()
+        events_statements_table, rate_limit = self._get_sample_collection_strategy()
+        if not events_statements_table:
+            return
+        if self._rate_limiter.rate_limit_s != rate_limit:
+            self._rate_limiter = ConstantRateLimiter(rate_limit)
+        start_time = time.time()
+
+        tags = self._tags + ["events_statements_table:{}".format(events_statements_table)]
+        rows = self._get_new_events_statements(events_statements_table, self._events_statements_row_limit)
+        rows = self._filter_valid_statement_rows(rows)
+        events = self._collect_plans_for_statements(rows)
+        submitted_count, failed_count = statement_samples_client.submit_events(events)
+        self._check.count(
+            "dd.mysql.statement_samples.error", failed_count, tags=self._tags + ["error:submit-events"]
+        )
+        self._check.histogram("dd.mysql.collect_statement_samples.time", (time.time() - start_time) * 1000, tags=tags)
+        self._check.count("dd.mysql.collect_statement_samples.events_submitted.count", submitted_count, tags=tags)
+        self._check.gauge(
+            "dd.mysql.collect_statement_samples.seen_samples_cache.len", len(self._seen_samples_cache), tags=tags
+        )
+        self._check.gauge(
+            "dd.mysql.collect_statement_samples.explained_statements_cache.len",
+            len(self._explained_statements_cache),
+            tags=tags,
+        )
+        self._check.gauge(
+            "dd.mysql.collect_statement_samples.collection_strategy_cache.len",
+            len(self._collection_strategy_cache),
+            tags=tags,
+        )
+
+    def _explain_statement(self, cursor, statement, schema, obfuscated_statement):
+        """
+        Tries the available methods used to explain a statement for the given schema. If a non-retryable
+        error occurs (such as a permissions error), then statements executed under the schema will be
+        disallowed in future attempts.
+        """
+        start_time = time.time()
+        strategy_cache_key = 'explain_strategy:%s' % schema
+        explain_strategy_error = 'ERROR'
+        tags = self._tags + ["schema:{}".format(schema)]
+
+        self._log.debug('explaining statement. schema=%s, statement="%s"', schema, statement)
+
+        if not self._can_explain(obfuscated_statement):
+            self._log.debug('Skipping statement which cannot be explained: %s', obfuscated_statement)
+            return None
+
+        if self._collection_strategy_cache.get(strategy_cache_key) == explain_strategy_error:
+            self._log.debug('Skipping statement due to cached collection failure: %s', obfuscated_statement)
+            return None
+
+        try:
+            # If there was a default schema when this query was run, then switch to it before trying to collect
+            # the execution plan. This is necessary when the statement uses non-fully qualified tables
+            # e.g. `select * from mytable` instead of `select * from myschema.mytable`
+            if schema:
+                self._cursor_run(cursor, 'USE `{}`'.format(schema))
+        except pymysql.err.DatabaseError as e:
+            if len(e.args) != 2:
+                raise
+            if e.args[0] in PYMYSQL_NON_RETRYABLE_ERRORS:
+                self._collection_strategy_cache[strategy_cache_key] = explain_strategy_error
+            self._check.count(
+                "dd.mysql.statement_samples.error", 1, tags=tags + ["error:explain-use-schema-{}".format(type(e))]
+            )
+            self._log.debug(
+                'Failed to collect execution plan because schema could not be accessed. error=%s, schema=%s, '
+                'statement="%s"',
+                e.args,
+                schema,
+                obfuscated_statement,
+            )
+            return None
+
+        # Use a cached strategy for the schema, if any, or try each strategy to collect plans
+        strategies = list(self._preferred_explain_strategies)
+        cached = self._collection_strategy_cache.get(strategy_cache_key)
+        if cached:
+            strategies.remove(cached)
+            strategies.insert(0, cached)
+
+        for strategy in strategies:
+            try:
+                if not schema and strategy == "PROCEDURE":
+                    self._log.debug(
+                        'skipping PROCEDURE strategy as there is no default schema for this statement="%s"',
+                        obfuscated_statement,
+                    )
+                    continue
+                plan = self._explain_strategies[strategy](cursor, statement, obfuscated_statement)
+                if plan:
+                    self._collection_strategy_cache[strategy_cache_key] = strategy
+                    self._log.debug(
+                        'Successfully collected execution plan. strategy=%s, schema=%s, statement="%s"',
+                        strategy,
+                        schema,
+                        obfuscated_statement
+                    )
+                    self._check.histogram(
+                        "dd.mysql.run_explain.time",
+                        (time.time() - start_time) * 1000,
+                        tags=self._tags + ["strategy:{}".format(strategy)],
+                    )
+                    return plan
+            except pymysql.err.DatabaseError as e:
+                if len(e.args) != 2:
+                    raise
+                # we don't cache failed plan collection failures for specific queries because some queries in a schema
+                # can fail while others succeed. The failed collection will be cached for the specific query
+                # so we won't try to explain it again for the cache duration there.
+                self._check.count(
+                    "dd.mysql.statement_samples.error",
+                    1,
+                    tags=tags + ["error:explain-attempt-{}-{}".format(strategy, type(e))],
+                )
+                self._log.debug(
+                    'Failed to collect execution plan. error=%s, strategy=%s, schema=%s, statement="%s"',
+                    e.args,
+                    strategy,
+                    schema,
+                    obfuscated_statement,
+                )
+                continue
+        return None
+
+    def _run_explain(self, cursor, statement, obfuscated_statement):
+        """
+        Run the explain using the EXPLAIN statement
+        """
+        self._log.debug("running query [EXPLAIN FORMAT=json %s]", obfuscated_statement)
+        cursor.execute('EXPLAIN FORMAT=json {}'.format(statement))
+        return cursor.fetchone()[0]
+
+    def _run_explain_procedure(self, cursor, statement, obfuscated_statement):
+        """
+        Run the explain by calling the stored procedure if available.
+        """
+        self._cursor_run(cursor, 'CALL {}(%s)'.format(self._explain_procedure), statement, obfuscated_statement)
+        return cursor.fetchone()[0]
+
+    def _run_fully_qualified_explain_procedure(self, cursor, statement, obfuscated_statement):
+        """
+        Run the explain by calling the fully qualified stored procedure if available.
+        """
+        self._cursor_run(
+            cursor, 'CALL {}(%s)'.format(self._fully_qualified_explain_procedure), statement, obfuscated_statement
+        )
+        return cursor.fetchone()[0]
+
+    @staticmethod
+    def _can_explain(obfuscated_statement):
+        return obfuscated_statement.split(' ', 1)[0].lower() in VALID_EXPLAIN_STATEMENTS
+
+    @staticmethod
+    def _parse_execution_plan_cost(execution_plan):
+        """
+        Parses the total cost from the execution plan, if set. If not set, returns cost of 0.
+        """
+        cost = json.loads(execution_plan).get('query_block', {}).get('cost_info', {}).get('query_cost', 0.0)
+        return float(cost or 0.0)

--- a/mysql/requirements.in
+++ b/mysql/requirements.in
@@ -1,2 +1,4 @@
+cachetools==3.1.1
 cryptography==3.3.2
 pymysql==0.9.3
+futures==3.3.0; python_version < '3.0'

--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=16.5.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=16.6.0'
 
 setup(
     name='datadog-mysql',

--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.7.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=16.5.0'
 
 setup(
     name='datadog-mysql',

--- a/mysql/tests/compose/mariadb.conf
+++ b/mysql/tests/compose/mariadb.conf
@@ -9,6 +9,6 @@ long_query_time = 0.1  # Facilitates local slow query log testing.
 # log_short_format=ON  # Uncomment to simulate short log format.
 performance_schema = ON
 performance-schema-instrument='stage/%=ON'
-performance-schema-consumer-events-stages-current=ON
-performance-schema-consumer-events-stages-history=ON
-performance-schema-consumer-events-stages-history-long=ON
+performance-schema-consumer-events-statements-current=ON
+performance-schema-consumer-events-statements-history=ON
+performance-schema-consumer-events-statements-history-long=ON

--- a/mysql/tests/compose/mysql.conf
+++ b/mysql/tests/compose/mysql.conf
@@ -7,7 +7,15 @@ slow_query_log = on
 slow_query_log_file = /var/log/mysql/mysql_slow.log
 long_query_time = 0.1  # Facilitates local slow query log testing.
 # log_short_format=ON  # Uncomment to simulate short log format.
+performance_schema=ON
+performance-schema-consumer-events-statements-current=ON
+performance-schema-consumer-events-statements-history=ON
+performance-schema-consumer-events-statements-history-long=ON
+
+[mysqld-5.7]
+performance_schema_max_sql_text_length = 4096
 
 [mysqld-8.0]
 general_log_file = /opt/bitnami/mysql/logs/mysql.log
 slow_query_log_file = /opt/bitnami/mysql/logs/mysql_slow.log
+performance_schema_max_sql_text_length = 4096

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -7,6 +7,7 @@ import os
 import mock
 import pymysql
 import pytest
+
 from datadog_checks.dev import TempDir, WaitFor, docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs
 
@@ -186,13 +187,15 @@ def _create_explain_procedure(conn, schema):
 def _create_enable_consumers_procedure(conn):
     logger.debug("creating enable_events_statements_consumers procedure")
     cur = conn.cursor()
-    cur.execute("""
+    cur.execute(
+        """
         CREATE PROCEDURE datadog.enable_events_statements_consumers()
             SQL SECURITY DEFINER
         BEGIN
             UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
         END;
-    """)
+    """
+    )
     cur.execute("GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers to 'dog'@'%'")
     cur.close()
 

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -1,16 +1,18 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
 import os
 
 import mock
 import pymysql
 import pytest
-
 from datadog_checks.dev import TempDir, WaitFor, docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs
 
 from . import common, tags
+
+logger = logging.getLogger(__name__)
 
 MYSQL_FLAVOR = os.getenv('MYSQL_FLAVOR')
 MYSQL_VERSION = os.getenv('MYSQL_VERSION')
@@ -101,7 +103,6 @@ def instance_complex():
                 'field': 'age',
             },
         ],
-        'deep_database_monitoring': True,
     }
 
 
@@ -151,31 +152,106 @@ def version_metadata():
     }
 
 
+def _init_datadog_sample_collection(conn):
+    logger.debug("initializing datadog sample collection")
+    cur = conn.cursor()
+    cur.execute("CREATE DATABASE datadog")
+    cur.execute("GRANT CREATE TEMPORARY TABLES ON `datadog`.* TO 'dog'@'%'")
+    _create_explain_procedure(conn, "datadog")
+    _create_explain_procedure(conn, "mysql")
+    _create_enable_consumers_procedure(conn)
+
+
+def _create_explain_procedure(conn, schema):
+    logger.debug("creating explain procedure in schema=%s", schema)
+    cur = conn.cursor()
+    cur.execute(
+        """
+    CREATE PROCEDURE {schema}.explain_statement(IN query TEXT)
+        SQL SECURITY DEFINER
+    BEGIN
+        SET @explain := CONCAT('EXPLAIN FORMAT=json ', query);
+        PREPARE stmt FROM @explain;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END;
+    """.format(
+            schema=schema
+        )
+    )
+    cur.execute("GRANT EXECUTE ON PROCEDURE {schema}.explain_statement to 'dog'@'%'".format(schema=schema))
+    cur.close()
+
+
+def _create_enable_consumers_procedure(conn):
+    logger.debug("creating enable_events_statements_consumers procedure")
+    cur = conn.cursor()
+    cur.execute("""
+        CREATE PROCEDURE datadog.enable_events_statements_consumers()
+            SQL SECURITY DEFINER
+        BEGIN
+            UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
+        END;
+    """)
+    cur.execute("GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers to 'dog'@'%'")
+    cur.close()
+
+
 def init_master():
+    logger.debug("initializing master")
     conn = pymysql.connect(host=common.HOST, port=common.PORT, user='root')
     _add_dog_user(conn)
+    _add_bob_user(conn)
+    _init_datadog_sample_collection(conn)
+
+
+@pytest.fixture
+def root_conn():
+    conn = pymysql.connect(host=common.HOST, port=common.PORT, user='root')
+    yield conn
+    conn.close()
 
 
 def init_slave():
+    logger.debug("initializing slave")
     pymysql.connect(host=common.HOST, port=common.SLAVE_PORT, user=common.USER, passwd=common.PASS)
 
 
 def _add_dog_user(conn):
     cur = conn.cursor()
-    cur.execute("CREATE USER 'dog'@'%' IDENTIFIED BY 'dog';")
-    if MYSQL_FLAVOR == 'mysql' and MYSQL_VERSION == '8.0':
-        cur.execute("GRANT REPLICATION CLIENT ON *.* TO 'dog'@'%';")
-        cur.execute("ALTER USER 'dog'@'%' WITH MAX_USER_CONNECTIONS 5;")
-    else:
-        cur.execute("GRANT REPLICATION CLIENT ON *.* TO 'dog'@'%' WITH MAX_USER_CONNECTIONS 5;")
-    cur.execute("GRANT PROCESS ON *.* TO 'dog'@'%';")
+    cur.execute("SELECT count(*) FROM mysql.user WHERE User = 'dog' and Host = '%'")
+    if cur.fetchone()[0] == 0:
+        # gracefully handle retries due to partial failure later on
+        cur.execute("CREATE USER 'dog'@'%' IDENTIFIED BY 'dog'")
+    cur.execute("GRANT PROCESS ON *.* TO 'dog'@'%'")
+    cur.execute("GRANT REPLICATION CLIENT ON *.* TO 'dog'@'%'")
     cur.execute("GRANT SELECT ON performance_schema.* TO 'dog'@'%'")
+    if MYSQL_FLAVOR == 'mysql' and MYSQL_VERSION == '8.0':
+        cur.execute("ALTER USER 'dog'@'%' WITH MAX_USER_CONNECTIONS 0")
+    else:
+        cur.execute("UPDATE mysql.user SET max_user_connections = 0 WHERE user='dog' AND host='%'")
+        cur.execute("FLUSH PRIVILEGES")
+
+
+def _add_bob_user(conn):
+    cur = conn.cursor()
+    cur.execute("CREATE USER 'bob'@'%' IDENTIFIED BY 'bob'")
+    cur.execute("GRANT USAGE on *.* to 'bob'@'%'")
+
+
+@pytest.fixture
+def bob_conn():
+    conn = pymysql.connect(host=common.HOST, port=common.PORT, user='bob', password='bob')
+    yield conn
+    conn.close()
 
 
 def populate_database():
+    logger.debug("populating database")
     conn = pymysql.connect(host=common.HOST, port=common.PORT, user='root')
 
     cur = conn.cursor()
+
     cur.execute("USE mysql;")
     cur.execute("CREATE DATABASE testdb;")
     cur.execute("USE testdb;")
@@ -183,7 +259,9 @@ def populate_database():
     cur.execute("INSERT INTO testdb.users (name,age) VALUES('Alice',25);")
     cur.execute("INSERT INTO testdb.users (name,age) VALUES('Bob',20);")
     cur.execute("GRANT SELECT ON testdb.users TO 'dog'@'%';")
+    cur.execute("GRANT SELECT ON testdb.users TO 'bob'@'%';")
     cur.close()
+    _create_explain_procedure(conn, "testdb")
 
 
 def _wait_for_it_script():

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -463,7 +463,7 @@ def test_statement_samples_max_per_digest(dbm_instance):
         mysql_check.check(dbm_instance)
     rows = mysql_check._statement_samples._get_new_events_statements('events_statements_history_long', 1000)
     count_by_digest = Counter(r['digest'] for r in rows)
-    for digest, count in count_by_digest.items():
+    for _, count in count_by_digest.items():
         assert count == 1, "we should be reading exactly one row per digest out of the database"
 
 

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -2,22 +2,33 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import copy
+import json
 import subprocess
+import time
+from collections import Counter
 from contextlib import closing
 from os import environ
 
 import mock
 import psutil
 import pytest
-from pkg_resources import parse_version
-
+from datadog_checks.base.utils.db.statement_samples import statement_samples_client
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.mysql import MySql, statements
 from datadog_checks.mysql.version_utils import get_version
+from pkg_resources import parse_version
 
 from . import common, tags, variables
 from .common import MYSQL_VERSION_PARSED
+
+
+@pytest.fixture
+def dbm_instance(instance_complex):
+    instance_complex['deep_database_monitoring'] = True
+    instance_complex['min_collection_interval'] = 1
+    instance_complex['statement_samples'] = {'enabled': True, 'run_sync': False, 'collections_per_second': 1}
+    return instance_complex
 
 
 @pytest.mark.integration
@@ -210,7 +221,7 @@ def test_complex_config_replica(aggregator, instance_complex):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_statement_metrics(aggregator, instance_complex):
+def test_statement_metrics(aggregator, dbm_instance):
     QUERY = 'select * from information_schema.processlist'
     QUERY_DIGEST_TEXT = 'SELECT * FROM `information_schema` . `processlist`'
     # The query signature should match the query and consistency of this tag has product impact. Do not change
@@ -228,8 +239,7 @@ def test_statement_metrics(aggregator, instance_complex):
         QUERY_DIGEST = '6817a67871eb7edddad5b7836c93330aa3c98801ac759eed1bea6db1a34579c4'
         QUERY_SIGNATURE = '9d73cb71644af0a2'
 
-    config = copy.deepcopy(instance_complex)
-    mysql_check = MySql(common.CHECK_NAME, {}, instances=[config])
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
 
     def run_query(q):
         with mysql_check._connect() as db:
@@ -238,11 +248,11 @@ def test_statement_metrics(aggregator, instance_complex):
 
     # Run a query
     run_query(QUERY)
-    mysql_check.check(config)
+    mysql_check.check(dbm_instance)
 
     # Run the query and check a second time so statement metrics are computed from the previous run
     run_query(QUERY)
-    mysql_check.check(config)
+    mysql_check.check(dbm_instance)
     for name in statements.STATEMENT_METRICS.values():
         aggregator.assert_metric(
             name,
@@ -318,6 +328,150 @@ def test_generate_synthetic_rows():
             'rows_examined': 0,
         },
     ]
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize(
+    "events_statements_table",
+    ["events_statements_current", "events_statements_history", "events_statements_history_long", None],
+)
+@pytest.mark.parametrize("explain_strategy", ['PROCEDURE', 'FQ_PROCEDURE', 'STATEMENT', None])
+@pytest.mark.parametrize(
+    "schema,statement",
+    [
+        (None, 'select name as nam from testdb.users'),
+        ('information_schema', 'select name as nam from testdb.users'),
+        ('testdb', 'select name as nam from users'),
+    ],
+)
+def test_statement_samples_collect(dbm_instance, bob_conn, events_statements_table, explain_strategy, schema,
+                                   statement):
+    # try to collect a sample from all supported events_statements tables using all possible strategies
+    dbm_instance['statement_samples']['events_statements_table'] = events_statements_table
+    dbm_instance['statement_samples']['run_sync'] = True
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+    if explain_strategy:
+        mysql_check._statement_samples._preferred_explain_strategies = [explain_strategy]
+
+    mysql_check.check(dbm_instance)
+    statement_samples_client._events = []
+    mysql_check._statement_samples._init_caches()
+
+    # we deliberately want to keep the connection open for the duration of the test to ensure
+    # the query remains in the events_statements_current and events_statements_history tables
+    # it would be cleared out upon connection close otherwise
+    with closing(bob_conn.cursor()) as cursor:
+        # run the check once, then clear out all saved events
+        # on the next check run it should only capture events since the last checkpoint
+        if schema:
+            cursor.execute("use {}".format(schema))
+        cursor.execute(statement)
+    mysql_check.check(dbm_instance)
+    matching = [e for e in statement_samples_client._events if e['db']['statement'] == statement]
+    assert len(matching) > 0, "should have collected an event"
+    with_plans = [e for e in matching if e['db']['plan']['definition'] is not None]
+    if schema == 'testdb' and explain_strategy == 'FQ_PROCEDURE':
+        # explain via the FQ_PROCEDURE will fail if a query contains non-fully-qualified tables because it will
+        # default to the schema of the FQ_PROCEDURE, so in case of "select * from testdb" it'll try to do
+        # "select start from datadog.testdb" which would be the wrong schema.
+        assert not with_plans, "cannot collect plan in this case"
+    elif schema == 'information_schema' and explain_strategy == 'PROCEDURE':
+        # we can't create an explain_statement procedure in performance_schema so this is not expected to work
+        assert not with_plans, "cannot collect plan in this case"
+    elif not schema and explain_strategy == 'PROCEDURE':
+        # if there is no default schema then we cannot use the non-fully-qualified procedure strategy
+        assert not with_plans, "cannot collect plan in this case"
+    else:
+        event = with_plans[0]
+        assert 'query_block' in json.loads(event['db']['plan']['definition']), "invalid json execution plan"
+
+    # we avoid closing these in a try/finally block in order to maintain the connections in case we want to
+    # debug the test with --pdb
+    mysql_check._statement_samples.close()
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_statement_samples_rate_limit(aggregator, bob_conn, dbm_instance):
+    dbm_instance['statement_samples']['collections_per_second'] = 0.5
+    query = "select name as nam from testdb.users where name = 'hello'"
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+    with closing(bob_conn.cursor()) as cursor:
+        for _ in range(5):
+            cursor.execute(query)
+            mysql_check.check(dbm_instance)
+            time.sleep(1)
+    matching = [e for e in statement_samples_client._events if e['db']['statement'] == query]
+    assert len(matching) == 1, "should have collected exactly one event due to sample rate limit"
+    metrics = aggregator.metrics("dd.mysql.collect_statement_samples.time")
+    assert 2 < len(metrics) < 6
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_statement_samples_loop_inactive_stop(aggregator, dbm_instance):
+    # confirm that the collection loop stops on its own after the check has not been run for a while
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+    mysql_check.check(dbm_instance)
+    while mysql_check._statement_samples._collection_loop_future.running():
+        time.sleep(0.1)
+    # make sure there were no unhandled exceptions
+    mysql_check._statement_samples._collection_loop_future.result()
+    aggregator.assert_metric("dd.mysql.statement_samples.collection_loop_inactive_stop")
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_statement_samples_max_per_digest(dbm_instance):
+    # clear out any events from previous test runs
+    statement_samples_client._events = []
+    dbm_instance['statement_samples']['run_sync'] = True
+    dbm_instance['statement_samples']['events_statements_table'] = 'events_statements_history_long'
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+    for _ in range(3):
+        mysql_check.check(dbm_instance)
+    rows = mysql_check._statement_samples._get_new_events_statements('events_statements_history_long', 1000)
+    count_by_digest = Counter(r['digest'] for r in rows)
+    for digest, count in count_by_digest.items():
+        assert count == 1, "we should be reading exactly one row per digest out of the database"
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_statement_samples_invalid_explain_procedure(aggregator, dbm_instance):
+    dbm_instance['statement_samples']['run_sync'] = True
+    dbm_instance['statement_samples']['explain_procedure'] = 'hello'
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+    mysql_check.check(dbm_instance)
+    aggregator.assert_metric_has_tag_prefix("dd.mysql.statement_samples.error", "error:explain-")
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize("events_statements_enable_procedure",
+                         ["datadog.enable_events_statements_consumers", "invalid_proc"])
+def test_statement_samples_enable_consumers(dbm_instance, root_conn, events_statements_enable_procedure):
+    dbm_instance['statement_samples']['run_sync'] = True
+    dbm_instance['statement_samples']['events_statements_enable_procedure'] = events_statements_enable_procedure
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+
+    # deliberately disable one of the consumers
+    with closing(root_conn.cursor()) as cursor:
+        cursor.execute(
+            "UPDATE performance_schema.setup_consumers SET enabled='NO'  WHERE name = "
+            "'events_statements_history_long';")
+
+    original_enabled_consumers = mysql_check._statement_samples._get_enabled_performance_schema_consumers()
+    assert original_enabled_consumers == {'events_statements_current', 'events_statements_history'}
+
+    mysql_check.check(dbm_instance)
+
+    enabled_consumers = mysql_check._statement_samples._get_enabled_performance_schema_consumers()
+    if events_statements_enable_procedure == "datadog.enable_events_statements_consumers":
+        assert enabled_consumers == original_enabled_consumers.union({'events_statements_history_long'})
+    else:
+        assert enabled_consumers == original_enabled_consumers
 
 
 def _test_optional_metrics(aggregator, optional_metrics, at_least):

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -351,7 +351,6 @@ def test_generate_synthetic_rows():
 def test_statement_samples_collect(
     dbm_instance, bob_conn, events_statements_table, explain_strategy, schema, statement, caplog
 ):
-    dbm_instance = copy.deepcopy(dbm_instance)
     caplog.set_level(logging.INFO, logger="datadog_checks.mysql.collection_utils")
     caplog.set_level(logging.DEBUG, logger="datadog_checks")
     caplog.set_level(logging.DEBUG, logger="tests.test_mysql")

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import copy
-import json
 import subprocess
 import time
 from collections import Counter
@@ -12,12 +11,14 @@ from os import environ
 import mock
 import psutil
 import pytest
+from pkg_resources import parse_version
+
 from datadog_checks.base.utils.db.statement_samples import statement_samples_client
 from datadog_checks.base.utils.platform import Platform
+from datadog_checks.base.utils.serialization import json
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.mysql import MySql, statements
 from datadog_checks.mysql.version_utils import get_version
-from pkg_resources import parse_version
 
 from . import common, tags, variables
 from .common import MYSQL_VERSION_PARSED
@@ -345,8 +346,9 @@ def test_generate_synthetic_rows():
         ('testdb', 'select name as nam from users'),
     ],
 )
-def test_statement_samples_collect(dbm_instance, bob_conn, events_statements_table, explain_strategy, schema,
-                                   statement):
+def test_statement_samples_collect(
+    dbm_instance, bob_conn, events_statements_table, explain_strategy, schema, statement
+):
     # try to collect a sample from all supported events_statements tables using all possible strategies
     dbm_instance['statement_samples']['events_statements_table'] = events_statements_table
     dbm_instance['statement_samples']['run_sync'] = True
@@ -449,8 +451,9 @@ def test_statement_samples_invalid_explain_procedure(aggregator, dbm_instance):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-@pytest.mark.parametrize("events_statements_enable_procedure",
-                         ["datadog.enable_events_statements_consumers", "invalid_proc"])
+@pytest.mark.parametrize(
+    "events_statements_enable_procedure", ["datadog.enable_events_statements_consumers", "invalid_proc"]
+)
 def test_statement_samples_enable_consumers(dbm_instance, root_conn, events_statements_enable_procedure):
     dbm_instance['statement_samples']['run_sync'] = True
     dbm_instance['statement_samples']['events_statements_enable_procedure'] = events_statements_enable_procedure
@@ -460,7 +463,8 @@ def test_statement_samples_enable_consumers(dbm_instance, root_conn, events_stat
     with closing(root_conn.cursor()) as cursor:
         cursor.execute(
             "UPDATE performance_schema.setup_consumers SET enabled='NO'  WHERE name = "
-            "'events_statements_history_long';")
+            "'events_statements_history_long';"
+        )
 
     original_enabled_consumers = mysql_check._statement_samples._get_enabled_performance_schema_consumers()
     assert original_enabled_consumers == {'events_statements_current', 'events_statements_history'}

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -24,7 +24,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    -e../datadog_checks_base[deps,db]
+    -e../datadog_checks_base[deps,db,json]
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in


### PR DESCRIPTION
### What does this PR do?

Adds a new feature to "Deep Database Monitoring", enabling collection of statement samples and execution plans. 

Follow-up to:
*  #7851 - mysql DBM statement metrics
* https://github.com/DataDog/integrations-core/pull/8627 - Collect postgres statement samples & execution plans

#### How it works

If enabled, a python thread is launched during a regular check run:
* collects statement samples at the configured rate limit (default 1 collection per second)
* maintains its own `pymysql` connection as `pymysql` is not thread safe so we can't share with the main check
* collects execution plans through a mysql procedure that the user must install into each database being monitored (if we wanted the agent to collect execution plans directly by running `EXPLAIN` then it would need full write permission to all tables)
* shuts down if it detects that the main check has stopped running

During one "collection" we do the following:
1. read out all new statements from `performance_schema.events_statement_{current|history|history_long}`
1. try to collect an execution plan for each statement
1. submit events directly to the new database monitoring event intake

#### Rate Limiting

There are several different rate limits to keep load on the database to a minimum and to avoid reingesting duplicate events:
* `collections_per_second`: limits how often collections are done (each collection is a query to an `events_statements_*` table)
* `explained_statements_cache`: ttl limits how often we attempt to collect an execution plan for a given normalized query
* `seen_samples_cache`: ttl limits how often we ingest statement samples for the same normalized query and execution plan

#### Events statements tables

The check will collect samples from the best available `events_statements` table. It's up to the user to enable the required `events_statements` consumers. Some managed databases like RDS Aurora replicas don't support `events_statements_history_long` in which case we fall back to one of the other tables.
1. `events_statements_history_long` - preferred as it has the longest retention giving us the highest chance of catching infrequent & fast queries
1. `events_statements_current` - less likely to catch infrequent & fast queries
1. `events_statements_history` - least preferred table because

#### Configuration

```yaml
statement_samples:
  enabled: false
  # default rate depends on which events_statements table is being used. user can override.
  collections_per_second: -1
  # the best table is chosen automatically by the check. user can override.
  events_statements_table: ''
  events_statements_row_limit: 5000
  explain_procedure: 'explain_statement'
  fully_qualified_explain_procedure: 'datadog.explain_statement'
  events_statements_temp_table_name: 'datadog.temp_events'
  events_statements_enable_procedure: 'datadog.enable_events_statements_consumers'
```

#### Motivation

Collect statement samples & execution plans, enabling deeper insight into what's running on the database and how queries are being executed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
