### PR TITLE
Avoid mounting check confd volume if there is no config

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -233,14 +233,15 @@ class DockerInterface(object):
         env_vars.update(self.env_vars)
 
         volumes = [
-            # Mount the config directory, not the file, to ensure updates are propagated
-            # https://github.com/moby/moby/issues/15793#issuecomment-135411504
-            f'{self.config_dir}:{get_agent_conf_dir(self.check, self.agent_version)}',
             # Mount the check directory
             f'{path_join(get_root(), self.check)}:{self.check_mount_dir}',
             # Mount the /proc directory
             '/proc:/host/proc',
         ]
+        if self.config:
+            # Mount the config directory, not the file, to ensure updates are propagated
+            # https://github.com/moby/moby/issues/15793#issuecomment-135411504
+            volumes.append(f'{self.config_dir}:{get_agent_conf_dir(self.check, self.agent_version)}')
         if not ON_WINDOWS:
             volumes.extend(self.metadata.get('docker_volumes', []))
         else:


### PR DESCRIPTION
### What does this PR do?

Avoid mounting check confd volume if there is no config

Related PR: https://github.com/DataDog/integrations-core/pull/8719

### Motivation

This change is needed for snmp test requiring `/etc/datadog-agent/conf.d/snmp.d/auto_conf.yaml` to be present.

Currently, check confd (e.g. `/etc/datadog-agent/conf.d/snmp.d`) is always mounted and will make `auto_conf.yaml` unavailable.

Right now, `ddev` will mount `confd` even if there is no config.