### PR TITLE
Fix description of the `path` option

### DIFF
--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -47,10 +47,8 @@ files:
     options:
     - name: path
       description: |
-        The check will subscribe to the path for events. It can be one of the following:
-
-          - the name of an Admin or Operational channel (you cannot subscribe to Analytic or Debug channels)
-          - the full path to a log file, usually ending in .evt, .evtx, or .etl
+        The check will subscribe to the path for events. It must the name of an Admin or Operational
+        channel (you cannot subscribe to Analytic or Debug channels).
 
         The path is required if `legacy_mode` is set to `false`.
       value:

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -49,10 +49,8 @@ instances:
 
   -
     ## @param path - string - optional
-    ## The check will subscribe to the path for events. It can be one of the following:
-    ##
-    ##   - the name of an Admin or Operational channel (you cannot subscribe to Analytic or Debug channels)
-    ##   - the full path to a log file, usually ending in .evt, .evtx, or .etl
+    ## The check will subscribe to the path for events. It must the name of an Admin or Operational
+    ## channel (you cannot subscribe to Analytic or Debug channels).
     ##
     ## The path is required if `legacy_mode` is set to `false`.
     #


### PR DESCRIPTION
### Motivation

Microsoft docs are incorrect: https://social.msdn.microsoft.com/Forums/sqlserver/en-US/bc3b8642-2573-4481-a1e6-111004edf36e/how-to-use-an-event-log-file-path-in-evtsubscribe?forum=vcgeneral