### PR TITLE
Fix snmp listener architecture doc typo

### DIFF
--- a/docs/developer/architecture/snmp.md
+++ b/docs/developer/architecture/snmp.md
@@ -95,6 +95,7 @@ snmp_listener:
       community: public
     - network: 10.0.1.0/30
       version: 3
+      user: my-snmp-user
       authentication_protocol: SHA
       authentication_key: "*****"
       privacy_protocol: AES


### PR DESCRIPTION
### What does this PR do?

Fix snmp listener architecture doc typo

### Motivation

`user` is needed for snmp v3 config