### PR TITLE
[HOLD see TODO] Add loader config to AD template

### DIFF
--- a/snmp/datadog_checks/snmp/data/auto_conf.yaml
+++ b/snmp/datadog_checks/snmp/data/auto_conf.yaml
@@ -74,6 +74,13 @@ instances:
     #
     context_name: "%%extra_context_name%%"
 
+    ## @param loader - string - optional
+    ## Check loader to use. Available loaders for snmp:
+    ## - core: will use corecheck SNMP integration
+    ## - python: will use python SNMP integration
+    #
+    loader: "%%extra_loader%%"
+
     ## @param tags - list of key:value element - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.
     ##


### PR DESCRIPTION
Related PR: https://github.com/DataDog/datadog-agent/pull/7514

TODO:

- [ ] Check what happen if `extra_loader` is missing when this AD template is used with DCA not containing https://github.com/DataDog/datadog-agent/pull/7514

If user use this new AD template with loader, it will fail here: https://github.com/DataDog/datadog-agent/blob/e081bed84866686eeab56a98da5ff9b4b9f03ded/pkg/autodiscovery/configresolver/configresolver.go#L250-L253
