### PR TITLE
Shutdown statement sampler thread on cancel

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -56,6 +56,9 @@ class PostgreSql(AgentCheck):
         self.statement_samples = PostgresStatementSamples(self, self._config)
         self._clean_state()
 
+    def cancel(self):
+        self.statement_samples.cancel()
+
     def _clean_state(self):
         self._version = None
         self._is_aurora = None

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import threading
 import time
 from concurrent.futures.thread import ThreadPoolExecutor
 
@@ -63,6 +64,7 @@ class PostgresStatementSamples(object):
         self._activity_last_query_start = None
         self._last_check_run = 0
         self._collection_loop_future = None
+        self._cancel_event = threading.Event()
         self._tags = None
         self._tags_str = None
         self._service = "postgres"
@@ -89,6 +91,9 @@ class PostgresStatementSamples(object):
             maxsize=int(self._config.statement_samples_config.get('seen_samples_cache_maxsize', 10000)),
             ttl=60 * 60 / int(self._config.statement_samples_config.get('samples_per_hour_per_query', 15)),
         )
+
+    def cancel(self):
+        self._cancel_event.set()
 
     def run_sampler(self, tags):
         """
@@ -175,6 +180,10 @@ class PostgresStatementSamples(object):
         try:
             self._log.info("Starting statement sampler collection loop")
             while True:
+                if self._cancel_event.isSet():
+                    self._log.info("Collection loop cancelled")
+                    self._check.count("dd.postgres.statement_samples.collection_loop_cancel", 1, tags=self._tags)
+                    break
                 if time.time() - self._last_check_run > self._config.min_collection_interval * 2:
                     self._log.info("Sampler collection loop stopping due to check inactivity")
                     self._check.count("dd.postgres.statement_samples.collection_loop_inactive_stop", 1, tags=self._tags)
@@ -198,9 +207,9 @@ class PostgresStatementSamples(object):
             )
         finally:
             self._log.info("Shutting down statement sampler collection loop")
-            self.close()
+            self._close_db_conn()
 
-    def close(self):
+    def _close_db_conn(self):
         if self._db and not self._db.closed:
             try:
                 self._db.close()


### PR DESCRIPTION
### What does this PR do?
Use the cancel feature added in https://github.com/DataDog/integrations-core/pull/8463 to ensure the statement sampler thread is stopped when the check is unscheduled.

Follow-up to https://github.com/DataDog/integrations-core/pull/8627

### Motivation
Faster resource cleanup when a check is unscheduled. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
