### PR TITLE
Add a timeout for Kubernetes API calls

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/kube_leader/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kube_leader/mixins.py
@@ -17,6 +17,8 @@ client = config = None
 # will be tried in the order of the list
 ELECTION_ANNOTATION_NAMES = ["control-plane.alpha.kubernetes.io/leader"]
 
+K8S_REQUEST_TIMEOUT = 30
+
 
 class KubeLeaderElectionMixin(object):
     """
@@ -80,7 +82,7 @@ class KubeLeaderElectionMixin(object):
     @staticmethod
     def _get_record_from_lease(client, name, namespace):
         coordination_v1 = client.CoordinationV1Api()
-        obj = coordination_v1.read_namespaced_lease(name, namespace)
+        obj = coordination_v1.read_namespaced_lease(name, namespace, _request_timeout=K8S_REQUEST_TIMEOUT)
 
         return ElectionRecordLease(obj)
 
@@ -89,9 +91,9 @@ class KubeLeaderElectionMixin(object):
         v1 = client.CoreV1Api()
 
         if kind.lower() in ["endpoints", "endpoint", "ep"]:
-            obj = v1.read_namespaced_endpoints(name, namespace)
+            obj = v1.read_namespaced_endpoints(name, namespace, _request_timeout=K8S_REQUEST_TIMEOUT)
         elif kind.lower() in ["configmap", "cm"]:
-            obj = v1.read_namespaced_config_map(name, namespace)
+            obj = v1.read_namespaced_config_map(name, namespace, _request_timeout=K8S_REQUEST_TIMEOUT)
         else:
             raise ValueError("Unknown kind {}".format(kind))
 

--- a/datadog_checks_base/tests/test_kube_leader.py
+++ b/datadog_checks_base/tests/test_kube_leader.py
@@ -219,7 +219,7 @@ class TestBaseCheck:
         c.check(EP_INSTANCE)
 
         assert c.get_warnings() == []
-        mock_read_endpoints.assert_called_once_with("thisrecord", "myns")
+        mock_read_endpoints.assert_called_once_with("thisrecord", "myns", _request_timeout=30)
         aggregator.assert_metric("base.leader_election.transitions", value=7, tags=EP_TAGS)
         aggregator.assert_metric("base.leader_election.lease_duration", value=60, tags=EP_TAGS)
         aggregator.assert_service_check("base.leader_election.status", status=AgentCheck.CRITICAL, tags=EP_TAGS)
@@ -231,7 +231,7 @@ class TestBaseCheck:
         c.check(CM_INSTANCE)
 
         assert c.get_warnings() == []
-        mock_read_configmap.assert_called_once_with("thisrecord", "myns")
+        mock_read_configmap.assert_called_once_with("thisrecord", "myns", _request_timeout=30)
         aggregator.assert_metric("base.leader_election.transitions", value=7, tags=CM_TAGS)
         aggregator.assert_metric("base.leader_election.lease_duration", value=60, tags=CM_TAGS)
         aggregator.assert_service_check("base.leader_election.status", status=AgentCheck.CRITICAL, tags=CM_TAGS)


### PR DESCRIPTION
### What does this PR do?

Add a timeout for Kubernetes API calls.

### Motivation

Guarantee that checks cannot remain blocked forever, even in case of network issue blackholing all the packets.

### Additional Notes

We add the [`_request_timeout` parameter which is documented here](https://github.com/kubernetes-client/python/blob/b79ad6837b2f5326c7dad488a64eed7c3987e856/kubernetes/client/api/coordination_v1_api.py#L1092-L1095).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
