### PR TITLE
[ddev] Skip cherry-pick commits in `ddev release trello testable`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -130,10 +130,9 @@ def _get_and_parse_commits(base_ref: str, target_ref: str) -> List[Tuple[str, st
 
     commits = []
     for line in reversed(lines):
-        sign, _, commit = line.partition(' ')
+        sign, commit_hash, commit_subject = line.split(' ', 2)
         if sign == '-':
             continue
-        commit_hash, _, commit_subject = commit.partition(' ')
         commits.append((commit_hash, commit_subject))
 
     return commits

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -110,7 +110,7 @@ def _all_synced_with_remote(refs: Sequence[str]) -> bool:
     return all(ref not in result.stderr for ref in refs)
 
 
-def _get_and_parse_commits(base_ref: str, target_ref: str, cherry_picks:bool) -> List[Tuple[str, str]]:
+def _get_and_parse_commits(base_ref: str, target_ref: str, cherry_picks: bool) -> List[Tuple[str, str]]:
     echo_info(f'Getting diff between {base_ref!r} and {target_ref!r}... ', nl=False)
 
     # Format as '<commit_hash> <subject line>', e.g.:
@@ -216,24 +216,24 @@ def pick_card_member(config: dict, author: str, team: str) -> Optional[str]:
     '--move-cards',
     is_flag=True,
     help='Do not create a card for a change, but move the existing card from '
-         + '`HAVE BUGS - FIXME` or `FIXED - Ready to Rebuild` to INBOX team',
+    + '`HAVE BUGS - FIXME` or `FIXED - Ready to Rebuild` to INBOX team',
 )
 @click.option(
     '--cherry-picks',
     is_flag=True,
     help='Check if commits were cherry-picked from `target_ref` onto `base_ref` and skip them.'
-         ' Command may take long if there are many commits.'
+    ' Command may take long if there are many commits.',
 )
 @click.pass_context
 def testable(
-        ctx: click.Context,
-        base_ref: str,
-        target_ref: str,
-        milestone: str,
-        dry_run: bool,
-        update_rc_builds_cards: bool,
-        move_cards: bool,
-        cherry_picks: bool
+    ctx: click.Context,
+    base_ref: str,
+    target_ref: str,
+    milestone: str,
+    dry_run: bool,
+    update_rc_builds_cards: bool,
+    move_cards: bool,
+    cherry_picks: bool,
 ) -> None:
     """
     Create a Trello card for changes since a previous release (referenced by `BASE_REF`)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -144,6 +144,7 @@ def _parse_commits(commit_lines: List[str], base_ref: str, cherry_picks: bool) -
             commit_hash, _, commit_subject = line.partition(' ')
             if _commit_cherry_picked(base_ref, commit_hash):
                 # skip this commit
+                echo_warning(f'Skipping {commit_subject}, it was cherry-picked in {base_ref}.')
                 continue
             commits.append((commit_hash, commit_subject))
         # 3. delete temp branch and apply stash if needed

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -113,10 +113,6 @@ def _all_synced_with_remote(refs: Sequence[str]) -> bool:
 def _get_and_parse_commits(base_ref: str, target_ref: str) -> List[Tuple[str, str]]:
     echo_info(f'Getting diff between {base_ref!r} and {target_ref!r}... ', nl=False)
 
-    # Format as '<commit_hash> <subject line>', e.g.:
-    # 'a70a792f9d1775b7d6d910044522f7a0d6941ad7 Update README.md'
-    pretty_format = '%H %s'
-
     diff_command = f'git --no-pager cherry -v {base_ref} {target_ref}'
 
     try:
@@ -132,6 +128,7 @@ def _get_and_parse_commits(base_ref: str, target_ref: str) -> List[Tuple[str, st
     for line in reversed(lines):
         sign, commit_hash, commit_subject = line.split(' ', 2)
         if sign == '-':
+            echo_info(f'Skipping {commit_subject}, it was cherry-picked in {base_ref}')
             continue
         commits.append((commit_hash, commit_subject))
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -160,7 +160,7 @@ def _parse_commits(commit_lines: List[str], base_ref: str, cherry_picks: bool) -
     return commits
 
 
-def _commit_cherry_picked(base_ref, commit_hash):
+def _commit_cherry_picked(base_ref, commit_hash) -> bool:
     run_command(f'git cherry-pick -n {commit_hash}', capture=True)
     result = run_command('git --no-pager diff --staged', capture=True)
     run_command('git reset --hard HEAD', capture=True)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -113,6 +113,8 @@ def _all_synced_with_remote(refs: Sequence[str]) -> bool:
 def _get_and_parse_commits(base_ref: str, target_ref: str) -> List[Tuple[str, str]]:
     echo_info(f'Getting diff between {base_ref!r} and {target_ref!r}... ', nl=False)
 
+    # Outputs as '<sign> <commit_hash> <subject line>', e.g.:
+    # '+ 32837dac944b9dcc23d6b54370657d661226c3ac Update README.md (#8778)'
     diff_command = f'git --no-pager cherry -v {base_ref} {target_ref}'
 
     try:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -110,7 +110,7 @@ def _all_synced_with_remote(refs: Sequence[str]) -> bool:
     return all(ref not in result.stderr for ref in refs)
 
 
-def _get_and_parse_commits(base_ref: str, target_ref: str) -> List[Tuple[str, str]]:
+def _get_and_parse_commits(base_ref: str, target_ref: str, cherry_picks:bool) -> List[Tuple[str, str]]:
     echo_info(f'Getting diff between {base_ref!r} and {target_ref!r}... ', nl=False)
 
     # Format as '<commit_hash> <subject line>', e.g.:
@@ -127,23 +127,52 @@ def _get_and_parse_commits(base_ref: str, target_ref: str) -> List[Tuple[str, st
 
     echo_success('Success!')
     lines: List[str] = result.stdout.splitlines()
+    return _parse_commits(lines, base_ref, cherry_picks)
 
+
+def _parse_commits(commit_lines: List[str], base_ref: str, cherry_picks: bool) -> List[Tuple[str, str]]:
     commits = []
 
-    for line in reversed(lines):
-        commit_hash, _, commit_subject = line.partition(' ')
-        commits.append((commit_hash, commit_subject))
+    if cherry_picks:
+        # 1. stash if we need to and checkout temp branch
+        need_stash = run_command('git --no-pager diff', capture=True).stdout
+        if need_stash:
+            run_command('git stash -q', capture=True)
+        run_command(f'git checkout -B ddev_testable/is-cherry {base_ref}', capture=True)
+        # 2. check if commits were cherry-picked
+        for line in reversed(commit_lines):
+            commit_hash, _, commit_subject = line.partition(' ')
+            if _commit_cherry_picked(base_ref, commit_hash):
+                # skip this commit
+                continue
+            commits.append((commit_hash, commit_subject))
+        # 3. delete temp branch and apply stash if needed
+        run_command('git checkout @{-1}', capture=True)
+        run_command('git branch -D ddev_testable/is-cherry', capture=True)
+        if need_stash:
+            run_command("git stash pop -q", capture=True)
+    else:
+        for line in reversed(commit_lines):
+            commit_hash, _, commit_subject = line.partition(' ')
+            commits.append((commit_hash, commit_subject))
 
     return commits
 
 
-def get_commits_between(base_ref: str, target_ref: str, *, root: str) -> List[Tuple[str, str]]:
+def _commit_cherry_picked(base_ref, commit_hash):
+    run_command(f'git cherry-pick -n {commit_hash}', capture=True)
+    result = run_command('git --no-pager diff --staged', capture=True)
+    run_command('git reset --hard HEAD', capture=True)
+    return len(result.stdout) == 0
+
+
+def get_commits_between(base_ref: str, target_ref: str, cherry_picks: bool, *, root: str) -> List[Tuple[str, str]]:
     with chdir(root):
         if not _all_synced_with_remote((base_ref, target_ref)):
             abort(f'Your repository is not sync with the remote repository. Please run `git fetch` in {root!r} folder.')
 
         try:
-            return _get_and_parse_commits(base_ref, target_ref)
+            return _get_and_parse_commits(base_ref, target_ref, cherry_picks)
         except SubprocessError as exc:
             echo_failure(str(exc))
             echo_failure('Unable to get the diff.')
@@ -186,17 +215,24 @@ def pick_card_member(config: dict, author: str, team: str) -> Optional[str]:
     '--move-cards',
     is_flag=True,
     help='Do not create a card for a change, but move the existing card from '
-    + '`HAVE BUGS - FIXME` or `FIXED - Ready to Rebuild` to INBOX team',
+         + '`HAVE BUGS - FIXME` or `FIXED - Ready to Rebuild` to INBOX team',
+)
+@click.option(
+    '--cherry-picks',
+    is_flag=True,
+    help='Check if commits were cherry-picked from `target_ref` onto `base_ref` and skip them.'
+         ' Command may take long if there are many commits.'
 )
 @click.pass_context
 def testable(
-    ctx: click.Context,
-    base_ref: str,
-    target_ref: str,
-    milestone: str,
-    dry_run: bool,
-    update_rc_builds_cards: bool,
-    move_cards: bool,
+        ctx: click.Context,
+        base_ref: str,
+        target_ref: str,
+        milestone: str,
+        dry_run: bool,
+        update_rc_builds_cards: bool,
+        move_cards: bool,
+        cherry_picks: bool
 ) -> None:
     """
     Create a Trello card for changes since a previous release (referenced by `BASE_REF`)
@@ -247,7 +283,7 @@ def testable(
     if repo not in ('integrations-core', 'datadog-agent'):
         abort(f'Repo `{repo}` is unsupported.')
 
-    commits = get_commits_between(base_ref, target_ref, root=root)
+    commits = get_commits_between(base_ref, target_ref, cherry_picks, root=root)
     num_changes = len(commits)
 
     if not num_changes:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Performs git operations to determine whether a commit in the `target_ref` was cherry picked by the `base_ref` and discards it from the cards to QA. 

There are 2 cases that can happen:
1. Cherry-picked commits have different commit hash values, so we can't compare that.
2. Sometimes teams do not `squash and merge` causing cherry-picked commits to have different messages. Can't compare message either.

We can check via a `git diff`

To test this: I created 3 branches:
- [`lg/trello-target`](https://github.com/DataDog/integrations-core/commits/lg/trello-base)  The target reference. 
- [`lg/trello-base-squash`](https://github.com/DataDog/integrations-core/commits/lg/trello-base-squash) Contains a cherry-picked commit #9118 from `lg/trello-target`. Note that commit hashes are different. 
- [`lg/trello-base-nosquash`](https://github.com/DataDog/integrations-core/commits/lg/trello-base-nosquash) Contains the same commit as squash branch but this time the commit was not squashed and merged. note the message is different.

The main difference between these 3 branches are these two commits. #9117 and #9118

If we want to create the QA cards from `lg/trello-base-squash` to `lg/trello-target` and avoid cherry-picked commits:
```
➜ ddev release trello testable -n --cherry-picks lg/trello-base-squash lg/trello-target
Getting diff between 'lg/trello-base-squash' and 'lg/trello-target'... Success!
Skipping Fix integration log checking (#9118), it was cherry-picked in lg/trello-base-squash.
```
We only get commits that were not cherry-picked. Before:
```
➜ ddev release trello testable -n lg/trello-base-squash lg/trello-target               
Getting diff between 'lg/trello-base-squash' and 'lg/trello-target'... Success!
...
(2 of 2) Fix integration log checking
         Url: https://github.com/DataDog/integrations-core/pull/9118
         Author: luisgonzalex
         Labels: changelog/Fixed, dev/tooling, integration/datadog_checks_dev
...    
```
You get the PR that was cherry-picked. 

Similarly, it works with commits that were not `squash and merged`:
```
➜ ddev release trello testable -n --cherry-picks lg/trello-base-nosquash lg/trello-target
Getting diff between 'lg/trello-base-nosquash' and 'lg/trello-target'... Success!
Skipping Fix integration log checking (#9118), it was cherry-picked in lg/trello-base-nosquash.
```
I also tested out a practical use case where we might want to create cards from one release to what is in `origin/master`:
```
➜ ddev release trello testable -n --cherry-picks 7.27.0-rc.5 origin/master 
Getting diff between '7.27.0-rc.5' and 'origin/master'... Success!
Skipping Fix snmp get bulk log (#8803), it was cherry-picked in 7.27.0-rc.5.
Skipping [Release] Bumped snmp version to 5.0.1 (#8806), it was cherry-picked in 7.27.0-rc.5.
Skipping Cache API client connection (#8808), it was cherry-picked in 7.27.0-rc.5.
Skipping Fix collection of PendingTime (#8817), it was cherry-picked in 7.27.0-rc.5.
Skipping Import kube client when needed (#8820), it was cherry-picked in 7.27.0-rc.5.
Skipping Fix empty queue parsing (#8852), it was cherry-picked in 7.27.0-rc.5.
Skipping Bumped postfix version to 1.8.3 (#8854), it was cherry-picked in 7.27.0-rc.5.
Skipping Revert "Pin decorator to 4.4.2 (#9074)" (#9093), it was cherry-picked in 7.27.0-rc.5.
```
And you can look for yourself here to see that the commits were indeed cherry picked. 

On [`7.27.0-rc.5`](https://github.com/DataDog/integrations-core/commits/7.27.0-rc.5):
![image](https://user-images.githubusercontent.com/39505100/114218670-55630f00-992f-11eb-8f83-23b90a3b6f79.png)

And on [`master`](https://github.com/DataDog/integrations-core/commits/master?after=f2d620c4a4d9d9bf1d0cc32f585eb82ad893f721+104&branch=master):
![image](https://user-images.githubusercontent.com/39505100/114219286-12556b80-9930-11eb-8e4b-61abcf1d9bbf.png)


### Motivation
<!-- What inspired you to submit this pull request? -->
AI-1080
