### PR TITLE
Restore correct default value of tls_verify

### DIFF
--- a/http_check/assets/configuration/spec.yaml
+++ b/http_check/assets/configuration/spec.yaml
@@ -163,3 +163,5 @@ files:
         example: true
     - template: instances/default
     - template: instances/http
+      overrides:
+        tls_verify.value.example: false

--- a/http_check/datadog_checks/http_check/config_models/defaults.py
+++ b/http_check/datadog_checks/http_check/config_models/defaults.py
@@ -217,7 +217,7 @@ def instance_tls_use_host_header(field, value):
 
 
 def instance_tls_verify(field, value):
-    return True
+    return False
 
 
 def instance_use_legacy_auth_encoding(field, value):

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -408,10 +408,10 @@ instances:
     #
     # aws_service: <AWS_SERVICE>
 
-    ## @param tls_verify - boolean - optional - default: true
+    ## @param tls_verify - boolean - optional - default: false
     ## Instructs the check to validate the TLS certificate of services.
     #
-    # tls_verify: true
+    # tls_verify: false
 
     ## @param tls_use_host_header - boolean - optional - default: false
     ## If a `Host` header is set, this enables its use for SNI (matching against the TLS certificate CN or SAN).


### PR DESCRIPTION
The default value has always been `false` for the http_check. The wrong value is documented since https://github.com/DataDog/integrations-core/pull/7245/