### PR TITLE
Fix default config validation to include openmetrics template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -25,6 +25,7 @@ FILE_INDENT = ' ' * 8
 
 IGNORE_DEFAULT_INSTANCE = {'ceph', 'dotnetclr', 'gunicorn', 'marathon', 'pgbouncer', 'process', 'supervisord'}
 
+TEMPLATES = ['default', 'openmetrics_legacy', 'openmetrics', 'jmx']
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate default configuration files')
 @click.argument('check', autocompletion=complete_valid_checks, required=False)
@@ -157,11 +158,12 @@ def validate_default_template(spec_file):
 
     for line in spec_file.split('\n'):
         if any(
-            template in line
-            for template in ['init_config/default', 'init_config/openmetrics_legacy', 'init_config/jmx']
+            "init_config/{}".format(template) in line
+            for template in TEMPLATES
         ):
             init_config_default = True
-        if any(template in line for template in ['instances/default', 'instances/openmetrics_legacy', 'instances/jmx']):
+        if any(
+            "instances/{}".format(template) in line for template in TEMPLATES):
             instances_default = True
 
         if instances_default and init_config_default:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -27,6 +27,7 @@ IGNORE_DEFAULT_INSTANCE = {'ceph', 'dotnetclr', 'gunicorn', 'marathon', 'pgbounc
 
 TEMPLATES = ['default', 'openmetrics_legacy', 'openmetrics', 'jmx']
 
+
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate default configuration files')
 @click.argument('check', autocompletion=complete_valid_checks, required=False)
 @click.option('--sync', '-s', is_flag=True, help='Generate example configuration files based on specifications')
@@ -157,13 +158,9 @@ def validate_default_template(spec_file):
         return True
 
     for line in spec_file.split('\n'):
-        if any(
-            "init_config/{}".format(template) in line
-            for template in TEMPLATES
-        ):
+        if any("init_config/{}".format(template) in line for template in TEMPLATES):
             init_config_default = True
-        if any(
-            "instances/{}".format(template) in line for template in TEMPLATES):
+        if any("instances/{}".format(template) in line for template in TEMPLATES):
             instances_default = True
 
         if instances_default and init_config_default:


### PR DESCRIPTION
### What does this PR do?
Refactor templates that contain default config template and include openmetrics v2 template.
### Motivation
CI fails for kong despite openmetrics template containing default template.
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
