### PR TITLE
Improve orjson compatibility

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/sql.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/sql.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 import mmh3
 
-from datadog_checks.base.utils.serialization import json
+from datadog_checks.base.utils.serialization import json, sort_keys_kwargs
 
 # Unicode character "Arabic Decimal Separator" (U+066B) is a character which looks like an ascii
 # comma, but is not treated like a comma when parsing metrics tags. This is used to replace
@@ -51,5 +51,5 @@ def compute_exec_plan_signature(normalized_json_plan):
     """
     if not normalized_json_plan:
         return None
-    with_sorted_keys = json.dumps(json.loads(normalized_json_plan), sort_keys=True)
+    with_sorted_keys = json.dumps(json.loads(normalized_json_plan), **sort_keys_kwargs)
     return format(mmh3.hash64(with_sorted_keys, signed=False)[0], 'x')

--- a/datadog_checks_base/datadog_checks/base/utils/serialization.py
+++ b/datadog_checks_base/datadog_checks/base/utils/serialization.py
@@ -7,13 +7,14 @@ try:
     import orjson as json
 
     impl = 'orjson'
+    sort_keys_kwargs = {'option': json.OPT_SORT_KEYS}
 except ImportError:
     import json
 
     impl = 'stdlib'
+    sort_keys_kwargs = {'sort_keys': True}
 
 logger = logging.getLogger(__name__)
 logger.debug('Using JSON implementation from %s', impl)
-
 
 __all__ = ['json']

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -301,6 +301,8 @@ class PostgresStatementSamples(object):
         plan, normalized_plan, obfuscated_plan, plan_signature, plan_cost = None, None, None, None, None
         if plan_dict:
             plan = json.dumps(plan_dict)
+            # if we're using the orjson implementation then json.dumps returns bytes
+            plan = plan.decode('utf-8') if isinstance(plan, bytes) else plan
             normalized_plan = datadog_agent.obfuscate_sql_exec_plan(plan, normalize=True)
             obfuscated_plan = datadog_agent.obfuscate_sql_exec_plan(plan)
             plan_signature = compute_exec_plan_signature(normalized_plan)

--- a/postgres/tox.ini
+++ b/postgres/tox.ini
@@ -18,7 +18,7 @@ passenv =
     DOCKER*
     COMPOSE*
 deps =
-    -e../datadog_checks_base[deps,db]
+    -e../datadog_checks_base[deps,db,json]
     -rrequirements-dev.txt
 commands =
     pip install -r requirements.in


### PR DESCRIPTION
### What does this PR do?

  * Fixes `AttributeError: module 'orjson' has no attribute 'JSONEncoder'` when importing `datadog_checks.base.utils.db.statement_samples` where `orjson` is installed.
  * Add `datadog_checks_base` `json` dependency to postgres tests so we're testing orjson correctly
  * Update statement sampler stub to serialize events to/from json to ensure we're testing the json serialization during integration tests.

### Motivation

Fix broken import for DBM in case of `orjson` dependency being installed. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
