### PR TITLE
Allow prometheus metrics path to be configurable

### DIFF
--- a/amazon_msk/assets/configuration/spec.yaml
+++ b/amazon_msk/assets/configuration/spec.yaml
@@ -36,6 +36,12 @@ files:
       value:
         type: integer
         example: 11002
+    - name: prometheus_metrics_path
+      description: |
+        The path where Prometheus serves metrics.
+      value:
+        type: string
+        example: /metrics
     - template: instances/openmetrics_legacy
       overrides:
         prometheus_url.hidden: true

--- a/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
+++ b/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
@@ -29,6 +29,7 @@ class AmazonMskCheck(OpenMetricsBaseCheck):
             (int(self.instance.get('jmx_exporter_port', 11001)), JMX_METRICS_MAP, JMX_METRICS_OVERRIDES),
             (int(self.instance.get('node_exporter_port', 11002)), NODE_METRICS_MAP, NODE_METRICS_OVERRIDES),
         )
+        self._prometheus_metrics_path = self.instance('prometheus_metrics_path', '/metrics')
 
         instance = self.instance.copy()
         instance['prometheus_url'] = 'necessary for scraper creation'
@@ -77,8 +78,8 @@ class AmazonMskCheck(OpenMetricsBaseCheck):
 
             for endpoint in broker_info['Endpoints']:
                 for (port, metrics_mapper, type_overrides) in self._exporter_data:
-                    self._scraper_config['prometheus_url'] = '{}://{}:{}/metrics'.format(
-                        self._endpoint_prefix, endpoint, port
+                    self._scraper_config['prometheus_url'] = '{}://{}:{}{}'.format(
+                        self._endpoint_prefix, endpoint, port, self._prometheus_metrics_path
                     )
                     self._scraper_config['metrics_mapper'] = metrics_mapper
                     self._scraper_config['type_overrides'] = type_overrides

--- a/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
+++ b/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
@@ -29,7 +29,7 @@ class AmazonMskCheck(OpenMetricsBaseCheck):
             (int(self.instance.get('jmx_exporter_port', 11001)), JMX_METRICS_MAP, JMX_METRICS_OVERRIDES),
             (int(self.instance.get('node_exporter_port', 11002)), NODE_METRICS_MAP, NODE_METRICS_OVERRIDES),
         )
-        self._prometheus_metrics_path = self.instance('prometheus_metrics_path', '/metrics')
+        self._prometheus_metrics_path = self.instance.get('prometheus_metrics_path', '/metrics')
 
         instance = self.instance.copy()
         instance['prometheus_url'] = 'necessary for scraper creation'

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -74,6 +74,11 @@ instances:
     #
     # node_exporter_port: 11002
 
+    ## @param prometheus_metrics_path - string - optional - default: /metrics
+    ## The path where Prometheus serves metrics.
+    #
+    # prometheus_metrics_path: /metrics
+
     ## @param prometheus_metrics_prefix - string - optional
     ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #

--- a/amazon_msk/tests/test_unit.py
+++ b/amazon_msk/tests/test_unit.py
@@ -60,3 +60,38 @@ def assert_jmx_metrics(aggregator, tags):
         metric = 'aws.msk.{}'.format(metric)
         for tag in tags:
             aggregator.assert_metric_has_tag(metric, tag)
+
+
+@pytest.mark.usefixtures('mock_data')
+def test_custom_metric_path(aggregator, instance, mock_client):
+    instance['prometheus_metrics_path'] = '/'
+    c = AmazonMskCheck('amazon_msk', {}, [instance])
+    assert not c.run()
+
+    caller, client = mock_client
+    cluster_arn = instance['cluster_arn']
+    region_name = cluster_arn.split(':')[3]
+
+    caller.assert_called_once_with('kafka', region_name=region_name)
+    client.list_nodes.assert_called_once_with(ClusterArn=cluster_arn)
+
+    global_tags = ['cluster_arn:{}'.format(cluster_arn), 'region_name:{}'.format(region_name)]
+    global_tags.extend(instance['tags'])
+    aggregator.assert_service_check(c.SERVICE_CHECK_CONNECT, c.OK, tags=global_tags)
+
+    for node_info in client.list_nodes()['NodeInfoList']:
+        broker_info = node_info['BrokerNodeInfo']
+        broker_tags = ['broker_id:{}'.format(broker_info['BrokerId'])]
+        broker_tags.extend(global_tags)
+
+        assert_node_metrics(aggregator, broker_tags)
+        assert_jmx_metrics(aggregator, broker_tags)
+
+        for endpoint in broker_info['Endpoints']:
+            for port in (11001, 11002):
+                service_check_tags = ['endpoint:http://{}:{}/'.format(endpoint, port)]
+                service_check_tags.extend(global_tags)
+
+                aggregator.assert_service_check('aws.msk.prometheus.health', c.OK, tags=service_check_tags)
+
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
Some amazon msk instances may not expose metrics at `/metrics` path. This PR makes the path configurable.

### Motivation
User req
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
