### PR TITLE
Ensure delimited identifiers in USE statements

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -9,6 +9,8 @@ from __future__ import division
 from collections import defaultdict
 from functools import partial
 
+from .utils import construct_use_statement
+
 # Queries
 ALL_INSTANCES = 'ALL'
 
@@ -429,7 +431,7 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
 
         for db in cls._DATABASES:
             # use statements need to be executed separate from select queries
-            ctx = 'use {}'.format(db)
+            ctx = construct_use_statement(db)
             logger.debug("%s: changing cursor context via use statement: %s", cls.__name__, ctx)
             cursor.execute(ctx)
             logger.debug("%s: fetch_all executing query: %s", cls.__name__, cls.QUERY_BASE)
@@ -455,7 +457,7 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
 
         # reset back to previous db
         logger.debug("%s: reverting cursor context via use statement to %s", cls.__name__, current_db)
-        cursor.execute('use {}'.format(str(current_db)))
+        cursor.execute(construct_use_statement(current_db))
 
         return rows, columns
 

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -17,4 +17,4 @@ def set_default_driver_conf():
 
 
 def construct_use_statement(database):
-    return 'use "{}"'.format(database)
+    return 'use [{}]'.format(database)

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -14,3 +14,7 @@ def set_default_driver_conf():
         # Use default `./driver_config/odbcinst.ini` when Agent is running in docker.
         # `freetds` is shipped with the Docker Agent.
         os.environ.setdefault('ODBCSYSINI', DRIVER_CONFIG_DIR)
+
+
+def construct_use_statement(database):
+    return 'use "{}"'.format(database)


### PR DESCRIPTION
### Motivation

When collecting example database `9000_foo`:

```
error: sqlserver:894db28bbe138638 | (sqlserver.py:459) | Error running `fetch_all` for metrics SqlDatabaseFileStats - skipping.  Error: ('42000', "[42000] [FreeTDS][SQL Server]Incorrect syntax near '9000'. (102) (SQLExecDirectW)")
```

From https://docs.microsoft.com/en-us/sql/t-sql/language-elements/use-transact-sql:

```
database_name
Is the name of the database or database snapshot to which the user context is switched. Database and database snapshot names must comply with the rules for identifiers.
```

then https://docs.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers

```
The first character must be one of the following:

* A letter as defined by the Unicode Standard 3.2. The Unicode definition of letters includes Latin characters from a through z, from A through Z, and also letter characters from other languages.

* The underscore (_), at sign (@), or number sign (#).
```