### PR TITLE
Remove -n option when uploading base and dev

### DIFF
--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -29,7 +29,7 @@ jobs:
         ddev config set repo core
 
     - name: Release ddev
-      run: ddev release upload -n datadog_checks_base
+      run: ddev release upload datadog_checks_base
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_BASE }}

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -29,7 +29,7 @@ jobs:
         ddev config set repo core
 
     - name: Release ddev
-      run: ddev release upload -n datadog_checks_dev
+      run: ddev release upload datadog_checks_dev
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_DEV }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Cleanup for #8846 

### Motivation
<!-- What inspired you to submit this pull request? -->
Had left `-n` (dry run) mode in place. :facepalm:

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Tags were created and wheels were signed. Doesn't seem to be a way to "trigger" a workflow manually, which is a pain. Means we can't trigger the Actions again until next release, since we can't remove the tags from GitHub and re-create them (they're already released and in our index), right?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
