### PR TITLE
Support redis 6 cpu metrics

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -98,6 +98,8 @@ class Redis(AgentCheck):
         'used_cpu_sys_children': 'redis.cpu.sys_children',
         'used_cpu_user': 'redis.cpu.user',
         'used_cpu_user_children': 'redis.cpu.user_children',
+        'used_cpu_sys_main_thread': 'redis.cpu.sys_main_thread',
+        'used_cpu_user_main_thread': 'redis.cpu.user_main_thread',
         # stats
         'keyspace_hits': 'redis.stats.keyspace_hits',
         'keyspace_misses': 'redis.stats.keyspace_misses',

--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -19,6 +19,8 @@ redis.cpu.sys,gauge,,,,System CPU consumed by the Redis server.,-1,redis,cpu sys
 redis.cpu.sys_children,gauge,,,,System CPU consumed by the background processes.,-1,redis,cpu sys children
 redis.cpu.user,gauge,,,,User CPU consumed by the Redis server.,-1,redis,cpu user
 redis.cpu.user_children,gauge,,,,User CPU consumed by the background processes.,-1,redis,cpu user children
+redis.cpu.sys_main_thread,gauge,,,,System CPU consumed by the Redis server main thread.,-1,redis,cpu sys main thread
+redis.cpu.user_main_thread,gauge,,,,User CPU consumed by the Redis server main thread.,-1,redis,cpu sys main thread
 redis.expires,gauge,,key,,The number of keys with an expiration.,0,redis,expires
 redis.expires.percent,gauge,,percent,,Percentage of total keys with an expiration.,0,redis,expires pct
 redis.info.latency_ms,gauge,,millisecond,,The latency of the redis INFO command.,0,redis,info latency

--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -19,8 +19,8 @@ redis.cpu.sys,gauge,,,,System CPU consumed by the Redis server.,-1,redis,cpu sys
 redis.cpu.sys_children,gauge,,,,System CPU consumed by the background processes.,-1,redis,cpu sys children
 redis.cpu.user,gauge,,,,User CPU consumed by the Redis server.,-1,redis,cpu user
 redis.cpu.user_children,gauge,,,,User CPU consumed by the background processes.,-1,redis,cpu user children
-redis.cpu.sys_main_thread,gauge,,,,System CPU consumed by the Redis server main thread.,-1,redis,cpu sys main thread
-redis.cpu.user_main_thread,gauge,,,,User CPU consumed by the Redis server main thread.,-1,redis,cpu sys main thread
+redis.cpu.sys_main_thread,gauge,,,,System CPU consumed by the Redis server main thread. This metric is only provided by redis >=6.x.,-1,redis,cpu sys main thread
+redis.cpu.user_main_thread,gauge,,,,User CPU consumed by the Redis server main thread. This metric is only provided by redis >=6.x.,-1,redis,cpu sys main thread
 redis.expires,gauge,,key,,The number of keys with an expiration.,0,redis,expires
 redis.expires.percent,gauge,,percent,,Percentage of total keys with an expiration.,0,redis,expires pct
 redis.info.latency_ms,gauge,,millisecond,,The latency of the redis INFO command.,0,redis,info latency

--- a/redisdb/tests/test_e2e.py
+++ b/redisdb/tests/test_e2e.py
@@ -112,5 +112,7 @@ def test_e2e_v_latest(dd_agent_check, master_instance):
     aggregator.assert_metric('redis.active_defrag.misses', count=2, tags=tags)
     aggregator.assert_metric('redis.active_defrag.key_hits', count=2, tags=tags)
     aggregator.assert_metric('redis.active_defrag.key_misses', count=2, tags=tags)
+    aggregator.assert_metric('redis.cpu.sys_main_thread', count=1, tags=tags)
+    aggregator.assert_metric('redis.cpu.user_main_thread', count=1, tags=tags)
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

Since Redis 6 brings support for multi threaded IO, this PR adds support to redisdb to retrieve  `used_cpu_sys_main_thread` and `used_cpu_user_main_thread` from `info` and store them as metrics. These metrics will help determine how much CPU is being used from the main thread rather than the sum of all threads. 

### Motivation

We will be supporting Redis 6 in the near future and will need the new metrics piped to Datadog for evaluation and monitoring.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
