### PR TITLE
Allow configurability of the ignore_metrics option

### DIFF
--- a/kubelet/datadog_checks/kubelet/data/conf.yaml.default
+++ b/kubelet/datadog_checks/kubelet/data/conf.yaml.default
@@ -57,3 +57,14 @@ instances:
     #
     # enabled_gauges:
     #   - filesystem.*
+
+    ## @param ignore_metrics - list of strings - optional
+    ## A list of metrics to ignore, use the "*" wildcard can be used to match multiple metric names.
+    ## This option is only supported for the `/metrics/cadvisor` endpoint.
+    #
+    # ignore_metrics:
+    #   - <IGNORED_METRIC_NAME>
+    #   - <PREFIX_*>
+    #   - <*_SUFFIX>
+    #   - <PREFIX_*_SUFFIX>
+    #   - <*_SUBSTRING_*>

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -157,6 +157,12 @@ class KubeletCheck(
 
         cadvisor_instance = self._create_cadvisor_prometheus_instance(inst)
 
+        if len(inst.get('ignore_metrics', {})) > 0:
+            # Add entries from configuration to ignore_metrics in the cadvisor collector.
+            cadvisor_instance['ignore_metrics'].extend(
+                m for m in inst.get('ignore_metrics', {}) if m not in cadvisor_instance['ignore_metrics']
+            )
+
         # configuring the collection of some of the metrics (via the cadvisor or the summary endpoint)
         self.max_depth = inst.get('max_depth', DEFAULT_MAX_DEPTH)
         enabled_gauges = inst.get('enabled_gauges', DEFAULT_ENABLED_GAUGES)


### PR DESCRIPTION
### What does this PR do?

The option to ignore metrics from the /metrics/cadvisor endpoint was hardcoded. This PR allows users to extend the list should they choose to not collect a subset of metrics.

### Motivation

Customer FR.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
