### PR TITLE
Update defaults for legacy OpenMetrics config spec template

### DIFF
--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -60,14 +60,14 @@ instances:
     tags:
       - dns-pod:%%host%%
 
-    ## @param metrics - list of strings - required
+    ## @param metrics - list of strings - optional
     ## List of metrics to be fetched from the prometheus endpoint, if there's a
     ## value it'll be renamed. This list should contain at least one metric.
     #
-    metrics:
-      - coredns_template_matches_total: template_matches_count
-      - coredns_template_template_failures_total: template_templating_failures_count
-      - coredns_template_rr_failures_total: template_resource_record_failures_count
+    # metrics:
+    #   - coredns_template_matches_total: template_matches_count
+    #   - coredns_template_template_failures_total: template_templating_failures_count
+    #   - coredns_template_rr_failures_total: template_resource_record_failures_count
 
     ## @param prometheus_metrics_prefix - string - optional
     ## Removes a given <PREFIX> from exposed Prometheus metrics.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy.yaml
@@ -4,14 +4,12 @@
   value:
     type: string
 - name: namespace
-  required: true
   hidden: true
   description: The namespace to be prepended to all metrics.
   value:
     type: string
     example: service
 - name: metrics
-  required: true
   hidden: true
   description: |
     List of metrics to be fetched from the prometheus endpoint, if there's a

--- a/istio/datadog_checks/istio/config_models/defaults.py
+++ b/istio/datadog_checks/istio/config_models/defaults.py
@@ -140,12 +140,20 @@ def instance_log_requests(field, value):
     return False
 
 
+def instance_metrics(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_min_collection_interval(field, value):
     return 15
 
 
 def instance_mixer_endpoint(field, value):
     return 'http://istio-telemetry.istio-system:15014/metrics'
+
+
+def instance_namespace(field, value):
+    return 'service'
 
 
 def instance_ntlm_domain(field, value):

--- a/istio/datadog_checks/istio/config_models/instance.py
+++ b/istio/datadog_checks/istio/config_models/instance.py
@@ -87,10 +87,10 @@ class InstanceConfig(BaseModel):
     label_to_hostname: Optional[str]
     labels_mapper: Optional[Mapping[str, Any]]
     log_requests: Optional[bool]
-    metrics: Sequence[str]
+    metrics: Optional[Sequence[str]]
     min_collection_interval: Optional[float]
     mixer_endpoint: Optional[str]
-    namespace: str
+    namespace: Optional[str]
     ntlm_domain: Optional[str]
     password: Optional[str]
     persist_connections: Optional[bool]

--- a/openmetrics/assets/configuration/spec.yaml
+++ b/openmetrics/assets/configuration/spec.yaml
@@ -9,5 +9,7 @@ files:
       options:
         - template: instances/openmetrics_legacy
           overrides:
+            namespace.required: true
             namespace.hidden: false
+            metrics.required: true
             metrics.hidden: false


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/integrations-core/pull/8883#discussion_r604652583

Integrations set `metrics` and `namespace` themselves