### PR TITLE
Update test-all-checks.yml

### DIFF
--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -3,6 +3,7 @@ parameters:
   pip_cache_config: null
   run_py2_tests: true
   force_base_package: false
+  test_e2e: true
 jobs:
 - template: ./test-all.yml
   parameters:


### PR DESCRIPTION
The `test_e2e` parameter has to be declared in `test-all-checks` for it to be properly recognized.