### PR TITLE
Tag collection only available from vSphere 6.5

### DIFF
--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -278,7 +278,7 @@ files:
           - os_type:windows
           - application_name:my_app
           Note: Tag collection works only for vSphere 6.5 and above.
-                Tag collection needs vSphere REST API Tagging features and an endpoint (tagging.tag_association.object_to_tags)
+                Tag collection needs vSphere REST API Tagging and an endpoint (tagging.tag_association.object_to_tags)
                 only available from vSphere 6.5.
         value:
           type: boolean

--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -277,7 +277,7 @@ files:
           Examples:
           - os_type:windows
           - application_name:my_app
-          Note: Tag collection works only for vSphere 6.5 and above.
+          Note: Tag collection works only for vSphere 6.0 and above.
                 Tag collection needs vSphere REST API that is only available since this version.
         value:
           type: boolean

--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -277,6 +277,8 @@ files:
           Examples:
           - os_type:windows
           - application_name:my_app
+          Note: Tag collection works only for vSphere 6.5 and above.
+                Tag collection needs vSphere REST API that is only available since this version.
         value:
           type: boolean
           example: false

--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -277,8 +277,9 @@ files:
           Examples:
           - os_type:windows
           - application_name:my_app
-          Note: Tag collection works only for vSphere 6.0 and above.
-                Tag collection needs vSphere REST API that is only available since this version.
+          Note: Tag collection works only for vSphere 6.5 and above.
+                Tag collection needs vSphere REST API Tagging features and an endpoint (tagging.tag_association.object_to_tags)
+                only available from vSphere 6.5.
         value:
           type: boolean
           example: false

--- a/vsphere/datadog_checks/vsphere/api_rest.py
+++ b/vsphere/datadog_checks/vsphere/api_rest.py
@@ -193,6 +193,8 @@ class VSphereRestClient(object):
         Get all tags identifiers for a given set of objects
         Doc:
         https://vmware.github.io/vsphere-automation-sdk-rest/6.5/operations/com/vmware/cis/tagging/tag_association.list_attached_tags_on_objects-operation.html
+
+        This operation was added in vSphere API 6.5
         """
         payload = {"object_ids": [{"id": mor._moId, "type": MOR_TYPE_MAPPING_TO_STRING[type(mor)]} for mor in mors]}
         tag_associations = self._request_json(

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -214,6 +214,8 @@ instances:
     ## Examples:
     ## - os_type:windows
     ## - application_name:my_app
+    ## Note: Tag collection works only for vSphere 6.5 and above.
+    ##       Tag collection needs vSphere REST API that is only available since this version.
     #
     # collect_tags: false
 

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -215,7 +215,8 @@ instances:
     ## - os_type:windows
     ## - application_name:my_app
     ## Note: Tag collection works only for vSphere 6.5 and above.
-    ##       Tag collection needs vSphere REST API that is only available since this version.
+    ##       Tag collection needs vSphere REST API Tagging and an endpoint (tagging.tag_association.object_to_tags)
+    ##       only available from vSphere 6.5.
     #
     # collect_tags: false
 


### PR DESCRIPTION
### What does this PR do?

Tag collection only available from vSphere 6.5

### Motivation

vSphere integration tag collection uses vSphere REST API, and the vSphere REST API is available only [since vSphere 6.5](https://blogs.vmware.com/developer/2016/10/whats-new-developer-automation-interfaces-65.html).

https://blogs.vmware.com/code/2017/02/02/getting-started-vsphere-automation-sdk-rest/
