### PR TITLE
haproxy: update haproxy versions used for tests

### DIFF
--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -2,8 +2,8 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{16,17,18,20,21}-legacy
-    py{27,38}-{20,21,22,23,24}
+    py{27,38}-{17,18,20}-legacy
+    py{27,38}-{20,22,23,24}
 
 [testenv]
 ensure_default_envdir = true
@@ -24,14 +24,12 @@ deps =
 setenv =
   HAPROXY_LEGACY=false
   legacy: HAPROXY_LEGACY=true
-  16: HAPROXY_VERSION=1.6.15
-  17: HAPROXY_VERSION=1.7.12
-  18: HAPROXY_VERSION=1.8.27
-  20: HAPROXY_VERSION=2.0.20
-  21: HAPROXY_VERSION=2.1.11
-  22: HAPROXY_VERSION=2.2.9
-  23: HAPROXY_VERSION=2.3.5
-  24: HAPROXY_VERSION=2.4-dev10
+  17: HAPROXY_VERSION=1.7.13
+  18: HAPROXY_VERSION=1.8.29
+  20: HAPROXY_VERSION=2.0.21
+  22: HAPROXY_VERSION=2.2.11
+  23: HAPROXY_VERSION=2.3.8
+  24: HAPROXY_VERSION=2.4-dev13
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?

removing: 1.6 and 2.1 support, they are no longer supported, see also
http://www.haproxy.org/

updating minors: 1.7, 1.8, 2.0, 2.2, 2.3, 2.4

### Motivation

keep tests up to date

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
