### PR TITLE
Rewrite `timeout` function with `multiprocessing` module

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/process_timeout.py
+++ b/datadog_checks_base/datadog_checks/base/utils/process_timeout.py
@@ -1,0 +1,79 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import functools
+from multiprocessing import Process, Queue
+from queue import Empty
+
+from .timeout import TimeoutException
+
+_process_by_func = {}
+
+
+class ResultNotAvailableException(Exception):
+    pass
+
+
+class ProcessMethod(Process):
+    """
+    Descendant of `Process` class.
+    Run the specified target method with the specified arguments.
+    Store result and exceptions.
+    """
+
+    def __init__(self, target, args, kwargs):
+        Process.__init__(self)
+        self.daemon = True
+        self.target, self.args, self.kwargs = target, args, kwargs
+        self.__result_queue = Queue(maxsize=1)
+        self.start()
+
+    def run(self):
+        try:
+            self.__result_queue.put_nowait(self.target(*self.args, **self.kwargs))
+        except Exception as e:
+            self.__result_queue.put_nowait(e)
+
+    @property
+    def result(self):
+        try:
+            return self.__result_queue.get_nowait()
+        except Empty:
+            raise ResultNotAvailableException
+
+
+def timeout(timeout):
+    """
+    A decorator to timeout a function. Decorated method calls are executed in a separate new process
+    with a specified timeout.
+    Also checks if a process for the same function already exists before creating a new one.
+    Note: function result must be pickleable.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            # Create new process if none exists
+            key = "{0}:{1}:{2}:{3}".format(id(func), func.__name__, args, kwargs)
+            if key not in _process_by_func:
+                _process_by_func[key] = ProcessMethod(func, args, kwargs)
+
+            worker = _process_by_func[key]
+            worker.join(timeout)
+
+            try:
+                # Delete process after join
+                del _process_by_func[key]
+            except KeyError:
+                # Already deleted
+                pass
+
+            if worker.is_alive():
+                worker.terminate()
+                raise TimeoutException()
+
+            return worker.result
+
+        return wrapper
+
+    return decorator

--- a/datadog_checks_base/datadog_checks/base/utils/timeout.py
+++ b/datadog_checks_base/datadog_checks/base/utils/timeout.py
@@ -17,7 +17,7 @@ class TimeoutException(Exception):
 
 class ThreadMethod(Thread):
     """
-    Deprecated: Please use multiprocessing module instead
+    Deprecated: Please use process_timeout module instead
 
     Descendant of `Thread` class.
     Run the specified target method with the specified arguments.
@@ -42,7 +42,7 @@ class ThreadMethod(Thread):
 
 def timeout(timeout):
     """
-    Deprecated: Please use multiprocessing module instead
+    Deprecated: Please use process_timeout module instead
 
     A decorator to timeout a function. Decorated method calls are executed in a separate new thread
     with a specified timeout.

--- a/disk/tests/conftest.py
+++ b/disk/tests/conftest.py
@@ -32,6 +32,15 @@ def psutil_mocks():
         yield
 
 
+@pytest.fixture
+def timeout_mock():
+    def no_timeout(fun):
+        return lambda *args: fun(args)
+
+    with mock.patch('datadog_checks.disk.disk.timeout', return_value=no_timeout):
+        yield
+
+
 @pytest.fixture(scope='session')
 def dd_environment(instance_basic_volume):
     yield instance_basic_volume, E2E_METADATA

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -44,7 +44,7 @@ def test_bad_config():
         Disk('disk', {}, [{}, {}])
 
 
-@pytest.mark.usefixtures('psutil_mocks')
+@pytest.mark.usefixtures('psutil_mocks', 'timeout_mock')
 def test_default(aggregator, gauge_metrics, rate_metrics, count_metrics):
     """
     Mock psutil and run the check
@@ -89,7 +89,7 @@ def test_default(aggregator, gauge_metrics, rate_metrics, count_metrics):
         aggregator.reset()
 
 
-@pytest.mark.usefixtures('psutil_mocks')
+@pytest.mark.usefixtures('psutil_mocks', 'timeout_mock')
 def test_rw(aggregator):
     """
     Check for 'ro' option in the mounts
@@ -101,7 +101,7 @@ def test_rw(aggregator):
     aggregator.assert_service_check('disk.read_write', status=Disk.CRITICAL)
 
 
-@pytest.mark.usefixtures('psutil_mocks')
+@pytest.mark.usefixtures('psutil_mocks', 'timeout_mock')
 def test_use_mount(aggregator, instance_basic_mount, gauge_metrics, rate_metrics, count_metrics):
     """
     Same as above, using mount to tag
@@ -126,7 +126,7 @@ def test_use_mount(aggregator, instance_basic_mount, gauge_metrics, rate_metrics
     aggregator.assert_all_metrics_covered()
 
 
-@pytest.mark.usefixtures('psutil_mocks')
+@pytest.mark.usefixtures('psutil_mocks', 'timeout_mock')
 def test_device_tagging(aggregator, gauge_metrics, rate_metrics, count_metrics):
     instance = {
         'use_mount': 'no',


### PR DESCRIPTION
### What does this PR do?

Rewrite `timeout` function using `multiprocessing` module

### Motivation

Avoid leaking threads since we can't kill them (AP-942)

### Additional Notes

Unit tests don't work well with multiprocessing since mock objects are not pickleable so we need to monkeypatch the timeout function.

Test cases:

- [ ] Test that it works on Linux and reports correct results
- [ ] Test that it works on Windows and reports correct results
- [ ] Test that it works on macOS and reports correct results
- [ ] Test that it times out when simulating faulty disk

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
