### PR TITLE
Handle availability replica metrics on earlier versions

### DIFF
--- a/zk/requirements-dev.txt
+++ b/zk/requirements-dev.txt
@@ -1,0 +1,1 @@
+-e ../datadog_checks_dev

--- a/zk/requirements-dev.txt
+++ b/zk/requirements-dev.txt
@@ -1,1 +1,0 @@
--e ../datadog_checks_dev


### PR DESCRIPTION
### What does this PR do?
The column `is_primary_replica` only exists on the table `sys.dm_hadr_database_replica_states` for versions of [SQL Server 2014 and later](https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-hadr-database-replica-states-transact-sql?view=sql-server-ver15).  

This PR catches the exception and uses the tag value of `unknown` instead.  

### Motivation
Better compatibility.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
