### PR TITLE
Add ddev example committer tool

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/__init__.py
@@ -6,13 +6,14 @@ import click
 from ..console import CONTEXT_SETTINGS
 from .catalog import catalog
 from .changes import changes
+from .create_commits import create_example_commits
 from .dashboard import dash
 from .jmx import jmx
 from .prometheus import prom
 from .scripts import scripts
 from .snmp import snmp
 
-ALL_COMMANDS = (catalog, changes, dash, jmx, prom, scripts, snmp)
+ALL_COMMANDS = (catalog, changes, create_example_commits, dash, jmx, prom, scripts, snmp)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Collection of useful utilities')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/create_commits.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/create_commits.py
@@ -1,0 +1,62 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+import os
+import shutil
+
+import click
+
+from ...constants import get_root
+from ...git import get_current_branch, git_commit
+from ..console import CONTEXT_SETTINGS, abort, echo_info
+
+"""
+This script will create sequential commits on a branch in the specified repo,
+to demonstrate the process of building a new integration.
+
+It first checks to make sure the "master" or "main" branches are not active, then proceeds
+to copy and commit the contents of each of the folders in this directory.
+
+Argument `source_dir` should be a directory with numbered subdirectories in the order
+of commits.  The name of the subdirectory will be the commit message, and the contents
+will be committed to the repo on the feature branch in ascending order.
+
+"""
+
+
+@click.command(context_settings=CONTEXT_SETTINGS, short_help='Create branch commits from example repo')
+@click.argument('source_dir')
+@click.option('--prefix', '-p', default='', help='Optional text to prefix each commit')
+@click.pass_context
+def create_example_commits(ctx, source_dir, prefix):
+    repo_choice = ctx.obj['repo_choice']
+    root = get_root()
+    branch = get_current_branch()
+    source_dir = os.path.expanduser(source_dir)
+
+    if not os.path.exists(source_dir):
+        abort(f'Source directory path `{source_dir}`, not found')
+
+    echo_info(f'Using `{source_dir}` as source directory ...')
+
+    if branch in ('master', 'main'):
+        abort(f'Change to a feature branch on `{repo_choice}`, and rerun the command.')
+
+    echo_info(f'Destination repo `{repo_choice}` on branch `{branch}` located at `{root}` ...')
+
+    stages = [x for x in sorted(os.listdir(source_dir)) if x[0].isdigit()]
+    echo_info(f"Found the following stages to commit: {', '.join(stages)}")
+
+    for stage in stages:
+        base = os.path.join(source_dir, stage)
+        targets = []
+        for contents in os.listdir(base):
+            target = os.path.join(get_root(), contents)
+            shutil.copytree(os.path.join(base, contents), target, dirs_exist_ok=True)
+            targets.append(target)
+
+        echo_info(f'Committing files from {targets} under commit {stage} ..')
+        git_commit(targets, f'{prefix} {stage}')
+
+    echo_info('Done.')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -98,7 +98,7 @@ def git_commit(targets, message, force=False, sign=False, update=False):
     """
     Commit the changes for the given targets.
 
-    `targets` - be files or directiries
+    `targets` - be files or directories
     `message` - the commit message
     `force` - (optional) force the commit
     `sign` - sign with `-S` option


### PR DESCRIPTION
### What does this PR do?
Adds new helper script to ddev to sequentially create commits in a target repo.

Takes a source directory that contains a series of subdirectories, and iterates through them commiting the contents to the  branch on the target repo.

This formalizes the script that created the example commits in `integrations-extras`, as can be seen in the `DASH2020` [branch](https://github.com/DataDog/integrations-extras/commits/DASH2020/GitHub_Repo).

Example output:

```
❯ ddev -e meta create-example-commits ~/dd/integrations-example/github_repo -p "Example commit:"
Using `~/dd/integrations-example/github_repo` as source directory ...
Change to a feature branch on `extras`, and rerun the command.
```
```
❯ ddev -e meta create-example-commits ~/dd/integrations-example/github_repo -p "Example commit:"
Using `~/dd/integrations-example/github_repo` as source directory ...
Destination repo `extras` on branch `mg/testtest` located at `~/dd/integrations-extras` ...
Found the following stages to commit: 1-create, 2-configurations, 3-service-checks, 4-metrics, 5-packaging, 6-advanced
Committing files from ['~/dd/integrations-extras/github_repo'] under commit 1-create ..
[mg/testtest 705a52c] Example commit: 1-create
 19 files changed, 302 insertions(+)
 create mode 100644 github_repo/CHANGELOG.md
 create mode 100644 github_repo/MANIFEST.in
 create mode 100644 github_repo/README.md
 create mode 100644 github_repo/assets/configuration/spec.yaml
 create mode 100644 github_repo/assets/service_checks.json
 create mode 100644 github_repo/datadog_checks/__init__.py
 create mode 100644 github_repo/datadog_checks/github_repo/__about__.py
 create mode 100644 github_repo/datadog_checks/github_repo/__init__.py
 create mode 100644 github_repo/datadog_checks/github_repo/check.py
 create mode 100644 github_repo/datadog_checks/github_repo/data/conf.yaml.example
 create mode 100644 github_repo/manifest.json
 create mode 100644 github_repo/metadata.csv
 create mode 100644 github_repo/requirements-dev.txt
 create mode 100644 github_repo/requirements.in
 create mode 100644 github_repo/setup.py
 create mode 100644 github_repo/tests/__init__.py
 create mode 100644 github_repo/tests/conftest.py
 create mode 100644 github_repo/tests/test_github_repo.py
 create mode 100644 github_repo/tox.ini
Committing files from ['~/dd/integrations-extras/github_repo'] under commit 2-configurations ..
[mg/testtest 59b4bde] Example commit: 2-configurations
 5 files changed, 75 insertions(+), 15 deletions(-)
Committing files from ['~/dd/integrations-extras/github_repo'] under commit 3-service-checks ..
[mg/testtest 00b6039] Example commit: 3-service-checks
 2 files changed, 35 insertions(+), 5 deletions(-)
Committing files from ['~/dd/integrations-extras/github_repo'] under commit 4-metrics ..
[mg/testtest 7cbdc64] Example commit: 4-metrics
 3 files changed, 57 insertions(+), 3 deletions(-)
 create mode 100644 github_repo/tests/test_e2e.py
Committing files from ['~/dd/integrations-extras/github_repo'] under commit 5-packaging ..
[mg/testtest 6dfce32] Example commit: 5-packaging
 6 files changed, 24 insertions(+), 5 deletions(-)
 rewrite github_repo/assets/service_checks.json (100%)
Committing files from ['~/dd/integrations-extras/github_repo'] under commit 6-advanced ..
[mg/testtest 00581c2] Example commit: 6-advanced
 15 files changed, 397 insertions(+), 49 deletions(-)
 create mode 100644 github_repo/assets/dashboards/metrics.json
 create mode 100644 github_repo/tests/fixtures/commits.json
 create mode 100644 github_repo/tests/fixtures/contributors.json
 create mode 100644 github_repo/tests/fixtures/github.json
 create mode 100644 github_repo/tests/fixtures/repo.json
 create mode 100644 github_repo/tests/fixtures/stargazers.json
 create mode 100644 github_repo/tests/fixtures/subscribers.json
 create mode 100644 github_repo/tests/fixtures/watchers.json
 rewrite github_repo/tests/test_e2e.py (71%)
Done.
```

### Motivation
Simplify the process of creating sequential example commits. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
