### PR TITLE
Increase Kubelet default scraping time from 15s to 20s

### DIFF
--- a/kubelet/datadog_checks/kubelet/data/conf.yaml.default
+++ b/kubelet/datadog_checks/kubelet/data/conf.yaml.default
@@ -68,3 +68,9 @@ instances:
     #   - <*_SUFFIX>
     #   - <PREFIX_*_SUFFIX>
     #   - <*_SUBSTRING_*>
+
+    ## @param min_collection_interval - integer - optional - default: 15
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    min_collection_interval: 20

--- a/kubelet/datadog_checks/kubelet/data/conf.yaml.example
+++ b/kubelet/datadog_checks/kubelet/data/conf.yaml.example
@@ -54,3 +54,9 @@ instances:
     #
     # enabled_gauges:
     #   - filesystem.*
+
+    ## @param min_collection_interval - integer - optional - default: 15
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    min_collection_interval: 20


### PR DESCRIPTION
### What does this PR do?
Increase Kubelet default scraping time from 15s to 20s to avoid rates with `0` values due to cAdvisor dynamic refresh time which oscillates between 10 and 20s.

### Motivation
Avoid bad data points (see https://github.com/google/cadvisor/blob/master/docs/runtime_options.md#housekeeping)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
