### PR TITLE
Elasticsearch, Apache, Postgres - Docker, Kubernetes, ECS instructions

### DIFF
--- a/apache/README.md
+++ b/apache/README.md
@@ -71,29 +71,128 @@ _Available for Agent versions >6.0_
 3. [Restart the Agent][5].
 
 <!-- xxz tab xxx -->
-<!-- xxx tab "Containerized" xxx -->
+<!-- xxx tab "Docker" xxx -->
 
-#### Containerized
+#### Docker
 
-For containerized environments, see the [Autodiscovery Integration Templates][6] for guidance on applying the parameters below.
+To configure this check for an Agent running on a container:
 
 ##### Metric collection
 
-| Parameter            | Value                                                         |
-| -------------------- | ------------------------------------------------------------- |
-| `<INTEGRATION_NAME>` | `apache`                                                      |
-| `<INIT_CONFIG>`      | blank or `{}`                                                 |
-| `<INSTANCE_CONFIG>`  | `{"apache_status_url": "http://%%host%%/server-status?auto"}` |
+Set [Autodiscovery Integrations Templates][15] as Docker labels on your application container:
+
+```yaml
+LABEL "com.datadoghq.ad.check_names"='["apache"]'
+LABEL "com.datadoghq.ad.init_configs"='[{}]'
+LABEL "com.datadoghq.ad.instances"='[{"apache_status_url": "http://%%host%%/server-status?auto"}
+]'
+```
 
 ##### Log collection
 
 _Available for Agent versions >6.0_
 
-Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes log collection documentation][7].
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Docker log collection documentation][16].
 
-| Parameter      | Value                                               |
-| -------------- | --------------------------------------------------- |
-| `<LOG_CONFIG>` | `{"source": "apache", "service": "<SERVICE_NAME>"}` |
+Then, set [Log Integrations][17] as Docker labels:
+
+```yaml
+LABEL "com.datadoghq.ad.logs"='[{"source": "apache", "service": "<SERVICE_NAME>"}]'
+```
+
+<!-- xxz tab xxx -->
+<!-- xxx tab "Kubernetes" xxx -->
+
+#### Kubernetes
+
+To configure this check for an Agent running on Kubernetes:
+
+##### Metric collection
+
+Set [Autodiscovery Integrations Templates][18] as pod annotations on your application container. Aside from this, templates can also be configure via [a file, a configmap, or a key-value store][19].
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: apache
+  annotations:
+    ad.datadoghq.com/apache.check_names: '["apache"]'
+    ad.datadoghq.com/apache.init_configs: '[{}]'
+    ad.datadoghq.com/apache.instances: |
+      [
+        {
+          "apache_status_url": "http://%%host%%/server-status?auto"
+        }
+      ]
+  labels:
+    name: apache
+```
+
+##### Log collection
+
+_Available for Agent versions >6.0_
+
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Kubernetes log collection documentation][20].
+
+Then, set [Log Integrations][21] as pod annotations. This can also be configure via [a file, a configmap, or a key-value store][22].
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: apache
+  annotations:
+    ad.datadoghq.com/apache.logs: '[{"source":"apache","service":"<YOUR_APP_NAME>"}]'
+  labels:
+    name: apache
+```
+
+
+<!-- xxz tab xxx -->
+<!-- xxx tab "ECS" xxx -->
+
+#### ECS
+
+To configure this check for an Agent running on ECS:
+
+##### Metric collection
+
+Set [Autodiscovery Integrations Templates][23] as Docker labels on your application container:
+
+```json
+{
+  "containerDefinitions": [{
+    "name": "apache",
+    "image": "apache:latest",
+    "dockerLabels": {
+      "com.datadoghq.ad.check_names": "[\"apache\"]",
+      "com.datadoghq.ad.init_configs": "[{}]",
+      "com.datadoghq.ad.instances": "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"}]"
+    }
+  }]
+}
+```
+
+##### Log collection
+
+_Available for Agent versions >6.0_
+
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [ECS log collection documentation][24].
+
+Then, set [Log Integrations][25] as Docker labels:
+
+```yaml
+{
+  "containerDefinitions": [{
+    "name": "apache",
+    "image": "apache:latest",
+    "dockerLabels": {
+      "com.datadoghq.ad.logs": "[{\"source\":\"apache\",\"service\":\"<YOUR_APP_NAME>\"}]"
+    }
+  }]
+}
+```
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
@@ -148,3 +247,14 @@ Additional helpful documentation, links, and articles:
 [12]: https://www.datadoghq.com/blog/monitoring-apache-web-server-performance
 [13]: https://www.datadoghq.com/blog/collect-apache-performance-metrics
 [14]: https://www.datadoghq.com/blog/monitor-apache-web-server-datadog
+[15]: https://docs.datadoghq.com/agent/docker/integrations/?tab=docker
+[16]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#installation
+[17]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#log-integrations
+[18]: https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes
+[19]: https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes#configuration
+[20]: https://docs.datadoghq.com/agent/kubernetes/log/?tab=containerinstallation#setup
+[21]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#log-integrations
+[22]: https://docs.datadoghq.com/agent/kubernetes/log/?tab=daemonset#configuration
+[23]: https://docs.datadoghq.com/agent/docker/integrations/?tab=docker
+[24]: https://docs.datadoghq.com/agent/amazon_ecs/logs/?tab=linux
+[25]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#log-integrations

--- a/apache/README.md
+++ b/apache/README.md
@@ -84,8 +84,7 @@ Set [Autodiscovery Integrations Templates][15] as Docker labels on your applicat
 ```yaml
 LABEL "com.datadoghq.ad.check_names"='["apache"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"apache_status_url": "http://%%host%%/server-status?auto"}
-]'
+LABEL "com.datadoghq.ad.instances"='[{"apache_status_url": "http://%%host%%/server-status?auto"}]'
 ```
 
 ##### Log collection

--- a/apache/README.md
+++ b/apache/README.md
@@ -109,7 +109,7 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-Set [Autodiscovery Integrations Templates][18] as pod annotations on your application container. Aside from this, templates can also be configure via [a file, a configmap, or a key-value store][19].
+Set [Autodiscovery Integrations Templates][18] as pod annotations on your application container. Aside from this, templates can also be configure with [a file, a configmap, or a key-value store][19].
 
 ```yaml
 apiVersion: v1
@@ -135,7 +135,7 @@ _Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Kubernetes log collection documentation][20].
 
-Then, set [Log Integrations][21] as pod annotations. This can also be configure via [a file, a configmap, or a key-value store][22].
+Then, set [Log Integrations][21] as pod annotations. This can also be configure with [a file, a configmap, or a key-value store][22].
 
 ```yaml
 apiVersion: v1

--- a/apache/README.md
+++ b/apache/README.md
@@ -125,7 +125,7 @@ metadata:
       ]
   spec:
     containers:
-    - name: apache
+      - name: apache
 ```
 
 ##### Log collection

--- a/apache/README.md
+++ b/apache/README.md
@@ -108,7 +108,7 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-Set [Autodiscovery Integrations Templates][18] as pod annotations on your application container. Aside from this, templates can also be configure with [a file, a configmap, or a key-value store][19].
+Set [Autodiscovery Integrations Templates][18] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][19].
 
 ```yaml
 apiVersion: v1
@@ -179,7 +179,7 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see t
 
 Then, set [Log Integrations][25] as Docker labels:
 
-```yaml
+```json
 {
   "containerDefinitions": [{
     "name": "apache",

--- a/apache/README.md
+++ b/apache/README.md
@@ -123,9 +123,9 @@ metadata:
           "apache_status_url": "http://%%host%%/server-status?auto"
         }
       ]
-  spec:
-    containers:
-      - name: apache
+spec:
+  containers:
+    - name: apache
 ```
 
 ##### Log collection
@@ -141,10 +141,10 @@ kind: Pod
 metadata:
   name: apache
   annotations:
-    ad.datadoghq.com/apache.logs: '[{"source":"apache","service":"<YOUR_APP_NAME>"}]'
-  spec:
-    containers:
-      - name: apache
+    ad.datadoghq.com/apache.logs: '[{"source":"apache","service":"<SERVICE_NAME>"}]'
+spec:
+  containers:
+    - name: apache
 ```
 
 

--- a/apache/README.md
+++ b/apache/README.md
@@ -90,7 +90,6 @@ LABEL "com.datadoghq.ad.instances"='[{"apache_status_url": "http://%%host%%/serv
 
 ##### Log collection
 
-_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Docker log collection documentation][16].
 

--- a/apache/README.md
+++ b/apache/README.md
@@ -130,7 +130,6 @@ metadata:
 
 ##### Log collection
 
-_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Kubernetes log collection documentation][20].
 
@@ -175,7 +174,6 @@ Set [Autodiscovery Integrations Templates][23] as Docker labels on your applicat
 
 ##### Log collection
 
-_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [ECS log collection documentation][24].
 

--- a/apache/README.md
+++ b/apache/README.md
@@ -123,8 +123,9 @@ metadata:
           "apache_status_url": "http://%%host%%/server-status?auto"
         }
       ]
-  labels:
-    name: apache
+  spec:
+  containers:
+    - name: apache
 ```
 
 ##### Log collection

--- a/apache/README.md
+++ b/apache/README.md
@@ -124,7 +124,7 @@ metadata:
         }
       ]
   spec:
-  containers:
+    containers:
     - name: apache
 ```
 
@@ -133,7 +133,7 @@ metadata:
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Kubernetes log collection documentation][20].
 
-Then, set [Log Integrations][21] as pod annotations. This can also be configure with [a file, a configmap, or a key-value store][22].
+Then, set [Log Integrations][21] as pod annotations. This can also be configured with [a file, a configmap, or a key-value store][22].
 
 ```yaml
 apiVersion: v1
@@ -142,8 +142,9 @@ metadata:
   name: apache
   annotations:
     ad.datadoghq.com/apache.logs: '[{"source":"apache","service":"<YOUR_APP_NAME>"}]'
-  labels:
-    name: apache
+  spec:
+    containers:
+      - name: apache
 ```
 
 

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -312,47 +312,6 @@ Then, [instrument your application container][7] and set `DD_AGENT_HOST` to the 
 
 
 <!-- xxz tab xxx -->
-<!-- xxx tab "Containerized" xxx -->
-
-#### Containerized
-
-For containerized environments, see the [Autodiscovery Integration Templates][8] for guidance on applying the parameters below.
-
-##### Metric collection
-
-| Parameter            | Value                              |
-| -------------------- | ---------------------------------- |
-| `<INTEGRATION_NAME>` | `elastic`                          |
-| `<INIT_CONFIG>`      | blank or `{}`                      |
-| `<INSTANCE_CONFIG>`  | `{"url": "https://%%host%%:9200"}` |
-
-##### Trace collection
-
-APM for containerized apps is supported on hosts running Agent v6+ but requires extra configuration to begin collecting traces.
-
-Required environment variables on the Agent container:
-
-| Parameter            | Value                                                                      |
-| -------------------- | -------------------------------------------------------------------------- |
-| `<DD_API_KEY>` | `api_key`                                                                  |
-| `<DD_APM_ENABLED>`      | true                                                              |
-| `<DD_APM_NON_LOCAL_TRAFFIC>`  | true |
-
-See [Tracing Kubernetes Applications][17] and the [Kubernetes Daemon Setup][18] for a complete list of available environment variables and configuration.
-
-Then, [instrument your application container][7] and set `DD_AGENT_HOST` to the name of your Agent container.
-
-##### Log collection
-
-_Available for Agent versions >6.0_
-
-Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes log collection documentation][9].
-
-| Parameter      | Value                                                      |
-| -------------- | ---------------------------------------------------------- |
-| `<LOG_CONFIG>` | `{"source": "elasticsearch", "service": "<SERVICE_NAME>"}` |
-
-<!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
 
 ### Validation

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -140,6 +140,178 @@ _Available for Agent versions >6.0_
 4. [Restart the Agent][5].
 
 <!-- xxz tab xxx -->
+<!-- xxx tab "Docker" xxx -->
+
+#### Docker
+
+To configure this check for an Agent running on a container:
+
+##### Metric collection
+
+Set [Autodiscovery Integrations Templates][22] as Docker labels on your application container:
+
+```yaml
+LABEL "com.datadoghq.ad.check_names"='["elastic"]'
+LABEL "com.datadoghq.ad.init_configs"='[{}]'
+LABEL "com.datadoghq.ad.instances"='[{"url": "https://%%host%%:9200"}]'
+```
+
+##### Log collection
+
+_Available for Agent versions >6.0_
+
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Docker log collection documentation][23].
+
+Then, set [Log Integrations][24] as Docker labels:
+
+```yaml
+LABEL "com.datadoghq.ad.logs"='[{"source":"elasticsearch","service":"<SERVICE_NAME>"}]'
+```
+
+##### Trace collection
+
+APM for containerized apps is supported on Agent v6+ but requires extra configuration to begin collecting traces.
+
+Required environment variables on the Agent container:
+
+| Parameter            | Value                                                                      |
+| -------------------- | -------------------------------------------------------------------------- |
+| `<DD_API_KEY>` | `api_key`                                                                  |
+| `<DD_APM_ENABLED>`      | true                                                              |
+| `<DD_APM_NON_LOCAL_TRAFFIC>`  | true |
+
+See [Tracing Kubernetes Applications][17] and the [Kubernetes Daemon Setup][18] for a complete list of available environment variables and configuration.
+
+Then, [instrument your application container][7] and set `DD_AGENT_HOST` to the name of your Agent container.
+
+
+<!-- xxz tab xxx -->
+<!-- xxx tab "Kubernetes" xxx -->
+
+#### Kubernetes
+
+To configure this check for an Agent running on Kubernetes:
+
+##### Metric collection
+
+Set [Autodiscovery Integrations Templates][25] as pod annotations on your application container. Aside from this, templates can also be configure via [a file, a configmap, or a key-value store][26].
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: elasticsearch
+  annotations:
+    ad.datadoghq.com/elasticsearch.check_names: '["elasticsearch"]'
+    ad.datadoghq.com/elasticsearch.init_configs: '[{}]'
+    ad.datadoghq.com/elasticsearch.instances: |
+      [
+        {
+          "url": "https://%%host%%:9200"
+        }
+      ]
+  labels:
+    name: elasticsearch
+```
+
+##### Log collection
+
+_Available for Agent versions >6.0_
+
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Kubernetes log collection documentation][27].
+
+Then, set [Log Integrations][28] as pod annotations. This can also be configure via [a file, a configmap, or a key-value store][29].
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: elasticsearch
+  annotations:
+    ad.datadoghq.com/elasticsearch.logs: '[{"source":"elasticsearch","service":"<SERVICE_NAME"}]'
+  labels:
+    name: elasticsearch
+```
+
+##### Trace collection
+
+APM for containerized apps is supported on hosts running Agent v6+ but requires extra configuration to begin collecting traces.
+
+Required environment variables on the Agent container:
+
+| Parameter            | Value                                                                      |
+| -------------------- | -------------------------------------------------------------------------- |
+| `<DD_API_KEY>` | `api_key`                                                                  |
+| `<DD_APM_ENABLED>`      | true                                                              |
+| `<DD_APM_NON_LOCAL_TRAFFIC>`  | true |
+
+See [Tracing Kubernetes Applications][17] and the [Kubernetes Daemon Setup][18] for a complete list of available environment variables and configuration.
+
+Then, [instrument your application container][7] and set `DD_AGENT_HOST` to the name of your Agent container.
+
+<!-- xxz tab xxx -->
+<!-- xxx tab "ECS" xxx -->
+
+#### ECS
+
+To configure this check for an Agent running on ECS:
+
+##### Metric collection
+
+Set [Autodiscovery Integrations Templates][30] as Docker labels on your application container:
+
+```json
+{
+  "containerDefinitions": [{
+    "name": "elasticsearch",
+    "image": "elasticsearch:latest",
+    "dockerLabels": {
+      "com.datadoghq.ad.check_names": "[\"elastic\"]",
+      "com.datadoghq.ad.init_configs": "[{}]",
+      "com.datadoghq.ad.instances": "[{\"url\": \"https://%%host%%:9200\"}]"
+    }
+  }]
+}
+```
+
+##### Log collection
+
+_Available for Agent versions >6.0_
+
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [ECS log collection documentation][31].
+
+Then, set [Log Integrations][32] as Docker labels:
+
+```yaml
+{
+  "containerDefinitions": [{
+    "name": "elasticsearch",
+    "image": "elasticsearch:latest",
+    "dockerLabels": {
+      "com.datadoghq.ad.logs": "[{\"source\":\"elasticsearch\",\"service\":\"<SERVICE_NAME>\"}]"
+    }
+  }]
+}
+```
+
+##### Trace collection
+
+APM for containerized apps is supported on Agent v6+ but requires extra configuration to begin collecting traces.
+
+Required environment variables on the Agent container:
+
+| Parameter            | Value                                                                      |
+| -------------------- | -------------------------------------------------------------------------- |
+| `<DD_API_KEY>` | `api_key`                                                                  |
+| `<DD_APM_ENABLED>`      | true                                                              |
+| `<DD_APM_NON_LOCAL_TRAFFIC>`  | true |
+
+See [Tracing Kubernetes Applications][17] and the [Kubernetes Daemon Setup][18] for a complete list of available environment variables and configuration.
+
+Then, [instrument your application container][7] and set `DD_AGENT_HOST` to the [EC2 private IP address][33].
+
+
+<!-- xxz tab xxx -->
 <!-- xxx tab "Containerized" xxx -->
 
 #### Containerized
@@ -243,3 +415,15 @@ To get a better idea of how (or why) to integrate your Elasticsearch cluster wit
 [19]: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html#es-managedomains-signing-service-requests
 [20]: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials
 [21]: https://docs.datadoghq.com/getting_started/tagging/assigning_tags?tab=noncontainerizedenvironments#file-location
+[22]: https://docs.datadoghq.com/agent/docker/integrations/?tab=docker
+[23]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#installation
+[24]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#log-integrations
+[25]: https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes
+[26]: https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes#configuration
+[27]: https://docs.datadoghq.com/agent/kubernetes/log/?tab=containerinstallation#setup
+[28]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#log-integrations
+[29]: https://docs.datadoghq.com/agent/kubernetes/log/?tab=daemonset#configuration
+[30]: https://docs.datadoghq.com/agent/docker/integrations/?tab=docker
+[31]: https://docs.datadoghq.com/agent/amazon_ecs/logs/?tab=linux
+[32]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#log-integrations
+[33]: https://docs.datadoghq.com/agent/amazon_ecs/apm/?tab=ec2metadataendpoint#setup

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -193,7 +193,7 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-Set [Autodiscovery Integrations Templates][25] as pod annotations on your application container. Aside from this, templates can also be configure with [a file, a configmap, or a key-value store][26].
+Set [Autodiscovery Integrations Templates][25] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][26].
 
 ```yaml
 apiVersion: v1
@@ -209,8 +209,9 @@ metadata:
           "url": "https://%%host%%:9200"
         }
       ]
-  labels:
-    name: elasticsearch
+  spec:
+    containers:
+      - name: elasticsearch
 ```
 
 ##### Log collection
@@ -218,7 +219,7 @@ metadata:
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Kubernetes log collection documentation][27].
 
-Then, set [Log Integrations][28] as pod annotations. This can also be configure with [a file, a configmap, or a key-value store][29].
+Then, set [Log Integrations][28] as pod annotations. This can also be configured with [a file, a configmap, or a key-value store][29].
 
 ```yaml
 apiVersion: v1
@@ -227,8 +228,9 @@ metadata:
   name: elasticsearch
   annotations:
     ad.datadoghq.com/elasticsearch.logs: '[{"source":"elasticsearch","service":"<SERVICE_NAME"}]'
-  labels:
-    name: elasticsearch
+  spec:
+    containers:
+      - name: elasticsearch
 ```
 
 ##### Trace collection
@@ -279,7 +281,7 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see t
 
 Then, set [Log Integrations][32] as Docker labels:
 
-```yaml
+```json
 {
   "containerDefinitions": [{
     "name": "elasticsearch",

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -215,7 +215,6 @@ metadata:
 
 ##### Log collection
 
-_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Kubernetes log collection documentation][27].
 
@@ -275,7 +274,6 @@ Set [Autodiscovery Integrations Templates][30] as Docker labels on your applicat
 
 ##### Log collection
 
-_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [ECS log collection documentation][31].
 

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -158,7 +158,6 @@ LABEL "com.datadoghq.ad.instances"='[{"url": "https://%%host%%:9200"}]'
 
 ##### Log collection
 
-_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Docker log collection documentation][23].
 

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -194,7 +194,7 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-Set [Autodiscovery Integrations Templates][25] as pod annotations on your application container. Aside from this, templates can also be configure via [a file, a configmap, or a key-value store][26].
+Set [Autodiscovery Integrations Templates][25] as pod annotations on your application container. Aside from this, templates can also be configure with [a file, a configmap, or a key-value store][26].
 
 ```yaml
 apiVersion: v1
@@ -220,7 +220,7 @@ _Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Kubernetes log collection documentation][27].
 
-Then, set [Log Integrations][28] as pod annotations. This can also be configure via [a file, a configmap, or a key-value store][29].
+Then, set [Log Integrations][28] as pod annotations. This can also be configure with [a file, a configmap, or a key-value store][29].
 
 ```yaml
 apiVersion: v1

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -209,9 +209,9 @@ metadata:
           "url": "https://%%host%%:9200"
         }
       ]
-  spec:
-    containers:
-      - name: elasticsearch
+spec:
+  containers:
+    - name: elasticsearch
 ```
 
 ##### Log collection
@@ -227,10 +227,10 @@ kind: Pod
 metadata:
   name: elasticsearch
   annotations:
-    ad.datadoghq.com/elasticsearch.logs: '[{"source":"elasticsearch","service":"<SERVICE_NAME"}]'
-  spec:
-    containers:
-      - name: elasticsearch
+    ad.datadoghq.com/elasticsearch.logs: '[{"source":"elasticsearch","service":"<SERVICE_NAME>"}]'
+spec:
+  containers:
+    - name: elasticsearch
 ```
 
 ##### Trace collection

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -173,19 +173,101 @@ PostgreSQL default logging is to `stderr`, and logs do not include detailed info
 5. [Restart the Agent][4].
 
 <!-- xxz tab xxx -->
-<!-- xxx tab "Containerized" xxx -->
+<!-- xxx tab "Docker" xxx -->
 
-#### Containerized
+#### Docker
 
-For containerized environments, see the [Autodiscovery Integration Templates][7] for guidance on applying the parameters below.
+To configure this check for an Agent running on a container:
 
 ##### Metric collection
 
-| Parameter            | Value                                                                           |
-| -------------------- | ------------------------------------------------------------------------------- |
-| `<INTEGRATION_NAME>` | `postgres`                                                                      |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                   |
-| `<INSTANCE_CONFIG>`  | `{"host":"%%host%%", "port":5432,"username":"datadog","password":"<PASSWORD>"}` |
+Set [Autodiscovery Integrations Templates][20] as Docker labels on your application container:
+
+```yaml
+LABEL "com.datadoghq.ad.check_names"='["postgres"]'
+LABEL "com.datadoghq.ad.init_configs"='[{}]'
+LABEL "com.datadoghq.ad.instances"='[{"host":"%%host%%", "port":5432,"username":"datadog","password":"<PASSWORD>"}]'
+```
+
+##### Log collection
+
+_Available for Agent versions >6.0_
+
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Docker log collection documentation][21].
+
+Then, set [Log Integrations][22] as Docker labels:
+
+```yaml
+LABEL "com.datadoghq.ad.logs"='[{"source":"postgresql","service":"postgresql"}]'
+```
+
+##### Trace collection
+
+APM for containerized apps is supported on Agent v6+ but requires extra configuration to begin collecting traces.
+
+Required environment variables on the Agent container:
+
+| Parameter            | Value                                                                      |
+| -------------------- | -------------------------------------------------------------------------- |
+| `<DD_API_KEY>` | `api_key`                                                                  |
+| `<DD_APM_ENABLED>`      | true                                                              |
+| `<DD_APM_NON_LOCAL_TRAFFIC>`  | true |
+
+See [Tracing Docker Applications][31] for a complete list of available environment variables and configuration.
+
+Then, [instrument your application container that makes requests to Postgres][32] and set `DD_AGENT_HOST` to the name of your Agent container.
+
+
+<!-- xxz tab xxx -->
+<!-- xxx tab "Kubernetes" xxx -->
+
+#### Kubernetes
+
+To configure this check for an Agent running on Kubernetes:
+
+##### Metric collection
+
+Set [Autodiscovery Integrations Templates][23] as pod annotations on your application container. Aside from this, templates can also be configure via [a file, a configmap, or a key-value store][24].
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: postgres
+  annotations:
+    ad.datadoghq.com/postgres.check_names: '["postgres"]'
+    ad.datadoghq.com/postgres.init_configs: '[{}]'
+    ad.datadoghq.com/postgres.instances: |
+      [
+        {
+          "host": "%%host%%",
+          "port":"5432",
+          "username":"datadog",
+          "password":"<PASSWORD>"
+        }
+      ]
+  labels:
+    name: postgres
+```
+
+##### Log collection
+
+_Available for Agent versions >6.0_
+
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Kubernetes log collection documentation][25].
+
+Then, set [Log Integrations][26] as pod annotations. This can also be configure via [a file, a configmap, or a key-value store][27].
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: postgres
+  annotations:
+    ad.datadoghq.com/postgres.logs: '[{"source":"postgresql","service":"postgresql"}]'
+  labels:
+    name: postgres
+```
 
 ##### Trace collection
 
@@ -199,19 +281,70 @@ Required environment variables on the Agent container:
 | `<DD_APM_ENABLED>`      | true                                                              |
 | `<DD_APM_NON_LOCAL_TRAFFIC>`  | true |
 
-See [Tracing Kubernetes Applications][18] and the [Kubernetes Daemon Setup][19] for a complete list of available environment variables and configuration.
+See [Tracing Kubernetes Applications][33] and the [Kubernetes DaemonSet Setup][34] for a complete list of available environment variables and configuration.
 
-Then, [instrument your application container][6] and set `DD_AGENT_HOST` to the name of your Agent container.
+Then, [instrument your application container that makes requests to Postgres][32].
+
+<!-- xxz tab xxx -->
+<!-- xxx tab "ECS" xxx -->
+
+#### ECS
+
+To configure this check for an Agent running on ECS:
+
+##### Metric collection
+
+Set [Autodiscovery Integrations Templates][28] as Docker labels on your application container:
+
+```json
+{
+  "containerDefinitions": [{
+    "name": "postgres",
+    "image": "postgres:latest",
+    "dockerLabels": {
+      "com.datadoghq.ad.check_names": "[\"postgres\"]",
+      "com.datadoghq.ad.init_configs": "[{}]",
+      "com.datadoghq.ad.instances": "[{\"host\":\"%%host%%\", \"port\":5432,\"username\":\"datadog\",\"password\":\"<PASSWORD>\"}]"
+    }
+  }]
+}
+```
 
 ##### Log collection
 
 _Available for Agent versions >6.0_
 
-Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes log collection documentation][8].
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [ECS log collection documentation][29].
 
-| Parameter      | Value                                               |
-| -------------- | --------------------------------------------------- |
-| `<LOG_CONFIG>` | `{"source": "postgresql", "service": "postgresql"}` |
+Then, set [Log Integrations][30] as Docker labels:
+
+```yaml
+{
+  "containerDefinitions": [{
+    "name": "postgres",
+    "image": "postgres:latest",
+    "dockerLabels": {
+      "com.datadoghq.ad.logs": "[{\"source\":\"postgresql\",\"service\":\"postgresql\"}]"
+    }
+  }]
+}
+```
+
+##### Trace collection
+
+APM for containerized apps is supported on Agent v6+ but requires extra configuration to begin collecting traces.
+
+Required environment variables on the Agent container:
+
+| Parameter            | Value                                                                      |
+| -------------------- | -------------------------------------------------------------------------- |
+| `<DD_API_KEY>` | `api_key`                                                                  |
+| `<DD_APM_ENABLED>`      | true                                                              |
+| `<DD_APM_NON_LOCAL_TRAFFIC>`  | true |
+
+See [Tracing Docker Applications][31] for a complete list of available environment variables and configuration.
+
+Then, [instrument your application container that makes requests to Postgres][32] and set `DD_AGENT_HOST` to the [EC2 private IP address][35].
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
@@ -271,3 +404,14 @@ Additional helpful documentation, links, and articles:
 [17]: https://www.postgresql.org/message-id/20100210180532.GA20138@depesz.com
 [18]: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=java
 [19]: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#apm-and-distributed-tracing
+[20]: https://docs.datadoghq.com/agent/docker/integrations/?tab=docker
+[21]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#installation
+[22]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#log-integrations
+[23]: https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes
+[24]: https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes#configuration
+[25]: https://docs.datadoghq.com/agent/kubernetes/log/?tab=containerinstallation#setup
+[26]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#log-integrations
+[27]: https://docs.datadoghq.com/agent/kubernetes/log/?tab=daemonset#configuration
+[28]: https://docs.datadoghq.com/agent/docker/integrations/?tab=docker
+[29]: https://docs.datadoghq.com/agent/amazon_ecs/logs/?tab=linux
+[30]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#log-integrations

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -415,3 +415,6 @@ Additional helpful documentation, links, and articles:
 [28]: https://docs.datadoghq.com/agent/docker/integrations/?tab=docker
 [29]: https://docs.datadoghq.com/agent/amazon_ecs/logs/?tab=linux
 [30]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#log-integrations
+[31]: https://docs.datadoghq.com/agent/amazon_ecs/logs/?tab=linux
+[32]: https://docs.datadoghq.com/agent/docker/log/?tab=containerinstallation#log-integrations
+[33]: https://docs.datadoghq.com/agent/amazon_ecs/apm/?tab=ec2metadataendpoint#setup

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -341,7 +341,7 @@ Required environment variables on the Agent container:
 
 See [Tracing Docker Applications][31] for a complete list of available environment variables and configuration.
 
-Then, [instrument your application container that makes requests to Postgres][32] and set `DD_AGENT_HOST` to the [EC2 private IP address][35].
+Then, [instrument your application container that makes requests to Postgres][32] and set `DD_AGENT_HOST` to the [EC2 private IP address][33].
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -191,7 +191,6 @@ LABEL "com.datadoghq.ad.instances"='[{"host":"%%host%%", "port":5432,"username":
 
 ##### Log collection
 
-_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Docker log collection documentation][21].
 
@@ -252,7 +251,6 @@ metadata:
 
 ##### Log collection
 
-_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Kubernetes log collection documentation][25].
 
@@ -312,7 +310,6 @@ Set [Autodiscovery Integrations Templates][28] as Docker labels on your applicat
 
 ##### Log collection
 
-_Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [ECS log collection documentation][29].
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -226,7 +226,7 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-Set [Autodiscovery Integrations Templates][23] as pod annotations on your application container. Aside from this, templates can also be configure with [a file, a configmap, or a key-value store][24].
+Set [Autodiscovery Integrations Templates][23] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][24].
 
 ```yaml
 apiVersion: v1
@@ -245,8 +245,9 @@ metadata:
           "password":"<PASSWORD>"
         }
       ]
-  labels:
-    name: postgres
+  spec:
+    containers:
+      - name: postgres
 ```
 
 ##### Log collection
@@ -254,7 +255,7 @@ metadata:
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Kubernetes log collection documentation][25].
 
-Then, set [Log Integrations][26] as pod annotations. This can also be configure with [a file, a configmap, or a key-value store][27].
+Then, set [Log Integrations][26] as pod annotations. This can also be configured with [a file, a configmap, or a key-value store][27].
 
 ```yaml
 apiVersion: v1
@@ -263,8 +264,9 @@ metadata:
   name: postgres
   annotations:
     ad.datadoghq.com/postgres.logs: '[{"source":"postgresql","service":"postgresql"}]'
-  labels:
-    name: postgres
+  spec:
+    containers:
+      - name: postgres
 ```
 
 ##### Trace collection
@@ -315,7 +317,7 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see t
 
 Then, set [Log Integrations][30] as Docker labels:
 
-```yaml
+```json
 {
   "containerDefinitions": [{
     "name": "postgres",

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -245,9 +245,9 @@ metadata:
           "password":"<PASSWORD>"
         }
       ]
-  spec:
-    containers:
-      - name: postgres
+spec:
+  containers:
+    - name: postgres
 ```
 
 ##### Log collection
@@ -263,10 +263,10 @@ kind: Pod
 metadata:
   name: postgres
   annotations:
-    ad.datadoghq.com/postgres.logs: '[{"source":"postgresql","service":"postgresql"}]'
-  spec:
-    containers:
-      - name: postgres
+    ad.datadoghq.com/postgres.logs: '[{"source":"postgresql","service":"<SERVICE_NAME>"}]'
+spec:
+  containers:
+    - name: postgres
 ```
 
 ##### Trace collection

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -227,7 +227,7 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-Set [Autodiscovery Integrations Templates][23] as pod annotations on your application container. Aside from this, templates can also be configure via [a file, a configmap, or a key-value store][24].
+Set [Autodiscovery Integrations Templates][23] as pod annotations on your application container. Aside from this, templates can also be configure with [a file, a configmap, or a key-value store][24].
 
 ```yaml
 apiVersion: v1
@@ -256,7 +256,7 @@ _Available for Agent versions >6.0_
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Kubernetes log collection documentation][25].
 
-Then, set [Log Integrations][26] as pod annotations. This can also be configure via [a file, a configmap, or a key-value store][27].
+Then, set [Log Integrations][26] as pod annotations. This can also be configure with [a file, a configmap, or a key-value store][27].
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds Docker, Kubernetes, and ECS instructions for configuring Elasticsearch, Apache, and Postgres integrations.

https://docs-staging.datadoghq.com/cswatt/okr-previews-2/integrations/elastic
https://docs-staging.datadoghq.com/cswatt/okr-previews-2/integrations/apache
https://docs-staging.datadoghq.com/cswatt/okr-previews-2/integrations/postgres

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
