### PR TITLE
Fix QA card assignment to be distributed randomly and equally

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -33,6 +33,7 @@ def create_trello_card(
     dry_run: bool,
     pr_author: str,
     config: dict,
+    card_assignments: dict,
 ) -> None:
     labels = ', '.join(f'`{label}`' for label in sorted(pr_labels))
     body = f'''\
@@ -42,8 +43,7 @@ Labels: {labels}
 
 {pr_body}'''
     for team in teams:
-        member = pick_card_member(config, pr_author, team)
-        tester_name = member
+        tester_name, member = pick_card_member(config, pr_author, team.lower(), card_assignments)
         if member is None:
             tester = _select_trello_tester(client, testerSelector, team, pr_author, pr_num, pr_url)
             if tester:
@@ -154,7 +154,7 @@ def get_commits_between(base_ref: str, target_ref: str, *, root: str) -> List[Tu
             raise click.Abort
 
 
-def pick_card_member(config: dict, author: str, team: str) -> Optional[str]:
+def pick_card_member(config: dict, author: str, team: str, card_assignments: dict) -> Optional[str]:
     """Return a member to assign to the created issue.
     In practice, it returns one trello user which is not the PR author, for the given team.
     For it to work, you need a `trello_users_$team` table in your ddev configuration,
@@ -165,11 +165,18 @@ def pick_card_member(config: dict, author: str, team: str) -> Optional[str]:
         john = "xxxxxxxxxxxxxxxxxxxxx"
         alice = "yyyyyyyyyyyyyyyyyyyy"
     """
-    users = config.get(f'trello_users_{team.lower()}')
+    users = config.get(f'trello_users_{team}')
     if not users:
         return None
-    member = random.choice([key for user, key in users.items() if user != author])
-    return member
+    if team not in card_assignments:
+        # initialize map team -> user -> QA cards assigned
+        team_members = list(users)
+        random.shuffle(team_members)
+        card_assignments[team] = dict.fromkeys(team_members, 0)
+
+    member = min([member for member in card_assignments[team] if member != author], key=card_assignments[team].get)
+    card_assignments[team][member] += 1
+    return member, users[member]
 
 
 @click.command(
@@ -296,6 +303,8 @@ def testable(
     if update_rc_builds_cards:
         rc_build_cards_updater = RCBuildCardsUpdater(trello, target_ref)
 
+    card_assignments = {}
+
     github_teams = trello.label_github_team_map.values()
     testerSelector = create_tester_selector(trello, repo, github_teams, user_config, APP_DIR)
     for i, (commit_hash, commit_subject) in enumerate(commits, 1):
@@ -398,6 +407,7 @@ def testable(
                 dry_run,
                 pr_author,
                 user_config,
+                card_assignments,
             )
             continue
 
@@ -469,6 +479,7 @@ def testable(
                     dry_run,
                     pr_author,
                     user_config,
+                    card_assignments,
                 )
 
             finished = True

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import random
 import time
-from typing import List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 import click
 
@@ -154,7 +154,7 @@ def get_commits_between(base_ref: str, target_ref: str, *, root: str) -> List[Tu
             raise click.Abort
 
 
-def pick_card_member(config: dict, author: str, team: str, card_assignments: dict) -> Optional[str]:
+def pick_card_member(config: dict, author: str, team: str, card_assignments: dict) -> Tuple[Any, Any]:
     """Return a member to assign to the created issue.
     In practice, it returns one trello user which is not the PR author, for the given team.
     For it to work, you need a `trello_users_$team` table in your ddev configuration,
@@ -167,7 +167,7 @@ def pick_card_member(config: dict, author: str, team: str, card_assignments: dic
     """
     users = config.get(f'trello_users_{team}')
     if not users:
-        return None
+        return None, None
     if team not in card_assignments:
         # initialize map team -> user -> QA cards assigned
         team_members = list(users)
@@ -303,7 +303,7 @@ def testable(
     if update_rc_builds_cards:
         rc_build_cards_updater = RCBuildCardsUpdater(trello, target_ref)
 
-    card_assignments = {}
+    card_assignments: Dict[str, Dict[str, int]] = {}
 
     github_teams = trello.label_github_team_map.values()
     testerSelector = create_tester_selector(trello, repo, github_teams, user_config, APP_DIR)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`ddev trello release command` assigns cards at random if you define a user table in `ddev config`. This can produce lop-sided assignments of QA cards:
```
Card assignments using ddev config
        - ChristineTChen: 4
        - FlorianVeaux: 2
        - hithwen: 2
        - mgarabed: 1
        - ofek: 1
        - coignetp: 1
        - luisgonzalex: 0
```
This fix implements a different strategy to even out the QA cards while still being random.
1. Shuffle user defined list.
2. Assign card to user with least cards assigned (if there are multiple, will be assigned to first user with that minimum. Since order is shuffled initially, there are no adversarial cases). 

So now we have:
```
Card assignments using ddev config
integrations
        - ChristineTChen: 1
        - FlorianVeaux: 1
        - hithwen: 2
        - mgarabed: 2
        - ofek: 2
        - coignetp: 1
        - luisgonzalex: 2
```
```
Card assignments using ddev config
integrations
        - ChristineTChen: 2
        - FlorianVeaux: 2
        - hithwen: 1
        - mgarabed: 2
        - ofek: 2
        - coignetp: 1
        - luisgonzalex: 1

```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
