### PR TITLE
Rename network to device_network tag

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/meraki-cloud-controller.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/meraki-cloud-controller.yaml
@@ -33,7 +33,7 @@ metrics:
       - column:
           OID: 1.3.6.1.4.1.29671.1.1.4.1.11
           name: devNetworkName
-        tag: network
+        tag: device_network
   - MIB: MERAKI-CLOUD-CONTROLLER-MIB
     table:
       OID: 1.3.6.1.4.1.29671.1.1.5

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -668,7 +668,7 @@ def test_meraki_cloud_controller(aggregator):
     common.assert_common_metrics(aggregator, common_tags)
 
     dev_metrics = ['devStatus', 'devClientCount']
-    dev_tags = ['device:Gymnasium', 'product:MR16-HW', 'network:L_NETWORK'] + common_tags
+    dev_tags = ['device:Gymnasium', 'product:MR16-HW', 'device_network:L_NETWORK'] + common_tags
     for metric in dev_metrics:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=dev_tags, count=1)
 


### PR DESCRIPTION
### What does this PR do?

Rename network to device_network tag

Related PRs:

- https://github.com/DataDog/datadog-agent/pull/7513
- https://github.com/DataDog/integrations-core/pull/8684

### Motivation

To avoid conflicting with `network` tag used for autodiscovery.


### Additional Notes

- `devClientCount` is not used in monitors ✅ 
- `devStatus` is not used in monitors ✅ 
- `devClientCount` is not used in dashboard TBC
- `devStatus` is not used in dashboard TBC