### PR TITLE
Add ability to look for wildcards in metric transformers.

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -735,7 +735,7 @@ class OpenMetricsScraperMixin(object):
                 return
             # check for wilcards in transformers
             for transformerkey in metric_transformers.keys():
-                if transformerkey.endswith('*') and metric.name.startswith(transformerkey[:-1]):                    
+                if transformerkey.endswith('*') and metric.name.startswith(transformerkey[:-1]):
                     transformer = metric_transformers[transformerkey]
                     transformer(metric, scraper_config, transformerkey)
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -733,6 +733,11 @@ class OpenMetricsScraperMixin(object):
                     self.log.warning('Error handling metric: %s - error: %s', metric.name, err)
 
                 return
+            # check for wilcards in transformers
+            for transformerkey in metric_transformers.keys():
+                if transformerkey.endswith('*') and metric.name.startswith(transformerkey[:-1]):                    
+                    transformer = metric_transformers[transformerkey]
+                    transformer(metric, scraper_config, transformerkey)
 
             # try matching wildcards
             if scraper_config['_wildcards_re'] and scraper_config['_wildcards_re'].search(metric.name):


### PR DESCRIPTION

### What does this PR do?
Update process_metrics to look for wildcards in metric transformers.

### Motivation
This will be used to gather additional Vault metrics. 

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
