### PR TITLE
Add logic to enable/disable metrics collected from the summary endpoint

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -108,6 +108,18 @@ TRANSFORM_VALUE_HISTOGRAMS = {
     'kubelet_runtime_operations_duration_seconds': 'kubelet.runtime.operations.duration',
 }
 
+DEFAULT_MAX_DEPTH = 10
+DEFAULT_ENABLED_RATES = ['diskio.io_service_bytes.stats.total', 'network.??_bytes', 'cpu.*.total']
+DEFAULT_ENABLED_GAUGES = [
+    'memory.cache',
+    'memory.usage',
+    'memory.swap',
+    'memory.working_set',
+    'memory.rss',
+    'filesystem.usage',
+]
+DEFAULT_POD_LEVEL_METRICS = ['network.*']
+
 log = logging.getLogger('collector')
 
 
@@ -144,6 +156,16 @@ class KubeletCheck(
         inst = instances[0] if instances else None
 
         cadvisor_instance = self._create_cadvisor_prometheus_instance(inst)
+
+        # configuring the collection of some of the metrics (via the cadvisor or the summary endpoint)
+        self.max_depth = inst.get('max_depth', DEFAULT_MAX_DEPTH)
+        enabled_gauges = inst.get('enabled_gauges', DEFAULT_ENABLED_GAUGES)
+        self.enabled_gauges = ["{0}.{1}".format(self.NAMESPACE, x) for x in enabled_gauges]
+        enabled_rates = inst.get('enabled_rates', DEFAULT_ENABLED_RATES)
+        self.enabled_rates = ["{0}.{1}".format(self.NAMESPACE, x) for x in enabled_rates]
+        pod_level_metrics = inst.get('pod_level_metrics', DEFAULT_POD_LEVEL_METRICS)
+        self.pod_level_metrics = ["{0}.{1}".format(self.NAMESPACE, x) for x in pod_level_metrics]
+
         kubelet_instance = self._create_kubelet_prometheus_instance(inst)
         generic_instances = [cadvisor_instance, kubelet_instance]
         super(KubeletCheck, self).__init__(name, init_config, generic_instances)

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -1056,6 +1056,17 @@ def test_process_stats_summary_as_source(monkeypatch, aggregator, tagger):
     )
 
 
+def test_kubelet_check_disable_summary_rates(monkeypatch, aggregator):
+    check = KubeletCheck('kubelet', {}, [{'enabled_rates': ['*unsupported_regex*']}])
+    pod_list_utils = PodListUtils(json.loads(mock_from_file('pods_windows.json')))
+    stats = json.loads(mock_from_file('stats_summary_windows.json'))
+
+    check.process_stats_summary(pod_list_utils, stats, [], True)  # windows/non-cadvisor case
+
+    assert len(aggregator.metrics('kubernetes.network.tx_bytes')) == 0  # rate disabled
+    assert len(aggregator.metrics('kubernetes.filesystem.usage_pct')) > 0  # gauge enabled
+
+
 def test_silent_tls_warning(caplog, monkeypatch, aggregator):
     check = KubeletCheck('kubelet', {}, [{}])
     check.kube_health_url = "https://example.com/"


### PR DESCRIPTION
### What does this PR do?
In order to best support kubernetes on windows we introduced https://github.com/DataDog/integrations-core/pull/6497 - However, this feature does not honour the configuration available for the cadvisor collector that can be used to disable/enable the collection of certain rates or certain types of metrics (for now, network but easily extnensible).

### Motivation
Customer Feature Req.

### Additional Notes
I moved around the parameters into the init of the super as we can't have a standalone cadvisor.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ x Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
