### PR TITLE
Add sidecar injection failed and skipped metrics

### DIFF
--- a/istio/datadog_checks/istio/metrics.py
+++ b/istio/datadog_checks/istio/metrics.py
@@ -303,4 +303,6 @@ ISTIOD_METRICS = {
     'process_virtual_memory_max_bytes': 'process.virtual_memory_max_bytes',
     'sidecar_injection_requests_total': 'sidecar_injection.requests_total',
     'sidecar_injection_success_total': 'sidecar_injection.success_total',
+    'sidecar_injection_failure_total': 'sidecar_injection.failure_total',
+    'sidecar_injection_skip_total': 'sidecar_injection.skip_total'
 }

--- a/istio/datadog_checks/istio/metrics.py
+++ b/istio/datadog_checks/istio/metrics.py
@@ -304,5 +304,5 @@ ISTIOD_METRICS = {
     'sidecar_injection_requests_total': 'sidecar_injection.requests_total',
     'sidecar_injection_success_total': 'sidecar_injection.success_total',
     'sidecar_injection_failure_total': 'sidecar_injection.failure_total',
-    'sidecar_injection_skip_total': 'sidecar_injection.skip_total'
+    'sidecar_injection_skip_total': 'sidecar_injection.skip_total',
 }

--- a/istio/metadata.csv
+++ b/istio/metadata.csv
@@ -256,6 +256,8 @@ istio.pilot.xds.push.time.sum,gauge,,,,Sum of observed values of total time Pilo
 istio.process.virtual_memory_max_bytes,gauge,,byte,,Maximum amount of virtual memory available in bytes,0,istio,
 istio.sidecar_injection.requests_total,count,,request,,Total number of sidecar injection requests,0,istio,
 istio.sidecar_injection.success_total,count,,request,,Total number of successful sidecar injection requests,0,istio,
+istio.sidecar_injection.failure_total,count,,request,,Total number of failed sidecar injection requests,0,istio,
+istio.sidecar_injection.skip_total,count,,request,,Total number of skipped sidecar injection requests,0,istio,
 istio.mesh.request.duration.milliseconds.sum,gauge,,millisecond,,Total sum of observed values for duration of requests in ms,0,istio,
 istio.mesh.request.duration.milliseconds.count,gauge,,,,Total count of observed values for duration of requests,0,istio,
 istio.mesh.tcp.connections_closed.total,gauge,,,,Total closed connections,0,istio,


### PR DESCRIPTION
Include and document sidecar injection failure_total and skipped_total
