### PR TITLE
[documentation] IIS - Remove Containerized Installation directions

### DIFF
--- a/iis/README.md
+++ b/iis/README.md
@@ -12,9 +12,6 @@ Collect IIS metrics aggregated across all of your sites, or on a per-site basis.
 
 The IIS check is packaged with the Agent. To start gathering your IIS metrics and logs, [install the Agent][2] on your IIS servers.
 
-<!-- xxx tabs xxx -->	
-<!-- xxx tab "Host" xxx -->	
-
 #### Host
 
 To configure this check for an Agent running on a host:
@@ -76,8 +73,6 @@ Need help? Contact [Datadog support][11].
 [4]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [5]: https://github.com/DataDog/integrations-core/blob/master/iis/datadog_checks/iis/data/conf.yaml.example
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[7]: https://docs.datadoghq.com/agent/kubernetes/integrations/
-[8]: https://docs.datadoghq.com/agent/kubernetes/log/
 [9]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [10]: https://github.com/DataDog/integrations-core/blob/master/iis/metadata.csv
 [11]: https://docs.datadoghq.com/help/

--- a/iis/README.md
+++ b/iis/README.md
@@ -47,32 +47,6 @@ To configure this check for an Agent running on a host:
 
 3. [Restart the Agent][6].
 
-<!-- xxz tab xxx -->
-<!-- xxx tab "Containerized" xxx -->
-
-#### Containerized
-
-For containerized environments, see the [Autodiscovery Integration Templates][7] for guidance on applying the parameters below.
-
-##### Metric collection
-
-| Parameter            | Value                  |
-| -------------------- | ---------------------- |
-| `<INTEGRATION_NAME>` | `iis`                  |
-| `<INIT_CONFIG>`      | blank or `{}`          |
-| `<INSTANCE_CONFIG>`  | `{"host": "%%host%%"}` |
-
-##### Log collection
-
-Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes log collection documentation][8].
-
-| Parameter      | Value                                            |
-| -------------- | ------------------------------------------------ |
-| `<LOG_CONFIG>` | `{"source": "iis", "service": "<SERVICE_NAME>"}` |
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
-
 ### Validation
 
 [Run the Agent's status subcommand][9] and look for `iis` under the Checks section.


### PR DESCRIPTION
The IIS integration cannot be run in a window's container due to limitations on Microsoft's end. Therefore, we should not have instructions suggesting this is possible. 

### What does this PR do?
Removes the containerized installation tab section

### Motivation
Support Escalation for reference: https://datadoghq.atlassian.net/browse/CONS-3741

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
