### PR TITLE
Adding set of recommended monitors

### DIFF
--- a/iis/assets/monitors/err.json
+++ b/iis/assets/monitors/err.json
@@ -1,5 +1,5 @@
 {
-	"name": "[IIS] Increase of not found error per second for site: {{site.name}}",
+	"name": "[IIS] Increase of 404 error per second for site: {{site.name}}",
 	"type": "query alert",
 	"query": "avg(last_4h):anomalies(avg:iis.errors.not_found{*} by {site}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
 	"message": "An increase of not found errors per second for site: {{site.name}}  has been detected over the last 15mins. Typically reported as an HTTP 404 response code.",

--- a/iis/assets/monitors/err.json
+++ b/iis/assets/monitors/err.json
@@ -1,0 +1,34 @@
+{
+	"name": "[IIS] Increase of not found error per second for site: {{site.name}}",
+	"type": "query alert",
+	"query": "avg(last_4h):anomalies(avg:iis.errors.not_found{*} by {site}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+	"message": "An increase of not found errors per second for site: {{site.name}}  has been detected over the last 15mins. Typically reported as an HTTP 404 response code.",
+	"tags": [
+		"integration:iis"
+	],
+	"options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+		"require_full_window": true,
+		"notify_no_data": false,
+		"renotify_interval": 0,
+		"escalation_message": "",
+		"no_data_timeframe": null,
+		"include_tags": true,
+		"thresholds": {
+			"critical": 1,
+			"critical_recovery": 0
+		},
+		"threshold_windows": {
+			"trigger_window": "last_15m",
+			"recovery_window": "last_15m"
+		}
+	},
+	"priority": null,
+	"restricted_roles": null,
+    "recommended_monitor_metadata": {
+        "description": "Notifies when IIS not found error per second are higher than usual for a specific site."
+      }
+}

--- a/iis/assets/monitors/lock.json
+++ b/iis/assets/monitors/lock.json
@@ -29,6 +29,6 @@
 	"priority": null,
 	"restricted_roles": null,
     "recommended_monitor_metadata": {
-        "description": "Notifies when IIS not found error per second are higher than usual for a specific site."
+        "description": "Notifies when IIS not locked error per second are higher than usual for a specific site."
       }
 }

--- a/iis/assets/monitors/lock.json
+++ b/iis/assets/monitors/lock.json
@@ -1,0 +1,34 @@
+{
+	"name": "[IIS] Increase of locked error per second for site: {{site.name}}",
+	"type": "query alert",
+	"query": "avg(last_4h):anomalies(avg:iis.errors.locked{*} by {site}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+	"message": "An increase of locked errors per second for site: {{site.name}}  has been detected over the last 15mins. Typically reported as an HTTP 423 response code.",
+	"tags": [
+		"integration:iis"
+	],
+	"options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+		"require_full_window": true,
+		"notify_no_data": false,
+		"renotify_interval": 0,
+		"escalation_message": "",
+		"no_data_timeframe": null,
+		"include_tags": true,
+		"thresholds": {
+			"critical": 1,
+			"critical_recovery": 0
+		},
+		"threshold_windows": {
+			"trigger_window": "last_15m",
+			"recovery_window": "last_15m"
+		}
+	},
+	"priority": null,
+	"restricted_roles": null,
+    "recommended_monitor_metadata": {
+        "description": "Notifies when IIS not found error per second are higher than usual for a specific site."
+      }
+}

--- a/iis/assets/monitors/req.json
+++ b/iis/assets/monitors/req.json
@@ -1,0 +1,34 @@
+{
+	"name": "[IIS] Anomalous amount of requests for site: {{site.name}}",
+	"type": "query alert",
+	"query": "avg(last_4h):anomalies(avg:iis.httpd_request_method.get{*} by {site} + avg:iis.httpd_request_method.put{*} by {site} + avg:iis.httpd_request_method.head{*} by {site} + avg:iis.httpd_request_method.delete{*} by {site} + avg:iis.httpd_request_method.options{*} by {site}, 'agile', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+	"message": "An anomalous amount of requests for site: {{site.name}} has been detected over the last 15mins.",
+	"tags": [
+		"integration:iis"
+	],
+	"options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+		"require_full_window": true,
+		"notify_no_data": false,
+		"renotify_interval": 0,
+		"escalation_message": "",
+		"no_data_timeframe": null,
+		"include_tags": true,
+		"thresholds": {
+			"critical": 1,
+			"critical_recovery": 0
+		},
+		"threshold_windows": {
+			"trigger_window": "last_15m",
+			"recovery_window": "last_15m"
+		}
+	},
+	"priority": null,
+	"restricted_roles": null,
+    "recommended_monitor_metadata": {
+        "description": "Notifies when IIS requests are higher or lower than usual for a specific site."
+      }
+}

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -25,7 +25,11 @@
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
-    "monitors": {},
+    "monitors": {
+      "[IIS] Anomalous amount of requests for site: {{site.name}}": "assets/monitors/req.json",
+      "[IIS] Increase of not found error per second for site: {{site.name}}": "assets/monitors/err.json",
+      "[IIS] Increase of locked error per second for site: {{site.name}}": "assets/monitors/lock.json"
+    },
     "dashboards": {
       "iis": "assets/dashboards/iis_dashboard.json",
       "IIS-Overview": "assets/dashboards/iis_overview.json"


### PR DESCRIPTION
### What does this PR do?

Adds a set of recommended monitors for HAProxy, following the recommendation of the blog post:

https://www.datadoghq.com/blog/iis-metrics/

Monitors added leverage mostly anomaly monitors:

* [IIS] Anomalous amount of requests for site: {{site.name}}
* [IIS] Increase of not found error per second for site: {{site.name}}
* [IIS] Increase of locked error per second for site: {{site.name}}

### Motivation
More OOTB recommended monitors

