### PR TITLE
redisdb: correct default ssl_cert_reqs

### DIFF
--- a/redisdb/assets/configuration/spec.yaml
+++ b/redisdb/assets/configuration/spec.yaml
@@ -84,7 +84,7 @@ files:
           * 2 for ssl.CERT_REQUIRED (required and validated)
       value:
         type: integer
-        example: 0
+        example: 2
     - name: keys
       description: |
         Enter the list of keys to collect the lengths from.

--- a/redisdb/datadog_checks/redisdb/data/conf.yaml.example
+++ b/redisdb/datadog_checks/redisdb/data/conf.yaml.example
@@ -77,14 +77,14 @@ instances:
     #
     # ssl_ca_certs: <CERT_PATH>
 
-    ## @param ssl_cert_reqs - integer - optional - default: 0
+    ## @param ssl_cert_reqs - integer - optional - default: 2
     ## Specifies whether a certificate is required from the
     ## other side of the connection, and whether it's validated if provided.
     ##   * 0 for ssl.CERT_NONE (certificates ignored)
     ##   * 1 for ssl.CERT_OPTIONAL (not required, but validated if provided)
     ##   * 2 for ssl.CERT_REQUIRED (required and validated)
     #
-    # ssl_cert_reqs: 0
+    # ssl_cert_reqs: 2
 
     ## @param keys - list of strings - optional
     ## Enter the list of keys to collect the lengths from.


### PR DESCRIPTION
### What does this PR do?

Fixes the config.yaml documentation to correctly show that the default when not specifying `ssl_cert_reqs` is 2 (require)

### Motivation

I was getting SSL errors that I didn't expect when adding a configuration for redis on Heroku, since Heroku requires you not verify the self-signed certificates they use for Redis. After some digging, I realized that the actual default for `ssl_cert_reqs` is to require them: https://redis-py.readthedocs.io/en/stable/#redis.Redis

### Additional Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
