### PR TITLE
Revert way of checking if it's aurora

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -27,7 +27,7 @@ from .util import (
     fmt,
     get_schema_field,
 )
-from .version_utils import V9, get_raw_version, is_aurora, parse_version, transform_version
+from .version_utils import V9, VersionUtils
 
 MAX_CUSTOM_RESULTS = 100
 
@@ -37,13 +37,14 @@ class PostgreSql(AgentCheck):
 
     SOURCE_TYPE_NAME = 'postgresql'
     SERVICE_CHECK_NAME = 'postgres.can_connect'
-    METADATA_TRANSFORMERS = {'version': transform_version}
+    METADATA_TRANSFORMERS = {'version': VersionUtils.transform_version}
 
     def __init__(self, name, init_config, instances):
         super(PostgreSql, self).__init__(name, init_config, instances)
         self.db = None
         self._version = None
         self._is_aurora = None
+        self._version_utils = VersionUtils()
         # Deprecate custom_metrics in favor of custom_queries
         if 'custom_metrics' in self.instance:
             self.warning(
@@ -74,15 +75,15 @@ class PostgreSql(AgentCheck):
     @property
     def version(self):
         if self._version is None:
-            raw_version = get_raw_version(self.db)
-            self._version = parse_version(raw_version)
+            raw_version = self._version_utils.get_raw_version(self.db)
+            self._version = self._version_utils.parse_version(raw_version)
             self.set_metadata('version', raw_version)
         return self._version
 
     @property
     def is_aurora(self):
         if self._is_aurora is None:
-            self._is_aurora = is_aurora(self.db)
+            self._is_aurora = self._version_utils.is_aurora(self.db)
         return self._is_aurora
 
     def _build_relations_config(self, yamlconfig):

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -39,7 +39,7 @@ class VersionUtils(object):
                 return result
         except Exception as e:
             self.log.debug(
-                "Captured exception {} while determining if the DB is aurora. Assuming is not".format(str(e))
+                "Captured exception %s while determining if the DB is aurora. Assuming is not", str(e)
             )
             db.rollback()
             return False
@@ -50,7 +50,7 @@ class VersionUtils(object):
             return True
         except Exception as e:
             self.log.debug(
-                "Captured exception {} while determining if the DB is aurora. Assuming is not".format(str(e))
+                "Captured exception %s while determining if the DB is aurora. Assuming is not", str(e)
             )
             db.rollback()
             return False

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -32,10 +32,8 @@ class VersionUtils(object):
         cursor = db.cursor()
         try:
             # This query is preferred to the one below cause it does not pollute PG logs with errors
-            cursor.execute("select exists(select 1 from pg_proc where proname = 'aurora_version');")
-            result = cursor.fetchone()[0]
-            if result is not None:
-                return result
+            cursor.execute('select AURORA_VERSION();')
+            return True
         except Exception as e:
             self.log.debug("Captured exception %s while determining if the DB is aurora. Assuming is not", str(e))
             db.rollback()

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -35,17 +35,7 @@ class VersionUtils(object):
             cursor.execute("select exists(select 1 from pg_proc where proname = 'aurora_version');")
             result = cursor.fetchone()[0]
             if result is not None:
-                # In some Aurora versions the above query returns None
                 return result
-        except Exception as e:
-            self.log.debug("Captured exception %s while determining if the DB is aurora. Assuming is not", str(e))
-            db.rollback()
-            return False
-        self.log.debug("Could not determine if the DB is aurora from pg_proc table")
-        try:
-            # It will raise UndefinedFunction on non aurora instances (and the error will pop on PG logs)
-            cursor.execute("select AURORA_VERSION();")
-            return True
         except Exception as e:
             self.log.debug("Captured exception %s while determining if the DB is aurora. Assuming is not", str(e))
             db.rollback()

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -38,9 +38,7 @@ class VersionUtils(object):
                 # In some Aurora versions the above query returns None
                 return result
         except Exception as e:
-            self.log.debug(
-                "Captured exception %s while determining if the DB is aurora. Assuming is not", str(e)
-            )
+            self.log.debug("Captured exception %s while determining if the DB is aurora. Assuming is not", str(e))
             db.rollback()
             return False
         self.log.debug("Could not determine if the DB is aurora from pg_proc table")
@@ -49,9 +47,7 @@ class VersionUtils(object):
             cursor.execute("select AURORA_VERSION();")
             return True
         except Exception as e:
-            self.log.debug(
-                "Captured exception %s while determining if the DB is aurora. Assuming is not", str(e)
-            )
+            self.log.debug("Captured exception %s while determining if the DB is aurora. Assuming is not", str(e))
             db.rollback()
             return False
 

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -31,7 +31,7 @@ class VersionUtils(object):
     def is_aurora(self, db):
         cursor = db.cursor()
         try:
-            # This query is preferred to the one below cause it does not pollute PG logs with errors
+            # This query will pollute PG logs in non aurora versions but is the only reliable way of detecting aurora
             cursor.execute('select AURORA_VERSION();')
             return True
         except Exception as e:

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -6,6 +6,8 @@ import re
 import semver
 from semver import VersionInfo
 
+from datadog_checks.base.log import get_check_logger
+
 V8_3 = VersionInfo(**semver.parse("8.3.0"))
 V9 = VersionInfo(**semver.parse("9.0.0"))
 V9_1 = VersionInfo(**semver.parse("9.1.0"))
@@ -15,69 +17,80 @@ V9_6 = VersionInfo(**semver.parse("9.6.0"))
 V10 = VersionInfo(**semver.parse("10.0.0"))
 
 
-def get_raw_version(db):
-    cursor = db.cursor()
-    cursor.execute('SHOW SERVER_VERSION;')
-    raw_version = cursor.fetchone()[0]
-    return raw_version
+class VersionUtils(object):
+    def __init__(self):
+        self.log = get_check_logger()
 
+    @staticmethod
+    def get_raw_version(db):
+        cursor = db.cursor()
+        cursor.execute('SHOW SERVER_VERSION;')
+        raw_version = cursor.fetchone()[0]
+        return raw_version
 
-def is_aurora(db):
-    cursor = db.cursor()
-    try:
-        # This query is preferred to the one below cause it does not pollute PG logs with errors
-        cursor.execute("select exists(select 1 from pg_proc where proname = 'aurora_version');")
-        result = cursor.fetchone()[0]
-        if result is not None:
-            # In some Aurora versions the above query returns None
-            return result
-    except Exception:
-        db.rollback()
-        return False
-    try:
-        # It will raise UndefinedFunction on non aurora instances (and the error will pop on PG logs)
-        cursor.execute("select AURORA_VERSION();")
-        return True
-    except Exception:
-        db.rollback()
-        return False
+    def is_aurora(self, db):
+        cursor = db.cursor()
+        try:
+            # This query is preferred to the one below cause it does not pollute PG logs with errors
+            cursor.execute("select exists(select 1 from pg_proc where proname = 'aurora_version');")
+            result = cursor.fetchone()[0]
+            if result is not None:
+                # In some Aurora versions the above query returns None
+                return result
+        except Exception as e:
+            self.log.debug(
+                "Captured exception {} while determining if the DB is aurora. Assuming is not".format(str(e))
+            )
+            db.rollback()
+            return False
+        self.log.debug("Could not determine if the DB is aurora from pg_proc table")
+        try:
+            # It will raise UndefinedFunction on non aurora instances (and the error will pop on PG logs)
+            cursor.execute("select AURORA_VERSION();")
+            return True
+        except Exception as e:
+            self.log.debug(
+                "Captured exception {} while determining if the DB is aurora. Assuming is not".format(str(e))
+            )
+            db.rollback()
+            return False
 
+    @staticmethod
+    def parse_version(raw_version):
+        try:
+            # Only works for MAJOR.MINOR.PATCH(-PRE_RELEASE)
+            return semver.parse_version_info(raw_version)
+        except ValueError:
+            pass
+        try:
+            # Version may be missing minor eg: 10.0
+            version = raw_version.split(' ')[0].split('.')
+            version = [int(part) for part in version]
+            while len(version) < 3:
+                version.append(0)
+            return VersionInfo(*version)
+        except ValueError:
+            # Postgres might be in development, with format \d+[beta|rc]\d+
+            match = re.match(r'(\d+)([a-zA-Z]+)(\d+)', raw_version)
+            if match:
+                version = list(match.groups())
+                return semver.parse_version_info('{}.0.0-{}.{}'.format(*version))
+        raise Exception("Cannot determine which version is {}".format(raw_version))
 
-def parse_version(raw_version):
-    try:
-        # Only works for MAJOR.MINOR.PATCH(-PRE_RELEASE)
-        return semver.parse_version_info(raw_version)
-    except ValueError:
-        pass
-    try:
-        # Version may be missing minor eg: 10.0
-        version = raw_version.split(' ')[0].split('.')
-        version = [int(part) for part in version]
-        while len(version) < 3:
-            version.append(0)
-        return VersionInfo(*version)
-    except ValueError:
-        # Postgres might be in development, with format \d+[beta|rc]\d+
-        match = re.match(r'(\d+)([a-zA-Z]+)(\d+)', raw_version)
-        if match:
-            version = list(match.groups())
-            return semver.parse_version_info('{}.0.0-{}.{}'.format(*version))
-    raise Exception("Cannot determine which version is {}".format(raw_version))
-
-
-def transform_version(raw_version, options=None):
-    """
-    :param raw_version: raw version in str format
-    :param options: keyword arguments to pass to any defined transformer
-    """
-    version = parse_version(raw_version)
-    transformed = {
-        'version.major': str(version.major),
-        'version.minor': str(version.minor),
-        'version.patch': str(version.patch),
-        'version.raw': raw_version,
-        'version.scheme': 'semver',
-    }
-    if version.prerelease:
-        transformed['version.release'] = version.prerelease
-    return transformed
+    @staticmethod
+    def transform_version(raw_version, options=None):
+        """
+        :param raw_version: raw version in str format
+        :param options: keyword arguments to pass to any defined transformer
+        """
+        version = VersionUtils.parse_version(raw_version)
+        transformed = {
+            'version.major': str(version.major),
+            'version.minor': str(version.minor),
+            'version.patch': str(version.patch),
+            'version.raw': raw_version,
+            'version.scheme': 'semver',
+        }
+        if version.prerelease:
+            transformed['version.release'] = version.prerelease
+        return transformed

--- a/postgres/tests/test_version_utils.py
+++ b/postgres/tests/test_version_utils.py
@@ -4,7 +4,7 @@
 import pytest
 from semver import VersionInfo
 
-from datadog_checks.postgres.version_utils import parse_version, transform_version
+from datadog_checks.postgres.version_utils import VersionUtils
 
 pytestmark = pytest.mark.unit
 
@@ -13,40 +13,40 @@ def test_parse_version():
     """
     Test _get_version() to make sure the check is properly parsing Postgres versions
     """
-    version = parse_version('9.5.3')
+    version = VersionUtils.parse_version('9.5.3')
     assert version == VersionInfo(9, 5, 3)
 
     # Test #.# style versions
-    v10_2 = parse_version('10.2')
+    v10_2 = VersionUtils.parse_version('10.2')
     assert v10_2 == VersionInfo(10, 2, 0)
 
-    v11 = parse_version('11')
+    v11 = VersionUtils.parse_version('11')
     assert v11 == VersionInfo(11, 0, 0)
 
     # Test #beta# style versions
-    beta11 = parse_version('11beta3')
+    beta11 = VersionUtils.parse_version('11beta3')
     assert beta11 == VersionInfo(11, 0, 0, prerelease='beta.3')
 
     assert v10_2 < beta11
     assert v11 > beta11
 
     # Test #rc# style versions
-    version = parse_version('11rc1')
+    version = VersionUtils.parse_version('11rc1')
     assert version == VersionInfo(11, 0, 0, prerelease='rc.1')
 
     # Test #nightly# style versions
-    version = parse_version('11nightly3')
+    version = VersionUtils.parse_version('11nightly3')
     assert version == VersionInfo(11, 0, 0, 'nightly.3')
 
 
 def test_throws_exception_for_unknown_version_format():
     with pytest.raises(Exception) as e:
-        parse_version('dontKnow')
+        VersionUtils.parse_version('dontKnow')
     assert e.value.args[0] == "Cannot determine which version is dontKnow"
 
 
 def test_transform_version():
-    version = transform_version('11beta4')
+    version = VersionUtils.transform_version('11beta4')
     expected = {
         'version.raw': '11beta4',
         'version.major': '11',
@@ -57,7 +57,7 @@ def test_transform_version():
     }
     assert expected == version
 
-    version = transform_version('10.0')
+    version = VersionUtils.transform_version('10.0')
     expected = {
         'version.raw': '10.0',
         'version.major': '10',
@@ -67,7 +67,7 @@ def test_transform_version():
     }
     assert expected == version
 
-    version = transform_version('10.5.4')
+    version = VersionUtils.transform_version('10.5.4')
     expected = {
         'version.raw': '10.5.4',
         'version.major': '10',


### PR DESCRIPTION
The current method we have does not work well for all aurora versions and we were not correctly unsetting it when the exception was captured

We stoped using this query in https://github.com/DataDog/integrations-core/pull/7542 because it was polluting logs although https://github.com/DataDog/integrations-core/pull/7480 made it happen less often

**Best review hiding whitespace changes**

Changes:
* Make VersionUtils a class so it can log messages
* Revert way of checking for aurora
* When FeatureNotSupported is raised aurora is set to False instead of None and replication_metrics are depleted
* We log self.aurora instead of self._aurora