### PR TITLE
Add `native_dynamic` OpenMetrics transformer

### DIFF
--- a/datadog_checks_base/tests/openmetrics/test_transformers/test_native_dynamic.py
+++ b/datadog_checks_base/tests/openmetrics/test_transformers/test_native_dynamic.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from ...utils import requires_py3
+from ..utils import get_check
+
+pytestmark = [
+    requires_py3,
+    pytest.mark.openmetrics,
+    pytest.mark.openmetrics_transformers,
+    pytest.mark.openmetrics_transformers_native_dynamic,
+]
+
+
+def test_basic(aggregator, dd_run_check, mock_http_response):
+    mock_http_response(
+        """
+        # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+        # TYPE go_memstats_alloc_bytes gauge
+        go_memstats_alloc_bytes 1.900688e+06
+        # HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+        # TYPE go_memstats_alloc_bytes_total counter
+        go_memstats_alloc_bytes_total 2.58684656e+08
+        """
+    )
+    check = get_check({'metrics': [{'go_memstats_alloc_bytes': {'type': 'native_dynamic'}}]})
+    dd_run_check(check)
+
+    aggregator.assert_metric(
+        'test.go_memstats_alloc_bytes', 1900688, metric_type=aggregator.GAUGE, tags=['endpoint:test']
+    )
+    aggregator.assert_metric(
+        'test.go_memstats_alloc_bytes.count', 258684656, metric_type=aggregator.MONOTONIC_COUNT, tags=['endpoint:test']
+    )
+
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### Motivation

(working on `amazon_msk` PR)

For endpoints that emit non-unique metric names https://github.com/OpenObservability/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#metricset

> Each MetricFamily name MUST be unique.

The spec/clients strip `_total` from counters, see

- https://github.com/prometheus/client_python/pull/300/commits/a4dd93bcc6a0422e10cfa585048d1813909c6786
- https://prometheus.github.io/client_java/io/prometheus/client/Counter.html