### PR TITLE
Add rest_api_options to expose all RequestsWrapper options

### DIFF
--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -5,6 +5,10 @@ files:
   - template: init_config
     options:
     - template: init_config/default
+    - name: rest_api_options
+      description: REST API options
+      options:
+        - template: init_config/http
   - template: instances
     options:
       - name: host
@@ -421,6 +425,10 @@ files:
         value:
           type: boolean
           example: true
+      - name: rest_api_options
+        description: REST API options
+        options:
+          - template: instances/http
       - template: instances/default
         overrides:
           empty_default_hostname.display_priority: 1

--- a/vsphere/assets/configuration/spec.yaml
+++ b/vsphere/assets/configuration/spec.yaml
@@ -6,7 +6,10 @@ files:
     options:
     - template: init_config/default
     - name: rest_api_options
-      description: REST API options
+      description: |
+        REST API options
+        Those options are used when making vSphere REST API calls to retrieve vSphere tags
+        when `collect_tags` instance config is enabled.
       options:
         - template: init_config/http
   - template: instances
@@ -426,7 +429,10 @@ files:
           type: boolean
           example: true
       - name: rest_api_options
-        description: REST API options
+        description: |
+          REST API options
+          The options are used when making vSphere REST API calls to retrieve vSphere tags
+          when `collect_tags` instance config is enabled.
         options:
           - template: instances/http
       - template: instances/default

--- a/vsphere/datadog_checks/vsphere/api_rest.py
+++ b/vsphere/datadog_checks/vsphere/api_rest.py
@@ -147,8 +147,9 @@ class VSphereRestClient(object):
             'tls_verify': config.ssl_verify,
             'tls_ignore_warning': config.tls_ignore_warning,
         }
+        http_config.update(config.rest_api_options)
         self._api_base_url = "https://{}/rest/com/vmware/cis/".format(config.hostname)
-        self._http = RequestsWrapper(http_config, {})
+        self._http = RequestsWrapper(http_config, config.shared_rest_api_options)
 
     def connect_session(self):
         # type: () -> None

--- a/vsphere/datadog_checks/vsphere/api_rest.py
+++ b/vsphere/datadog_checks/vsphere/api_rest.py
@@ -140,16 +140,8 @@ class VSphereRestClient(object):
     def __init__(self, config, log):
         # type: (VSphereConfig, CheckLoggingAdapter) -> None
         self.log = log
-        http_config = {
-            'username': config.username,
-            'password': config.password,
-            'tls_ca_cert': config.ssl_capath,
-            'tls_verify': config.ssl_verify,
-            'tls_ignore_warning': config.tls_ignore_warning,
-        }
-        http_config.update(config.rest_api_options)
         self._api_base_url = "https://{}/rest/com/vmware/cis/".format(config.hostname)
-        self._http = RequestsWrapper(http_config, config.shared_rest_api_options)
+        self._http = RequestsWrapper(config.rest_api_options, config.shared_rest_api_options)
 
     def connect_session(self):
         # type: () -> None

--- a/vsphere/datadog_checks/vsphere/config.py
+++ b/vsphere/datadog_checks/vsphere/config.py
@@ -1,11 +1,12 @@
 import re
-from typing import List
+from typing import Any, Dict, List
 
 from pyVmomi import vim
 from six import iteritems, string_types
 
 from datadog_checks.base import ConfigurationError, is_affirmative
 from datadog_checks.base.log import CheckLoggingAdapter
+from datadog_checks.base.types import InitConfigType
 from datadog_checks.vsphere.constants import (
     ALLOWED_FILTER_PROPERTIES,
     ALLOWED_FILTER_TYPES,
@@ -28,8 +29,8 @@ from datadog_checks.vsphere.types import InstanceConfig, MetricFilterConfig, Met
 
 
 class VSphereConfig(object):
-    def __init__(self, instance, log):
-        # type: (InstanceConfig, CheckLoggingAdapter) -> None
+    def __init__(self, instance, init_config, log):
+        # type: (InstanceConfig, InitConfigType, CheckLoggingAdapter) -> None
         self.log = log
 
         # Connection parameters
@@ -39,6 +40,8 @@ class VSphereConfig(object):
         self.ssl_verify = is_affirmative(instance.get('ssl_verify', True))
         self.ssl_capath = instance.get('ssl_capath')
         self.tls_ignore_warning = instance.get('tls_ignore_warning', False)
+        self.rest_api_options = instance.get('rest_api_options', {})  # type: Dict[str, Any]
+        self.shared_rest_api_options = init_config.get('rest_api_options', {})  # type: Dict[str, Any]
 
         # vSphere options
         self.collection_level = instance.get("collection_level", 1)

--- a/vsphere/datadog_checks/vsphere/config.py
+++ b/vsphere/datadog_checks/vsphere/config.py
@@ -40,7 +40,15 @@ class VSphereConfig(object):
         self.ssl_verify = is_affirmative(instance.get('ssl_verify', True))
         self.ssl_capath = instance.get('ssl_capath')
         self.tls_ignore_warning = instance.get('tls_ignore_warning', False)
-        self.rest_api_options = instance.get('rest_api_options', {})  # type: Dict[str, Any]
+
+        self.rest_api_options = {
+            'username': self.username,
+            'password': self.password,
+            'tls_ca_cert': self.ssl_capath,
+            'tls_verify': self.ssl_verify,
+            'tls_ignore_warning': self.tls_ignore_warning,
+        }
+        self.rest_api_options.update(instance.get('rest_api_options', {}))
         self.shared_rest_api_options = init_config.get('rest_api_options', {})  # type: Dict[str, Any]
 
         # vSphere options

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -9,6 +9,42 @@ init_config:
     #
     # service: <SERVICE>
 
+    ## REST API options
+    #
+    rest_api_options:
+
+        ## @param proxy - mapping - optional
+        ## Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
+        ## to specify hosts that must bypass proxies.
+        ##
+        ## The SOCKS protocol is also supported like so:
+        ##
+        ##   socks5://user:pass@host:port
+        ##
+        ## Using the scheme `socks5` causes the DNS resolution to happen on the
+        ## client, rather than on the proxy server. This is in line with `curl`,
+        ## which uses the scheme to decide whether to do the DNS resolution on
+        ## the client or proxy. If you want to resolve the domains on the proxy
+        ## server, use `socks5h` as the scheme.
+        #
+        # proxy:
+        #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+        #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+        #   no_proxy:
+        #   - <HOSTNAME_1>
+        #   - <HOSTNAME_2>
+
+        ## @param skip_proxy - boolean - optional - default: false
+        ## If set to `true`, this makes the check bypass any proxy
+        ## settings enabled and attempt to reach services directly.
+        #
+        # skip_proxy: false
+
+        ## @param timeout - number - optional - default: 10
+        ## The timeout for connecting to services.
+        #
+        # timeout: 10
+
 ## Every instance is scheduled independent of the others.
 #
 instances:
@@ -340,6 +376,288 @@ instances:
     ## The default value is true.
     #
     # include_datastore_cluster_folder_tag: true
+
+    ## REST API options
+    #
+    rest_api_options:
+
+        ## @param proxy - mapping - optional
+        ## This overrides the `proxy` setting in `init_config`.
+        ##
+        ## Set HTTP or HTTPS proxies for this instance. Use the `no_proxy` list
+        ## to specify hosts that must bypass proxies.
+        ##
+        ## The SOCKS protocol is also supported, for example:
+        ##
+        ##   socks5://user:pass@host:port
+        ##
+        ## Using the scheme `socks5` causes the DNS resolution to happen on the
+        ## client, rather than on the proxy server. This is in line with `curl`,
+        ## which uses the scheme to decide whether to do the DNS resolution on
+        ## the client or proxy. If you want to resolve the domains on the proxy
+        ## server, use `socks5h` as the scheme.
+        #
+        # proxy:
+        #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+        #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+        #   no_proxy:
+        #   - <HOSTNAME_1>
+        #   - <HOSTNAME_2>
+
+        ## @param skip_proxy - boolean - optional - default: false
+        ## This overrides the `skip_proxy` setting in `init_config`.
+        ##
+        ## If set to `true`, this makes the check bypass any proxy
+        ## settings enabled and attempt to reach services directly.
+        #
+        # skip_proxy: false
+
+        ## @param auth_type - string - optional - default: basic
+        ## The type of authentication to use. The available types (and related options) are:
+        ##
+        ##   - basic
+        ##     |__ username
+        ##     |__ password
+        ##     |__ use_legacy_auth_encoding
+        ##   - digest
+        ##     |__ username
+        ##     |__ password
+        ##   - ntlm
+        ##     |__ ntlm_domain
+        ##     |__ password
+        ##   - kerberos
+        ##     |__ kerberos_auth
+        ##     |__ kerberos_cache
+        ##     |__ kerberos_delegate
+        ##     |__ kerberos_force_initiate
+        ##     |__ kerberos_hostname
+        ##     |__ kerberos_keytab
+        ##     |__ kerberos_principal
+        ##   - aws
+        ##     |__ aws_region
+        ##     |__ aws_host
+        ##     |__ aws_service
+        ##
+        ## The `aws` auth type relies on boto3 to automatically gather AWS credentials, for example: from `.aws/credentials`.
+        ## Details: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials
+        #
+        # auth_type: basic
+
+        ## @param use_legacy_auth_encoding - boolean - optional - default: true
+        ## When `auth_type` is set to `basic`, this determines whether to encode as `latin1` rather than `utf-8`.
+        #
+        # use_legacy_auth_encoding: true
+
+        ## @param username - string - optional
+        ## The username to use if services are behind basic or digest auth.
+        #
+        # username: <USERNAME>
+
+        ## @param password - string - optional
+        ## The password to use if services are behind basic or NTLM auth.
+        #
+        # password: <PASSWORD>
+
+        ## @param ntlm_domain - string - optional
+        ## If your services use NTLM authentication, specify
+        ## the domain used in the check. For NTLM Auth, append
+        ## the username to domain, not as the `username` parameter.
+        #
+        # ntlm_domain: <NTLM_DOMAIN>\<USERNAME>
+
+        ## @param kerberos_auth - string - optional - default: disabled
+        ## If your services use Kerberos authentication, you can specify the Kerberos
+        ## strategy to use between:
+        ##
+        ##   - required
+        ##   - optional
+        ##   - disabled
+        ##
+        ## See https://github.com/requests/requests-kerberos#mutual-authentication
+        #
+        # kerberos_auth: disabled
+
+        ## @param kerberos_cache - string - optional
+        ## Sets the KRB5CCNAME environment variable.
+        ## It should point to a credential cache with a valid TGT.
+        #
+        # kerberos_cache: <KERBEROS_CACHE>
+
+        ## @param kerberos_delegate - boolean - optional - default: false
+        ## Set to `true` to enable Kerberos delegation of credentials to a server that requests delegation.
+        ##
+        ## See https://github.com/requests/requests-kerberos#delegation
+        #
+        # kerberos_delegate: false
+
+        ## @param kerberos_force_initiate - boolean - optional - default: false
+        ## Set to `true` to preemptively initiate the Kerberos GSS exchange and
+        ## present a Kerberos ticket on the initial request (and all subsequent).
+        ##
+        ## See https://github.com/requests/requests-kerberos#preemptive-authentication
+        #
+        # kerberos_force_initiate: false
+
+        ## @param kerberos_hostname - string - optional
+        ## Override the hostname used for the Kerberos GSS exchange if its DNS name doesn't
+        ## match its Kerberos hostname, for example: behind a content switch or load balancer.
+        ##
+        ## See https://github.com/requests/requests-kerberos#hostname-override
+        #
+        # kerberos_hostname: <KERBEROS_HOSTNAME>
+
+        ## @param kerberos_principal - string - optional
+        ## Set an explicit principal, to force Kerberos to look for a
+        ## matching credential cache for the named user.
+        ##
+        ## See https://github.com/requests/requests-kerberos#explicit-principal
+        #
+        # kerberos_principal: <KERBEROS_PRINCIPAL>
+
+        ## @param kerberos_keytab - string - optional
+        ## Set the path to your Kerberos key tab file.
+        #
+        # kerberos_keytab: <KEYTAB_FILE_PATH>
+
+        ## @param auth_token - mapping - optional
+        ## This allows for the use of authentication information from dynamic sources.
+        ## Both a reader and writer must be configured.
+        ##
+        ## The available readers are:
+        ##
+        ##   - type: file
+        ##     path (required): The absolute path for the file to read from.
+        ##     pattern: A regular expression pattern with a single capture group used to find the
+        ##              token rather than using the entire file, for example: Your secret is (.+)
+        ##
+        ## The available writers are:
+        ##
+        ##   - type: header
+        ##     name (required): The name of the field, for example: Authorization
+        ##     value: The template value, for example `Bearer <TOKEN>`. The default is: <TOKEN>
+        ##     placeholder: The substring in `value` to replace by the token, defaults to: <TOKEN>
+        #
+        # auth_token:
+        #   reader:
+        #     type: <READER_TYPE>
+        #     <OPTION_1>: <VALUE_1>
+        #     <OPTION_2>: <VALUE_2>
+        #   writer:
+        #     type: <WRITER_TYPE>
+        #     <OPTION_1>: <VALUE_1>
+        #     <OPTION_2>: <VALUE_2>
+
+        ## @param aws_region - string - optional
+        ## If your services require AWS Signature Version 4 signing, set the region.
+        ##
+        ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+        #
+        # aws_region: <AWS_REGION>
+
+        ## @param aws_host - string - optional
+        ## If your services require AWS Signature Version 4 signing, set the host.
+        ##
+        ## Note: This setting is not necessary for official integrations.
+        ##
+        ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+        #
+        # aws_host: <AWS_HOST>
+
+        ## @param aws_service - string - optional
+        ## If your services require AWS Signature Version 4 signing, set the service code. For a list
+        ## of available service codes, see https://docs.aws.amazon.com/general/latest/gr/rande.html
+        ##
+        ## Note: This setting is not necessary for official integrations.
+        ##
+        ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+        #
+        # aws_service: <AWS_SERVICE>
+
+        ## @param tls_verify - boolean - optional - default: true
+        ## Instructs the check to validate the TLS certificate of services.
+        #
+        # tls_verify: true
+
+        ## @param tls_use_host_header - boolean - optional - default: false
+        ## If a `Host` header is set, this enables its use for SNI (matching against the TLS certificate CN or SAN).
+        #
+        # tls_use_host_header: false
+
+        ## @param tls_ignore_warning - boolean - optional - default: false
+        ## If `tls_verify` is disabled, security warnings are logged by the check.
+        ## Disable those by setting `tls_ignore_warning` to true.
+        ##
+        ## Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration.
+        ## If enabled for multiple instances, spurious warnings might still appear even if `tls_ignore_warning` is set
+        ## to true.
+        #
+        # tls_ignore_warning: false
+
+        ## @param tls_cert - string - optional
+        ## The path to a single file in PEM format containing a certificate as well as any
+        ## number of CA certificates needed to establish the certificate's authenticity for
+        ## use when connecting to services. It may also contain an unencrypted private key to use.
+        #
+        # tls_cert: <CERT_PATH>
+
+        ## @param tls_private_key - string - optional
+        ## The unencrypted private key to use for `tls_cert` when connecting to services. This is
+        ## required if `tls_cert` is set and it does not already contain a private key.
+        #
+        # tls_private_key: <PRIVATE_KEY_PATH>
+
+        ## @param tls_ca_cert - string - optional
+        ## The path to a file of concatenated CA certificates in PEM format or a directory
+        ## containing several CA certificates in PEM format. If a directory, the directory
+        ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
+        ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+        #
+        # tls_ca_cert: <CA_CERT_PATH>
+
+        ## @param headers - mapping - optional
+        ## The headers parameter allows you to send specific headers with every request.
+        ## You can use it for explicitly specifying the host header or adding headers for
+        ## authorization purposes.
+        ##
+        ## This overrides any default headers.
+        #
+        # headers:
+        #   Host: <ALTERNATIVE_HOSTNAME>
+        #   X-Auth-Token: <AUTH_TOKEN>
+
+        ## @param extra_headers - mapping - optional
+        ## Additional headers to send with every request.
+        #
+        # extra_headers:
+        #   Host: <ALTERNATIVE_HOSTNAME>
+        #   X-Auth-Token: <AUTH_TOKEN>
+
+        ## @param timeout - number - optional - default: 10
+        ## The timeout for accessing services.
+        ##
+        ## This overrides the `timeout` setting in `init_config`.
+        #
+        # timeout: 10
+
+        ## @param connect_timeout - number - optional
+        ## The connect timeout for accessing services. Defaults to `timeout`.
+        #
+        # connect_timeout: <CONNECT_TIMEOUT>
+
+        ## @param read_timeout - number - optional
+        ## The read timeout for accessing services. Defaults to `timeout`.
+        #
+        # read_timeout: <READ_TIMEOUT>
+
+        ## @param log_requests - boolean - optional - default: false
+        ## Whether or not to debug log the HTTP(S) requests made, including the method and URL.
+        #
+        # log_requests: false
+
+        ## @param persist_connections - boolean - optional - default: false
+        ## Whether or not to persist cookies and use connection pooling for increased performance.
+        #
+        # persist_connections: false
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -10,6 +10,8 @@ init_config:
     # service: <SERVICE>
 
     ## REST API options
+    ## Those options are used when making vSphere REST API calls to retrieve vSphere tags
+    ## when `collect_tags` instance config is enabled.
     #
     rest_api_options:
 
@@ -378,6 +380,8 @@ instances:
     # include_datastore_cluster_folder_tag: true
 
     ## REST API options
+    ## The options are used when making vSphere REST API calls to retrieve vSphere tags
+    ## when `collect_tags` instance config is enabled.
     #
     rest_api_options:
 

--- a/vsphere/datadog_checks/vsphere/types.py
+++ b/vsphere/datadog_checks/vsphere/types.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Pattern, Type, TypedDict
+from typing import Any, Dict, List, Optional, Pattern, Type, TypedDict
 
 # CONFIG ALIASES
 from pyVmomi import vim
@@ -40,6 +40,7 @@ InstanceConfig = TypedDict(
         'metric_filters': MetricFilterConfig,
         'collect_per_instance_filters': MetricFilterConfig,
         'include_datastore_cluster_folder_tag': bool,
+        'rest_api_options': Dict[str, Any],
     },
 )
 

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -75,7 +75,7 @@ class VSphereCheck(AgentCheck):
         # type: (*Any, **Any) -> None
         super(VSphereCheck, self).__init__(*args, **kwargs)
         instance = cast(InstanceConfig, self.instance)
-        self._config = VSphereConfig(instance, self.log)
+        self._config = VSphereConfig(instance, self.init_config, self.log)
 
         self.latest_event_query = get_current_datetime()
         self.infrastructure_cache = InfrastructureCache(interval_sec=self._config.refresh_infrastructure_cache_interval)

--- a/vsphere/tests/test_api.py
+++ b/vsphere/tests/test_api.py
@@ -20,7 +20,7 @@ def test_ssl_verify_false(realtime_instance):
     ) as load_verify_locations:
         smart_connect = connect.SmartConnect
 
-        config = VSphereConfig(realtime_instance, MagicMock())
+        config = VSphereConfig(realtime_instance, {}, MagicMock())
         VSphereAPI(config, MagicMock())
 
         actual_context = smart_connect.call_args.kwargs['sslContext']  # type: ssl.SSLContext
@@ -38,7 +38,7 @@ def test_ssl_cert(realtime_instance):
     ) as load_verify_locations:
         smart_connect = connect.SmartConnect
 
-        config = VSphereConfig(realtime_instance, MagicMock())
+        config = VSphereConfig(realtime_instance, {}, MagicMock())
         VSphereAPI(config, MagicMock())
 
         actual_context = smart_connect.call_args.kwargs['sslContext']  # type: ssl.SSLContext
@@ -55,7 +55,7 @@ def test_connect_success(realtime_instance):
         smart_connect.return_value = connection
         get_about_info = connection.content.about.version.__str__
 
-        config = VSphereConfig(realtime_instance, MagicMock())
+        config = VSphereConfig(realtime_instance, {}, MagicMock())
         api = VSphereAPI(config, MagicMock())
         smart_connect.assert_called_once_with(
             host=realtime_instance['host'],
@@ -76,7 +76,7 @@ def test_connect_failure(realtime_instance):
         version_info = connection.content.about.version.__str__
         version_info.side_effect = Exception('foo')
 
-        config = VSphereConfig(realtime_instance, MagicMock())
+        config = VSphereConfig(realtime_instance, {}, MagicMock())
         with pytest.raises(APIConnectionError):
             VSphereAPI(config, MagicMock())
 
@@ -91,7 +91,7 @@ def test_connect_failure(realtime_instance):
 
 def test_get_infrastructure(realtime_instance):
     with patch('datadog_checks.vsphere.api.connect'):
-        config = VSphereConfig(realtime_instance, MagicMock())
+        config = VSphereConfig(realtime_instance, {}, MagicMock())
         api = VSphereAPI(config, MagicMock())
 
         container_view = api._conn.content.viewManager.CreateContainerView.return_value
@@ -134,7 +134,7 @@ def test_get_infrastructure(realtime_instance):
 )
 def test_smart_retry(realtime_instance, exception, expected_calls):
     with patch('datadog_checks.vsphere.api.connect') as connect:
-        config = VSphereConfig(realtime_instance, MagicMock())
+        config = VSphereConfig(realtime_instance, {}, MagicMock())
         api = VSphereAPI(config, MagicMock())
 
         smart_connect = connect.SmartConnect
@@ -152,7 +152,7 @@ def test_smart_retry(realtime_instance, exception, expected_calls):
 
 def test_get_max_query_metrics(realtime_instance):
     with patch('datadog_checks.vsphere.api.connect'):
-        config = VSphereConfig(realtime_instance, MagicMock())
+        config = VSphereConfig(realtime_instance, {}, MagicMock())
         api = VSphereAPI(config, MagicMock())
         values = [12, -1]
         expected = [12, float('inf')]
@@ -168,7 +168,7 @@ def test_get_max_query_metrics(realtime_instance):
 
 def test_get_new_events_success_without_fallback(realtime_instance):
     with patch('datadog_checks.vsphere.api.connect'):
-        config = VSphereConfig(realtime_instance, MagicMock())
+        config = VSphereConfig(realtime_instance, {}, MagicMock())
         api = VSphereAPI(config, MagicMock())
 
         returned_events = [vim.event.Event(), vim.event.Event(), vim.event.Event()]
@@ -180,7 +180,7 @@ def test_get_new_events_success_without_fallback(realtime_instance):
 
 def test_get_new_events_failure_without_fallback(realtime_instance):
     with patch('datadog_checks.vsphere.api.connect'):
-        config = VSphereConfig(realtime_instance, MagicMock())
+        config = VSphereConfig(realtime_instance, {}, MagicMock())
         api = VSphereAPI(config, MagicMock())
 
         api._conn.content.eventManager.QueryEvents.side_effect = SoapAdapter.ParserError("some parse error")
@@ -193,7 +193,7 @@ def test_get_new_events_with_fallback(realtime_instance):
     realtime_instance['use_collect_events_fallback'] = True
 
     with patch('datadog_checks.vsphere.api.connect'):
-        config = VSphereConfig(realtime_instance, MagicMock())
+        config = VSphereConfig(realtime_instance, {}, MagicMock())
         api = VSphereAPI(config, MagicMock())
 
         event1 = vim.event.Event(key=1)

--- a/vsphere/tests/test_api_rest.py
+++ b/vsphere/tests/test_api_rest.py
@@ -15,7 +15,7 @@ logger = logging.getLogger()
 
 @pytest.mark.usefixtures("mock_rest_api", "mock_type")
 def test_get_resource_tags(realtime_instance):
-    config = VSphereConfig(realtime_instance, logger)
+    config = VSphereConfig(realtime_instance, {}, logger)
     mock_api = VSphereRestAPI(config, log=logger)
     mock_mors = [MagicMock(spec=vim.VirtualMachine, _moId="foo")]
 
@@ -33,7 +33,7 @@ def test_get_resource_tags(realtime_instance):
 
 @pytest.mark.usefixtures("mock_rest_api")
 def test_create_session(realtime_instance):
-    config = VSphereConfig(realtime_instance, logger)
+    config = VSphereConfig(realtime_instance, {}, logger)
     mock_api = VSphereRestAPI(config, log=logger)
 
     assert mock_api._client._http.options['headers']['vmware-api-session-id'] == "dummy-token"
@@ -43,7 +43,7 @@ def test_create_session(realtime_instance):
 @pytest.mark.parametrize(("batch_size", "number_of_batches"), [(25, 40), (100, 10), (101, 10)])
 def test_make_batch(realtime_instance, batch_size, number_of_batches):
     realtime_instance['batch_tags_collector_size'] = batch_size
-    config = VSphereConfig(realtime_instance, logger)
+    config = VSphereConfig(realtime_instance, {}, logger)
     mock_api = VSphereRestAPI(config, log=logger)
     data_to_batch = list(range(1000))
 

--- a/vsphere/tests/test_cache.py
+++ b/vsphere/tests/test_cache.py
@@ -77,7 +77,7 @@ def test_metrics_metadata_cache():
 @pytest.mark.usefixtures("mock_type", "mock_rest_api")
 def test_infrastructure_cache(realtime_instance):
     cache = InfrastructureCache(float('inf'))
-    config = VSphereConfig(realtime_instance, logger)
+    config = VSphereConfig(realtime_instance, {}, logger)
     mock_api = VSphereRestAPI(config, log=logger)
 
     mors = {MagicMock(spec=k, _moId="foo"): object() for k in ALL_RESOURCES_WITH_METRICS * 2}

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -98,7 +98,7 @@ def test_events_only(aggregator, events_only_instance):
 def test_external_host_tags(aggregator, realtime_instance):
     realtime_instance['collect_tags'] = True
     check = VSphereCheck('vsphere', {}, [realtime_instance])
-    config = VSphereConfig(realtime_instance, MagicMock())
+    config = VSphereConfig(realtime_instance, {}, MagicMock())
     check.api = MockedAPI(config)
     check.api_rest = VSphereRestAPI(config, MagicMock())
 
@@ -302,7 +302,7 @@ def test_refresh_tags_cache_should_not_raise_exception(aggregator, dd_run_check,
 def test_renew_rest_api_session_on_failure(aggregator, dd_run_check, realtime_instance):
     realtime_instance.update({'collect_tags': True})
     check = VSphereCheck('vsphere', {}, [realtime_instance])
-    config = VSphereConfig(realtime_instance, MagicMock())
+    config = VSphereConfig(realtime_instance, {}, MagicMock())
     check.api_rest = VSphereRestAPI(config, MagicMock())
     check.api_rest.make_batch = MagicMock(side_effect=[Exception, []])
     check.api_rest.smart_connect = MagicMock()

--- a/vsphere/tests/test_filters.py
+++ b/vsphere/tests/test_filters.py
@@ -90,7 +90,7 @@ def test_is_realtime_resource_collected_by_filters(realtime_instance):
 
     formatted_filters = check._config.resource_filters
 
-    config = VSphereConfig(realtime_instance, MagicMock())
+    config = VSphereConfig(realtime_instance, {}, MagicMock())
     infra = MockedAPI(config).get_infrastructure()
     resources = [m for m in infra if m.__class__ in (vim.VirtualMachine, vim.HostSystem)]
     VM2_1 = next(r for r in resources if infra.get(r).get('name') == 'VM2-1')

--- a/vsphere/tests/test_lab.py
+++ b/vsphere/tests/test_lab.py
@@ -45,7 +45,7 @@ def test_lab(aggregator):
         'collect_attributes': True,
         'rest_api_options': {
             'timeout': '5',
-        }
+        },
     }
     check = VSphereCheck('vsphere', {}, [instance])
     check.initiate_api_connection()

--- a/vsphere/tests/test_lab.py
+++ b/vsphere/tests/test_lab.py
@@ -43,6 +43,9 @@ def test_lab(aggregator):
         'ssl_verify': False,
         'collect_tags': True,
         'collect_attributes': True,
+        'rest_api_options': {
+            'timeout': '5',
+        }
     }
     check = VSphereCheck('vsphere', {}, [instance])
     check.initiate_api_connection()
@@ -50,6 +53,7 @@ def test_lab(aggregator):
 
     # Basic assert
     aggregator.assert_metric('vsphere.cpu.coreUtilization.avg')
+    aggregator.assert_metric_has_tag('vsphere.cpu.usage.avg', 'MyCategoryFoo:MyTagFoo')  # verify collect_tags works
     print("TOTAL metrics: {}".format(len(aggregator._metrics)))
 
     # Write all metrics to a file

--- a/vsphere/tests/test_utils.py
+++ b/vsphere/tests/test_utils.py
@@ -46,6 +46,7 @@ def test_should_collect_per_instance_values(metric_name, resource_type, expect_m
             'password': 'baz',
             'collect_per_instance_filters': {'vm': [r'cpu\..*\.sum']},
         },
+        {},
         None,
     )
 


### PR DESCRIPTION
### What does this PR do?

Add `rest_api_options` to expose all RequestsWrapper options for vSphere REST API client.

Since vSphere uses multiple ways to collect data, the rest api options are namespaced with `init_config.rest_api_options` and `instances[].rest_api_options` to avoid confusion.

vSphere uses:
- REST API for vSphere tags
- pyVmomi (SOAP) for the rest (infrastructure metadata, metrics, etc)

The alternative is to expose the options at the root of `init_config/instancesp[]`, but that might create confusion, since it won't be clear if `instancesp[].timeout` is used for REST API or pyVmomi.

### Motivation

Customer case: user need to configure REST API timeout.