### PR TITLE
Add a boolean to send certificate duration

### DIFF
--- a/tls/assets/configuration/spec.yaml
+++ b/tls/assets/configuration/spec.yaml
@@ -85,6 +85,14 @@ files:
       value:
         example: false
         type: boolean
+    - name: send_cert_duration
+      description: |
+        Whether or not to send the days or seconds of a certificates valid duration.
+
+        If enabled this will send the duration of the certificates valid timespan in days and seconds.
+      value:
+        example: false
+        type: boolean
     - name: intermediate_cert_refresh_interval
       description: |
         When `fetch_intermediate_certs` is set to `true`, this indicates how often to

--- a/tls/assets/configuration/spec.yaml
+++ b/tls/assets/configuration/spec.yaml
@@ -87,9 +87,7 @@ files:
         type: boolean
     - name: send_cert_duration
       description: |
-        Whether or not to send the days or seconds of a certificates valid duration.
-
-        If enabled this will send the duration of the certificates valid timespan in days and seconds.
+        Whether or not to send the certificate's valid issue duration as `tls.issued_days` and `tls.issued_seconds`.
       value:
         example: false
         type: boolean

--- a/tls/datadog_checks/tls/data/conf.yaml.example
+++ b/tls/datadog_checks/tls/data/conf.yaml.example
@@ -82,6 +82,13 @@ instances:
     #
     # fetch_intermediate_certs: false
 
+    ## @param send_cert_duration - boolean - optional - default: false
+    ## Whether or not to send the days or seconds of a certificates valid duration.
+    ##
+    ## If enabled this will send the duration of the certificates valid timespan in days and seconds.
+    #
+    # send_cert_duration: false
+
     ## @param intermediate_cert_refresh_interval - number - optional - default: 60
     ## When `fetch_intermediate_certs` is set to `true`, this indicates how often to
     ## refresh the intermediate certificate cache in minutes.

--- a/tls/datadog_checks/tls/data/conf.yaml.example
+++ b/tls/datadog_checks/tls/data/conf.yaml.example
@@ -83,9 +83,7 @@ instances:
     # fetch_intermediate_certs: false
 
     ## @param send_cert_duration - boolean - optional - default: false
-    ## Whether or not to send the days or seconds of a certificates valid duration.
-    ##
-    ## If enabled this will send the duration of the certificates valid timespan in days and seconds.
+    ## Whether or not to send the certificate's valid issue duration as `tls.issued_days` and `tls.issued_seconds`.
     #
     # send_cert_duration: false
 

--- a/tls/metadata.csv
+++ b/tls/metadata.csv
@@ -1,5 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 tls.days_left,gauge,,day,,Days until X.509 certificate expiration,1,tls,Days until expiration
 tls.seconds_left,gauge,,second,,Seconds until X.509 certificate expiration,1,tls,Seconds until expiration
-tls.issued_days,count,,day,Day duration of timespan certificate is issued for,1,tls,Certificate duration in days
-tls.issued_seconds,count,,seconds,Second duration of timespan certificate is issued for,1,tls,Certificate duration in seconds
+tls.issued_days,count,,day,,Day duration of timespan certificate is issued for,1,tls,Certificate duration in days
+tls.issued_seconds,count,,seconds,,Second duration of timespan certificate is issued for,1,tls,Certificate duration in seconds

--- a/tls/metadata.csv
+++ b/tls/metadata.csv
@@ -1,3 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 tls.days_left,gauge,,day,,Days until X.509 certificate expiration,1,tls,Days until expiration
 tls.seconds_left,gauge,,second,,Seconds until X.509 certificate expiration,1,tls,Seconds until expiration
+tls.issued_days,count,,day,Day duration of timespan certificate is issued for,1,tls,Certificate duration in days
+tls.issued_seconds,count,,seconds,Second duration of timespan certificate is issued for,1,tls,Certificate duration in seconds

--- a/tls/metadata.csv
+++ b/tls/metadata.csv
@@ -2,4 +2,4 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 tls.days_left,gauge,,day,,Days until X.509 certificate expiration,1,tls,Days until expiration
 tls.seconds_left,gauge,,second,,Seconds until X.509 certificate expiration,1,tls,Seconds until expiration
 tls.issued_days,count,,day,,Day duration of timespan certificate is issued for,1,tls,Certificate duration in days
-tls.issued_seconds,count,,seconds,,Second duration of timespan certificate is issued for,1,tls,Certificate duration in seconds
+tls.issued_seconds,count,,second,,Second duration of timespan certificate is issued for,1,tls,Certificate duration in seconds

--- a/tls/tests/conftest.py
+++ b/tls/tests/conftest.py
@@ -104,6 +104,11 @@ def instance_local_cert_expired(certs):
     yield {'local_cert_path': certs['expired.pem'], 'tls_validate_hostname': False}
 
 
+@pytest.fixture
+def instance_local_send_cert_duration(certs):
+    yield {'local_cert_path': certs['valid.pem'], 'tls_validate_hostname': False, 'send_cert_duration': True}
+
+
 @pytest.fixture(scope='session')
 def instance_local_cert_critical_days(certs):
     yield {'local_cert_path': certs['valid.pem'], 'tls_validate_hostname': False, 'days_critical': 200}
@@ -212,6 +217,11 @@ def instance_remote_cert_expired():
 @pytest.fixture
 def instance_remote_fetch_intermediate_certs():
     return {'server': 'incomplete-chain.badssl.com', 'fetch_intermediate_certs': True}
+
+
+@pytest.fixture
+def instance_remote_send_cert_duration():
+    return {'server': 'https://valid.mock', 'send_cert_duration': True, 'tls_ca_cert': CA_CERT}
 
 
 @pytest.fixture

--- a/tls/tests/test_local.py
+++ b/tls/tests/test_local.py
@@ -120,6 +120,22 @@ def test_cert_expired(aggregator, instance_local_cert_expired):
     aggregator.assert_all_metrics_covered()
 
 
+def test_cert_send_cert_duration(aggregator, instance_local_send_cert_duration):
+    c = TLSCheck('tls', {}, [instance_local_send_cert_duration])
+    c.check(None)
+
+    aggregator.assert_service_check(SERVICE_CHECK_CAN_CONNECT, count=0)
+    aggregator.assert_service_check(SERVICE_CHECK_VERSION, count=0)
+    aggregator.assert_service_check(SERVICE_CHECK_VALIDATION, status=c.OK, tags=c._tags, count=1)
+    aggregator.assert_service_check(SERVICE_CHECK_EXPIRATION, status=c.OK, tags=c._tags, count=1)
+
+    aggregator.assert_metric('tls.days_left', count=1)
+    aggregator.assert_metric('tls.seconds_left', count=1)
+    aggregator.assert_metric('tls.issued_days', count=1)
+    aggregator.assert_metric('tls.issued_seconds', count=1)
+    aggregator.assert_all_metrics_covered()
+
+
 def test_cert_critical_days(aggregator, instance_local_cert_critical_days):
     c = TLSCheck('tls', {}, [instance_local_cert_critical_days])
     c.check(None)

--- a/tls/tests/test_remote.py
+++ b/tls/tests/test_remote.py
@@ -250,6 +250,22 @@ def test_fetch_intermediate_certs(aggregator, instance_remote_fetch_intermediate
     aggregator.assert_all_metrics_covered()
 
 
+def test_cert_send_cert_duration(aggregator, instance_remote_send_cert_duration):
+    c = TLSCheck('tls', {}, [instance_remote_send_cert_duration])
+    c.check(None)
+
+    aggregator.assert_service_check(SERVICE_CHECK_CAN_CONNECT, status=c.OK, tags=c._tags, count=1)
+    aggregator.assert_service_check(SERVICE_CHECK_VERSION, status=c.OK, tags=c._tags, count=1)
+    aggregator.assert_service_check(SERVICE_CHECK_VALIDATION, status=c.OK, tags=c._tags, count=1)
+    aggregator.assert_service_check(SERVICE_CHECK_EXPIRATION, status=c.OK, tags=c._tags, count=1)
+
+    aggregator.assert_metric('tls.days_left', count=1)
+    aggregator.assert_metric('tls.seconds_left', count=1)
+    aggregator.assert_metric('tls.issued_days', count=1)
+    aggregator.assert_metric('tls.issued_seconds', count=1)
+    aggregator.assert_all_metrics_covered()
+
+
 def test_cert_critical_days(aggregator, instance_remote_cert_critical_days):
     c = TLSCheck('tls', {}, [instance_remote_cert_critical_days])
     c.check(None)


### PR DESCRIPTION
### What does this PR do?
This adds a boolean to the TLS integration to send certificates duration as a metric. 

### Motivation
In order to successfully monitor  certificates expiration it is helpful to compare the certificates expiration in days/seconds against the actual length of time the certificate is issued for. This would allow for percentage based monitoring rather than time based ones. 


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
