### PR TITLE
Upgrade isort

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -18,7 +18,7 @@ FIX_DEFAULT_ENVDIR_FLAG = 'ensure_default_envdir'
 
 # Style deps:
 # We pin deps in order to make CI more stable/reliable.
-ISORT_DEP = 'isort[pyproject]==5.5.1'
+ISORT_DEP = 'isort==5.8.0'
 BLACK_DEP = 'black==20.8b1'
 FLAKE8_DEP = 'flake8==3.8.3'
 FLAKE8_BUGBEAR_DEP = 'flake8-bugbear==20.1.4'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Part of [Before Freeze checklist](https://datadoghq.dev/integrations-core/process/agent-release/pre-release/#before-freeze)
https://pypi.org/project/isort/


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Doesn't seem like the `pyproject` option worked for either version.
```
➜ pip install "isort[pyproject]==5.5.1"     
Collecting isort[pyproject]==5.5.1
  Using cached isort-5.5.1-py3-none-any.whl (95 kB)
WARNING: isort 5.5.1 does not provide the extra 'pyproject'
```

```
➜ pip install "isort[pyproject]==5.8.0"
Collecting isort[pyproject]==5.8.0
  Using cached isort-5.8.0-py3-none-any.whl (103 kB)
WARNING: isort 5.8.0 does not provide the extra 'pyproject'
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
