### PR TITLE
Add documentation for Kafka Consumer log collection

### DIFF
--- a/kafka_consumer/README.md
+++ b/kafka_consumer/README.md
@@ -25,29 +25,35 @@ The Agent's Kafka consumer check is included in the [Datadog Agent][112] package
 
 To configure this check for an Agent running on a host:
 
+##### Metric collection
+
 1. Edit the `kafka_consumer.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent’s configuration directory][114]. See the [sample kafka_consumer.d/conf.yaml][113] for all available configuration options.
 
 2. [Restart the Agent][115].
+
+##### Log collection
+
+This check does not collect additional logs. To collect logs from Kafka brokers, see [log collection instructions for Kafka][116].
 
 <!-- xxz tab xxx -->
 <!-- xxx tab "Containerized" xxx -->
 
 #### Containerized
 
-For containerized environments, see the [Autodiscovery with JMX][116] guide.
+For containerized environments, see the [Autodiscovery with JMX][117] guide.
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
 
 ### Validation
 
-[Run the Agent's status subcommand][117] and look for `kafka_consumer` under the Checks section.
+[Run the Agent's status subcommand][118] and look for `kafka_consumer` under the Checks section.
 
 ## Data Collected
 
 ### Metrics
 
-See [metadata.csv][118] for a list of metrics provided by this check.
+See [metadata.csv][119] for a list of metrics provided by this check.
 
 ### Events
 
@@ -60,27 +66,28 @@ The Kafka-consumer check does not include any service checks.
 
 ## Troubleshooting
 
-- [Troubleshooting and Deep Dive for Kafka][119]
-- [Agent failed to retrieve RMIServer stub][1110]
-- [Producer and Consumer metrics don't appear in my Datadog application][1111]
+- [Troubleshooting and Deep Dive for Kafka][1110]
+- [Agent failed to retrieve RMIServer stub][1111]
+- [Producer and Consumer metrics don't appear in my Datadog application][1112]
 
 ## Further Reading
 
-- [Monitoring Kafka performance metrics][1112]
-- [Collecting Kafka performance metrics][1113]
-- [Monitoring Kafka with Datadog][1114]
+- [Monitoring Kafka performance metrics][1113]
+- [Collecting Kafka performance metrics][1114]
+- [Monitoring Kafka with Datadog][1115]
 
 [111]: https://raw.githubusercontent.com/DataDog/integrations-core/master/kafka_consumer/images/kafka_dashboard.png
 [112]: https://app.datadoghq.com/account/settings#agent
 [113]: https://github.com/DataDog/integrations-core/blob/master/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
 [114]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [115]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[116]: https://docs.datadoghq.com/agent/guide/autodiscovery-with-jmx/?tab=containerizedagent
-[117]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[118]: https://github.com/DataDog/integrations-core/blob/master/kafka_consumer/metadata.csv
-[119]: https://docs.datadoghq.com/integrations/faq/troubleshooting-and-deep-dive-for-kafka/
-[1110]: https://docs.datadoghq.com/integrations/faq/agent-failed-to-retrieve-rmierver-stub/
-[1111]: https://docs.datadoghq.com/integrations/faq/producer-and-consumer-metrics-don-t-appear-in-my-datadog-application/
-[1112]: https://www.datadoghq.com/blog/monitoring-kafka-performance-metrics
-[1113]: https://www.datadoghq.com/blog/collecting-kafka-performance-metrics
-[1114]: https://www.datadoghq.com/blog/monitor-kafka-with-datadog
+[116]: https://docs.datadoghq.com/integrations/kafka/#log-collection
+[117]: https://docs.datadoghq.com/agent/guide/autodiscovery-with-jmx/?tab=containerizedagent
+[118]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[119]: https://github.com/DataDog/integrations-core/blob/master/kafka_consumer/metadata.csv
+[1110]: https://docs.datadoghq.com/integrations/faq/troubleshooting-and-deep-dive-for-kafka/
+[1111]: https://docs.datadoghq.com/integrations/faq/agent-failed-to-retrieve-rmierver-stub/
+[1112]: https://docs.datadoghq.com/integrations/faq/producer-and-consumer-metrics-don-t-appear-in-my-datadog-application/
+[1113]: https://www.datadoghq.com/blog/monitoring-kafka-performance-metrics
+[1114]: https://www.datadoghq.com/blog/collecting-kafka-performance-metrics
+[1115]: https://www.datadoghq.com/blog/monitor-kafka-with-datadog


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add documentation on log collection for the `kafka_consumer` check.

### Motivation
<!-- What inspired you to submit this pull request? -->
* Log collection coverage
* No log support to add, since `kafka_consumer` does not monitor a separate technology (it only collects metrics about consumer offsets), and `kafka` and `zk` integrations already cover log collection for Kafka and ZooKeeper respectively.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
* For some reason link numbers don't start from 1. Will submit a separate PR for this, to keep things cleaner.
* Status will be marked as "done" in [Status](https://datadoghq.dev/integrations-core/meta/status/) thanks to the "Log collection" header (see also `cassandra_nodetool` via #8387).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
