### PR TITLE
Bump minimum base package version

### DIFF
--- a/kong/setup.py
+++ b/kong/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=16.1.0'
 
 setup(
     name='datadog-kong',


### PR DESCRIPTION
Bump base package requirement.
#9031 uses the new openmetrics check implementation
