### PR TITLE
Bump oracle image

### DIFF
--- a/oracle/tests/conftest.py
+++ b/oracle/tests/conftest.py
@@ -76,7 +76,13 @@ def dd_environment():
     with docker_run(
         COMPOSE_FILE,
         conditions=[
-            CheckDockerLogs(COMPOSE_FILE, ['The database is ready for use'], wait=5, attempts=120),
+            CheckDockerLogs(COMPOSE_FILE,
+                            [
+                                'Database creation complete.',
+                                'DATABASE IS READY TO USE!',
+                                'XDB initialized.'
+                            ],
+                            wait=5, attempts=120),
             WaitFor(create_user),
         ],
         env_vars={'ORACLE_DATABASE_VERSION': ORACLE_DATABASE_VERSION},

--- a/oracle/tests/conftest.py
+++ b/oracle/tests/conftest.py
@@ -80,7 +80,7 @@ def dd_environment():
                 COMPOSE_FILE,
                 ['Database creation complete.', 'DATABASE IS READY TO USE!'],
                 wait=10,
-                attempts=60,
+                attempts=120,
             ),
             WaitFor(create_user),
         ],

--- a/oracle/tests/conftest.py
+++ b/oracle/tests/conftest.py
@@ -78,7 +78,7 @@ def dd_environment():
         conditions=[
             CheckDockerLogs(
                 COMPOSE_FILE,
-                ['Database creation complete.', 'DATABASE IS READY TO USE!', 'XDB initialized.'],
+                ['Database creation complete.', 'DATABASE IS READY TO USE!'],
                 wait=10,
                 attempts=60,
             ),

--- a/oracle/tests/conftest.py
+++ b/oracle/tests/conftest.py
@@ -76,13 +76,12 @@ def dd_environment():
     with docker_run(
         COMPOSE_FILE,
         conditions=[
-            CheckDockerLogs(COMPOSE_FILE,
-                            [
-                                'Database creation complete.',
-                                'DATABASE IS READY TO USE!',
-                                'XDB initialized.'
-                            ],
-                            wait=5, attempts=120),
+            CheckDockerLogs(
+                COMPOSE_FILE,
+                ['Database creation complete.', 'DATABASE IS READY TO USE!', 'XDB initialized.'],
+                wait=10,
+                attempts=60,
+            ),
             WaitFor(create_user),
         ],
         env_vars={'ORACLE_DATABASE_VERSION': ORACLE_DATABASE_VERSION},

--- a/oracle/tests/docker/docker-compose.yaml
+++ b/oracle/tests/docker/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3'
 services:
   oracle:
     container_name: oracle-database
-    image: container-registry.oracle.com/database/enterprise:${ORACLE_DATABASE_VERSION}-slim
+    image: container-registry.oracle.com/database/enterprise:${ORACLE_DATABASE_VERSION}
     shm_size: '8gb'
     volumes:
       - ./data:/host/data

--- a/oracle/tox.ini
+++ b/oracle/tox.ini
@@ -24,7 +24,7 @@ setenv =
     jdbc: CLIENT_LIB=jdbc
     oracle: CLIENT_LIB=oracle
     # Patching ends 2026/3/31
-    latest: ORACLE_DATABASE_VERSION=19.3.0.0  # 9.3 although listed on the registry is not available ¯\_(ツ)_/¯
+    latest: ORACLE_DATABASE_VERSION=latest  # 19.3 although listed on the registry is not available ¯\_(ツ)_/¯
 commands =
     pip install -r requirements.in
     oracle: pip uninstall -y jpype1 # Should work even if jpype is not installed.

--- a/oracle/tox.ini
+++ b/oracle/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{19.3}-{oracle,jdbc}
+    py{27,38}-{latest}-{oracle,jdbc}
 
 [testenv]
 ensure_default_envdir = true
@@ -24,7 +24,7 @@ setenv =
     jdbc: CLIENT_LIB=jdbc
     oracle: CLIENT_LIB=oracle
     # Patching ends 2026/3/31
-    19.3: ORACLE_DATABASE_VERSION=19.3.0.0
+    latest: ORACLE_DATABASE_VERSION=19.3.0.0  # 9.3 although listed on the registry is not available ¯\_(ツ)_/¯
 commands =
     pip install -r requirements.in
     oracle: pip uninstall -y jpype1 # Should work even if jpype is not installed.

--- a/oracle/tox.ini
+++ b/oracle/tox.ini
@@ -24,7 +24,9 @@ setenv =
     jdbc: CLIENT_LIB=jdbc
     oracle: CLIENT_LIB=oracle
     # Patching ends 2026/3/31
-    latest: ORACLE_DATABASE_VERSION=latest  # 19.3 although listed on the registry is not available ¯\_(ツ)_/¯
+    # Should be 19.3.0.0 although listed on the registry is not available ¯\_(ツ)_/¯
+    # https://community.oracle.com/mosc/discussion/4492484/tagged-docker-image-in-container-registry-oracle-com/
+    latest: ORACLE_DATABASE_VERSION=latest
 commands =
     pip install -r requirements.in
     oracle: pip uninstall -y jpype1 # Should work even if jpype is not installed.

--- a/oracle/tox.ini
+++ b/oracle/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{12.2}-{oracle,jdbc}
+    py{27,38}-{19.3}-{oracle,jdbc}
 
 [testenv]
 ensure_default_envdir = true
@@ -23,7 +23,8 @@ passenv =
 setenv =
     jdbc: CLIENT_LIB=jdbc
     oracle: CLIENT_LIB=oracle
-    12.2: ORACLE_DATABASE_VERSION=12.2.0.1
+    # Patching ends 2026/3/31
+    19.3: ORACLE_DATABASE_VERSION=19.3.0.0
 commands =
     pip install -r requirements.in
     oracle: pip uninstall -y jpype1 # Should work even if jpype is not installed.


### PR DESCRIPTION
Premier support and patching ended for 12.2 on 2020/11/20
Image should be pinned to 19.3 but it does not download. I've left a message about that in the community board https://community.oracle.com/mosc/discussion/4492484/tagged-docker-image-in-container-registry-oracle-com/p1?new=1