### PR TITLE
Fix snmp get bulk log

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -217,12 +217,15 @@ class SnmpCheck(AgentCheck):
         )
         for oid in config.oid_config.bulk_oids:
             try:
+                oid_object_type = oid.as_object_type()
                 self.log.debug(
-                    '[%s] Running SNMP command getBulk on OID %s', fetch_id, OIDPrinter((oid,), with_values=False)
+                    '[%s] Running SNMP command getBulk on OID %s',
+                    fetch_id,
+                    OIDPrinter((oid_object_type,), with_values=False),
                 )
                 binds = snmp_bulk(
                     config,
-                    oid.as_object_type(),
+                    oid_object_type,
                     self._NON_REPEATERS,
                     self._MAX_REPETITIONS,
                     enforce_constraints,

--- a/snmp/datadog_checks/snmp/utils.py
+++ b/snmp/datadog_checks/snmp/utils.py
@@ -253,7 +253,7 @@ class OIDPrinter(object):
     """
 
     def __init__(self, oids, with_values):
-        # type: (Union[Mapping, Sequence], bool) -> None
+        # type: (Union[Mapping, Sequence[ObjectType]], bool) -> None
         self.oids = oids
         self.with_values = with_values
 

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -558,7 +558,9 @@ def test_table_v3_SHA_AES(aggregator):
     aggregator.all_metrics_asserted()
 
 
-def test_bulk_table(aggregator):
+def test_bulk_table(aggregator, caplog):
+    caplog.set_level(logging.DEBUG)  # Needed to test that debug logs won't raise exceptions
+
     instance = common.generate_instance_config(common.BULK_TABULAR_OBJECTS)
     instance['bulk_threshold'] = 5
     check = common.create_check(instance)


### PR DESCRIPTION
### What does this PR do?

Fix snmp get bulk log

### Motivation

The OIDPrinter takes a list of ObjectType as input

Related to this fix PR https://github.com/DataDog/integrations-core/pull/8688
