### PR TITLE
Cache API client connection

### DIFF
--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -178,7 +178,7 @@ class MongoDb(AgentCheck):
     def check(self, _):
         try:
             self._check()
-        except Exception:
+        except pymongo.errors.ConnectionFailure:
             self._api_client = None
             raise
 

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -77,6 +77,15 @@ class MongoDb(AgentCheck):
         self.collectors = []
         self.last_states_by_server = {}
 
+        self._api_client = None
+
+    @property
+    def api_client(self):
+        if self._api_client is None:
+            self._api_client = MongoApi(self._config, self.log)
+
+        return self._api_client
+
     @classmethod
     def get_library_versions(cls):
         return {'pymongo': pymongo.version}
@@ -163,7 +172,13 @@ class MongoDb(AgentCheck):
 
     def check(self, _):
         try:
-            api = MongoApi(self._config, self.log)
+            self._check()
+        except Exception:
+            self._api_client = None
+
+    def _check(self):
+        try:
+            api = self.api_client
             self.log.debug("Connected!")
         except Exception:
             self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=self._config.service_check_tags)

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -175,6 +175,7 @@ class MongoDb(AgentCheck):
             self._check()
         except Exception:
             self._api_client = None
+            raise
 
     def _check(self):
         try:

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -82,7 +82,12 @@ class MongoDb(AgentCheck):
     @property
     def api_client(self):
         if self._api_client is None:
-            self._api_client = MongoApi(self._config, self.log)
+            try:
+                self._api_client = MongoApi(self._config, self.log)
+                self.log.debug("Connected!")
+            except Exception:
+                self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=self._config.service_check_tags)
+                raise
 
         return self._api_client
 
@@ -178,12 +183,7 @@ class MongoDb(AgentCheck):
             raise
 
     def _check(self):
-        try:
-            api = self.api_client
-            self.log.debug("Connected!")
-        except Exception:
-            self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=self._config.service_check_tags)
-            raise
+        api = self.api_client
 
         try:
             mongo_version = api.server_info().get('version', '0.0')


### PR DESCRIPTION
### Motivation

1. Better performance
2. For times when Mongo reaches the max connection count, the integration starts failing to report metrics because it can no longer connect