### PR TITLE
update prometheus docs for alertmanager

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -4,7 +4,7 @@
 
 Connect to Prometheus to:
 - Extract custom metrics from Prometheus endpoints
-- See Prometheus Alertmanager alerts in your event stream
+- See Prometheus Alertmanager alerts in your Datadog event stream
 
 **Note**: Datadog recommends using the [OpenMetrics check][10] since it is more efficient and fully supports Prometheus text format. Use the Prometheus check only when the metrics endpoint does not support a text format.
 

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -70,7 +70,7 @@ Note: Bucket data for a given `<HISTOGRAM_METRIC_NAME>` Prometheus histogram met
 
 ### Events
 
-Prometheus Alertmanager alerts will be automatically sent into Datadog event stream following webhook configuration
+Prometheus Alertmanager alerts are automatically sent to your Datadog event stream following the webhook configuration.
 
 ### Service Checks
 

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -43,7 +43,7 @@ Due to the nature of this integration, it's possible to submit a high number of 
 If `send_monotonic_counter: True`, the Agent sends the deltas of the values in question, and the in-app type is set to count (this is the default behaviour). If `send_monotonic_counter: False`, the Agent sends the raw, monotonically increasing value, and the in-app type is set to gauge.
 
 #### Send Prometheus Alertmanager alerts in the event stream
-1. Edit Alertmanager configuration file, `alertmanager.yml`, to include the following:
+1. Edit the Alertmanager configuration file, `alertmanager.yml`, to include the following:
 ```
 receivers:
 - name: datadog

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Connect to Prometheus to:
-- Extract custom metrics from any Prometheus endpoints 
+- Extract custom metrics from Prometheus endpoints
 - See Prometheus Alertmanager alerts in your event stream
 
 **Note**: Datadog recommends using the [OpenMetrics check][10] since it is more efficient and fully supports Prometheus text format. Use the Prometheus check only when the metrics endpoint does not support a text format.

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -3,8 +3,8 @@
 ## Overview
 
 Connect to Prometheus to:
-- Extract custom metrics from any Prometheus endpoints. 
-- See Prometheus Alertmanager alerts in your event stream.
+- Extract custom metrics from any Prometheus endpoints 
+- See Prometheus Alertmanager alerts in your event stream
 
 **Note**: Datadog recommends using the [OpenMetrics check][10] since it is more efficient and fully supports Prometheus text format. Use the Prometheus check only when the metrics endpoint does not support a text format.
 

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -51,7 +51,7 @@ receivers:
   - send_resolved: true
     url: https://app.datadoghq.com/intake/webhook/prometheus?api_key=<DATADOG_API_KEY>
 ```
-2. Restart Prometheus and Alertmanager services
+2. Restart the Prometheus and Alertmanager services.
 ```
 sudo systemctl restart prometheus.service alertmanager.service
 ```

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -2,7 +2,11 @@
 
 ## Overview
 
-Extract custom metrics from any Prometheus endpoints. **Note**: Datadog recommends using the [OpenMetrics check][10] since it is more efficient and fully supports Prometheus text format. Use the Prometheus check only when the metrics endpoint does not support a text format.
+Connect to Prometheus to:
+- Extract custom metrics from any Prometheus endpoints. 
+- See Prometheus Alertmanager alerts in your event stream.
+
+**Note**: Datadog recommends using the [OpenMetrics check][10] since it is more efficient and fully supports Prometheus text format. Use the Prometheus check only when the metrics endpoint does not support a text format.
 
 <div class="alert alert-warning">
 All the metrics retrieved by this integration are considered <a href="https://docs.datadoghq.com/developers/metrics/custom_metrics">custom metrics</a>.
@@ -38,6 +42,20 @@ Due to the nature of this integration, it's possible to submit a high number of 
 
 If `send_monotonic_counter: True`, the Agent sends the deltas of the values in question, and the in-app type is set to count (this is the default behaviour). If `send_monotonic_counter: False`, the Agent sends the raw, monotonically increasing value, and the in-app type is set to gauge.
 
+#### Send Prometheus Alertmanager alerts in the event stream
+1. Edit Alertmanager configuration file, `alertmanager.yml`, to include the following:
+```
+receivers:
+- name: datadog
+  webhook_configs: 
+  - send_resolved: true
+    url: https://app.datadoghq.com/intake/webhook/prometheus?api_key=<DATADOG_API_KEY>
+```
+2. Restart Prometheus and Alertmanager services
+```
+sudo systemctl restart prometheus.service alertmanager.service
+```
+
 ### Validation
 
 [Run the Agent's `status` subcommand][3] and look for `prometheus` under the Checks section.
@@ -52,7 +70,7 @@ Note: Bucket data for a given `<HISTOGRAM_METRIC_NAME>` Prometheus histogram met
 
 ### Events
 
-The Prometheus check does not include any events.
+Prometheus Alertmanager alerts will be automatically sent into Datadog event stream following webhook configuration
 
 ### Service Checks
 
@@ -67,6 +85,7 @@ Need help? Contact [Datadog support][4].
 - [Introducing Prometheus support for Datadog Agent 6][5]
 - [Configuring a Prometheus Check][6]
 - [Writing a custom Prometheus Check][7]
+- [Prometheus Alertmanager Documentation] [11]
 
 [2]: https://github.com/DataDog/integrations-core/blob/master/prometheus/datadog_checks/prometheus/data/conf.yaml.example
 [3]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
@@ -77,3 +96,4 @@ Need help? Contact [Datadog support][4].
 [8]: https://docs.datadoghq.com/getting_started/integrations/prometheus/
 [9]: https://docs.datadoghq.com/getting_started/integrations/prometheus?tab=docker#configuration
 [10]: https://docs.datadoghq.com/integrations/openmetrics/
+[11]: https://prometheus.io/docs/alerting/latest/alertmanager/


### PR DESCRIPTION
### What does this PR do?
This PR updates the documentation to inform users how to configure our new alertmanager integration

### Motivation
deployment of our new alertmanager integration into production

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
