### PR TITLE
Add merging of duplicate rows in statement_metrics

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
@@ -46,7 +46,7 @@ class StatementMetrics:
         new_cache = {}
         metrics = set(metrics)
 
-        rows = merge_duplicate_rows(rows, metrics, key)
+        rows = _merge_duplicate_rows(rows, metrics, key)
         if len(rows) > 0:
             dropped_metrics = metrics - set(rows[0].keys())
             if dropped_metrics:
@@ -105,10 +105,11 @@ class StatementMetrics:
         return result
 
 
-def merge_duplicate_rows(rows, metrics, key):
+def _merge_duplicate_rows(rows, metrics, key):
     """
-    Given a list of query rows, apply query normalization and compute query signatures to detect duplicate
-    queries_by_key and merge them into a single row.
+    Given a list of query rows, merge all duplicate rows as determined by the key function into a single row
+    with the sum of the stats of all duplicates. This is motivated by database integrations such as postgres
+    that can report many instances of a query that are considered the same after the agent normalization.
 
     - **rows** (_List[dict]_) - rows from current check run
     - **metrics** (_List[str]_) - the metrics to compute for each row

--- a/datadog_checks_base/tests/test_db_statements.py
+++ b/datadog_checks_base/tests/test_db_statements.py
@@ -6,7 +6,7 @@ import copy
 
 import pytest
 
-from datadog_checks.base.utils.db.statement_metrics import StatementMetrics, apply_row_limits, merge_duplicate_rows
+from datadog_checks.base.utils.db.statement_metrics import StatementMetrics, apply_row_limits
 
 
 def add_to_dict(a, b):
@@ -146,7 +146,7 @@ class TestStatementMetrics:
             {
                 'count': 14,
                 'time': 2006,
-                'errors': 2,
+                'errors': 32,
                 'query': 'SELECT * FROM table1 where id = ANY(?)',
                 'query_signature': 'sig1',
                 'db': 'puppies',
@@ -154,7 +154,7 @@ class TestStatementMetrics:
             },
             {
                 'count': 26,
-                'time': 106,
+                'time': 125,
                 'errors': 1,
                 'query': 'SELECT * FROM table1 where id = ANY(?, ?)',
                 'query_signature': 'sig1',
@@ -171,8 +171,8 @@ class TestStatementMetrics:
         expected_merged_metrics = [
             {
                 'count': 2,
-                'time': 2,
-                'errors': 2,
+                'time': 21,
+                'errors': 32,
                 'db': 'puppies',
                 'query': 'SELECT * FROM table1 where id = ANY(?)',
                 'query_signature': 'sig1',
@@ -181,68 +181,6 @@ class TestStatementMetrics:
         ]
 
         assert expected_merged_metrics == metrics
-
-    def test_merge_duplicate_rows(self):
-        def key(row):
-            return row['query_signature']
-
-        metrics = ['count', 'time']
-
-        rows = [
-            {
-                'count': 13,
-                'time': 2005,
-                'errors': 1,
-                'query': 'SELECT * FROM table1 where id = ANY(?)',
-                'query_signature': 'sig1',
-                'db': 'puppies',
-                'user': 'dog',
-            },
-            {
-                'count': 25,
-                'time': 105,
-                'errors': 0,
-                'query': 'SELECT * FROM table1 where id = ANY(?, ?)',
-                'query_signature': 'sig1',
-                'db': 'puppies',
-                'user': 'dog',
-            },
-            {
-                'count': 1,
-                'time': 100,
-                'errors': 0,
-                'query': 'SELECT * FROM table2',
-                'query_signature': 'sig2',
-                'db': 'puppies',
-                'user': 'dog',
-            },
-        ]
-
-        expected_merged_rows = [
-            {
-                'count': 38,
-                'time': 2110,
-                'errors': 1,
-                'db': 'puppies',
-                'query': 'SELECT * FROM table1 where id = ANY(?)',
-                'query_signature': 'sig1',
-                'user': 'dog',
-            },
-            {
-                'count': 1,
-                'time': 100,
-                'errors': 0,
-                'db': 'puppies',
-                'query': 'SELECT * FROM table2',
-                'query_signature': 'sig2',
-                'user': 'dog',
-            },
-        ]
-
-        metrics = merge_duplicate_rows(rows, metrics, key=key)
-
-        expected_by_query = {v['query']: v for v in expected_merged_rows}
-        assert expected_by_query == {v['query']: v for v in metrics}
 
     def test_apply_row_limits(self):
         def assert_any_order(a, b):

--- a/datadog_checks_base/tests/test_db_statements.py
+++ b/datadog_checks_base/tests/test_db_statements.py
@@ -1,8 +1,11 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import unicode_literals
+
 import copy
 
+import mock
 import pytest
 
 from datadog_checks.base.utils.db.statement_metrics import StatementMetrics, apply_row_limits
@@ -64,17 +67,38 @@ class TestStatementMetrics:
         ]
         expected = [
             # First row only incremented 'errors' which is not a tracked metric, so it is omitted from the output
-            {'count': 1, 'time': 15, 'errors': 0, 'query': 'ROLLBACK', 'db': 'puppies', 'user': 'dog'},
-            {'count': 20, 'time': 900, 'errors': 0, 'query': 'select * from kennel', 'db': 'puppies', 'user': 'rover'},
+            {
+                'count': 1,
+                'time': 15,
+                'errors': 0,
+                'normalized_query': 'ROLLBACK',
+                'query': 'ROLLBACK',
+                'query_signature': 'c7143367a3417869',
+                'db': 'puppies',
+                'user': 'dog',
+            },
+            {
+                'count': 20,
+                'time': 900,
+                'errors': 0,
+                'normalized_query': 'select * from kennel',
+                'query': 'select * from kennel',
+                'query_signature': '5e9800b54915b61',
+                'db': 'puppies',
+                'user': 'rover',
+            },
             {
                 'count': 7,
                 'time': 0.5,
                 'errors': 0,
+                'normalized_query': 'update kennel set breed="dalmatian" where id = ?',
                 'query': 'update kennel set breed="dalmatian" where id = ?',
+                'query_signature': '69d8ea328b5d1f04',
                 'db': 'puppies',
                 'user': 'rover',
             },
         ]
+        
         assert expected == sm.compute_derivative_rows(rows2, metrics, key=key)
         # No changes should produce no rows
         assert [] == sm.compute_derivative_rows(rows2, metrics, key=key)
@@ -108,6 +132,80 @@ class TestStatementMetrics:
         assert 2 == len(sm.compute_derivative_rows(rows2, metrics, key=key))  # both rows computed
         assert 1 == len(sm.compute_derivative_rows(rows3, metrics, key=key))  # only 1 row computed
         assert 2 == len(sm.compute_derivative_rows(rows4, metrics, key=key))  # both rows computed
+
+    def test_compute_derivative_rows_with_duplicates(self, datadog_agent):
+        sm = StatementMetrics()
+
+        def key(row):
+            return (row['query_signature'], row['db'], row['user'])
+
+        metrics = ['count', 'time']
+
+        rows1 = [
+            {
+                'count': 13,
+                'time': 2005,
+                'errors': 1,
+                'query': 'SELECT * FROM table1 where id = ANY(?, ?)',
+                'db': 'puppies',
+                'user': 'dog',
+            },
+            {
+                'count': 25,
+                'time': 105,
+                'errors': 0,
+                'query': 'SELECT * FROM table1 where id = ANY(?)',
+                'db': 'puppies',
+                'user': 'dog',
+            },
+        ]
+
+        rows2 = [
+            {
+                'count': 14,
+                'time': 2006,
+                'errors': 2,
+                'query': 'SELECT * FROM table1 where id = ANY(?, ?)',
+                'db': 'puppies',
+                'user': 'dog',
+            },
+            {
+                'count': 26,
+                'time': 106,
+                'errors': 1,
+                'query': 'SELECT * FROM table1 where id = ANY(?)',
+                'db': 'puppies',
+                'user': 'dog',
+            },
+        ]
+
+        normalized_query = 'select * from table1 where id = ANY( ? )'
+
+        def obfuscate_sql(query):
+            if 'table1' in query:
+                return normalized_query
+            return query
+
+        with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
+            mock_agent.side_effect = obfuscate_sql
+            # Run a first check to initialize tracking
+            sm.compute_derivative_rows(rows1, metrics, key=key)
+            # Run the check again to compute the metrics
+            metrics = sm.compute_derivative_rows(rows2, metrics, key=key)
+
+        expected_merged_metrics = {
+            'count': 2,
+            'time': 2,
+            'errors': 2,
+            'db': 'puppies',
+            'normalized_query': normalized_query,
+            'query': rows2[0]['query'],
+            'query_signature': 'a33e13237f376bc1',
+            'user': 'dog',
+        }
+
+        assert 1 == len(metrics)
+        assert expected_merged_metrics == metrics[0]
 
     def test_apply_row_limits(self):
         def assert_any_order(a, b):


### PR DESCRIPTION
### What does this PR do?
This PR aims to fix bad query metrics due to duplicate query stat rows. This was first noted as wrong Postgres query trends showing up like this but because the way we determine query identity is based on the agent's normalized query, this is a good candidate for logic to be present in the base _statement_metrics.py_.

Concrete example of duplication resulting in bad query metrics: 
<img width="528" alt="Screen Shot 2021-04-21 at 1 45 07 PM" src="https://user-images.githubusercontent.com/788439/115895929-c87c8300-a40f-11eb-92ce-e8b85ea115c2.png">

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
