### PR TITLE
Fix logs validation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,14 +30,15 @@ validate-log-integrations:
   only:
   - schedules
   variables:
-    WEBUI_INTGS_FILE: web-ui/javascript/datadog/logs/lib/integrations/integrations.ts
+    WEBUI_INTGS_FILE: web-ui/javascript/datadog/logs/lib/shared/integrations/integrations.ts
     LOGS_BACKEND_INTGS_ROOT: logs-backend/service/src/main/resources/integrations/
     INTEGRATIONS_CORE_ROOT: .
   script:
+    - cd /app
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/Datadog/web-ui.git --depth 1
-    - ts-node /scripts/parse_ts.ts > logs_integrations.json
+    - ts-node parse_ts.ts > logs_integrations.json
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/Datadog/logs-backend.git --depth 1
-    - python3 /scripts/validate_log_intgs.py logs_integrations.json 2> errors.txt
+    - python3 validate_log_intgs.py logs_integrations.json 2> errors.txt
   artifacts:
     paths:
     - errors.txt

--- a/.gitlab/validate-logs-intgs/Dockerfile
+++ b/.gitlab/validate-logs-intgs/Dockerfile
@@ -2,6 +2,7 @@ FROM node:alpine
 RUN apk add git python3 --no-cache
 RUN pip3 install pyyaml
 RUN npm install -g ts-node
+WORKDIR /app
 RUN npm install typescript @typescript-eslint/parser @typescript-eslint/typescript-estree @types/node
-COPY parse_ts.ts /scripts/parse_ts.ts
-COPY validate_log_intgs.py /scripts/validate_log_intgs.py
+COPY parse_ts.ts /app/parse_ts.ts
+COPY validate_log_intgs.py /app/validate_log_intgs.py


### PR DESCRIPTION
I realized that the logs pipeline validation was failing for two reasons:
- `node` now disallows installing libs in the root folder of the container. This means that we were not building new docker images of the validator.
- `web-ui` moved the integrations.ts file from `javascript/datadog/logs/lib/integrations/integrations.ts` to `javascript/datadog/logs/lib/shared/integrations/integrations.ts`

The pipeline was **silently** failing for a separate reason, solved in https://github.com/DataDog/integrations-core/pull/8872/s