### PR TITLE
Support new aggregator APIs for the event platform

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -510,6 +510,20 @@ class AgentCheck(object):
             tags,
         )
 
+    def database_monitoring_query_sample(self, raw_event):
+        # type: (str) -> None
+        if raw_event is None:
+            return
+
+        aggregator.submit_event_platform_event(self, self.check_id, to_native_string(raw_event), "dbm-samples")
+
+    def database_monitoring_query_metrics(self, raw_event):
+        # type: (str) -> None
+        if raw_event is None:
+            return
+
+        aggregator.submit_event_platform_event(self, self.check_id, to_native_string(raw_event), "dbm-metrics")
+
     def _submit_metric(
         self, mtype, name, value, tags=None, hostname=None, device_name=None, raw=False, flush_first_value=False
     ):

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
+import json
 import re
 from collections import OrderedDict, defaultdict
 
@@ -77,6 +78,8 @@ class AggregatorStub(object):
         self._asserted = set()
         self._service_checks = defaultdict(list)
         self._events = []
+        # dict[event_type, [events]]
+        self._event_platform_events = {}
         self._histogram_buckets = defaultdict(list)
 
     @classmethod
@@ -103,6 +106,9 @@ class AggregatorStub(object):
 
     def submit_event(self, check, check_id, event):
         self._events.append(event)
+
+    def submit_event_platform_event(self, check, check_id, raw_event, event_type):
+        self._event_platform_events[event_type].append(raw_event)
 
     def submit_histogram_bucket(
         self, check, check_id, name, value, lower_bound, upper_bound, monotonic, hostname, tags
@@ -149,6 +155,12 @@ class AggregatorStub(object):
         Return all events
         """
         return self._events
+
+    def get_event_platform_events(self, event_type, parse_json=True):
+        """
+        Return all event platform events for the event_type
+        """
+        return [json.loads(e) if parse_json else e for e in self._event_platform_events[event_type]]
 
     def histogram_bucket(self, name):
         """
@@ -460,6 +472,7 @@ class AggregatorStub(object):
         self._asserted = set()
         self._service_checks = defaultdict(list)
         self._events = []
+        self._event_platform_events = defaultdict(list)
 
     def all_metrics_asserted(self):
         assert self.metrics_asserted_pct >= 100.0

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import datetime
+import decimal
 import logging
 import socket
 import time
@@ -115,3 +117,11 @@ def resolve_db_host(db_host):
         )
 
     return db_host
+
+
+def default_json_event_encoding(o):
+    if isinstance(o, decimal.Decimal):
+        return float(o)
+    if isinstance(o, (datetime.date, datetime.datetime)):
+        return o.isoformat()
+    raise TypeError


### PR DESCRIPTION
### What does this PR do?

Follow-up to https://github.com/DataDog/datadog-agent/pull/7735: add the aggregator `submit_event_platform_event` API as well as two new APIs that build on this to submit `dbm-samples` and `dbm-metrics`.

Also add a new `default_json_event_encoding` to be used for when `datadog_checks/base/utils/db/statement_samples.py` is removed in https://github.com/DataDog/integrations-core/pull/9166

### Motivation

Enable checks to use the new aggregator API to submit event platform events. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
