### PR TITLE
Add databases to E2E with non-standard names

### DIFF
--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -4,3 +4,6 @@ RESTORE DATABASE [AdventureWorks2017] FROM  DISK = N'/var/opt/mssql/backup/Adven
 FILE = 1,  MOVE N'AdventureWorks2017' TO N'/var/opt/mssql/data/AdventureWorks2017.mdf',
 MOVE N'AdventureWorks2017_log' TO N'/var/opt/mssql/data/AdventureWorks2017_log.ldf',
 REPLACE, NOUNLOAD,  STATS = 2;
+-- Add example databases with non-standard names
+CREATE DATABASE [1234_TEST];
+CREATE DATABASE [TEST WITH SPACES];


### PR DESCRIPTION
### What does this PR do?
Updates E2E environment to include databases that would trigger the error fixed with #8832 

### Motivation
Test coverage

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
