### PR TITLE
Fix `aiflow` prefix typo

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -70,7 +70,7 @@ Connect Airflow to DogStatsD (included in the Datadog Agent) by using the Airflo
            name: "airflow.job.end"
            tags:
              job_name: "$1"
-         - match: "aiflow.*_<job_name>_heartbeat_failure"
+         - match: "airflow.*_<job_name>_heartbeat_failure"
            name: airflow.job.heartbeat.failure
            tags:
              job_name: "$1"

--- a/airflow/metadata.csv
+++ b/airflow/metadata.csv
@@ -13,7 +13,7 @@ airflow.previously_succeeded,count,,task,,Number of previously succeeded task in
 airflow.zombies_killed,count,,task,,Zombie tasks killed,0,airflow,zombies_killed
 airflow.scheduler_heartbeat,count,,,,Scheduler heartbeats,0,airflow,scheduler_heartbeat
 airflow.dag_processing.processes,count,,,,Number of currently running DAG parsing processes,0,airflow,dag_proc.processes
-aiflow.dag_processing.manager_stalls,count,,,,Number of stalled `DagFileProcessorManager`,0,airflow,dag_proc.manager_stalls
+airflow.dag_processing.manager_stalls,count,,,,Number of stalled `DagFileProcessorManager`,0,airflow,dag_proc.manager_stalls
 airflow.dag_file_refresh_error,count,,error,,Number of failures loading any DAG files,0,airflow,dag_file_refresh_error
 airflow.scheduler.critical_section_duration,gauge,,millisecond,,Milliseconds spent in the critical section of scheduler loop -- only a single scheduler can enter this loop at a time,0,airflow,critical_section_duration
 airflow.scheduler.tasks.killed_externally,count,,task,,Number of tasks killed externally,-1,airflow,scheduler.tasks.killed_externally


### PR DESCRIPTION
### What does this PR do?
`aiflow` has the wrong prefix


### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
