### PR TITLE
Fix authSource config option.

### DIFF
--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -40,7 +40,7 @@ class MongoConfig(object):
             self.scheme = instance.get('connection_scheme', 'mongodb')
             self.db_name = instance.get('database')
             self.additional_options = instance.get('options', {})
-            self.auth_source = self.additional_options.get('authsource') or self.db_name or 'admin'
+            self.auth_source = self.additional_options.get('authSource') or self.db_name or 'admin'
 
         if not self.hosts:
             raise ConfigurationError('No `hosts` specified')

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -209,12 +209,11 @@ def test_auth_source(check):
     """
     instance = {
         'hosts': ['localhost', 'localhost:27018'],
-        'database': 'test',
-        'options': {'authSource': 'authDB'},  # Special character
+        'options': {'authSource': 'authDB'},
     }
     config = check(instance)._config
     assert config.hosts == ['localhost', 'localhost:27018']
-    assert config.clean_server_name == "mongodb://localhost,localhost:27018/test?authSource=authDB"
+    assert config.clean_server_name == "mongodb://localhost,localhost:27018/?authSource=authDB"
     assert config.auth_source == 'authDB'
     assert config.do_auth is False
 
@@ -230,6 +229,21 @@ def test_no_auth_source(check):
     assert config.hosts == ['localhost', 'localhost:27018']
     assert config.clean_server_name == "mongodb://localhost,localhost:27018/"
     assert config.auth_source == 'admin'
+    assert config.do_auth is False
+
+
+def test_no_auth_source_with_db(check):
+    """
+    Configuring the check without authSource but with database should default authSource to database.
+    """
+    instance = {
+        'hosts': ['localhost', 'localhost:27018'],
+        'database': 'test',
+    }
+    config = check(instance)._config
+    assert config.hosts == ['localhost', 'localhost:27018']
+    assert config.clean_server_name == "mongodb://localhost,localhost:27018/test"
+    assert config.auth_source == 'test'
     assert config.do_auth is False
 
 

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -90,6 +90,28 @@ def test_state_translation(check, instance):
     assert 'UNKNOWN' == get_state_name(500)
 
 
+def test_uri_fields(check, instance):
+    """
+    Unit test for functionality of parse_mongo_uri
+    """
+    server_names = (
+        (
+            "mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/?authSource=authDB",
+            (
+                "myDBReader",
+                "D1fficultP@ssw0rd",
+                None,
+                [('mongodb0.example.com', 27017)],
+                'mongodb://myDBReader:*****@mongodb0.example.com:27017/?authSource=authDB',
+                'authDB',
+            ),
+        ),
+    )
+
+    for server, expected_parse in server_names:
+        assert expected_parse == parse_mongo_uri(server)
+
+
 def test_server_uri_sanitization(check, instance):
     # Batch with `sanitize_username` set to False
     server_names = (
@@ -180,6 +202,7 @@ def test_no_auth(check):
     assert config.auth_source == 'test'
     assert config.do_auth is False
 
+
 def test_auth_source(check):
     """
     Configuring the check with authSource.
@@ -194,6 +217,7 @@ def test_auth_source(check):
     assert config.clean_server_name == "mongodb://localhost,localhost:27018/test?authSource=authDB"
     assert config.auth_source == 'authDB'
     assert config.do_auth is False
+
 
 def test_no_auth_source(check):
     """

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -180,6 +180,34 @@ def test_no_auth(check):
     assert config.auth_source == 'test'
     assert config.do_auth is False
 
+def test_auth_source(check):
+    """
+    Configuring the check with authSource.
+    """
+    instance = {
+        'hosts': ['localhost', 'localhost:27018'],
+        'database': 'test',
+        'options': {'authSource': 'authDB'},  # Special character
+    }
+    config = check(instance)._config
+    assert config.hosts == ['localhost', 'localhost:27018']
+    assert config.clean_server_name == "mongodb://localhost,localhost:27018/test?authSource=authDB"
+    assert config.auth_source == 'authDB'
+    assert config.do_auth is False
+
+def test_no_auth_source(check):
+    """
+    Configuring the check without authSource and without database should default authSource to 'admin'.
+    """
+    instance = {
+        'hosts': ['localhost', 'localhost:27018'],
+    }
+    config = check(instance)._config
+    assert config.hosts == ['localhost', 'localhost:27018']
+    assert config.clean_server_name == "mongodb://localhost,localhost:27018/"
+    assert config.auth_source == 'admin'
+    assert config.do_auth is False
+
 
 @pytest.mark.parametrize(
     'options, is_error',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Address issue #8747. Two places where we used `authsource` instead of `authSource`.
1. Parsing instance configs.
    Required change since `authSource` is used by `mongo`. Tests confirm that this field was not being parsed correctly. 

2. Parsing mongo uri.
    No change required. Calls `pymongo` method which returns a [`_CaseInsensitiveDictionary`](https://github.com/mongodb/mongo-python-driver/blob/master/pymongo/uri_parser.py#L136).  Tests added to confirm correctness. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
