### PR TITLE
Support the `--changed` flag for E2E testing

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -44,16 +44,17 @@ from .stop import stop
 @click.option('--profile-memory', '-pm', is_flag=True, help='Whether to collect metrics about memory usage')
 @click.option('--junit', '-j', 'junit', is_flag=True, help='Generate junit reports')
 @click.option('--filter', '-k', 'test_filter', help='Only run tests matching given substring expression')
+@click.option('--changed', is_flag=True, help='Only test changed checks')
 @click.pass_context
-def test(ctx, checks, agent, python, dev, base, env_vars, new_env, profile_memory, junit, test_filter):
+def test(ctx, checks, agent, python, dev, base, env_vars, new_env, profile_memory, junit, test_filter, changed):
     """Test an environment."""
-    check_envs = get_tox_envs(checks, e2e_tests_only=True)
+    check_envs = get_tox_envs(checks, e2e_tests_only=True, changed_only=changed)
     tests_ran = False
 
-    # If no checks are specified it means we're testing what has changed compared
+    # If no checks or a subset of checks are specified it means we're testing what has changed compared
     # to master, probably on CI rather than during local development. In this case,
     # ensure environments and Agents are spun up and down.
-    if not checks:
+    if not checks or changed:
         new_env = True
 
     # Default to testing the local development version.


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/integrations-core/blob/97021c770a5a9661596a0f19265d1828f54d9717/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py#L45

### Motivation

https://github.com/DataDog/integrations-core/pull/9140