### PR TITLE
Fix test import

### DIFF
--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -23,8 +23,8 @@ from datadog_checks.base.utils.headers import headers as agent_headers
 from datadog_checks.base.utils.http import STANDARD_FIELDS, RequestsWrapper, is_uds_url, quote_uds_url
 from datadog_checks.base.utils.time import get_timestamp
 from datadog_checks.dev import EnvVars, TempDir
-from datadog_checks.dev.utils import ON_WINDOWS, running_on_windows_ci
 from datadog_checks.dev.fs import read_file, write_file
+from datadog_checks.dev.utils import ON_WINDOWS, running_on_windows_ci
 
 pytestmark = pytest.mark.http
 

--- a/datadog_checks_base/tests/test_http.py
+++ b/datadog_checks_base/tests/test_http.py
@@ -23,7 +23,8 @@ from datadog_checks.base.utils.headers import headers as agent_headers
 from datadog_checks.base.utils.http import STANDARD_FIELDS, RequestsWrapper, is_uds_url, quote_uds_url
 from datadog_checks.base.utils.time import get_timestamp
 from datadog_checks.dev import EnvVars, TempDir
-from datadog_checks.dev.utils import ON_WINDOWS, read_file, running_on_windows_ci, write_file
+from datadog_checks.dev.utils import ON_WINDOWS, running_on_windows_ci
+from datadog_checks.dev.fs import read_file, write_file
 
 pytestmark = pytest.mark.http
 

--- a/datadog_checks_dev/datadog_checks/dev/fs.py
+++ b/datadog_checks_dev/datadog_checks/dev/fs.py
@@ -9,7 +9,6 @@ import inspect
 import os
 import shutil
 from contextlib import contextmanager
-from io import open
 from tempfile import mkdtemp
 
 from six import PY3, text_type

--- a/datadog_checks_dev/datadog_checks/dev/fs.py
+++ b/datadog_checks_dev/datadog_checks/dev/fs.py
@@ -6,6 +6,7 @@ Filesystem utility functions abstracting common operations, specially designed t
 by Integrations within tests.
 """
 import inspect
+from io import open
 import os
 import shutil
 from contextlib import contextmanager

--- a/datadog_checks_dev/datadog_checks/dev/fs.py
+++ b/datadog_checks_dev/datadog_checks/dev/fs.py
@@ -6,10 +6,10 @@ Filesystem utility functions abstracting common operations, specially designed t
 by Integrations within tests.
 """
 import inspect
-from io import open
 import os
 import shutil
 from contextlib import contextmanager
+from io import open
 from tempfile import mkdtemp
 
 from six import PY3, text_type


### PR DESCRIPTION
### What does this PR do?
fileutils refactor caused importError in base test, https://github.com/DataDog/integrations-core/pull/9023

### Motivation
```
tests/test_http.py:26: in <module>
    from datadog_checks.dev.utils import ON_WINDOWS, read_file, running_on_windows_ci, write_file
E   ImportError: cannot import name 'write_file' from 'datadog_checks.dev.utils' (/home/vsts/work/1/s/datadog_checks_dev/datadog_checks/dev/utils.py)
```
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
