### PR TITLE
Improve exception handling for database queries

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -137,7 +137,9 @@ files:
         type: boolean
         example: false
     - name: include_db_fragmentation_metrics
-      description: Include database fragmentation metrics.
+      description: |
+        Include database fragmentation metrics. Note these queries can be resource intensive on large datasets.
+        Recommend to limit these via autodiscovery or specific database instances.
       value:
         type: boolean
         example: false

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -136,7 +136,8 @@ instances:
     # include_task_scheduler_metrics: false
 
     ## @param include_db_fragmentation_metrics - boolean - optional - default: false
-    ## Include database fragmentation metrics.
+    ## Include database fragmentation metrics. Note these queries can be resource intensive on large datasets.
+    ## Recommend to limit these via autodiscovery or specific database instances.
     #
     # include_db_fragmentation_metrics: false
 

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from functools import partial
 
 from datadog_checks.base.errors import CheckException
+
 from .utils import construct_use_statement, time_func
 
 # Queries
@@ -446,7 +447,7 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
             query_columns = ['database'] + [i[0] for i in cursor.description]
             if columns:
                 if columns != query_columns:
-                    raise CheckException('Assertion error: %s != %s'.format(columns, query_columns))
+                    raise CheckException('Assertion error: {} != {}'.format(columns, query_columns))
             else:
                 columns = query_columns
 
@@ -654,7 +655,7 @@ class SqlDbFragmentation(BaseSqlServerMetric):
             query_columns = [i[0] for i in cursor.description]
             if columns:
                 if columns != query_columns:
-                    raise CheckException('Assertion error: %s != %s'.format(columns, query_columns))
+                    raise CheckException('Assertion error: {} != {}'.format(columns, query_columns))
             else:
                 columns = query_columns
 

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -9,6 +9,7 @@ from __future__ import division
 from collections import defaultdict
 from functools import partial
 
+from datadog_checks.base.errors import CheckException
 from .utils import construct_use_statement, time_func
 
 # Queries
@@ -444,7 +445,8 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
 
             query_columns = ['database'] + [i[0] for i in cursor.description]
             if columns:
-                assert columns == query_columns
+                if columns != query_columns:
+                    raise CheckException('Assertion error: %s != %s'.format(columns, query_columns))
             else:
                 columns = query_columns
 
@@ -651,7 +653,8 @@ class SqlDbFragmentation(BaseSqlServerMetric):
 
             query_columns = [i[0] for i in cursor.description]
             if columns:
-                assert columns == query_columns
+                if columns != query_columns:
+                    raise CheckException('Assertion error: %s != %s'.format(columns, query_columns))
             else:
                 columns = query_columns
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -457,7 +457,7 @@ class SQLServer(AgentCheck):
                             rows, cols = getattr(metrics, cls).fetch_all_values(cursor, metric_names, self.log)
                         except Exception as e:
                             self.log.error("Error running `fetch_all` for metrics %s - skipping.  Error: %s", cls, e)
-                            continue
+                            rows, cols = None, None
 
                         instance_results[cls] = rows, cols
 
@@ -466,10 +466,12 @@ class SQLServer(AgentCheck):
                     if type(metric) is metrics.SqlIncrFractionMetric:
                         # special case, since it uses the same results as SqlFractionMetric
                         rows, cols = instance_results['SqlFractionMetric']
-                        metric.fetch_metric(rows, cols)
+                        if rows is not None:
+                            metric.fetch_metric(rows, cols)
                     else:
                         rows, cols = instance_results[metric.__class__.__name__]
-                        metric.fetch_metric(rows, cols)
+                        if rows is not None:
+                            metric.fetch_metric(rows, cols)
 
             # reuse connection for any custom queries
             self._query_manager.execute()

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -2,11 +2,25 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+import time
+
+from six import PY3
 
 from datadog_checks.base.utils.platform import Platform
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 DRIVER_CONFIG_DIR = os.path.join(CURRENT_DIR, 'data', 'driver_config')
+
+if PY3:
+    # use higher precision clock available in Python3
+    time_func = time.perf_counter
+elif Platform.is_win32():
+    # for tiny time deltas, time.time on Windows reports the same value
+    # of the clock more than once, causing the computation of response_time
+    # to be often 0; let's use time.clock that is more precise.
+    time_func = time.clock
+else:
+    time_func = time.time
 
 
 def set_default_driver_conf():


### PR DESCRIPTION
### What does this PR do?
Adds more exception handling for specific queries, and breaks down the `SqlFragmentation` metric class to query on a database by database basis.  Previously, a single database that was in a "non-good" state would cause the whole SELECT to fail, now it will log the error for the specific database and continue.

Also added a note regarding the potential performance impacts of turning on the option `include_fragmentation_metrics`.

### Motivation
Resiliency.

### Additional Notes
For QAing this change, the following steps were taken:

1. Start E2E env via `ddev env start sqlserver py38-default`
2. Verify metrics report successfully via `ddev env check sqlserver py38-default --table -l debug`
3. Execute the following SQL statements to put a database in a recovering state:

```sql
BACKUP DATABASE AdventureWorks2017
TO DISK = 'AW2017.bak'
WITH INIT;

RESTORE DATABASE AdventureWorks2017
FROM DISK = 'AW2017.bak'
WITH NORECOVERY ;
```

4. Reload agent: `ddev env reload sqlserver`
5. Verify these database metrics do not report, and emit `WARNING` messages in output: `ddev env check sqlserver py38-default --table -l debug`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
