### PR TITLE
postgres & mysql: fix flaky DBM thread tests

### DIFF
--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -427,8 +427,6 @@ def test_statement_samples_loop_inactive_stop(aggregator, dbm_instance):
     # confirm that the collection loop stops on its own after the check has not been run for a while
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
     mysql_check.check(dbm_instance)
-    while mysql_check._statement_samples._collection_loop_future.running():
-        time.sleep(0.1)
     # make sure there were no unhandled exceptions
     mysql_check._statement_samples._collection_loop_future.result()
     aggregator.assert_metric("dd.mysql.statement_samples.collection_loop_inactive_stop")
@@ -440,7 +438,6 @@ def test_statement_samples_check_cancel(aggregator, dbm_instance):
     # confirm that the collection loop stops on its own after the check has not been run for a while
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
     mysql_check.check(dbm_instance)
-    assert mysql_check._statement_samples._collection_loop_future.running(), "thread should be running"
     mysql_check.cancel()
     # wait for it to stop and make sure it doesn't throw any exceptions
     mysql_check._statement_samples._collection_loop_future.result()

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -345,8 +345,6 @@ def test_statement_samples_collection_loop_inactive_stop(aggregator, integration
     check = integration_check(dbm_instance)
     check._connect()
     check.check(dbm_instance)
-    while check.statement_samples._collection_loop_future.running():
-        time.sleep(0.1)
     # make sure there were no unhandled exceptions
     check.statement_samples._collection_loop_future.result()
     aggregator.assert_metric("dd.postgres.statement_samples.collection_loop_inactive_stop")
@@ -357,7 +355,6 @@ def test_statement_samples_collection_loop_cancel(aggregator, integration_check,
     check = integration_check(dbm_instance)
     check._connect()
     check.check(dbm_instance)
-    assert check.statement_samples._collection_loop_future.running(), "thread should be running"
     check.cancel()
     # wait for it to stop and make sure it doesn't throw any exceptions
     check.statement_samples._collection_loop_future.result()
@@ -381,8 +378,6 @@ def test_statement_samples_invalid_activity_view(aggregator, integration_check, 
     check = integration_check(dbm_instance)
     check._connect()
     check.check(dbm_instance)
-    while check.statement_samples._collection_loop_future.running():
-        time.sleep(0.1)
     # make sure there were no unhandled exceptions
     check.statement_samples._collection_loop_future.result()
     aggregator.assert_metric_has_tag_prefix("dd.postgres.statement_samples.error", "error:database-")


### PR DESCRIPTION
### What does this PR do?
Fix flaky statement samples tests for postgres & mysql: stop waiting on thread start as it's unnecessary since we wait on thread stop anyway.

### Motivation
Fix flaky tests.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
