### PR TITLE
Enable disable_legacy_cluster_tag option

### DIFF
--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -92,7 +92,9 @@ files:
       description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `elastic_cluster`.
       value:
         type: boolean
-        example: false
+        default: false
+        example: true
+      enabled: true
     - template: instances/default
     - template: instances/http
   - template: logs

--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -92,7 +92,7 @@ files:
       description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `elastic_cluster`.
       value:
         type: boolean
-        default: false
+        display_default: false
         example: true
       enabled: true
     - template: instances/default

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -116,7 +116,7 @@ instances:
     #
     # gc_collectors_as_rate: false
 
-    ## @param disable_legacy_cluster_tag - boolean - optional - default: true
+    ## @param disable_legacy_cluster_tag - boolean - optional - default: false
     ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `elastic_cluster`.
     #
     disable_legacy_cluster_tag: true

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -116,10 +116,10 @@ instances:
     #
     # gc_collectors_as_rate: false
 
-    ## @param disable_legacy_cluster_tag - boolean - optional - default: false
+    ## @param disable_legacy_cluster_tag - boolean - optional - default: true
     ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `elastic_cluster`.
     #
-    # disable_legacy_cluster_tag: false
+    disable_legacy_cluster_tag: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/vault/assets/configuration/spec.yaml
+++ b/vault/assets/configuration/spec.yaml
@@ -40,7 +40,9 @@ files:
       description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `vault_cluster`.
       value:
         type: boolean
-        example: false
+        display_default: false
+        example: true
+      enabled: true
     - template: instances/http
     - template: instances/default
   - template: logs

--- a/vault/datadog_checks/vault/data/conf.yaml.example
+++ b/vault/datadog_checks/vault/data/conf.yaml.example
@@ -74,7 +74,7 @@ instances:
     ## @param disable_legacy_cluster_tag - boolean - optional - default: false
     ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `vault_cluster`.
     #
-    # disable_legacy_cluster_tag: false
+    disable_legacy_cluster_tag: true
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/yarn/assets/configuration/spec.yaml
+++ b/yarn/assets/configuration/spec.yaml
@@ -100,7 +100,9 @@ files:
             description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `yarn_cluster`.
             value:
               type: boolean
-              example: false
+              display_default: false
+              example: true
+            enabled: true
           - template: instances/http
           - template: instances/default
 

--- a/yarn/datadog_checks/yarn/data/conf.yaml.example
+++ b/yarn/datadog_checks/yarn/data/conf.yaml.example
@@ -127,7 +127,7 @@ instances:
     ## @param disable_legacy_cluster_tag - boolean - optional - default: false
     ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `yarn_cluster`.
     #
-    # disable_legacy_cluster_tag: false
+    disable_legacy_cluster_tag: true
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.


### PR DESCRIPTION
### What does this PR do?
Enable `disable_legacy_cluster_tag` by default
### Motivation
New configurations of the integration will not be using cluster_name tag

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
