### PR TITLE
Support Cat allocation metrics

### DIFF
--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -75,8 +75,7 @@ files:
         example: true
     - name: cat_allocation_stats
       description: |
-        If you enable the "cat_allocation_stats" flag, statistics over cat allocation metrics
-        are collected by the check and sent to the backend. 
+        Enable to collect Elastic Cat Allocation metrics.
         Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html.
       value:
         type: boolean

--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -73,6 +73,14 @@ files:
       value:
         type: boolean
         example: true
+    - name: cat_allocation_stats
+      description: |
+        If you enable the "cat_allocation_stats" flag, statistics over cat allocation metrics
+        are collected by the check and sent to the backend. 
+        Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html.
+      value:
+        type: boolean
+        example: false
     - name: admin_forwarder
       description: |
         It is used to signify a URL that includes a context root

--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -75,7 +75,7 @@ files:
         example: true
     - name: cat_allocation_stats
       description: |
-        Enable to collect Elastic Cat Allocation metrics. Available only for v >= 7.2
+        Enable to collect Elastic Cat Allocation metrics. Available only for Elasticsearch 7.2 or higher.
         Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html.
       value:
         type: boolean

--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -75,7 +75,7 @@ files:
         example: true
     - name: cat_allocation_stats
       description: |
-        Enable to collect Elastic Cat Allocation metrics.
+        Enable to collect Elastic Cat Allocation metrics. Available only for v >= 7.2
         Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html.
       value:
         type: boolean

--- a/elastic/datadog_checks/elastic/config.py
+++ b/elastic/datadog_checks/elastic/config.py
@@ -21,6 +21,7 @@ ESInstanceConfig = namedtuple(
         'tags',
         'url',
         'pending_task_stats',
+        'cat_allocation_stats',
     ],
 )
 
@@ -43,6 +44,7 @@ def from_instance(instance):
         cluster_stats = is_affirmative(instance.get('is_external', False))
     pending_task_stats = is_affirmative(instance.get('pending_task_stats', True))
     admin_forwarder = is_affirmative(instance.get('admin_forwarder', False))
+    cat_allocation_stats = is_affirmative(instance.get('cat_allocation_stats', False))
 
     # Support URLs that have a path in them from the config, for
     # backwards-compatibility.
@@ -73,5 +75,6 @@ def from_instance(instance):
         tags=tags,
         url=url,
         pending_task_stats=pending_task_stats,
+        cat_allocation_stats=cat_allocation_stats,
     )
     return config

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -103,6 +103,13 @@ instances:
     #
     # pending_task_stats: true
 
+    ## @param cat_allocation_stats - boolean - optional - default: false
+    ## If you enable the "cat_allocation_stats" flag, statistics over cat allocation metrics
+    ## are collected by the check and sent to the backend. 
+    ## Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html.
+    #
+    # cat_allocation_stats: false
+
     ## @param admin_forwarder - boolean - optional - default: false
     ## It is used to signify a URL that includes a context root
     ## needed for a forwarder application to access Elasticsearch REST services for example

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -104,7 +104,7 @@ instances:
     # pending_task_stats: true
 
     ## @param cat_allocation_stats - boolean - optional - default: false
-    ## Enable to collect Elastic Cat Allocation metrics.
+    ## Enable to collect Elastic Cat Allocation metrics. Available only for v >= 7.2
     ## Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html.
     #
     # cat_allocation_stats: false

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -104,7 +104,7 @@ instances:
     # pending_task_stats: true
 
     ## @param cat_allocation_stats - boolean - optional - default: false
-    ## Enable to collect Elastic Cat Allocation metrics. Available only for v >= 7.2
+    ## Enable to collect Elastic Cat Allocation metrics. Available only for Elasticsearch 7.2 or higher.
     ## Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html.
     #
     # cat_allocation_stats: false

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -104,8 +104,7 @@ instances:
     # pending_task_stats: true
 
     ## @param cat_allocation_stats - boolean - optional - default: false
-    ## If you enable the "cat_allocation_stats" flag, statistics over cat allocation metrics
-    ## are collected by the check and sent to the backend. 
+    ## Enable to collect Elastic Cat Allocation metrics.
     ## Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html.
     #
     # cat_allocation_stats: false

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -390,8 +390,7 @@ class ESCheck(AgentCheck):
                 self._process_metric(policy_data, metric, *desc, tags=tags)
 
     def _process_cat_allocation_data(self, admin_forwarder, version, base_tags):
-        cat_allocation_url = '/_cat/allocation?v=true&format=json&bytes=b'
-        cat_allocation_url = self._join_url(cat_allocation_url, admin_forwarder)
+        cat_allocation_url = self._join_url(CAT_ALLOC_PATH, admin_forwarder)
         cat_allocation_data = self._get_data(cat_allocation_url)
         cat_allocation_metrics = cat_allocation_stats_for_version(version)
 

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -126,6 +126,7 @@ class ESCheck(AgentCheck):
 
         # Load the cat allocation data.
         if version >= [7, 2, 0] and self._config.cat_allocation_stats:
+            self.log.debug("Collecting cat allocation metrics")
             try:
                 self._process_cat_allocation_data(admin_forwarder, version, base_tags)
             except requests.ReadTimeout as e:

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -387,7 +387,9 @@ class ESCheck(AgentCheck):
 
     def _process_cat_allocation_data(self, admin_forwarder, version, base_tags):
         if version < [7, 2, 0]:
-            self.log.warning("Collecting cat allocation metrics is not supported in version %s. Skipping", '.'.join(version))
+            self.log.warning(
+                "Collecting cat allocation metrics is not supported in version %s. Skipping", '.'.join(version)
+            )
             return
 
         self.log.debug("Collecting cat allocation metrics")
@@ -395,18 +397,20 @@ class ESCheck(AgentCheck):
         cat_allocation_url = self._join_url(CAT_ALLOC_PATH, admin_forwarder)
         try:
             cat_allocation_data = self._get_data(cat_allocation_url)
-         except requests.ReadTimeout as e:
-             self.log.error("Timed out reading cat allocation stats from servers (%s) - stats will be missing", e)
-             return
-                   
+        except requests.ReadTimeout as e:
+            self.log.error("Timed out reading cat allocation stats from servers (%s) - stats will be missing", e)
+            return
+
         cat_allocation_metrics = {}
         cat_allocation_metrics.update(CAT_ALLOCATION_METRICS)
-        
+
         # we need to remap metric names because the ones from elastic
         # contain dots and that would confuse `_process_metric()` (sic)
         data_to_collect = {'disk.indices', 'disk.used', 'disk.avail', 'disk.total', 'disk.percent', 'shards'}
         for dic in cat_allocation_data:
-            cat_allocation_dic = {k.replace('.', '_'): v for k, v in dic.items() if k in data_to_collect and v is not None}
+            cat_allocation_dic = {
+                k.replace('.', '_'): v for k, v in dic.items() if k in data_to_collect and v is not None
+            }
             tags = base_tags + ['node_name:' + dic.get('node').lower()]
             for metric in cat_allocation_metrics:
                 desc = cat_allocation_metrics[metric]

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -390,6 +390,7 @@ class ESCheck(AgentCheck):
                 self._process_metric(policy_data, metric, *desc, tags=tags)
 
     def _process_cat_allocation_data(self, admin_forwarder, version, base_tags):
+        CAT_ALLOC_PATH = '/_cat/allocation?v=true&format=json&bytes=b'
         cat_allocation_url = self._join_url(CAT_ALLOC_PATH, admin_forwarder)
         cat_allocation_data = self._get_data(cat_allocation_url)
         cat_allocation_metrics = cat_allocation_stats_for_version(version)

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -401,9 +401,6 @@ class ESCheck(AgentCheck):
             self.log.error("Timed out reading cat allocation stats from servers (%s) - stats will be missing", e)
             return
 
-        cat_allocation_metrics = {}
-        cat_allocation_metrics.update(CAT_ALLOCATION_METRICS)
-
         # we need to remap metric names because the ones from elastic
         # contain dots and that would confuse `_process_metric()` (sic)
         data_to_collect = {'disk.indices', 'disk.used', 'disk.avail', 'disk.total', 'disk.percent', 'shards'}
@@ -412,7 +409,7 @@ class ESCheck(AgentCheck):
                 k.replace('.', '_'): v for k, v in dic.items() if k in data_to_collect and v is not None
             }
             tags = base_tags + ['node_name:' + dic.get('node').lower()]
-            for metric in cat_allocation_metrics:
+            for metric in CAT_ALLOCATION_METRICS:
                 desc = cat_allocation_metrics[metric]
                 self._process_metric(cat_allocation_dic, metric, *desc, tags=tags)
 

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -12,8 +12,8 @@ from datadog_checks.base import AgentCheck, is_affirmative, to_string
 
 from .config import from_instance
 from .metrics import (
+    CAT_ALLOCATION_METRICS,
     CLUSTER_PENDING_TASKS,
-    cat_allocation_stats_for_version,
     health_stats_for_version,
     index_stats_for_version,
     node_system_stats_for_version,
@@ -393,7 +393,8 @@ class ESCheck(AgentCheck):
         CAT_ALLOC_PATH = '/_cat/allocation?v=true&format=json&bytes=b'
         cat_allocation_url = self._join_url(CAT_ALLOC_PATH, admin_forwarder)
         cat_allocation_data = self._get_data(cat_allocation_url)
-        cat_allocation_metrics = cat_allocation_stats_for_version(version)
+        cat_allocation_metrics = {}
+        cat_allocation_metrics.update(CAT_ALLOCATION_METRICS)
 
         # we need to remap metric names because the ones from elastic
         # contain dots and that would confuse `_process_metric()` (sic)

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -127,12 +127,8 @@ class ESCheck(AgentCheck):
                 self.log.warning("Timed out reading index stats from servers (%s) - stats will be missing", e)
 
         # Load the cat allocation data.
-        if version >= [7, 2, 0] and self._config.cat_allocation_stats:
-            self.log.debug("Collecting cat allocation metrics")
-            try:
-                self._process_cat_allocation_data(admin_forwarder, version, base_tags)
-            except requests.ReadTimeout as e:
-                self.log.warning("Timed out reading cat allocation stats from servers (%s) - stats will be missing", e)
+        if self._config.cat_allocation_stats:
+            self._process_cat_allocation_data(admin_forwarder, version, base_tags)
 
         # If we're here we did not have any ES conn issues
         self.service_check(self.SERVICE_CHECK_CONNECT_NAME, AgentCheck.OK, tags=self._config.service_check_tags)

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import json
+import sys
 import time
 from collections import defaultdict
 
@@ -399,12 +401,13 @@ class ESCheck(AgentCheck):
         # we need to remap metric names because the ones from elastic
         # contain dots and that would confuse `_process_metric()` (sic)
         for dic in cat_allocation_data:
+            json.dump(dic, sys.stdout)
             cat_allocation_dic = {
-                'disk_indices': dic.get(u'disk.indices'),
-                'disk_used': dic.get(u'disk.used'),
-                'disk_avail': dic.get(u'disk.avail'),
-                'disk_total': dic.get(u'disk.total'),
-                'disk_percent': dic.get(u'disk.percent'),
+                'disk_indices': dic.get('disk.indices'),
+                'disk_used': dic.get('disk.used'),
+                'disk_avail': dic.get('disk.avail'),
+                'disk_total': dic.get('disk.total'),
+                'disk_percent': dic.get('disk.percent'),
                 'shards': dic.get(u'shards'),
             }
 
@@ -412,9 +415,9 @@ class ESCheck(AgentCheck):
             for key, value in list(iteritems(dic)):
                 if value is None:
                     del dic[key]
-                    self.log.debug("The cat allocation node_name %s has no metric data for %s", dic.get(u'node'), key)
+                    self.log.debug("The cat allocation node_name %s has no metric data for %s", dic.get('node'), key)
 
-            tags = base_tags + ['node_name:' + dic.get(u'node').lower()]
+            tags = base_tags + ['node_name:' + dic.get('node').lower()]
             for metric in cat_allocation_metrics:
                 desc = cat_allocation_metrics[metric]
                 self._process_metric(cat_allocation_dic, metric, *desc, tags=tags)

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -37,6 +37,7 @@ class ESCheck(AgentCheck):
 
     SERVICE_CHECK_CONNECT_NAME = 'elasticsearch.can_connect'
     SERVICE_CHECK_CLUSTER_STATUS = 'elasticsearch.cluster_health'
+    CAT_ALLOC_PATH = '/_cat/allocation?v=true&format=json&bytes=b'
     SOURCE_TYPE_NAME = 'elasticsearch'
 
     def __init__(self, name, init_config, instances):
@@ -393,8 +394,7 @@ class ESCheck(AgentCheck):
             return
 
         self.log.debug("Collecting cat allocation metrics")
-        CAT_ALLOC_PATH = '/_cat/allocation?v=true&format=json&bytes=b'
-        cat_allocation_url = self._join_url(CAT_ALLOC_PATH, admin_forwarder)
+        cat_allocation_url = self._join_url(self.CAT_ALLOC_PATH, admin_forwarder)
         try:
             cat_allocation_data = self._get_data(cat_allocation_url)
         except requests.ReadTimeout as e:
@@ -410,7 +410,7 @@ class ESCheck(AgentCheck):
             }
             tags = base_tags + ['node_name:' + dic.get('node').lower()]
             for metric in CAT_ALLOCATION_METRICS:
-                desc = cat_allocation_metrics[metric]
+                desc = CAT_ALLOCATION_METRICS[metric]
                 self._process_metric(cat_allocation_dic, metric, *desc, tags=tags)
 
     def _create_event(self, status, tags=None):

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -387,7 +387,7 @@ class ESCheck(AgentCheck):
 
     def _process_cat_allocation_data(self, admin_forwarder, version, base_tags):
         if version < [7, 2, 0]:
-            self.log.warning(
+            self.log.debug(
                 "Collecting cat allocation metrics is not supported in version %s. Skipping", '.'.join(version)
             )
             return

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -411,7 +411,7 @@ class ESCheck(AgentCheck):
             for key, value in list(iteritems(dic)):
                 if value is None:
                     del dic[key]
-                    self.log.warning("The cat allocation node_name %s has no metric data for %s", dic.get(u'node'), key)
+                    self.log.debug("The cat allocation node_name %s has no metric data for %s", dic.get(u'node'), key)
 
             tags = base_tags + ['node_name:' + dic.get(u'node').lower()]
             for metric in cat_allocation_metrics:

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-import json
-import sys
 import time
 from collections import defaultdict
 
@@ -406,7 +404,7 @@ class ESCheck(AgentCheck):
         
         # we need to remap metric names because the ones from elastic
         # contain dots and that would confuse `_process_metric()` (sic)
-        data_to_collect = {'disk.indices', ''disk.used', 'disk.avail', 'disk.total', 'disk.percent', 'shards'}
+        data_to_collect = {'disk.indices', 'disk.used', 'disk.avail', 'disk.total', 'disk.percent', 'shards'}
         for dic in cat_allocation_data:
             cat_allocation_dic = {k.replace('.', '_'): v for k, v in dic.items() if k in data_to_collect and v is not None}
             tags = base_tags + ['node_name:' + dic.get('node').lower()]

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -388,31 +388,27 @@ class ESCheck(AgentCheck):
                 self._process_metric(policy_data, metric, *desc, tags=tags)
 
     def _process_cat_allocation_data(self, admin_forwarder, version, base_tags):
+        if version < [7, 2, 0]:
+            self.log.warning("Collecting cat allocation metrics is not supported in version %s. Skipping", '.'.join(version))
+            return
+
+        self.log.debug("Collecting cat allocation metrics")
         CAT_ALLOC_PATH = '/_cat/allocation?v=true&format=json&bytes=b'
         cat_allocation_url = self._join_url(CAT_ALLOC_PATH, admin_forwarder)
-        cat_allocation_data = self._get_data(cat_allocation_url)
+        try:
+            cat_allocation_data = self._get_data(cat_allocation_url)
+         except requests.ReadTimeout as e:
+             self.log.error("Timed out reading cat allocation stats from servers (%s) - stats will be missing", e)
+             return
+                   
         cat_allocation_metrics = {}
         cat_allocation_metrics.update(CAT_ALLOCATION_METRICS)
-
+        
         # we need to remap metric names because the ones from elastic
         # contain dots and that would confuse `_process_metric()` (sic)
+        data_to_collect = {'disk.indices', ''disk.used', 'disk.avail', 'disk.total', 'disk.percent', 'shards'}
         for dic in cat_allocation_data:
-            json.dump(dic, sys.stdout)
-            cat_allocation_dic = {
-                'disk_indices': dic.get('disk.indices'),
-                'disk_used': dic.get('disk.used'),
-                'disk_avail': dic.get('disk.avail'),
-                'disk_total': dic.get('disk.total'),
-                'disk_percent': dic.get('disk.percent'),
-                'shards': dic.get(u'shards'),
-            }
-
-            # Ensure that dic does not contain None values
-            for key, value in list(iteritems(dic)):
-                if value is None:
-                    del dic[key]
-                    self.log.debug("The cat allocation node_name %s has no metric data for %s", dic.get('node'), key)
-
+            cat_allocation_dic = {k.replace('.', '_'): v for k, v in dic.items() if k in data_to_collect and v is not None}
             tags = base_tags + ['node_name:' + dic.get('node').lower()]
             for metric in cat_allocation_metrics:
                 desc = cat_allocation_metrics[metric]

--- a/elastic/datadog_checks/elastic/metrics.py
+++ b/elastic/datadog_checks/elastic/metrics.py
@@ -524,6 +524,15 @@ NODE_SYSTEM_METRICS_POST_5 = {
     'elasticsearch.process.cpu.percent': ('gauge', 'process.cpu.percent'),
 }
 
+CAT_ALLOCATION_METRICS = {
+    'elasticsearch.shards': ('gauge', 'shards'),
+    'elasticsearch.disk.indices': ('gauge', 'disk_indices'),
+    'elasticsearch.disk.used': ('gauge', 'disk_used'),
+    'elasticsearch.disk.avail': ('gauge', 'disk_avail'),
+    'elasticsearch.disk.total': ('gauge', 'disk_total'),
+    'elasticsearch.disk.percent': ('gauge', 'disk_percent'),
+}
+
 
 def stats_for_version(version, jvm_rate=False):
     """
@@ -653,3 +662,14 @@ def node_system_stats_for_version(version):
         node_system_stats.update(NODE_SYSTEM_METRICS_POST_5)
 
     return node_system_stats
+
+
+def cat_allocation_stats_for_version(version):
+    """
+    Get the proper set of Cat Allocations metrics for the specified ES version
+    """
+    cat_allocation_metrics = {}
+    if version >= [7, 2, 0]:
+        cat_allocation_metrics.update(CAT_ALLOCATION_METRICS)
+
+    return cat_allocation_metrics

--- a/elastic/datadog_checks/elastic/metrics.py
+++ b/elastic/datadog_checks/elastic/metrics.py
@@ -662,14 +662,3 @@ def node_system_stats_for_version(version):
         node_system_stats.update(NODE_SYSTEM_METRICS_POST_5)
 
     return node_system_stats
-
-
-def cat_allocation_stats_for_version(version):
-    """
-    Get the proper set of Cat Allocations metrics for the specified ES version
-    """
-    cat_allocation_metrics = {}
-    if version >= [7, 2, 0]:
-        cat_allocation_metrics.update(CAT_ALLOCATION_METRICS)
-
-    return cat_allocation_metrics

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -24,7 +24,7 @@ elasticsearch.docs.deleted,gauge,,document,,The total number of documents delete
 elasticsearch.disk.avail,gauge,,byte,,The free disk space available to Elasticsearch.,0,elasticsearch,disk avail
 elasticsearch.disk.indices,gauge,,byte,,The disk space used by the node’s shards.,0,elasticsearch,disk indices
 elasticsearch.disk.percent,gauge,,byte,,The total percentage of disk space in use. Calculated as disk.used / disk.total.,0,elasticsearch,disk percent
-elasticsearch.disk.total,gauge,,byte,,Total disk space for the node including in-use and available space.,0,elasticsearch,disk total
+elasticsearch.disk.total,gauge,,byte,,The total disk space for the node including in-use and available space.,0,elasticsearch,disk total
 elasticsearch.disk.used,gauge,,byte,,Total disk space in use.,0,elasticsearch,disk used
 elasticsearch.fielddata.evictions,gauge,,eviction,,The total  number of evictions from the fielddata cache.,0,elasticsearch,fielddata cache evictions
 elasticsearch.fielddata.size,gauge,,byte,,The size of the fielddata cache.,0,elasticsearch,fielddata cache size

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -23,7 +23,7 @@ elasticsearch.docs.count,gauge,,document,,The total number of documents in the c
 elasticsearch.docs.deleted,gauge,,document,,The total number of documents deleted from the cluster across all shards.,0,elasticsearch,docs deleted
 elasticsearch.disk.avail,gauge,,byte,,The free disk space available to Elasticsearch.,0,elasticsearch,disk avail
 elasticsearch.disk.indices,gauge,,byte,,The disk space used by the node's shards.,0,elasticsearch,disk indices
-elasticsearch.disk.percent,gauge,,byte,,The total percentage of disk space in use. Calculated as disk.used / disk.total.,0,elasticsearch,disk percent
+elasticsearch.disk.percent,gauge,,percent,,The total percentage of disk space in use. Calculated as disk.used / disk.total.,0,elasticsearch,disk percent
 elasticsearch.disk.total,gauge,,byte,,The total disk space for the node including in-use and available space.,0,elasticsearch,disk total
 elasticsearch.disk.used,gauge,,byte,,The total disk space in use.,0,elasticsearch,disk used
 elasticsearch.fielddata.evictions,gauge,,eviction,,The total  number of evictions from the fielddata cache.,0,elasticsearch,fielddata cache evictions

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -137,8 +137,7 @@ elasticsearch.refresh.total.time,gauge,,second,,The total time spent on index re
 elasticsearch.refresh.external_total,gauge,,refresh,,The total number of external index refreshes.,0,elasticsearch,total refreshes
 elasticsearch.refresh.external_total.time,gauge,,second,,The total time spent on external index refreshes.,0,elasticsearch,total refresh time
 elasticsearch.relocating_shards,gauge,,shard,,The number of shards that are relocating from one node to another.,0,elasticsearch,relocating shards
-elasticsearch.shards,gauge,,fetch,,Number of primary and replica shards assigned to the node.,0,elasticsearch,current fetches
-elasticsearch.search.fetch.current,gauge,,shard,,The number of search fetches currently running.,0,elasticsearch,shards
+elasticsearch.search.fetch.current,gauge,,fetch,,The number of search fetches currently running.,0,elasticsearch,current fetches
 elasticsearch.search.fetch.open_contexts,gauge,,query,,The number of active searches.,0,elasticsearch,active searches
 elasticsearch.search.fetch.time,gauge,,second,,The total time spent on the search fetch.,0,elasticsearch,total fetch time
 elasticsearch.search.fetch.total,gauge,,fetch,,The total number of search fetches.,0,elasticsearch,total fetches
@@ -148,6 +147,7 @@ elasticsearch.search.query.total,gauge,,query,,The total number of queries.,0,el
 elasticsearch.search.scroll.current,gauge,,query,,The number of currently active scroll queries.,0,elasticsearch,current scroll queries
 elasticsearch.search.scroll.time,gauge,,second,,The total time spent on scroll queries.,0,elasticsearch,total scroll query time
 elasticsearch.search.scroll.total,gauge,,query,,The total number of scroll queries.,0,elasticsearch,total scroll queries
+elasticsearch.shards,gauge,,shard,,Number of primary and replica shards assigned to the node.,0,elasticsearch,shards
 elasticsearch.slm.snapshot_deletion_failures,gauge,,error,,The total number of snapshot deletion failures.,0,elasticsearch,slm del fail
 elasticsearch.slm.snapshots_deleted,gauge,,,,The total number of deleted snapshots.,0,elasticsearch,slm del
 elasticsearch.slm.snapshots_failed,gauge,,error,,The total number of failed snapshots.,0,elasticsearch,slm fail

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -21,6 +21,11 @@ elasticsearch.cache.filter.size,gauge,,byte,,The size of the filter cache.,0,ela
 elasticsearch.cluster_status,gauge,,,,"The elasticsearch cluster health as a number: red = 0, yellow = 1, green = 2",0,elasticsearch,cluster status
 elasticsearch.docs.count,gauge,,document,,The total number of documents in the cluster across all shards.,0,elasticsearch,docs count
 elasticsearch.docs.deleted,gauge,,document,,The total number of documents deleted from the cluster across all shards.,0,elasticsearch,docs deleted
+elasticsearch.disk.avail,gauge,,byte,,Free disk space available to Elasticsearch.,0,elasticsearch,disk avail
+elasticsearch.disk.indices,gauge,,byte,,Disk space used by the node’s shards.,0,elasticsearch,disk indices
+elasticsearch.disk.percent,gauge,,byte,,Total percentage of disk space in use. Calculated as disk.used / disk.total.,0,elasticsearch,disk percent
+elasticsearch.disk.total,gauge,,byte,,Total disk space for the node including in-use and available space.,0,elasticsearch,disk total
+elasticsearch.disk.used,gauge,,byte,,Total disk space in use.,0,elasticsearch,disk used
 elasticsearch.fielddata.evictions,gauge,,eviction,,The total  number of evictions from the fielddata cache.,0,elasticsearch,fielddata cache evictions
 elasticsearch.fielddata.size,gauge,,byte,,The size of the fielddata cache.,0,elasticsearch,fielddata cache size
 elasticsearch.flush.total,gauge,,flush,,The total number of index flushes to disk since start.,0,elasticsearch,total index flushes
@@ -132,7 +137,8 @@ elasticsearch.refresh.total.time,gauge,,second,,The total time spent on index re
 elasticsearch.refresh.external_total,gauge,,refresh,,The total number of external index refreshes.,0,elasticsearch,total refreshes
 elasticsearch.refresh.external_total.time,gauge,,second,,The total time spent on external index refreshes.,0,elasticsearch,total refresh time
 elasticsearch.relocating_shards,gauge,,shard,,The number of shards that are relocating from one node to another.,0,elasticsearch,relocating shards
-elasticsearch.search.fetch.current,gauge,,fetch,,The number of search fetches currently running.,0,elasticsearch,current fetches
+elasticsearch.shards,gauge,,fetch,,Number of primary and replica shards assigned to the node.,0,elasticsearch,current fetches
+elasticsearch.search.fetch.current,gauge,,shard,,The number of search fetches currently running.,0,elasticsearch,shards
 elasticsearch.search.fetch.open_contexts,gauge,,query,,The number of active searches.,0,elasticsearch,active searches
 elasticsearch.search.fetch.time,gauge,,second,,The total time spent on the search fetch.,0,elasticsearch,total fetch time
 elasticsearch.search.fetch.total,gauge,,fetch,,The total number of search fetches.,0,elasticsearch,total fetches

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -22,7 +22,7 @@ elasticsearch.cluster_status,gauge,,,,"The elasticsearch cluster health as a num
 elasticsearch.docs.count,gauge,,document,,The total number of documents in the cluster across all shards.,0,elasticsearch,docs count
 elasticsearch.docs.deleted,gauge,,document,,The total number of documents deleted from the cluster across all shards.,0,elasticsearch,docs deleted
 elasticsearch.disk.avail,gauge,,byte,,The free disk space available to Elasticsearch.,0,elasticsearch,disk avail
-elasticsearch.disk.indices,gauge,,byte,,The disk space used by the node’s shards.,0,elasticsearch,disk indices
+elasticsearch.disk.indices,gauge,,byte,,The disk space used by the node's shards.,0,elasticsearch,disk indices
 elasticsearch.disk.percent,gauge,,byte,,The total percentage of disk space in use. Calculated as disk.used / disk.total.,0,elasticsearch,disk percent
 elasticsearch.disk.total,gauge,,byte,,The total disk space for the node including in-use and available space.,0,elasticsearch,disk total
 elasticsearch.disk.used,gauge,,byte,,The total disk space in use.,0,elasticsearch,disk used

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -23,7 +23,7 @@ elasticsearch.docs.count,gauge,,document,,The total number of documents in the c
 elasticsearch.docs.deleted,gauge,,document,,The total number of documents deleted from the cluster across all shards.,0,elasticsearch,docs deleted
 elasticsearch.disk.avail,gauge,,byte,,The free disk space available to Elasticsearch.,0,elasticsearch,disk avail
 elasticsearch.disk.indices,gauge,,byte,,The disk space used by the node’s shards.,0,elasticsearch,disk indices
-elasticsearch.disk.percent,gauge,,byte,,Total percentage of disk space in use. Calculated as disk.used / disk.total.,0,elasticsearch,disk percent
+elasticsearch.disk.percent,gauge,,byte,,The total percentage of disk space in use. Calculated as disk.used / disk.total.,0,elasticsearch,disk percent
 elasticsearch.disk.total,gauge,,byte,,Total disk space for the node including in-use and available space.,0,elasticsearch,disk total
 elasticsearch.disk.used,gauge,,byte,,Total disk space in use.,0,elasticsearch,disk used
 elasticsearch.fielddata.evictions,gauge,,eviction,,The total  number of evictions from the fielddata cache.,0,elasticsearch,fielddata cache evictions

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -21,7 +21,7 @@ elasticsearch.cache.filter.size,gauge,,byte,,The size of the filter cache.,0,ela
 elasticsearch.cluster_status,gauge,,,,"The elasticsearch cluster health as a number: red = 0, yellow = 1, green = 2",0,elasticsearch,cluster status
 elasticsearch.docs.count,gauge,,document,,The total number of documents in the cluster across all shards.,0,elasticsearch,docs count
 elasticsearch.docs.deleted,gauge,,document,,The total number of documents deleted from the cluster across all shards.,0,elasticsearch,docs deleted
-elasticsearch.disk.avail,gauge,,byte,,Free disk space available to Elasticsearch.,0,elasticsearch,disk avail
+elasticsearch.disk.avail,gauge,,byte,,The free disk space available to Elasticsearch.,0,elasticsearch,disk avail
 elasticsearch.disk.indices,gauge,,byte,,Disk space used by the node’s shards.,0,elasticsearch,disk indices
 elasticsearch.disk.percent,gauge,,byte,,Total percentage of disk space in use. Calculated as disk.used / disk.total.,0,elasticsearch,disk percent
 elasticsearch.disk.total,gauge,,byte,,Total disk space for the node including in-use and available space.,0,elasticsearch,disk total

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -25,7 +25,7 @@ elasticsearch.disk.avail,gauge,,byte,,The free disk space available to Elasticse
 elasticsearch.disk.indices,gauge,,byte,,The disk space used by the node’s shards.,0,elasticsearch,disk indices
 elasticsearch.disk.percent,gauge,,byte,,The total percentage of disk space in use. Calculated as disk.used / disk.total.,0,elasticsearch,disk percent
 elasticsearch.disk.total,gauge,,byte,,The total disk space for the node including in-use and available space.,0,elasticsearch,disk total
-elasticsearch.disk.used,gauge,,byte,,Total disk space in use.,0,elasticsearch,disk used
+elasticsearch.disk.used,gauge,,byte,,The total disk space in use.,0,elasticsearch,disk used
 elasticsearch.fielddata.evictions,gauge,,eviction,,The total  number of evictions from the fielddata cache.,0,elasticsearch,fielddata cache evictions
 elasticsearch.fielddata.size,gauge,,byte,,The size of the fielddata cache.,0,elasticsearch,fielddata cache size
 elasticsearch.flush.total,gauge,,flush,,The total number of index flushes to disk since start.,0,elasticsearch,total index flushes

--- a/elastic/metadata.csv
+++ b/elastic/metadata.csv
@@ -22,7 +22,7 @@ elasticsearch.cluster_status,gauge,,,,"The elasticsearch cluster health as a num
 elasticsearch.docs.count,gauge,,document,,The total number of documents in the cluster across all shards.,0,elasticsearch,docs count
 elasticsearch.docs.deleted,gauge,,document,,The total number of documents deleted from the cluster across all shards.,0,elasticsearch,docs deleted
 elasticsearch.disk.avail,gauge,,byte,,The free disk space available to Elasticsearch.,0,elasticsearch,disk avail
-elasticsearch.disk.indices,gauge,,byte,,Disk space used by the node’s shards.,0,elasticsearch,disk indices
+elasticsearch.disk.indices,gauge,,byte,,The disk space used by the node’s shards.,0,elasticsearch,disk indices
 elasticsearch.disk.percent,gauge,,byte,,Total percentage of disk space in use. Calculated as disk.used / disk.total.,0,elasticsearch,disk percent
 elasticsearch.disk.total,gauge,,byte,,Total disk space for the node including in-use and available space.,0,elasticsearch,disk total
 elasticsearch.disk.used,gauge,,byte,,Total disk space in use.,0,elasticsearch,disk used

--- a/elastic/tests/test_elastic.py
+++ b/elastic/tests/test_elastic.py
@@ -12,6 +12,7 @@ from datadog_checks.base import ConfigurationError
 from datadog_checks.elastic import ESCheck
 from datadog_checks.elastic.config import from_instance
 from datadog_checks.elastic.metrics import (
+    CAT_ALLOCATION_METRICS,
     CLUSTER_PENDING_TASKS,
     STATS_METRICS,
     ADDITIONAL_METRICS_1_x,
@@ -204,14 +205,19 @@ def test_index_metrics(dd_environment, aggregator, instance, cluster_tags):
 
 @pytest.mark.integration
 def test_cat_allocation_metrics(dd_environment, aggregator, instance, cluster_tags):
+    instance['cat_allocation_stats'] = True
+    # print(instance['cat_allocation_stats'], 'instance[cat_allocation_stats]')
     elastic_check = ESCheck('elastic', {}, instances=[instance])
+    cat_allocation_metrics = {}
+    cat_allocation_metrics.update(CAT_ALLOCATION_METRICS)
+    print(cat_allocation_metrics)
     es_version = elastic_check._get_es_version()
     if es_version < [7, 2, 0]:
         pytest.skip("Cat Allocation metrics are only tested in version 7.2.0+")
 
     elastic_check.check(None)
-
-    elastic_check._process_cat_allocation_data(aggregator, es_version, cluster_tags)
+    for m_name in cat_allocation_metrics:
+        aggregator.assert_metric(m_name)
 
 
 @pytest.mark.integration

--- a/elastic/tests/test_elastic.py
+++ b/elastic/tests/test_elastic.py
@@ -203,6 +203,18 @@ def test_index_metrics(dd_environment, aggregator, instance, cluster_tags):
 
 
 @pytest.mark.integration
+def test_cat_allocation_metrics(dd_environment, aggregator, instance, cluster_tags):
+    elastic_check = ESCheck('elastic', {}, instances=[instance])
+    es_version = elastic_check._get_es_version()
+    if es_version < [6, 4, 2]:
+        pytest.skip("Cat Allocation metrics are only tested in version 6.4.2+")
+
+    elastic_check.check(None)
+
+    elastic_check._process_cat_allocation_data(aggregator, es_version, cluster_tags)
+
+
+@pytest.mark.integration
 def test_health_event(dd_environment, aggregator):
     dummy_tags = ['elastique:recherche']
     instance = {'url': URL, 'username': USER, 'password': PASSWORD, 'tags': dummy_tags}

--- a/elastic/tests/test_elastic.py
+++ b/elastic/tests/test_elastic.py
@@ -206,8 +206,8 @@ def test_index_metrics(dd_environment, aggregator, instance, cluster_tags):
 def test_cat_allocation_metrics(dd_environment, aggregator, instance, cluster_tags):
     elastic_check = ESCheck('elastic', {}, instances=[instance])
     es_version = elastic_check._get_es_version()
-    if es_version < [6, 4, 2]:
-        pytest.skip("Cat Allocation metrics are only tested in version 6.4.2+")
+    if es_version < [7, 2, 0]:
+        pytest.skip("Cat Allocation metrics are only tested in version 7.2.0+")
 
     elastic_check.check(None)
 

--- a/elastic/tests/test_elastic.py
+++ b/elastic/tests/test_elastic.py
@@ -207,14 +207,9 @@ def test_index_metrics(dd_environment, aggregator, instance, cluster_tags):
 def test_cat_allocation_metrics(dd_environment, aggregator, instance, cluster_tags):
     instance['cat_allocation_stats'] = True
     elastic_check = ESCheck('elastic', {}, instances=[instance])
-    cat_allocation_metrics = {}
-    cat_allocation_metrics.update(CAT_ALLOCATION_METRICS)
-    es_version = elastic_check._get_es_version()
-    if es_version < [7, 2, 0]:
-        pytest.skip("Cat Allocation metrics are only tested in version 7.2.0+")
 
     elastic_check.check(None)
-    for m_name in cat_allocation_metrics:
+    for m_name in CAT_ALLOCATION_METRICS:
         aggregator.assert_metric(m_name)
 
 

--- a/elastic/tests/test_elastic.py
+++ b/elastic/tests/test_elastic.py
@@ -206,11 +206,9 @@ def test_index_metrics(dd_environment, aggregator, instance, cluster_tags):
 @pytest.mark.integration
 def test_cat_allocation_metrics(dd_environment, aggregator, instance, cluster_tags):
     instance['cat_allocation_stats'] = True
-    # print(instance['cat_allocation_stats'], 'instance[cat_allocation_stats]')
     elastic_check = ESCheck('elastic', {}, instances=[instance])
     cat_allocation_metrics = {}
     cat_allocation_metrics.update(CAT_ALLOCATION_METRICS)
-    print(cat_allocation_metrics)
     es_version = elastic_check._get_es_version()
     if es_version < [7, 2, 0]:
         pytest.skip("Cat Allocation metrics are only tested in version 7.2.0+")


### PR DESCRIPTION
### What does this PR do?
Collects [Elastic Cat Allocations metrics](https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.htm). The existing instance was initialized in `config.py`. The new metrics were added to `metrics.py`. The function to get the data from `/_cat/allocation` is in `elastic.py`. A boolean was added to `spec.yaml` and `conf.yaml.example` in order to only enable the collection if the user wants to get the data. A test for the `elastic.py` function was added to `test_elastic.py`. The units of the metrics are `shard` and `byte`.

### Motivation
It was required by a customer in [this FR](https://datadoghq.atlassian.net/secure/RapidBoard.jspa?rapidView=610&projectKey=FRAGENT&modal=detail&selectedIssue=FRAGENT-1063&quickFilter=599).

### Additional Notes
This is how I tested the changed:
1. Set `ddev` following [this documentation](https://datadoghq.atlassian.net/wiki/spaces/TS/pages/328437595/ddev+tooling+agent+integrations) and created a new environment using `pyenv virtualenv 3.8.0 my-virtual-env-3.8.0`.
2. Removed the `.tox` files (`rm -Rf .tox`).
3. Cleaned the environment (`ddev clean`).
4. Started the integration, using `--dev` to build my local code (`ddev env start elastic py38-7.7 --dev`).
5. Launched the check manually (`ddev env check elastic`) --> **184** metrics are reported.
```
=========
Collector
=========

  Running Checks
  ==============

    elastic (1.24.0)
    ----------------
      Instance ID: elastic:xxxxxxx [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/elastic.d/elastic.yaml
      Total Runs: 1
      Metric Samples: Last Run: 191, Total: 191
      Events: Last Run: 1, Total: 1
      Service Checks: Last Run: 2, Total: 2
      Average Execution Time : 80ms
      Last Execution Date : 2021-03-18 18:08:08 UTC (1616090888000)
      Last Successful Execution Date : 2021-03-18 18:08:08 UTC (1616090888000)
      metadata:
        version.major: 7
        version.minor: 7
        version.patch: 0
        version.raw: 7.7.0
        version.scheme: semver
```
6. Added `cat_allocation_stats: true` in `/Users/<your_username>/Library/Application\ Support/dd-checks-dev/envs/<integration_name>/<env_id>/config/<integration_name>.yaml`.
7. Launched the check manually (`ddev env check elastic`) --> **191** metrics are reported since the output of `curl -X GET "localhost:9200/_cat/allocation?v=true&format=json&pretty&bytes=b"` in my local computer is:

```
[
  {
    "shards" : "1",
    "disk.indices" : "208",
    "disk.used" : "34464833536",
    "disk.avail" : "28260790272",
    "disk.total" : "62725623808",
    "disk.percent" : "54",
    "host" : "xxx.xx.x.x",
    "ip" : "xxx.xx.x.x",
    "node" : "test-node"
  },
  {
    "shards" : "1",
    "disk.indices" : null,
    "disk.used" : null,
    "disk.avail" : null,
    "disk.total" : null,
    "disk.percent" : null,
    "host" : null,
    "ip" : null,
    "node" : "UNASSIGNED"
  }
]
```
8. Built the e2e instance check only (`ddev env test elastic`) --> passed.
```
  py38-7.7: commands succeeded
  congratulations :)
```
9. Reloaded the file, in order to see the changes in my personal account (`ddev env reload elastic py38-7.7`). [The metrics are reported in my sandbox](https://support-admin.us1.prod.dog/admin/switch_handle_get/org_id/292765?next_url=%2Fnotebook%2F450545%2Felasticsearch-ddev). 
![Image 2021-03-18 at 7 37 54 PM](https://user-images.githubusercontent.com/23095219/111679332-7ac59700-8821-11eb-9ad8-73ee259cad27.jpg)
10. Launched `ddev test elastic` --> passed.

Note that launching `ddev env check elastic` after `ddev test elastic` gives `111 connexion errors` which I believe is expected. Don't hesitate to reproduce and your side and let me know if you have questions.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached