### PR TITLE
Fix wrong timestamp for DBM beta feature

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -19,6 +19,7 @@ from datadog_checks.base.utils.db.sql import compute_exec_plan_signature, comput
 from datadog_checks.base.utils.db.statement_samples import statement_samples_client
 from datadog_checks.base.utils.db.utils import ConstantRateLimiter, resolve_db_host
 from datadog_checks.base.utils.serialization import json
+from datadog_checks.base.utils.time import get_timestamp
 
 VALID_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update'})
 
@@ -343,12 +344,14 @@ class PostgresStatementSamples(object):
                 },
                 'postgres': {k: v for k, v in row.items() if k not in pg_stat_activity_sample_exclude_keys},
             }
+            event['timestamp'] = time.time() * 1000
             if row['state'] in {'idle', 'idle in transaction'}:
                 if row['state_change'] and row['query_start']:
                     event['duration'] = (row['state_change'] - row['query_start']).total_seconds() * 1e9
-                    event['timestamp'] = time.mktime(row['state_change'].timetuple()) * 1000
-            else:
-                event['timestamp'] = time.time() * 1000
+                    # If the transaction is idle then we have a more specific "end time" than the current time at
+                    # which we're collecting this event. Can only be done if the datetime has a timezone.
+                    if row['state_change'].tzinfo:
+                        event['timestamp'] = get_timestamp(row['state_change']) * 1000
             return event
 
     def _explain_pg_stat_activity(self, rows):


### PR DESCRIPTION
### What does this PR do?

The timestamp derived from the last `state_change` was wrong because it didn't take into account the timezone, causing some events to be dropped during intake. Now we do an explicit conversion to a unix timestamp from the UTC Unix epoch date.

### Motivation
Fix wrong timestamps.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
