### PR TITLE
Reflect default port in config

### DIFF
--- a/twemproxy/assets/configuration/spec.yaml
+++ b/twemproxy/assets/configuration/spec.yaml
@@ -17,6 +17,6 @@ files:
       description: Twemproxy port to connect to.
       required: True
       value:
-        example: 22222
+        example: 2222
         type: integer
     - template: instances/default

--- a/twemproxy/datadog_checks/twemproxy/data/conf.yaml.example
+++ b/twemproxy/datadog_checks/twemproxy/data/conf.yaml.example
@@ -21,7 +21,7 @@ instances:
     ## @param port - integer - required
     ## Twemproxy port to connect to.
     #
-    port: 22222
+    port: 2222
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.


### PR DESCRIPTION
### What does this PR do?
The port default is 2222 https://github.com/DataDog/integrations-core/blob/master/twemproxy/datadog_checks/twemproxy/twemproxy.py#L112
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
