### PR TITLE
💄 Use SVG logo for Databricks dash

### DIFF
--- a/databricks/assets/dashboards/databricks_overview.json
+++ b/databricks/assets/dashboards/databricks_overview.json
@@ -420,7 +420,7 @@
             "definition": {
                 "sizing": "fit",
                 "type": "image",
-                "url": "/static/images/avatars/bot/databricks@2x.png"
+                "url": "/static/images/logos/databricks_avatar.svg"
             },
             "id": 6923169892567062,
             "layout": {


### PR DESCRIPTION
### What does this PR do?
Uses the SVG Databricks logo instead of the deprecated PNG version on the new Databricks dashboard.

### Motivation
Thanks to our handy RUM monitor, I got an alert for a new view of a PNG logo 🙂. (We can't remove every PNGs altogether yet, unfortunately, because they're still used in emails 😕.) 

<img width="1129" alt="Screen Shot 2021-03-17 at 2 57 18 PM" src="https://user-images.githubusercontent.com/1048442/111524060-60f95680-8732-11eb-8694-8dd1ad96cf5d.png">

### Additional Notes
No visual changes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
