### PR TITLE
Add loader to snmp config example

### DIFF
--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -5,6 +5,13 @@
 
 init_config:
 
+  ## @param loader - string - optional - default: python
+  ## Check loader to use. Available loaders:
+  ## - core: will use corecheck SNMP integration
+  ## - python: will use python SNMP integration
+  #
+  # loader: core
+
   ## @param mibs_folder - string - optional
   ## Specify an additional folder for your custom mib files (python format).
   #
@@ -289,3 +296,10 @@ instances:
     ##         the OIDs will be refreshed only according to the refresh interval.
     #
     # refresh_oids_cache_interval: 3600
+
+    ## @param loader - string - optional - default: python
+    ## Check loader to use. Available loaders:
+    ## - core: will use corecheck SNMP integration
+    ## - python: will use python SNMP integration
+    #
+    # loader: core

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -6,11 +6,11 @@
 init_config:
 
   ## @param loader - string - optional - default: python
-  ## Check loader to use. Available loaders:
-  ## - core: will use corecheck SNMP integration
-  ## - python: will use python SNMP integration
+  ## Check loader to use for all instances. Available loaders:
+  ## - core: (recommended) will use new corecheck SNMP integration
+  ## - python: will use legacy python SNMP integration
   #
-  # loader: core
+  loader: core
 
   ## @param mibs_folder - string - optional
   ## Specify an additional folder for your custom mib files (python format).
@@ -299,7 +299,7 @@ instances:
 
     ## @param loader - string - optional - default: python
     ## Check loader to use. Available loaders:
-    ## - core: will use corecheck SNMP integration
-    ## - python: will use python SNMP integration
+    ## - core: (recommended) will use new corecheck SNMP integration
+    ## - python: will use legacy python SNMP integration
     #
     # loader: core


### PR DESCRIPTION
Document loader config feature allowing user to switch from different implementations of the same integration