### PR TITLE
Fix integration log checking

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -608,8 +608,9 @@ def has_logs(check):
     readme_file = get_readme_file(check)
     if os.path.exists(readme_file):
         with open(readme_file, 'r', encoding='utf-8') as f:
-            if '# Log collection' in f.read():
+            if '# log collection' in f.read().lower():
                 return True
+    return False
 
 
 def find_legacy_signature(check):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Two ways we decide whether an intg. has log support
1. It has a logs section in the config
2. It has a logs section in the readme

Checking the readme was looking for "# Log collection", but we don't seem to be consistent on the casing. It seems like `# Log collection` is the most popular. 

We can either accept it and use this PR or I can make the change for all intgs. to use the correct casing. WDYT?

```bash
➜ git grep "# Log Collection"
aspdotnet/README.md:#### Log Collection
cassandra/README.md:##### Log Collection
cilium/README.md:##### Log Collection
clickhouse/README.md:##### Log Collection
datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/README.md:### Log Collection
ecs_fargate/README.md:### Log Collection
fluentd/README.md:##### Log Collection
harbor/README.md:##### Log Collection
mcache/README.md:#### Log Collection
proxysql/README.md:##### Log Collection
sidekiq/README.md:### Log Collection
vault/README.md:#### Log Collection
vertica/README.md:#### Log Collection
voltdb/README.md:#### Log Collection
```

```bash
➜ git grep "# Log collection"
kafka/README.md:##### Log collection
kafka/README.md:##### Log collection
kafka_consumer/README.md:##### Log collection
kong/README.md:##### Log collection
kong/README.md:##### Log collection
kube_scheduler/README.md:#### Log collection
kyototycoon/README.md:##### Log collection
lighttpd/README.md:#### Log collection
linkerd/README.md:##### Log collection
mapr/README.md:#### Log collection
mapreduce/README.md:##### Log collection
marathon/README.md:##### Log collection
marathon/README.md:##### Log collection
.... and much more
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
