### PR TITLE
Revert metadata change

### DIFF
--- a/activemq/metadata.csv
+++ b/activemq/metadata.csv
@@ -26,7 +26,7 @@ activemq.artemis.total_messages_acknowledged,rate,,connection,,"(Artemis only) N
 activemq.artemis.total_consumer_count,rate,,,,"(Artemis only) Number of consumers consuming messages from all the queues on this server, as a rate.",0,activemq,art total consumers
 activemq.artemis.address.size,gauge,,byte,,(Artemis only) Number of estimated bytes being used by all the queue(s) bound to this address; used to control paging and blocking.,0,activemq,add size
 activemq.artemis.address.pages_count,gauge,,page,,(Artemis only) Number of pages used by this address.,0,activemq,add pages
-activemq.artemis.address.number_of_messages,gauge,,message,,"(Artemis only) The sum of messages on queue(s), including messages in delivery.",0,activemq,add num mess
+activemq.artemis.address.number_of_messages,rate,,message,,"(Artemis only) The sum of messages on queue(s), including messages in delivery.",0,activemq,add num mess
 activemq.artemis.address.bytes_per_page,gauge,,byte,,(Artemis only) Number of bytes used by each page for this address.,0,activemq,add bytes page
 activemq.artemis.address.routed_messages,rate,,message,,"(Artemis only) Number of messages routed to one or more bindings, as a rate.",0,activemq,add routed
 activemq.artemis.address.unrouted_messages,rate,,message,,"(Artemis only) Number of messages not routed to any bindings, as a rate.",0,activemq,add unrouted


### PR DESCRIPTION
### What does this PR do?
PR #8814 addressed several issues with `metadata.csv` but included a metric type change that now causes issues with testing.

This PR reverts that field back to a `rate`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
For some reason, the last commit in that referenced PR passed CI tests, but after the merge it fails, hence this update. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
