### PR TITLE
Apply default limits to MySQL statement summaries

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -246,7 +246,7 @@ files:
               type: boolean
               example: false
               display_default: false
-          - name: statement_metric_limits
+          - name: statement_metrics_limits
             description: |
               Defines the top and bottom limits on queries to track for each metric. These limits apply only to the
               ALPHA features of Deep Database Monitoring. It is recommended to leave these settings at their default

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -246,6 +246,21 @@ files:
               type: boolean
               example: false
               display_default: false
+          - name: statement_metric_limits
+            description: |
+              Defines the top and bottom limits on queries to track for each metric. These limits apply only to the
+              ALPHA features of Deep Database Monitoring. It is recommended to leave these settings at their default
+              values unless instructed otherwise. This API may change in the future.
+
+              If you would like to hear more about Deep Database Monitoring, please reach out to your customer
+              success manager or Datadog support.
+            value:
+              type: object
+              example:
+                calls: [100, 0]
+                time: [100, 0]
+                <METRIC_COLUMN>: [<TOP_K_LIMIT>, <BOTTOM_K_LIMIT>]
+              display_default: false
 
           - template: instances/default
 

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -29,7 +29,7 @@ class MySQLConfig(object):
         self.max_custom_queries = instance.get('max_custom_queries', DEFAULT_MAX_CUSTOM_QUERIES)
         self.charset = instance.get('charset')
         self.deep_database_monitoring = is_affirmative(instance.get('deep_database_monitoring', False))
-        self.statement_metric_limits = instance.get('statement_metric_limits', None)
+        self.statement_metrics_limits = instance.get('statement_metrics_limits', None)
         self.configuration_checks()
 
     def _build_tags(self, custom_tags):

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -29,6 +29,7 @@ class MySQLConfig(object):
         self.max_custom_queries = instance.get('max_custom_queries', DEFAULT_MAX_CUSTOM_QUERIES)
         self.charset = instance.get('charset')
         self.deep_database_monitoring = is_affirmative(instance.get('deep_database_monitoring', False))
+        self.statement_metric_limits = instance.get('statement_metric_limits', None)
         self.configuration_checks()
 
     def _build_tags(self, custom_tags):

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -25,14 +25,14 @@ init_config:
 #
 instances:
 
-    ## @param host - string - optional - default: localhost
+    ## @param host - string - optional
     ## MySQL host to connect to.
     ## NOTE: Even if the host is "localhost", the agent connects to MySQL using TCP/IP, unless you also
     ## provide a value for the sock key (below).
     #
   - host: localhost
 
-    ## @param user - string - optional - default: datadog
+    ## @param user - string - optional
     ## Username used to connect to MySQL.
     #
     user: datadog
@@ -53,7 +53,7 @@ instances:
     #
     # sock: <SOCK>
 
-    ## @param charset - string - optional - default: utf8
+    ## @param charset - string - optional
     ## Charset you want to use.
     #
     # charset: utf8
@@ -232,7 +232,7 @@ instances:
     #
     # deep_database_monitoring: false
 
-    ## @param statement_metric_limits - mapping - optional
+    ## @param statement_metrics_limits - mapping - optional - default: false
     ## Defines the top and bottom limits on queries to track for each metric. These limits apply only to the
     ## ALPHA features of Deep Database Monitoring. It is recommended to leave these settings at their default
     ## values unless instructed otherwise. This API may change in the future.
@@ -240,7 +240,7 @@ instances:
     ## If you would like to hear more about Deep Database Monitoring, please reach out to your customer
     ## success manager or Datadog support.
     #
-    # statement_metric_limits:
+    # statement_metrics_limits:
     #   calls:
     #   - 100
     #   - 0

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -232,6 +232,19 @@ instances:
     #
     # deep_database_monitoring: false
 
+    ## @param statement_metric_limits - mapping - optional - default: null
+    ## Defines the top and bottom limits on queries to track for each metric. These limits apply only to the
+    ## ALPHA features of Deep Database Monitoring. It is recommended to leave these settings at their default
+    ## values unless instructed otherwise. This API may change in the future.
+    ##
+    ## If you would like to hear more about Deep Database Monitoring, please reach out to your customer
+    ## success manager or Datadog support.
+    #
+    # statement_metric_limits:
+    #   count: [100, 0]
+    #   time: [100, 0]
+    #   <METRIC_COLUMN>: [<TOP_K_LIMIT>, <BOTTOM_K_LIMIT>]
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -25,14 +25,14 @@ init_config:
 #
 instances:
 
-    ## @param host - string - optional
+    ## @param host - string - optional - default: localhost
     ## MySQL host to connect to.
     ## NOTE: Even if the host is "localhost", the agent connects to MySQL using TCP/IP, unless you also
     ## provide a value for the sock key (below).
     #
   - host: localhost
 
-    ## @param user - string - optional
+    ## @param user - string - optional - default: datadog
     ## Username used to connect to MySQL.
     #
     user: datadog
@@ -53,7 +53,7 @@ instances:
     #
     # sock: <SOCK>
 
-    ## @param charset - string - optional
+    ## @param charset - string - optional - default: utf8
     ## Charset you want to use.
     #
     # charset: utf8
@@ -232,7 +232,7 @@ instances:
     #
     # deep_database_monitoring: false
 
-    ## @param statement_metric_limits - mapping - optional - default: null
+    ## @param statement_metric_limits - mapping - optional
     ## Defines the top and bottom limits on queries to track for each metric. These limits apply only to the
     ## ALPHA features of Deep Database Monitoring. It is recommended to leave these settings at their default
     ## values unless instructed otherwise. This API may change in the future.
@@ -241,9 +241,15 @@ instances:
     ## success manager or Datadog support.
     #
     # statement_metric_limits:
-    #   count: [100, 0]
-    #   time: [100, 0]
-    #   <METRIC_COLUMN>: [<TOP_K_LIMIT>, <BOTTOM_K_LIMIT>]
+    #   calls:
+    #   - 100
+    #   - 0
+    #   time:
+    #   - 100
+    #   - 0
+    #   <METRIC_COLUMN>:
+    #   - <TOP_K_LIMIT>
+    #   - <BOTTOM_K_LIMIT>
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -98,7 +98,7 @@ class MySQLStatementMetrics(object):
 
     def _collect_per_statement_metrics(self, db):
         # type: (pymysql.connections.Connection) -> List[Metric]
-        metrics = []
+        metrics = []  # type: List[Metric]
 
         def keyfunc(row):
             return (row['schema'], row['digest'])

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -40,6 +40,8 @@ STATEMENT_METRICS = {
     'rows_examined': 'mysql.queries.rows_examined',
 }
 
+# These limits define the top K and bottom K unique query rows for each metric. For each check run the
+# max metrics sent will be sum of all numbers below (in practice, much less due to overlap in rows).
 DEFAULT_STATEMENT_METRIC_LIMITS = {
     'count': (800, 0),
     'errors': (100, 0),

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -111,7 +111,7 @@ class MySQLStatementMetrics(object):
         rows = generate_synthetic_rows(rows)
         rows = apply_row_limits(
             rows,
-            self.config.statement_metric_limits or DEFAULT_STATEMENT_METRIC_LIMITS,
+            self.config.statement_metrics_limits or DEFAULT_STATEMENT_METRIC_LIMITS,
             tiebreaker_metric='count',
             tiebreaker_reverse=True,
             key=keyfunc,

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -42,7 +42,7 @@ STATEMENT_METRICS = {
 
 # These limits define the top K and bottom K unique query rows for each metric. For each check run the
 # max metrics sent will be sum of all numbers below (in practice, much less due to overlap in rows).
-DEFAULT_STATEMENT_METRIC_LIMITS = {
+DEFAULT_STATEMENT_METRICS_LIMITS = {
     'count': (400, 0),
     'errors': (100, 0),
     'time': (400, 0),
@@ -111,7 +111,7 @@ class MySQLStatementMetrics(object):
         rows = generate_synthetic_rows(rows)
         rows = apply_row_limits(
             rows,
-            self.config.statement_metrics_limits or DEFAULT_STATEMENT_METRIC_LIMITS,
+            self.config.statement_metrics_limits or DEFAULT_STATEMENT_METRICS_LIMITS,
             tiebreaker_metric='count',
             tiebreaker_reverse=True,
             key=keyfunc,

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -43,20 +43,20 @@ STATEMENT_METRICS = {
 # These limits define the top K and bottom K unique query rows for each metric. For each check run the
 # max metrics sent will be sum of all numbers below (in practice, much less due to overlap in rows).
 DEFAULT_STATEMENT_METRIC_LIMITS = {
-    'count': (800, 0),
+    'count': (400, 0),
     'errors': (100, 0),
-    'time': (800, 0),
-    'select_scan': (100, 0),
-    'select_full_join': (100, 0),
-    'no_index_used': (100, 0),
-    'no_good_index_used': (100, 0),
-    'lock_time': (100, 0),
+    'time': (400, 0),
+    'select_scan': (50, 0),
+    'select_full_join': (50, 0),
+    'no_index_used': (50, 0),
+    'no_good_index_used': (50, 0),
+    'lock_time': (50, 0),
     'rows_affected': (100, 0),
     'rows_sent': (100, 0),
     'rows_examined': (100, 0),
     # Synthetic column limits
-    'avg_time': (800, 0),
-    'rows_sent_ratio': (0, 100),
+    'avg_time': (400, 0),
+    'rows_sent_ratio': (0, 50),
 }
 
 
@@ -111,7 +111,7 @@ class MySQLStatementMetrics(object):
         rows = generate_synthetic_rows(rows)
         rows = apply_row_limits(
             rows,
-            DEFAULT_STATEMENT_METRIC_LIMITS,
+            self.config.statement_metric_limits or DEFAULT_STATEMENT_METRIC_LIMITS,
             tiebreaker_metric='count',
             tiebreaker_reverse=True,
             key=keyfunc,

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -57,7 +57,9 @@ def test_e2e(dd_agent_check, instance_complex):
     aggregator = dd_agent_check(instance_complex)
 
     _assert_complex_config(aggregator)
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=['alice.age', 'bob.age'])
+    aggregator.assert_metrics_using_metadata(
+        get_metadata_metrics(), exclude=['alice.age', 'bob.age'] + variables.STATEMENT_VARS
+    )
 
 
 def _assert_complex_config(aggregator):

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -72,6 +72,7 @@ def _assert_complex_config(aggregator):
         + variables.SYSTEM_METRICS
         + variables.SCHEMA_VARS
         + variables.SYNTHETIC_VARS
+        + variables.STATEMENT_VARS
     )
 
     if MYSQL_VERSION_PARSED >= parse_version('5.6'):
@@ -163,6 +164,7 @@ def test_complex_config_replica(aggregator, instance_complex):
         + variables.SYSTEM_METRICS
         + variables.SCHEMA_VARS
         + variables.SYNTHETIC_VARS
+        + variables.STATEMENT_VARS
     )
 
     if MYSQL_VERSION_PARSED >= parse_version('5.6') and environ.get('MYSQL_FLAVOR') != 'mariadb':
@@ -250,6 +252,70 @@ def test_statement_metrics(aggregator, instance_complex):
             ],
             count=1,
         )
+
+
+def test_generate_synthetic_rows():
+    rows = [
+        {
+            'count': 45,
+            'errors': 1,
+            'time': 1134,
+            'select_scan': 100,
+            'select_full_join': 98,
+            'no_index_used': 54,
+            'no_good_index_used': 12,
+            'lock_time': 1500,
+            'rows_affected': 10,
+            'rows_sent': 20,
+            'rows_examined': 50,
+        },
+        {
+            'count': 0,
+            'errors': 0,
+            'time': 0,
+            'select_scan': 0,
+            'select_full_join': 0,
+            'no_index_used': 0,
+            'no_good_index_used': 0,
+            'lock_time': 0,
+            'rows_affected': 0,
+            'rows_sent': 0,
+            'rows_examined': 0,
+        },
+    ]
+    result = statements.generate_synthetic_rows(rows)
+    assert result == [
+        {
+            'avg_time': 25.2,
+            'count': 45,
+            'errors': 1,
+            'time': 1134,
+            'select_scan': 100,
+            'select_full_join': 98,
+            'no_index_used': 54,
+            'no_good_index_used': 12,
+            'lock_time': 1500,
+            'rows_affected': 10,
+            'rows_sent': 20,
+            'rows_sent_ratio': 0.4,
+            'rows_examined': 50,
+        },
+        {
+            'avg_time': 0,
+            'count': 0,
+            'errors': 0,
+            'time': 0,
+            'select_scan': 0,
+            'select_full_join': 0,
+            'no_index_used': 0,
+            'no_good_index_used': 0,
+            'lock_time': 0,
+            'rows_affected': 0,
+            'rows_sent': 0,
+            'rows_sent_ratio': 0,
+            'rows_examined': 0,
+        },
+    ]
 
 
 def _test_optional_metrics(aggregator, optional_metrics, at_least):

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -230,3 +230,5 @@ PERFORMANCE_VARS = ['mysql.performance.query_run_time.avg', 'mysql.performance.d
 SCHEMA_VARS = ['mysql.info.schema.size']
 
 SYNTHETIC_VARS = ['mysql.performance.qcache.utilization', 'mysql.performance.qcache.utilization.instant']
+
+STATEMENT_VARS = ['dd.mysql.queries.query_rows_raw', 'dd.mysql.queries.query_rows_limited']


### PR DESCRIPTION
### What does this PR do?

This PR moves from tracking metrics for _all_ statements on every check run to only tracking the top statements across declared metrics. Applying this logic in the agent is a temporary measure to reduce cardinality while we build out a new intake to ingest aggregate payloads and do cardinality control on the backend.

To keep more of the "interesting" queries, this also limits the top queries to some "synthetic" metrics that are not actually emitted to the backend, but should be used to keep the top queries (e.g. average time ).

Postgres PR is here: https://github.com/DataDog/integrations-core/pull/8647

### Motivation

Initially the product requirement for statement metrics was to have no limits, but since then we've received more data and feedback from customers that they really only care about the "top" queries.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
