### PR TITLE
Fix error printing json errors when error on list object

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -300,7 +300,9 @@ def manifest(ctx, fix):
             if errors:
                 file_failures += 1
                 for error in errors:
-                    display_queue.append((echo_failure, f'  {"->".join(map(str, error.absolute_path))} Error: {error.message}'))
+                    display_queue.append(
+                        (echo_failure, f'  {"->".join(map(str, error.absolute_path))} Error: {error.message}')
+                    )
 
             # guid
             guid = decoded.get('guid')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -300,8 +300,7 @@ def manifest(ctx, fix):
             if errors:
                 file_failures += 1
                 for error in errors:
-                    path_structure = [str(path) for path in error.absolute_path]
-                    display_queue.append((echo_failure, f'  {"->".join(path_structure)} Error: {error.message}'))
+                    display_queue.append((echo_failure, f'  {"->".join(map(str, error.absolute_path))} Error: {error.message}'))
 
             # guid
             guid = decoded.get('guid')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -300,7 +300,8 @@ def manifest(ctx, fix):
             if errors:
                 file_failures += 1
                 for error in errors:
-                    display_queue.append((echo_failure, f'  {"->".join(error.absolute_path)}:{error.message}'))
+                    path_structure = [str(path) for path in error.absolute_path]
+                    display_queue.append((echo_failure, f'  {"->".join(path_structure)} Error: {error.message}'))
 
             # guid
             guid = decoded.get('guid')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes a bug where the error printing fails if the JSON schema error is about a list object. 
Ensures all elements of the jsonschema path are strings before trying to join them together


Resolves errors like:

```
f'  {"->".join(error.absolute_path)}:{error.message}'
*** TypeError: sequence item 1: expected str instance, int found
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
