### PR TITLE
(docs) Add link to SonarQube

### DIFF
--- a/sonarqube/README.md
+++ b/sonarqube/README.md
@@ -247,6 +247,10 @@ SonarQube does not include any events.
 
 ## Troubleshooting
 
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
 Need help? Contact [Datadog support][5].
 
 [1]: https://www.sonarqube.org

--- a/sonarqube/manifest.json
+++ b/sonarqube/manifest.json
@@ -39,5 +39,11 @@
       "source": "sonarqube"
     },
     "metrics_metadata": "metadata.csv"
-  }
+  },
+  "further_reading": [
+    {"link": "https://www.datadoghq.com/blog/datadog-sonarqube-integration/",
+      "tag": "Blog",
+      "text": "Monitor code quality in Datadog with SonarQube"
+    }
+  ]
 }


### PR DESCRIPTION
### What does this PR do?
Adds the standard Further Reading section and a blog link to this integration's README.

### Motivation
New blog post: https://www.datadoghq.com/blog/datadog-sonarqube-integration/

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
