### PR TITLE
Clarify SonarQube integration installation and configuration instructions

### DIFF
--- a/sonarqube/README.md
+++ b/sonarqube/README.md
@@ -13,6 +13,87 @@ No additional installation is needed on your server.
 
 ### Configuration
 
+SonarQube exposes metrics from two sources: its web API and JMX. To collect all of the
+[metrics specified below](#metrics), configure three instances of this check. One to monitor SonarQube's web API, and
+the other two to monitor SonarQube's JMX beans.
+
+Documentation on SonarQube's web API is available at `/web_api` on your SonarQube web UI. By default this integration
+collects all relevant SonarQube performance metrics exposed through SonarQube's JMX beans. The configuration for these
+default metrics is available in the [sonarqube.d/metrics.yaml][12] file. Documentation on these beans is available on
+[SonarQube's website][13].
+
+SonarQube's JMX server is not enabled by default. More information on how to enable and configure JMX within SonarQube
+in available within the [SonarQube documentation][14].
+
+This is a basic `sonarqube.d/conf.yaml` example based on SonarQube and JMX defaults. You can use it as a starting point
+when configuring for both the host-based or container-based agent installation.
+
+```yaml
+init_config:
+    is_jmx: false
+    collect_default_metrics: true
+instances:
+  # Web API instance
+  - is_jmx: false
+    web_endpoint: http://localhost:9000
+    auth_type: basic
+    username: <username>    # Defined in the Web UI
+    password: <password>    # Defined in the Web UI
+    default_tag: component  # Optional
+    components:
+      my-project:
+        tag: project_name
+  # Web JMX instance
+  - is_jmx: true
+    host: localhost
+    port: 10443
+    user: <username>      # Defined in SonarQube's sonar.properties file
+    password: <password>  # Defined in SonarQube's sonar.properties file
+  # Compute Engine JMX instance
+  - is_jmx: true
+    host: localhost
+    port: 10444
+    user: <username>      # Defined in SonarQube's sonar.properties file
+    password: <password>  # Defined in SonarQube's sonar.properties file
+```
+
+> Note: Once the integration is configured, have SonarQube scan at least one project so that the metrics to populate in
+> Datadog.
+
+Metrics collected by this integation will be tagged with a `component` tag by default. If you wish to change the tag
+name on a per component basis, specify the `tag` property within the component definition. To set it for all projects,
+set the `default_tag` property on the instance config.
+
+> Note: Projects in SonarQube often contain multiple source control branches. This integration can only collect metrics
+> from the default branch in SonarQube (typically `main`).
+
+In addition, SonarQube exposes a Search Server which can monitored using an additional instance of this integration and
+configuration of the JMX metrics which you want to collect. To learn how to customize the metrics to collect, visit the
+[JMX Checks documentation][4] for more detailed instructions. For inspriration, use the example config below and
+default JMX metric config in [sonarqube.d/metrics.yaml][12].
+
+```yaml
+init_config:
+  # The list of metrics to be collected by the integration.
+  config:
+    - include:
+      domain: SonarQube
+      name: <name>
+      exclude_tags:
+        - name
+      attribute:
+        MyMetric:
+          alias: sonarqube.search_server.my_metric
+          metric_type: gauge
+instances:
+  # Search Server JMX instance
+  - is_jmx: true
+    host: localhost
+    port: 10445
+    user: <username>      # Defined in SonarQube's sonar.properties file
+    password: <password>  # Defined in SonarQube's sonar.properties file
+```
+
 <!-- xxx tabs xxx -->
 <!-- xxx tab "Host" xxx -->
 
@@ -113,6 +194,11 @@ JMXFetch
   Initialized checks
   ==================
     sonarqube
+      instance_name : sonarqube-localhost-10444
+      message : <no value>
+      metric_count : 33
+      service_check_count : 0
+      status : OK
       instance_name : sonarqube-localhost-10443
       message : <no value>
       metric_count : 38
@@ -128,24 +214,17 @@ Collector
 =========
   Running Checks
   ==============
-    sonarqube (1.0.0)
+    sonarqube (1.1.0)
     -----------------
-      Instance ID: sonarqube:f872f6fd88ce0d82 [OK]
-      Configuration Source: file:/etc/datadog-agent/conf.d/sonarqube.d/sonarqube.yaml
-      Total Runs: 2,925
-      Metric Samples: Last Run: 39, Total: 114,075
+      Instance ID: sonarqube:1249c1ed7c7b489a [OK]
+      Configuration Source: file:/etc/datadog-agent/conf.d/sonarqube.d/conf.yaml
+      Total Runs: 51
+      Metric Samples: Last Run: 39, Total: 1,989
       Events: Last Run: 0, Total: 0
-      Service Checks: Last Run: 1, Total: 2,925
-      Average Execution Time : 29ms
-      Last Execution Date : 2020-10-29 13:25:37.000000 UTC
-      Last Successful Execution Date : 2020-10-29 13:25:37.000000 UTC
-      metadata:
-        version.build: 37579
-        version.major: 8
-        version.minor: 5
-        version.patch: 0
-        version.raw: 8.5.0.37579
-        version.scheme: semver
+      Service Checks: Last Run: 1, Total: 51
+      Average Execution Time : 1.19s
+      Last Execution Date : 2021-03-12 00:00:44.000000 UTC
+      Last Successful Execution Date : 2021-03-12 00:00:44.000000 UTC
 ```
 
 ## Data Collected
@@ -181,3 +260,6 @@ Need help? Contact [Datadog support][5].
 [9]: https://docs.datadoghq.com/agent/docker/log/
 [10]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [11]: https://github.com/DataDog/integrations-core/blob/master/sonarqube/metadata.csv
+[12]: https://github.com/DataDog/integrations-core/blob/master/sonarqube/datadog_checks/sonarqube/data/metrics.yaml
+[13]: https://docs.sonarqube.org/latest/instance-administration/monitoring/
+[14]: https://docs.sonarqube.org/latest/instance-administration/monitoring/#header-4


### PR DESCRIPTION
### What does this PR do?

Clarifies how to configure SonarQube to collect all metrics available from SonarQube's Web API and JMX beans. 

### Motivation

Had issues with a customer configuring the integration correctly and found the docs to be very opaque about configuration details. After solving their issue, I want to improve our docs so other customers don't run into this issue in the future.

### Additional Notes

There is a [ticket](https://datadog.zendesk.com/agent/tickets/445200) and [escalation](https://datadoghq.atlassian.net/browse/AGENT-5805) for more context.

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have `changelog/` and `integration/` labels attached
