### PR TITLE
remove process signature from tokumx

### DIFF
--- a/tokumx/manifest.json
+++ b/tokumx/manifest.json
@@ -12,9 +12,7 @@
   "metric_prefix": "tokumx.",
   "metric_to_check": "tokumx.uptime",
   "name": "tokumx",
-  "process_signatures": [
-    "mongod --config /etc/tokumx.conf"
-  ],
+  "process_signatures": [],
   "public_title": "Datadog-TokuMX Integration",
   "short_description": "Track metrics for opcounters, replication lag, cache table size, and more.",
   "support": "core",


### PR DESCRIPTION
### What does this PR do?
The process signature of `tokumx` contains file path, which caused some problems when Processes team tries to use it to parse the command line. I discussed with @DataDog/agent-integrations they mentioned that this integration is old and deprecating, so we agreed to stop supporting it.

### Motivation
cc: @DataDog/processes 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
