### PR TITLE
Add replication_mode tag to replication service check

### DIFF
--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -65,7 +65,9 @@ def test_e2e(dd_agent_check, instance_complex):
 def _assert_complex_config(aggregator):
     # Test service check
     aggregator.assert_service_check('mysql.can_connect', status=MySql.OK, tags=tags.SC_TAGS, count=1)
-    aggregator.assert_service_check('mysql.replication.slave_running', status=MySql.OK, tags=tags.SC_TAGS, at_least=1)
+    aggregator.assert_service_check(
+        'mysql.replication.slave_running', status=MySql.OK, tags=tags.SC_TAGS + ['replication_mode:source'], at_least=1
+    )
     testable_metrics = (
         variables.STATUS_VARS
         + variables.VARIABLES_VARS
@@ -155,7 +157,10 @@ def test_complex_config_replica(aggregator, instance_complex):
 
     # Travis MySQL not running replication - FIX in flavored test.
     aggregator.assert_service_check(
-        'mysql.replication.slave_running', status=MySql.OK, tags=tags.SC_TAGS_REPLICA, at_least=1
+        'mysql.replication.slave_running',
+        status=MySql.OK,
+        tags=tags.SC_TAGS_REPLICA + ['replication_mode:replica'],
+        at_least=1,
     )
 
     testable_metrics = (
@@ -398,35 +403,99 @@ def test_parse_get_version():
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    'replica_io_running, replica_sql_running, check_status',
+    'replica_io_running, replica_sql_running, source_host, slaves_connected, check_status_repl, check_status_source',
     [
-        pytest.param(('Slave_IO_Running', {}), ('Slave_SQL_Running', {}), MySql.CRITICAL),
-        pytest.param(('Replica_IO_Running', {}), ('Replica_SQL_Running', {}), MySql.CRITICAL),
-        pytest.param(('Replica_IO_Running', None), ('Replica_SQL_Running', None), MySql.OK),
-        pytest.param(('Slave_IO_Running', {'stuff': 'yes'}), ('Slave_SQL_Running', {}), MySql.WARNING),
-        pytest.param(('Replica_IO_Running', {'stuff': 'yes'}), ('Replica_SQL_Running', {}), MySql.WARNING),
-        pytest.param(('Slave_IO_Running', {}), ('Slave_SQL_Running', {'stuff': 'yes'}), MySql.WARNING),
-        pytest.param(('Replica_IO_Running', {}), ('Replica_SQL_Running', {'stuff': 'yes'}), MySql.WARNING),
-        pytest.param(('Slave_IO_Running', {'stuff': 'yes'}), ('Slave_SQL_Running', {'stuff': 'yes'}), MySql.OK),
-        pytest.param(('Replica_IO_Running', {'stuff': 'yes'}), ('Replica_SQL_Running', {'stuff': 'yes'}), MySql.OK),
+        # Replica host only
+        pytest.param(('Slave_IO_Running', {}), ('Slave_SQL_Running', {}), 'source', 0, MySql.CRITICAL, None),
+        pytest.param(('Replica_IO_Running', {}), ('Replica_SQL_Running', {}), 'source', 0, MySql.CRITICAL, None),
+        pytest.param(('Slave_IO_Running', {'a': 'yes'}), ('Slave_SQL_Running', {}), 'source', 0, MySql.WARNING, None),
+        pytest.param(
+            ('Replica_IO_Running', {'a': 'yes'}), ('Replica_SQL_Running', {}), 'source', 0, MySql.WARNING, None
+        ),
+        pytest.param(('Slave_IO_Running', {}), ('Slave_SQL_Running', {'a': 'yes'}), 'source', 0, MySql.WARNING, None),
+        pytest.param(
+            ('Replica_IO_Running', {}), ('Replica_SQL_Running', {'a': 'yes'}), 'source', 0, MySql.WARNING, None
+        ),
+        pytest.param(
+            ('Slave_IO_Running', {'a': 'yes'}), ('Slave_SQL_Running', {'a': 'yes'}), 'source', 0, MySql.OK, None
+        ),
+        pytest.param(
+            ('Replica_IO_Running', {'a': 'yes'}),
+            ('Replica_SQL_Running', {'a': 'yes'}),
+            'source',
+            0,
+            MySql.OK,
+            None,
+        ),
+        # Source host only
+        pytest.param(('Replica_IO_Running', None), ('Replica_SQL_Running', None), None, 1, None, MySql.OK),
+        pytest.param(('Replica_IO_Running', None), ('Replica_SQL_Running', None), None, 0, None, MySql.WARNING),
+        # Source and replica host
+        pytest.param(('Replica_IO_Running', {}), ('Replica_SQL_Running', {}), 'source', 1, MySql.CRITICAL, MySql.OK),
+        pytest.param(
+            ('Replica_IO_Running', {'a': 'yes'}), ('Replica_SQL_Running', {}), 'source', 1, MySql.WARNING, MySql.OK
+        ),
+        pytest.param(
+            ('Slave_IO_Running', {'a': 'yes'}),
+            ('Slave_SQL_Running', {'a': 'yes'}),
+            'source',
+            1,
+            MySql.OK,
+            MySql.OK,
+        ),
     ],
 )
-def test_replication_check_status(replica_io_running, replica_sql_running, check_status, instance_basic, aggregator):
+def test_replication_check_status(
+    replica_io_running,
+    replica_sql_running,
+    source_host,
+    slaves_connected,
+    check_status_repl,
+    check_status_source,
+    instance_basic,
+    aggregator,
+):
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[instance_basic])
     mysql_check.service_check_tags = ['foo:bar']
     mocked_results = {
-        'Slaves_connected': 1,
+        'Slaves_connected': slaves_connected,
         'Binlog_enabled': True,
     }
     if replica_io_running[1] is not None:
         mocked_results[replica_io_running[0]] = replica_io_running[1]
     if replica_sql_running[1] is not None:
         mocked_results[replica_sql_running[0]] = replica_sql_running[1]
+    if source_host:
+        mocked_results['Master_Host'] = source_host
 
     mysql_check._check_replication_status(mocked_results)
+    expected_service_check_len = 0
 
-    aggregator.assert_service_check('mysql.replication.slave_running', check_status, tags=['foo:bar'], count=1)
-    aggregator.assert_service_check('mysql.replication.replica_running', check_status, tags=['foo:bar'], count=1)
+    if check_status_repl is not None:
+        aggregator.assert_service_check(
+            'mysql.replication.slave_running', check_status_repl, tags=['foo:bar', 'replication_mode:replica'], count=1
+        )
+        aggregator.assert_service_check(
+            'mysql.replication.replica_running',
+            check_status_repl,
+            tags=['foo:bar', 'replication_mode:replica'],
+            count=1,
+        )
+        expected_service_check_len += 1
+
+    if check_status_source is not None:
+        aggregator.assert_service_check(
+            'mysql.replication.slave_running', check_status_source, tags=['foo:bar', 'replication_mode:source'], count=1
+        )
+        aggregator.assert_service_check(
+            'mysql.replication.replica_running',
+            check_status_source,
+            tags=['foo:bar', 'replication_mode:source'],
+            count=1,
+        )
+        expected_service_check_len += 1
+
+    assert len(aggregator.service_checks('mysql.replication.slave_running')) == expected_service_check_len
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

A host can be running as a source (master) or a replica (slave) or even both (see https://dev.mysql.com/doc/refman/8.0/en/replication-solutions-performance.html and https://severalnines.com/resources/database-management-tutorials/mysql-replication-high-availability-tutorial). We currently do not consider that a host can be both.

Metric concerned: `mysql.replication.slave_running`
Service checks concerned: `mysql.replication.slave_running`, `mysql.replication.replica_running`

This PR adds an additional tag to these metric/service checks named `replication_mode`, and its value depends on the host being considered a source or a replica.

Ex:
* Source-only host: one `mysql.replication.replica_running` with `replication_mode:source`
* Replica-only host: one `mysql.replication.replica_running` with `replication_mode:replica`
* Relay host: one `mysql.replication.replica_running` with `replication_mode:source` and one `mysql.replication.replica_running` with `replication_mode:replica`. The status can be different.

<!-- Behaviour before this PR:
* For a replica host (a host with a `Master_Host` or a `Source_Host`): depending on `Replica_IO_Running`, `Slave_IO_Running`, `Replica_SQL_Running` and `Slave_SQL_Running` values, submit a single value for each concerned metric/service checks
* For a source host (a host without `Master_Host` or `Source_host`): depending on the number of replica connected and the binlog status, submit a single value for each concerned metric/service checks
* For a relay host (source and replica): no behaviour defined, considered as a replica, but the status -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Support request

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This PR still send service checks named `mysql.replication.replica_running` when looking at a source or relay host for backward compatibility, but there is an additional tag to make the difference with a replica.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
