### PR TITLE
Support XDR metrics for Aerospike Enterprise 5.0+

### DIFF
--- a/aerospike/assets/configuration/spec.yaml
+++ b/aerospike/assets/configuration/spec.yaml
@@ -72,7 +72,7 @@ files:
           - migrate_rx_objs
           - migrate_tx_objs
     - name: namespaces
-      description: all namespaces are collected by default. If you want to collect specific namespaces specify them here.
+      description: All namespaces are collected by default. If you want to collect specific namespaces specify them here.
       value:
         type: array
         items:
@@ -81,7 +81,11 @@ files:
           - example_namespace
           - another_example_namespace
     - name: datacenters
-      description: all datacenters are collected by default. If you want to collect specific datacenters specify them here.
+      description: |
+        For Aerospike v4 or lower, all datacenters are collected by default.
+        If you want to collect specific datacenters specify them here.
+
+        Aerospike v5 or higher, you must specify a list of datacenters to monitor XDR metrics.
       value:
         type: array
         items:

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -28,6 +28,7 @@ SERVICE_CHECK_CONNECT = '%s.can_connect' % SOURCE_TYPE_NAME
 DATACENTER_SERVICE_CHECK_CONNECT = '%s.datacenter.can_connect' % SOURCE_TYPE_NAME
 CLUSTER_METRIC_TYPE = SOURCE_TYPE_NAME
 DATACENTER_METRIC_TYPE = '%s.datacenter' % SOURCE_TYPE_NAME
+XDR_DATACENTER_METRIC_TYPE = '%s.xdr_dc' % SOURCE_TYPE_NAME
 NAMESPACE_METRIC_TYPE = '%s.namespace' % SOURCE_TYPE_NAME
 NAMESPACE_TPS_METRIC_TYPE = '%s.namespace.tps' % SOURCE_TYPE_NAME
 NAMESPACE_LATENCY_METRIC_TYPE = '%s.namespace.latency' % SOURCE_TYPE_NAME
@@ -233,9 +234,30 @@ class AerospikeCheck(AgentCheck):
         if self._required_datacenters:
             for dc in self._required_datacenters:
                 datacenter_tags = ['datacenter:{}'.format(dc)]
-                # Do not separate because of multiple dc output
                 data = self.get_info('get-stats:context=xdr;dc={}'.format(dc), separator=None)
                 self.log.debug("Got data for dc `%s`: %s", dc, data)
+                parsed_data = data.split("\n")
+                tags = list()
+                for line in parsed_data:
+                    line = line.strip()
+                    if 'returned' in line:
+                        # Parse remote dc host and port from
+                        # `ip-10-10-17-247.ec2.internal:3000 (10.10.17.247) returned:`
+                        remote_dc = line.split(" (")[0].split(":")
+                        tags = [
+                            'remote_dc_host:{}'.format(remote_dc[0]),
+                            'remote_dc_port:{}'.format(remote_dc[1]),
+                        ] + datacenter_tags
+                    else:
+                        # Parse metrics from
+                        # lag=0;in_queue=0;in_progress=0;success=98344698;abandoned=0;not_found=0;filtered_out=0;...
+                        xdr_metrics = line.split(';')
+                        self.log.debug("For dc host tags {}, got: {}".format(tags, xdr_metrics))
+                        for item in xdr_metrics:
+                            metric = item.split('=')
+                            key = metric[0]
+                            value = metric[1]
+                            self.send(XDR_DATACENTER_METRIC_TYPE, key, value, tags)
         else:
             self.log.debug("No datacenters were specified to collect XDR metrics: %s", self._required_datacenters)
 

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -239,7 +239,6 @@ class AerospikeCheck(AgentCheck):
             for dc in self._required_datacenters:
                 datacenter_tags = ['datacenter:{}'.format(dc)]
                 data = self.get_info('get-stats:context=xdr;dc={}'.format(dc), separator=None)
-                self.log.debug("Got metrics for dc %s: %s", dc, data)
                 if not data:
                     self.log.debug("Got invalid data for dc %s", dc)
                     continue

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -242,6 +242,8 @@ class AerospikeCheck(AgentCheck):
                 if not data:
                     self.log.debug("Got invalid data for dc %s", dc)
                     continue
+                if data.startswith('ERROR:'):
+                    self.log.debug("Error collecting XDR metrics: %s", data)
                 self.log.debug("Got data for dc `%s`: %s", dc, data)
                 parsed_data = data.split("\n")
                 tags = list()

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -247,24 +247,26 @@ class AerospikeCheck(AgentCheck):
                 tags = list()
                 for line in parsed_data:
                     line = line.strip()
-                    if 'returned' in line:
-                        # Parse remote dc host and port from
-                        # `ip-10-10-17-247.ec2.internal:3000 (10.10.17.247) returned:`
-                        remote_dc = line.split(" (")[0].split(":")
-                        tags = [
-                            'remote_dc_host:{}'.format(remote_dc[0]),
-                            'remote_dc_port:{}'.format(remote_dc[1]),
-                        ] + datacenter_tags
-                    else:
-                        # Parse metrics from
-                        # lag=0;in_queue=0;in_progress=0;success=98344698;abandoned=0;not_found=0;filtered_out=0;...
-                        xdr_metrics = line.split(';')
-                        self.log.debug("For dc host tags %s, got: %s", tags, xdr_metrics)
-                        for item in xdr_metrics:
-                            metric = item.split('=')
-                            key = metric[0]
-                            value = metric[1]
-                            self.send(XDR_DATACENTER_METRIC_TYPE, key, value, tags)
+                    if line:
+                        if 'returned' in line:
+                            # Parse remote dc host and port from
+                            # `ip-10-10-17-247.ec2.internal:3000 (10.10.17.247) returned:`
+                            remote_dc = line.split(" (")[0].split(":")
+                            tags = [
+                                'remote_dc_host:{}'.format(remote_dc[0]),
+                                'remote_dc_port:{}'.format(remote_dc[1]),
+                            ] + datacenter_tags
+                        else:
+                            if line
+                            # Parse metrics from
+                            # lag=0;in_queue=0;in_progress=0;success=98344698;abandoned=0;not_found=0;filtered_out=0;...
+                            xdr_metrics = line.split(';')
+                            self.log.debug("For dc host tags %s, got: %s", tags, xdr_metrics)
+                            for item in xdr_metrics:
+                                metric = item.split('=')
+                                key = metric[0]
+                                value = metric[1]
+                                self.send(XDR_DATACENTER_METRIC_TYPE, key, value, tags)
         else:
             self.log.debug("No datacenters were specified to collect XDR metrics: %s", self._required_datacenters)
 

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -239,6 +239,7 @@ class AerospikeCheck(AgentCheck):
             for dc in self._required_datacenters:
                 datacenter_tags = ['datacenter:{}'.format(dc)]
                 data = self.get_info('get-stats:context=xdr;dc={}'.format(dc), separator=None)
+                self.log.debug("Got metrics for dc %s: %s", dc, data)
                 if not data:
                     self.log.debug("Got invalid data for dc %s", dc)
                     continue
@@ -257,7 +258,6 @@ class AerospikeCheck(AgentCheck):
                                 'remote_dc_port:{}'.format(remote_dc[1]),
                             ] + datacenter_tags
                         else:
-                            if line
                             # Parse metrics from
                             # lag=0;in_queue=0;in_progress=0;success=98344698;abandoned=0;not_found=0;filtered_out=0;...
                             xdr_metrics = line.split(';')

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -253,10 +253,12 @@ class AerospikeCheck(AgentCheck):
                             # Parse remote dc host and port from
                             # `ip-10-10-17-247.ec2.internal:3000 (10.10.17.247) returned:`
                             remote_dc = line.split(" (")[0].split(":")
-                            tags.extend([
-                                'remote_dc_host:{}'.format(remote_dc[0]),
-                                'remote_dc_port:{}'.format(remote_dc[1]),
-                            ])
+                            tags.extend(
+                                [
+                                    'remote_dc_host:{}'.format(remote_dc[0]),
+                                    'remote_dc_port:{}'.format(remote_dc[1]),
+                                ]
+                            )
                         else:
                             # Parse metrics from
                             # lag=0;in_queue=0;in_progress=0;success=98344698;abandoned=0;not_found=0;filtered_out=0;...

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -241,14 +241,16 @@ class AerospikeCheck(AgentCheck):
                 if not data:
                     self.log.debug("Got invalid data for dc %s", dc)
                     continue
-                if data.startswith('ERROR:'):
-                    self.log.debug("Error collecting XDR metrics: %s", data)
                 self.log.debug("Got data for dc `%s`: %s", dc, data)
                 parsed_data = data.split("\n")
                 tags = ['datacenter:{}'.format(dc)]
                 for line in parsed_data:
                     line = line.strip()
                     if line:
+                        if line.startswith('ERROR:'):
+                            self.log.debug("Error collecting XDR metrics: %s", data)
+                            continue
+
                         if 'returned' in line:
                             # Parse remote dc host and port from
                             # `ip-10-10-17-247.ec2.internal:3000 (10.10.17.247) returned:`

--- a/aerospike/datadog_checks/aerospike/data/conf.yaml.example
+++ b/aerospike/datadog_checks/aerospike/data/conf.yaml.example
@@ -65,14 +65,17 @@ instances:
     #   - migrate_tx_objs
 
     ## @param namespaces - list of strings - optional
-    ## all namespaces are collected by default. If you want to collect specific namespaces specify them here.
+    ## All namespaces are collected by default. If you want to collect specific namespaces specify them here.
     #
     # namespaces:
     #   - example_namespace
     #   - another_example_namespace
 
     ## @param datacenters - list of strings - optional
-    ## all datacenters are collected by default. If you want to collect specific datacenters specify them here.
+    ## For Aerospike v4 or lower, all datacenters are collected by default.
+    ## If you want to collect specific datacenters specify them here.
+    ##
+    ## Aerospike v5 or higher, you must specify a list of datacenters to monitor XDR metrics.
     #
     # datacenters:
     #   - example_datacenter

--- a/aerospike/tests/common.py
+++ b/aerospike/tests/common.py
@@ -105,6 +105,11 @@ MOCK_DATACENTER_METRICS = [
     'dc_as_size=2',
 ]
 
+MOCK_XDR_DATACENTER_METRICS = """
+ip-10-10-17-247.ec2.internal:3000 (10.10.17.247) returned:\n
+lag=0;in_queue=0;in_progress=0;success=98344698;abandoned=0;not_found=0;filtered_out=0;retry_no_node=0;retry_conn_reset=775483;retry_dest=0;recoveries=293;recoveries_pending=0;hot_keys=20291210;uncompressed_pct=0.000;compression_ratio=1.000;throughput=0;latency_ms=17;lap_us=348    
+"""
+
 
 DATACENTER_METRICS = [
     'aerospike.datacenter.dc_timelag',
@@ -122,4 +127,25 @@ DATACENTER_METRICS = [
     'aerospike.datacenter.dc_size',
     'aerospike.datacenter.dc_as_open_conn',
     'aerospike.datacenter.dc_as_size',
+]
+
+XDR_DC_METRICS = [
+    'aerospike.xdr_dc.lag',
+    'aerospike.xdr_dc.in_queue',
+    'aerospike.xdr_dc.in_progress',
+    'aerospike.xdr_dc.success',
+    'aerospike.xdr_dc.abandoned',
+    'aerospike.xdr_dc.not_found',
+    'aerospike.xdr_dc.filtered_out',
+    'aerospike.xdr_dc.retry_no_node',
+    'aerospike.xdr_dc.retry_conn_reset',
+    'aerospike.xdr_dc.retry_dest',
+    'aerospike.xdr_dc.recoveries',
+    'aerospike.xdr_dc.recoveries_pending',
+    'aerospike.xdr_dc.hot_keys',
+    'aerospike.xdr_dc.uncompressed_pct',
+    'aerospike.xdr_dc.compression_ratio',
+    'aerospike.xdr_dc.throughput',
+    'aerospike.xdr_dc.latency_ms',
+    'aerospike.xdr_dc.lap_us',
 ]

--- a/aerospike/tests/common.py
+++ b/aerospike/tests/common.py
@@ -107,9 +107,8 @@ MOCK_DATACENTER_METRICS = [
 
 MOCK_XDR_DATACENTER_METRICS = """
 ip-10-10-17-247.ec2.internal:3000 (10.10.17.247) returned:\n
-lag=0;in_queue=0;in_progress=0;success=98344698;abandoned=0;not_found=0;filtered_out=0;retry_no_node=0;retry_conn_reset=775483;retry_dest=0;recoveries=293;recoveries_pending=0;hot_keys=20291210;uncompressed_pct=0.000;compression_ratio=1.000;throughput=0;latency_ms=17;lap_us=348    
+lag=0;in_queue=0;in_progress=0;success=98344698;abandoned=0;not_found=0;filtered_out=0;retry_no_node=0;retry_conn_reset=775483;retry_dest=0;recoveries=293;recoveries_pending=0;hot_keys=20291210;uncompressed_pct=0.000;compression_ratio=1.000;throughput=0;latency_ms=17;lap_us=348
 """
-
 
 DATACENTER_METRICS = [
     'aerospike.datacenter.dc_timelag',

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -39,7 +39,14 @@ def test_datacenter_metrics(aggregator):
 def test_xdr_metrics(aggregator):
     check = AerospikeCheck('aerospike', {}, [common.INSTANCE])
     check.get_info = mock.MagicMock(
-        return_value="ip-10-10-17-247.ec2.internal:3000 (10.10.17.247) returned:\nlag=0;in_queue=0;in_progress=0;success=98344698;abandoned=0;not_found=0;filtered_out=0;retry_no_node=0;retry_conn_reset=775483;retry_dest=0;recoveries=293;recoveries_pending=0;hot_keys=20291210;uncompressed_pct=0.000;compression_ratio=1.000;throughput=0;latency_ms=17;lap_us=348    \n\nip-10-10-17-144.ec2.internal:3000 (10.10.17.144) returned:\nlag=0;in_queue=0;in_progress=0;success=98294822;abandoned=0;not_found=0;filtered_out=0;retry_no_node=0;retry_conn_reset=813513;retry_dest=0;recoveries=293;recoveries_pending=0;hot_keys=20286479;uncompressed_pct=0.000;compression_ratio=1.000;throughput=0;latency_ms=14;lap_us=232\n\n"
+        return_value="ip-10-10-17-247.ec2.internal:3000 (10.10.17.247) returned:\nlag=0;in_queue=0;in_progress=0;"
+        "success=98344698;abandoned=0;not_found=0;filtered_out=0;retry_no_node=0;retry_conn_reset=775483;"
+        "retry_dest=0;recoveries=293;recoveries_pending=0;hot_keys=20291210;uncompressed_pct=0.000;"
+        "compression_ratio=1.000;throughput=0;latency_ms=17;lap_us=348    \n\nip-10-10-17-144.ec2.internal"
+        ":3000 (10.10.17.144) returned:\nlag=0;in_queue=0;in_progress=0;success=98294822;abandoned=0;"
+        "not_found=0;filtered_out=0;retry_no_node=0;retry_conn_reset=813513;retry_dest=0;recoveries=293;"
+        "recoveries_pending=0;hot_keys=20286479;uncompressed_pct=0.000;compression_ratio=1.000;"
+        "throughput=0;latency_ms=14;lap_us=232\n\n"
     )
     check.collect_xdr()
 

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -38,22 +38,19 @@ def test_datacenter_metrics(aggregator):
 
 def test_xdr_metrics(aggregator):
     check = AerospikeCheck('aerospike', {}, [common.INSTANCE])
-    original_get_info = check.get_info
+    check.get_info = mock.MagicMock(
+        return_value="""
+        ip-10-10-17-247.ec2.internal:3000 (10.10.17.247) returned:\nlag=0;in_queue=0;in_progress=0;success=98344698;
+        abandoned=0;not_found=0;filtered_out=0;retry_no_node=0;retry_conn_reset=775483;retry_dest=0;recoveries=293;
+        recoveries_pending=0;hot_keys=20291210;uncompressed_pct=0.000;compression_ratio=1.000;throughput=0;
+        latency_ms=17;lap_us=348    \n\nip-10-10-17-144.ec2.internal:3000 (10.10.17.144) returned:\nlag=0;
+        in_queue=0;in_progress=0;success=98294822;abandoned=0;not_found=0;filtered_out=0;retry_no_node=0;
+        retry_conn_reset=813513;retry_dest=0;recoveries=293;recoveries_pending=0;hot_keys=20286479;
+        uncompressed_pct=0.000;compression_ratio=1.000;throughput=0;latency_ms=14;lap_us=232\n\n
+        """
+    )
+    check.collect_latency(None)
 
-    def mock_get_info(command, separator=None):
-        if command.startswith('get-stats:context=xdr;dc='):
-            return common.MOCK_XDR_DATACENTER_METRICS
-
-        return original_get_info(command, separator)
-
-    check.get_info = mock_get_info
-    check._client = mock.MagicMock()
-    check.get_namespaces = mock.MagicMock()
-    check.collect_info = mock.MagicMock()
-    check.collect_throughput = mock.MagicMock()
-    check.collect_latency = mock.MagicMock()
-    check.collect_xdr = mock.MagicMock()
-    check.check(None)
     for metric in common.XDR_DC_METRICS:
         aggregator.assert_metric(metric)
 

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -49,7 +49,7 @@ def test_xdr_metrics(aggregator):
         uncompressed_pct=0.000;compression_ratio=1.000;throughput=0;latency_ms=14;lap_us=232\n\n
         """
     )
-    check.collect_latency(None)
+    check.collect_xdr()
 
     for metric in common.XDR_DC_METRICS:
         aggregator.assert_metric(metric)

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -54,6 +54,17 @@ def test_xdr_metrics(aggregator):
         aggregator.assert_metric(metric)
 
 
+def test_collect_xdr_invalid_data(aggregator):
+    check = AerospikeCheck('aerospike', {}, [common.INSTANCE])
+    check.get_info = mock.MagicMock(return_value=["ERROR::XDR-not-configured"])
+    check.log = mock.MagicMock()
+    check.collect_xdr(None)
+
+    check.log.debug.assert_called_with('Error collecting XDR metrics: ERROR::XDR-not-configured')
+
+    aggregator.assert_all_metrics_covered()  # no metric
+
+
 def test_connection_uses_tls():
     instance = copy.deepcopy(common.INSTANCE)
     tls_config = {'cafile': 'my-ca-file', 'certfile': 'my-certfile', 'keyfile': 'my-keyfile'}

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -39,15 +39,7 @@ def test_datacenter_metrics(aggregator):
 def test_xdr_metrics(aggregator):
     check = AerospikeCheck('aerospike', {}, [common.INSTANCE])
     check.get_info = mock.MagicMock(
-        return_value="""
-        ip-10-10-17-247.ec2.internal:3000 (10.10.17.247) returned:\nlag=0;in_queue=0;in_progress=0;success=98344698;
-        abandoned=0;not_found=0;filtered_out=0;retry_no_node=0;retry_conn_reset=775483;retry_dest=0;recoveries=293;
-        recoveries_pending=0;hot_keys=20291210;uncompressed_pct=0.000;compression_ratio=1.000;throughput=0;
-        latency_ms=17;lap_us=348    \n\nip-10-10-17-144.ec2.internal:3000 (10.10.17.144) returned:\nlag=0;
-        in_queue=0;in_progress=0;success=98294822;abandoned=0;not_found=0;filtered_out=0;retry_no_node=0;
-        retry_conn_reset=813513;retry_dest=0;recoveries=293;recoveries_pending=0;hot_keys=20286479;
-        uncompressed_pct=0.000;compression_ratio=1.000;throughput=0;latency_ms=14;lap_us=232\n\n
-        """
+        return_value="ip-10-10-17-247.ec2.internal:3000 (10.10.17.247) returned:\nlag=0;in_queue=0;in_progress=0;success=98344698;abandoned=0;not_found=0;filtered_out=0;retry_no_node=0;retry_conn_reset=775483;retry_dest=0;recoveries=293;recoveries_pending=0;hot_keys=20291210;uncompressed_pct=0.000;compression_ratio=1.000;throughput=0;latency_ms=17;lap_us=348    \n\nip-10-10-17-144.ec2.internal:3000 (10.10.17.144) returned:\nlag=0;in_queue=0;in_progress=0;success=98294822;abandoned=0;not_found=0;filtered_out=0;retry_no_node=0;retry_conn_reset=813513;retry_dest=0;recoveries=293;recoveries_pending=0;hot_keys=20286479;uncompressed_pct=0.000;compression_ratio=1.000;throughput=0;latency_ms=14;lap_us=232\n\n"
     )
     check.collect_xdr()
 

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -71,9 +71,8 @@ def test_multiple_xdr_metrics(aggregator):
 
 def test_collect_xdr_invalid_data(aggregator):
     check = AerospikeCheck('aerospike', {}, [common.INSTANCE])
-    check.get_info = mock.MagicMock(return_value=[])
     check.log = mock.MagicMock()
-    with mock.patch('requests.get', side_effect="ERROR::XDR-not-configured"):
+    with mock.patch('datadog_checks.aerospike.aerospike.get_info', side_effect="ERROR::XDR-not-configured"):
         check.collect_xdr()
         check.log.debug.assert_called_with('Error collecting XDR metrics: ERROR::XDR-not-configured')
 

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -74,7 +74,7 @@ def test_collect_xdr_invalid_data(aggregator):
     check.log = mock.MagicMock()
     with mock.patch('datadog_checks.aerospike.AerospikeCheck.get_info', return_value="ERROR::XDR-not-configured"):
         check.collect_xdr()
-        check.log.debug.assert_called_with('Error collecting XDR metrics: ERROR::XDR-not-configured')
+        check.log.debug.assert_called_with('Error collecting XDR metrics: %s', 'ERROR::XDR-not-configured')
 
     aggregator.assert_all_metrics_covered()  # no metric
 

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -72,7 +72,7 @@ def test_multiple_xdr_metrics(aggregator):
 def test_collect_xdr_invalid_data(aggregator):
     check = AerospikeCheck('aerospike', {}, [common.INSTANCE])
     check.log = mock.MagicMock()
-    with mock.patch('datadog_checks.aerospike.aerospike.get_info', side_effect="ERROR::XDR-not-configured"):
+    with mock.patch('datadog_checks.aerospike.AerospikeCheck.get_info', side_effect="ERROR::XDR-not-configured"):
         check.collect_xdr()
         check.log.debug.assert_called_with('Error collecting XDR metrics: ERROR::XDR-not-configured')
 

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -72,7 +72,7 @@ def test_multiple_xdr_metrics(aggregator):
 def test_collect_xdr_invalid_data(aggregator):
     check = AerospikeCheck('aerospike', {}, [common.INSTANCE])
     check.log = mock.MagicMock()
-    with mock.patch('datadog_checks.aerospike.AerospikeCheck.get_info', side_effect="ERROR::XDR-not-configured"):
+    with mock.patch('datadog_checks.aerospike.AerospikeCheck.get_info', return_value="ERROR::XDR-not-configured"):
         check.collect_xdr()
         check.log.debug.assert_called_with('Error collecting XDR metrics: ERROR::XDR-not-configured')
 

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -39,6 +39,19 @@ def test_datacenter_metrics(aggregator):
 def test_xdr_metrics(aggregator):
     check = AerospikeCheck('aerospike', {}, [common.INSTANCE])
     check.get_info = mock.MagicMock(
+        return_value="lag=0;in_queue=0;in_progress=0;success=0;abandoned=0;not_found=0;filtered_out=0;"
+        "retry_no_node=0;retry_conn_reset=0;retry_dest=0;recoveries=0;recoveries_pending=0;hot_keys=0;"
+        "uncompressed_pct=0.000;compression_ratio=1.000;nodes=0;throughput=0;latency_ms=0;lap_us=1"
+    )
+    check.collect_xdr()
+
+    for metric in common.XDR_DC_METRICS:
+        aggregator.assert_metric(metric, tags=['datacenter:test'])
+
+
+def test_multiple_xdr_metrics(aggregator):
+    check = AerospikeCheck('aerospike', {}, [common.INSTANCE])
+    check.get_info = mock.MagicMock(
         return_value="ip-10-10-17-247.ec2.internal:3000 (10.10.17.247) returned:\nlag=0;in_queue=0;in_progress=0;"
         "success=98344698;abandoned=0;not_found=0;filtered_out=0;retry_no_node=0;retry_conn_reset=775483;"
         "retry_dest=0;recoveries=293;recoveries_pending=0;hot_keys=20291210;uncompressed_pct=0.000;"
@@ -49,18 +62,20 @@ def test_xdr_metrics(aggregator):
         "throughput=0;latency_ms=14;lap_us=232\n\n"
     )
     check.collect_xdr()
-
-    for metric in common.XDR_DC_METRICS:
-        aggregator.assert_metric(metric)
+    for host in ['ip-10-10-17-247.ec2.internal', 'ip-10-10-17-144.ec2.internal']:
+        for metric in common.XDR_DC_METRICS:
+            aggregator.assert_metric(
+                metric, tags=['datacenter:test', 'remote_dc_port:3000', 'remote_dc_host:{}'.format(host)]
+            )
 
 
 def test_collect_xdr_invalid_data(aggregator):
     check = AerospikeCheck('aerospike', {}, [common.INSTANCE])
-    check.get_info = mock.MagicMock(return_value=["ERROR::XDR-not-configured"])
+    check.get_info = mock.MagicMock(return_value=[])
     check.log = mock.MagicMock()
-    check.collect_xdr(None)
-
-    check.log.debug.assert_called_with('Error collecting XDR metrics: ERROR::XDR-not-configured')
+    with mock.patch('requests.get', side_effect="ERROR::XDR-not-configured"):
+        check.collect_xdr()
+        check.log.debug.assert_called_with('Error collecting XDR metrics: ERROR::XDR-not-configured')
 
     aggregator.assert_all_metrics_covered()  # no metric
 


### PR DESCRIPTION
### What does this PR do?
This PR supports for XDR metrics introduced in Aerospike 5.0+
### Motivation
The `dcs` command was removed along with `xdr_` metrics under the statistics command.
https://www.aerospike.com/docs/operations/configure/cross-datacenter/parameters_and_metrics.html#xdr-metrics-removed-in-version-5-0
### Additional Notes
These metrics are Aerospike Enterprise only

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
