### PR TITLE
Update kafka_consumer_offsets option description

### DIFF
--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -225,7 +225,8 @@ files:
         description: |
           DEPRECATION NOTICE: This option is only used for fetching consumer offsets
           from Zookeeper and is deprecated.
-          This setting only applies if zk_connect_str is set
+          This setting only applies if `zk_connect_str` is set and cannot work with
+          `monitor_unlisted_consumer_groups` since the generated list comes from Zookeeper.
           Set to true to fetch consumer offsets from both Zookeeper and Kafka
           Set to false to fetch consumer offsets only from Zookeeper.
         value:

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -231,7 +231,8 @@ instances:
     ## @param kafka_consumer_offsets - boolean - optional - default: false
     ## DEPRECATION NOTICE: This option is only used for fetching consumer offsets
     ## from Zookeeper and is deprecated.
-    ## This setting only applies if zk_connect_str is set
+    ## This setting only applies if `zk_connect_str` is set and cannot work with
+    ## `monitor_unlisted_consumer_groups` since the generated list comes from Zookeeper.
     ## Set to true to fetch consumer offsets from both Zookeeper and Kafka
     ## Set to false to fetch consumer offsets only from Zookeeper.
     #


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update the option description to specify `kafka_consumer_offsets` and `monitor_unlisted_consumer_groups` can't be used at the same time.
`monitor_unlisted_consumer_groups` get the consumer group list from Zookeeper, so it the Kafka ones are not listed.
`kafka_consumer_offsets` needs the consumer groups to be explicitly listed.

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
