### PR TITLE
Update tagger get-pip.py script

### DIFF
--- a/.gitlab/tagger/Dockerfile
+++ b/.gitlab/tagger/Dockerfile
@@ -36,7 +36,7 @@ ENV LANG=C.UTF-8
 COPY . ${DDEV_ROOT}
 
 # Install pip
-RUN curl -sSL https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py | python3 \
+RUN curl -sSL https://bootstrap.pypa.io/get-pip.py | python3 \
  # Install ddev for release tagging
  && pip3 install --no-cache-dir ${DDEV_ROOT}[cli] \
  # Install awscli for access to GitHub deploy key stored in SSM


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Found this while monitoring release of #8853 

Old `get-pip.py` started raising this, which breaks the tagger:

```
Step 8/8 : RUN curl -sSL https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py | python3  && pip3 install --no-cache-dir ${DDEV_ROOT}[cli]  && pip3 install --no-cache-dir awscli==1.16.129
 ---> Running in c108c7f30607
Hi there!
The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:
    https://bootstrap.pypa.io/get-pip.py
Sorry if this change causes any inconvenience for you!
We don't have a good mechanism to make more gradual changes here, and this
renaming is a part of an effort to make it easier to us to update these
scripts, when there's a pip release. It's also essential for improving how we
handle the `get-pip.py` scripts, when pip drops support for a Python minor
version.
There are no more renames/URL changes planned, and we don't expect that a need
would arise to do this again in the near future.
Thanks for understanding!
- Pradyun, on behalf of the volunteers who maintain pip.
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
