### PR TITLE
Add log support for Twemproxy

### DIFF
--- a/twemproxy/README.md
+++ b/twemproxy/README.md
@@ -47,6 +47,31 @@ For containerized environments, see the [Autodiscovery Integration Templates][1]
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
 
+##### Log collection
+
+1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
+
+   ```yaml
+   logs_enabled: true
+   ```
+
+2. Add this configuration block to your `twemproxy.d/conf.yaml` file to start collecting your Apache Logs:
+
+   ```yaml
+   logs:
+     - type: file
+       path: "<LOG_FILE_PATH>"
+       source: twemproxy
+       service: "<SERVICE_NAME>"
+   ```
+
+    Change the `path` and `service` parameter values and configure them for your environment. See the [sample twemproxy.d/conf.yaml][4] for all available configuration options.
+   
+3. [Restart the Agent][5].
+
+See [Datadog's documentation][9] for additional information on how to configure the Agent for log collection in Kubernetes environments.
+
+
 ### Validation
 
 [Run the Agent's `status` subcommand][6] and look for `twemproxy` under the Checks section.
@@ -78,3 +103,4 @@ Need help? Contact [Datadog support][8].
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [7]: https://github.com/DataDog/integrations-core/blob/master/twemproxy/metadata.csv
 [8]: https://docs.datadoghq.com/help/
+[9]: https://docs.datadoghq.com/agent/kubernetes/log/

--- a/twemproxy/README.md
+++ b/twemproxy/README.md
@@ -77,10 +77,6 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
 
-
-See [Datadog's documentation][9] for additional information on how to configure the Agent for log collection in Kubernetes environments.
-
-
 ### Validation
 
 [Run the Agent's `status` subcommand][6] and look for `twemproxy` under the Checks section.

--- a/twemproxy/README.md
+++ b/twemproxy/README.md
@@ -31,9 +31,6 @@ To configure this check for an Agent running on a host:
 
 2. [Restart the Agent][5] to begin sending Twemproxy metrics to Datadog.
 
-<!-- xxz tab xxx -->
-<!-- xxx tab "Containerized" xxx -->
-
 ##### Log collection
 
 1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
@@ -55,6 +52,9 @@ To configure this check for an Agent running on a host:
     Change the `path` and `service` parameter values and configure them for your environment. See the [sample twemproxy.d/conf.yaml][4] for all available configuration options.
    
 3. [Restart the Agent][5].
+
+<!-- xxz tab xxx -->
+<!-- xxx tab "Containerized" xxx -->
 
 #### Containerized
 

--- a/twemproxy/README.md
+++ b/twemproxy/README.md
@@ -34,19 +34,6 @@ To configure this check for an Agent running on a host:
 <!-- xxz tab xxx -->
 <!-- xxx tab "Containerized" xxx -->
 
-#### Containerized
-
-For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying the parameters below.
-
-| Parameter            | Value                                  |
-| -------------------- | -------------------------------------- |
-| `<INTEGRATION_NAME>` | `twemproxy`                            |
-| `<INIT_CONFIG>`      | blank or `{}`                          |
-| `<INSTANCE_CONFIG>`  | `{"host": "%%host%%", "port":"22222"}` |
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
-
 ##### Log collection
 
 1. Collecting logs is disabled by default in the Datadog Agent, you need to enable it in `datadog.yaml`:
@@ -68,6 +55,28 @@ For containerized environments, see the [Autodiscovery Integration Templates][1]
     Change the `path` and `service` parameter values and configure them for your environment. See the [sample twemproxy.d/conf.yaml][4] for all available configuration options.
    
 3. [Restart the Agent][5].
+
+#### Containerized
+
+For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying the parameters below.
+
+| Parameter            | Value                                  |
+| -------------------- | -------------------------------------- |
+| `<INTEGRATION_NAME>` | `twemproxy`                            |
+| `<INIT_CONFIG>`      | blank or `{}`                          |
+| `<INSTANCE_CONFIG>`  | `{"host": "%%host%%", "port":"22222"}` |
+
+##### Log collection
+
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes log collection documentation][9].
+
+| Parameter      | Value                                            |
+| -------------- | ------------------------------------------------ |
+| `<LOG_CONFIG>` | `{"source": "twemproxy", "service": "<SERVICE_NAME>"}` |
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
+
 
 See [Datadog's documentation][9] for additional information on how to configure the Agent for log collection in Kubernetes environments.
 

--- a/twemproxy/assets/configuration/spec.yaml
+++ b/twemproxy/assets/configuration/spec.yaml
@@ -20,3 +20,8 @@ files:
         example: 22222
         type: integer
     - template: instances/default
+  - template: logs
+    example:
+      - type: file
+        path: var/log/twemproxy/*.log
+        source: twemproxy

--- a/twemproxy/datadog_checks/twemproxy/data/conf.yaml.example
+++ b/twemproxy/datadog_checks/twemproxy/data/conf.yaml.example
@@ -51,3 +51,23 @@ instances:
     ## This is useful for cluster-level checks.
     #
     # empty_default_hostname: false
+
+## Log Section
+##
+## type - required - Type of log input source (tcp / udp / file / windows_event)
+## port / path / channel_path - required - Set port if type is tcp or udp.
+##                                         Set path if type is file.
+##                                         Set channel_path if type is windows_event.
+## source  - required - Attribute that defines which Integration sent the logs.
+## encoding - optional - For file specifies the file encoding, default is utf-8, other
+##                       possible values are utf-16-le and utf-16-be.
+## service - optional - The name of the service that generates the log.
+##                      Overrides any `service` defined in the `init_config` section.
+## tags - optional - Add tags to the collected logs.
+##
+## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
+#
+# logs:
+#   - type: file
+#     path: var/log/twemproxy/*.log
+#     source: twemproxy

--- a/twemproxy/manifest.json
+++ b/twemproxy/manifest.json
@@ -1,7 +1,8 @@
 {
   "categories": [
     "web",
-    "autodiscovery"
+    "autodiscovery",
+    "log collection"
   ],
   "creates_events": false,
   "display_name": "Twemproxy",
@@ -29,7 +30,9 @@
     "monitors": {},
     "dashboards": {},
     "service_checks": "assets/service_checks.json",
-    "logs": {},
+    "logs": {
+      "source": "twemproxy"
+    },
     "metrics_metadata": "metadata.csv"
   }
 }

--- a/twemproxy/tests/compose/docker-compose.yaml
+++ b/twemproxy/tests/compose/docker-compose.yaml
@@ -44,3 +44,5 @@ services:
       - ETCD_HOST=etcd0:4001
     depends_on:
       - etcd0
+    volumes:
+      - ${DD_LOG_1}:/var/log/twemproxy/stderr.log

--- a/twemproxy/tests/conftest.py
+++ b/twemproxy/tests/conftest.py
@@ -26,7 +26,7 @@ def dd_environment():
     up.
     """
     with docker_run(common.COMPOSE_FILE, service_name="etcd0", conditions=[setup_post_data]):
-        with docker_run(common.COMPOSE_FILE, log_patterns="twemproxy entered RUNNING state"):
+        with docker_run(common.COMPOSE_FILE, log_patterns="twemproxy entered RUNNING state", mount_logs=True):
             yield common.INSTANCE
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Add Twemproxy log documentation
- Update docker configuration to allow logs to be sent via our e2e env. 

web-ui PR: Datadog/web-ui#30664
logs-backend: DataDog/logs-backend#18527
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
