### PR TITLE
Add RabbitMQ recommended monitors

### DIFF
--- a/rabbitmq/assets/monitors/disk_usage.json
+++ b/rabbitmq/assets/monitors/disk_usage.json
@@ -1,9 +1,8 @@
 {
-  "id": 0,
   "name": "[RabbitMQ] Level of disk usage is too high for host: {{host.name}} ",
   "type": "query alert",
   "query": "avg(last_5m):avg:rabbitmq.node.mem_used{*} by {host} / avg:system.mem.total{*} by {host} * 100 > 35",
-  "message": "RabbitMQ is using too many resources on host: {{host.name}}.  It may block connections and won't be able to perform many internal operations. ",
+  "message": "RabbitMQ is using too many resources on host: {{host.name}}.  It may block connections and won't be able to perform many internal operations.",
   "tags": [
     "integration:rabbitmq"
   ],

--- a/rabbitmq/assets/monitors/disk_usage.json
+++ b/rabbitmq/assets/monitors/disk_usage.json
@@ -1,0 +1,30 @@
+{
+  "id": 0,
+  "name": "[RabbitMQ] Level of disk usage is too high for host: {{host.name}} ",
+  "type": "metric alert",
+  "query": "avg(last_5m):avg:rabbitmq.node.mem_used{*} by {host} / avg:system.mem.total{*} by {host} * 100 > 35",
+  "message": "RabbitMQ is using too many resources on host: {{host.name}}.  It may block connections and won't be able to perform many internal operations. ",
+  "tags": [
+    "integration:rabbitmq"
+  ],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": "0",
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 35,
+      "warning": 30
+    }
+  },
+  "priority": null,
+  "recommended_monitor_metadata": {
+    "description": "Notify your team when a host's disk usage reaches critical levels."
+  }
+}

--- a/rabbitmq/assets/monitors/disk_usage.json
+++ b/rabbitmq/assets/monitors/disk_usage.json
@@ -1,7 +1,7 @@
 {
   "id": 0,
   "name": "[RabbitMQ] Level of disk usage is too high for host: {{host.name}} ",
-  "type": "metric alert",
+  "type": "query alert",
   "query": "avg(last_5m):avg:rabbitmq.node.mem_used{*} by {host} / avg:system.mem.total{*} by {host} * 100 > 35",
   "message": "RabbitMQ is using too many resources on host: {{host.name}}.  It may block connections and won't be able to perform many internal operations. ",
   "tags": [

--- a/rabbitmq/assets/monitors/message_unacknowledge_rate_anomaly.json
+++ b/rabbitmq/assets/monitors/message_unacknowledge_rate_anomaly.json
@@ -28,6 +28,6 @@
   },
   "priority": null,
   "recommended_monitor_metadata": {
-    "description": "Notify your team when a RabbitMQ queue's message unacknowledged rate is higher than usual."
+    "description": "Notify your team when a RabbitMQ message unacknowledged rate is higher than usual."
   }
 }

--- a/rabbitmq/assets/monitors/message_unacknowledge_rate_anomaly.json
+++ b/rabbitmq/assets/monitors/message_unacknowledge_rate_anomaly.json
@@ -1,7 +1,7 @@
 {
   "id": 0,
   "name": "[RabbitMQ] Messages unacknowledged rate is higher than usual on: {{rabbitmq_node.name}}",
-  "type": "metric alert",
+  "type": "query alert",
   "query": "avg(last_4h):anomalies(avg:rabbitmq.queue.messages_unacknowledged.rate{*} by {rabbitmq_queue}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='hourly') >= 1",
   "message": "The rate at which messages are being delivered without receiving acknowledgement is higher than usual.  It may block connections and won't be able to perform many internal operations. There may be errors or performance issues downstream.\n\nHost: {{host.name}}\nRabbitMQ Queue: {{rabbitmq_queue.name}} ",
   "tags": [

--- a/rabbitmq/assets/monitors/message_unacknowledge_rate_anomaly.json
+++ b/rabbitmq/assets/monitors/message_unacknowledge_rate_anomaly.json
@@ -1,9 +1,8 @@
 {
-  "id": 0,
-  "name": "[RabbitMQ] Messages unacknowledged rate is higher than usual on: {{rabbitmq_node.name}}",
+  "name": "[RabbitMQ] Messages unacknowledged rate is higher than usual on: {{host.name}}",
   "type": "query alert",
-  "query": "avg(last_4h):anomalies(avg:rabbitmq.queue.messages_unacknowledged.rate{*} by {rabbitmq_queue}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='hourly') >= 1",
-  "message": "The rate at which messages are being delivered without receiving acknowledgement is higher than usual.  It may block connections and won't be able to perform many internal operations. There may be errors or performance issues downstream.\n\nHost: {{host.name}}\nRabbitMQ Queue: {{rabbitmq_queue.name}} ",
+  "query": "avg(last_4h):anomalies(avg:rabbitmq.queue.messages_unacknowledged.rate{*} by {rabbitmq_queue,host}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='hourly') >= 1",
+  "message": "The rate at which messages are being delivered without receiving acknowledgement is higher than usual. There may be errors or performance issues downstream.\n\nHost: {{host.name}}\nRabbitMQ Queue: {{rabbitmq_queue.name}}",
   "tags": [
     "integration:rabbitmq"
   ],

--- a/rabbitmq/assets/monitors/message_unacknowledge_rate_anomaly.json
+++ b/rabbitmq/assets/monitors/message_unacknowledge_rate_anomaly.json
@@ -1,0 +1,34 @@
+{
+  "id": 0,
+  "name": "[RabbitMQ] Messages unacknowledged rate is higher than usual on: {{rabbitmq_node.name}}",
+  "type": "metric alert",
+  "query": "avg(last_4h):anomalies(avg:rabbitmq.queue.messages_unacknowledged.rate{*} by {rabbitmq_queue}, 'agile', 2, direction='above', alert_window='last_15m', interval=60, count_default_zero='true', seasonality='hourly') >= 1",
+  "message": "The rate at which messages are being delivered without receiving acknowledgement is higher than usual.  It may block connections and won't be able to perform many internal operations. There may be errors or performance issues downstream.\n\nHost: {{host.name}}\nRabbitMQ Queue: {{rabbitmq_queue.name}} ",
+  "tags": [
+    "integration:rabbitmq"
+  ],
+  "options": {
+    "notify_audit": false,
+    "locked": false,
+    "timeout_h": 0,
+    "new_host_delay": 300,
+    "require_full_window": true,
+    "notify_no_data": false,
+    "renotify_interval": "0",
+    "escalation_message": "",
+    "no_data_timeframe": null,
+    "include_tags": true,
+    "thresholds": {
+      "critical": 1,
+      "critical_recovery": 0
+    },
+    "threshold_windows": {
+      "trigger_window": "last_15m",
+      "recovery_window": "last_15m"
+    }
+  },
+  "priority": null,
+  "recommended_monitor_metadata": {
+    "description": "Notify your team when a RabbitMQ queue's message unacknowledged rate is higher than usual."
+  }
+}

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -30,7 +30,9 @@
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
-    "monitors": {},
+    "monitors": {
+      "disk_usage": "assets/monitors/disk_usage.json"
+    },
     "dashboards": {
       "rabbitmq_screenboard": "assets/dashboards/rabbitmq_screenboard_dashboard.json",
       "rabbitmq": "assets/dashboards/rabbitmq_dashboard.json"

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -31,7 +31,8 @@
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {
-      "disk_usage": "assets/monitors/disk_usage.json"
+      "disk_usage": "assets/monitors/disk_usage.json",
+      "message_unacknowledge_rate_anomaly": "assets/monitors/message_unacknowledge_rate_anomaly.json"
     },
     "dashboards": {
       "rabbitmq_screenboard": "assets/dashboards/rabbitmq_screenboard_dashboard.json",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add 2 recommended monitors for RabbitMQ, based on [Monitoring RabbitMQ performance with Datadog](https://www.datadoghq.com/blog/monitoring-rabbitmq-performance-with-datadog/) and [Key metrics for RabbitMQ monitoring](https://www.datadoghq.com/blog/rabbitmq-monitoring/#nodes) blogs.

Staging seems to be broken for collection of metrics, so clicking on the tiles will not render properly. https://dd.datad0g.com/monitors#recommended?q=integration:RabbitMQ&p=1

- Abnormal `message_unacknowledge` rate -- [dddev link](https://dddev.datadoghq.com/monitors/32884265)
- High level of `disk_usage` -- [dddev link](https://dddev.datadoghq.com/monitors/32883966)

### Motivation
<!-- What inspired you to submit this pull request? -->
Recommended monitors coverage

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
