### PR TITLE
Fix warning log format

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -320,12 +320,12 @@ class KafkaCheck(AgentCheck):
                 if partitions is None:
                     msg = (
                         "Consumer group: %s has offsets for topic: %s, partition: %s, but that topic has no partitions "
-                        "in the cluster, so skipping reporting these offsets.",
+                        "in the cluster, so skipping reporting these offsets."
                     )
                 else:
                     msg = (
                         "Consumer group: %s has offsets for topic: %s, partition: %s, but that topic partition isn't "
-                        "included in the cluster partitions, so skipping reporting these offsets.",
+                        "included in the cluster partitions, so skipping reporting these offsets."
                     )
                 self.log.warning(msg, consumer_group, topic, partition)
                 self.kafka_client._client.cluster.request_update()  # force metadata update on next poll()

--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -324,12 +324,12 @@ class LegacyKafkaCheck_0_10_2(AgentCheck):
                 if partitions is None:
                     msg = (
                         "Consumer group: %s has offsets for topic: %s, partition: %s, but that topic has no partitions "
-                        "in the cluster, so skipping reporting these offsets.",
+                        "in the cluster, so skipping reporting these offsets."
                     )
                 else:
                     msg = (
                         "Consumer group: %s has offsets for topic: %s, partition: %s, but that topic partition isn't "
-                        "included in the cluster partitions, so skipping reporting these offsets.",
+                        "included in the cluster partitions, so skipping reporting these offsets."
                     )
                 self.log.warning(msg, consumer_group, topic, partition)
                 self._kafka_client.cluster.request_update()  # force metadata update on next poll()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
From 
`| (kafka_consumer.py:330) | ("Consumer group: my_consumer has offsets for topic: marvel, partition: 0, but that topic partition isn't included in the cluster partitions, so skipping reporting these offsets.",)`
to
`| (kafka_consumer.py:330) | Consumer group: my_consumer has offsets for topic: marvel, partition: 0, but that topic partition isn't included in the cluster partitions, so skipping reporting these offsets.`

### Motivation
<!-- What inspired you to submit this pull request? -->
qa

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
