### PR TITLE
Support 0.4.0 metrics server renamed metric names

### DIFF
--- a/kube_metrics_server/datadog_checks/kube_metrics_server/kube_metrics_server.py
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/kube_metrics_server.py
@@ -7,6 +7,7 @@ from datadog_checks.base import OpenMetricsBaseCheck
 COUNTERS = {
     'authenticated_user_requests': 'authenticated_user.requests',
     'metrics_server_kubelet_summary_scrapes_total': 'kubelet_summary_scrapes_total',
+    'metrics_server_kubelet_request_total': 'kubelet_summary_scrapes_total',
 }
 
 HISTOGRAMS = {
@@ -14,10 +15,14 @@ HISTOGRAMS = {
     'metrics_server_scraper_duration_seconds': 'scraper_duration',
 }
 
-SUMMARIES = {'metrics_server_kubelet_summary_request_duration_seconds': 'kubelet_summary_request_duration'}
+SUMMARIES = {
+    'metrics_server_kubelet_summary_request_duration_seconds': 'kubelet_summary_request_duration',
+    'metrics_server_kubelet_request_duration_seconds': 'kubelet_summary_request_duration',
+}
 
 GAUGES = {
     'metrics_server_scraper_last_time_seconds': 'scraper_last_time',
+    'metrics_server_kubelet_last_request_time_seconds': 'scraper_last_time',
     'process_max_fds': 'process.max_fds',
     'process_open_fds': 'process.open_fds',
 }


### PR DESCRIPTION
### What does this PR do?
In metrics server v0.4.0, metric names were renamed. https://github.com/kubernetes-sigs/metrics-server/releases
This PR supports both the new and old metric names.

### Motivation
I upgraded to metrics server 0.4.2 and noticed metrics are not submitted to datadog because of the missing metric names in the check.

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
