### PR TITLE
Update kong status url

### DIFF
--- a/kong/README.md
+++ b/kong/README.md
@@ -30,7 +30,7 @@ To configure this check for an Agent running on a host:
      ## @param kong_status_url - string - required
      ## URL where Kong exposes its status.
      #
-     - kong_status_url: http://localhost:8001/status/
+     - kong_status_url: http://localhost:8100/status/
    ```
 
 2. [Restart the Agent][4].
@@ -79,7 +79,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][5]
 | -------------------- | ----------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `kong`                                                |
 | `<INIT_CONFIG>`      | blank or `{}`                                         |
-| `<INSTANCE_CONFIG>`  | `{"kong_status_url": "http://%%host%%:8001/status/"}` |
+| `<INSTANCE_CONFIG>`  | `{"kong_status_url": "http://%%host%%:8100/status/"}` |
 
 ##### Log collection
 


### PR DESCRIPTION
Default port seems to be `8100`

### What does this PR do?
Change default port for Kong status service

### Motivation
Implementation of monitoring with Datadog using the Kubernetes manifests provided by Kong


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
