### PR TITLE
Update metrics in vSphere tdefault dashbaord

### DIFF
--- a/vsphere/assets/dashboards/vsphere_dashboard.json
+++ b/vsphere/assets/dashboards/vsphere_dashboard.json
@@ -14,7 +14,7 @@
             "definition": {
                 "requests": [
                     {
-                        "q": "avg:vsphere.cpu.usage{$scope}"
+                        "q": "avg:vsphere.cpu.usage.avg{$scope}"
                     }
                 ],
                 "type": "timeseries",
@@ -25,10 +25,10 @@
             "definition": {
                 "requests": [
                     {
-                        "q": "avg:vsphere.cpu.ready{$scope}"
+                        "q": "avg:vsphere.cpu.ready.sum{$scope}"
                     },
                     {
-                        "q": "avg:vsphere.cpu.wait{$scope}"
+                        "q": "avg:vsphere.cpu.wait.sum{$scope}"
                     }
                 ],
                 "type": "timeseries",
@@ -39,7 +39,7 @@
             "definition": {
                 "requests": [
                     {
-                        "q": "avg:vsphere.net.transmitted{$scope}"
+                        "q": "avg:vsphere.net.transmitted.avg{$scope}"
                     }
                 ],
                 "type": "timeseries",
@@ -50,7 +50,7 @@
             "definition": {
                 "requests": [
                     {
-                        "q": "avg:vsphere.net.received{$scope}"
+                        "q": "avg:vsphere.net.received.avg{$scope}"
                     }
                 ],
                 "type": "timeseries",


### PR DESCRIPTION
### What does this PR do?
Update the metrics in the default dashboard to match the metrics in metrics.py

### Motivation
Customer reached out about missing metrics:
https://datadog.zendesk.com/agent/tickets/451474 

### Additional Notes
Noticed that there was incorrect metrics in the default dashboard after a customer reached out about "missing" vSphere metrics. Looks like the metrics were different from the metrics in metrics.py:
https://github.com/DataDog/integrations-core/blob/master/vsphere/datadog_checks/vsphere/metrics.py#L399

