### PR TITLE
Add legacy check only description

### DIFF
--- a/haproxy/metadata.csv
+++ b/haproxy/metadata.csv
@@ -1,5 +1,4 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-haproxy.backend_hosts,gauge,,host,,Number of backend hosts.,0,haproxy,backend hosts
 haproxy.backend.active.servers,gauge,,,,Current number of active servers.,0,haproxy,
 haproxy.backend.backup.servers,gauge,,,,Current number of backup servers.,0,haproxy,
 haproxy.backend.bytes.in.total,gauge,,byte,,Current total of incoming bytes. By default submitted as count if using prometheus,0,haproxy,
@@ -47,52 +46,33 @@ haproxy.backend.status,gauge,,,,"Current status of the service. <= 2.3: gauge va
 haproxy.backend.total.time.average.seconds,gauge,,,,Avg. total time for last 1024 successful connections.,0,haproxy,
 haproxy.backend.uweight,gauge,,,,Server's user weight or sum of active servers' user weights for a backend (>= 2.4).,0,haproxy,
 haproxy.backend.weight,gauge,,,,Service weight.,0,haproxy,
-haproxy.backend.bytes.in_rate,gauge,,byte,second,Rate of bytes in on backend hosts.,0,haproxy,backend bytes in rate
-haproxy.backend.bytes.out_rate,gauge,,byte,second,Rate of bytes out on backend hosts.,0,haproxy,backend bytes out rate
-haproxy.backend.connect.time,gauge,,millisecond,,Average connect time over the last 1024 backend requests.,0,haproxy,backend conn time
-haproxy.backend.denied.req_rate,gauge,,request,second,Number of backend requests denied due to security concerns.,-1,haproxy,backend den req rate
-haproxy.backend.denied.resp_rate,gauge,,response,second,Number of backend responses denied due to security concerns.,-1,haproxy,backend den resp rate
-haproxy.backend.errors.con_rate,gauge,,error,second,Rate of backend requests that encountered an error trying to connect to a backend server.,-1,haproxy,backend err conn rate
-haproxy.backend.errors.resp_rate,gauge,,error,second,Rate of backend responses aborted due to error.,-1,haproxy,backend err resp rate
-haproxy.backend.queue.current,gauge,,request,,Number of backend requests without an assigned backend.,0,haproxy,backend queue
-haproxy.backend.queue.time,gauge,,millisecond,,Average queue time over the last 1024 backend requests.,0,haproxy,backend queue time
-haproxy.backend.response.1xx,gauge,,response,,Backend HTTP responses with 1xx code.,0,haproxy,backend resp 1xx
-haproxy.backend.response.2xx,gauge,,response,,Backend HTTP responses with 2xx code.,0,haproxy,backend resp 2xx
-haproxy.backend.response.3xx,gauge,,response,,Backend HTTP responses with 3xx code.,0,haproxy,backend resp 3xx
-haproxy.backend.response.4xx,gauge,,response,,Backend HTTP responses with 4xx code.,-1,haproxy,backend resp 4xx
-haproxy.backend.response.5xx,gauge,,response,,Backend HTTP responses with 5xx code.,-1,haproxy,backend resp 5xx
-haproxy.backend.response.other,gauge,,response,,Backend HTTP responses with other code (protocol error).,0,haproxy,backend resp other
-haproxy.backend.response.time,gauge,,millisecond,,Average response time over the last 1024 backend requests (0 for TCP).,-1,haproxy,backend resp time
-haproxy.backend.requests.tot_rate,gauge,,request,second,Rate of total number of backend HTTP requests.,0,haproxy,backend total req rate
-haproxy.backend.session.current,gauge,,connection,,Number of active backend sessions.,0,haproxy,backend sess
-haproxy.backend.session.limit,gauge,,connection,,Configured backend session limit.,0,haproxy,backend sess lim
-haproxy.backend.session.pct,gauge,,percent,,Percentage of sessions in use (backend.session.current/backend.session.limit * 100).,-1,haproxy,backend sess pct
-haproxy.backend.session.rate,gauge,,connection,second,Number of backend sessions created per second.,0,haproxy,backend sess rate
-haproxy.backend.session.time,gauge,,millisecond,,Average total session time over the last 1024 requests.,0,haproxy,backend sess time
-haproxy.backend.uptime,gauge,,second,,Number of seconds since the last UP<->DOWN transition,0,haproxy,backend uptime
-haproxy.backend.warnings.redis_rate,gauge,,error,second,Number of times a request was redispatched to another server.,-1,haproxy,backend warn redis rate
-haproxy.backend.warnings.retr_rate,gauge,,error,second,Number of times a connection to a server was retried.,-1,haproxy,backend warn retry rate
-haproxy.count_per_status,gauge,,host,,Number of hosts by status (UP/DOWN/NOLB/MAINT).,0,haproxy,hosts status
-haproxy.frontend.bytes.in_rate,gauge,,byte,second,Rate of bytes in on frontend hosts.,0,haproxy,frontend bytes in rate
-haproxy.frontend.bytes.out_rate,gauge,,byte,second,Rate of bytes out on frontend hosts.,0,haproxy,frontend bytes out rate
-haproxy.frontend.connections.rate,gauge,,connection,second,Number of connections per second.,0,haproxy,frontend connections rate
-haproxy.frontend.connections.tot_rate,gauge,,connection,second,Rate of total number of frontend connections.,0,haproxy,frontend tot connections rate
-haproxy.frontend.denied.req_rate,gauge,,request,second,Number of frontend requests denied due to security concerns.,-1,haproxy,frontend den req rate
-haproxy.frontend.denied.resp_rate,gauge,,response,second,Number of frontend responses denied due to security concerns.,-1,haproxy,frontend den resp rate
-haproxy.frontend.errors.req_rate,gauge,,error,second,Rate of frontend request errors.,-1,haproxy,frontend err req rate
-haproxy.frontend.requests.intercepted,gauge,,request,second,Number of intercepted frontend requests per second.,0,haproxy,frontend intercepted req rate
-haproxy.frontend.requests.rate,gauge,,request,second,Number of frontend HTTP requests per second.,0,haproxy,frontend req rate
-haproxy.frontend.requests.tot_rate,gauge,,request,second,Rate of total number of frontend HTTP requests.,0,haproxy,frontend total req rate
-haproxy.frontend.response.1xx,gauge,,response,,Frontend HTTP responses with 1xx code.,0,haproxy,frontend resp 1xx
-haproxy.frontend.response.2xx,gauge,,response,,Frontend HTTP responses with 2xx code.,0,haproxy,frontend resp 2xx
-haproxy.frontend.response.3xx,gauge,,response,,Frontend HTTP responses with 3xx code.,0,haproxy,frontend resp 3xx
-haproxy.frontend.response.4xx,gauge,,response,,Frontend HTTP responses with 4xx code.,-1,haproxy,frontend resp 4xx
-haproxy.frontend.response.5xx,gauge,,response,,Frontend HTTP responses with 5xx code.,-1,haproxy,frontend resp 5xx
-haproxy.frontend.response.other,gauge,,response,,Frontend HTTP responses with other code (protocol error).,0,haproxy,frontend resp other
-haproxy.frontend.session.current,gauge,,connection,,Number of active frontend sessions.,0,haproxy,frontend sess
-haproxy.frontend.session.limit,gauge,,connection,,Configured frontend session limit.,0,haproxy,frontend sess lim
-haproxy.frontend.session.pct,gauge,,percent,,Percentage of sessions in use (frontend.session.current/frontend.session.limit * 100).,-1,haproxy,frontend sess pct
-haproxy.frontend.session.rate,gauge,,connection,second,Number of frontend sessions created per second.,0,haproxy,frontend sess rate
+haproxy.backend_hosts,gauge,,host,,Number of backend hosts (legacy check only).,0,haproxy,backend hosts
+haproxy.backend.bytes.in_rate,gauge,,byte,second,Rate of bytes in on backend hosts (legacy check only).,0,haproxy,backend bytes in rate
+haproxy.backend.bytes.out_rate,gauge,,byte,second,Rate of bytes out on backend hosts (legacy check only).,0,haproxy,backend bytes out rate
+haproxy.backend.connect.time,gauge,,millisecond,,Average connect time over the last 1024 backend requests (legacy check only).,0,haproxy,backend conn time
+haproxy.backend.denied.req_rate,gauge,,request,second,Number of backend requests denied due to security concerns (legacy check only).,-1,haproxy,backend den req rate
+haproxy.backend.denied.resp_rate,gauge,,response,second,Number of backend responses denied due to security concerns (legacy check only).,-1,haproxy,backend den resp rate
+haproxy.backend.errors.con_rate,gauge,,error,second,Rate of backend requests that encountered an error trying to connect to a backend server (legacy check only).,-1,haproxy,backend err conn rate
+haproxy.backend.errors.resp_rate,gauge,,error,second,Rate of backend responses aborted due to error (legacy check only).,-1,haproxy,backend err resp rate
+haproxy.backend.queue.current,gauge,,request,,Number of backend requests without an assigned backend (legacy check only).,0,haproxy,backend queue
+haproxy.backend.queue.time,gauge,,millisecond,,Average queue time over the last 1024 backend requests (legacy check only).,0,haproxy,backend queue time
+haproxy.backend.response.1xx,gauge,,response,,Backend HTTP responses with 1xx code (legacy check only).,0,haproxy,backend resp 1xx
+haproxy.backend.response.2xx,gauge,,response,,Backend HTTP responses with 2xx code (legacy check only).,0,haproxy,backend resp 2xx
+haproxy.backend.response.3xx,gauge,,response,,Backend HTTP responses with 3xx code (legacy check only).,0,haproxy,backend resp 3xx
+haproxy.backend.response.4xx,gauge,,response,,Backend HTTP responses with 4xx code (legacy check only).,-1,haproxy,backend resp 4xx
+haproxy.backend.response.5xx,gauge,,response,,Backend HTTP responses with 5xx code (legacy check only).,-1,haproxy,backend resp 5xx
+haproxy.backend.response.other,gauge,,response,,"Backend HTTP responses with other code (protocol error, legacy check only).",0,haproxy,backend resp other
+haproxy.backend.response.time,gauge,,millisecond,,"Average response time over the last 1024 backend requests (0 for TCP, legacy check only).",-1,haproxy,backend resp time
+haproxy.backend.requests.tot_rate,gauge,,request,second,Rate of total number of backend HTTP requests (legacy check only).,0,haproxy,backend total req rate
+haproxy.backend.session.current,gauge,,connection,,Number of active backend sessions (legacy check only).,0,haproxy,backend sess
+haproxy.backend.session.limit,gauge,,connection,,Configured backend session limit (legacy check only).,0,haproxy,backend sess lim
+haproxy.backend.session.pct,gauge,,percent,,"Percentage of sessions in use (backend.session.current/backend.session.limit * 100, legacy check only).",-1,haproxy,backend sess pct
+haproxy.backend.session.rate,gauge,,connection,second,Number of backend sessions created per second (legacy check only).,0,haproxy,backend sess rate
+haproxy.backend.session.time,gauge,,millisecond,,Average total session time over the last 1024 requests (legacy check only).,0,haproxy,backend sess time
+haproxy.backend.uptime,gauge,,second,,Number of seconds since the last UP<->DOWN transition (legacy check only),0,haproxy,backend uptime
+haproxy.backend.warnings.redis_rate,gauge,,error,second,Number of times a request was redispatched to another server (legacy check only).,-1,haproxy,backend warn redis rate
+haproxy.backend.warnings.retr_rate,gauge,,error,second,Number of times a connection to a server was retried (legacy check only).,-1,haproxy,backend warn retry rate
+haproxy.count_per_status,gauge,,host,,Number of hosts by status (UP/DOWN/NOLB/MAINT) (legacy check only).,0,haproxy,hosts status
 haproxy.frontend.bytes.in.total,gauge,,byte,,Current total of incoming bytes. By default submitted as count if using prometheus,0,haproxy,
 haproxy.frontend.bytes.out.total,gauge,,byte,,Current total of outgoing bytes. By default submitted as count if using prometheus,0,haproxy,
 haproxy.frontend.connections.rate.max,gauge,,,,Maximum observed number of connections per second.,0,haproxy,
@@ -121,6 +101,26 @@ haproxy.frontend.requests.denied.total,count,,,,Total number of denied requests.
 haproxy.frontend.responses.denied.total,count,,,,Total number of denied responses.,0,haproxy,
 haproxy.frontend.sessions.total,count,,,,Total number of sessions.,0,haproxy,
 haproxy.frontend.status,gauge,,,,"Current status of the service. <= 2.3: gauge value determines state (frontend: 0=STOP, 1=UP, 2=FULL - backend: 0=DOWN, 1=UP - server: 0=DOWN, 1=UP, 2=MAINT, 3=DRAIN, 4=NOLB). >= 2.4 per state label value.",0,haproxy,
+haproxy.frontend.bytes.in_rate,gauge,,byte,second,Rate of bytes in on frontend hosts (legacy check only).,0,haproxy,frontend bytes in rate
+haproxy.frontend.bytes.out_rate,gauge,,byte,second,Rate of bytes out on frontend hosts (legacy check only).,0,haproxy,frontend bytes out rate
+haproxy.frontend.connections.rate,gauge,,connection,second,Number of connections per second (legacy check only).,0,haproxy,frontend connections rate
+haproxy.frontend.connections.tot_rate,gauge,,connection,second,Rate of total number of frontend connections (legacy check only).,0,haproxy,frontend tot connections rate
+haproxy.frontend.denied.req_rate,gauge,,request,second,Number of frontend requests denied due to security concerns (legacy check only).,-1,haproxy,frontend den req rate
+haproxy.frontend.denied.resp_rate,gauge,,response,second,Number of frontend responses denied due to security concerns (legacy check only).,-1,haproxy,frontend den resp rate
+haproxy.frontend.errors.req_rate,gauge,,error,second,Rate of frontend request errors (legacy check only).,-1,haproxy,frontend err req rate
+haproxy.frontend.requests.intercepted,gauge,,request,second,Number of intercepted frontend requests per second (legacy check only).,0,haproxy,frontend intercepted req rate
+haproxy.frontend.requests.rate,gauge,,request,second,Number of frontend HTTP requests per second (legacy check only).,0,haproxy,frontend req rate
+haproxy.frontend.requests.tot_rate,gauge,,request,second,Rate of total number of frontend HTTP requests (legacy check only).,0,haproxy,frontend total req rate
+haproxy.frontend.response.1xx,gauge,,response,,Frontend HTTP responses with 1xx code (legacy check only).,0,haproxy,frontend resp 1xx
+haproxy.frontend.response.2xx,gauge,,response,,Frontend HTTP responses with 2xx code (legacy check only).,0,haproxy,frontend resp 2xx
+haproxy.frontend.response.3xx,gauge,,response,,Frontend HTTP responses with 3xx code (legacy check only).,0,haproxy,frontend resp 3xx
+haproxy.frontend.response.4xx,gauge,,response,,Frontend HTTP responses with 4xx code (legacy check only).,-1,haproxy,frontend resp 4xx
+haproxy.frontend.response.5xx,gauge,,response,,Frontend HTTP responses with 5xx code (legacy check only).,-1,haproxy,frontend resp 5xx
+haproxy.frontend.response.other,gauge,,response,,Frontend HTTP responses with other code (protocol error) (legacy check only).,0,haproxy,frontend resp other
+haproxy.frontend.session.current,gauge,,connection,,Number of active frontend sessions (legacy check only).,0,haproxy,frontend sess
+haproxy.frontend.session.limit,gauge,,connection,,Configured frontend session limit (legacy check only).,0,haproxy,frontend sess lim
+haproxy.frontend.session.pct,gauge,,percent,,"Percentage of sessions in use (frontend.session.current/frontend.session.limit * 100, legacy check only).",-1,haproxy,frontend sess pct
+haproxy.frontend.session.rate,gauge,,connection,second,Number of frontend sessions created per second (legacy check only).,0,haproxy,frontend sess rate
 haproxy.process.active.peers,gauge,,,,Current number of active peers.,0,haproxy,
 haproxy.process.build_info,gauge,,,,Build info.,0,haproxy,
 haproxy.process.busy.polling.enabled,gauge,,,,Non zero if the busy polling is enabled.,0,haproxy,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add a `legacy check only` description for metrics not sent by the prometheus check.

### Motivation
<!-- What inspired you to submit this pull request? -->
Some of the metrics in the `metadata.csv` are only emitted by the legacy check, other only emitted by the prometheus check, and some are emitted by both check. It can be confusing to know which metric to expect when running the check, so let's be more clear about that

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
