### PR TITLE
Provide better error message when api version cannot be determined

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -54,9 +54,10 @@ class KafkaCheck(AgentCheck):
             # the legacy code path regardless of kafka version
             try:
                 kafka_version = cls._determine_kafka_version(init_config, instance)
-            except Exception as e:
+            except Exception:
                 raise CheckException(
-                    "Could not determine kafka version. You can avoid this by specifying kafka_client_api_version option."
+                    "Could not determine kafka version. "
+                    "You can avoid this by specifying kafka_client_api_version option."
                 )
             if kafka_version >= (0, 10, 2):
                 return super(KafkaCheck, cls).__new__(cls)

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -4,7 +4,6 @@
 from collections import defaultdict
 from time import time
 
-from datadog_checks.base.errors import CheckException
 from kafka import KafkaAdminClient, KafkaClient
 from kafka import errors as kafka_errors
 from kafka.protocol.offset import OffsetRequest, OffsetResetStrategy, OffsetResponse
@@ -12,6 +11,7 @@ from kafka.structs import TopicPartition
 from six import string_types
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
+from datadog_checks.base.errors import CheckException
 
 from .constants import BROKER_REQUESTS_BATCH_SIZE, CONTEXT_UPPER_BOUND, DEFAULT_KAFKA_TIMEOUT, KAFKA_INTERNAL_TOPICS
 from .legacy_0_10_2 import LegacyKafkaCheck_0_10_2
@@ -55,7 +55,9 @@ class KafkaCheck(AgentCheck):
             try:
                 kafka_version = cls._determine_kafka_version(init_config, instance)
             except Exception as e:
-                raise CheckException("Could not determine kafka version. You can avoid this by specifying kafka_client_api_version option." )
+                raise CheckException(
+                    "Could not determine kafka version. You can avoid this by specifying kafka_client_api_version option."
+                )
             if kafka_version >= (0, 10, 2):
                 return super(KafkaCheck, cls).__new__(cls)
         return LegacyKafkaCheck_0_10_2(name, init_config, instances)


### PR DESCRIPTION
If Kafka is not available at the time of agent start the error that shows in the logs is NoBrokerAvailable which is confusing both for users and SEs.

Often times the customer setup can have simultaneous agent+kafka starts and in that case the agent tries to hit kafka too soon. We should make more explicit how to avoid the situation.