### PR TITLE
Add actions to auto-release base and dev packages

### DIFF
--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -29,4 +29,7 @@ jobs:
         ddev config set repo core
 
     - name: Release ddev
-      run: ddev release upload datadog_checks_base
+      run: ddev release upload -n datadog_checks_base
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_BASE }}

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -1,0 +1,32 @@
+name: release-base
+
+on:
+  push:
+    tags:
+      - datadog_checks_base-*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Upgrade Python packaging tools
+      run: pip install --disable-pip-version-check --upgrade pip setuptools wheel
+
+    - name: Install ddev
+      run: pip install -e ./datadog_checks_dev[cli]
+
+    - name: Configure ddev
+      run: |
+        ddev config set repos.core .
+        ddev config set repo core
+
+    - name: Release ddev
+      run: ddev release upload datadog_checks_base

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,32 @@
+name: release-dev
+
+on:
+  push:
+    tags:
+      - datadog_checks_dev-*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Upgrade Python packaging tools
+      run: pip install --disable-pip-version-check --upgrade pip setuptools wheel
+
+    - name: Install ddev
+      run: pip install -e ./datadog_checks_dev[cli]
+
+    - name: Configure ddev
+      run: |
+        ddev config set repos.core .
+        ddev config set repo core
+
+    - name: Release ddev
+      run: ddev release upload datadog_checks_dev

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -29,4 +29,7 @@ jobs:
         ddev config set repo core
 
     - name: Release ddev
-      run: ddev release upload datadog_checks_dev
+      run: ddev release upload -n datadog_checks_dev
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_DEV }}

--- a/docs/developer/.snippets/links.txt
+++ b/docs/developer/.snippets/links.txt
@@ -116,6 +116,8 @@
 [python-pdb]: https://docs.python.org/3/library/pdb.html
 [requests-github]: https://github.com/psf/requests
 [requests-unixsocket-pypi]: https://pypi.org/project/requests-unixsocket/
+[release-base.yml]: https://github.com/DataDog/integrations-core/blob/master/.github/workflows/release-base.yml
+[release-dev.yml]: https://github.com/DataDog/integrations-core/blob/master/.github/workflows/release-dev.yml
 [root-tox-config]: https://github.com/DataDog/integrations-core/blob/master/tox.ini
 [rtloader]: https://github.com/DataDog/datadog-agent/tree/master/rtloader
 [semver-home]: https://semver.org

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -75,8 +75,12 @@ To see all checks that need to be released, run `ddev release show ready`.
 
 ### PyPI
 
-If you released `datadog_checks_base` or `datadog_checks_dev` then you will need to upload to [PyPI][]
+If you released `datadog_checks_base` or `datadog_checks_dev` then these must be uploaded to [PyPI][]
 for use by [integrations-extras][].
+
+Since 2021-03-19 this is automatically handled by two GitHub Action jobs: [release-base.yml][] and [release-dev.yml][].
+
+In case you need to do it manually:
 
 ```
 ddev release upload datadog_checks_[base|dev]

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -78,7 +78,7 @@ To see all checks that need to be released, run `ddev release show ready`.
 If you released `datadog_checks_base` or `datadog_checks_dev` then these must be uploaded to [PyPI][]
 for use by [integrations-extras][].
 
-Since 2021-03-19 this is automatically handled by two GitHub Action jobs: [release-base.yml][] and [release-dev.yml][].
+This is automatically handled by two GitHub Action jobs: [release-base.yml][] and [release-dev.yml][].
 
 In case you need to do it manually:
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add two GitHub Action workflows to automate releasing of `datadog_checks_base` and `datadog_checks_dev`.

* Add workflows YAML files
* Link to `PYPI_TOKEN_(BASE|DEV)` secrets (generated on PyPI and added to repo secrets separately)

### Motivation
<!-- What inspired you to submit this pull request? -->
Ensure team members do not forget about publishing base and dev (after regular releases, while preparing an Agent release, etc).

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Not sure how to test this. We don't have team credentials for test.pypi.org, and `ddev release upload` doesn't support pointing at that yet. I'd suggest we merge if this looks good, and confirm the workflow is fine upon next base or dev release?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
