### PR TITLE
[us.1 prod] fixed typo for Custer Instance to Cluster Instance

### DIFF
--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -48,5 +48,5 @@ sqlserver.task.context_switches_count,gauge,,unit,,Number of scheduler context s
 sqlserver.task.pending_io_count,gauge,,unit,,Number of physical I/Os that are performed by this task.,0,sql_server,task io pending
 sqlserver.task.pending_io_byte_count,gauge,,byte,,Total byte count of I/Os that are performed by this task.,0,sql_server,task io byte
 sqlserver.task.pending_io_byte_average,gauge,,byte,,Average byte count of I/Os that are performed by this task.,0,sql_server,task avg io byte
-sqlserver.fci.status,gauge,,,,Status of the node in a SQL Server failover custer instance,0,sql_server,fci status
+sqlserver.fci.status,gauge,,,,Status of the node in a SQL Server failover cluster instance,0,sql_server,fci status
 sqlserver.fci.is_current_owner,gauge,,,,Whether or not this node is the current owner of the SQL Server FCI ,0,sql_server,fci current owner


### PR DESCRIPTION

### What does this PR do?

Update Metadata so the word Custer appropriately states Cluster instance

### Motivation
Typo on Docs page looks unprofessional

### Additional Notes
https://a.cl.ly/GGu6D19J 
Image of issue, found that the issue is in the metadata.csv that populates the page -> https://docs.datadoghq.com/integrations/sqlserver/?tab=host#setup
Under metric -> sqlserver.fci.status

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
