### PR TITLE
[kubernetes] add jobs & cronjobs dashboard

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_jobs.json
+++ b/kubernetes/assets/dashboards/kubernetes_jobs.json
@@ -5,22 +5,22 @@
     "template_variables": [
         {
             "default": "*",
-            "name": "cluster_name",
+            "name": "kube_cluster_name",
             "prefix": "kube_cluster_name"
         },
         {
             "default": "*",
-            "name": "namespace",
+            "name": "kube_namespace",
             "prefix": "kube_namespace"
         },
         {
             "default": "*",
-            "name": "cronjob",
+            "name": "kube_cronjob",
             "prefix": "kube_cronjob"
         },
         {
             "default": "*",
-            "name": "job",
+            "name": "kube_job",
             "prefix": "kube_job"
         }
     ],
@@ -47,7 +47,7 @@
                                             "value": 0
                                         }
                                     ],
-                                    "q": "sum:kubernetes_state.job.count{$cluster_name}"
+                                    "q": "sum:kubernetes_state.job.count{$kube_cluster_name}"
                                 }
                             ],
                             "title": "Current Jobs",
@@ -87,7 +87,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes_state.job.count{$cluster_name}"
+                                            "query": "sum:kubernetes_state.job.count{$kube_cluster_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -134,7 +134,7 @@
                                             "value": 0
                                         }
                                     ],
-                                    "q": "sum:kubernetes_state.job.succeeded{$cluster_name}.as_count()"
+                                    "q": "sum:kubernetes_state.job.succeeded{$kube_cluster_name}.as_count()"
                                 }
                             ],
                             "title": "Succeeded job pods",
@@ -175,7 +175,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes_state.job.succeeded{$cluster_name}.as_count()"
+                                            "query": "sum:kubernetes_state.job.succeeded{$kube_cluster_name}.as_count()"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -187,7 +187,6 @@
                                 }
                             ],
                             "show_legend": true,
-                            "time": {},
                             "title": "Number of succeeded Job pods",
                             "title_align": "left",
                             "title_size": "16",
@@ -223,7 +222,7 @@
                                             "value": 0
                                         }
                                     ],
-                                    "q": "sum:kubernetes_state.job.failed{$cluster_name}.as_count()"
+                                    "q": "sum:kubernetes_state.job.failed{$kube_cluster_name}.as_count()"
                                 }
                             ],
                             "title": "Failed Job Pods",
@@ -264,7 +263,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes_state.job.failed{$cluster_name}.as_count()"
+                                            "query": "sum:kubernetes_state.job.failed{$kube_cluster_name}.as_count()"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -276,7 +275,6 @@
                                 }
                             ],
                             "show_legend": true,
-                            "time": {},
                             "title": "Number of failed Job Pods",
                             "title_align": "left",
                             "title_size": "16",
@@ -329,17 +327,17 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.cpu.requests{$cluster_name,$namespace,$cronjob,$job}"
+                                            "query": "sum:kubernetes.cpu.requests{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job}"
                                         },
                                         {
                                             "data_source": "metrics",
                                             "name": "query3",
-                                            "query": "sum:kubernetes.cpu.limits{$cluster_name,$namespace,$cronjob,$job}"
+                                            "query": "sum:kubernetes.cpu.limits{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job}"
                                         },
                                         {
                                             "data_source": "metrics",
                                             "name": "query2",
-                                            "query": "sum:kubernetes.cpu.usage.total{$cluster_name,$namespace,$cronjob,$job}"
+                                            "query": "sum:kubernetes.cpu.usage.total{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -403,17 +401,17 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.memory.requests{$cluster_name,$namespace,$cronjob,$job}"
+                                            "query": "sum:kubernetes.memory.requests{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job}"
                                         },
                                         {
                                             "data_source": "metrics",
                                             "name": "query2",
-                                            "query": "sum:kubernetes.memory.rss{$cluster_name,$namespace,$cronjob,$job}"
+                                            "query": "sum:kubernetes.memory.rss{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job}"
                                         },
                                         {
                                             "data_source": "metrics",
                                             "name": "query3",
-                                            "query": "sum:kubernetes.memory.limits{$cluster_name,$namespace,$cronjob,$job}"
+                                            "query": "sum:kubernetes.memory.limits{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -451,22 +449,21 @@
                                 {
                                     "aggregator": "avg",
                                     "alias": "Average number of jobs",
-                                    "q": "top(sum:kubernetes_state.job.count{$cluster_name} by {kube_cluster_name}, 25, 'last', 'desc')"
+                                    "q": "top(sum:kubernetes_state.job.count{$kube_cluster_name} by {kube_cluster_name}, 25, 'last', 'desc')"
                                 },
                                 {
                                     "aggregator": "sum",
                                     "alias": "# of succeeded job pods",
-                                    "q": "top(sum:kubernetes_state.job.succeeded{$cluster_name} by {kube_cluster_name}.as_count(), 25, 'last', 'desc')"
+                                    "q": "top(sum:kubernetes_state.job.succeeded{$kube_cluster_name} by {kube_cluster_name}.as_count(), 25, 'last', 'desc')"
                                 },
                                 {
                                     "aggregator": "sum",
                                     "alias": "# of failed job pods",
                                     "limit": 10,
                                     "order": "desc",
-                                    "q": "top(sum:kubernetes_state.job.failed{$cluster_name} by {kube_cluster_name}.as_count(), 25, 'last', 'desc')"
+                                    "q": "top(sum:kubernetes_state.job.failed{$kube_cluster_name} by {kube_cluster_name}.as_count(), 25, 'last', 'desc')"
                                 }
                             ],
-                            "time": {},
                             "title": "Number of Jobs per cluster",
                             "title_align": "left",
                             "title_size": "16",
@@ -504,7 +501,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes_state.job.count{$cluster_name} by {kube_cluster_name}"
+                                            "query": "sum:kubernetes_state.job.count{$kube_cluster_name} by {kube_cluster_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -544,12 +541,12 @@
                                     "alias": "Last number of jobs",
                                     "limit": 10,
                                     "order": "desc",
-                                    "q": "top(sum:kubernetes_state.job.count{$cluster_name,owner_kind:cronjob} by {owner_name}, 50, 'mean', 'desc')"
+                                    "q": "top(sum:kubernetes_state.job.count{$kube_cluster_name,owner_kind:cronjob} by {owner_name}, 50, 'mean', 'desc')"
                                 },
                                 {
                                     "aggregator": "avg",
                                     "alias": "Average number of jobs",
-                                    "q": "top(sum:kubernetes_state.job.count{$cluster_name,owner_kind:cronjob} by {owner_name}, 50, 'mean', 'desc')"
+                                    "q": "top(sum:kubernetes_state.job.count{$kube_cluster_name,owner_kind:cronjob} by {owner_name}, 50, 'mean', 'desc')"
                                 }
                             ],
                             "title": "Top Cronjobs by Job Count",
@@ -589,7 +586,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes_state.job.count{$cluster_name,owner_kind:cronjob} by {owner_name}"
+                                            "query": "sum:kubernetes_state.job.count{$kube_cluster_name,owner_kind:cronjob} by {owner_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -643,7 +640,7 @@
                                     ],
                                     "limit": 5,
                                     "order": "desc",
-                                    "q": "top(exclude_null(sum:kubernetes.cpu.usage.total{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
+                                    "q": "top(exclude_null(sum:kubernetes.cpu.usage.total{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
                                 },
                                 {
                                     "aggregator": "avg",
@@ -651,7 +648,7 @@
                                     "cell_display_mode": [
                                         "bar"
                                     ],
-                                    "q": "top(exclude_null(sum:kubernetes.memory.usage{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
+                                    "q": "top(exclude_null(sum:kubernetes.memory.usage{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
                                 },
                                 {
                                     "aggregator": "avg",
@@ -659,7 +656,7 @@
                                     "cell_display_mode": [
                                         "bar"
                                     ],
-                                    "q": "top(exclude_null(sum:kubernetes.network.rx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
+                                    "q": "top(exclude_null(sum:kubernetes.network.rx_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
                                 },
                                 {
                                     "aggregator": "avg",
@@ -667,7 +664,7 @@
                                     "cell_display_mode": [
                                         "bar"
                                     ],
-                                    "q": "top(exclude_null(sum:kubernetes.network.tx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
+                                    "q": "top(exclude_null(sum:kubernetes.network.tx_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
                                 },
                                 {
                                     "aggregator": "avg",
@@ -675,7 +672,7 @@
                                     "cell_display_mode": [
                                         "bar"
                                     ],
-                                    "q": "top(exclude_null(sum:kubernetes.io.read_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
+                                    "q": "top(exclude_null(sum:kubernetes.io.read_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
                                 },
                                 {
                                     "aggregator": "avg",
@@ -683,7 +680,7 @@
                                     "cell_display_mode": [
                                         "bar"
                                     ],
-                                    "q": "top(exclude_null(sum:kubernetes.io.write_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
+                                    "q": "top(exclude_null(sum:kubernetes.io.write_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
                                 }
                             ],
                             "title": "Jobs resources consumption",
@@ -723,7 +720,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.cpu.usage.total{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}"
+                                            "query": "sum:kubernetes.cpu.usage.total{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_job}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -775,7 +772,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.memory.usage{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}"
+                                            "query": "sum:kubernetes.memory.usage{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_job}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -832,7 +829,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.io.read_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_job}"
+                                            "query": "sum:kubernetes.io.read_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_namespace,kube_cluster_name,kube_job}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -855,7 +852,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.io.write_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_job}"
+                                            "query": "sum:kubernetes.io.write_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_namespace,kube_cluster_name,kube_job}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -912,7 +909,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.network.rx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_job}"
+                                            "query": "sum:kubernetes.network.rx_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_namespace,kube_cluster_name,kube_job}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -935,7 +932,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.network.tx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_job}"
+                                            "query": "sum:kubernetes.network.tx_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_namespace,kube_cluster_name,kube_job}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -1002,12 +999,12 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.network.rx_errors{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}"
+                                            "query": "sum:kubernetes.network.rx_errors{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_job}"
                                         },
                                         {
                                             "data_source": "metrics",
                                             "name": "query2",
-                                            "query": "sum:kubernetes.network.tx_errors{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}"
+                                            "query": "sum:kubernetes.network.tx_errors{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_job}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -1062,7 +1059,7 @@
                                     ],
                                     "limit": 10,
                                     "order": "desc",
-                                    "q": "top(exclude_null(sum:kubernetes.cpu.usage.total{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
+                                    "q": "top(exclude_null(sum:kubernetes.cpu.usage.total{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
                                 },
                                 {
                                     "aggregator": "avg",
@@ -1070,7 +1067,7 @@
                                     "cell_display_mode": [
                                         "bar"
                                     ],
-                                    "q": "top(exclude_null(sum:kubernetes.memory.usage{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
+                                    "q": "top(exclude_null(sum:kubernetes.memory.usage{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
                                 },
                                 {
                                     "aggregator": "avg",
@@ -1078,7 +1075,7 @@
                                     "cell_display_mode": [
                                         "bar"
                                     ],
-                                    "q": "top(exclude_null(sum:kubernetes.network.rx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
+                                    "q": "top(exclude_null(sum:kubernetes.network.rx_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
                                 },
                                 {
                                     "aggregator": "avg",
@@ -1086,7 +1083,7 @@
                                     "cell_display_mode": [
                                         "bar"
                                     ],
-                                    "q": "top(exclude_null(sum:kubernetes.network.tx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
+                                    "q": "top(exclude_null(sum:kubernetes.network.tx_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
                                 },
                                 {
                                     "aggregator": "avg",
@@ -1094,7 +1091,7 @@
                                     "cell_display_mode": [
                                         "bar"
                                     ],
-                                    "q": "top(exclude_null(sum:kubernetes.io.read_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
+                                    "q": "top(exclude_null(sum:kubernetes.io.read_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
                                 },
                                 {
                                     "aggregator": "avg",
@@ -1102,7 +1099,7 @@
                                     "cell_display_mode": [
                                         "bar"
                                     ],
-                                    "q": "top(exclude_null(sum:kubernetes.io.write_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
+                                    "q": "top(exclude_null(sum:kubernetes.io.write_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
                                 }
                             ],
                             "title": "CronJobs resources consumption",
@@ -1142,7 +1139,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.cpu.usage.total{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}"
+                                            "query": "sum:kubernetes.cpu.usage.total{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_cronjob}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -1194,7 +1191,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.memory.usage{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}"
+                                            "query": "sum:kubernetes.memory.usage{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_cronjob}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -1251,7 +1248,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.io.read_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_cronjob}"
+                                            "query": "sum:kubernetes.io.read_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_namespace,kube_cluster_name,kube_cronjob}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -1274,7 +1271,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.io.write_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_cronjob}"
+                                            "query": "sum:kubernetes.io.write_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_namespace,kube_cluster_name,kube_cronjob}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -1331,7 +1328,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.network.rx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_cronjob}"
+                                            "query": "sum:kubernetes.network.rx_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_namespace,kube_cluster_name,kube_cronjob}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -1354,7 +1351,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.network.tx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_cronjob}"
+                                            "query": "sum:kubernetes.network.tx_bytes{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_namespace,kube_cluster_name,kube_cronjob}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -1421,12 +1418,12 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes.network.rx_errors{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}"
+                                            "query": "sum:kubernetes.network.rx_errors{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_cronjob}"
                                         },
                                         {
                                             "data_source": "metrics",
                                             "name": "query2",
-                                            "query": "sum:kubernetes.network.tx_errors{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}"
+                                            "query": "sum:kubernetes.network.tx_errors{$kube_cluster_name,$kube_namespace,$kube_cronjob,$kube_job} by {kube_cluster_name,kube_namespace,kube_cronjob}"
                                         }
                                     ],
                                     "response_format": "timeseries",

--- a/kubernetes/assets/dashboards/kubernetes_jobs.json
+++ b/kubernetes/assets/dashboards/kubernetes_jobs.json
@@ -349,7 +349,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "CPU requests, limits and usage",
+                            "title": "CPU requests, limits, and usage",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",

--- a/kubernetes/assets/dashboards/kubernetes_jobs.json
+++ b/kubernetes/assets/dashboards/kubernetes_jobs.json
@@ -1,6 +1,6 @@
 {
     "author_name": "Datadog",
-    "description": "### This dashboard allows you to monitor Kubernetes Jobs & Cronjobs.",
+    "description": "### This dashboard allows you to monitor Kubernetes Jobs & Cronjobs.\n",
     "layout_type": "ordered",
     "template_variables": [
         {
@@ -99,7 +99,7 @@
                                 }
                             ],
                             "show_legend": false,
-                            "title": "Jobs",
+                            "title": "Number of distinct Jobs",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -122,11 +122,11 @@
                     {
                         "definition": {
                             "autoscale": true,
-                            "custom_unit": "jobs",
+                            "custom_unit": "pods",
                             "precision": 0,
                             "requests": [
                                 {
-                                    "aggregator": "last",
+                                    "aggregator": "sum",
                                     "conditional_formats": [
                                         {
                                             "comparator": ">",
@@ -137,7 +137,7 @@
                                     "q": "sum:kubernetes_state.job.succeeded{$cluster_name}.as_count()"
                                 }
                             ],
-                            "title": "Succeeded Jobs",
+                            "title": "Succeeded job pods",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "query_value"
@@ -163,10 +163,10 @@
                             "markers": [],
                             "requests": [
                                 {
-                                    "display_type": "line",
+                                    "display_type": "bars",
                                     "formulas": [
                                         {
-                                            "alias": "Succeeded jobs",
+                                            "alias": "Succeeded pods",
                                             "formula": "query1"
                                         }
                                     ],
@@ -187,7 +187,8 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Succeeded Jobs",
+                            "time": {},
+                            "title": "Number of succeeded Job pods",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -210,11 +211,11 @@
                     {
                         "definition": {
                             "autoscale": true,
-                            "custom_unit": "jobs",
+                            "custom_unit": "pods",
                             "precision": 0,
                             "requests": [
                                 {
-                                    "aggregator": "last",
+                                    "aggregator": "sum",
                                     "conditional_formats": [
                                         {
                                             "comparator": ">",
@@ -225,7 +226,7 @@
                                     "q": "sum:kubernetes_state.job.failed{$cluster_name}.as_count()"
                                 }
                             ],
-                            "title": "Failed Jobs",
+                            "title": "Failed Job Pods",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "query_value"
@@ -251,10 +252,10 @@
                             "markers": [],
                             "requests": [
                                 {
-                                    "display_type": "line",
+                                    "display_type": "bars",
                                     "formulas": [
                                         {
-                                            "alias": "Failed jobs",
+                                            "alias": "Failed pods",
                                             "formula": "query1"
                                         }
                                     ],
@@ -275,7 +276,8 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Failed Jobs",
+                            "time": {},
+                            "title": "Number of failed Job Pods",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -447,16 +449,21 @@
                         "definition": {
                             "requests": [
                                 {
-                                    "aggregator": "last",
-                                    "alias": "Last number of jobs",
-                                    "limit": 10,
-                                    "order": "desc",
-                                    "q": "top(sum:kubernetes_state.job.count{$cluster_name} by {kube_cluster_name}, 25, 'last', 'desc')"
-                                },
-                                {
                                     "aggregator": "avg",
                                     "alias": "Average number of jobs",
                                     "q": "top(sum:kubernetes_state.job.count{$cluster_name} by {kube_cluster_name}, 25, 'last', 'desc')"
+                                },
+                                {
+                                    "aggregator": "sum",
+                                    "alias": "# of succeeded job pods",
+                                    "q": "top(sum:kubernetes_state.job.succeeded{$cluster_name} by {kube_cluster_name}.as_count(), 25, 'last', 'desc')"
+                                },
+                                {
+                                    "aggregator": "sum",
+                                    "alias": "# of failed job pods",
+                                    "limit": 10,
+                                    "order": "desc",
+                                    "q": "top(sum:kubernetes_state.job.failed{$cluster_name} by {kube_cluster_name}.as_count(), 25, 'last', 'desc')"
                                 }
                             ],
                             "time": {},
@@ -468,7 +475,7 @@
                         "id": 7493103153404182,
                         "layout": {
                             "height": 3,
-                            "width": 5,
+                            "width": 6,
                             "x": 0,
                             "y": 8
                         }
@@ -508,8 +515,7 @@
                                     }
                                 }
                             ],
-                            "show_legend": false,
-                            "time": {},
+                            "show_legend": true,
                             "title": "Number of jobs per cluster",
                             "title_align": "left",
                             "title_size": "16",
@@ -525,8 +531,8 @@
                         "id": 3115489599066434,
                         "layout": {
                             "height": 3,
-                            "width": 7,
-                            "x": 5,
+                            "width": 6,
+                            "x": 6,
                             "y": 8
                         }
                     },
@@ -554,7 +560,7 @@
                         "id": 1511746031025034,
                         "layout": {
                             "height": 3,
-                            "width": 5,
+                            "width": 6,
                             "x": 0,
                             "y": 11
                         }
@@ -610,8 +616,8 @@
                         "id": 7620774346478920,
                         "layout": {
                             "height": 3,
-                            "width": 7,
-                            "x": 5,
+                            "width": 6,
+                            "x": 6,
                             "y": 11
                         }
                     }
@@ -680,7 +686,6 @@
                                     "q": "top(exclude_null(sum:kubernetes.io.write_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
                                 }
                             ],
-                            "time": {},
                             "title": "Jobs resources consumption",
                             "title_align": "left",
                             "title_size": "16",
@@ -862,7 +867,6 @@
                                 }
                             ],
                             "show_legend": true,
-                            "time": {},
                             "title": "Disk Usage by job",
                             "title_align": "left",
                             "title_size": "16",
@@ -943,7 +947,6 @@
                                 }
                             ],
                             "show_legend": true,
-                            "time": {},
                             "title": "Network Usage (Rx / Tx rate) by job",
                             "title_align": "left",
                             "title_size": "16",
@@ -1016,7 +1019,6 @@
                                 }
                             ],
                             "show_legend": true,
-                            "time": {},
                             "title": "Network Errors by job",
                             "title_align": "left",
                             "title_size": "16",
@@ -1103,7 +1105,6 @@
                                     "q": "top(exclude_null(sum:kubernetes.io.write_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
                                 }
                             ],
-                            "time": {},
                             "title": "CronJobs resources consumption",
                             "title_align": "left",
                             "title_size": "16",
@@ -1285,7 +1286,6 @@
                                 }
                             ],
                             "show_legend": true,
-                            "time": {},
                             "title": "Disk Usage by CronJob",
                             "title_align": "left",
                             "title_size": "16",
@@ -1366,7 +1366,6 @@
                                 }
                             ],
                             "show_legend": true,
-                            "time": {},
                             "title": "Network Usage (Rx / Tx rate) by CronJob",
                             "title_align": "left",
                             "title_size": "16",

--- a/kubernetes/assets/dashboards/kubernetes_jobs.json
+++ b/kubernetes/assets/dashboards/kubernetes_jobs.json
@@ -1,0 +1,1470 @@
+{
+    "author_name": "Datadog",
+    "description": "### This dashboard allows you to monitor Kubernetes Jobs & Cronjobs.",
+    "layout_type": "ordered",
+    "template_variables": [
+        {
+            "default": "*",
+            "name": "cluster_name",
+            "prefix": "kube_cluster_name"
+        },
+        {
+            "default": "*",
+            "name": "namespace",
+            "prefix": "kube_namespace"
+        },
+        {
+            "default": "*",
+            "name": "cronjob",
+            "prefix": "kube_cronjob"
+        },
+        {
+            "default": "*",
+            "name": "job",
+            "prefix": "kube_job"
+        }
+    ],
+    "title": "Kubernetes Jobs & Cronjobs Overview",
+    "widgets": [
+        {
+            "definition": {
+                "background_color": "blue",
+                "layout_type": "ordered",
+                "title": "Overview",
+                "type": "group",
+                "widgets": [
+                    {
+                        "definition": {
+                            "custom_unit": "jobs",
+                            "precision": 0,
+                            "requests": [
+                                {
+                                    "aggregator": "last",
+                                    "conditional_formats": [
+                                        {
+                                            "comparator": ">",
+                                            "palette": "white_on_green",
+                                            "value": 0
+                                        }
+                                    ],
+                                    "q": "sum:kubernetes_state.job.count{$cluster_name}"
+                                }
+                            ],
+                            "title": "Current Jobs",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "query_value"
+                        },
+                        "id": 495495303234449,
+                        "layout": {
+                            "height": 3,
+                            "width": 2,
+                            "x": 0,
+                            "y": 0
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "Jobs",
+                                            "formula": "forecast(query1, 'seasonal', 1)"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes_state.job.count{$cluster_name}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "dog_classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": false,
+                            "title": "Jobs",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 4633946546415220,
+                        "layout": {
+                            "height": 3,
+                            "width": 10,
+                            "x": 2,
+                            "y": 0
+                        }
+                    },
+                    {
+                        "definition": {
+                            "autoscale": true,
+                            "custom_unit": "jobs",
+                            "precision": 0,
+                            "requests": [
+                                {
+                                    "aggregator": "last",
+                                    "conditional_formats": [
+                                        {
+                                            "comparator": ">",
+                                            "palette": "green_on_white",
+                                            "value": 0
+                                        }
+                                    ],
+                                    "q": "sum:kubernetes_state.job.succeeded{$cluster_name}.as_count()"
+                                }
+                            ],
+                            "title": "Succeeded Jobs",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "query_value"
+                        },
+                        "id": 3697942345670966,
+                        "layout": {
+                            "height": 2,
+                            "width": 2,
+                            "x": 0,
+                            "y": 3
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "Succeeded jobs",
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "on_right_yaxis": false,
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes_state.job.succeeded{$cluster_name}.as_count()"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "green"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Succeeded Jobs",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 6081756008356946,
+                        "layout": {
+                            "height": 2,
+                            "width": 4,
+                            "x": 2,
+                            "y": 3
+                        }
+                    },
+                    {
+                        "definition": {
+                            "autoscale": true,
+                            "custom_unit": "jobs",
+                            "precision": 0,
+                            "requests": [
+                                {
+                                    "aggregator": "last",
+                                    "conditional_formats": [
+                                        {
+                                            "comparator": ">",
+                                            "palette": "red_on_white",
+                                            "value": 0
+                                        }
+                                    ],
+                                    "q": "sum:kubernetes_state.job.failed{$cluster_name}.as_count()"
+                                }
+                            ],
+                            "title": "Failed Jobs",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "query_value"
+                        },
+                        "id": 8095652452993779,
+                        "layout": {
+                            "height": 2,
+                            "width": 2,
+                            "x": 6,
+                            "y": 3
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "Failed jobs",
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "on_right_yaxis": false,
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes_state.job.failed{$cluster_name}.as_count()"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "warm"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Failed Jobs",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 2489289306317092,
+                        "layout": {
+                            "height": 2,
+                            "width": 4,
+                            "x": 8,
+                            "y": 3
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "CPU requests",
+                                            "formula": "query1"
+                                        },
+                                        {
+                                            "alias": "CPU limits",
+                                            "formula": "query3"
+                                        },
+                                        {
+                                            "alias": "CPU usage",
+                                            "formula": "query2 / 1000000000"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.cpu.requests{$cluster_name,$namespace,$cronjob,$job}"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query3",
+                                            "query": "sum:kubernetes.cpu.limits{$cluster_name,$namespace,$cronjob,$job}"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query2",
+                                            "query": "sum:kubernetes.cpu.usage.total{$cluster_name,$namespace,$cronjob,$job}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "dog_classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "CPU requests, limits and usage",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 5976272967560328,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 0,
+                            "y": 5
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "Memory requests",
+                                            "formula": "query1"
+                                        },
+                                        {
+                                            "alias": "Memory RSS",
+                                            "formula": "query2"
+                                        },
+                                        {
+                                            "alias": "Memory limits",
+                                            "formula": "query3"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.memory.requests{$cluster_name,$namespace,$cronjob,$job}"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query2",
+                                            "query": "sum:kubernetes.memory.rss{$cluster_name,$namespace,$cronjob,$job}"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query3",
+                                            "query": "sum:kubernetes.memory.limits{$cluster_name,$namespace,$cronjob,$job}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "dog_classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Memory requests, limits and usage",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 3689528099455169,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 6,
+                            "y": 5
+                        }
+                    },
+                    {
+                        "definition": {
+                            "requests": [
+                                {
+                                    "aggregator": "last",
+                                    "alias": "Last number of jobs",
+                                    "limit": 10,
+                                    "order": "desc",
+                                    "q": "top(sum:kubernetes_state.job.count{$cluster_name} by {kube_cluster_name}, 25, 'last', 'desc')"
+                                },
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "Average number of jobs",
+                                    "q": "top(sum:kubernetes_state.job.count{$cluster_name} by {kube_cluster_name}, 25, 'last', 'desc')"
+                                }
+                            ],
+                            "time": {},
+                            "title": "Number of Jobs per cluster",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "query_table"
+                        },
+                        "id": 7493103153404182,
+                        "layout": {
+                            "height": 3,
+                            "width": 5,
+                            "x": 0,
+                            "y": 8
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "Jobs",
+                                            "formula": "exclude_null(query1)"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes_state.job.count{$cluster_name} by {kube_cluster_name}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "dog_classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": false,
+                            "time": {},
+                            "title": "Number of jobs per cluster",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 3115489599066434,
+                        "layout": {
+                            "height": 3,
+                            "width": 7,
+                            "x": 5,
+                            "y": 8
+                        }
+                    },
+                    {
+                        "definition": {
+                            "requests": [
+                                {
+                                    "aggregator": "last",
+                                    "alias": "Last number of jobs",
+                                    "limit": 10,
+                                    "order": "desc",
+                                    "q": "top(sum:kubernetes_state.job.count{$cluster_name,owner_kind:cronjob} by {owner_name}, 50, 'mean', 'desc')"
+                                },
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "Average number of jobs",
+                                    "q": "top(sum:kubernetes_state.job.count{$cluster_name,owner_kind:cronjob} by {owner_name}, 50, 'mean', 'desc')"
+                                }
+                            ],
+                            "title": "Top Cronjobs by Job Count",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "query_table"
+                        },
+                        "id": 1511746031025034,
+                        "layout": {
+                            "height": 3,
+                            "width": 5,
+                            "x": 0,
+                            "y": 11
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "Jobs",
+                                            "formula": "exclude_null(query1)"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes_state.job.count{$cluster_name,owner_kind:cronjob} by {owner_name}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "dog_classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Cronjobs by Job Count",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 7620774346478920,
+                        "layout": {
+                            "height": 3,
+                            "width": 7,
+                            "x": 5,
+                            "y": 11
+                        }
+                    }
+                ]
+            },
+            "id": 1458895847794888
+        },
+        {
+            "definition": {
+                "background_color": "pink",
+                "layout_type": "ordered",
+                "title": "Jobs overview",
+                "type": "group",
+                "widgets": [
+                    {
+                        "definition": {
+                            "requests": [
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "CPU usage",
+                                    "cell_display_mode": [
+                                        "bar"
+                                    ],
+                                    "limit": 5,
+                                    "order": "desc",
+                                    "q": "top(exclude_null(sum:kubernetes.cpu.usage.total{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
+                                },
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "Memory usage",
+                                    "cell_display_mode": [
+                                        "bar"
+                                    ],
+                                    "q": "top(exclude_null(sum:kubernetes.memory.usage{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
+                                },
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "Network Read bytes",
+                                    "cell_display_mode": [
+                                        "bar"
+                                    ],
+                                    "q": "top(exclude_null(sum:kubernetes.network.rx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
+                                },
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "Network Transmitted bytes",
+                                    "cell_display_mode": [
+                                        "bar"
+                                    ],
+                                    "q": "top(exclude_null(sum:kubernetes.network.tx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
+                                },
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "Disk read",
+                                    "cell_display_mode": [
+                                        "bar"
+                                    ],
+                                    "q": "top(exclude_null(sum:kubernetes.io.read_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
+                                },
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "Disk Write",
+                                    "cell_display_mode": [
+                                        "bar"
+                                    ],
+                                    "q": "top(exclude_null(sum:kubernetes.io.write_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}), 10, 'mean', 'desc')"
+                                }
+                            ],
+                            "time": {},
+                            "title": "Jobs resources consumption",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "query_table"
+                        },
+                        "id": 5568031515431654,
+                        "layout": {
+                            "height": 3,
+                            "width": 12,
+                            "x": 0,
+                            "y": 0
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "CPU usage",
+                                            "formula": "exclude_null(query1)"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.cpu.usage.total{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "dog_classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "CPU Usage by Job",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": false
+                            }
+                        },
+                        "id": 513833055520238,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 0,
+                            "y": 3
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "Memory usage",
+                                            "formula": "exclude_null(query1)"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.memory.usage{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "dog_classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Memory Usage by Job",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 2022201690431970,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 6,
+                            "y": 3
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "bars",
+                                    "formulas": [
+                                        {
+                                            "alias": "Read bytes",
+                                            "formula": "exclude_null(query1)"
+                                        }
+                                    ],
+                                    "on_right_yaxis": false,
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.io.read_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_job}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "cool"
+                                    }
+                                },
+                                {
+                                    "display_type": "bars",
+                                    "formulas": [
+                                        {
+                                            "alias": "Write bytes",
+                                            "formula": "-exclude_null(query1)"
+                                        }
+                                    ],
+                                    "on_right_yaxis": false,
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.io.write_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_job}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "warm"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "time": {},
+                            "title": "Disk Usage by job",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 4502071610879346,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 0,
+                            "y": 6
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "bars",
+                                    "formulas": [
+                                        {
+                                            "alias": "Received bytes",
+                                            "formula": "exclude_null(query1)"
+                                        }
+                                    ],
+                                    "on_right_yaxis": false,
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.network.rx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_job}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "cool"
+                                    }
+                                },
+                                {
+                                    "display_type": "bars",
+                                    "formulas": [
+                                        {
+                                            "alias": "Transmitted bytes",
+                                            "formula": "-exclude_null(query1)"
+                                        }
+                                    ],
+                                    "on_right_yaxis": false,
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.network.tx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_job}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "warm"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "time": {},
+                            "title": "Network Usage (Rx / Tx rate) by job",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 6825427277535870,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 6,
+                            "y": 6
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [
+                                {
+                                    "display_type": "ok dashed",
+                                    "label": "y = 0",
+                                    "value": "y = 0"
+                                }
+                            ],
+                            "requests": [
+                                {
+                                    "display_type": "bars",
+                                    "formulas": [
+                                        {
+                                            "alias": "RX errors",
+                                            "formula": "exclude_null(query1)"
+                                        },
+                                        {
+                                            "alias": "TX errors",
+                                            "formula": "exclude_null(query2)"
+                                        }
+                                    ],
+                                    "on_right_yaxis": false,
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.network.rx_errors{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query2",
+                                            "query": "sum:kubernetes.network.tx_errors{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_job}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "warm"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "time": {},
+                            "title": "Network Errors by job",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 7240988677557072,
+                        "layout": {
+                            "height": 3,
+                            "width": 12,
+                            "x": 0,
+                            "y": 9
+                        }
+                    }
+                ]
+            },
+            "id": 5983520079327052
+        },
+        {
+            "definition": {
+                "background_color": "purple",
+                "layout_type": "ordered",
+                "show_title": true,
+                "title": "Cronjob overview",
+                "type": "group",
+                "widgets": [
+                    {
+                        "definition": {
+                            "requests": [
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "CPU usage",
+                                    "cell_display_mode": [
+                                        "bar"
+                                    ],
+                                    "limit": 10,
+                                    "order": "desc",
+                                    "q": "top(exclude_null(sum:kubernetes.cpu.usage.total{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
+                                },
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "Memory usage",
+                                    "cell_display_mode": [
+                                        "bar"
+                                    ],
+                                    "q": "top(exclude_null(sum:kubernetes.memory.usage{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
+                                },
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "Network Read bytes",
+                                    "cell_display_mode": [
+                                        "bar"
+                                    ],
+                                    "q": "top(exclude_null(sum:kubernetes.network.rx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
+                                },
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "Network Transmitted bytes",
+                                    "cell_display_mode": [
+                                        "bar"
+                                    ],
+                                    "q": "top(exclude_null(sum:kubernetes.network.tx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
+                                },
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "Disk read",
+                                    "cell_display_mode": [
+                                        "bar"
+                                    ],
+                                    "q": "top(exclude_null(sum:kubernetes.io.read_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
+                                },
+                                {
+                                    "aggregator": "avg",
+                                    "alias": "Disk Write",
+                                    "cell_display_mode": [
+                                        "bar"
+                                    ],
+                                    "q": "top(exclude_null(sum:kubernetes.io.write_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}), 10, 'mean', 'desc')"
+                                }
+                            ],
+                            "time": {},
+                            "title": "CronJobs resources consumption",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "query_table"
+                        },
+                        "id": 4331347145875336,
+                        "layout": {
+                            "height": 4,
+                            "width": 12,
+                            "x": 0,
+                            "y": 0
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "CPU usage",
+                                            "formula": "exclude_null(query1)"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.cpu.usage.total{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "dog_classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "CPU Usage by CronJob",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": false
+                            }
+                        },
+                        "id": 6707953278415024,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 0,
+                            "y": 4
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "Memory usage",
+                                            "formula": "exclude_null(query1)"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.memory.usage{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "dog_classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Memory Usage by CronJob",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 8213158952686726,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 6,
+                            "y": 4
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "bars",
+                                    "formulas": [
+                                        {
+                                            "alias": "Read bytes",
+                                            "formula": "exclude_null(query1)"
+                                        }
+                                    ],
+                                    "on_right_yaxis": false,
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.io.read_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_cronjob}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "cool"
+                                    }
+                                },
+                                {
+                                    "display_type": "bars",
+                                    "formulas": [
+                                        {
+                                            "alias": "Write bytes",
+                                            "formula": "-exclude_null(query1)"
+                                        }
+                                    ],
+                                    "on_right_yaxis": false,
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.io.write_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_cronjob}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "warm"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "time": {},
+                            "title": "Disk Usage by CronJob",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 8375686906918214,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 0,
+                            "y": 7
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "bars",
+                                    "formulas": [
+                                        {
+                                            "alias": "Received bytes",
+                                            "formula": "exclude_null(query1)"
+                                        }
+                                    ],
+                                    "on_right_yaxis": false,
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.network.rx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_cronjob}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "cool"
+                                    }
+                                },
+                                {
+                                    "display_type": "bars",
+                                    "formulas": [
+                                        {
+                                            "alias": "Transmitted bytes",
+                                            "formula": "-exclude_null(query1)"
+                                        }
+                                    ],
+                                    "on_right_yaxis": false,
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.network.tx_bytes{$cluster_name,$namespace,$cronjob,$job} by {kube_namespace,kube_cluster_name,kube_cronjob}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "warm"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "time": {},
+                            "title": "Network Usage (Rx / Tx rate) by CronJob",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 8486397881003725,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 6,
+                            "y": 7
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "markers": [
+                                {
+                                    "display_type": "ok dashed",
+                                    "label": "y = 0",
+                                    "value": "y = 0"
+                                }
+                            ],
+                            "requests": [
+                                {
+                                    "display_type": "bars",
+                                    "formulas": [
+                                        {
+                                            "alias": "RX errors",
+                                            "formula": "exclude_null(query1)"
+                                        },
+                                        {
+                                            "alias": "TX errors",
+                                            "formula": "exclude_null(query2)"
+                                        }
+                                    ],
+                                    "on_right_yaxis": false,
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes.network.rx_errors{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query2",
+                                            "query": "sum:kubernetes.network.tx_errors{$cluster_name,$namespace,$cronjob,$job} by {kube_cluster_name,kube_namespace,kube_cronjob}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "warm"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Network Errors by CronJob",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 3942798973980899,
+                        "layout": {
+                            "height": 3,
+                            "width": 12,
+                            "x": 0,
+                            "y": 10
+                        }
+                    }
+                ]
+            },
+            "id": 1991208644233094,
+            "layout": {
+                "is_column_break": true
+            }
+        }
+    ]
+}

--- a/kubernetes/assets/dashboards/kubernetes_jobs.json
+++ b/kubernetes/assets/dashboards/kubernetes_jobs.json
@@ -1,6 +1,6 @@
 {
     "author_name": "Datadog",
-    "description": "### This dashboard allows you to monitor Kubernetes Jobs & Cronjobs.\n",
+    "description": "### This dashboard allows you to monitor Kubernetes Jobs and CronJobs.\n",
     "layout_type": "ordered",
     "template_variables": [
         {
@@ -24,7 +24,7 @@
             "prefix": "kube_job"
         }
     ],
-    "title": "Kubernetes Jobs & Cronjobs Overview",
+    "title": "Kubernetes Jobs and CronJobs Overview",
     "widgets": [
         {
             "definition": {
@@ -137,7 +137,7 @@
                                     "q": "sum:kubernetes_state.job.succeeded{$kube_cluster_name}.as_count()"
                                 }
                             ],
-                            "title": "Succeeded job pods",
+                            "title": "Successful Job Pods",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "query_value"
@@ -166,7 +166,7 @@
                                     "display_type": "bars",
                                     "formulas": [
                                         {
-                                            "alias": "Succeeded pods",
+                                            "alias": "Succeeded Pods",
                                             "formula": "query1"
                                         }
                                     ],
@@ -187,7 +187,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Number of succeeded Job pods",
+                            "title": "Number of successful Job Pods",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -254,7 +254,7 @@
                                     "display_type": "bars",
                                     "formulas": [
                                         {
-                                            "alias": "Failed pods",
+                                            "alias": "Failed Pods",
                                             "formula": "query1"
                                         }
                                     ],
@@ -423,7 +423,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Memory requests, limits and usage",
+                            "title": "Memory requests, limits, and usage",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -448,17 +448,17 @@
                             "requests": [
                                 {
                                     "aggregator": "avg",
-                                    "alias": "Average number of jobs",
+                                    "alias": "Average number of Jobs",
                                     "q": "top(sum:kubernetes_state.job.count{$kube_cluster_name} by {kube_cluster_name}, 25, 'last', 'desc')"
                                 },
                                 {
                                     "aggregator": "sum",
-                                    "alias": "# of succeeded job pods",
+                                    "alias": "# of successful Job Pods",
                                     "q": "top(sum:kubernetes_state.job.succeeded{$kube_cluster_name} by {kube_cluster_name}.as_count(), 25, 'last', 'desc')"
                                 },
                                 {
                                     "aggregator": "sum",
-                                    "alias": "# of failed job pods",
+                                    "alias": "# of failed job Pods",
                                     "limit": 10,
                                     "order": "desc",
                                     "q": "top(sum:kubernetes_state.job.failed{$kube_cluster_name} by {kube_cluster_name}.as_count(), 25, 'last', 'desc')"
@@ -513,7 +513,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Number of jobs per cluster",
+                            "title": "Number of Jobs per cluster",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -538,18 +538,18 @@
                             "requests": [
                                 {
                                     "aggregator": "last",
-                                    "alias": "Last number of jobs",
+                                    "alias": "Last number of Jobs",
                                     "limit": 10,
                                     "order": "desc",
                                     "q": "top(sum:kubernetes_state.job.count{$kube_cluster_name,owner_kind:cronjob} by {owner_name}, 50, 'mean', 'desc')"
                                 },
                                 {
                                     "aggregator": "avg",
-                                    "alias": "Average number of jobs",
+                                    "alias": "Average number of Jobs",
                                     "q": "top(sum:kubernetes_state.job.count{$kube_cluster_name,owner_kind:cronjob} by {owner_name}, 50, 'mean', 'desc')"
                                 }
                             ],
-                            "title": "Top Cronjobs by Job Count",
+                            "title": "Top Cronjobs by Job count",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "query_table"
@@ -598,7 +598,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Cronjobs by Job Count",
+                            "title": "Cronjobs by Job count",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -652,7 +652,7 @@
                                 },
                                 {
                                     "aggregator": "avg",
-                                    "alias": "Network Read bytes",
+                                    "alias": "Network read bytes",
                                     "cell_display_mode": [
                                         "bar"
                                     ],
@@ -660,7 +660,7 @@
                                 },
                                 {
                                     "aggregator": "avg",
-                                    "alias": "Network Transmitted bytes",
+                                    "alias": "Network transmitted bytes",
                                     "cell_display_mode": [
                                         "bar"
                                     ],
@@ -676,7 +676,7 @@
                                 },
                                 {
                                     "aggregator": "avg",
-                                    "alias": "Disk Write",
+                                    "alias": "Disk write",
                                     "cell_display_mode": [
                                         "bar"
                                     ],
@@ -732,7 +732,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "CPU Usage by Job",
+                            "title": "CPU usage by Job",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -784,7 +784,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Memory Usage by Job",
+                            "title": "Memory usage by Job",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -864,7 +864,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Disk Usage by job",
+                            "title": "Disk usage by Job",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -944,7 +944,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Network Usage (Rx / Tx rate) by job",
+                            "title": "Network usage (Rx / Tx rate) by Job",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -1016,7 +1016,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Network Errors by job",
+                            "title": "Network errors by Job",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -1045,7 +1045,7 @@
                 "background_color": "purple",
                 "layout_type": "ordered",
                 "show_title": true,
-                "title": "Cronjob overview",
+                "title": "CronJob overview",
                 "type": "group",
                 "widgets": [
                     {
@@ -1071,7 +1071,7 @@
                                 },
                                 {
                                     "aggregator": "avg",
-                                    "alias": "Network Read bytes",
+                                    "alias": "Network read bytes",
                                     "cell_display_mode": [
                                         "bar"
                                     ],
@@ -1079,7 +1079,7 @@
                                 },
                                 {
                                     "aggregator": "avg",
-                                    "alias": "Network Transmitted bytes",
+                                    "alias": "Network transmitted bytes",
                                     "cell_display_mode": [
                                         "bar"
                                     ],
@@ -1095,7 +1095,7 @@
                                 },
                                 {
                                     "aggregator": "avg",
-                                    "alias": "Disk Write",
+                                    "alias": "Disk write",
                                     "cell_display_mode": [
                                         "bar"
                                     ],
@@ -1151,7 +1151,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "CPU Usage by CronJob",
+                            "title": "CPU usage by CronJob",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -1203,7 +1203,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Memory Usage by CronJob",
+                            "title": "Memory usage by CronJob",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -1283,7 +1283,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Disk Usage by CronJob",
+                            "title": "Disk usage by CronJob",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -1363,7 +1363,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Network Usage (Rx / Tx rate) by CronJob",
+                            "title": "Network usage (Rx / Tx rate) by CronJob",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",
@@ -1435,7 +1435,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Network Errors by CronJob",
+                            "title": "Network errors by CronJob",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries",

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -39,7 +39,8 @@
       "Kubernetes Deployments Overview": "assets/dashboards/kubernetes_deployments.json",
       "Kubernetes ReplicaSets Overview": "assets/dashboards/kubernetes_replicasets.json",
       "Kubernetes Services Overview": "assets/dashboards/kubernetes_services.json",
-      "Kubernetes DaemonDets Overview": "assets/dashboards/kubernetes_daemonsets.json"
+      "Kubernetes DaemonDets Overview": "assets/dashboards/kubernetes_daemonsets.json",
+      "Kubernetes Jobs & Cronjobs Overview": "assets/dashboards/kubernetes_jobs.json"
     },
     "service_checks": "assets/service_checks.json",
     "logs": {},


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a default Kubernetes dashboard to monitor jobs & cronjobs.

See it in prod: https://app.datadoghq.com/dashboard/vci-wuu-nhr/kubernetes-jobs--cronjobs-overview-cloned

### Motivation
<!-- What inspired you to submit this pull request? -->

We are working on adding support for jobs & cronjobs in Kubernetes Resources for Live Containers, adding a dashboard as well makes sens.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
