### PR TITLE
Add `vsphere_cluster` tag from host parent

### DIFF
--- a/vsphere/datadog_checks/vsphere/utils.py
+++ b/vsphere/datadog_checks/vsphere/utils.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-from typing import List, Type
+from typing import List, Optional, Type
 
 from pyVmomi import vim
 from six import iteritems
@@ -86,7 +86,7 @@ def is_metric_excluded_by_filters(metric_name, mor_type, metric_filters):
 
 
 def get_tags_recursively(mor, infrastructure_data, config, include_only=None):
-    # type: (vim.ManagedEntity, InfrastructureData, VSphereConfig, List[str]) -> List[str]
+    # type: (vim.ManagedEntity, InfrastructureData, VSphereConfig, Optional[List[str]]) -> List[str]
     """Go up the resources hierarchy from the given mor. Note that a host running a VM is not considered to be a
     parent of that VM.
 

--- a/vsphere/datadog_checks/vsphere/utils.py
+++ b/vsphere/datadog_checks/vsphere/utils.py
@@ -124,16 +124,16 @@ def get_tags_recursively(mor, infrastructure_data, config, include_only=None):
     parent = infrastructure_data.get(mor, {}).get('parent')
     if parent is None:
         return tags
-    parent_tags = get_tags_recursively(parent, infrastructure_data, config)
-    parent_tags.extend(tags)
-    if include_only:
-        filtered_parent_tags = []
-        for tag in parent_tags:
-            for prefix in include_only:
-                if tag.startswith(prefix + ":"):
-                    filtered_parent_tags.append(tag)
-        parent_tags = filtered_parent_tags
-    return parent_tags
+    tags.extend(get_tags_recursively(parent, infrastructure_data, config))
+    if not include_only:
+        return tags
+    filtered_tags = []
+    for tag in tags:
+        for prefix in include_only:
+            if not tag.startswith(prefix + ":"):
+                continue
+            filtered_tags.append(tag)
+    return filtered_tags
 
 
 def should_collect_per_instance_values(config, metric_name, resource_type):

--- a/vsphere/datadog_checks/vsphere/utils.py
+++ b/vsphere/datadog_checks/vsphere/utils.py
@@ -100,26 +100,26 @@ def get_tags_recursively(mor, infrastructure_data, config, include_only=None):
 
     """
     tags = []
-    parent_props = infrastructure_data.get(mor, {})
-    parent_name = to_string(parent_props.get('name', 'unknown'))
+    properties = infrastructure_data.get(mor, {})
+    entity_name = to_string(properties.get('name', 'unknown'))
     if isinstance(mor, vim.HostSystem):
-        tags.append('vsphere_host:{}'.format(parent_name))
+        tags.append('vsphere_host:{}'.format(entity_name))
     elif isinstance(mor, vim.Folder):
         if isinstance(mor, vim.StoragePod):
-            tags.append('vsphere_datastore_cluster:{}'.format(parent_name))
+            tags.append('vsphere_datastore_cluster:{}'.format(entity_name))
             # Legacy mode: keep it as "folder"
             if config.include_datastore_cluster_folder_tag:
-                tags.append('vsphere_folder:{}'.format(parent_name))
+                tags.append('vsphere_folder:{}'.format(entity_name))
         else:
-            tags.append('vsphere_folder:{}'.format(parent_name))
+            tags.append('vsphere_folder:{}'.format(entity_name))
     elif isinstance(mor, vim.ComputeResource):
         if isinstance(mor, vim.ClusterComputeResource):
-            tags.append('vsphere_cluster:{}'.format(parent_name))
-        tags.append('vsphere_compute:{}'.format(parent_name))
+            tags.append('vsphere_cluster:{}'.format(entity_name))
+        tags.append('vsphere_compute:{}'.format(entity_name))
     elif isinstance(mor, vim.Datacenter):
-        tags.append('vsphere_datacenter:{}'.format(parent_name))
+        tags.append('vsphere_datacenter:{}'.format(entity_name))
     elif isinstance(mor, vim.Datastore):
-        tags.append('vsphere_datastore:{}'.format(parent_name))
+        tags.append('vsphere_datastore:{}'.format(entity_name))
 
     parent = infrastructure_data.get(mor, {}).get('parent')
     if parent is None:

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -238,6 +238,11 @@ class VSphereCheck(AgentCheck):
                 tags.append('vsphere_{}:{}'.format(mor_type_str, mor_name))
 
             tags.extend(get_parent_tags_recursively(mor, infrastructure_data, self.config))
+            tags.extend(
+                get_parent_tags_recursively(
+                    mor, infrastructure_data, self.config, parent_field='runtime.host', include_only=['vsphere_cluster']
+                )
+            )
             tags.append('vsphere_type:{}'.format(mor_type_str))
 
             # Attach tags from fetched attributes.

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -42,7 +42,7 @@ from datadog_checks.vsphere.utils import (
     MOR_TYPE_AS_STRING,
     format_metric_name,
     get_mapped_instance_tag,
-    get_parent_tags_recursively,
+    get_tags_recursively,
     is_metric_excluded_by_filters,
     is_resource_collected_by_filters,
     should_collect_per_instance_values,
@@ -237,12 +237,16 @@ class VSphereCheck(AgentCheck):
             else:
                 tags.append('vsphere_{}:{}'.format(mor_type_str, mor_name))
 
-            tags.extend(get_parent_tags_recursively(mor, infrastructure_data, self.config))
-            tags.extend(
-                get_parent_tags_recursively(
-                    mor, infrastructure_data, self.config, parent_field='runtime.host', include_only=['vsphere_cluster']
+            parent = properties.get('parent')
+            runtime_host = properties.get('runtime.host')
+            if parent is not None:
+                tags.extend(get_tags_recursively(parent, infrastructure_data, self.config))
+            if runtime_host is not None:
+                tags.extend(
+                    get_tags_recursively(
+                        runtime_host, infrastructure_data, self.config, include_only=['vsphere_cluster']
+                    )
                 )
-            )
             tags.append('vsphere_type:{}'.format(mor_type_str))
 
             # Attach tags from fetched attributes.

--- a/vsphere/tests/fixtures/host_tags_values.json
+++ b/vsphere/tests/fixtures/host_tags_values.json
@@ -8,6 +8,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -21,6 +22,7 @@
                 "vsphere_folder:Datacenters",
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -92,6 +94,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -106,6 +109,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -119,6 +123,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -133,6 +138,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -147,6 +153,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -161,6 +168,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -175,6 +183,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -189,6 +198,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -203,6 +213,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -217,6 +228,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -231,6 +243,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -245,6 +258,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -259,6 +273,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -273,6 +288,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -287,6 +303,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -301,6 +318,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "my_cat_name_1:my_tag_name_1",
                 "my_cat_name_2:my_tag_name_2",
@@ -317,6 +335,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -331,6 +350,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -345,6 +365,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -359,6 +380,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]
@@ -373,6 +395,7 @@
                 "vsphere_datacenter:Datacenter2",
                 "vsphere_folder:vm",
                 "vsphere_folder:Discovered virtual machine",
+                "vsphere_cluster:Cluster2",
                 "vsphere_type:vm",
                 "vcenter_server:FAKE"
             ]

--- a/vsphere/tests/fixtures/metrics_realtime_values.json
+++ b/vsphere/tests/fixtures/metrics_realtime_values.json
@@ -10743,6 +10743,7 @@
         "value": 20.0,
         "tags": [
             "vcenter_server:FAKE",
+            "vsphere_cluster:Cluster2",
             "vsphere_datacenter:Datacenter2",
             "vsphere_folder:Datacenters",
             "vsphere_folder:Discovered virtual machine",
@@ -10756,6 +10757,7 @@
         "value": 2.0,
         "tags": [
             "vcenter_server:FAKE",
+            "vsphere_cluster:Cluster2",
             "vsphere_datacenter:Datacenter2",
             "vsphere_folder:Datacenters",
             "vsphere_folder:Discovered virtual machine",
@@ -10769,6 +10771,7 @@
         "value": 1.0,
         "tags": [
             "vcenter_server:FAKE",
+            "vsphere_cluster:Cluster2",
             "vsphere_datacenter:Datacenter2",
             "vsphere_folder:Datacenters",
             "vsphere_folder:vm",

--- a/vsphere/tests/legacy/test_vsphere.py
+++ b/vsphere/tests/legacy/test_vsphere.py
@@ -551,7 +551,7 @@ def test__collect_metrics_async_hostname(vsphere, instance, aggregator):
     aggregator.assert_metric('vsphere.mymetric', value=23.4, hostname="foo")
 
 
-def test_check(vsphere, instance):
+def test_check_run(vsphere, instance):
     """
     Test the check() method
     """

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -118,7 +118,7 @@ def test_external_host_tags(aggregator, realtime_instance):
         ex_tags, sub_tags = ex[1]['vsphere'], sub[1]['vsphere']
         ex_tags = [to_string(t) for t in ex_tags]  # json library loads data in unicode, let's convert back to native
         assert ex_host == sub_host
-        assert ex_tags == sub_tags
+        assert sorted(ex_tags) == sorted(sub_tags)
 
     check.config.excluded_host_tags = ['vsphere_host']
     check.set_external_tags = MagicMock()
@@ -130,7 +130,7 @@ def test_external_host_tags(aggregator, realtime_instance):
         ex_tags, sub_tags = ex[1]['vsphere'], sub[1]['vsphere']
         ex_tags = [to_string(t) for t in ex_tags if 'vsphere_host:' not in t]
         assert ex_host == sub_host
-        assert ex_tags == sub_tags
+        assert sorted(ex_tags) == sorted(sub_tags)
 
     check.set_external_tags = MagicMock()
     check.submit_external_host_tags()


### PR DESCRIPTION
### What does this PR do?

Add `vsphere_cluster` tag from host parent

### Motivation

User request.

### Additional Notes

Hosts are not considered as `parent` of VMs. To attach the correct `vsphere_cluster` to VMs, we need to get `vsphere_cluster` tags using `runtime.host` (ManagedEntity) property.

Example resource tree:

```
Folder:group-1
 |  name: Datacenters
 |  parent: null
 |
 |- Datacenter:datacenter-1
    |  name: XXXX
    |  parent: Folder:group-1
    |
    |- Folder:group-2
    |  |  name: host
    |  |  parent: Datacenter:datacenter-1
    |  |
    |  |- ClusterComputeResource:domain-1
    |     |  name: cluster1
    |     |  parent: Folder:group-2
    |     |
    |     |- HostSystem:host-1
    |          name: myhost.com
    |          parent: ClusterComputeResource:domain-1
    |
    |- Folder:group-3
        |    name: vm
        |    parent: Datacenter:datacenter-1
        |
        |- Folder:group-4
           |     name: FolderX
           |     parent: Folder:group-3
           |
           |- VirtualMachine:vm-1
                guest.hostName: vm1
                name: vm1
                parent: Folder:group-4
                runtime.host: HostSystem:host-1
                runtime.powerState: poweredOn
```

In this case, we want `vm1` (`VirtualMachine:vm-1`) to be tagged with `cluster1` (`ClusterComputeResource:domain-1`)