### PR TITLE
[doc]erin-leeds/fixed hyperlink under postfix log collection

### DIFF
--- a/postfix/README.md
+++ b/postfix/README.md
@@ -138,7 +138,7 @@ Postfix sends logs to the syslog daemon, which then writes logs to the file syst
    logs_enabled: true
    ```
 
-2. Add the following configuration block to your `postfix.d/conf.yaml` file. Change the `path` and `service` parameter values based on your environment. See the [sample postfix.d/conf.yaml][5] for all available configuration options.
+2. Add the following configuration block to your `postfix.d/conf.yaml` file. Change the `path` and `service` parameter values based on your environment. See the [sample postfix.d/conf.yaml][4] for all available configuration options.
 
    ```yaml
    logs:


### PR DESCRIPTION
### What does this PR do?
Under log collection here: https://docs.datadoghq.com/integrations/postfix/#log-collection
Hyperlink to sample postfix.d/conf.yaml took you to Agent Command docs

This PR changes the link to the GitHub repo: https://github.com/DataDog/integrations-core/blob/master/postfix/datadog_checks/postfix/data/conf.yaml.example

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
