### PR TITLE
Apply default limits to Postres statement metrics

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -192,7 +192,7 @@ files:
         type: boolean
         example: false
         display_default: false
-    - name: statement_metric_limits
+    - name: statement_metrics_limits
       description: |
         Defines the top and bottom limits on queries to track for each metric. These limits apply only to the
         ALPHA features of Deep Database Monitoring. It is recommended to leave these settings at their default

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -192,6 +192,21 @@ files:
         type: boolean
         example: false
         display_default: false
+    - name: statement_metric_limits
+      description: |
+        Defines the top and bottom limits on queries to track for each metric. These limits apply only to the
+        ALPHA features of Deep Database Monitoring. It is recommended to leave these settings at their default
+        values unless instructed otherwise. This API may change in the future.
+
+        If you would like to hear more about Deep Database Monitoring, please reach out to your customer
+        success manager or Datadog support.
+      value:
+        type: object
+        example:
+          calls: [100, 0]
+          time: [100, 0]
+          <METRIC_COLUMN>: [<TOP_K_LIMIT>, <BOTTOM_K_LIMIT>]
+        display_default: false
     - name: pg_stat_statements_view
       description: |
         Set this value if you want to define a custom view or function to allow the datadog user to query the

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -62,6 +62,7 @@ class PostgresConfig:
 
         # Deep Database monitoring adds additional telemetry for statement metrics
         self.deep_database_monitoring = is_affirmative(instance.get('deep_database_monitoring', False))
+        self.statement_metric_limits = instance.get('statement_metric_limits', None)
         # Support a custom view when datadog user has insufficient privilege to see queries
         self.pg_stat_statements_view = instance.get('pg_stat_statements_view', 'pg_stat_statements')
 

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -62,7 +62,7 @@ class PostgresConfig:
 
         # Deep Database monitoring adds additional telemetry for statement metrics
         self.deep_database_monitoring = is_affirmative(instance.get('deep_database_monitoring', False))
-        self.statement_metric_limits = instance.get('statement_metric_limits', None)
+        self.statement_metrics_limits = instance.get('statement_metrics_limits', None)
         # Support a custom view when datadog user has insufficient privilege to see queries
         self.pg_stat_statements_view = instance.get('pg_stat_statements_view', 'pg_stat_statements')
 

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -35,7 +35,7 @@ instances:
     #
     # password: <PASSWORD>
 
-    ## @param dbname - string - optional
+    ## @param dbname - string - optional - default: postgres
     ## The name of the PostgresSQL database to monitor.
     ## Note: If omitted, the default system Postgres database is queried.
     #
@@ -66,7 +66,7 @@ instances:
     #
     # ssl: 'false'
 
-    ## @param query_timeout - integer - optional - default: 1000
+    ## @param query_timeout - integer - optional
     ## Adds a statement_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STATEMENT-TIMEOUT
     ## to all metric collection queries. Aborts any statement that takes more than the specified number of milliseconds,
     ## starting from the time the command arrives at the server from the client. A value of zero turns this off.
@@ -167,7 +167,7 @@ instances:
     #
     # deep_database_monitoring: false
 
-    ## @param statement_metric_limits - mapping - optional
+    ## @param statement_metrics_limits - mapping - optional - default: false
     ## Defines the top and bottom limits on queries to track for each metric. These limits apply only to the
     ## ALPHA features of Deep Database Monitoring. It is recommended to leave these settings at their default
     ## values unless instructed otherwise. This API may change in the future.
@@ -175,7 +175,7 @@ instances:
     ## If you would like to hear more about Deep Database Monitoring, please reach out to your customer
     ## success manager or Datadog support.
     #
-    # statement_metric_limits:
+    # statement_metrics_limits:
     #   calls:
     #   - 100
     #   - 0

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -35,7 +35,7 @@ instances:
     #
     # password: <PASSWORD>
 
-    ## @param dbname - string - optional - default: postgres
+    ## @param dbname - string - optional
     ## The name of the PostgresSQL database to monitor.
     ## Note: If omitted, the default system Postgres database is queried.
     #
@@ -66,7 +66,7 @@ instances:
     #
     # ssl: 'false'
 
-    ## @param query_timeout - integer - optional
+    ## @param query_timeout - integer - optional - default: 1000
     ## Adds a statement_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STATEMENT-TIMEOUT
     ## to all metric collection queries. Aborts any statement that takes more than the specified number of milliseconds,
     ## starting from the time the command arrives at the server from the client. A value of zero turns this off.
@@ -166,6 +166,25 @@ instances:
     ## success manager or Datadog support.
     #
     # deep_database_monitoring: false
+
+    ## @param statement_metric_limits - mapping - optional
+    ## Defines the top and bottom limits on queries to track for each metric. These limits apply only to the
+    ## ALPHA features of Deep Database Monitoring. It is recommended to leave these settings at their default
+    ## values unless instructed otherwise. This API may change in the future.
+    ##
+    ## If you would like to hear more about Deep Database Monitoring, please reach out to your customer
+    ## success manager or Datadog support.
+    #
+    # statement_metric_limits:
+    #   calls:
+    #   - 100
+    #   - 0
+    #   time:
+    #   - 100
+    #   - 0
+    #   <METRIC_COLUMN>:
+    #   - <TOP_K_LIMIT>
+    #   - <BOTTOM_K_LIMIT>
 
     ## @param pg_stat_statements_view - string - optional - default: show_pg_stat_statements()
     ## Set this value if you want to define a custom view or function to allow the datadog user to query the

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -187,7 +187,7 @@ class PostgresStatementMetrics(object):
         rows = generate_synthetic_rows(rows)
         rows = apply_row_limits(
             rows,
-            self.config.statement_metric_limits or DEFAULT_STATEMENT_METRIC_LIMITS,
+            self.config.statement_metrics_limits or DEFAULT_STATEMENT_METRIC_LIMITS,
             tiebreaker_metric='calls',
             tiebreaker_reverse=True,
             key=row_keyfunc

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -190,7 +190,7 @@ class PostgresStatementMetrics(object):
             self.config.statement_metrics_limits or DEFAULT_STATEMENT_METRICS_LIMITS,
             tiebreaker_metric='calls',
             tiebreaker_reverse=True,
-            key=row_keyfunc
+            key=row_keyfunc,
         )
         metrics.append(('dd.postgres.queries.query_rows_limited', len(rows), []))
 

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -65,7 +65,7 @@ PG_STAT_STATEMENTS_TAG_COLUMNS = {
 
 # These limits define the top K and bottom K unique query rows for each metric. For each check run the
 # max metrics sent will be sum of all numbers below (in practice, much less due to overlap in rows).
-DEFAULT_STATEMENT_METRIC_LIMITS = {
+DEFAULT_STATEMENT_METRICS_LIMITS = {
     'calls': (400, 0),
     'total_time': (400, 0),
     'rows': (400, 0),
@@ -187,7 +187,7 @@ class PostgresStatementMetrics(object):
         rows = generate_synthetic_rows(rows)
         rows = apply_row_limits(
             rows,
-            self.config.statement_metrics_limits or DEFAULT_STATEMENT_METRIC_LIMITS,
+            self.config.statement_metrics_limits or DEFAULT_STATEMENT_METRICS_LIMITS,
             tiebreaker_metric='calls',
             tiebreaker_reverse=True,
             key=row_keyfunc

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -66,9 +66,9 @@ PG_STAT_STATEMENTS_TAG_COLUMNS = {
 # These limits define the top K and bottom K unique query rows for each metric. For each check run the
 # max metrics sent will be sum of all numbers below (in practice, much less due to overlap in rows).
 DEFAULT_STATEMENT_METRIC_LIMITS = {
-    'calls': (800, 0),
-    'total_time': (800, 0),
-    'rows': (800, 0),
+    'calls': (400, 0),
+    'total_time': (400, 0),
+    'rows': (400, 0),
     'shared_blks_hit': (50, 0),
     'shared_blks_read': (50, 0),
     'shared_blks_dirtied': (50, 0),
@@ -80,8 +80,8 @@ DEFAULT_STATEMENT_METRIC_LIMITS = {
     'temp_blks_read': (50, 0),
     'temp_blks_written': (50, 0),
     # Synthetic column limits
-    'avg_time': (800, 0),
-    'shared_blks_ratio': (0, 100),
+    'avg_time': (400, 0),
+    'shared_blks_ratio': (0, 50),
 }
 
 
@@ -186,7 +186,11 @@ class PostgresStatementMetrics(object):
 
         rows = generate_synthetic_rows(rows)
         rows = apply_row_limits(
-            rows, DEFAULT_STATEMENT_METRIC_LIMITS, tiebreaker_metric='calls', tiebreaker_reverse=True, key=row_keyfunc
+            rows,
+            self.config.statement_metric_limits or DEFAULT_STATEMENT_METRIC_LIMITS,
+            tiebreaker_metric='calls',
+            tiebreaker_reverse=True,
+            key=row_keyfunc
         )
         metrics.append(('dd.postgres.queries.query_rows_limited', len(rows), []))
 

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -181,10 +181,13 @@ class PostgresStatementMetrics(object):
             return (queryid, row['datname'], row['rolname'])
 
         rows = self._state.compute_derivative_rows(rows, PG_STAT_STATEMENTS_METRIC_COLUMNS.keys(), key=row_keyfunc)
+        metrics.append(('dd.postgres.queries.query_rows_raw', len(rows) , []))
+
         rows = generate_synthetic_rows(rows)
         rows = apply_row_limits(
             rows, DEFAULT_STATEMENT_METRIC_LIMITS, tiebreaker_metric='calls', tiebreaker_reverse=True, key=row_keyfunc
         )
+        metrics.append(('dd.postgres.queries.query_rows_limited', len(rows) , []))
 
         for row in rows:
             try:

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -9,7 +9,7 @@ from pytest import fail
 from semver import VersionInfo
 from six import iteritems
 
-from datadog_checks.postgres import util
+from datadog_checks.postgres import statements, util
 
 from .common import SCHEMA_NAME
 
@@ -260,3 +260,75 @@ def test_query_timeout_connection_string(aggregator, integration_check, pg_insta
     except psycopg2.OperationalError:
         # could not connect to server because there is no server running
         pass
+
+
+def test_generate_synthetic_rows():
+    rows = [
+        {
+            'calls': 45,
+            'total_time': 1134,
+            'rows': 800,
+            'shared_blks_hit': 15,
+            'shared_blks_read': 5,
+            'shared_blks_dirtied': 10,
+            'shared_blks_written': 10,
+            'local_blks_hit': 10,
+            'local_blks_read': 10,
+            'local_blks_dirtied': 10,
+            'local_blks_written': 10,
+            'temp_blks_read': 10,
+            'temp_blks_written': 10,
+        },
+        {
+            'calls': 0,
+            'total_time': 0,
+            'rows': 0,
+            'shared_blks_hit': 0,
+            'shared_blks_read': 0,
+            'shared_blks_dirtied': 0,
+            'shared_blks_written': 0,
+            'local_blks_hit': 0,
+            'local_blks_read': 0,
+            'local_blks_dirtied': 0,
+            'local_blks_written': 0,
+            'temp_blks_read': 0,
+            'temp_blks_written': 10,
+        },
+    ]
+    result = statements.generate_synthetic_rows(rows)
+    assert result == [
+        {
+            'avg_time': 25.2,
+            'calls': 45,
+            'total_time': 1134,
+            'rows': 800,
+            'shared_blks_ratio': 0.75,
+            'shared_blks_hit': 15,
+            'shared_blks_read': 5,
+            'shared_blks_dirtied': 10,
+            'shared_blks_written': 10,
+            'local_blks_hit': 10,
+            'local_blks_read': 10,
+            'local_blks_dirtied': 10,
+            'local_blks_written': 10,
+            'temp_blks_read': 10,
+            'temp_blks_written': 10,
+        },
+        {
+            'avg_time': 0,
+            'calls': 0,
+            'total_time': 0,
+            'rows': 0,
+            'shared_blks_ratio': 0,
+            'shared_blks_hit': 0,
+            'shared_blks_read': 0,
+            'shared_blks_dirtied': 0,
+            'shared_blks_written': 0,
+            'local_blks_hit': 0,
+            'local_blks_read': 0,
+            'local_blks_dirtied': 0,
+            'local_blks_written': 0,
+            'temp_blks_read': 0,
+            'temp_blks_written': 10,
+        },
+    ]


### PR DESCRIPTION
### What does this PR do?

This PR moves from tracking metrics for _all_ statements on every check run to only tracking the top statements across declared metrics. Applying this logic in the agent is a temporary measure to reduce cardinality while we build out a new intake to ingest aggregate payloads and do cardinality control on the backend.

To keep more of the "interesting" queries, this also limits the top queries to some "synthetic" metrics that are not actually emitted to the backend, but should be used to keep the top queries (e.g. average time ).

MySQL PR is here: https://github.com/DataDog/integrations-core/pull/8646

### Motivation

Initially the product requirement for statement metrics was to have no limits, but since then we've received more data and feedback from customers that they really only care about the "top" queries.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
