### PR TITLE
Clarify configuration and metric collection documentation

### DIFF
--- a/cisco_aci/README.md
+++ b/cisco_aci/README.md
@@ -30,7 +30,7 @@ To configure this check for an Agent running on a host:
 
    instances:
         ## @param aci_url - string - required
-        ## Url to query to gather metrics.
+        ## URL to query to gather metrics.
         #
       - aci_url: http://localhost
     

--- a/cisco_aci/README.md
+++ b/cisco_aci/README.md
@@ -54,7 +54,7 @@ To configure this check for an Agent running on a host:
         #   - <TENANT_2>
    ```
    
-   *NOTE*: Be sure to specify any tenants in order for the integration to collect metrics on applications, EPG, etc.
+   *NOTE*: Be sure to specify any tenants for the integration to collect metrics on applications, EPG, etc.
 
 2. [Restart the Agent][5] to begin sending Cisco ACI metrics to Datadog.
 

--- a/cisco_aci/README.md
+++ b/cisco_aci/README.md
@@ -29,23 +29,32 @@ To configure this check for an Agent running on a host:
    init_config:
 
    instances:
-     ## @param aci_url - string - required
-     ## Url to query to gather metrics.
-     #
-     - aci_url: localhost
-
-       ## @param username - string - required
-       ## Authentication can use either a user auth or a certificate.
-       ## If using the user auth, enter in this parameter the associated username.
-       #
-       username: datadog
-
-       ## @param pwd - string - required
-       ## Authentication can use either a user auth or a certificate.
-       ## If using the user auth, enter in this parameter the associated password.
-       #
-       pwd: datadog
+        ## @param aci_url - string - required
+        ## Url to query to gather metrics.
+        #
+      - aci_url: http://localhost
+    
+        ## @param username - string - required
+        ## Authentication can use either a user auth or a certificate.
+        ## If using the user auth, enter the `username` and `pwd` configuration.
+        #
+        username: datadog
+    
+        ## @param pwd - string - required
+        ## Authentication can use either a user auth or a certificate.
+        ## If using the user auth, enter the `username` and `pwd` configuration.
+        #
+        pwd: <PWD>
+    
+        ## @param tenant - list of strings - optional
+        ## List of tenants to collect metrics data.
+        #
+        # tenant:
+        #   - <TENANT_1>
+        #   - <TENANT_2>
    ```
+   
+   *NOTE*: Be sure to specify any tenants in order for the integration to collect metrics on applications, EPG, etc.
 
 2. [Restart the Agent][5] to begin sending Cisco ACI metrics to Datadog.
 

--- a/cisco_aci/README.md
+++ b/cisco_aci/README.md
@@ -47,7 +47,7 @@ To configure this check for an Agent running on a host:
         pwd: <PWD>
     
         ## @param tenant - list of strings - optional
-        ## List of tenants to collect metrics data.
+        ## List of tenants to collect metrics data from.
         #
         # tenant:
         #   - <TENANT_1>

--- a/cisco_aci/assets/configuration/spec.yaml
+++ b/cisco_aci/assets/configuration/spec.yaml
@@ -30,7 +30,7 @@ files:
         type: string
     - name: tenant
       description: |
-        List of tenants to collect metrics data.
+        List of tenants to collect metrics data from.
       value:
         type: array
         items:

--- a/cisco_aci/assets/configuration/spec.yaml
+++ b/cisco_aci/assets/configuration/spec.yaml
@@ -30,7 +30,7 @@ files:
         type: string
     - name: tenant
       description: |
-        List of tenants to collect data from
+        List of tenants to collect metrics data.
       value:
         type: array
         items:

--- a/cisco_aci/assets/configuration/spec.yaml
+++ b/cisco_aci/assets/configuration/spec.yaml
@@ -16,7 +16,7 @@ files:
     options:
     - name: aci_url
       required: true
-      description: Url to query to gather metrics.
+      description: URL to query to gather metrics.
       value:
         type: string
         example: http://localhost

--- a/cisco_aci/assets/configuration/spec.yaml
+++ b/cisco_aci/assets/configuration/spec.yaml
@@ -19,7 +19,7 @@ files:
       description: Url to query to gather metrics.
       value:
         type: string
-        example: localhost
+        example: http://localhost
       display_priority: 10
     - name: pwd
       required: true

--- a/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
+++ b/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
@@ -51,7 +51,7 @@ instances:
     ## @param aci_url - string - required
     ## Url to query to gather metrics.
     #
-  - aci_url: localhost
+  - aci_url: http://localhost
 
     ## @param username - string - required
     ## Authentication can use either a user auth or a certificate.

--- a/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
+++ b/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
@@ -66,7 +66,7 @@ instances:
     pwd: <PWD>
 
     ## @param tenant - list of strings - optional
-    ## List of tenants to collect data from
+    ## List of tenants to collect metrics data.
     #
     # tenant:
     #   - <TENANT_1>

--- a/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
+++ b/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
@@ -49,7 +49,7 @@ init_config:
 instances:
 
     ## @param aci_url - string - required
-    ## Url to query to gather metrics.
+    ## URL to query to gather metrics.
     #
   - aci_url: http://localhost
 
@@ -66,7 +66,7 @@ instances:
     pwd: <PWD>
 
     ## @param tenant - list of strings - optional
-    ## List of tenants to collect metrics data.
+    ## List of tenants to collect metrics data from.
     #
     # tenant:
     #   - <TENANT_1>


### PR DESCRIPTION
### What does this PR do?
Fix the `aci_url` config example to include schema `http://`

Include `tenants` option as part of configuration in the docs. Mention that it needs to be specified for apps/EPG stats.

### Motivation

Resolves https://github.com/DataDog/integrations-core/issues/9061 and https://github.com/DataDog/integrations-core/issues/9073
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
