### PR TITLE
Backport of #9122: Remove the `kubernetes.storage.operation.*` metrics because of a volumetry issue

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -87,7 +87,6 @@ NEW_1_14_GAUGES = {
 
 DEFAULT_HISTOGRAMS = {
     'apiserver_client_certificate_expiration_seconds': 'apiserver.certificate.expiration',
-    'storage_operation_duration_seconds': 'storage.operation.duration',
 }
 
 DEPRECATED_HISTOGRAMS = {

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -68,7 +68,6 @@ kubernetes.kubelet.container.log_filesystem.used_bytes,gauge,,byte,,Bytes used b
 kubernetes.kubelet.pod.start.duration,gauge,,microsecond,,Duration in microseconds for a single pod to go from pending to running,0,kubernetes,k8s.kubelet.pod.start.duration
 kubernetes.kubelet.pod.worker.duration,gauge,,microsecond,,"Duration in microseconds to sync a single pod. Broken down by operation type: create, update, or sync",0,kubernetes,k8s.kubelet.pod.worker.duration
 kubernetes.kubelet.pod.worker.start.duration,gauge,,microsecond,,Duration in microseconds from seeing a pod to starting a worker,0,kubernetes,k8s.kubelet.pod.worker.start.duration
-kubernetes.storage.operation.duration,gauge,,second,,Storage operation duration,0,kubernetes,k8s.storage.operation.duration
 kubernetes.kubelet.docker.operations,count,,operation,,The number of docker operations,0,kubernetes,k8s.docker.ops
 kubernetes.kubelet.docker.errors,count,,operation,,The number of docker operations errors,-1,kubernetes,k8s.docker.err
 kubernetes.kubelet.docker.operations.duration.sum,gauge,,operation,,The sum of duration of docker operations,0,kubernetes,k8s.docker.duration

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -112,8 +112,6 @@ EXPECTED_METRICS_PROMETHEUS = [
     'kubernetes.kubelet.pod.start.duration.count',
     'kubernetes.kubelet.pod.worker.start.duration.sum',
     'kubernetes.kubelet.pod.worker.start.duration.count',
-    'kubernetes.storage.operation.duration.sum',
-    'kubernetes.storage.operation.duration.count',
     'kubernetes.go_threads',
     'kubernetes.go_goroutines',
 ]


### PR DESCRIPTION
### What does this PR do?

Remove the `kubernetes.storage.operation.*` metrics.

### Motivation

This histogram metric generates a too high cardinality.

### Additional Notes

This metric was introduced in `7.27.0` by #8562.

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have `changelog/` and `integration/` labels attached
