### PR TITLE
Enable metric_to_check validation on extras

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -479,7 +479,7 @@ def manifest(ctx, fix):
                     ):
                         file_failures += 1
                         display_queue.append((echo_failure, f'  metric_to_check not in metadata.csv: {metric!r}'))
-            elif metadata_in_manifest and check_name != 'snmp' and not (is_extras or is_marketplace):
+            elif metadata_in_manifest and check_name != 'snmp' and not is_marketplace:
                 # TODO remove exemptions for integrations-extras and marketplace in future
                 # if we have a metadata.csv file but no `metric_to_check` raise an error
                 metadata_file = get_metadata_file(check_name)


### PR DESCRIPTION
All integrations with metrics now define it since https://github.com/DataDog/integrations-extras/pull/837