### PR TITLE
Add Postgres recommended monitors

### DIFF
--- a/postgres/assets/monitors/percent_usage_connections.json
+++ b/postgres/assets/monitors/percent_usage_connections.json
@@ -1,0 +1,35 @@
+{
+	"name": "[Postgres] Number of connections is approaching connection limit on {{host.name}}",
+	"type": "query alert",
+	"query": "avg(last_15m):avg:postgresql.percent_usage_connections{*} > 0.9",
+	"message": "Please check host {{host.name}}, as the Postgres connection pool is approaching saturation.",
+	"tags": [
+		"integration:postgres"
+	  ],
+	"options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+		"require_full_window": true,
+		"notify_no_data": false,
+		"renotify_interval": "0",
+		"escalation_message": "",
+		"no_data_timeframe": null,
+		"include_tags": true,
+		"thresholds": {
+			"critical": 0.9,
+			"warning": 0.8,
+			"critical_recovery": 0.9,
+			"warning_recovery": 0.8
+		},
+		"threshold_windows": {
+			"trigger_window": "last_15m",
+			"recovery_window": "last_15m"
+		}
+	},
+	"priority": null,
+	"recommended_monitor_metadata": {
+		"description": "Notify your team when a host's connection pool approaches saturation."
+	}
+}

--- a/postgres/assets/monitors/replication_delay.json
+++ b/postgres/assets/monitors/replication_delay.json
@@ -1,0 +1,33 @@
+{
+	"name": "[Postgres] Replication delay is abnormally high on {{host.name}}",
+	"type": "query alert",
+	"query": "avg(last_1h):anomalies(avg:postgresql.replication_delay{*}, 'basic', 2, direction='above', alert_window='last_15m', interval=20, count_default_zero='true') >= 1",
+	"message": "Please check host {{host.name}}, as replication delay has been abnormally high.",
+	"tags": [
+		"integration:postgres"
+	  ],
+	"options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+		"require_full_window": true,
+		"notify_no_data": false,
+		"renotify_interval": "0",
+		"escalation_message": "",
+		"no_data_timeframe": null,
+		"include_tags": true,
+		"thresholds": {
+			"critical": 1,
+			"critical_recovery": 0
+		},
+		"threshold_windows": {
+			"trigger_window": "last_15m",
+			"recovery_window": "last_15m"
+		}
+	},
+	"priority": null,
+	"recommended_monitor_metadata": {
+		"description": "Notify your team when Postgres replication delay is unusually high."
+	}
+}

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -38,7 +38,10 @@
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
-    "monitors": {},
+    "monitors": {
+      "percent_usage_connections": "assets/monitors/percent_usage_connections.json",
+      "replication_delay": "assets/monitors/replication_delay.json"
+    },
     "dashboards": {
       "postgresql": "assets/dashboards/postgresql_dashboard.json",
       "postgresql_screenboard": "assets/dashboards/postgresql_screenboard_dashboard.json"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add 2 recommended monitors for Postgres, based on [blog posts](https://www.datadoghq.com/blog/collect-postgresql-data-with-datadog/#alerting):
* Abnormal `replication_delay`
* High `percent_connection_usage`

Staging link: (WIP)

### Motivation
<!-- What inspired you to submit this pull request? -->
Recommended monitors coverage

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
