### PR TITLE
Make kind cluster name kubeadm compliant

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/kind.py
+++ b/datadog_checks_dev/datadog_checks/dev/kind.py
@@ -38,6 +38,8 @@ def kind_run(sleep=None, endpoints=None, conditions=None, env_vars=None, wrapper
 
     # An extra level deep because of the context manager
     check_name = get_current_check_name(depth=2)
+    # Replace undercores as kubeadm doesn't accept them
+    check_name = check_name.replace("_", "-")
     cluster_name = 'cluster-{}-{}'.format(check_name, get_tox_env())
 
     with TempDir(cluster_name) as temp_dir:


### PR DESCRIPTION
### What does this PR do?
For checks with undercores in their names, when creating a kind cluster for e2e tests, replace the undercore with a dash for the cluster name to avoid errors.

### Motivation

Right now, this class creates the kind cluster using the name of the integration, but if the integration has an undercore in its name, it will error, as kubeadm doesn't accept undercores in the cluster names.

When I tried to create an e2e test for `cert_manager`, I got the following error:

```
ERROR: failed to create cluster: failed to init node with kubeadm: command "docker exec --privileged cluster-cert_manager-py38-control-plane kubeadm init --skip-phases=preflight --config=/kind/kubeadm.conf --skip-token-print --v=6" failed with error: exit status 1

Command Output: I0308 08:35:30.043618     232 initconfiguration.go:201] loading configuration from "/kind/kubeadm.conf"
[config] WARNING: Ignored YAML document with GroupVersionKind kubeadm.k8s.io/v1beta2, Kind=JoinConfiguration
hostport cluster-cert_manager-py38-control-plane:6443: host 'cluster-cert_manager-py38-control-plane' must be a valid IP address or a valid RFC-1123 DNS subdomain
```

This patch fixes this.

