### PR TITLE
[AI-1263] [Tomcat] Adding OOTB monitors

### DIFF
--- a/tomcat/assets/monitors/error_count.json
+++ b/tomcat/assets/monitors/error_count.json
@@ -1,5 +1,5 @@
 {
-  "name": "[Tomcat] Increase of the number of errors/second for host: {{host.name}}",
+  "name": "[Tomcat] Increase of the errors/second rate for host: {{host.name}}",
   "type": "query alert",
   "query": "avg(last_4h):anomalies(avg:tomcat.error_count{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
   "message": "There is an increase of the number of errors per second on all request processors for host: {{host.name}}\n\nErrors indicate an issue with the Tomcat server itself, a host, a deployed application, or an application servlet. This includes errors generated when the Tomcat server runs out of memory, can’t find a requested file or servlet, or is unable to serve a JSP due to syntax errors in the servlet codebase.",

--- a/tomcat/assets/monitors/error_count.json
+++ b/tomcat/assets/monitors/error_count.json
@@ -1,0 +1,30 @@
+{
+  "name": "[Tomcat] Increase of the number of errors/second for host: {{host.name}}",
+  "type": "query alert",
+  "query": "avg(last_4h):anomalies(avg:tomcat.error_count{*} by {host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+  "message": "There is an increase of the number of errors per second on all request processors for host: {{host.name}}\n\nErrors indicate an issue with the Tomcat server itself, a host, a deployed application, or an application servlet. This includes errors generated when the Tomcat server runs out of memory, can’t find a requested file or servlet, or is unable to serve a JSP due to syntax errors in the servlet codebase.",
+  "tags": ["integration:tomcat"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 1,
+      "critical_recovery": 0
+    },
+    "threshold_windows": {
+      "trigger_window": "last_15m",
+      "recovery_window": "last_15m"
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when Tomcat experiences an increase of error rate for a specific host."
+  }
+}

--- a/tomcat/assets/monitors/max_proc_time.json
+++ b/tomcat/assets/monitors/max_proc_time.json
@@ -1,0 +1,30 @@
+{
+  "name": "[Tomcat] Anomalous max processing time for host {{host.name}}",
+  "type": "query alert",
+  "query": "avg(last_4h):anomalies(avg:tomcat.max_time{*} by {host}, 'agile', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+  "message": "There is an anomaly in the Tomcat max processing time on host: {{host.name}} \n\n`tomcat.max_time` indicates the maximum amount of time it takes for the server to process one request: from the time an available thread starts processing the request to the time it returns a response. Its value updates whenever the server detects a longer request processing time than the current `tomcat.max_time`.\n\nA spike in max processing time could indicate that a JSP page isn’t loading or an associated process (such as a database query) is taking too long to complete. ",
+  "tags": ["integration:tomcat"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 1,
+      "critical_recovery": 0
+    },
+    "threshold_windows": {
+      "trigger_window": "last_15m",
+      "recovery_window": "last_15m"
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when Tomcat experiences an anomalous max processing time for a specific host."
+  }
+}

--- a/tomcat/assets/monitors/processing_time.json
+++ b/tomcat/assets/monitors/processing_time.json
@@ -1,0 +1,30 @@
+{
+  "name": "[Tomcat] Anomalous average processing time for host {{host.name}}",
+  "type": "query alert",
+  "query": "avg(last_4h):anomalies(avg:tomcat.processing_time{*} by {host}, 'agile', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+  "message": "There is an anomaly in the Tomcat average processing time on host: {{host.name}} \n\nIf the processing time increases as traffic increases, then you may not have enough worker threads to process the requests, or your server is reaching its threshold and consuming too much memory.\n\nNote: When compared with the `tomcat.request_count` metric, you can gauge how many requests your server can efficiently handle.",
+  "tags": ["integration:tomcat"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 1,
+      "critical_recovery": 0
+    },
+    "threshold_windows": {
+      "trigger_window": "last_15m",
+      "recovery_window": "last_15m"
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when Tomcat experiences an anomalous processing time for a specific host."
+  }
+}

--- a/tomcat/assets/monitors/req_count.json
+++ b/tomcat/assets/monitors/req_count.json
@@ -1,0 +1,30 @@
+{
+  "name": "[Tomcat] Anomalous request rate for host {{host.name}}",
+  "type": "query alert",
+  "query": "avg(last_4h):anomalies(avg:tomcat.request_count{*} by {host}, 'agile', 2, direction='both', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='daily') >= 1",
+  "message": "There is an anomaly in the amount of requests handled by Tomcat on host: {{host.name}} ",
+  "tags": ["integration:tomcat"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 1,
+      "critical_recovery": 0
+    },
+    "threshold_windows": {
+      "trigger_window": "last_15m",
+      "recovery_window": "last_15m"
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when Tomcat experiences an anomalous number of request rate for a specific host."
+  }
+}

--- a/tomcat/assets/monitors/thread_busy.json
+++ b/tomcat/assets/monitors/thread_busy.json
@@ -1,0 +1,26 @@
+{
+  "name": "[Tomcat] % of busy threads is high for host: {{host.name}}",
+  "type": "query alert",
+  "query": "avg(last_5m):( avg:tomcat.threads.busy{*} by {host} / max:tomcat.threads.max{*} by {host} ) * 100 > 70",
+  "message": "{{#is_alert}}\n\nALERT: The current amount of busy threads represents {{value}} % of the maximum number of allowed worker threads for host: {{host.name}}\n\n{{/is_alert}} \n\n{{#is_warning}}\n\nWARNING: The current amount of busy threads represents {{value}} % of the maximum number of allowed worker threads for host: {{host.name}}\n\n{{/is_warning}} \n\n",
+  "tags": ["integration:tomcat"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 70,
+      "warning": 50
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when Tomcat current amount of busy threads represents a high percentage of the maximum number of allowed worker threads for a specific host."
+  }
+}

--- a/tomcat/assets/monitors/thread_count_max.json
+++ b/tomcat/assets/monitors/thread_count_max.json
@@ -1,0 +1,26 @@
+{
+  "name": "[Tomcat] % of busy threads is high for host: {{host.name}}",
+  "type": "query alert",
+  "query": "avg(last_5m):( avg:tomcat.threads.busy{*} by {host} / avg:tomcat.threads.count{*} by {host} ) * 100 > 70",
+  "message": "{{#is_alert}}\n\nALERT: The current amount of busy threads represents {{value}} % of  the current amount of threads managed by the thread pool for host: {{host.name}}\n\n{{/is_alert}} \n\n{{#is_warning}}\n\nWARNING: The current amount of busy threads represents {{value}} % of  the current amount of threads managed by the thread pool for host: {{host.name}}\n\n{{/is_warning}} \n\nLearn in the [Key metrics for monitoring Tomcat](https://www.datadoghq.com/blog/tomcat-architecture-and-performance/#fine-tuning-tomcat-thread-usage) blog post how you could fine-tune your Tomcat thread usage.",
+  "tags": ["integration:tomcat"],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": 0,
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 70,
+      "warning": 50
+    }
+  },
+  "recommended_monitor_metadata": {
+    "description": "Notifies when Tomcat current amount of busy threads represents a high percentage of the current amount of threads managed by the thread pool for a specific host."
+  }
+}

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -30,7 +30,14 @@
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
-    "monitors": {},
+    "monitors": {
+      "[Tomcat] Anomalous request rate for host {{host.name}}": "assets/monitors/req_count.json",
+      "[Tomcat] Anomalous max processing time for host {{host.name}}": "assets/monitors/max_proc_time.json",
+      "[Tomcat] Anomalous average processing time for host {{host.name}}": "assets/monitors/processing_time.json",
+      "[Tomcat] % of thread count managed by the thread pool is high for host: {{host.name}}": "assets/monitors/thread_count_max.json",
+      "[Tomcat] % of busy threads is high for host: {{host.name}}": "assets/monitors/thread_busy.json",
+      "[Tomcat] Increase of the number of errors/second for host: {{host.name}}": "assets/monitors/error_count.json"
+    },
     "dashboards": {
       "tomcat--overview": "assets/dashboards/overview.json",
       "tomcat": "assets/dashboards/metrics.json"

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -36,7 +36,7 @@
       "[Tomcat] Anomalous average processing time for host {{host.name}}": "assets/monitors/processing_time.json",
       "[Tomcat] % of thread count managed by the thread pool is high for host: {{host.name}}": "assets/monitors/thread_count_max.json",
       "[Tomcat] % of busy threads is high for host: {{host.name}}": "assets/monitors/thread_busy.json",
-      "[Tomcat] Increase of the number of errors/second for host: {{host.name}}": "assets/monitors/error_count.json"
+      "[Tomcat] Increase of the errors/second rate for host: {{host.name}}": "assets/monitors/error_count.json"
     },
     "dashboards": {
       "tomcat--overview": "assets/dashboards/overview.json",


### PR DESCRIPTION
### What does this PR do?
Adds a set of OOTB monitors for the Tomcat integration following recommendation from: 

https://www.datadoghq.com/blog/tomcat-architecture-and-performance/

Monitors added are:

* [Tomcat] Anomalous request rate for host {{host.name}}
* [Tomcat] Anomalous max processing time for host {{host.name}}
* [Tomcat] Anomalous average processing time for host {{host.name}}
* [Tomcat] % of thread count managed by the thread pool is high for host: {{host.name}}
* [Tomcat] % of busy threads is high for host: {{host.name}}
* [Tomcat] Increase of the errors/second rate for host: {{host.name}}

### Motivation
More OOTB monitors.

### Additional Notes

The article recommends setting JVM monitors as well, but i think this should be addressed in another PR