### PR TITLE
postgres check: bump datadog_checks_base min version

### DIFF
--- a/postgres/setup.py
+++ b/postgres/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.3.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=16.5.0'
 
 setup(
     name='datadog-postgres',


### PR DESCRIPTION
### What does this PR do?

Bump datadog_checks_base min version for the postgres check. 

Follow-up to https://github.com/DataDog/integrations-core/pull/8627

Depends on https://github.com/DataDog/integrations-core/pull/8759

### Motivation

Fix broken build due to old datadog_checks_base minimum version.

```
E   ImportError: cannot import name 'compute_exec_plan_signature' from 'datadog_checks.base.utils.db.sql' (/home/vsts/work/1/s/postgres/.tox/py38/lib/python3.8/site-packages/datadog_checks/base/utils/db/sql.py)
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
