### PR TITLE
Revert "Pin decorator to 4.4.2"

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -15,7 +15,6 @@ cryptography==3.3.2; python_version < "3.0"
 cryptography==3.4.6; python_version > "3.0"
 cx-oracle==7.2.0
 ddtrace==0.32.2
-decorator==4.4.2; python_version < "3.0"
 dnspython==1.16.0
 enum34==1.1.6; python_version < "3.0"
 flup-py3==1.0.3; python_version > "3.0"

--- a/openstack_controller/requirements.in
+++ b/openstack_controller/requirements.in
@@ -1,3 +1,1 @@
 openstacksdk==0.24.0
-# Pinning the transitive dependency as the latest (5.0.1) fails to install on python2.
-decorator==4.4.2; python_version < "3.0"


### PR DESCRIPTION
Reverts DataDog/integrations-core#9074

This is not required anymore as the decorator maintainer yanked the bad wheels that could not be installed on py2: https://github.com/micheles/decorator/issues/102