### PR TITLE
Fix passing of the 'test_e2e' var in the CI

### DIFF
--- a/.azure-pipelines/templates/test-all.yml
+++ b/.azure-pipelines/templates/test-all.yml
@@ -20,7 +20,7 @@ jobs:
       pip_cache_config: ${{ parameters.pip_cache_config }}
       run_py2_tests: ${{ parameters.run_py2_tests }}
       force_base_package: ${{ parameters.force_base_package }}
-      test_e2e: ${{ and(parameters.test_e2e, eq(check.os, 'linux')) }}  # e2e tests cannot run on windows
+      test_e2e: ${{ and(eq(parameters.test_e2e, 'true'), eq(check.os, 'linux')) }}  # e2e tests cannot run on windows
 
       # Avoid max step limits
       ${{ if eq(check.checkName, 'datadog_checks_base') }}:


### PR DESCRIPTION
`parameters.test_e2e` is a string, so it evaluates to true regardless of the content of that string.