### PR TITLE
Add default dashboard and additional init script examples

### DIFF
--- a/databricks/README.md
+++ b/databricks/README.md
@@ -14,19 +14,25 @@ Monitor Databricks Spark applications with the [Datadog Spark integration][2]. I
 
 Configure the Spark integration to monitor your Apache Spark Cluster on Databricks and collect system and Spark metrics.
 
-Be sure to replace the `<DATADOG_API_KEY>` placeholders with your own API key and run the notebook once to save the init script as a global configuration. Read more about the Databricks Datadog Init scripts [here][2].
+1. Determine the best init script below for your Databricks cluster environment. 
 
-When configuring the cluster, add `DD_ENVIRONMENT` environment variable to add a global environment tag.
+2. Copy and run the contents into a notebook. The notebook will create an init script that will install a Datadog Agent on your clusters.
+    The notebook only needs to be run once to save the script as a global configuration. Read more about the Databricks Datadog Init scripts [here][2].
+    
+    Be sure to replace the `<DATADOG_API_KEY>`placeholders with your own API key and `<init-script-folder>` path in the first line.
+        
+3. Configure a new Databricks cluster with the `datadog-install-driver-only.sh` cluster-scoped init script using the UI, Databricks CLI, or invoking the Clusters API.
+    - Add `DD_ENV` environment variable under Advanced Options to add a global environment tag to better identify your clusters.
+
 
 #### Standard cluster
 
 <!-- xxx tabs xxx -->
 <!-- xxx tab "Driver only" xxx -->
 ##### Install the Datadog Agent on Driver
-Create a notebook with the following script to install the Datadog Agent on the driver node of the cluster.
-to install the Datadog Agent and collect system and Spark metrics.
+Install the Datadog Agent on the driver node of the cluster.
 
-This is a updated version of the [Datadog Init Script][4] Databricks notebook
+This is a updated version of the [Datadog Init Script][4] Databricks notebook example.
 
 ```shell script
 %python 
@@ -70,7 +76,7 @@ instances:
       streaming_metrics: true" > /etc/datadog-agent/conf.d/spark.yaml
 
   # INCLUDE GLOBAL TAGS (environment, cluster_id, cluster_name)
-  sudo sed -i '/# tags:/ s/^/tags:\\n  - environment:${DD_ENVIRONMENT}\\n  - host_ip:${SPARK_LOCAL_IP}\\n  - spark_host:driver\\n/'  /etc/datadog-agent/datadog.yaml
+  sudo sed -i '/# tags:/ s/^/tags:\\n  - environment:${DD_ENV}\\n  - cluster_id:${DB_CLUSTER_ID}\\n  - cluster_name:${DB_CLUSTER_NAME}\\n  - host_ip:${SPARK_LOCAL_IP}\\n  - spark_host:driver\\n/'  /etc/datadog-agent/datadog.yaml
 
   # RESTARTING AGENT
   sudo service datadog-agent restart
@@ -123,9 +129,9 @@ instances:
       streaming_metrics: true" > /etc/datadog-agent/conf.d/spark.d/conf.yaml
 
   # INCLUDE GLOBAL TAGS (environment, cluster_id, cluster_name)
-  sudo sed -i '/# tags:/ s/^/tags:\\n  - environment:${DD_ENVIRONMENT}\\n  - host_ip:${SPARK_LOCAL_IP}\\n  - spark_host:driver\\n/'  /etc/datadog-agent/datadog.yaml
+  sudo sed -i '/# tags:/ s/^/tags:\\n  - environment:${DD_ENV}\\n  - cluster_id:${DB_CLUSTER_ID}\\n  - cluster_name:${DB_CLUSTER_NAME}\\n  - host_ip:${SPARK_LOCAL_IP}\\n  - spark_host:driver\\n/'  /etc/datadog-agent/datadog.yaml
 else
-  sudo sed -i '/# tags:/ s/^/tags:\\n  - environment:${DD_ENVIRONMENT}\\n   - host_ip:${SPARK_LOCAL_IP}\\n  - spark_host:worker\\n/'  /etc/datadog-agent/datadog.yaml
+  sudo sed -i '/# tags:/ s/^/tags:\\n  - environment:${DD_ENV}\\n  - cluster_id:${DB_CLUSTER_ID}\\n  - cluster_name:${DB_CLUSTER_NAME}\\n  - host_ip:${SPARK_LOCAL_IP}\\n  - spark_host:worker\\n/'  /etc/datadog-agent/datadog.yaml
 fi
 
   # RESTARTING AGENT
@@ -178,6 +184,8 @@ instances:
     - spark_url: http://\$DB_DRIVER_IP:\$DB_DRIVER_PORT
       spark_cluster_mode: spark_driver_mode
       cluster_name: \$current" > /etc/datadog-agent/conf.d/spark.yaml
+
+  sudo sed -i '/# tags:/ s/^/tags:\\n  - environment:${DD_ENV}\\n  - cluster_id:${DB_CLUSTER_ID}\\n  - cluster_name:${DB_CLUSTER_NAME}\\n  - host_ip:${SPARK_LOCAL_IP}\\n  - spark_host:driver\\n/'  /etc/datadog-agent/datadog.yaml
 
   # RESTARTING AGENT
   sudo service datadog-agent restart

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -50,7 +50,7 @@ if [[ \${DB_IS_DRIVER} = "TRUE" ]]; then
   echo "On the driver. Installing Datadog ..."
   
   # CONFIGURE HOST TAGS FOR CLUSTER
-  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:${SPARK_LOCAL_IP}","spark_host:driver"
+  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:${SPARK_LOCAL_IP}","spark_node:driver"
 
   # INSTALL THE LATEST DATADOG AGENT 7
   DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=DD_TAGS bash -c "\$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
@@ -107,7 +107,7 @@ cat <<EOF >> /tmp/start_datadog.sh
 if [[ \${DB_IS_DRIVER} = "TRUE" ]]; then
 
   # CONFIGURE HOST TAGS FOR DRIVER
-  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:${SPARK_LOCAL_IP}","spark_host:driver"
+  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:${SPARK_LOCAL_IP}","spark_node:driver"
 
   # INSTALL THE LATEST DATADOG AGENT 7 ON DRIVER AND WORKER NODES
   DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
@@ -128,11 +128,11 @@ instances:
     - spark_url: http://\${DB_DRIVER_IP}:\${DB_DRIVER_PORT}
       spark_cluster_mode: spark_driver_mode
       cluster_name: \${hostip}
-      streaming_metrics: true" > /etc/datadog-agent/conf.d/spark.d/spark.yaml
+      streaming_metrics: true" > /etc/datadog-agent/conf.d/spark.yaml
 else
 
   # CONFIGURE HOST TAGS FOR WORKERS
-  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:${SPARK_LOCAL_IP}","spark_host:worker"
+  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:${SPARK_LOCAL_IP}","spark_node:worker"
 
   # INSTALL THE LATEST DATADOG AGENT 7 ON DRIVER AND WORKER NODES
   DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
@@ -174,7 +174,7 @@ if [ \$DB_IS_DRIVER ]; then
   echo "On the driver. Installing Datadog ..."
 
   # CONFIGURE HOST TAGS FOR DRIVER
-  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:${SPARK_LOCAL_IP}","spark_host:driver"
+  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:${SPARK_LOCAL_IP}","spark_node:driver"
 
   # INSTALL THE LATEST DATADOG AGENT 7 ON DRIVER AND WORKER NODES
   DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -18,6 +18,8 @@ Be sure to replace the `<DATADOG_API_KEY>` placeholders with your own API key an
 
 #### Standard cluster
 
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Driver only" xxx -->
 ##### Install the Datadog Agent on Driver
 Create a notebook with the following script to install the Datadog Agent on the driver node of the cluster.
 to install the Datadog Agent and collect system and Spark metrics.
@@ -82,6 +84,8 @@ fi
 """, True)
 ```
 
+<!-- xxz tab xxx -->
+<!-- xxx tab "All nodes" xxx -->
 ##### Install the Datadog Agent on Driver and Worker Nodes
 
 ```shell script
@@ -131,6 +135,8 @@ chmod a+x /tmp/start_datadog.sh
 /tmp/start_datadog.sh >> /tmp/datadog_start.log 2>&1 & disown
 """, True)
 ```
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 #### Job cluster
 

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -16,6 +16,8 @@ Configure the Spark integration to monitor your Apache Spark Cluster on Databric
 
 Be sure to replace the `<DATADOG_API_KEY>` placeholders with your own API key and run the notebook once to save the init script as a global configuration. Read more about the Databricks Datadog Init scripts [here][2].
 
+When configuring the cluster, add `DD_ENVIRONMENT` environment variable to add a global environment tag.
+
 #### Standard cluster
 
 <!-- xxx tabs xxx -->
@@ -68,7 +70,7 @@ instances:
       streaming_metrics: true" > /etc/datadog-agent/conf.d/spark.yaml
 
   # INCLUDE GLOBAL TAGS (environment, cluster_id, cluster_name)
-  sudo sed -i '/# tags:/ s/^/tags:\\n  - environment:${DD_ENVIRONMENT}\\n  - cluster_id:${DB_CLUSTER_ID}\\n  - databricks_cluster:${DB_CLUSTER_NAME}\\n  - host_ip:${SPARK_LOCAL_IP}\\n  - spark_host:driver\\n/'  /etc/datadog-agent/datadog.yaml
+  sudo sed -i '/# tags:/ s/^/tags:\\n  - environment:${DD_ENVIRONMENT}\\n  - host_ip:${SPARK_LOCAL_IP}\\n  - spark_host:driver\\n/'  /etc/datadog-agent/datadog.yaml
 
   # RESTARTING AGENT
   sudo service datadog-agent restart
@@ -121,9 +123,9 @@ instances:
       streaming_metrics: true" > /etc/datadog-agent/conf.d/spark.d/conf.yaml
 
   # INCLUDE GLOBAL TAGS (environment, cluster_id, cluster_name)
-  sudo sed -i '/# tags:/ s/^/tags:\\n  - environment:${DD_ENVIRONMENT}\\n  - cluster_id:${DB_CLUSTER_ID}\\n  - cluster_name:${DB_CLUSTER_NAME}\\n  - host_ip:${SPARK_LOCAL_IP}\\n  - spark_host:driver\\n/'  /etc/datadog-agent/datadog.yaml
+  sudo sed -i '/# tags:/ s/^/tags:\\n  - environment:${DD_ENVIRONMENT}\\n  - host_ip:${SPARK_LOCAL_IP}\\n  - spark_host:driver\\n/'  /etc/datadog-agent/datadog.yaml
 else
-  sudo sed -i '/# tags:/ s/^/tags:\\n  - environment:${DD_ENVIRONMENT}\\n  - cluster_id:${DB_CLUSTER_ID}\\n  - cluster_name:${DB_CLUSTER_NAME}\\n  - host_ip:${SPARK_LOCAL_IP}\\n  - spark_host:worker\\n/'  /etc/datadog-agent/datadog.yaml
+  sudo sed -i '/# tags:/ s/^/tags:\\n  - environment:${DD_ENVIRONMENT}\\n   - host_ip:${SPARK_LOCAL_IP}\\n  - spark_host:worker\\n/'  /etc/datadog-agent/datadog.yaml
 fi
 
   # RESTARTING AGENT

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -164,7 +164,7 @@ if [ \$DB_IS_DRIVER ]; then
 
   current=\$(hostname -I | xargs)
 
-  # WRITING SPARK CONFIG FILE FOR STREAMING SPARK METRICS
+  # WRITING SPARK CONFIG FILE
   echo "init_config:
 instances:
     - spark_url: http://\$DB_DRIVER_IP:\$DB_DRIVER_PORT

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -32,6 +32,8 @@ Configure the Spark integration to monitor your Apache Spark Cluster on Databric
 ##### Install the Datadog Agent on Driver
 Install the Datadog Agent on the driver node of the cluster. This is a updated version of the [Datadog Init Script][4] Databricks notebook example.
 
+After creating the `datadog-install-driver-only.sh` script, add the init script path in the [cluster configuration page](https://docs.databricks.com/clusters/init-scripts.html#configure-a-cluster-scoped-init-script-using-the-ui).
+
 ```shell script
 %python 
 
@@ -113,6 +115,8 @@ fi
 <!-- xxx tab "All nodes" xxx -->
 ##### Install the Datadog Agent on Driver and Worker Nodes
 
+After creating the `datadog-install-driver-workers.sh` script, add the init script path in the [cluster configuration page](https://docs.databricks.com/clusters/init-scripts.html#configure-a-cluster-scoped-init-script-using-the-ui).
+
 ```shell script
 %python 
 
@@ -193,8 +197,7 @@ chmod a+x /tmp/start_datadog.sh
 <!-- xxz tabs xxx -->
 
 #### Job cluster
-
-For job clusters, use the following script to configure the Spark integration.
+After creating the `datadog-install-job-driver-mode.sh` script, add the init script path in the [cluster configuration page](https://docs.databricks.com/clusters/init-scripts.html#configure-a-cluster-scoped-init-script-using-the-ui).
 
 **Note**: Job clusters are monitored in `spark_driver_mode` with the Spark UI port.
 

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -48,7 +48,7 @@ if [[ \${DB_IS_DRIVER} = "TRUE" ]]; then
   echo "On the driver. Installing Datadog ..."
   
   # CONFIGURE HOST TAGS FOR CLUSTER
-  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:${SPARK_LOCAL_IP}","spark_node:driver"
+  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:\${SPARK_LOCAL_IP}","spark_node:driver"
 
   # INSTALL THE LATEST DATADOG AGENT 7
   DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=DD_TAGS bash -c "\$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
@@ -128,7 +128,7 @@ if [[ \${DB_IS_DRIVER} = "TRUE" ]]; then
 
   echo "Installing Datadog agent in the driver (master node) ..."
   # CONFIGURE HOST TAGS FOR DRIVER
-  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:${SPARK_LOCAL_IP}","spark_node:driver"
+  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:\${SPARK_LOCAL_IP}","spark_node:driver"
 
   # INSTALL THE LATEST DATADOG AGENT 7 ON DRIVER AND WORKER NODES
   DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
@@ -173,7 +173,7 @@ logs:
 else
 
   # CONFIGURE HOST TAGS FOR WORKERS
-  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:${SPARK_LOCAL_IP}","spark_node:worker"
+  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:\${SPARK_LOCAL_IP}","spark_node:worker"
 
   # INSTALL THE LATEST DATADOG AGENT 7 ON DRIVER AND WORKER NODES
   DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
@@ -215,7 +215,7 @@ if [ \$DB_IS_DRIVER ]; then
   echo "On the driver. Installing Datadog ..."
 
   # CONFIGURE HOST TAGS FOR DRIVER
-  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:${SPARK_LOCAL_IP}","spark_node:driver"
+  DD_TAGS="environment:\${DD_ENV}","databricks_cluster_id:\${DB_CLUSTER_ID}","databricks_cluster_name:\${DB_CLUSTER_NAME}","spark_host_ip:\${SPARK_LOCAL_IP}","spark_node:driver"
 
   # INSTALL THE LATEST DATADOG AGENT 7 ON DRIVER AND WORKER NODES
   DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=\$DD_API_KEY DD_HOST_TAGS=\$DD_TAGS bash -c "\$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"

--- a/databricks/assets/dashboards/databricks_overview.json
+++ b/databricks/assets/dashboards/databricks_overview.json
@@ -36,7 +36,7 @@
                 "requests": [
                     {
                         "display_type": "bars",
-                        "q": "sum:spark.job.count{status:succeeded,$spark_node,$databricks_cluster_name}",
+                        "q": "sum:spark.job.count{status:succeeded,$spark_node,$databricks_cluster_name,$app_name}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -46,7 +46,7 @@
                     {
                         "display_type": "bars",
                         "on_right_yaxis": false,
-                        "q": "sum:spark.job.count{status:running,$spark_node,$databricks_cluster_name}",
+                        "q": "sum:spark.job.count{status:running,$spark_node,$databricks_cluster_name,$app_name}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -56,7 +56,7 @@
                     {
                         "display_type": "bars",
                         "on_right_yaxis": false,
-                        "q": "avg:spark.job.count{status:failed,$spark_node,$databricks_cluster_name}",
+                        "q": "avg:spark.job.count{status:failed,$spark_node,$databricks_cluster_name,$app_name}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -90,13 +90,12 @@
         },
         {
             "definition": {
-                "custom_links": [],
                 "custom_unit": " ",
                 "precision": 0,
                 "requests": [
                     {
                         "aggregator": "last",
-                        "q": "sum:spark.job.num_tasks{status:running,$spark_node,$databricks_cluster_name}"
+                        "q": "sum:spark.job.num_tasks{status:running,$spark_node,$databricks_cluster_name,$app_name}"
                     }
                 ],
                 "time": {
@@ -122,7 +121,7 @@
                 "requests": [
                     {
                         "aggregator": "last",
-                        "q": "sum:spark.job.count{status:running,$spark_node,$databricks_cluster_name}"
+                        "q": "sum:spark.job.count{status:running,$spark_node,$databricks_cluster_name,$app_name}"
                     }
                 ],
                 "time": {
@@ -148,7 +147,7 @@
                 "requests": [
                     {
                         "aggregator": "last",
-                        "q": "sum:spark.executor.count{$spark_node,$databricks_cluster_name}"
+                        "q": "sum:spark.executor.count{$spark_node,$databricks_cluster_name,$app_name}"
                     }
                 ],
                 "time": {
@@ -169,12 +168,11 @@
         },
         {
             "definition": {
-                "custom_links": [],
                 "precision": 0,
                 "requests": [
                     {
                         "aggregator": "last",
-                        "q": "sum:spark.stage.count{status:active,$spark_node,$databricks_cluster_name}"
+                        "q": "sum:spark.stage.count{status:active,$spark_node,$databricks_cluster_name,$app_name}"
                     }
                 ],
                 "time": {
@@ -208,7 +206,7 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "sum:spark.job.num_tasks{status:running,$spark_node,$databricks_cluster_name}",
+                        "q": "sum:spark.job.num_tasks{status:running,$spark_node,$databricks_cluster_name,$app_name}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -218,7 +216,7 @@
                     {
                         "display_type": "line",
                         "on_right_yaxis": false,
-                        "q": "sum:spark.job.num_completed_tasks{$spark_node,$databricks_cluster_name}",
+                        "q": "sum:spark.job.num_completed_tasks{$spark_node,$databricks_cluster_name,$app_name}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -228,7 +226,7 @@
                     {
                         "display_type": "line",
                         "on_right_yaxis": false,
-                        "q": "sum:spark.job.num_skipped_tasks{$spark_node,$databricks_cluster_name}",
+                        "q": "sum:spark.job.num_skipped_tasks{$spark_node,$databricks_cluster_name,$app_name}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -238,7 +236,7 @@
                     {
                         "display_type": "line",
                         "on_right_yaxis": false,
-                        "q": "sum:spark.job.num_failed_tasks{$spark_node,$databricks_cluster_name}",
+                        "q": "sum:spark.job.num_failed_tasks{$spark_node,$databricks_cluster_name,$app_name}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -277,11 +275,11 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "sum:spark.stage.input_bytes{$spark_node,$databricks_cluster_name}"
+                        "q": "sum:spark.stage.input_bytes{$spark_node,$databricks_cluster_name,$app_name}"
                     },
                     {
                         "display_type": "line",
-                        "q": "sum:spark.stage.output_bytes{$spark_node,$databricks_cluster_name}"
+                        "q": "sum:spark.stage.output_bytes{$spark_node,$databricks_cluster_name,$app_name}"
                     }
                 ],
                 "show_legend": false,
@@ -308,11 +306,11 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "sum:spark.stage.input_records{$spark_node,$databricks_cluster_name}"
+                        "q": "sum:spark.stage.input_records{$spark_node,$databricks_cluster_name,$app_name}"
                     },
                     {
                         "display_type": "line",
-                        "q": "sum:spark.stage.output_records{$spark_node,$databricks_cluster_name}"
+                        "q": "sum:spark.stage.output_records{$spark_node,$databricks_cluster_name,$app_name}"
                     }
                 ],
                 "show_legend": false,
@@ -339,15 +337,15 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "sum:spark.stage.shuffle_read_bytes{$spark_node,$databricks_cluster_name}"
+                        "q": "sum:spark.stage.shuffle_read_bytes{$spark_node,$databricks_cluster_name,$app_name}"
                     },
                     {
                         "display_type": "line",
-                        "q": "sum:spark.stage.shuffle_write_bytes{$spark_node,$databricks_cluster_name}"
+                        "q": "sum:spark.stage.shuffle_write_bytes{$spark_node,$databricks_cluster_name,$app_name}"
                     },
                     {
                         "display_type": "line",
-                        "q": "sum:spark.stage.shuffle_write_bytes{$spark_node,$databricks_cluster_name}"
+                        "q": "sum:spark.stage.shuffle_write_bytes{$spark_node,$databricks_cluster_name,$app_name}"
                     }
                 ],
                 "show_legend": false,
@@ -374,11 +372,11 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "avg:spark.stage.shuffle_read_records{$spark_node,$databricks_cluster_name}"
+                        "q": "avg:spark.stage.shuffle_read_records{$spark_node,$databricks_cluster_name,$app_name}"
                     },
                     {
                         "display_type": "line",
-                        "q": "avg:spark.stage.shuffle_write_records{$spark_node,$databricks_cluster_name}"
+                        "q": "avg:spark.stage.shuffle_write_records{$spark_node,$databricks_cluster_name,$app_name}"
                     }
                 ],
                 "show_legend": false,
@@ -400,7 +398,7 @@
         },
         {
             "definition": {
-                "query": "spark has status $spark_node $databricks_cluster_name",
+                "query": "spark has status $spark_node $databricks_cluster_name $app_name",
                 "tags_execution": "and",
                 "time": {
                     "live_span": "1d"
@@ -439,7 +437,7 @@
                 "node_type": "host",
                 "requests": {
                     "fill": {
-                        "q": "avg:system.cpu.user{$databricks_cluster_name,$spark_node} by {host}"
+                        "q": "avg:system.cpu.user{$databricks_cluster_name,$spark_node,$app_name} by {host}"
                     }
                 },
                 "scope": [
@@ -597,7 +595,7 @@
                 ],
                 "indexes": [],
                 "message_display": "expanded-md",
-                "query": "service:databricks",
+                "query": "service:databricks $databricks_cluster_name $spark_node",
                 "show_date_column": true,
                 "show_message_column": true,
                 "sort": {
@@ -653,7 +651,7 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "sum:spark.driver.disk_used{$spark_node,$databricks_cluster_name}.as_count()",
+                        "q": "sum:spark.driver.disk_used{$spark_node,$databricks_cluster_name,$app_name}.as_count()",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -700,7 +698,7 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "sum:spark.driver.memory_used{$spark_node,$databricks_cluster_name}.as_count()",
+                        "q": "sum:spark.driver.memory_used{$spark_node,$databricks_cluster_name,$app_name}.as_count()",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -747,7 +745,7 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "sum:spark.executor.disk_used{$spark_node,$databricks_cluster_name}.as_count()",
+                        "q": "sum:spark.executor.disk_used{$spark_node,$databricks_cluster_name,$app_name}.as_count()",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -794,7 +792,7 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "sum:spark.job.num_active_stages{$spark_node,$databricks_cluster_name}.as_count()",
+                        "q": "sum:spark.job.num_active_stages{$spark_node,$databricks_cluster_name,$app_name}.as_count()",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -804,7 +802,7 @@
                     {
                         "display_type": "line",
                         "on_right_yaxis": false,
-                        "q": "sum:spark.job.num_failed_stages{$spark_node,$databricks_cluster_name}.as_count()",
+                        "q": "sum:spark.job.num_failed_stages{$spark_node,$databricks_cluster_name,$app_name}.as_count()",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -814,7 +812,7 @@
                     {
                         "display_type": "line",
                         "on_right_yaxis": false,
-                        "q": "sum:spark.job.num_skipped_stages{$spark_node,$databricks_cluster_name}.as_count()",
+                        "q": "sum:spark.job.num_skipped_stages{$spark_node,$databricks_cluster_name,$app_name}.as_count()",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -940,7 +938,7 @@
                 "requests": [
                     {
                         "display_type": "line",
-                        "q": "sum:spark.executor.memory_used{$spark_node,$databricks_cluster_name}.as_count()",
+                        "q": "sum:spark.executor.memory_used{$spark_node,$databricks_cluster_name,$app_name}.as_count()",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",
@@ -1052,7 +1050,7 @@
                     },
                     {
                         "display_type": "line",
-                        "q": "sum:system.load.15{$spark_node,$databricks_cluster_name}",
+                        "q": "sum:system.load.15{$spark_node,$databricks_cluster_name,$app_name}",
                         "style": {
                             "line_type": "solid",
                             "line_width": "normal",

--- a/databricks/assets/dashboards/databricks_overview.json
+++ b/databricks/assets/dashboards/databricks_overview.json
@@ -1,0 +1,1109 @@
+{
+    "author_name": "Datadog",
+    "description": "This dashboard tracks the current status of your Spark jobs, tasks, and stages on your Databricks clusters. It also allows you to track expensive operations like shuffles, which point to possible areas for optimization. Further reading on Spark monitoring:\n\n- [Docs for Datadog's Databricks integration](https://docs.datadoghq.com/integrations/databricks/)\n\nClone this template dashboard to make changes and add your own graph widgets. ",
+    "layout_type": "free",
+    "template_variables": [
+        {
+            "default": "*",
+            "name": "spark_node",
+            "prefix": "spark_node"
+        },
+        {
+            "default": "*",
+            "name": "databricks_cluster_name",
+            "prefix": "databricks_cluster_name"
+        },
+        {
+            "default": "*",
+            "name": "app_name",
+            "prefix": "app_name"
+        }
+    ],
+    "title": "Databricks Spark Overview",
+    "widgets": [
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "legend_size": "0",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "bars",
+                        "q": "sum:spark.job.count{status:succeeded,$spark_node,$databricks_cluster_name}",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    },
+                    {
+                        "display_type": "bars",
+                        "on_right_yaxis": false,
+                        "q": "sum:spark.job.count{status:running,$spark_node,$databricks_cluster_name}",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "purple"
+                        }
+                    },
+                    {
+                        "display_type": "bars",
+                        "on_right_yaxis": false,
+                        "q": "avg:spark.job.count{status:failed,$spark_node,$databricks_cluster_name}",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "warm"
+                        }
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "Jobs by status",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 1,
+            "layout": {
+                "height": 15,
+                "width": 38,
+                "x": 20,
+                "y": 106
+            }
+        },
+        {
+            "definition": {
+                "custom_links": [],
+                "custom_unit": " ",
+                "precision": 0,
+                "requests": [
+                    {
+                        "aggregator": "last",
+                        "q": "sum:spark.job.num_tasks{status:running,$spark_node,$databricks_cluster_name}"
+                    }
+                ],
+                "time": {
+                    "live_span": "1h"
+                },
+                "title": "Tasks Running",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "query_value"
+            },
+            "id": 2,
+            "layout": {
+                "height": 11,
+                "width": 15,
+                "x": 36,
+                "y": 19
+            }
+        },
+        {
+            "definition": {
+                "custom_links": [],
+                "precision": 0,
+                "requests": [
+                    {
+                        "aggregator": "last",
+                        "q": "sum:spark.job.count{status:running,$spark_node,$databricks_cluster_name}"
+                    }
+                ],
+                "time": {
+                    "live_span": "1h"
+                },
+                "title": "Jobs Running",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "query_value"
+            },
+            "id": 3,
+            "layout": {
+                "height": 11,
+                "width": 15,
+                "x": 36,
+                "y": 7
+            }
+        },
+        {
+            "definition": {
+                "custom_links": [],
+                "precision": 0,
+                "requests": [
+                    {
+                        "aggregator": "last",
+                        "q": "sum:spark.executor.count{$spark_node,$databricks_cluster_name}"
+                    }
+                ],
+                "time": {
+                    "live_span": "1h"
+                },
+                "title": "Executors",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "query_value"
+            },
+            "id": 4,
+            "layout": {
+                "height": 11,
+                "width": 15,
+                "x": 20,
+                "y": 7
+            }
+        },
+        {
+            "definition": {
+                "custom_links": [],
+                "precision": 0,
+                "requests": [
+                    {
+                        "aggregator": "last",
+                        "q": "sum:spark.stage.count{status:active,$spark_node,$databricks_cluster_name}"
+                    }
+                ],
+                "time": {
+                    "live_span": "1h"
+                },
+                "title": "Stages Running",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "query_value"
+            },
+            "id": 5,
+            "layout": {
+                "height": 11,
+                "width": 15,
+                "x": 20,
+                "y": 19
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "legend_size": "0",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "q": "sum:spark.job.num_tasks{status:running,$spark_node,$databricks_cluster_name}",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    },
+                    {
+                        "display_type": "line",
+                        "on_right_yaxis": false,
+                        "q": "sum:spark.job.num_completed_tasks{$spark_node,$databricks_cluster_name}",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "purple"
+                        }
+                    },
+                    {
+                        "display_type": "line",
+                        "on_right_yaxis": false,
+                        "q": "sum:spark.job.num_skipped_tasks{$spark_node,$databricks_cluster_name}",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "grey"
+                        }
+                    },
+                    {
+                        "display_type": "line",
+                        "on_right_yaxis": false,
+                        "q": "sum:spark.job.num_failed_tasks{$spark_node,$databricks_cluster_name}",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "warm"
+                        }
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "Job tasks",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 6,
+            "layout": {
+                "height": 15,
+                "width": 38,
+                "x": 59,
+                "y": 106
+            }
+        },
+        {
+            "definition": {
+                "custom_links": [],
+                "legend_size": "0",
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "q": "sum:spark.stage.input_bytes{$spark_node,$databricks_cluster_name}"
+                    },
+                    {
+                        "display_type": "line",
+                        "q": "sum:spark.stage.output_bytes{$spark_node,$databricks_cluster_name}"
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "Stage Input/Output Bytes",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries"
+            },
+            "id": 8,
+            "layout": {
+                "height": 15,
+                "width": 38,
+                "x": 59,
+                "y": 68
+            }
+        },
+        {
+            "definition": {
+                "custom_links": [],
+                "legend_size": "0",
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "q": "sum:spark.stage.input_records{$spark_node,$databricks_cluster_name}"
+                    },
+                    {
+                        "display_type": "line",
+                        "q": "sum:spark.stage.output_records{$spark_node,$databricks_cluster_name}"
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "Stage Input/Output Records",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries"
+            },
+            "id": 9,
+            "layout": {
+                "height": 15,
+                "width": 38,
+                "x": 20,
+                "y": 68
+            }
+        },
+        {
+            "definition": {
+                "custom_links": [],
+                "legend_size": "0",
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "q": "sum:spark.stage.shuffle_read_bytes{$spark_node,$databricks_cluster_name}"
+                    },
+                    {
+                        "display_type": "line",
+                        "q": "sum:spark.stage.shuffle_write_bytes{$spark_node,$databricks_cluster_name}"
+                    },
+                    {
+                        "display_type": "line",
+                        "q": "sum:spark.stage.shuffle_write_bytes{$spark_node,$databricks_cluster_name}"
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "Shuffle Read/Write Bytes",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries"
+            },
+            "id": 10,
+            "layout": {
+                "height": 15,
+                "width": 38,
+                "x": 59,
+                "y": 84
+            }
+        },
+        {
+            "definition": {
+                "custom_links": [],
+                "legend_size": "0",
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "q": "avg:spark.stage.shuffle_read_records{$spark_node,$databricks_cluster_name}"
+                    },
+                    {
+                        "display_type": "line",
+                        "q": "avg:spark.stage.shuffle_write_records{$spark_node,$databricks_cluster_name}"
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "Shuffle Read/Write Records",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries"
+            },
+            "id": 11,
+            "layout": {
+                "height": 15,
+                "width": 38,
+                "x": 20,
+                "y": 84
+            }
+        },
+        {
+            "definition": {
+                "query": "spark has status $spark_node $databricks_cluster_name",
+                "tags_execution": "and",
+                "time": {
+                    "live_span": "1d"
+                },
+                "title": "Spark Application Event Counts",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "event_timeline"
+            },
+            "id": 14,
+            "layout": {
+                "height": 9,
+                "width": 53,
+                "x": 98,
+                "y": 62
+            }
+        },
+        {
+            "definition": {
+                "sizing": "fit",
+                "type": "image",
+                "url": "/static/images/avatars/bot/databricks@2x.png"
+            },
+            "id": 6923169892567062,
+            "layout": {
+                "height": 12,
+                "width": 18,
+                "x": 1,
+                "y": 1
+            }
+        },
+        {
+            "definition": {
+                "no_group_hosts": true,
+                "no_metric_hosts": true,
+                "node_type": "host",
+                "requests": {
+                    "fill": {
+                        "q": "avg:system.cpu.user{$databricks_cluster_name,$spark_node} by {host}"
+                    }
+                },
+                "scope": [
+                    "$databricks_cluster_name",
+                    "$spark_node"
+                ],
+                "style": {
+                    "palette": "green_to_orange",
+                    "palette_flip": false
+                },
+                "title": "Clusters by name",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "hostmap"
+            },
+            "id": 1229753999311206,
+            "layout": {
+                "height": 23,
+                "width": 31,
+                "x": 20,
+                "y": 31
+            }
+        },
+        {
+            "definition": {
+                "background_color": "blue",
+                "content": "## Driver",
+                "font_size": "14",
+                "has_padding": true,
+                "show_tick": false,
+                "text_align": "center",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "top"
+            },
+            "id": 8960035777117260,
+            "layout": {
+                "height": 5,
+                "width": 53,
+                "x": 98,
+                "y": 7
+            }
+        },
+        {
+            "definition": {
+                "background_color": "vivid_blue",
+                "content": "## Spark Utilization",
+                "font_size": "14",
+                "has_padding": true,
+                "show_tick": false,
+                "text_align": "center",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "top"
+            },
+            "id": 7350862878747550,
+            "layout": {
+                "height": 5,
+                "width": 77,
+                "x": 20,
+                "y": 56
+            }
+        },
+        {
+            "definition": {
+                "background_color": "vivid_blue",
+                "content": "## Resource Overview",
+                "font_size": "14",
+                "has_padding": true,
+                "show_tick": false,
+                "text_align": "center",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "top"
+            },
+            "id": 8686124901378756,
+            "layout": {
+                "height": 5,
+                "width": 77,
+                "x": 20,
+                "y": 1
+            }
+        },
+        {
+            "definition": {
+                "background_color": "blue",
+                "content": "## Stages",
+                "font_size": "14",
+                "has_padding": true,
+                "show_tick": false,
+                "text_align": "center",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "top"
+            },
+            "id": 5686463021863234,
+            "layout": {
+                "height": 5,
+                "width": 77,
+                "x": 20,
+                "y": 62
+            }
+        },
+        {
+            "definition": {
+                "background_color": "blue",
+                "content": "## Jobs",
+                "font_size": "14",
+                "has_padding": true,
+                "show_tick": false,
+                "text_align": "center",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "top"
+            },
+            "id": 3811207773638468,
+            "layout": {
+                "height": 5,
+                "width": 77,
+                "x": 20,
+                "y": 100
+            }
+        },
+        {
+            "definition": {
+                "background_color": "vivid_blue",
+                "content": "## Logs",
+                "font_size": "14",
+                "has_padding": true,
+                "show_tick": false,
+                "text_align": "center",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "top"
+            },
+            "id": 1840504089064110,
+            "layout": {
+                "height": 5,
+                "width": 53,
+                "x": 98,
+                "y": 56
+            }
+        },
+        {
+            "definition": {
+                "columns": [
+                    "host",
+                    "service"
+                ],
+                "indexes": [],
+                "message_display": "expanded-md",
+                "query": "service:databricks",
+                "show_date_column": true,
+                "show_message_column": true,
+                "sort": {
+                    "column": "time",
+                    "order": "desc"
+                },
+                "title": "",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "log_stream"
+            },
+            "id": 683819160013726,
+            "layout": {
+                "height": 35,
+                "width": 53,
+                "x": 98,
+                "y": 74
+            }
+        },
+        {
+            "definition": {
+                "background_color": "blue",
+                "content": "## Executor",
+                "font_size": "14",
+                "has_padding": true,
+                "show_tick": false,
+                "text_align": "center",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "top"
+            },
+            "id": 4053892245219892,
+            "layout": {
+                "height": 5,
+                "width": 53,
+                "x": 98,
+                "y": 31
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "legend_size": "0",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "q": "sum:spark.driver.disk_used{$spark_node,$databricks_cluster_name}.as_count()",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "Disk used",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 3910475514087374,
+            "layout": {
+                "height": 16,
+                "width": 26,
+                "x": 125,
+                "y": 13
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "legend_size": "0",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "q": "sum:spark.driver.memory_used{$spark_node,$databricks_cluster_name}.as_count()",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "Memory used",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 2550647787685396,
+            "layout": {
+                "height": 16,
+                "width": 26,
+                "x": 98,
+                "y": 13
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "legend_size": "0",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "q": "sum:spark.executor.disk_used{$spark_node,$databricks_cluster_name}.as_count()",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "Disk used",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 1989121037430794,
+            "layout": {
+                "height": 17,
+                "width": 26,
+                "x": 125,
+                "y": 37
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "legend_size": "0",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "q": "sum:spark.job.num_active_stages{$spark_node,$databricks_cluster_name}.as_count()",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    },
+                    {
+                        "display_type": "line",
+                        "on_right_yaxis": false,
+                        "q": "sum:spark.job.num_failed_stages{$spark_node,$databricks_cluster_name}.as_count()",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "warm"
+                        }
+                    },
+                    {
+                        "display_type": "line",
+                        "on_right_yaxis": false,
+                        "q": "sum:spark.job.num_skipped_stages{$spark_node,$databricks_cluster_name}.as_count()",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "grey"
+                        }
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "Job stages",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 3386900080029476,
+            "layout": {
+                "height": 15,
+                "width": 38,
+                "x": 20,
+                "y": 122
+            }
+        },
+        {
+            "definition": {
+                "background_color": "vivid_blue",
+                "content": "## Spark Resources",
+                "font_size": "14",
+                "has_padding": true,
+                "show_tick": false,
+                "text_align": "center",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "top"
+            },
+            "id": 6857959232502226,
+            "layout": {
+                "height": 5,
+                "width": 53,
+                "x": 98,
+                "y": 1
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "legend_size": "0",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "on_right_yaxis": false,
+                        "q": "sum:system.mem.free{$spark_node,$databricks_cluster_name}",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "purple"
+                        }
+                    },
+                    {
+                        "display_type": "line",
+                        "on_right_yaxis": false,
+                        "q": "sum:system.mem.total{$spark_node,$databricks_cluster_name}",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "grey"
+                        }
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "System memory",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 8086606489508008,
+            "layout": {
+                "height": 15,
+                "width": 44,
+                "x": 53,
+                "y": 7
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "legend_size": "0",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "q": "sum:spark.executor.memory_used{$spark_node,$databricks_cluster_name}.as_count()",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "Memory used",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 617417483140790,
+            "layout": {
+                "height": 17,
+                "width": 26,
+                "x": 98,
+                "y": 37
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "legend_size": "0",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "q": "sum:system.cpu.pct{$spark_node,$databricks_cluster_name}",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "CPU percent utilization",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 4028442823303522,
+            "layout": {
+                "height": 15,
+                "width": 44,
+                "x": 53,
+                "y": 23
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "legend_size": "0",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "q": "sum:system.load.1{$spark_node,$databricks_cluster_name}",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    },
+                    {
+                        "display_type": "line",
+                        "q": "sum:system.load.5{$spark_node,$databricks_cluster_name}",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    },
+                    {
+                        "display_type": "line",
+                        "q": "sum:system.load.15{$spark_node,$databricks_cluster_name}",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "show_legend": false,
+                "time": {
+                    "live_span": "4h"
+                },
+                "title": "System load",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 2866533534112550,
+            "layout": {
+                "height": 15,
+                "width": 44,
+                "x": 53,
+                "y": 39
+            }
+        },
+        {
+            "definition": {
+                "background_color": "white",
+                "content": "This dashboard tracks the current status of your Spark jobs, tasks, and stages in your Databricks clusters. It also allows you to track the resource utilization of your nodes, which point to possible areas for optimization. Further reading on Databricks and Spark monitoring:\n\n[Docs for Datadog's Databricks integration](https://docs.datadoghq.com/integrations/databricks/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
+                "font_size": "14",
+                "has_padding": true,
+                "show_tick": false,
+                "text_align": "left",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "top"
+            },
+            "id": 7665647046384524,
+            "layout": {
+                "height": 35,
+                "width": 18,
+                "x": 1,
+                "y": 14
+            }
+        }
+    ]
+}

--- a/databricks/assets/dashboards/databricks_overview.json
+++ b/databricks/assets/dashboards/databricks_overview.json
@@ -84,7 +84,7 @@
             "layout": {
                 "height": 15,
                 "width": 38,
-                "x": 20,
+                "x": 22,
                 "y": 106
             }
         },
@@ -111,7 +111,7 @@
             "layout": {
                 "height": 11,
                 "width": 15,
-                "x": 36,
+                "x": 38,
                 "y": 19
             }
         },
@@ -137,7 +137,7 @@
             "layout": {
                 "height": 11,
                 "width": 15,
-                "x": 36,
+                "x": 38,
                 "y": 7
             }
         },
@@ -163,7 +163,7 @@
             "layout": {
                 "height": 11,
                 "width": 15,
-                "x": 20,
+                "x": 22,
                 "y": 7
             }
         },
@@ -189,7 +189,7 @@
             "layout": {
                 "height": 11,
                 "width": 15,
-                "x": 20,
+                "x": 22,
                 "y": 19
             }
         },
@@ -266,7 +266,7 @@
             "layout": {
                 "height": 15,
                 "width": 38,
-                "x": 59,
+                "x": 61,
                 "y": 106
             }
         },
@@ -297,7 +297,7 @@
             "layout": {
                 "height": 15,
                 "width": 38,
-                "x": 59,
+                "x": 61,
                 "y": 68
             }
         },
@@ -328,7 +328,7 @@
             "layout": {
                 "height": 15,
                 "width": 38,
-                "x": 20,
+                "x": 22,
                 "y": 68
             }
         },
@@ -363,7 +363,7 @@
             "layout": {
                 "height": 15,
                 "width": 38,
-                "x": 59,
+                "x": 61,
                 "y": 84
             }
         },
@@ -394,7 +394,7 @@
             "layout": {
                 "height": 15,
                 "width": 38,
-                "x": 20,
+                "x": 22,
                 "y": 84
             }
         },
@@ -414,7 +414,7 @@
             "layout": {
                 "height": 9,
                 "width": 53,
-                "x": 98,
+                "x": 100,
                 "y": 62
             }
         },
@@ -427,8 +427,8 @@
             "id": 6923169892567062,
             "layout": {
                 "height": 12,
-                "width": 18,
-                "x": 1,
+                "width": 21,
+                "x": 0,
                 "y": 1
             }
         },
@@ -459,13 +459,13 @@
             "layout": {
                 "height": 23,
                 "width": 31,
-                "x": 20,
+                "x": 22,
                 "y": 31
             }
         },
         {
             "definition": {
-                "background_color": "blue",
+                "background_color": "orange",
                 "content": "## Driver",
                 "font_size": "14",
                 "has_padding": true,
@@ -480,14 +480,14 @@
             "layout": {
                 "height": 5,
                 "width": 53,
-                "x": 98,
+                "x": 100,
                 "y": 7
             }
         },
         {
             "definition": {
-                "background_color": "vivid_blue",
-                "content": "## Spark Utilization",
+                "background_color": "vivid_orange",
+                "content": "## Spark Job Status",
                 "font_size": "14",
                 "has_padding": true,
                 "show_tick": false,
@@ -501,13 +501,13 @@
             "layout": {
                 "height": 5,
                 "width": 77,
-                "x": 20,
+                "x": 22,
                 "y": 56
             }
         },
         {
             "definition": {
-                "background_color": "vivid_blue",
+                "background_color": "vivid_orange",
                 "content": "## Resource Overview",
                 "font_size": "14",
                 "has_padding": true,
@@ -522,13 +522,13 @@
             "layout": {
                 "height": 5,
                 "width": 77,
-                "x": 20,
+                "x": 22,
                 "y": 1
             }
         },
         {
             "definition": {
-                "background_color": "blue",
+                "background_color": "orange",
                 "content": "## Stages",
                 "font_size": "14",
                 "has_padding": true,
@@ -543,13 +543,13 @@
             "layout": {
                 "height": 5,
                 "width": 77,
-                "x": 20,
+                "x": 22,
                 "y": 62
             }
         },
         {
             "definition": {
-                "background_color": "blue",
+                "background_color": "orange",
                 "content": "## Jobs",
                 "font_size": "14",
                 "has_padding": true,
@@ -564,14 +564,14 @@
             "layout": {
                 "height": 5,
                 "width": 77,
-                "x": 20,
+                "x": 22,
                 "y": 100
             }
         },
         {
             "definition": {
-                "background_color": "vivid_blue",
-                "content": "## Logs",
+                "background_color": "vivid_orange",
+                "content": "## Events and Logs",
                 "font_size": "14",
                 "has_padding": true,
                 "show_tick": false,
@@ -585,7 +585,7 @@
             "layout": {
                 "height": 5,
                 "width": 53,
-                "x": 98,
+                "x": 100,
                 "y": 56
             }
         },
@@ -613,13 +613,13 @@
             "layout": {
                 "height": 35,
                 "width": 53,
-                "x": 98,
+                "x": 100,
                 "y": 74
             }
         },
         {
             "definition": {
-                "background_color": "blue",
+                "background_color": "orange",
                 "content": "## Executor",
                 "font_size": "14",
                 "has_padding": true,
@@ -634,7 +634,7 @@
             "layout": {
                 "height": 5,
                 "width": 53,
-                "x": 98,
+                "x": 100,
                 "y": 31
             }
         },
@@ -681,7 +681,7 @@
             "layout": {
                 "height": 16,
                 "width": 26,
-                "x": 125,
+                "x": 127,
                 "y": 13
             }
         },
@@ -728,7 +728,7 @@
             "layout": {
                 "height": 16,
                 "width": 26,
-                "x": 98,
+                "x": 100,
                 "y": 13
             }
         },
@@ -775,7 +775,7 @@
             "layout": {
                 "height": 17,
                 "width": 26,
-                "x": 125,
+                "x": 127,
                 "y": 37
             }
         },
@@ -842,13 +842,13 @@
             "layout": {
                 "height": 15,
                 "width": 38,
-                "x": 20,
+                "x": 22,
                 "y": 122
             }
         },
         {
             "definition": {
-                "background_color": "vivid_blue",
+                "background_color": "vivid_orange",
                 "content": "## Spark Resources",
                 "font_size": "14",
                 "has_padding": true,
@@ -863,7 +863,7 @@
             "layout": {
                 "height": 5,
                 "width": 53,
-                "x": 98,
+                "x": 100,
                 "y": 1
             }
         },
@@ -921,7 +921,7 @@
             "layout": {
                 "height": 15,
                 "width": 44,
-                "x": 53,
+                "x": 55,
                 "y": 7
             }
         },
@@ -968,7 +968,7 @@
             "layout": {
                 "height": 17,
                 "width": 26,
-                "x": 98,
+                "x": 100,
                 "y": 37
             }
         },
@@ -1015,7 +1015,7 @@
             "layout": {
                 "height": 15,
                 "width": 44,
-                "x": 53,
+                "x": 55,
                 "y": 23
             }
         },
@@ -1080,14 +1080,35 @@
             "layout": {
                 "height": 15,
                 "width": 44,
-                "x": 53,
+                "x": 55,
                 "y": 39
             }
         },
         {
             "definition": {
                 "background_color": "white",
-                "content": "This dashboard tracks the current status of your Spark jobs, tasks, and stages in your Databricks clusters. It also allows you to track the resource utilization of your nodes, which point to possible areas for optimization. Further reading on Databricks and Spark monitoring:\n\n[Docs for Datadog's Databricks integration](https://docs.datadoghq.com/integrations/databricks/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
+                "content": "This dashboard tracks the current status of your Spark jobs, tasks, and stages in your Databricks clusters. It also allows you to track the resource utilization of your nodes, which point to possible areas for optimization. \n\nSee the [Datadog Databricks integration documentation](https://docs.datadoghq.com/integrations/databricks/) to find the suitable init script for your Databricks cluster environment.\n\nClone this template dashboard to make changes and add your own graph widgets.",
+                "font_size": "14",
+                "has_padding": true,
+                "show_tick": true,
+                "text_align": "left",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "top"
+            },
+            "id": 7665647046384524,
+            "layout": {
+                "height": 33,
+                "width": 21,
+                "x": 0,
+                "y": 15
+            }
+        },
+        {
+            "definition": {
+                "background_color": "gray",
+                "content": "Monitor the resource consumption on your Spark driver and worker nodes.\n\nIf there is high resource consumption on your clusters, consider choosing a larger Driver or Worker type for the cluster. Read more about configuring your [Databricks clusters](https://docs.databricks.com/clusters/configure.html).",
                 "font_size": "14",
                 "has_padding": true,
                 "show_tick": false,
@@ -1097,12 +1118,54 @@
                 "type": "note",
                 "vertical_align": "top"
             },
-            "id": 7665647046384524,
+            "id": 2699895617290038,
             "layout": {
-                "height": 35,
+                "height": 24,
                 "width": 18,
+                "x": 154,
+                "y": 7
+            }
+        },
+        {
+            "definition": {
+                "background_color": "gray",
+                "content": "The Datadog init scripts support logs configuration to collect and monitor your [Databrick's driver logs](https://docs.microsoft.com/en-us/azure/databricks/clusters/clusters-manage#driver-logs). \n\nYou can also modify the init scripts to configure additional logs instances to read from other log files in your environment. ",
+                "font_size": "14",
+                "has_padding": true,
+                "show_tick": false,
+                "text_align": "left",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "top"
+            },
+            "id": 7563107946559838,
+            "layout": {
+                "height": 24,
+                "width": 18,
+                "x": 154,
+                "y": 74
+            }
+        },
+        {
+            "definition": {
+                "background_color": "gray",
+                "content": "Monitor your Spark jobs, stages, and tasks by status. \n\nIncrease in stage failures may signify there is a problem with processing a Spark task like incorrect Spark configuration or code errors. Correlate the failures with your driver logs to observe for an exception.",
+                "font_size": "14",
+                "has_padding": true,
+                "show_tick": false,
+                "text_align": "left",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "top"
+            },
+            "id": 2025887844092124,
+            "layout": {
+                "height": 24,
+                "width": 19,
                 "x": 1,
-                "y": 14
+                "y": 77
             }
         }
     ]

--- a/databricks/manifest.json
+++ b/databricks/manifest.json
@@ -24,7 +24,9 @@
   "is_public": true,
   "integration_id": "databricks",
   "assets": {
-    "dashboards": {},
+    "dashboards": {
+      "Databricks Spark Overview": "assets/dashboards/databricks_overview.json"
+    },
     "saved_views": {},
     "monitors": {},
     "service_checks": "assets/service_checks.json",

--- a/databricks/manifest.json
+++ b/databricks/manifest.json
@@ -25,7 +25,7 @@
   "integration_id": "databricks",
   "assets": {
     "dashboards": {
-      "Databricks Spark Overview": "assets/dashboards/databricks_overview.json"
+      "Databricks Spark Overview": "assets/dashboards/spark_overview.json"
     },
     "saved_views": {},
     "monitors": {},

--- a/databricks/manifest.json
+++ b/databricks/manifest.json
@@ -25,7 +25,7 @@
   "integration_id": "databricks",
   "assets": {
     "dashboards": {
-      "Databricks Spark Overview": "assets/dashboards/spark_overview.json"
+      "Databricks Spark Overview": "assets/dashboards/databricks_overview.json"
     },
     "saved_views": {},
     "monitors": {},


### PR DESCRIPTION
### What does this PR do?
Add script suggestions from @levihernandez, thanks!
Clean up and further clarifications and added default dashboard

Scripts now include:
- logs configuration
- host level tags
- clear steps on running the init scripts and setting up clusters

### Additional Notes
<img width="841" alt="Screen Shot 2021-03-16 at 4 24 33 PM" src="https://user-images.githubusercontent.com/15065007/111374972-1c0eea80-8674-11eb-98ab-e13cbd2e49e7.png">
