### PR TITLE
Restore running e2e on master branch

### DIFF
--- a/.azure-pipelines/all_master.yml
+++ b/.azure-pipelines/all_master.yml
@@ -13,6 +13,7 @@ jobs:
 - template: './templates/test-all-checks.yml'
   parameters:
     run_py2_tests: false  # Don't run python2 tests on master
+    test_e2e: true
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
       restoreKeys: |


### PR DESCRIPTION
On this [PR](https://github.com/DataDog/integrations-core/pull/8443) I accidentally disabled running e2e tests on master https://github.com/DataDog/integrations-core/pull/8443/files#diff-b04da85e43f922caa2a7ca7648f2395f1842aecaf7e4786b0b2b9851b648c415R13
This PR fixes it