### PR TITLE
Fix empty queue parsing

### DIFF
--- a/postfix/datadog_checks/postfix/postfix.py
+++ b/postfix/datadog_checks/postfix/postfix.py
@@ -143,14 +143,17 @@ class PostfixCheck(AgentCheck):
 
         -- 1 Kbytes in 2 Requests.
         '''
-        for line in output.splitlines():
-            if '*' in line:
-                active_count += 1
-            elif '!' in line:
-                hold_count += 1
-            # Check the line starts with an ID
-            elif line[0:1].isalnum():
-                deferred_count += 1
+        lines = output.splitlines()
+        # Check output
+        if len(lines) > 1 and not output.startswith('Mail queue is empty'):
+            for line in lines:
+                if '*' in line:
+                    active_count += 1
+                elif '!' in line:
+                    hold_count += 1
+                # Check the line starts with an ID
+                elif line[0:1].isalnum():
+                    deferred_count += 1
 
         self.gauge(
             'postfix.queue.size', active_count, tags=tags + ['queue:active', 'instance:{}'.format(postfix_config_dir)]

--- a/postfix/tests/test_unit.py
+++ b/postfix/tests/test_unit.py
@@ -28,6 +28,19 @@ def test__get_postqueue_stats(aggregator):
         aggregator.assert_metric('postfix.queue.size', 2, tags=common_tags + ['queue:deferred'])
 
 
+def test__get_postqueue_stats_empty(aggregator):
+    check = PostfixCheck('postfix', {}, [])
+    common_tags = ['instance:/etc/postfix']
+
+    with mock.patch('datadog_checks.postfix.postfix.get_subprocess_output') as s:
+        s.side_effect = [(False, None, None), ('Mail queue is empty', None, None)]
+        check._get_postqueue_stats('/etc/postfix', [])
+
+        aggregator.assert_metric('postfix.queue.size', 0, tags=common_tags + ['queue:active'])
+        aggregator.assert_metric('postfix.queue.size', 0, tags=common_tags + ['queue:active'])
+        aggregator.assert_metric('postfix.queue.size', 0, tags=common_tags + ['queue:deferred'])
+
+
 @mock.patch(
     'datadog_checks.postfix.postfix.get_subprocess_output',
     return_value=('mail_version = {}'.format(MOCK_VERSION), None, None),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix parsing output when the queue is empty like:

```
bash-5.1# postqueue -p
Mail queue is empty
```

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
