### PR TITLE
Add `ddev env edit` command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/__init__.py
@@ -5,6 +5,7 @@ import click
 
 from ..console import CONTEXT_SETTINGS
 from .check import check_run
+from .edit import edit
 from .ls import ls
 from .prune import prune
 from .reload import reload_env
@@ -13,7 +14,7 @@ from .start import start
 from .stop import stop
 from .test import test
 
-ALL_COMMANDS = (check_run, ls, prune, reload_env, shell, start, stop, test)
+ALL_COMMANDS = (check_run, edit, ls, prune, reload_env, shell, start, stop, test)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Manage environments')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/edit.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/edit.py
@@ -11,18 +11,18 @@ from ...utils import complete_testable_checks, get_tox_file
 from ..console import CONTEXT_SETTINGS, abort, echo_failure
 
 
-@click.command(context_settings=CONTEXT_SETTINGS, short_help='Edit config file')
+@click.command(context_settings=CONTEXT_SETTINGS, short_help='Edit config file using default editor')
 @click.argument('check', autocompletion=complete_testable_checks)
 @click.argument('env', autocompletion=complete_envs)
+@click.option('--editor', '-e', help='Editor to use')
 @click.pass_context
-def edit(ctx, check, env):
+def edit(ctx, check, env, editor):
     """Start an environment."""
     if not file_exists(get_tox_file(check)):
         abort(f'`{check}` is not a testable check.')
 
     config_file = locate_config_file(check, env)
-    print(config_file)
     try:
-        click.edit(filename=config_file)
+        click.edit(editor=editor, filename=config_file, extension='.yaml')
     except click.ClickException as e:
         echo_failure(f'Failed to open `{config_file}` in editor. Error: {e}')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/edit.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/edit.py
@@ -1,0 +1,28 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import click
+
+from datadog_checks.dev.tooling.e2e.config import locate_config_file
+
+from ....fs import file_exists
+from ...testing import complete_envs
+from ...utils import complete_testable_checks, get_tox_file
+from ..console import CONTEXT_SETTINGS, abort, echo_failure
+
+
+@click.command(context_settings=CONTEXT_SETTINGS, short_help='Edit config file')
+@click.argument('check', autocompletion=complete_testable_checks)
+@click.argument('env', autocompletion=complete_envs)
+@click.pass_context
+def edit(ctx, check, env):
+    """Start an environment."""
+    if not file_exists(get_tox_file(check)):
+        abort(f'`{check}` is not a testable check.')
+
+    config_file = locate_config_file(check, env)
+    print(config_file)
+    try:
+        click.edit(filename=config_file)
+    except click.ClickException as e:
+        echo_failure(f'Failed to open `{config_file}` in editor. Error: {e}')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/edit.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/edit.py
@@ -6,14 +6,14 @@ import click
 from datadog_checks.dev.tooling.e2e.config import locate_config_file
 
 from ....fs import file_exists
-from ...testing import complete_envs
-from ...utils import complete_testable_checks, get_tox_file
+from ...testing import complete_active_checks, complete_configured_envs
+from ...utils import get_tox_file
 from ..console import CONTEXT_SETTINGS, abort, echo_failure
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Edit config file using default editor')
-@click.argument('check', autocompletion=complete_testable_checks)
-@click.argument('env', autocompletion=complete_envs)
+@click.argument('check', autocompletion=complete_active_checks)
+@click.argument('env', autocompletion=complete_configured_envs)
 @click.option('--editor', '-e', help='Editor to use')
 @click.pass_context
 def edit(ctx, check, env, editor):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -331,6 +331,9 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, org_name, profile
     else:
         config_message = 'Config file (copied to your clipboard): '
 
+    echo_success('To edit config file, do: ', nl=False)
+    echo_info(f'ddev env edit {check} {env}')
+
     echo_success(config_message, nl=False)
     echo_info(environment.config_file)
 


### PR DESCRIPTION
### What does this PR do?

Add `ddev env edit` command

#### Example usage:

First, start an env:
```
ddev env start druid py38
```

Use default editor:

```
ddev env edit druid py38
```

Use specific editor:
```
ddev env edit druid py38 -e vim
ddev env edit druid py38 --editor vim
ddev env edit druid py38 --editor my_editor
ddev env edit druid py38 --editor /path/to/my/editor
```

### Motivation

Makes it easier to edit the config file.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
