### PR TITLE
Fix retry parsing when metric has multiple metric parts

### DIFF
--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -87,7 +87,6 @@ class Envoy(AgentCheck):
                 continue
 
             try:
-                self.log.debug("!!Parsing....: {}".format(envoy_metric))
                 metric, tags, method = parse_metric(envoy_metric, retry=self.parse_unknown_metrics)
             except UnknownMetric:
                 if envoy_metric not in self.unknown_metrics:
@@ -101,7 +100,6 @@ class Envoy(AgentCheck):
                         self.log.debug('Unknown tag `%s` in metric `%s`', tag, envoy_metric)
                     self.unknown_tags[tag] += 1
                 continue
-            self.log.debug("!!GOT....: {}".format(metric))
 
             tags.extend(self.custom_tags)
 

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -87,6 +87,7 @@ class Envoy(AgentCheck):
                 continue
 
             try:
+                self.log.debug("!!Parsing....: {}".format(envoy_metric))
                 metric, tags, method = parse_metric(envoy_metric, retry=self.parse_unknown_metrics)
             except UnknownMetric:
                 if envoy_metric not in self.unknown_metrics:
@@ -100,6 +101,7 @@ class Envoy(AgentCheck):
                         self.log.debug('Unknown tag `%s` in metric `%s`', tag, envoy_metric)
                     self.unknown_tags[tag] += 1
                 continue
+            self.log.debug("!!GOT....: {}".format(metric))
 
             tags.extend(self.custom_tags)
 

--- a/envoy/datadog_checks/envoy/parser.py
+++ b/envoy/datadog_checks/envoy/parser.py
@@ -80,9 +80,14 @@ def parse_metric(metric, retry=False, metric_mapping=METRIC_TREE):
     parsed_metric = '.'.join(metric_parts)
     if parsed_metric not in METRICS:
         if retry:
+            skip_parts = []
             # Retry parsing for metrics by skipping the last matched metric part
             while len(metric_parts) > 1:
                 skip_part = metric_parts.pop()
+                if skip_part in skip_parts:
+                    raise UnknownMetric
+                else:
+                    skip_parts.append(skip_part)
                 (
                     metric_parts,
                     tag_value_builder,

--- a/envoy/tests/docker/default/front-envoy.yaml
+++ b/envoy/tests/docker/default/front-envoy.yaml
@@ -57,7 +57,7 @@ static_resources:
               socket_address:
                 address: service2
                 port_value: 80
-  - name: ms-catalog-category-appli.default.eu-west-3-stg.internal.ba3374ca-fb2a-3f3e-9ea6-79e021188673.consul
+  - name: xds_cluster
     http2_protocol_options: {}
     connect_timeout: 1s
     type: LOGICAL_DNS
@@ -77,14 +77,14 @@ dynamic_resources:
       api_type: GRPC
       grpc_services:
       - envoy_grpc:
-          cluster_name: service-xdr.default.eu-west-3-stg.internal.abcd.consul
+          cluster_name: xds_cluster
       set_node_on_first_message_only: true
   lds_config:
     api_config_source:
       api_type: GRPC
       grpc_services:
       - envoy_grpc:
-          cluster_name: service-xdr.default.eu-west-3-stg.internal.abcd.consul
+          cluster_name: xds_cluster
       set_node_on_first_message_only: true
 node:
   cluster: e2e-test-cluster

--- a/envoy/tests/docker/default/front-envoy.yaml
+++ b/envoy/tests/docker/default/front-envoy.yaml
@@ -57,13 +57,13 @@ static_resources:
               socket_address:
                 address: service2
                 port_value: 80
-  - name: xds_cluster
+  - name: ms-catalog-category-appli.default.eu-west-3-stg.internal.ba3374ca-fb2a-3f3e-9ea6-79e021188673.consul
     http2_protocol_options: {}
     connect_timeout: 1s
     type: LOGICAL_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
-      cluster_name: xds_cluster
+      cluster_name: ms-catalog-category-appli.default.eu-west-3-stg.internal.ba3374ca-fb2a-3f3e-9ea6-79e021188673.consul
       endpoints:
       - lb_endpoints:
         - endpoint:
@@ -77,14 +77,14 @@ dynamic_resources:
       api_type: GRPC
       grpc_services:
       - envoy_grpc:
-          cluster_name: xds_cluster
+          cluster_name: ms-catalog-category-appli.default.eu-west-3-stg.internal.ba3374ca-fb2a-3f3e-9ea6-79e021188673.consul
       set_node_on_first_message_only: true
   lds_config:
     api_config_source:
       api_type: GRPC
       grpc_services:
       - envoy_grpc:
-          cluster_name: xds_cluster
+          cluster_name: service-xdr.default.eu-west-3-stg.internal.abcd.consul
       set_node_on_first_message_only: true
 node:
   cluster: e2e-test-cluster

--- a/envoy/tests/docker/default/front-envoy.yaml
+++ b/envoy/tests/docker/default/front-envoy.yaml
@@ -63,7 +63,7 @@ static_resources:
     type: LOGICAL_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
-      cluster_name: ms-catalog-category-appli.default.eu-west-3-stg.internal.ba3374ca-fb2a-3f3e-9ea6-79e021188673.consul
+      cluster_name: service-xdr.default.eu-west-3-stg.internal.abcd.consul
       endpoints:
       - lb_endpoints:
         - endpoint:
@@ -77,7 +77,7 @@ dynamic_resources:
       api_type: GRPC
       grpc_services:
       - envoy_grpc:
-          cluster_name: ms-catalog-category-appli.default.eu-west-3-stg.internal.ba3374ca-fb2a-3f3e-9ea6-79e021188673.consul
+          cluster_name: service-xdr.default.eu-west-3-stg.internal.abcd.consul
       set_node_on_first_message_only: true
   lds_config:
     api_config_source:

--- a/envoy/tests/test_parser.py
+++ b/envoy/tests/test_parser.py
@@ -41,22 +41,14 @@ def test_retry_metric():
         METRICS[untagged_metric]['method'],
     )
 
-def test_retry2_metric():
-    metric = "cluster{}.upstream_rq_timeout"
-    untagged_metric = metric.format('')
-    tags = [tag for tags in METRICS[untagged_metric]['tags'] for tag in tags]
-    tag0 = 'ms-catalog-category-appli.default.eu-west-3-stg.internal.ba3374ca-fb2a-3f3e-9ea6-79e021188673.consul'
-    tagged_metric = metric.format('.{}'.format(tag0))
-    assert parse_metric(tagged_metric, retry=True) == (
-        METRIC_PREFIX + untagged_metric,
-        ['{}:{}'.format(tags[0], tag0)],
-        METRICS[untagged_metric]['method'],
-    )
-
 
 def test_retry_invalid_metric():
     with pytest.raises(UnknownMetric):
-        parse_metric("cluster.ms-catalog-category-appli.default.eu-west-3-stg.internal.ba3374ca-fb2a-3f3e-9ea6-79e021188673.consul.http2.dropped_headers_with_underscores", retry=True)
+        parse_metric(
+            "cluster.ms-catalog-category-appli.default.eu-west-3-stg.internal"
+            ".ba3374ca-fb2a-3f3e-9ea6-79e021188673.consul.http2.dropped_headers_with_underscores",
+            retry=True,
+        )
 
 
 def test_http_router_filter():

--- a/envoy/tests/test_parser.py
+++ b/envoy/tests/test_parser.py
@@ -41,10 +41,22 @@ def test_retry_metric():
         METRICS[untagged_metric]['method'],
     )
 
+def test_retry2_metric():
+    metric = "cluster{}.upstream_rq_timeout"
+    untagged_metric = metric.format('')
+    tags = [tag for tags in METRICS[untagged_metric]['tags'] for tag in tags]
+    tag0 = 'ms-catalog-category-appli.default.eu-west-3-stg.internal.ba3374ca-fb2a-3f3e-9ea6-79e021188673.consul'
+    tagged_metric = metric.format('.{}'.format(tag0))
+    assert parse_metric(tagged_metric, retry=True) == (
+        METRIC_PREFIX + untagged_metric,
+        ['{}:{}'.format(tags[0], tag0)],
+        METRICS[untagged_metric]['method'],
+    )
+
 
 def test_retry_invalid_metric():
     with pytest.raises(UnknownMetric):
-        parse_metric("cluster.internal.foo", retry=True)
+        parse_metric("cluster.ms-catalog-category-appli.default.eu-west-3-stg.internal.ba3374ca-fb2a-3f3e-9ea6-79e021188673.consul.http2.dropped_headers_with_underscores", retry=True)
 
 
 def test_http_router_filter():


### PR DESCRIPTION
### What does this PR do?
Metric containing multiple metric_parts for a metric that doesn't exist causes a loop. This PR tracks skip_parts.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
