### PR TITLE
Add retry option when metric is not found

### DIFF
--- a/envoy/assets/configuration/spec.yaml
+++ b/envoy/assets/configuration/spec.yaml
@@ -64,6 +64,12 @@ files:
       value:
         type: boolean
         example: true
+    - name: parse_unknown_metrics
+      description: |
+        Enable to retry parsing for metrics that initially resulted in an UnknownMetric exception.
+      value:
+        type: boolean
+        example: false
     - template: instances/default
     - template: instances/http
       overrides:

--- a/envoy/assets/configuration/spec.yaml
+++ b/envoy/assets/configuration/spec.yaml
@@ -66,7 +66,7 @@ files:
         example: true
     - name: parse_unknown_metrics
       description: |
-        Enable to retry parsing for metrics that initially resulted in an UnknownMetric exception.
+        Attempt parsing of metrics that are unknown and will otherwise be skipped.
       value:
         type: boolean
         example: false

--- a/envoy/datadog_checks/envoy/config_models/defaults.py
+++ b/envoy/datadog_checks/envoy/config_models/defaults.py
@@ -108,6 +108,10 @@ def instance_ntlm_domain(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_parse_unknown_metrics(field, value):
+    return False
+
+
 def instance_password(field, value):
     return get_default_field_value(field, value)
 

--- a/envoy/datadog_checks/envoy/config_models/instance.py
+++ b/envoy/datadog_checks/envoy/config_models/instance.py
@@ -56,6 +56,7 @@ class InstanceConfig(BaseModel):
     log_requests: Optional[bool]
     min_collection_interval: Optional[float]
     ntlm_domain: Optional[str]
+    parse_unknown_metrics: Optional[bool]
     password: Optional[str]
     persist_connections: Optional[bool]
     proxy: Optional[Proxy]

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -110,7 +110,7 @@ instances:
     # cache_metrics: true
 
     ## @param parse_unknown_metrics - boolean - optional - default: false
-    ## Enable to retry parsing for metrics that initially resulted in an UnknownMetric exception.
+    ## Attempt parsing of metrics that are unknown and will otherwise be skipped.
     #
     # parse_unknown_metrics: false
 

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -109,6 +109,11 @@ instances:
     #
     # cache_metrics: true
 
+    ## @param parse_unknown_metrics - boolean - optional - default: false
+    ## Enable to retry parsing for metrics that initially resulted in an UnknownMetric exception.
+    #
+    # parse_unknown_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/envoy/datadog_checks/envoy/parser.py
+++ b/envoy/datadog_checks/envoy/parser.py
@@ -83,9 +83,15 @@ def parse_metric(metric, retry=False, metric_mapping=METRIC_TREE):
             # Retry parsing for metrics by skipping the last matched metric part
             while len(metric_parts) > 1:
                 skip_part = metric_parts.pop()
-                metric_parts, tag_value_builder, tag_names, tag_values, unknown_tags, tags_to_build, last_mapping = _parse_metric(
-                    metric, metric_mapping, skip_part
-                )
+                (
+                    metric_parts,
+                    tag_value_builder,
+                    tag_names,
+                    tag_values,
+                    unknown_tags,
+                    tags_to_build,
+                    last_mapping,
+                ) = _parse_metric(metric, metric_mapping, skip_part)
                 parsed_metric = '.'.join(metric_parts)
                 if parsed_metric in METRICS:
                     break

--- a/envoy/datadog_checks/envoy/parser.py
+++ b/envoy/datadog_checks/envoy/parser.py
@@ -74,7 +74,6 @@ def parse_metric(metric, retry=True, metric_mapping=METRIC_TREE):
         'listener.0.0.0.0_80.downstream_cx_total' ->
         ('listener.downstream_cx_total', ['address:0.0.0.0_80'], 'count')
     """
-    metric = 'cluster.service-foo.default.eu-west-3-prd.internal.a4d363d6-a669-b02c-a274-52c1df12bd41.consul.upstream_cx_active'
     metric_parts, tag_value_builder, tag_names, tag_values, unknown_tags, tags_to_build = _parse_metric(
         metric, metric_mapping
     )
@@ -86,6 +85,8 @@ def parse_metric(metric, retry=True, metric_mapping=METRIC_TREE):
                 metric, metric_mapping, skip_part
             )
             parsed_metric = '.'.join(metric_parts)
+            if parsed_metric not in METRICS:
+                raise UnknownMetric
         else:
             raise UnknownMetric
     # Rebuild any trailing tags

--- a/envoy/tests/test_parser.py
+++ b/envoy/tests/test_parser.py
@@ -29,6 +29,24 @@ def test_cds():
     assert parse_metric(metric) == (METRIC_PREFIX + metric, list(tags), METRICS[metric]['method'])
 
 
+def test_retry_metric():
+    metric = "cluster{}.upstream_cx_total"
+    untagged_metric = metric.format('')
+    tags = [tag for tags in METRICS[untagged_metric]['tags'] for tag in tags]
+    tag0 = 'service-foo.default.eu-west-3-prd.internal.a4d363d6-a669-b02c-a274-52c1df12bd41.consul'
+    tagged_metric = metric.format('.{}'.format(tag0))
+    assert parse_metric(tagged_metric, retry=True) == (
+        METRIC_PREFIX + untagged_metric,
+        ['{}:{}'.format(tags[0], tag0)],
+        METRICS[untagged_metric]['method'],
+    )
+
+
+def test_retry_invalid_metric():
+    with pytest.raises(UnknownMetric):
+        parse_metric("cluster.internal.foo", retry=True)
+
+
 def test_http_router_filter():
     metric = 'http{}.rq_total'
     untagged_metric = metric.format('')


### PR DESCRIPTION
### What does this PR do?
Introduces a retry option when a metric is not found in metrics.py. This can happen when a metric name part appears in a tag (e.g internal).

### Motivation

Resolves https://github.com/DataDog/integrations-core/issues/8775

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
