### PR TITLE
Validate metric prefixes for all metric metadata

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -207,6 +207,7 @@ VALID_UNIT_NAMES = {
     'span',
 }
 
+ALLOWED_PREFIXES = ['system', 'jvm', 'http', 'datadog', 'sftp']
 PROVIDER_INTEGRATIONS = {'openmetrics', 'prometheus'}
 
 MAX_DESCRIPTION_LENGTH = 400
@@ -337,7 +338,7 @@ def metadata(check, check_duplicates, show_warnings):
             # metric_name header
             if metric_prefix:
                 prefix = row['metric_name'].split('.')[0]
-                if prefix not in ['system', 'jvm', 'http', 'datadog', 'sftp']:
+                if prefix not in ALLOWED_PREFIXES:
                     if not row['metric_name'].startswith(metric_prefix):
                         metric_prefix_count[prefix] += 1
             else:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -336,10 +336,10 @@ def metadata(check, check_duplicates, show_warnings):
 
             # metric_name header
             if metric_prefix:
-                if not row['metric_name'].startswith(metric_prefix):
-                    prefix = row['metric_name'].split('.')[0]
-                    metric_prefix_count[prefix] += 1
-
+                prefix = row['metric_name'].split('.')[0]
+                if prefix not in ['system', 'jvm', 'http', 'datadog']:
+                    if not row['metric_name'].startswith(metric_prefix):
+                        metric_prefix_count[prefix] += 1
             else:
                 errors = True
                 if not metric_prefix_error_shown and current_check not in PROVIDER_INTEGRATIONS:
@@ -417,7 +417,6 @@ def metadata(check, check_duplicates, show_warnings):
         if show_warnings:
             for header, count in empty_warning_count.items():
                 echo_warning(f'{current_check}: {header} is empty in {count} rows.')
-
 
     if errors:
         abort()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -339,6 +339,7 @@ def metadata(check, check_duplicates, show_warnings):
                 if not row['metric_name'].startswith(metric_prefix):
                     prefix = row['metric_name'].split('.')[0]
                     metric_prefix_count[prefix] += 1
+
             else:
                 errors = True
                 if not metric_prefix_error_shown and current_check not in PROVIDER_INTEGRATIONS:
@@ -407,17 +408,16 @@ def metadata(check, check_duplicates, show_warnings):
             errors = True
             echo_failure(f'{current_check}: {header} is empty in {count} rows.')
 
+        for prefix, count in metric_prefix_count.items():
+            echo_failure(
+                f"{current_check}: `{prefix}` appears {count} time(s) and does not match metric_prefix "
+                "defined in the manifest."
+            )
+
         if show_warnings:
             for header, count in empty_warning_count.items():
                 echo_warning(f'{current_check}: {header} is empty in {count} rows.')
 
-            for prefix, count in metric_prefix_count.items():
-                # Don't spam this warning when we're validating everything
-                if check:
-                    echo_warning(
-                        f"{current_check}: `{prefix}` appears {count} time(s) and does not match metric_prefix "
-                        "defined in the manifest."
-                    )
 
     if errors:
         abort()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -337,7 +337,7 @@ def metadata(check, check_duplicates, show_warnings):
             # metric_name header
             if metric_prefix:
                 prefix = row['metric_name'].split('.')[0]
-                if prefix not in ['system', 'jvm', 'http', 'datadog']:
+                if prefix not in ['system', 'jvm', 'http', 'datadog', 'sftp']:
                     if not row['metric_name'].startswith(metric_prefix):
                         metric_prefix_count[prefix] += 1
             else:


### PR DESCRIPTION
### What does this PR do?
Validate that any metric metadata metric name is prefixed with integration name
### Motivation
Ensure that integrations should only emit metrics from with its namespace.
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
