### PR TITLE
Send database monitoring query metrics to new intake

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -120,8 +120,8 @@ class MySql(AgentCheck):
                 self._collect_metrics(db, tags=tags)
                 self._collect_system_metrics(self._config.host, db, tags)
                 if self._config.deep_database_monitoring:
-                    self._statement_metrics.collect_per_statement_metrics(db, tags)
-                    self._statement_samples.run_sampler(tags)
+                    self._statement_metrics.collect_per_statement_metrics(db, self.service_check_tags)
+                    self._statement_samples.run_sampler(self.service_check_tags)
 
                 # keeping track of these:
                 self._put_qcache_stats()

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -83,7 +83,7 @@ class MySql(AgentCheck):
         self.check_initializations.append(self._query_manager.compile_queries)
         self.innodb_stats = InnoDBMetrics()
         self.check_initializations.append(self._config.configuration_checks)
-        self._statement_metrics = MySQLStatementMetrics(self._config)
+        self._statement_metrics = MySQLStatementMetrics(self, self._config)
         self._statement_samples = MySQLStatementSamples(self, self._config, self._get_connection_args())
 
     def execute_query_raw(self, query):
@@ -120,7 +120,7 @@ class MySql(AgentCheck):
                 self._collect_metrics(db, tags=tags)
                 self._collect_system_metrics(self._config.host, db, tags)
                 if self._config.deep_database_monitoring:
-                    self._collect_statement_metrics(db, tags)
+                    self._statement_metrics.collect_per_statement_metrics(db, tags)
                     self._statement_samples.run_sampler(tags)
 
                 # keeping track of these:
@@ -390,12 +390,6 @@ class MySql(AgentCheck):
         # deprecated in favor of service_check("mysql.replication.replica_running")
         self.service_check(self.SLAVE_SERVICE_CHECK_NAME, status, tags=self.service_check_tags + additional_tags)
         self.service_check(self.REPLICA_SERVICE_CHECK_NAME, status, tags=self.service_check_tags + additional_tags)
-
-    def _collect_statement_metrics(self, db, tags):
-        tags = self.service_check_tags + tags
-        metrics = self._statement_metrics.collect_per_statement_metrics(db)
-        for metric_name, metric_value, metric_tags in metrics:
-            self.count(metric_name, metric_value, tags=list(set(tags + metric_tags)))
 
     def _is_source_host(self, replicas, results):
         # type: (float, Dict[str, Any]) -> bool

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -70,9 +70,15 @@ class MySQLStatementMetrics(object):
         # (MySql, MySQLConfig) -> None
         self._check = check
         self._config = config
-        self._db_hostname = resolve_db_host(self._config.host)
+        self._db_hostname = None
         self.log = get_check_logger()
         self._state = StatementMetrics()
+
+    def _db_hostname_cached(self):
+        if self._db_hostname:
+            return self._db_hostname
+        self._db_hostname = resolve_db_host(self._config.host)
+        return self._db_hostname
 
     def collect_per_statement_metrics(self, db, tags):
         # type: (pymysql.connections.Connection, List[str]) -> None
@@ -81,7 +87,7 @@ class MySQLStatementMetrics(object):
             if not rows:
                 return
             payload = {
-                'host': self._db_hostname,
+                'host': self._db_hostname_cached(),
                 'timestamp': time.time() * 1000,
                 'min_collection_interval': self._config.min_collection_interval,
                 'tags': tags,

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 @pytest.fixture
 def dbm_instance(instance_complex):
     instance_complex['deep_database_monitoring'] = True
-    instance_complex['min_collection_interval'] = 1
     instance_complex['statement_samples'] = {
         'enabled': True,
         # set the default for tests to run sychronously to ensure we don't have orphaned threads running around
@@ -296,17 +295,29 @@ def test_statement_metrics(aggregator, dbm_instance):
     # Run the query and check a second time so statement metrics are computed from the previous run
     run_query(QUERY)
     mysql_check.check(dbm_instance)
-    for name in statements.STATEMENT_METRICS.values():
-        aggregator.assert_metric(
-            name,
-            tags=tags.SC_TAGS
-            + [
-                'query:{}'.format(QUERY_DIGEST_TEXT),
-                'query_signature:{}'.format(QUERY_SIGNATURE),
-                'digest:{}'.format(QUERY_DIGEST),
-            ],
-            count=1,
-        )
+
+    events = aggregator.get_event_platform_events("dbm-metrics")
+    assert len(events) == 1
+    event = events[0]
+
+    assert event['host'] == 'stubbed.hostname'
+    assert event['timestamp'] > 0
+    assert event['min_collection_interval'] == 15
+    assert set(event['tags']) == set(
+        tags.METRIC_TAGS + ['server:{}'.format(common.HOST), 'port:{}'.format(common.PORT)]
+    )
+
+    matching_rows = [r for r in event['mysql_rows'] if r['query_signature'] == QUERY_SIGNATURE]
+    assert len(matching_rows) == 1
+    row = matching_rows[0]
+
+    assert row['digest'] == QUERY_DIGEST
+    assert row['schema_name'] is None
+    assert row['digest_text'].strip() == QUERY_DIGEST_TEXT.strip()
+    assert row['query_signature'] == QUERY_SIGNATURE
+
+    for col in statements.METRICS_COLUMNS:
+        assert type(row[col]) in (float, int)
 
 
 @pytest.mark.integration
@@ -319,16 +330,6 @@ def test_statement_metrics_with_duplicates(aggregator, dbm_instance, datadog_age
     # the query signature for this test unless you know what you're doing. The query digest is determined by
     # mysql and varies across versions.
     query_signature = '94caeb4c54f97849'
-
-    if environ.get('MYSQL_FLAVOR') == 'mariadb':
-        query_digest = '9d1281ca764113522cfddefa25171e04'
-    elif environ.get('MYSQL_VERSION') == '5.6':
-        query_digest = '8ed22fb1a4d540751208966b7e322c3b'
-    elif environ.get('MYSQL_VERSION') == '5.7':
-        query_digest = '6b5a1b14bbeef4253f3d88bd6d2f41cf'
-    else:
-        # 8.0+
-        query_digest = 'bab5dd3d1abebc38338867fb4933301115cb3c40840fea30e1d6301cc14099c5'
 
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
 
@@ -355,78 +356,16 @@ def test_statement_metrics_with_duplicates(aggregator, dbm_instance, datadog_age
         run_query(query_two)
         mysql_check.check(dbm_instance)
 
-    expected_tags = tags.SC_TAGS + [
-        'query:{}'.format(normalized_query),
-        'query_signature:{}'.format(query_signature),
-        'digest:{}'.format(query_digest),
-    ]
+    events = aggregator.get_event_platform_events("dbm-metrics")
+    assert len(events) == 1
+    event = events[0]
 
-    aggregator.assert_metric('mysql.queries.count', count=1, tags=expected_tags)
-    aggregator.assert_metric('mysql.queries.count', value=2.0, tags=expected_tags)
+    matching_rows = [r for r in event['mysql_rows'] if r['query_signature'] == query_signature]
+    assert len(matching_rows) == 1
+    row = matching_rows[0]
 
-
-def test_generate_synthetic_rows():
-    rows = [
-        {
-            'count': 45,
-            'errors': 1,
-            'time': 1134,
-            'select_scan': 100,
-            'select_full_join': 98,
-            'no_index_used': 54,
-            'no_good_index_used': 12,
-            'lock_time': 1500,
-            'rows_affected': 10,
-            'rows_sent': 20,
-            'rows_examined': 50,
-        },
-        {
-            'count': 0,
-            'errors': 0,
-            'time': 0,
-            'select_scan': 0,
-            'select_full_join': 0,
-            'no_index_used': 0,
-            'no_good_index_used': 0,
-            'lock_time': 0,
-            'rows_affected': 0,
-            'rows_sent': 0,
-            'rows_examined': 0,
-        },
-    ]
-    result = statements.generate_synthetic_rows(rows)
-    assert result == [
-        {
-            'avg_time': 25.2,
-            'count': 45,
-            'errors': 1,
-            'time': 1134,
-            'select_scan': 100,
-            'select_full_join': 98,
-            'no_index_used': 54,
-            'no_good_index_used': 12,
-            'lock_time': 1500,
-            'rows_affected': 10,
-            'rows_sent': 20,
-            'rows_sent_ratio': 0.4,
-            'rows_examined': 50,
-        },
-        {
-            'avg_time': 0,
-            'count': 0,
-            'errors': 0,
-            'time': 0,
-            'select_scan': 0,
-            'select_full_join': 0,
-            'no_index_used': 0,
-            'no_good_index_used': 0,
-            'lock_time': 0,
-            'rows_affected': 0,
-            'rows_sent': 0,
-            'rows_sent_ratio': 0,
-            'rows_examined': 0,
-        },
-    ]
+    assert row['query_signature'] == query_signature
+    assert row['count_star'] == 2
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### What does this PR do?

Send DBM query metrics via the new aggregator API added in https://github.com/DataDog/integrations-core/pull/9165

### Motivation

Migrate to new DBM metrics intake.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
