### PR TITLE
Upgrade mkdocs-click

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ markdown_extensions:
   - markdown.extensions.toc:
       permalink: true
       toc_depth: "2-6"
+  - markdown.extensions.attr_list:  # https://github.com/DataDog/mkdocs-click#full-command-path-headers
   # Extra
   - mkdocs-click:
   - mkpatcher:

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     -e./datadog_checks_base[deps,http]
     -e./datadog_checks_dev[cli]
     ; for CLI auto-documentation of ddev
-    mkdocs-click==0.2.*
+    mkdocs-click==0.3.*
 setenv =
     ; Use a set timestamp for reproducible builds.
     ; See https://reproducible-builds.org/specs/source-date-epoch/


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Upgrade `mkdocs-click` to `0.3.*`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Benefit from improvements to improve https://datadoghq.dev/integrations-core/ddev/cli/, in particular:

* New table format -- https://github.com/DataDog/mkdocs-click/pull/25
* Now headers show full command paths (eg `ddev release make all` instead of `all`) -- https://github.com/DataDog/mkdocs-click/pull/36

(Full `mkdocs-click` changelog: https://github.com/DataDog/mkdocs-click/releases/tag/0.3.0)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Here's what it looks like now :-)

![Screenshot 2021-02-19 at 16 01 33](https://user-images.githubusercontent.com/15911462/108521238-ce4ccf80-72cb-11eb-93ac-b0be2b89dabf.png)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
