### PR TITLE
Use StrictInt instead of Int

### DIFF
--- a/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
+++ b/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional, Sequence
 
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, StrictInt, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -74,7 +74,7 @@ class InstanceConfig(BaseModel):
     health_service_check: Optional[bool]
     ignore_metrics: Optional[Sequence[str]]
     ignore_metrics_by_labels: Optional[IgnoreMetricsByLabels]
-    jmx_exporter_port: Optional[int]
+    jmx_exporter_port: Optional[StrictInt]
     kerberos_auth: Optional[str]
     kerberos_cache: Optional[str]
     kerberos_delegate: Optional[bool]
@@ -89,7 +89,7 @@ class InstanceConfig(BaseModel):
     metrics: Optional[Sequence[str]]
     min_collection_interval: Optional[float]
     namespace: Optional[str]
-    node_exporter_port: Optional[int]
+    node_exporter_port: Optional[StrictInt]
     ntlm_domain: Optional[str]
     password: Optional[str]
     persist_connections: Optional[bool]

--- a/cassandra/datadog_checks/cassandra/config_models/instance.py
+++ b/cassandra/datadog_checks/cassandra/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Optional, Sequence
 
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, StrictInt, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -29,7 +29,7 @@ class InstanceConfig(BaseModel):
     min_collection_interval: Optional[float]
     name: Optional[str]
     password: Optional[str]
-    port: int
+    port: StrictInt
     process_name_regex: Optional[str]
     rmi_client_timeout: Optional[float]
     rmi_connection_timeout: Optional[float]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/model.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/model.py
@@ -8,6 +8,7 @@ import yaml
 from datamodel_code_generator.format import CodeFormatter, PythonVersion
 from datamodel_code_generator.parser import LiteralType
 from datamodel_code_generator.parser.openapi import OpenAPIParser
+from datamodel_code_generator.types import StrictTypes, Types
 
 from ..constants import OPENAPI_SCHEMA_PROPERTIES
 from ..utils import sanitize_openapi_object_properties
@@ -240,6 +241,7 @@ class ModelConsumer:
                         strip_default_none=True,
                         # https://github.com/koxudaxi/datamodel-code-generator/pull/173
                         field_constraints=True,
+                        strict_types=[StrictTypes.int],
                     )
                     model_file_contents = parser.parse()
                 except Exception as e:

--- a/http_check/datadog_checks/http_check/config_models/instance.py
+++ b/http_check/datadog_checks/http_check/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional, Sequence
 
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, StrictInt, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -46,8 +46,8 @@ class InstanceConfig(BaseModel):
     connect_timeout: Optional[float]
     content_match: Optional[str]
     data: Optional[Mapping[str, Any]]
-    days_critical: Optional[int]
-    days_warning: Optional[int]
+    days_critical: Optional[StrictInt]
+    days_warning: Optional[StrictInt]
     empty_default_hostname: Optional[bool]
     extra_headers: Optional[Mapping[str, Any]]
     headers: Optional[Mapping[str, Any]]
@@ -71,8 +71,8 @@ class InstanceConfig(BaseModel):
     proxy: Optional[Proxy]
     read_timeout: Optional[float]
     reverse_content_match: Optional[bool]
-    seconds_critical: Optional[int]
-    seconds_warning: Optional[int]
+    seconds_critical: Optional[StrictInt]
+    seconds_warning: Optional[StrictInt]
     service: Optional[str]
     skip_proxy: Optional[bool]
     ssl_server_name: Optional[str]

--- a/kafka/datadog_checks/kafka/config_models/instance.py
+++ b/kafka/datadog_checks/kafka/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Optional, Sequence
 
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, StrictInt, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -28,7 +28,7 @@ class InstanceConfig(BaseModel):
     min_collection_interval: Optional[float]
     name: Optional[str]
     password: Optional[str]
-    port: int
+    port: StrictInt
     process_name_regex: Optional[str]
     rmi_client_timeout: Optional[float]
     rmi_connection_timeout: Optional[float]

--- a/mapr/datadog_checks/mapr/config_models/instance.py
+++ b/mapr/datadog_checks/mapr/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Optional, Sequence
 
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, StrictInt, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -23,7 +23,7 @@ class InstanceConfig(BaseModel):
     min_collection_interval: Optional[float]
     service: Optional[str]
     stream_path: Optional[str]
-    streams_count: Optional[int]
+    streams_count: Optional[StrictInt]
     tags: Optional[Sequence[str]]
     ticket_location: Optional[str]
 

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional, Sequence
 
-from pydantic import BaseModel, Field, root_validator, validator
+from pydantic import BaseModel, Field, StrictInt, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -50,20 +50,20 @@ class StatementSamples(BaseModel):
     class Config:
         allow_mutation = False
 
-    collection_strategy_cache_maxsize: Optional[int]
-    collection_strategy_cache_ttl: Optional[int]
+    collection_strategy_cache_maxsize: Optional[StrictInt]
+    collection_strategy_cache_ttl: Optional[StrictInt]
     collections_per_second: Optional[float]
     enabled: Optional[bool]
     events_statements_enable_procedure: Optional[str]
-    events_statements_row_limit: Optional[int]
+    events_statements_row_limit: Optional[StrictInt]
     events_statements_table: Optional[str]
     events_statements_temp_table_name: Optional[str]
     explain_procedure: Optional[str]
-    explained_statements_cache_maxsize: Optional[int]
-    explained_statements_per_hour_per_query: Optional[int]
+    explained_statements_cache_maxsize: Optional[StrictInt]
+    explained_statements_per_hour_per_query: Optional[StrictInt]
     fully_qualified_explain_procedure: Optional[str]
-    samples_per_hour_per_query: Optional[int]
-    seen_samples_cache_maxsize: Optional[int]
+    samples_per_hour_per_query: Optional[StrictInt]
+    seen_samples_cache_maxsize: Optional[StrictInt]
 
 
 class InstanceConfig(BaseModel):
@@ -77,7 +77,7 @@ class InstanceConfig(BaseModel):
     defaults_file: Optional[str]
     empty_default_hostname: Optional[bool]
     host: Optional[str]
-    max_custom_queries: Optional[int]
+    max_custom_queries: Optional[StrictInt]
     min_collection_interval: Optional[float]
     options: Optional[Options]
     pass_: Optional[str] = Field(None, alias='pass')

--- a/nginx/datadog_checks/nginx/config_models/instance.py
+++ b/nginx/datadog_checks/nginx/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional, Sequence
 
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, StrictInt, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -56,7 +56,7 @@ class InstanceConfig(BaseModel):
     ntlm_domain: Optional[str]
     password: Optional[str]
     persist_connections: Optional[bool]
-    plus_api_version: Optional[int]
+    plus_api_version: Optional[StrictInt]
     proxy: Optional[Proxy]
     read_timeout: Optional[float]
     service: Optional[str]

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional, Sequence
 
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, StrictInt, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -29,10 +29,10 @@ class StatementSamples(BaseModel):
     collections_per_second: Optional[float]
     enabled: Optional[bool]
     explain_function: Optional[str]
-    explained_statements_cache_maxsize: Optional[int]
-    explained_statements_per_hour_per_query: Optional[int]
-    samples_per_hour_per_query: Optional[int]
-    seen_samples_cache_maxsize: Optional[int]
+    explained_statements_cache_maxsize: Optional[StrictInt]
+    explained_statements_per_hour_per_query: Optional[StrictInt]
+    samples_per_hour_per_query: Optional[StrictInt]
+    seen_samples_cache_maxsize: Optional[StrictInt]
 
 
 class InstanceConfig(BaseModel):
@@ -51,18 +51,18 @@ class InstanceConfig(BaseModel):
     deep_database_monitoring: Optional[bool]
     empty_default_hostname: Optional[bool]
     host: str
-    max_relations: Optional[int]
+    max_relations: Optional[StrictInt]
     min_collection_interval: Optional[float]
     password: Optional[str]
     pg_stat_statements_view: Optional[str]
-    port: Optional[int]
-    query_timeout: Optional[int]
+    port: Optional[StrictInt]
+    query_timeout: Optional[StrictInt]
     relations: Optional[Sequence[Relation]]
     service: Optional[str]
     ssl: Optional[str]
     statement_metrics_limits: Optional[Mapping[str, Any]]
     statement_samples: Optional[StatementSamples]
-    table_count_limit: Optional[int]
+    table_count_limit: Optional[StrictInt]
     tag_replication_role: Optional[bool]
     tags: Optional[Sequence[str]]
     username: str

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/config_models/instance.py
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional, Sequence
 
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, StrictInt, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -57,7 +57,7 @@ class InstanceConfig(BaseModel):
     ntlm_domain: Optional[str]
     password: Optional[str]
     persist_connections: Optional[bool]
-    port: int
+    port: StrictInt
     proxy: Optional[Proxy]
     read_timeout: Optional[float]
     service: Optional[str]
@@ -72,7 +72,7 @@ class InstanceConfig(BaseModel):
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]
     username: Optional[str]
-    version: Optional[int]
+    version: Optional[StrictInt]
 
     @root_validator(pre=True)
     def _initial_validation(cls, values):

--- a/spark/datadog_checks/spark/config_models/instance.py
+++ b/spark/datadog_checks/spark/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional, Sequence
 
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, StrictInt, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -66,7 +66,7 @@ class InstanceConfig(BaseModel):
     spark_cluster_mode: Optional[str]
     spark_pre_20_mode: Optional[bool]
     spark_proxy_enabled: Optional[bool]
-    spark_ui_ports: Optional[Sequence[int]]
+    spark_ui_ports: Optional[Sequence[StrictInt]]
     spark_url: str
     streaming_metrics: Optional[bool]
     tags: Optional[Sequence[str]]

--- a/twemproxy/datadog_checks/twemproxy/config_models/instance.py
+++ b/twemproxy/datadog_checks/twemproxy/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Optional, Sequence
 
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, StrictInt, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -20,7 +20,7 @@ class InstanceConfig(BaseModel):
     empty_default_hostname: Optional[bool]
     host: str
     min_collection_interval: Optional[float]
-    port: int
+    port: StrictInt
     service: Optional[str]
     tags: Optional[Sequence[str]]
 

--- a/wmi_check/datadog_checks/wmi_check/config_models/instance.py
+++ b/wmi_check/datadog_checks/wmi_check/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional, Sequence
 
-from pydantic import BaseModel, Field, root_validator, validator
+from pydantic import BaseModel, Field, StrictInt, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -25,7 +25,7 @@ class InstanceConfig(BaseModel):
     min_collection_interval: Optional[float]
     namespace: Optional[str]
     password: Optional[str]
-    provider: Optional[int]
+    provider: Optional[StrictInt]
     service: Optional[str]
     tag_by: Optional[str]
     tag_queries: Optional[Sequence[Sequence[str]]]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Use `StrictInt` instead of `int` https://pydantic-docs.helpmanual.io/usage/types/#strict-types
Currently, validation won't fail if the attribute is set to `true`, but the check itself will fail. Using `StrictInt` allows the validation to fail.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
