### PR TITLE
Catch exception when closing lost connection

### DIFF
--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from contextlib import closing
 from itertools import chain
 
+from pyhdb import OperationalError
 from six import iteritems
 from six.moves import zip
 
@@ -99,7 +100,10 @@ class SapHanaCheck(AgentCheck):
                     continue
         finally:
             if self._connection_lost:
-                self._conn.close()
+                try:
+                    self._conn.close()
+                except OperationalError:
+                    self.log.debug("Could not close lost connection")
                 self._conn = None
                 self._connection_lost = False
 


### PR DESCRIPTION
Handle:

```
datadog_checks/sap_hana/sap_hana.py:102: in check
    self._conn.close()
.tox/py38/lib/python3.8/site-packages/pyhdb/connection.py:168: in close
    reply = self.send_request(request)
.tox/py38/lib/python3.8/site-packages/pyhdb/connection.py:84: in send_request
    return self.__send_message_recv_reply(payload.getvalue())
.tox/py38/lib/python3.8/site-packages/pyhdb/connection.py:121: in __send_message_recv_reply
    raise OperationalError("Lost connection to HANA server (%r)" % error)
E   pyhdb.exceptions.OperationalError: Lost connection to HANA server (BrokenPipeError(32, 'Broken pipe'))
```

Related: https://github.com/SAP/PyHDB/issues/68