### PR TITLE
Better support for dashboard filename

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
@@ -92,7 +92,7 @@ def export(ctx, url, integration, author):
                 match = display_name
 
         if match:
-            new_file_name = file_name.replace(match, '', 1).strip()
+            new_file_name = file_name.replace(match, '', 1).strip(" - ")
             if new_file_name:
                 file_name = new_file_name
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
@@ -92,7 +92,7 @@ def export(ctx, url, integration, author):
                 match = display_name
 
         if match:
-            new_file_name = file_name.replace(match, '', 1).strip(" - ")
+            new_file_name = file_name.replace(match, '', 1).strip(" -")
             if new_file_name:
                 file_name = new_file_name
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Using the `ddev meta dash export URL INTEGRATION` command with common dash names such as `INTEGRATION - Overview` caused the payload to be saved as such.

```
Successfully wrote dashboard: `-_overview.json` for integration: INTEGRATION
```
This fix removes the additional characters at the front.
```
Successfully wrote dashboard: `overview.json` for integration: INTEGRATION
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
