### PR TITLE
Remove marketplace option for ddev create

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -20,10 +20,12 @@ from .utils import kebab_case_name, normalize_package_name
 TEMPLATES_DIR = path_join(os.path.dirname(os.path.abspath(__file__)), 'templates', 'integration')
 BINARY_EXTENSIONS = ('.png',)
 SIMPLE_NAME = r'^\w+$'
+EXCLUDE_TEMPLATES = {"marketplace"}
 
 
 def get_valid_templates():
-    return sorted(os.listdir(TEMPLATES_DIR))
+    templates = [template for template in os.listdir(TEMPLATES_DIR) if template not in EXCLUDE_TEMPLATES]
+    return sorted(templates)
 
 
 def construct_template_fields(integration_name, repo_choice, **kwargs):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removes the `marketplace` type option for `ddev create` command. 
### Motivation
<!-- What inspired you to submit this pull request? -->
Marketplace integrations are created by setting `repo = "marketplace"` via `ddev config set repo marketplace`. Additionally, the `ddev create -t marketplace` command was not working as expected.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
