### PR TITLE
Add python loader tag to telemetry metrics

### DIFF
--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -26,7 +26,7 @@ steps:
       displayName: 'Run Unit/Integration tests (forced install of minimum datadog_checks_base package)'
 
 - ${{ if and(eq(parameters.test_e2e, 'true'), eq(parameters.repo, 'core'))}}:
-  - script: ddev env test --base --new-env --junit ${{ parameters.check }}
+  - script: ddev env test --base --new-env --junit ${{ parameters.check }} -a datadog/agent-dev:alex-snmp-loader-tag-py3
     displayName: 'Run E2E tests against latest base package'
     env:
       DD_API_KEY: $(DD_API_KEY)

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -26,7 +26,7 @@ steps:
       displayName: 'Run Unit/Integration tests (forced install of minimum datadog_checks_base package)'
 
 - ${{ if and(eq(parameters.test_e2e, 'true'), eq(parameters.repo, 'core'))}}:
-  - script: ddev env test --base --new-env --junit ${{ parameters.check }} -a datadog/agent-dev:alex-snmp-loader-tag-py3
+  - script: ddev env test --base --new-env --junit ${{ parameters.check }}
     displayName: 'Run E2E tests against latest base package'
     env:
       DD_API_KEY: $(DD_API_KEY)

--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -41,6 +41,7 @@ from .utils import (
 )
 
 DEFAULT_OID_BATCH_SIZE = 10
+LOADER_TAG = 'loader:python'
 
 _MAX_FETCH_NUMBER = 10 ** 6
 
@@ -396,13 +397,18 @@ class SnmpCheck(AgentCheck):
         else:
             _, tags = self._check_device(config)
 
+        self.submit_telemetry_metrics(start_time, tags)
+
+    def submit_telemetry_metrics(self, start_time, tags):
+        # type: (float, List[str]) -> None
+        telemetry_tags = tags + [LOADER_TAG]
         # Performance Metrics
         # - for single device, tags contain device specific tags
         # - for network, tags contain network tags, but won't contain individual device tags
         check_duration = time.time() - start_time
-        self.monotonic_count('datadog.snmp.check_interval', time.time(), tags=tags)
-        self.gauge('datadog.snmp.check_duration', check_duration, tags=tags)
-        self.gauge('datadog.snmp.submitted_metrics', self._submitted_metrics, tags=tags)
+        self.monotonic_count('datadog.snmp.check_interval', time.time(), tags=telemetry_tags)
+        self.gauge('datadog.snmp.check_duration', check_duration, tags=telemetry_tags)
+        self.gauge('datadog.snmp.submitted_metrics', self._submitted_metrics, tags=telemetry_tags)
 
     def _on_check_device_done(self, host, future):
         # type: (str, futures.Future) -> None
@@ -458,7 +464,7 @@ class SnmpCheck(AgentCheck):
 
             # Sending `snmp.devices_monitored` with value 1 will allow users to count devices
             # by using `sum by {X}` queries in UI. X being a tag like `autodiscovery_subnet`, `snmp_profile`, etc
-            self.gauge('snmp.devices_monitored', 1, tags=tags)
+            self.gauge('snmp.devices_monitored', 1, tags=tags + [LOADER_TAG])
 
             # Report service checks
             status = self.OK

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -265,7 +265,9 @@ def assert_common_check_run_metrics(aggregator, tags=None, is_e2e=False, loader=
     aggregator.assert_metric('datadog.snmp.submitted_metrics', metric_type=aggregator.GAUGE, tags=tags)
 
 
-def assert_common_device_metrics(aggregator, tags=None, is_e2e=False, count=None, devices_monitored_value=None, loader=None):
+def assert_common_device_metrics(
+    aggregator, tags=None, is_e2e=False, count=None, devices_monitored_value=None, loader=None
+):
     loader = loader or 'python'
     if tags is not None:
         tags = tags + ['loader:' + loader]

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -264,9 +264,9 @@ def assert_common_check_run_metrics(aggregator, tags=None, is_e2e=False):
     aggregator.assert_metric('datadog.snmp.submitted_metrics', metric_type=aggregator.GAUGE, tags=tags)
 
 
-def assert_common_device_metrics(aggregator, tags=None, is_e2e=False, count=None, value=None):
+def assert_common_device_metrics(aggregator, tags=None, is_e2e=False, count=None, devices_monitored_value=None):
     if tags is not None:
         tags = tags + ['loader:python']
     aggregator.assert_metric(
-        'snmp.devices_monitored', metric_type=aggregator.GAUGE, tags=tags, count=count, value=value
+        'snmp.devices_monitored', metric_type=aggregator.GAUGE, tags=tags, count=count, value=devices_monitored_value
     )

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -264,7 +264,9 @@ def assert_common_check_run_metrics(aggregator, tags=None, is_e2e=False):
     aggregator.assert_metric('datadog.snmp.submitted_metrics', metric_type=aggregator.GAUGE, tags=tags)
 
 
-def assert_common_device_metrics(aggregator, tags=None, is_e2e=False):
+def assert_common_device_metrics(aggregator, tags=None, is_e2e=False, count=None, value=None):
     if tags is not None:
         tags = tags + ['loader:python']
-    aggregator.assert_metric('snmp.devices_monitored', metric_type=aggregator.GAUGE, tags=tags)
+    aggregator.assert_metric(
+        'snmp.devices_monitored', metric_type=aggregator.GAUGE, tags=tags, count=count, value=value
+    )

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -248,25 +248,27 @@ def create_check(instance):
     return SnmpCheck('snmp', {}, [instance])
 
 
-def assert_common_metrics(aggregator, tags=None, is_e2e=False):
-    assert_common_check_run_metrics(aggregator, tags, is_e2e)
-    assert_common_device_metrics(aggregator, tags, is_e2e)
+def assert_common_metrics(aggregator, tags=None, is_e2e=False, loader=None):
+    assert_common_check_run_metrics(aggregator, tags, is_e2e, loader=loader)
+    assert_common_device_metrics(aggregator, tags, is_e2e, loader=loader)
 
 
-def assert_common_check_run_metrics(aggregator, tags=None, is_e2e=False):
+def assert_common_check_run_metrics(aggregator, tags=None, is_e2e=False, loader=None):
     monotonic_type = aggregator.MONOTONIC_COUNT
     if is_e2e:
         monotonic_type = aggregator.COUNT
+    loader = loader or 'python'
     if tags is not None:
-        tags = tags + ['loader:python']
+        tags = tags + ['loader:' + loader]
     aggregator.assert_metric('datadog.snmp.check_duration', metric_type=aggregator.GAUGE, tags=tags)
     aggregator.assert_metric('datadog.snmp.check_interval', metric_type=monotonic_type, tags=tags)
     aggregator.assert_metric('datadog.snmp.submitted_metrics', metric_type=aggregator.GAUGE, tags=tags)
 
 
-def assert_common_device_metrics(aggregator, tags=None, is_e2e=False, count=None, devices_monitored_value=None):
+def assert_common_device_metrics(aggregator, tags=None, is_e2e=False, count=None, devices_monitored_value=None, loader=None):
+    loader = loader or 'python'
     if tags is not None:
-        tags = tags + ['loader:python']
+        tags = tags + ['loader:' + loader]
     aggregator.assert_metric(
         'snmp.devices_monitored', metric_type=aggregator.GAUGE, tags=tags, count=count, value=devices_monitored_value
     )

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -257,10 +257,14 @@ def assert_common_check_run_metrics(aggregator, tags=None, is_e2e=False):
     monotonic_type = aggregator.MONOTONIC_COUNT
     if is_e2e:
         monotonic_type = aggregator.COUNT
+    if tags is not None:
+        tags = tags + ['loader:python']
     aggregator.assert_metric('datadog.snmp.check_duration', metric_type=aggregator.GAUGE, tags=tags)
     aggregator.assert_metric('datadog.snmp.check_interval', metric_type=monotonic_type, tags=tags)
     aggregator.assert_metric('datadog.snmp.submitted_metrics', metric_type=aggregator.GAUGE, tags=tags)
 
 
 def assert_common_device_metrics(aggregator, tags=None, is_e2e=False):
+    if tags is not None:
+        tags = tags + ['loader:python']
     aggregator.assert_metric('snmp.devices_monitored', metric_type=aggregator.GAUGE, tags=tags)

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -251,6 +251,8 @@ def test_submitted_metrics_count(aggregator):
     check = common.create_check(instance)
     check.check(instance)
 
+    telemetry_tags = common.CHECK_TAGS + ['loader:python']
+
     for metric in common.SCALAR_OBJECTS:
         metric_name = "snmp." + (metric.get('name') or metric.get('symbol'))
         aggregator.assert_metric(metric_name, tags=common.CHECK_TAGS, count=1)
@@ -263,13 +265,11 @@ def test_submitted_metrics_count(aggregator):
         value=total_snmp_submitted_metrics,
         metric_type=aggregator.GAUGE,
         count=1,
-        tags=common.CHECK_TAGS,
+        tags=telemetry_tags,
     )
+    aggregator.assert_metric('datadog.snmp.check_duration', metric_type=aggregator.GAUGE, count=1, tags=telemetry_tags)
     aggregator.assert_metric(
-        'datadog.snmp.check_duration', metric_type=aggregator.GAUGE, count=1, tags=common.CHECK_TAGS
-    )
-    aggregator.assert_metric(
-        'datadog.snmp.check_interval', metric_type=aggregator.MONOTONIC_COUNT, count=1, tags=common.CHECK_TAGS
+        'datadog.snmp.check_interval', metric_type=aggregator.MONOTONIC_COUNT, count=1, tags=telemetry_tags
     )
     common.assert_common_device_metrics(aggregator, tags=common.CHECK_TAGS)
     aggregator.all_metrics_asserted()

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -776,7 +776,7 @@ def test_profile_sysoid_list(aggregator, caplog):
 
         tags = common_tags + ['snmp_oid:{}'.format(device['sysobjectid'])]
         aggregator.assert_metric('snmp.IAmACounter32', tags=tags, count=1)
-        aggregator.assert_metric('snmp.devices_monitored', tags=tags, count=1, value=1)
+        common.assert_common_device_metrics('snmp.devices_monitored', tags=tags + ['loader:python'], count=1, value=1)
         common.assert_common_metrics(aggregator, tags)
         aggregator.assert_all_metrics_covered()
 
@@ -793,7 +793,9 @@ def test_profile_sysoid_list(aggregator, caplog):
         check.check(instance)
 
         assert 'No profile matching sysObjectID 1.3.6.1.4.1.9.1.1745' in caplog.text
-        aggregator.assert_metric('snmp.devices_monitored', tags=common.CHECK_TAGS, count=1, value=1)
+        common.assert_common_device_metrics(
+            'snmp.devices_monitored', tags=common.CHECK_TAGS + ['loader:python'], count=1, value=1
+        )
         common.assert_common_metrics(aggregator, common.CHECK_TAGS)
         aggregator.assert_all_metrics_covered()
 
@@ -939,7 +941,7 @@ def test_discovery(aggregator):
     aggregator.assert_metric('snmp.sysUpTimeInstance')
     aggregator.assert_metric('snmp.discovered_devices_count', tags=network_tags)
 
-    aggregator.assert_metric('snmp.devices_monitored', metric_type=aggregator.GAUGE, tags=check_tags)
+    common.assert_common_device_metrics(aggregator, tags=check_tags)
     common.assert_common_check_run_metrics(aggregator, network_tags)
     aggregator.assert_all_metrics_covered()
 
@@ -976,7 +978,7 @@ def test_discovery_devices_monitored_count(read_mock, aggregator):
 
     for device_ip in ['192.168.0.1', '192.168.0.2']:
         tags = check_tags + ['snmp_device:{}'.format(device_ip)]
-        aggregator.assert_metric('snmp.devices_monitored', metric_type=aggregator.GAUGE, value=1, count=1, tags=tags)
+        common.assert_common_device_metrics(aggregator, value=1, count=1, tags=tags)
 
     common.assert_common_check_run_metrics(aggregator, network_tags)
     aggregator.assert_all_metrics_covered()

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -793,9 +793,7 @@ def test_profile_sysoid_list(aggregator, caplog):
         check.check(instance)
 
         assert 'No profile matching sysObjectID 1.3.6.1.4.1.9.1.1745' in caplog.text
-        common.assert_common_device_metrics(
-            tags=common.CHECK_TAGS + ['loader:python'], count=1, devices_monitored_value=1
-        )
+        common.assert_common_device_metrics(aggregator, tags=common.CHECK_TAGS, count=1, devices_monitored_value=1)
         common.assert_common_metrics(aggregator, common.CHECK_TAGS)
         aggregator.assert_all_metrics_covered()
 

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -776,7 +776,7 @@ def test_profile_sysoid_list(aggregator, caplog):
 
         tags = common_tags + ['snmp_oid:{}'.format(device['sysobjectid'])]
         aggregator.assert_metric('snmp.IAmACounter32', tags=tags, count=1)
-        common.assert_common_device_metrics('snmp.devices_monitored', tags=tags + ['loader:python'], count=1, value=1)
+        common.assert_common_device_metrics(aggregator, tags=tags, count=1, devices_monitored_value=1)
         common.assert_common_metrics(aggregator, tags)
         aggregator.assert_all_metrics_covered()
 
@@ -794,7 +794,7 @@ def test_profile_sysoid_list(aggregator, caplog):
 
         assert 'No profile matching sysObjectID 1.3.6.1.4.1.9.1.1745' in caplog.text
         common.assert_common_device_metrics(
-            'snmp.devices_monitored', tags=common.CHECK_TAGS + ['loader:python'], count=1, value=1
+            tags=common.CHECK_TAGS + ['loader:python'], count=1, devices_monitored_value=1
         )
         common.assert_common_metrics(aggregator, common.CHECK_TAGS)
         aggregator.assert_all_metrics_covered()
@@ -978,7 +978,7 @@ def test_discovery_devices_monitored_count(read_mock, aggregator):
 
     for device_ip in ['192.168.0.1', '192.168.0.2']:
         tags = check_tags + ['snmp_device:{}'.format(device_ip)]
-        common.assert_common_device_metrics(aggregator, value=1, count=1, tags=tags)
+        common.assert_common_device_metrics(aggregator, devices_monitored_value=1, count=1, tags=tags)
 
     common.assert_common_check_run_metrics(aggregator, network_tags)
     aggregator.assert_all_metrics_covered()

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -46,7 +46,7 @@ def test_e2e_v1_with_apc_ups_profile(dd_agent_check):
         'upsAdvTestDiagnosticsResults',
     ]
 
-    common.assert_common_metrics(aggregator, tags, is_e2e=True)
+    common.assert_common_metrics(aggregator, tags, is_e2e=True, loader='core')
 
     for metric in metrics:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=2)

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -64,7 +64,7 @@ def test_e2e_v3_explicit_version(dd_agent_check):
     assert_python_vs_core(dd_agent_check, config, expected_total_count=489 + 5)
 
 
-def test_e2e_regex_match(dd_agent_check):
+def test_e2e_regex_match(dd_agent_check, aggregator):
     metrics = [
         {
             'MIB': "IF-MIB",
@@ -126,6 +126,7 @@ def test_e2e_regex_match(dd_agent_check):
     assert_python_vs_core(dd_agent_check, config)
 
     config['init_config']['loader'] = 'core'
+    aggregator.reset()
     aggregator = dd_agent_check(config, rate=True)
 
     # raw sysName: 41ba948911b9
@@ -136,6 +137,7 @@ def test_e2e_regex_match(dd_agent_check):
             'remainder:ba948911b9',
             'letter1:4',
             'letter2:1',
+            'loader:core',
             'snmp_device:' + instance['ip_address'],
         ],
     )


### PR DESCRIPTION
Require this PR + new master docker image for e2e: https://github.com/DataDog/datadog-agent/pull/7742
Demo Test PR based on snmp corecheck with loader tag: https://github.com/DataDog/integrations-core/pull/9039

### What does this PR do?

Add python loader tag

### Motivation

- Help comparing corecheck vs python performance
- Help knowing which loader/implementation is used (core or python)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
