### PR TITLE
[SNMP] Remove metric_prefix from snmp_tile integrations

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/manifest.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/manifest.json
@@ -3,7 +3,6 @@
   "maintainer": "{email}",
   "manifest_version": "1.0.0",
   "name": "snmp_{check_name}",
-  "metric_prefix": "snmp.",
   "metric_to_check": "",
   "creates_events": false,
   "short_description": "Collect SNMP metrics from your {integration_name} network devices.",

--- a/snmp_cisco/manifest.json
+++ b/snmp_cisco/manifest.json
@@ -3,7 +3,6 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "name": "snmp_cisco",
-  "metric_prefix": "snmp.",
   "metric_to_check": [
     "snmp.cefcFRUPowerAdminStatus",
     "snmp.devClientCount"

--- a/snmp_dell/manifest.json
+++ b/snmp_dell/manifest.json
@@ -3,7 +3,6 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "name": "snmp_dell",
-  "metric_prefix": "snmp.",
   "metric_to_check": [
     "snmp.fanSpeed",
     "snmp.systemStateChassisStatus",

--- a/snmp_juniper/manifest.json
+++ b/snmp_juniper/manifest.json
@@ -3,7 +3,6 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "name": "snmp_juniper",
-  "metric_prefix": "snmp.",
   "metric_to_check": [
     "snmp.jnxDcuStatsPackets",
     "snmp.jnxVirtualChassisPortInPkts",


### PR DESCRIPTION
### What does this PR do?

Remove `metric_prefix` from `snmp_tile` integrations

### Motivation

We recently added some `tile-only` integrations that do not generate metrics per se, and that are meant to show up in the integrations list so that customers can easily see which vendors we support with `snmp`. 

This was causing issues on the integration monitoring side: having multiple integration definitions with the same metric prefix makes it impossible to define which integration generated a metric. 

As `snmp_tile` integrations are all using metrics generated by `snmp` we decided to remove the `metric_prefix` from these integrations.

This PR updates also the template manifest used to generate new `snmp_tile` integrations in `ddev`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
