### PR TITLE
Remove reference to connection_scheme

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -183,7 +183,7 @@ files:
         Release: "8.0.0"
         Migration: |
           Use the following options instead:
-          hosts, username, password, database, options, connection_scheme
+          hosts, username, password, database, options
       description: |
         Specify the MongoDB URI, with database to use for reporting (defaults to "admin")
         E.g. mongodb://datadog:LnCbkX4uhpuLHSUrcayEoAZA@localhost:27016/admin

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -162,7 +162,7 @@ instances:
     ##
     ## Release: 8.0.0
     ## Migration: Use the following options instead:
-    ##            hosts, username, password, database, options, connection_scheme
+    ##            hosts, username, password, database, options
     #
     # server: mongodb://<USER>:<PASSWORD>@<HOST>:<PORT>/<DB_NAME>
 


### PR DESCRIPTION
### What does this PR do?
Removes reference to config option deprecated in https://github.com/DataDog/integrations-core/pull/9142
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
