### PR TITLE
Add new testing package to ddev

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/testing/requirements.py
+++ b/datadog_checks_dev/datadog_checks/dev/testing/requirements.py
@@ -1,0 +1,9 @@
+import pytest
+from six import PY2
+from datadog_checks.dev.utils import ON_MACOS, ON_WINDOWS
+
+requires_windows = pytest.mark.skipif(not ON_WINDOWS, reason='Requires Windows')
+requires_linux = pytest.mark.skipif(ON_MACOS or ON_WINDOWS, reason='Requires Linux')
+requires_unix = pytest.mark.skipif(ON_WINDOWS, reason='Requires Linux or macOS')
+
+requires_py3 = pytest.mark.skipif(PY2, reason='Test only available on Python 3')


### PR DESCRIPTION
Split of https://github.com/DataDog/integrations-core/pull/8732

Creates a new testing package in ddev, the idea is to move other testing tooling there too