### PR TITLE
Kafka - Added session metrics

### DIFF
--- a/kafka/datadog_checks/kafka/data/metrics.yaml
+++ b/kafka/datadog_checks/kafka/data/metrics.yaml
@@ -664,3 +664,21 @@ jmx_metrics:
           Count:
             metric_type: rate
             alias: kafka.session.zookeeper.sync.rate
+
+    #
+    # Session stats
+    #
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=FetchSessionCache,name=NumIncrementalFetchSessions'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.session.fetch.count
+    - include:
+        domain: 'kafka.server'
+        bean: 'kafka.server:type=FetchSessionCache,name=IncrementalFetchSessionEvictionsPerSec'
+        attribute:
+          Count:
+            alias: kafka.session.fetch.eviction
+            metric_type: rate

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -85,3 +85,5 @@ kafka.topic.messages_in.rate,gauge,10,message,,Incoming message rate by topic,0,
 kafka.topic.net.bytes_out.rate,gauge,10,byte,second,Outgoing byte rate by topic.,0,kafka,topic bytes out
 kafka.topic.net.bytes_in.rate,gauge,10,byte,second,Incoming byte rate by topic.,0,kafka,topic bytes in
 kafka.topic.net.bytes_rejected.rate,gauge,10,byte,second,Rejected byte rate by topic.,-1,kafka,topic bytes rejected
+kafka.session.fetch.count,gauge,10,,,Number of fetch sessions.,0,kafka,fetch sessions
+kafka.session.fetch.eviction,gauge,10,event,second,Eviction rate of fetch session.,0,kafka,eviction session rate

--- a/kafka/tests/common.py
+++ b/kafka/tests/common.py
@@ -59,4 +59,7 @@ KAFKA_E2E_METRICS = [
     "kafka.session.zookeeper.expire.rate",
     "kafka.session.zookeeper.readonly.rate",
     "kafka.session.zookeeper.sync.rate",
+    # Session
+    "kafka.session.fetch.count",
+    "kafka.session.fetch.eviction",
 ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
A new metric for the number of kafka sessions has been added.
This metric helps determine large scale of kafka parameters for `max.incremental.fetch.session.cache.slots`

### Motivation
<!-- What inspired you to submit this pull request? -->
When using kafka with many consumers, some parameters need to optimize performance.
https://cwiki.apache.org/confluence/display/KAFKA/KIP-227%3A+Introduce+Incremental+FetchRequests+to+Increase+Partition+Scalability


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
