### PR TITLE
Rename autodiscovery_subnet to network

### DIFF
--- a/snmp/datadog_checks/snmp/data/auto_conf.yaml
+++ b/snmp/datadog_checks/snmp/data/auto_conf.yaml
@@ -82,4 +82,4 @@ instances:
     tags:
       # The autodiscovery subnet the device is part of.
       # Used by Agent autodiscovery to pass subnet name.
-      - "autodiscovery_subnet:%%extra_autodiscovery_subnet%%"
+      - "network:%%extra_network%%"

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -172,7 +172,7 @@ class SnmpCheck(AgentCheck):
         instance['ip_address'] = ip_address
 
         instance.setdefault('tags', [])
-        instance['tags'].append('autodiscovery_subnet:{}'.format(network_address))
+        instance['tags'].append('network:{}'.format(network_address))
 
         return self._build_config(instance)
 
@@ -452,7 +452,7 @@ class SnmpCheck(AgentCheck):
             # At this point, `tags` might include some extra tags added in try clause
 
             # Sending `snmp.devices_monitored` with value 1 will allow users to count devices
-            # by using `sum by {X}` queries in UI. X being a tag like `autodiscovery_subnet`, `snmp_profile`, etc
+            # by using `sum by {X}` queries in UI. X being a tag like `network`, `snmp_profile`, etc
             self.gauge('snmp.devices_monitored', 1, tags=tags)
 
             # Report service checks

--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -76,7 +76,7 @@ def _autodiscovery_ready():
 
     autodiscovery_checks = []
     for result_line in result.stdout.splitlines():
-        if 'autodiscovery_subnet' in result_line:
+        if 'network' in result_line:
             autodiscovery_checks.append(result_line)
 
     # assert subnets discovered by `snmp_listener` config from datadog.yaml

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -900,7 +900,7 @@ def test_discovery(aggregator):
     check_tags = [
         'snmp_device:{}'.format(host),
         'snmp_profile:profile1',
-        'autodiscovery_subnet:{}'.format(to_native_string(network)),
+        'network:{}'.format(to_native_string(network)),
     ]
     network_tags = ['network:{}'.format(network)]
 
@@ -949,7 +949,7 @@ def test_discovery_devices_monitored_count(read_mock, aggregator):
     host = socket.gethostbyname(common.HOST)
     network = ipaddress.ip_network(u'{}/29'.format(host), strict=False).with_prefixlen
     check_tags = [
-        'autodiscovery_subnet:{}'.format(to_native_string(network)),
+        'network:{}'.format(to_native_string(network)),
     ]
     network_tags = ['network:{}'.format(network)]
     instance = {

--- a/snmp/tests/test_e2e.py
+++ b/snmp/tests/test_e2e.py
@@ -67,7 +67,7 @@ def test_e2e_agent_autodiscovery(dd_agent_check, container_ip, autodiscovery_rea
     common_tags = [
         'snmp_profile:generic-router',
         'snmp_device:{}'.format(snmp_device),
-        'autodiscovery_subnet:{}.0/29'.format(subnet_prefix),
+        'network:{}.0/29'.format(subnet_prefix),
     ]
 
     common.assert_common_metrics(aggregator, common_tags, is_e2e=True)
@@ -103,7 +103,7 @@ def test_e2e_agent_autodiscovery(dd_agent_check, container_ip, autodiscovery_rea
     # ==== apc_ups profile ===
     common_tags = [
         'snmp_device:{}'.format(snmp_device),
-        'autodiscovery_subnet:{}.0/28'.format(subnet_prefix),
+        'network:{}.0/28'.format(subnet_prefix),
         'snmp_profile:apc_ups',
         'model:APC Smart-UPS 600',
         'firmware_version:2.0.3-test',
@@ -152,7 +152,7 @@ def test_e2e_agent_autodiscovery(dd_agent_check, container_ip, autodiscovery_rea
     # ==== test snmp v3 ===
     common_tags = [
         'snmp_device:{}'.format(snmp_device),
-        'autodiscovery_subnet:{}.0/27'.format(subnet_prefix),
+        'network:{}.0/27'.format(subnet_prefix),
     ]
 
     common.assert_common_metrics(aggregator, common_tags, is_e2e=True)
@@ -160,7 +160,7 @@ def test_e2e_agent_autodiscovery(dd_agent_check, container_ip, autodiscovery_rea
     # test ignored IPs
     tags = [
         'snmp_device:{}'.format(_build_device_ip(container_ip, '2')),
-        'autodiscovery_subnet:{}.0/27'.format(subnet_prefix),
+        'network:{}.0/27'.format(subnet_prefix),
     ]
     aggregator.assert_metric('snmp.devices_monitored', count=0, tags=tags)
 

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -526,7 +526,7 @@ def test_discovery_tags():
         'snmp_device:192.168.0.2',
         'test:check',
         'snmp_profile:generic-router',
-        'autodiscovery_subnet:192.168.0.0/29',
+        'network:192.168.0.0/29',
     }
 
 
@@ -546,7 +546,7 @@ def test_cache_loading_tags(thread_mock, read_mock):
     check._start_discovery()
 
     config = check._config.discovered_instances['192.168.0.2']
-    assert set(config.tags) == {'autodiscovery_subnet:192.168.0.0/29', 'test:check', 'snmp_device:192.168.0.2'}
+    assert set(config.tags) == {'network:192.168.0.0/29', 'test:check', 'snmp_device:192.168.0.2'}
 
 
 def test_failed_to_collect_metrics():


### PR DESCRIPTION
### What does this PR do?

Rename autodiscovery_subnet to network
Related PRs:

- Requires https://github.com/DataDog/datadog-agent/pull/7513
- https://github.com/DataDog/integrations-core/pull/8685


### Motivation

Friendlier name and better consistency with network as tag key for snmp.discovered_devices_count

