### PR TITLE
Raise validation error if metadata.csv but no metric_to_check

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/all_validations.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/all_validations.py
@@ -53,7 +53,7 @@ IGNORE_DEFAULT_INSTANCE = {'ceph', 'dotnetclr', 'gunicorn', 'marathon', 'pgbounc
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Run all CI validations for a repo')
 @click.pass_context
-def all(ctx, check, sync, verbose):
+def all(ctx):
     """Run all CI validations for a repo."""
     repo_choice = ctx.obj['repo_choice']
     echo_info(f'Running validations for {repo_choice} repo ...')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -487,7 +487,7 @@ def manifest(ctx, fix):
                         # there are cases of metadata.csv files with just a header but no metrics
                         if row:
                             file_failures += 1
-                            display_queue.append((echo_failure, f'  metric_to_check not included in manifest.json'))
+                            display_queue.append((echo_failure, '  metric_to_check not included in manifest.json'))
                             break
 
             # support

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -479,6 +479,16 @@ def manifest(ctx, fix):
                     ):
                         file_failures += 1
                         display_queue.append((echo_failure, f'  metric_to_check not in metadata.csv: {metric!r}'))
+            elif metadata_in_manifest and check_name != 'snmp':
+                # if we have a metadata.csv file but no `metric_to_check` raise an error
+                metadata_file = get_metadata_file(check_name)
+                if os.path.isfile(metadata_file):
+                    for _, row in read_metadata_rows(metadata_file):
+                        # there are cases of metadata.csv files with just a header but no metrics
+                        if row:
+                            file_failures += 1
+                            display_queue.append((echo_failure, f'  metric_to_check not included in manifest.json'))
+                            break
 
             # support
             if is_extras:


### PR DESCRIPTION
Raises error if `metrics_to_check` is empty when the check actually reports metrics.

Includes fixes to 3 checks to pass validation.