### PR TITLE
Do not count snmp_ integrations

### DIFF
--- a/docs/developer/.scripts/33_render_status.py
+++ b/docs/developer/.scripts/33_render_status.py
@@ -119,6 +119,8 @@ def render_dashboard_progress():
     ]
 
     for integration in valid_integrations:
+        if 'snmp' in integration:
+            continue
         if has_dashboard(integration):
             integrations_with_dashboard += 1
             status = 'X'


### PR DESCRIPTION
Al snmp_* tiles are showing in the dashboard list and they should not