### PR TITLE
Fix models validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/models.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/models.py
@@ -39,9 +39,7 @@ def models(ctx, check, sync, verbose):
     if check:
         checks = [check]
     else:
-        checks = {'datadog_checks_base'}
-        checks.update(get_valid_checks())
-        checks = sorted(checks)
+        checks = sorted(get_valid_checks())
 
     specs_failed = {}
     files_failed = {}


### PR DESCRIPTION
`datadog_checks_base` is already included in `get_valid_checks` so we were testing it twice on core.

Also we were testing base on integrations-extras and marketplace which is not possible as the lib is not installed.