### PR TITLE
Deprecate connection_scheme

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -59,12 +59,6 @@ files:
       value:
         type: object
         properties: []
-    - name: connection_scheme
-      description: |
-        A prefix indicating the connection string format.
-      value:
-        example: mongodb
-        type: string
     - name: replica_check
       description: |
         Whether or not to read from available replicas.

--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -61,7 +61,7 @@ files:
         properties: []
     - name: connection_scheme
       description: |
-        A prefix indicating the connection string format e.g. mongodb+srv.
+        A prefix indicating the connection string format.
       value:
         example: mongodb
         type: string

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -37,6 +37,7 @@ class MongoConfig(object):
             self.hosts = instance.get('hosts', [])
             self.username = instance.get('username')
             self.password = instance.get('password')
+            # Deprecated
             self.scheme = instance.get('connection_scheme', 'mongodb')
             self.db_name = instance.get('database')
             self.additional_options = instance.get('options', {})
@@ -48,6 +49,9 @@ class MongoConfig(object):
         self.clean_server_name = self._get_clean_server_name()
         if self.password and not self.username:
             raise ConfigurationError('`username` must be set when a `password` is specified')
+
+        if self.scheme != 'mongodb':
+            self.log.info("connection_scheme is deprecated and shouldn't be set to a value other than 'mongodb'")
 
         if not self.db_name:
             self.log.info('No MongoDB database found in URI. Defaulting to admin.')

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -60,11 +60,6 @@ instances:
     #
     # options: {}
 
-    ## @param connection_scheme - string - optional - default: mongodb
-    ## A prefix indicating the connection string format.
-    #
-    # connection_scheme: mongodb
-
     ## @param replica_check - boolean - optional - default: true
     ## Whether or not to read from available replicas.
     ## Disable this if any replicas are inaccessible to the Agent. This option is not supported for sharded clusters.

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -61,7 +61,7 @@ instances:
     # options: {}
 
     ## @param connection_scheme - string - optional - default: mongodb
-    ## A prefix indicating the connection string format e.g. mongodb+srv.
+    ## A prefix indicating the connection string format.
     #
     # connection_scheme: mongodb
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
After datadog-mongo 2.0.0, the check is not compliant with using mongodb+srv scheme.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
