### PR TITLE
Update error message to remind people to enable SSO

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/github.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/github.py
@@ -214,5 +214,5 @@ class Github:
         raise Exception(
             'Make sure your GIT access token has one of the scope '
             + ", ".join(one_of_scopes)
-            + ' at https://github.com/settings/tokens'
+            + ' at https://github.com/settings/tokens and enable SSO on it'
         )


### PR DESCRIPTION
### What does this PR do?

### Motivation

Update error message to remind people to enable SSO on their token.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
