### PR TITLE
Ignore config models from coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -539,162 +539,116 @@ coverage:
 flags:
   active_directory:
     carryforward: true
-    ignore:
-    - active_directory/datadog_checks/active_directory/config_models
     paths:
     - active_directory/datadog_checks/active_directory
     - active_directory/tests
   activemq_xml:
     carryforward: true
-    ignore:
-    - activemq_xml/datadog_checks/activemq_xml/config_models
     paths:
     - activemq_xml/datadog_checks/activemq_xml
     - activemq_xml/tests
   aerospike:
     carryforward: true
-    ignore:
-    - aerospike/datadog_checks/aerospike/config_models
     paths:
     - aerospike/datadog_checks/aerospike
     - aerospike/tests
   airflow:
     carryforward: true
-    ignore:
-    - airflow/datadog_checks/airflow/config_models
     paths:
     - airflow/datadog_checks/airflow
     - airflow/tests
   amazon_msk:
     carryforward: true
-    ignore:
-    - amazon_msk/datadog_checks/amazon_msk/config_models
     paths:
     - amazon_msk/datadog_checks/amazon_msk
     - amazon_msk/tests
   ambari:
     carryforward: true
-    ignore:
-    - ambari/datadog_checks/ambari/config_models
     paths:
     - ambari/datadog_checks/ambari
     - ambari/tests
   apache:
     carryforward: true
-    ignore:
-    - apache/datadog_checks/apache/config_models
     paths:
     - apache/datadog_checks/apache
     - apache/tests
   aspdotnet:
     carryforward: true
-    ignore:
-    - aspdotnet/datadog_checks/aspdotnet/config_models
     paths:
     - aspdotnet/datadog_checks/aspdotnet
     - aspdotnet/tests
   azure_iot_edge:
     carryforward: true
-    ignore:
-    - azure_iot_edge/datadog_checks/azure_iot_edge/config_models
     paths:
     - azure_iot_edge/datadog_checks/azure_iot_edge
     - azure_iot_edge/tests
   btrfs:
     carryforward: true
-    ignore:
-    - btrfs/datadog_checks/btrfs/config_models
     paths:
     - btrfs/datadog_checks/btrfs
     - btrfs/tests
   cacti:
     carryforward: true
-    ignore:
-    - cacti/datadog_checks/cacti/config_models
     paths:
     - cacti/datadog_checks/cacti
     - cacti/tests
   cassandra_nodetool:
     carryforward: true
-    ignore:
-    - cassandra_nodetool/datadog_checks/cassandra_nodetool/config_models
     paths:
     - cassandra_nodetool/datadog_checks/cassandra_nodetool
     - cassandra_nodetool/tests
   ceph:
     carryforward: true
-    ignore:
-    - ceph/datadog_checks/ceph/config_models
     paths:
     - ceph/datadog_checks/ceph
     - ceph/tests
   cilium:
     carryforward: true
-    ignore:
-    - cilium/datadog_checks/cilium/config_models
     paths:
     - cilium/datadog_checks/cilium
     - cilium/tests
   cisco_aci:
     carryforward: true
-    ignore:
-    - cisco_aci/datadog_checks/cisco_aci/config_models
     paths:
     - cisco_aci/datadog_checks/cisco_aci
     - cisco_aci/tests
   clickhouse:
     carryforward: true
-    ignore:
-    - clickhouse/datadog_checks/clickhouse/config_models
     paths:
     - clickhouse/datadog_checks/clickhouse
     - clickhouse/tests
   cloud_foundry_api:
     carryforward: true
-    ignore:
-    - cloud_foundry_api/datadog_checks/cloud_foundry_api/config_models
     paths:
     - cloud_foundry_api/datadog_checks/cloud_foundry_api
     - cloud_foundry_api/tests
   cockroachdb:
     carryforward: true
-    ignore:
-    - cockroachdb/datadog_checks/cockroachdb/config_models
     paths:
     - cockroachdb/datadog_checks/cockroachdb
     - cockroachdb/tests
   consul:
     carryforward: true
-    ignore:
-    - consul/datadog_checks/consul/config_models
     paths:
     - consul/datadog_checks/consul
     - consul/tests
   coredns:
     carryforward: true
-    ignore:
-    - coredns/datadog_checks/coredns/config_models
     paths:
     - coredns/datadog_checks/coredns
     - coredns/tests
   couch:
     carryforward: true
-    ignore:
-    - couch/datadog_checks/couch/config_models
     paths:
     - couch/datadog_checks/couch
     - couch/tests
   couchbase:
     carryforward: true
-    ignore:
-    - couchbase/datadog_checks/couchbase/config_models
     paths:
     - couchbase/datadog_checks/couchbase
     - couchbase/tests
   crio:
     carryforward: true
-    ignore:
-    - crio/datadog_checks/crio/config_models
     paths:
     - crio/datadog_checks/crio
     - crio/tests
@@ -715,743 +669,531 @@ flags:
     - datadog_checks_downloader/tests
   directory:
     carryforward: true
-    ignore:
-    - directory/datadog_checks/directory/config_models
     paths:
     - directory/datadog_checks/directory
     - directory/tests
   disk:
     carryforward: true
-    ignore:
-    - disk/datadog_checks/disk/config_models
     paths:
     - disk/datadog_checks/disk
     - disk/tests
   dns_check:
     carryforward: true
-    ignore:
-    - dns_check/datadog_checks/dns_check/config_models
     paths:
     - dns_check/datadog_checks/dns_check
     - dns_check/tests
   dotnetclr:
     carryforward: true
-    ignore:
-    - dotnetclr/datadog_checks/dotnetclr/config_models
     paths:
     - dotnetclr/datadog_checks/dotnetclr
     - dotnetclr/tests
   druid:
     carryforward: true
-    ignore:
-    - druid/datadog_checks/druid/config_models
     paths:
     - druid/datadog_checks/druid
     - druid/tests
   ecs_fargate:
     carryforward: true
-    ignore:
-    - ecs_fargate/datadog_checks/ecs_fargate/config_models
     paths:
     - ecs_fargate/datadog_checks/ecs_fargate
     - ecs_fargate/tests
   eks_fargate:
     carryforward: true
-    ignore:
-    - eks_fargate/datadog_checks/eks_fargate/config_models
     paths:
     - eks_fargate/datadog_checks/eks_fargate
     - eks_fargate/tests
   elastic:
     carryforward: true
-    ignore:
-    - elastic/datadog_checks/elastic/config_models
     paths:
     - elastic/datadog_checks/elastic
     - elastic/tests
   envoy:
     carryforward: true
-    ignore:
-    - envoy/datadog_checks/envoy/config_models
     paths:
     - envoy/datadog_checks/envoy
     - envoy/tests
   etcd:
     carryforward: true
-    ignore:
-    - etcd/datadog_checks/etcd/config_models
     paths:
     - etcd/datadog_checks/etcd
     - etcd/tests
   exchange_server:
     carryforward: true
-    ignore:
-    - exchange_server/datadog_checks/exchange_server/config_models
     paths:
     - exchange_server/datadog_checks/exchange_server
     - exchange_server/tests
   external_dns:
     carryforward: true
-    ignore:
-    - external_dns/datadog_checks/external_dns/config_models
     paths:
     - external_dns/datadog_checks/external_dns
     - external_dns/tests
   fluentd:
     carryforward: true
-    ignore:
-    - fluentd/datadog_checks/fluentd/config_models
     paths:
     - fluentd/datadog_checks/fluentd
     - fluentd/tests
   gearmand:
     carryforward: true
-    ignore:
-    - gearmand/datadog_checks/gearmand/config_models
     paths:
     - gearmand/datadog_checks/gearmand
     - gearmand/tests
   gitlab:
     carryforward: true
-    ignore:
-    - gitlab/datadog_checks/gitlab/config_models
     paths:
     - gitlab/datadog_checks/gitlab
     - gitlab/tests
   gitlab_runner:
     carryforward: true
-    ignore:
-    - gitlab_runner/datadog_checks/gitlab_runner/config_models
     paths:
     - gitlab_runner/datadog_checks/gitlab_runner
     - gitlab_runner/tests
   glusterfs:
     carryforward: true
-    ignore:
-    - glusterfs/datadog_checks/glusterfs/config_models
     paths:
     - glusterfs/datadog_checks/glusterfs
     - glusterfs/tests
   go_expvar:
     carryforward: true
-    ignore:
-    - go_expvar/datadog_checks/go_expvar/config_models
     paths:
     - go_expvar/datadog_checks/go_expvar
     - go_expvar/tests
   gunicorn:
     carryforward: true
-    ignore:
-    - gunicorn/datadog_checks/gunicorn/config_models
     paths:
     - gunicorn/datadog_checks/gunicorn
     - gunicorn/tests
   haproxy:
     carryforward: true
-    ignore:
-    - haproxy/datadog_checks/haproxy/config_models
     paths:
     - haproxy/datadog_checks/haproxy
     - haproxy/tests
   harbor:
     carryforward: true
-    ignore:
-    - harbor/datadog_checks/harbor/config_models
     paths:
     - harbor/datadog_checks/harbor
     - harbor/tests
   hazelcast:
     carryforward: true
-    ignore:
-    - hazelcast/datadog_checks/hazelcast/config_models
     paths:
     - hazelcast/datadog_checks/hazelcast
     - hazelcast/tests
   hdfs_datanode:
     carryforward: true
-    ignore:
-    - hdfs_datanode/datadog_checks/hdfs_datanode/config_models
     paths:
     - hdfs_datanode/datadog_checks/hdfs_datanode
     - hdfs_datanode/tests
   hdfs_namenode:
     carryforward: true
-    ignore:
-    - hdfs_namenode/datadog_checks/hdfs_namenode/config_models
     paths:
     - hdfs_namenode/datadog_checks/hdfs_namenode
     - hdfs_namenode/tests
   http_check:
     carryforward: true
-    ignore:
-    - http_check/datadog_checks/http_check/config_models
     paths:
     - http_check/datadog_checks/http_check
     - http_check/tests
   ibm_db2:
     carryforward: true
-    ignore:
-    - ibm_db2/datadog_checks/ibm_db2/config_models
     paths:
     - ibm_db2/datadog_checks/ibm_db2
     - ibm_db2/tests
   ibm_mq:
     carryforward: true
-    ignore:
-    - ibm_mq/datadog_checks/ibm_mq/config_models
     paths:
     - ibm_mq/datadog_checks/ibm_mq
     - ibm_mq/tests
   ibm_was:
     carryforward: true
-    ignore:
-    - ibm_was/datadog_checks/ibm_was/config_models
     paths:
     - ibm_was/datadog_checks/ibm_was
     - ibm_was/tests
   iis:
     carryforward: true
-    ignore:
-    - iis/datadog_checks/iis/config_models
     paths:
     - iis/datadog_checks/iis
     - iis/tests
   istio:
     carryforward: true
-    ignore:
-    - istio/datadog_checks/istio/config_models
     paths:
     - istio/datadog_checks/istio
     - istio/tests
   kafka_consumer:
     carryforward: true
-    ignore:
-    - kafka_consumer/datadog_checks/kafka_consumer/config_models
     paths:
     - kafka_consumer/datadog_checks/kafka_consumer
     - kafka_consumer/tests
   kong:
     carryforward: true
-    ignore:
-    - kong/datadog_checks/kong/config_models
     paths:
     - kong/datadog_checks/kong
     - kong/tests
   kube_apiserver_metrics:
     carryforward: true
-    ignore:
-    - kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models
     paths:
     - kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics
     - kube_apiserver_metrics/tests
   kube_controller_manager:
     carryforward: true
-    ignore:
-    - kube_controller_manager/datadog_checks/kube_controller_manager/config_models
     paths:
     - kube_controller_manager/datadog_checks/kube_controller_manager
     - kube_controller_manager/tests
   kube_dns:
     carryforward: true
-    ignore:
-    - kube_dns/datadog_checks/kube_dns/config_models
     paths:
     - kube_dns/datadog_checks/kube_dns
     - kube_dns/tests
   kube_metrics_server:
     carryforward: true
-    ignore:
-    - kube_metrics_server/datadog_checks/kube_metrics_server/config_models
     paths:
     - kube_metrics_server/datadog_checks/kube_metrics_server
     - kube_metrics_server/tests
   kube_proxy:
     carryforward: true
-    ignore:
-    - kube_proxy/datadog_checks/kube_proxy/config_models
     paths:
     - kube_proxy/datadog_checks/kube_proxy
     - kube_proxy/tests
   kube_scheduler:
     carryforward: true
-    ignore:
-    - kube_scheduler/datadog_checks/kube_scheduler/config_models
     paths:
     - kube_scheduler/datadog_checks/kube_scheduler
     - kube_scheduler/tests
   kubelet:
     carryforward: true
-    ignore:
-    - kubelet/datadog_checks/kubelet/config_models
     paths:
     - kubelet/datadog_checks/kubelet
     - kubelet/tests
   kubernetes_state:
     carryforward: true
-    ignore:
-    - kubernetes_state/datadog_checks/kubernetes_state/config_models
     paths:
     - kubernetes_state/datadog_checks/kubernetes_state
     - kubernetes_state/tests
   kyototycoon:
     carryforward: true
-    ignore:
-    - kyototycoon/datadog_checks/kyototycoon/config_models
     paths:
     - kyototycoon/datadog_checks/kyototycoon
     - kyototycoon/tests
   lighttpd:
     carryforward: true
-    ignore:
-    - lighttpd/datadog_checks/lighttpd/config_models
     paths:
     - lighttpd/datadog_checks/lighttpd
     - lighttpd/tests
   linkerd:
     carryforward: true
-    ignore:
-    - linkerd/datadog_checks/linkerd/config_models
     paths:
     - linkerd/datadog_checks/linkerd
     - linkerd/tests
   linux_proc_extras:
     carryforward: true
-    ignore:
-    - linux_proc_extras/datadog_checks/linux_proc_extras/config_models
     paths:
     - linux_proc_extras/datadog_checks/linux_proc_extras
     - linux_proc_extras/tests
   mapr:
     carryforward: true
-    ignore:
-    - mapr/datadog_checks/mapr/config_models
     paths:
     - mapr/datadog_checks/mapr
     - mapr/tests
   mapreduce:
     carryforward: true
-    ignore:
-    - mapreduce/datadog_checks/mapreduce/config_models
     paths:
     - mapreduce/datadog_checks/mapreduce
     - mapreduce/tests
   marathon:
     carryforward: true
-    ignore:
-    - marathon/datadog_checks/marathon/config_models
     paths:
     - marathon/datadog_checks/marathon
     - marathon/tests
   marklogic:
     carryforward: true
-    ignore:
-    - marklogic/datadog_checks/marklogic/config_models
     paths:
     - marklogic/datadog_checks/marklogic
     - marklogic/tests
   mcache:
     carryforward: true
-    ignore:
-    - mcache/datadog_checks/mcache/config_models
     paths:
     - mcache/datadog_checks/mcache
     - mcache/tests
   mesos_master:
     carryforward: true
-    ignore:
-    - mesos_master/datadog_checks/mesos_master/config_models
     paths:
     - mesos_master/datadog_checks/mesos_master
     - mesos_master/tests
   mesos_slave:
     carryforward: true
-    ignore:
-    - mesos_slave/datadog_checks/mesos_slave/config_models
     paths:
     - mesos_slave/datadog_checks/mesos_slave
     - mesos_slave/tests
   mongo:
     carryforward: true
-    ignore:
-    - mongo/datadog_checks/mongo/config_models
     paths:
     - mongo/datadog_checks/mongo
     - mongo/tests
   mysql:
     carryforward: true
-    ignore:
-    - mysql/datadog_checks/mysql/config_models
     paths:
     - mysql/datadog_checks/mysql
     - mysql/tests
   nagios:
     carryforward: true
-    ignore:
-    - nagios/datadog_checks/nagios/config_models
     paths:
     - nagios/datadog_checks/nagios
     - nagios/tests
   network:
     carryforward: true
-    ignore:
-    - network/datadog_checks/network/config_models
     paths:
     - network/datadog_checks/network
     - network/tests
   nfsstat:
     carryforward: true
-    ignore:
-    - nfsstat/datadog_checks/nfsstat/config_models
     paths:
     - nfsstat/datadog_checks/nfsstat
     - nfsstat/tests
   nginx:
     carryforward: true
-    ignore:
-    - nginx/datadog_checks/nginx/config_models
     paths:
     - nginx/datadog_checks/nginx
     - nginx/tests
   nginx_ingress_controller:
     carryforward: true
-    ignore:
-    - nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models
     paths:
     - nginx_ingress_controller/datadog_checks/nginx_ingress_controller
     - nginx_ingress_controller/tests
   openldap:
     carryforward: true
-    ignore:
-    - openldap/datadog_checks/openldap/config_models
     paths:
     - openldap/datadog_checks/openldap
     - openldap/tests
   openmetrics:
     carryforward: true
-    ignore:
-    - openmetrics/datadog_checks/openmetrics/config_models
     paths:
     - openmetrics/datadog_checks/openmetrics
     - openmetrics/tests
   openstack:
     carryforward: true
-    ignore:
-    - openstack/datadog_checks/openstack/config_models
     paths:
     - openstack/datadog_checks/openstack
     - openstack/tests
   openstack_controller:
     carryforward: true
-    ignore:
-    - openstack_controller/datadog_checks/openstack_controller/config_models
     paths:
     - openstack_controller/datadog_checks/openstack_controller
     - openstack_controller/tests
   oracle:
     carryforward: true
-    ignore:
-    - oracle/datadog_checks/oracle/config_models
     paths:
     - oracle/datadog_checks/oracle
     - oracle/tests
   pdh_check:
     carryforward: true
-    ignore:
-    - pdh_check/datadog_checks/pdh_check/config_models
     paths:
     - pdh_check/datadog_checks/pdh_check
     - pdh_check/tests
   pgbouncer:
     carryforward: true
-    ignore:
-    - pgbouncer/datadog_checks/pgbouncer/config_models
     paths:
     - pgbouncer/datadog_checks/pgbouncer
     - pgbouncer/tests
   php_fpm:
     carryforward: true
-    ignore:
-    - php_fpm/datadog_checks/php_fpm/config_models
     paths:
     - php_fpm/datadog_checks/php_fpm
     - php_fpm/tests
   postfix:
     carryforward: true
-    ignore:
-    - postfix/datadog_checks/postfix/config_models
     paths:
     - postfix/datadog_checks/postfix
     - postfix/tests
   postgres:
     carryforward: true
-    ignore:
-    - postgres/datadog_checks/postgres/config_models
     paths:
     - postgres/datadog_checks/postgres
     - postgres/tests
   powerdns_recursor:
     carryforward: true
-    ignore:
-    - powerdns_recursor/datadog_checks/powerdns_recursor/config_models
     paths:
     - powerdns_recursor/datadog_checks/powerdns_recursor
     - powerdns_recursor/tests
   process:
     carryforward: true
-    ignore:
-    - process/datadog_checks/process/config_models
     paths:
     - process/datadog_checks/process
     - process/tests
   prometheus:
     carryforward: true
-    ignore:
-    - prometheus/datadog_checks/prometheus/config_models
     paths:
     - prometheus/datadog_checks/prometheus
     - prometheus/tests
   proxysql:
     carryforward: true
-    ignore:
-    - proxysql/datadog_checks/proxysql/config_models
     paths:
     - proxysql/datadog_checks/proxysql
     - proxysql/tests
   rabbitmq:
     carryforward: true
-    ignore:
-    - rabbitmq/datadog_checks/rabbitmq/config_models
     paths:
     - rabbitmq/datadog_checks/rabbitmq
     - rabbitmq/tests
   redisdb:
     carryforward: true
-    ignore:
-    - redisdb/datadog_checks/redisdb/config_models
     paths:
     - redisdb/datadog_checks/redisdb
     - redisdb/tests
   rethinkdb:
     carryforward: true
-    ignore:
-    - rethinkdb/datadog_checks/rethinkdb/config_models
     paths:
     - rethinkdb/datadog_checks/rethinkdb
     - rethinkdb/tests
   riak:
     carryforward: true
-    ignore:
-    - riak/datadog_checks/riak/config_models
     paths:
     - riak/datadog_checks/riak
     - riak/tests
   riakcs:
     carryforward: true
-    ignore:
-    - riakcs/datadog_checks/riakcs/config_models
     paths:
     - riakcs/datadog_checks/riakcs
     - riakcs/tests
   sap_hana:
     carryforward: true
-    ignore:
-    - sap_hana/datadog_checks/sap_hana/config_models
     paths:
     - sap_hana/datadog_checks/sap_hana
     - sap_hana/tests
   scylla:
     carryforward: true
-    ignore:
-    - scylla/datadog_checks/scylla/config_models
     paths:
     - scylla/datadog_checks/scylla
     - scylla/tests
   snmp:
     carryforward: true
-    ignore:
-    - snmp/datadog_checks/snmp/config_models
     paths:
     - snmp/datadog_checks/snmp
     - snmp/tests
   snowflake:
     carryforward: true
-    ignore:
-    - snowflake/datadog_checks/snowflake/config_models
     paths:
     - snowflake/datadog_checks/snowflake
     - snowflake/tests
   sonarqube:
     carryforward: true
-    ignore:
-    - sonarqube/datadog_checks/sonarqube/config_models
     paths:
     - sonarqube/datadog_checks/sonarqube
     - sonarqube/tests
   spark:
     carryforward: true
-    ignore:
-    - spark/datadog_checks/spark/config_models
     paths:
     - spark/datadog_checks/spark
     - spark/tests
   sqlserver:
     carryforward: true
-    ignore:
-    - sqlserver/datadog_checks/sqlserver/config_models
     paths:
     - sqlserver/datadog_checks/sqlserver
     - sqlserver/tests
   squid:
     carryforward: true
-    ignore:
-    - squid/datadog_checks/squid/config_models
     paths:
     - squid/datadog_checks/squid
     - squid/tests
   ssh_check:
     carryforward: true
-    ignore:
-    - ssh_check/datadog_checks/ssh_check/config_models
     paths:
     - ssh_check/datadog_checks/ssh_check
     - ssh_check/tests
   statsd:
     carryforward: true
-    ignore:
-    - statsd/datadog_checks/statsd/config_models
     paths:
     - statsd/datadog_checks/statsd
     - statsd/tests
   supervisord:
     carryforward: true
-    ignore:
-    - supervisord/datadog_checks/supervisord/config_models
     paths:
     - supervisord/datadog_checks/supervisord
     - supervisord/tests
   system_core:
     carryforward: true
-    ignore:
-    - system_core/datadog_checks/system_core/config_models
     paths:
     - system_core/datadog_checks/system_core
     - system_core/tests
   system_swap:
     carryforward: true
-    ignore:
-    - system_swap/datadog_checks/system_swap/config_models
     paths:
     - system_swap/datadog_checks/system_swap
     - system_swap/tests
   tcp_check:
     carryforward: true
-    ignore:
-    - tcp_check/datadog_checks/tcp_check/config_models
     paths:
     - tcp_check/datadog_checks/tcp_check
     - tcp_check/tests
   teamcity:
     carryforward: true
-    ignore:
-    - teamcity/datadog_checks/teamcity/config_models
     paths:
     - teamcity/datadog_checks/teamcity
     - teamcity/tests
   tls:
     carryforward: true
-    ignore:
-    - tls/datadog_checks/tls/config_models
     paths:
     - tls/datadog_checks/tls
     - tls/tests
   tokumx:
     carryforward: true
-    ignore:
-    - tokumx/datadog_checks/tokumx/config_models
     paths:
     - tokumx/datadog_checks/tokumx
     - tokumx/tests
   twemproxy:
     carryforward: true
-    ignore:
-    - twemproxy/datadog_checks/twemproxy/config_models
     paths:
     - twemproxy/datadog_checks/twemproxy
     - twemproxy/tests
   twistlock:
     carryforward: true
-    ignore:
-    - twistlock/datadog_checks/twistlock/config_models
     paths:
     - twistlock/datadog_checks/twistlock
     - twistlock/tests
   varnish:
     carryforward: true
-    ignore:
-    - varnish/datadog_checks/varnish/config_models
     paths:
     - varnish/datadog_checks/varnish
     - varnish/tests
   vault:
     carryforward: true
-    ignore:
-    - vault/datadog_checks/vault/config_models
     paths:
     - vault/datadog_checks/vault
     - vault/tests
   vertica:
     carryforward: true
-    ignore:
-    - vertica/datadog_checks/vertica/config_models
     paths:
     - vertica/datadog_checks/vertica
     - vertica/tests
   voltdb:
     carryforward: true
-    ignore:
-    - voltdb/datadog_checks/voltdb/config_models
     paths:
     - voltdb/datadog_checks/voltdb
     - voltdb/tests
   vsphere:
     carryforward: true
-    ignore:
-    - vsphere/datadog_checks/vsphere/config_models
     paths:
     - vsphere/datadog_checks/vsphere
     - vsphere/tests
   win32_event_log:
     carryforward: true
-    ignore:
-    - win32_event_log/datadog_checks/win32_event_log/config_models
     paths:
     - win32_event_log/datadog_checks/win32_event_log
     - win32_event_log/tests
   windows_service:
     carryforward: true
-    ignore:
-    - windows_service/datadog_checks/windows_service/config_models
     paths:
     - windows_service/datadog_checks/windows_service
     - windows_service/tests
   wmi_check:
     carryforward: true
-    ignore:
-    - wmi_check/datadog_checks/wmi_check/config_models
     paths:
     - wmi_check/datadog_checks/wmi_check
     - wmi_check/tests
   yarn:
     carryforward: true
-    ignore:
-    - yarn/datadog_checks/yarn/config_models
     paths:
     - yarn/datadog_checks/yarn
     - yarn/tests
   zk:
     carryforward: true
-    ignore:
-    - zk/datadog_checks/zk/config_models
     paths:
     - zk/datadog_checks/zk
     - zk/tests

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -539,116 +539,162 @@ coverage:
 flags:
   active_directory:
     carryforward: true
+    ignore:
+    - active_directory/datadog_checks/active_directory/config_models
     paths:
     - active_directory/datadog_checks/active_directory
     - active_directory/tests
   activemq_xml:
     carryforward: true
+    ignore:
+    - activemq_xml/datadog_checks/activemq_xml/config_models
     paths:
     - activemq_xml/datadog_checks/activemq_xml
     - activemq_xml/tests
   aerospike:
     carryforward: true
+    ignore:
+    - aerospike/datadog_checks/aerospike/config_models
     paths:
     - aerospike/datadog_checks/aerospike
     - aerospike/tests
   airflow:
     carryforward: true
+    ignore:
+    - airflow/datadog_checks/airflow/config_models
     paths:
     - airflow/datadog_checks/airflow
     - airflow/tests
   amazon_msk:
     carryforward: true
+    ignore:
+    - amazon_msk/datadog_checks/amazon_msk/config_models
     paths:
     - amazon_msk/datadog_checks/amazon_msk
     - amazon_msk/tests
   ambari:
     carryforward: true
+    ignore:
+    - ambari/datadog_checks/ambari/config_models
     paths:
     - ambari/datadog_checks/ambari
     - ambari/tests
   apache:
     carryforward: true
+    ignore:
+    - apache/datadog_checks/apache/config_models
     paths:
     - apache/datadog_checks/apache
     - apache/tests
   aspdotnet:
     carryforward: true
+    ignore:
+    - aspdotnet/datadog_checks/aspdotnet/config_models
     paths:
     - aspdotnet/datadog_checks/aspdotnet
     - aspdotnet/tests
   azure_iot_edge:
     carryforward: true
+    ignore:
+    - azure_iot_edge/datadog_checks/azure_iot_edge/config_models
     paths:
     - azure_iot_edge/datadog_checks/azure_iot_edge
     - azure_iot_edge/tests
   btrfs:
     carryforward: true
+    ignore:
+    - btrfs/datadog_checks/btrfs/config_models
     paths:
     - btrfs/datadog_checks/btrfs
     - btrfs/tests
   cacti:
     carryforward: true
+    ignore:
+    - cacti/datadog_checks/cacti/config_models
     paths:
     - cacti/datadog_checks/cacti
     - cacti/tests
   cassandra_nodetool:
     carryforward: true
+    ignore:
+    - cassandra_nodetool/datadog_checks/cassandra_nodetool/config_models
     paths:
     - cassandra_nodetool/datadog_checks/cassandra_nodetool
     - cassandra_nodetool/tests
   ceph:
     carryforward: true
+    ignore:
+    - ceph/datadog_checks/ceph/config_models
     paths:
     - ceph/datadog_checks/ceph
     - ceph/tests
   cilium:
     carryforward: true
+    ignore:
+    - cilium/datadog_checks/cilium/config_models
     paths:
     - cilium/datadog_checks/cilium
     - cilium/tests
   cisco_aci:
     carryforward: true
+    ignore:
+    - cisco_aci/datadog_checks/cisco_aci/config_models
     paths:
     - cisco_aci/datadog_checks/cisco_aci
     - cisco_aci/tests
   clickhouse:
     carryforward: true
+    ignore:
+    - clickhouse/datadog_checks/clickhouse/config_models
     paths:
     - clickhouse/datadog_checks/clickhouse
     - clickhouse/tests
   cloud_foundry_api:
     carryforward: true
+    ignore:
+    - cloud_foundry_api/datadog_checks/cloud_foundry_api/config_models
     paths:
     - cloud_foundry_api/datadog_checks/cloud_foundry_api
     - cloud_foundry_api/tests
   cockroachdb:
     carryforward: true
+    ignore:
+    - cockroachdb/datadog_checks/cockroachdb/config_models
     paths:
     - cockroachdb/datadog_checks/cockroachdb
     - cockroachdb/tests
   consul:
     carryforward: true
+    ignore:
+    - consul/datadog_checks/consul/config_models
     paths:
     - consul/datadog_checks/consul
     - consul/tests
   coredns:
     carryforward: true
+    ignore:
+    - coredns/datadog_checks/coredns/config_models
     paths:
     - coredns/datadog_checks/coredns
     - coredns/tests
   couch:
     carryforward: true
+    ignore:
+    - couch/datadog_checks/couch/config_models
     paths:
     - couch/datadog_checks/couch
     - couch/tests
   couchbase:
     carryforward: true
+    ignore:
+    - couchbase/datadog_checks/couchbase/config_models
     paths:
     - couchbase/datadog_checks/couchbase
     - couchbase/tests
   crio:
     carryforward: true
+    ignore:
+    - crio/datadog_checks/crio/config_models
     paths:
     - crio/datadog_checks/crio
     - crio/tests
@@ -669,531 +715,743 @@ flags:
     - datadog_checks_downloader/tests
   directory:
     carryforward: true
+    ignore:
+    - directory/datadog_checks/directory/config_models
     paths:
     - directory/datadog_checks/directory
     - directory/tests
   disk:
     carryforward: true
+    ignore:
+    - disk/datadog_checks/disk/config_models
     paths:
     - disk/datadog_checks/disk
     - disk/tests
   dns_check:
     carryforward: true
+    ignore:
+    - dns_check/datadog_checks/dns_check/config_models
     paths:
     - dns_check/datadog_checks/dns_check
     - dns_check/tests
   dotnetclr:
     carryforward: true
+    ignore:
+    - dotnetclr/datadog_checks/dotnetclr/config_models
     paths:
     - dotnetclr/datadog_checks/dotnetclr
     - dotnetclr/tests
   druid:
     carryforward: true
+    ignore:
+    - druid/datadog_checks/druid/config_models
     paths:
     - druid/datadog_checks/druid
     - druid/tests
   ecs_fargate:
     carryforward: true
+    ignore:
+    - ecs_fargate/datadog_checks/ecs_fargate/config_models
     paths:
     - ecs_fargate/datadog_checks/ecs_fargate
     - ecs_fargate/tests
   eks_fargate:
     carryforward: true
+    ignore:
+    - eks_fargate/datadog_checks/eks_fargate/config_models
     paths:
     - eks_fargate/datadog_checks/eks_fargate
     - eks_fargate/tests
   elastic:
     carryforward: true
+    ignore:
+    - elastic/datadog_checks/elastic/config_models
     paths:
     - elastic/datadog_checks/elastic
     - elastic/tests
   envoy:
     carryforward: true
+    ignore:
+    - envoy/datadog_checks/envoy/config_models
     paths:
     - envoy/datadog_checks/envoy
     - envoy/tests
   etcd:
     carryforward: true
+    ignore:
+    - etcd/datadog_checks/etcd/config_models
     paths:
     - etcd/datadog_checks/etcd
     - etcd/tests
   exchange_server:
     carryforward: true
+    ignore:
+    - exchange_server/datadog_checks/exchange_server/config_models
     paths:
     - exchange_server/datadog_checks/exchange_server
     - exchange_server/tests
   external_dns:
     carryforward: true
+    ignore:
+    - external_dns/datadog_checks/external_dns/config_models
     paths:
     - external_dns/datadog_checks/external_dns
     - external_dns/tests
   fluentd:
     carryforward: true
+    ignore:
+    - fluentd/datadog_checks/fluentd/config_models
     paths:
     - fluentd/datadog_checks/fluentd
     - fluentd/tests
   gearmand:
     carryforward: true
+    ignore:
+    - gearmand/datadog_checks/gearmand/config_models
     paths:
     - gearmand/datadog_checks/gearmand
     - gearmand/tests
   gitlab:
     carryforward: true
+    ignore:
+    - gitlab/datadog_checks/gitlab/config_models
     paths:
     - gitlab/datadog_checks/gitlab
     - gitlab/tests
   gitlab_runner:
     carryforward: true
+    ignore:
+    - gitlab_runner/datadog_checks/gitlab_runner/config_models
     paths:
     - gitlab_runner/datadog_checks/gitlab_runner
     - gitlab_runner/tests
   glusterfs:
     carryforward: true
+    ignore:
+    - glusterfs/datadog_checks/glusterfs/config_models
     paths:
     - glusterfs/datadog_checks/glusterfs
     - glusterfs/tests
   go_expvar:
     carryforward: true
+    ignore:
+    - go_expvar/datadog_checks/go_expvar/config_models
     paths:
     - go_expvar/datadog_checks/go_expvar
     - go_expvar/tests
   gunicorn:
     carryforward: true
+    ignore:
+    - gunicorn/datadog_checks/gunicorn/config_models
     paths:
     - gunicorn/datadog_checks/gunicorn
     - gunicorn/tests
   haproxy:
     carryforward: true
+    ignore:
+    - haproxy/datadog_checks/haproxy/config_models
     paths:
     - haproxy/datadog_checks/haproxy
     - haproxy/tests
   harbor:
     carryforward: true
+    ignore:
+    - harbor/datadog_checks/harbor/config_models
     paths:
     - harbor/datadog_checks/harbor
     - harbor/tests
   hazelcast:
     carryforward: true
+    ignore:
+    - hazelcast/datadog_checks/hazelcast/config_models
     paths:
     - hazelcast/datadog_checks/hazelcast
     - hazelcast/tests
   hdfs_datanode:
     carryforward: true
+    ignore:
+    - hdfs_datanode/datadog_checks/hdfs_datanode/config_models
     paths:
     - hdfs_datanode/datadog_checks/hdfs_datanode
     - hdfs_datanode/tests
   hdfs_namenode:
     carryforward: true
+    ignore:
+    - hdfs_namenode/datadog_checks/hdfs_namenode/config_models
     paths:
     - hdfs_namenode/datadog_checks/hdfs_namenode
     - hdfs_namenode/tests
   http_check:
     carryforward: true
+    ignore:
+    - http_check/datadog_checks/http_check/config_models
     paths:
     - http_check/datadog_checks/http_check
     - http_check/tests
   ibm_db2:
     carryforward: true
+    ignore:
+    - ibm_db2/datadog_checks/ibm_db2/config_models
     paths:
     - ibm_db2/datadog_checks/ibm_db2
     - ibm_db2/tests
   ibm_mq:
     carryforward: true
+    ignore:
+    - ibm_mq/datadog_checks/ibm_mq/config_models
     paths:
     - ibm_mq/datadog_checks/ibm_mq
     - ibm_mq/tests
   ibm_was:
     carryforward: true
+    ignore:
+    - ibm_was/datadog_checks/ibm_was/config_models
     paths:
     - ibm_was/datadog_checks/ibm_was
     - ibm_was/tests
   iis:
     carryforward: true
+    ignore:
+    - iis/datadog_checks/iis/config_models
     paths:
     - iis/datadog_checks/iis
     - iis/tests
   istio:
     carryforward: true
+    ignore:
+    - istio/datadog_checks/istio/config_models
     paths:
     - istio/datadog_checks/istio
     - istio/tests
   kafka_consumer:
     carryforward: true
+    ignore:
+    - kafka_consumer/datadog_checks/kafka_consumer/config_models
     paths:
     - kafka_consumer/datadog_checks/kafka_consumer
     - kafka_consumer/tests
   kong:
     carryforward: true
+    ignore:
+    - kong/datadog_checks/kong/config_models
     paths:
     - kong/datadog_checks/kong
     - kong/tests
   kube_apiserver_metrics:
     carryforward: true
+    ignore:
+    - kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models
     paths:
     - kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics
     - kube_apiserver_metrics/tests
   kube_controller_manager:
     carryforward: true
+    ignore:
+    - kube_controller_manager/datadog_checks/kube_controller_manager/config_models
     paths:
     - kube_controller_manager/datadog_checks/kube_controller_manager
     - kube_controller_manager/tests
   kube_dns:
     carryforward: true
+    ignore:
+    - kube_dns/datadog_checks/kube_dns/config_models
     paths:
     - kube_dns/datadog_checks/kube_dns
     - kube_dns/tests
   kube_metrics_server:
     carryforward: true
+    ignore:
+    - kube_metrics_server/datadog_checks/kube_metrics_server/config_models
     paths:
     - kube_metrics_server/datadog_checks/kube_metrics_server
     - kube_metrics_server/tests
   kube_proxy:
     carryforward: true
+    ignore:
+    - kube_proxy/datadog_checks/kube_proxy/config_models
     paths:
     - kube_proxy/datadog_checks/kube_proxy
     - kube_proxy/tests
   kube_scheduler:
     carryforward: true
+    ignore:
+    - kube_scheduler/datadog_checks/kube_scheduler/config_models
     paths:
     - kube_scheduler/datadog_checks/kube_scheduler
     - kube_scheduler/tests
   kubelet:
     carryforward: true
+    ignore:
+    - kubelet/datadog_checks/kubelet/config_models
     paths:
     - kubelet/datadog_checks/kubelet
     - kubelet/tests
   kubernetes_state:
     carryforward: true
+    ignore:
+    - kubernetes_state/datadog_checks/kubernetes_state/config_models
     paths:
     - kubernetes_state/datadog_checks/kubernetes_state
     - kubernetes_state/tests
   kyototycoon:
     carryforward: true
+    ignore:
+    - kyototycoon/datadog_checks/kyototycoon/config_models
     paths:
     - kyototycoon/datadog_checks/kyototycoon
     - kyototycoon/tests
   lighttpd:
     carryforward: true
+    ignore:
+    - lighttpd/datadog_checks/lighttpd/config_models
     paths:
     - lighttpd/datadog_checks/lighttpd
     - lighttpd/tests
   linkerd:
     carryforward: true
+    ignore:
+    - linkerd/datadog_checks/linkerd/config_models
     paths:
     - linkerd/datadog_checks/linkerd
     - linkerd/tests
   linux_proc_extras:
     carryforward: true
+    ignore:
+    - linux_proc_extras/datadog_checks/linux_proc_extras/config_models
     paths:
     - linux_proc_extras/datadog_checks/linux_proc_extras
     - linux_proc_extras/tests
   mapr:
     carryforward: true
+    ignore:
+    - mapr/datadog_checks/mapr/config_models
     paths:
     - mapr/datadog_checks/mapr
     - mapr/tests
   mapreduce:
     carryforward: true
+    ignore:
+    - mapreduce/datadog_checks/mapreduce/config_models
     paths:
     - mapreduce/datadog_checks/mapreduce
     - mapreduce/tests
   marathon:
     carryforward: true
+    ignore:
+    - marathon/datadog_checks/marathon/config_models
     paths:
     - marathon/datadog_checks/marathon
     - marathon/tests
   marklogic:
     carryforward: true
+    ignore:
+    - marklogic/datadog_checks/marklogic/config_models
     paths:
     - marklogic/datadog_checks/marklogic
     - marklogic/tests
   mcache:
     carryforward: true
+    ignore:
+    - mcache/datadog_checks/mcache/config_models
     paths:
     - mcache/datadog_checks/mcache
     - mcache/tests
   mesos_master:
     carryforward: true
+    ignore:
+    - mesos_master/datadog_checks/mesos_master/config_models
     paths:
     - mesos_master/datadog_checks/mesos_master
     - mesos_master/tests
   mesos_slave:
     carryforward: true
+    ignore:
+    - mesos_slave/datadog_checks/mesos_slave/config_models
     paths:
     - mesos_slave/datadog_checks/mesos_slave
     - mesos_slave/tests
   mongo:
     carryforward: true
+    ignore:
+    - mongo/datadog_checks/mongo/config_models
     paths:
     - mongo/datadog_checks/mongo
     - mongo/tests
   mysql:
     carryforward: true
+    ignore:
+    - mysql/datadog_checks/mysql/config_models
     paths:
     - mysql/datadog_checks/mysql
     - mysql/tests
   nagios:
     carryforward: true
+    ignore:
+    - nagios/datadog_checks/nagios/config_models
     paths:
     - nagios/datadog_checks/nagios
     - nagios/tests
   network:
     carryforward: true
+    ignore:
+    - network/datadog_checks/network/config_models
     paths:
     - network/datadog_checks/network
     - network/tests
   nfsstat:
     carryforward: true
+    ignore:
+    - nfsstat/datadog_checks/nfsstat/config_models
     paths:
     - nfsstat/datadog_checks/nfsstat
     - nfsstat/tests
   nginx:
     carryforward: true
+    ignore:
+    - nginx/datadog_checks/nginx/config_models
     paths:
     - nginx/datadog_checks/nginx
     - nginx/tests
   nginx_ingress_controller:
     carryforward: true
+    ignore:
+    - nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models
     paths:
     - nginx_ingress_controller/datadog_checks/nginx_ingress_controller
     - nginx_ingress_controller/tests
   openldap:
     carryforward: true
+    ignore:
+    - openldap/datadog_checks/openldap/config_models
     paths:
     - openldap/datadog_checks/openldap
     - openldap/tests
   openmetrics:
     carryforward: true
+    ignore:
+    - openmetrics/datadog_checks/openmetrics/config_models
     paths:
     - openmetrics/datadog_checks/openmetrics
     - openmetrics/tests
   openstack:
     carryforward: true
+    ignore:
+    - openstack/datadog_checks/openstack/config_models
     paths:
     - openstack/datadog_checks/openstack
     - openstack/tests
   openstack_controller:
     carryforward: true
+    ignore:
+    - openstack_controller/datadog_checks/openstack_controller/config_models
     paths:
     - openstack_controller/datadog_checks/openstack_controller
     - openstack_controller/tests
   oracle:
     carryforward: true
+    ignore:
+    - oracle/datadog_checks/oracle/config_models
     paths:
     - oracle/datadog_checks/oracle
     - oracle/tests
   pdh_check:
     carryforward: true
+    ignore:
+    - pdh_check/datadog_checks/pdh_check/config_models
     paths:
     - pdh_check/datadog_checks/pdh_check
     - pdh_check/tests
   pgbouncer:
     carryforward: true
+    ignore:
+    - pgbouncer/datadog_checks/pgbouncer/config_models
     paths:
     - pgbouncer/datadog_checks/pgbouncer
     - pgbouncer/tests
   php_fpm:
     carryforward: true
+    ignore:
+    - php_fpm/datadog_checks/php_fpm/config_models
     paths:
     - php_fpm/datadog_checks/php_fpm
     - php_fpm/tests
   postfix:
     carryforward: true
+    ignore:
+    - postfix/datadog_checks/postfix/config_models
     paths:
     - postfix/datadog_checks/postfix
     - postfix/tests
   postgres:
     carryforward: true
+    ignore:
+    - postgres/datadog_checks/postgres/config_models
     paths:
     - postgres/datadog_checks/postgres
     - postgres/tests
   powerdns_recursor:
     carryforward: true
+    ignore:
+    - powerdns_recursor/datadog_checks/powerdns_recursor/config_models
     paths:
     - powerdns_recursor/datadog_checks/powerdns_recursor
     - powerdns_recursor/tests
   process:
     carryforward: true
+    ignore:
+    - process/datadog_checks/process/config_models
     paths:
     - process/datadog_checks/process
     - process/tests
   prometheus:
     carryforward: true
+    ignore:
+    - prometheus/datadog_checks/prometheus/config_models
     paths:
     - prometheus/datadog_checks/prometheus
     - prometheus/tests
   proxysql:
     carryforward: true
+    ignore:
+    - proxysql/datadog_checks/proxysql/config_models
     paths:
     - proxysql/datadog_checks/proxysql
     - proxysql/tests
   rabbitmq:
     carryforward: true
+    ignore:
+    - rabbitmq/datadog_checks/rabbitmq/config_models
     paths:
     - rabbitmq/datadog_checks/rabbitmq
     - rabbitmq/tests
   redisdb:
     carryforward: true
+    ignore:
+    - redisdb/datadog_checks/redisdb/config_models
     paths:
     - redisdb/datadog_checks/redisdb
     - redisdb/tests
   rethinkdb:
     carryforward: true
+    ignore:
+    - rethinkdb/datadog_checks/rethinkdb/config_models
     paths:
     - rethinkdb/datadog_checks/rethinkdb
     - rethinkdb/tests
   riak:
     carryforward: true
+    ignore:
+    - riak/datadog_checks/riak/config_models
     paths:
     - riak/datadog_checks/riak
     - riak/tests
   riakcs:
     carryforward: true
+    ignore:
+    - riakcs/datadog_checks/riakcs/config_models
     paths:
     - riakcs/datadog_checks/riakcs
     - riakcs/tests
   sap_hana:
     carryforward: true
+    ignore:
+    - sap_hana/datadog_checks/sap_hana/config_models
     paths:
     - sap_hana/datadog_checks/sap_hana
     - sap_hana/tests
   scylla:
     carryforward: true
+    ignore:
+    - scylla/datadog_checks/scylla/config_models
     paths:
     - scylla/datadog_checks/scylla
     - scylla/tests
   snmp:
     carryforward: true
+    ignore:
+    - snmp/datadog_checks/snmp/config_models
     paths:
     - snmp/datadog_checks/snmp
     - snmp/tests
   snowflake:
     carryforward: true
+    ignore:
+    - snowflake/datadog_checks/snowflake/config_models
     paths:
     - snowflake/datadog_checks/snowflake
     - snowflake/tests
   sonarqube:
     carryforward: true
+    ignore:
+    - sonarqube/datadog_checks/sonarqube/config_models
     paths:
     - sonarqube/datadog_checks/sonarqube
     - sonarqube/tests
   spark:
     carryforward: true
+    ignore:
+    - spark/datadog_checks/spark/config_models
     paths:
     - spark/datadog_checks/spark
     - spark/tests
   sqlserver:
     carryforward: true
+    ignore:
+    - sqlserver/datadog_checks/sqlserver/config_models
     paths:
     - sqlserver/datadog_checks/sqlserver
     - sqlserver/tests
   squid:
     carryforward: true
+    ignore:
+    - squid/datadog_checks/squid/config_models
     paths:
     - squid/datadog_checks/squid
     - squid/tests
   ssh_check:
     carryforward: true
+    ignore:
+    - ssh_check/datadog_checks/ssh_check/config_models
     paths:
     - ssh_check/datadog_checks/ssh_check
     - ssh_check/tests
   statsd:
     carryforward: true
+    ignore:
+    - statsd/datadog_checks/statsd/config_models
     paths:
     - statsd/datadog_checks/statsd
     - statsd/tests
   supervisord:
     carryforward: true
+    ignore:
+    - supervisord/datadog_checks/supervisord/config_models
     paths:
     - supervisord/datadog_checks/supervisord
     - supervisord/tests
   system_core:
     carryforward: true
+    ignore:
+    - system_core/datadog_checks/system_core/config_models
     paths:
     - system_core/datadog_checks/system_core
     - system_core/tests
   system_swap:
     carryforward: true
+    ignore:
+    - system_swap/datadog_checks/system_swap/config_models
     paths:
     - system_swap/datadog_checks/system_swap
     - system_swap/tests
   tcp_check:
     carryforward: true
+    ignore:
+    - tcp_check/datadog_checks/tcp_check/config_models
     paths:
     - tcp_check/datadog_checks/tcp_check
     - tcp_check/tests
   teamcity:
     carryforward: true
+    ignore:
+    - teamcity/datadog_checks/teamcity/config_models
     paths:
     - teamcity/datadog_checks/teamcity
     - teamcity/tests
   tls:
     carryforward: true
+    ignore:
+    - tls/datadog_checks/tls/config_models
     paths:
     - tls/datadog_checks/tls
     - tls/tests
   tokumx:
     carryforward: true
+    ignore:
+    - tokumx/datadog_checks/tokumx/config_models
     paths:
     - tokumx/datadog_checks/tokumx
     - tokumx/tests
   twemproxy:
     carryforward: true
+    ignore:
+    - twemproxy/datadog_checks/twemproxy/config_models
     paths:
     - twemproxy/datadog_checks/twemproxy
     - twemproxy/tests
   twistlock:
     carryforward: true
+    ignore:
+    - twistlock/datadog_checks/twistlock/config_models
     paths:
     - twistlock/datadog_checks/twistlock
     - twistlock/tests
   varnish:
     carryforward: true
+    ignore:
+    - varnish/datadog_checks/varnish/config_models
     paths:
     - varnish/datadog_checks/varnish
     - varnish/tests
   vault:
     carryforward: true
+    ignore:
+    - vault/datadog_checks/vault/config_models
     paths:
     - vault/datadog_checks/vault
     - vault/tests
   vertica:
     carryforward: true
+    ignore:
+    - vertica/datadog_checks/vertica/config_models
     paths:
     - vertica/datadog_checks/vertica
     - vertica/tests
   voltdb:
     carryforward: true
+    ignore:
+    - voltdb/datadog_checks/voltdb/config_models
     paths:
     - voltdb/datadog_checks/voltdb
     - voltdb/tests
   vsphere:
     carryforward: true
+    ignore:
+    - vsphere/datadog_checks/vsphere/config_models
     paths:
     - vsphere/datadog_checks/vsphere
     - vsphere/tests
   win32_event_log:
     carryforward: true
+    ignore:
+    - win32_event_log/datadog_checks/win32_event_log/config_models
     paths:
     - win32_event_log/datadog_checks/win32_event_log
     - win32_event_log/tests
   windows_service:
     carryforward: true
+    ignore:
+    - windows_service/datadog_checks/windows_service/config_models
     paths:
     - windows_service/datadog_checks/windows_service
     - windows_service/tests
   wmi_check:
     carryforward: true
+    ignore:
+    - wmi_check/datadog_checks/wmi_check/config_models
     paths:
     - wmi_check/datadog_checks/wmi_check
     - wmi_check/tests
   yarn:
     carryforward: true
+    ignore:
+    - yarn/datadog_checks/yarn/config_models
     paths:
     - yarn/datadog_checks/yarn
     - yarn/tests
   zk:
     carryforward: true
+    ignore:
+    - zk/datadog_checks/zk/config_models
     paths:
     - zk/datadog_checks/zk
     - zk/tests

--- a/.coveragerc
+++ b/.coveragerc
@@ -12,6 +12,10 @@ omit =
     */test_bench.py
     */test_e2e.py
 
+    # Configuration models
+    # TODO: remove when python 2 is dropped
+    */datadog_checks/*/config_models/*
+
     # Vendored dependencies
     */datadog_checks/*/vendor/*
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
There `Sync config models` PRs are adding a folder to every integration. However, this folder is validated the the ddev command, so codecov does not consider it tested.

Having these folders it the code coverage seems irrelevant.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
