### PR TITLE
Add additional metric to manifest

### DIFF
--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -12,7 +12,10 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "metric_prefix": "activemq.",
-  "metric_to_check": "activemq.queue.size",
+  "metric_to_check": [
+      "activemq.queue.size",
+      "activemq.artemis.queue.message_count"
+  ],
   "name": "activemq",
   "process_signatures": [
     "activemq"


### PR DESCRIPTION
### What does this PR do?
Artemis installs look broken since they do not emit the current `metric_to_check` value.  This expands the field to include an Artemis specific metric name as well.
