### PR TITLE
Ignore metric_to_check validation for extras

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -479,7 +479,8 @@ def manifest(ctx, fix):
                     ):
                         file_failures += 1
                         display_queue.append((echo_failure, f'  metric_to_check not in metadata.csv: {metric!r}'))
-            elif metadata_in_manifest and check_name != 'snmp':
+            elif metadata_in_manifest and check_name != 'snmp' and not is_extras:
+                # TODO remove exemption for integrations-extras in future
                 # if we have a metadata.csv file but no `metric_to_check` raise an error
                 metadata_file = get_metadata_file(check_name)
                 if os.path.isfile(metadata_file):


### PR DESCRIPTION
### What does this PR do?
PR #9042 added validation for `metric_to_check` in manifest files.  In `integrations-extras` there are quite a few legacy checks which fail this validation so ignore them for now and remove this exemption once they have been fixed at a later date.

