### PR TITLE
Remove unused default config spec option

### DIFF
--- a/aspdotnet/assets/configuration/spec.yaml
+++ b/aspdotnet/assets/configuration/spec.yaml
@@ -16,12 +16,12 @@ files:
       value:
         type: string
         example: .
-        default: None
+        display_default: None
     - name: port
       description: ASP .NET port to connect to.
       required: true
       value:
         type: integer
         example: 26379
-        default: None
+        display_default: None
     - template: instances/default

--- a/aspdotnet/assets/configuration/spec.yaml
+++ b/aspdotnet/assets/configuration/spec.yaml
@@ -16,12 +16,12 @@ files:
       value:
         type: string
         example: .
-        display_default: None
+        display_default: null
     - name: port
       description: ASP .NET port to connect to.
       required: true
       value:
         type: integer
         example: 26379
-        display_default: None
+        display_default: null
     - template: instances/default

--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -23,7 +23,6 @@ files:
         The Prometheus endpoint is available for Consul versions v1.1.0 or higher.
       value:
         type: boolean
-        default: false
         example: false
     - name: catalog_checks
       description: Set to true to perform checks against the Consul service catalog.

--- a/envoy/assets/configuration/spec.yaml
+++ b/envoy/assets/configuration/spec.yaml
@@ -38,7 +38,6 @@ files:
           type: string
         example:
           - cluster\.(in|out)\..*
-        default: None
     - name: excluded_metrics
       description: |
         Excludes metrics using regular expressions.
@@ -58,7 +57,6 @@ files:
           type: string
         example:
           - ^http\..*
-        default: None
     - name: cache_metrics
       description: |
         Results are cached by default to decrease CPU utilization, at

--- a/haproxy/assets/configuration/spec.yaml
+++ b/haproxy/assets/configuration/spec.yaml
@@ -19,7 +19,6 @@ files:
     - name: url
       required: true
       value:
-        default: null
         example: http://localhost/admin?stats
         type: string
       description: |

--- a/http_check/assets/configuration/spec.yaml
+++ b/http_check/assets/configuration/spec.yaml
@@ -54,7 +54,6 @@ files:
       value:
         type: string
         example: '<REGEX>'
-        default: None
     - name: reverse_content_match
       description: |
         The reverse_content_match parameter will allow the content_match

--- a/kube_apiserver_metrics/assets/configuration/spec.yaml
+++ b/kube_apiserver_metrics/assets/configuration/spec.yaml
@@ -19,7 +19,7 @@ files:
       overrides:
         prometheus_url.value.example: https://localhost:443/metrics
         prometheus_url.display_priority: 1
-        bearer_token_auth.value.default: true
+        bearer_token_auth.value.display_default: true
         bearer_token_auth.value.example: true
 
 - name: auto_conf.yaml
@@ -49,13 +49,11 @@ files:
       description: Used to specify the path where the service account token is located.
       value:
         type: string
-        default: /var/run/secrets/kubernetes.io/serviceaccount/token
         example: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: ssl_verify
       description: Used to verify self signed certificates.
       value:
         type: boolean
-        default: false
         example: false
     - name: tags
       description: |

--- a/kube_scheduler/assets/configuration/spec.yaml
+++ b/kube_scheduler/assets/configuration/spec.yaml
@@ -57,11 +57,9 @@ files:
       description: Used to specify the path where the service account token is located.
       value:
         type: string
-        default: /var/run/secrets/kubernetes.io/serviceaccount/token
         example: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: ssl_verify
       description: Used to verify self signed certificates.
       value:
         type: boolean
-        default: false
         example: false

--- a/marklogic/assets/configuration/spec.yaml
+++ b/marklogic/assets/configuration/spec.yaml
@@ -20,7 +20,6 @@ files:
         `marklogic.database.health` and `marklogic.forests.health` service checks.
         To send the service checks, the MarkLogic user must have `manage-admin` permission.
       value:
-        default: false
         example: false
         type: boolean
     - name: resource_filters

--- a/mcache/assets/configuration/spec.yaml
+++ b/mcache/assets/configuration/spec.yaml
@@ -26,7 +26,6 @@ files:
       description: Port to use when connecting to `url`.
       value:
         type: integer
-        default: 11211
         example: 11211
     - name: username
       description: Username for the Mcache status endpoint authentication.
@@ -71,5 +70,4 @@ files:
       enabled: true
       value:
         type: integer
-        default: 11211
         example: 11211

--- a/mesos_slave/assets/configuration/spec.yaml
+++ b/mesos_slave/assets/configuration/spec.yaml
@@ -18,7 +18,6 @@ files:
           - name: master_port
             description: Port of your Mesos Master instance.
             value:
-              default: 5050
               example: 5050
               type: integer
           - name: tasks

--- a/pgbouncer/assets/configuration/spec.yaml
+++ b/pgbouncer/assets/configuration/spec.yaml
@@ -38,7 +38,6 @@ files:
       - name: use_cached
         description: Cache and re-use PostgreSQL connection or create a new one at each check run.
         value:
-          default: true
           example: true
           type: boolean
       - template: instances/default

--- a/php_fpm/assets/configuration/spec.yaml
+++ b/php_fpm/assets/configuration/spec.yaml
@@ -47,7 +47,6 @@ files:
       required: true
       value:
         type: boolean
-        default: false
         example: false
     - name: http_host
       description: |

--- a/proxysql/assets/configuration/spec.yaml
+++ b/proxysql/assets/configuration/spec.yaml
@@ -36,7 +36,7 @@ files:
         example: <PROXYSQL_ADMIN_PASSWORD>
     - template: instances/tls
       overrides:
-        tls_verify.default: false
+        tls_verify.display_default: false
         tls_verify.value.example: false
         tls_cert.hidden: true
         tls_private_key.hidden: true

--- a/supervisord/assets/configuration/spec.yaml
+++ b/supervisord/assets/configuration/spec.yaml
@@ -34,19 +34,16 @@ files:
           value:
             type: string
             example: <SOCKETFILE_PATH>
-            default: None
         - name: user
           description: Required only if a username is configured.
           value:
             type: string
             example: <USERNAME>
-            default: None
         - name: pass
           description: Required only if a password is configured.
           value:
             type: string
             example: <PASSWORD>
-            default: None
         - name: proc_regex
           description: Regex pattern[s] matching the names of processes to monitor.
           value:
@@ -54,7 +51,6 @@ files:
             items:
               type: string
             example: [<PROC_REGEX>]
-            default: None
         - name: proc_names
           description: |
             The process to monitor within this supervisord instance.
@@ -64,7 +60,6 @@ files:
             items:
               type: string
             example: [<PROCESS_NAME_1>, <PROCESS_NAME_2>]
-            default: None
         - template: instances/default
     - template: logs
       example:

--- a/tcp_check/assets/configuration/spec.yaml
+++ b/tcp_check/assets/configuration/spec.yaml
@@ -12,14 +12,12 @@ files:
       required: true
       value:
         type: string
-        default: null
         example: <TCP_CHECK_INSTANCE_NAME>
     - name: host
       description: Host to connect to.
       required: true
       value:
         type: string
-        default: null
         example: <TCP_HOST_TO_CONNECT_TO>
     - name: port
       description: Port of the host to connect to.

--- a/tokumx/assets/configuration/spec.yaml
+++ b/tokumx/assets/configuration/spec.yaml
@@ -22,7 +22,6 @@ files:
         for more details
       value:
         type: boolean
-        default: false
         example: false
     - name: ssl_keyfile
       description: Path to the private key file used to identify the local connection against Mongodb.


### PR DESCRIPTION
### What does this PR do?

Use `display_default` and remove unused `default` options
### Motivation
Follow up to https://github.com/DataDog/integrations-core/pull/8593

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
