### PR TITLE
Fix autodiscovery tagging

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -345,6 +345,8 @@ class SQLServer(AgentCheck):
                 self.instance_per_type_metrics[cls].append(m.base_name)
 
     def _add_performance_counters(self, metrics, metrics_to_collect, tags, db=None):
+        if db is not None:
+            tags = tags + ['database:{}'.format(db)]
         for name, counter_name, instance_name in metrics:
             try:
                 sql_type, base_name = self.get_sql_type(counter_name)

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -223,6 +223,40 @@ def test_autodiscovery_database_metrics(aggregator, dd_run_check, instance_autod
 @not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
+def test_autodiscovery_perf_counters(aggregator, dd_run_check, instance_autodiscovery):
+    instance_autodiscovery['autodiscovery_include'] = ['master', 'msdb']
+    check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
+    dd_run_check(check)
+
+    expected_metrics = [
+        'sqlserver.database.backup_restore_throughput',
+        'sqlserver.database.log_bytes_flushed',
+        'sqlserver.database.log_flushes',
+        'sqlserver.database.log_flush_wait',
+        'sqlserver.database.transactions',
+        'sqlserver.database.write_transactions',
+        'sqlserver.database.active_transactions'
+    ]
+    master_tags = [
+        'database:master',
+        'optional:tag1',
+    ]
+    msdb_tags = [
+        'database:msdb',
+        'optional:tag1',
+    ]
+    base_tags = [
+        'optional:tag1'
+    ]
+    for metric in expected_metrics:
+        aggregator.assert_metric(metric, tags=master_tags)
+        aggregator.assert_metric(metric, tags=msdb_tags)
+        aggregator.assert_metric(metric, tags=base_tags)
+
+
+@not_windows_ci
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 def test_custom_queries(aggregator, dd_run_check, instance_docker):
     instance = copy(instance_docker)
     querya = copy(CUSTOM_QUERY_A)


### PR DESCRIPTION
Support for auto-discovering databases in the sqlserver integration was introduced in this PR: https://github.com/DataDog/integrations-core/pull/8115/s

But a bug was found with performance counter metrics, the `database` tag was not attached leading to multiple metrics sharing the same context and overriding each other.