### PR TITLE
Account for name change in replica metrics

### DIFF
--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -244,8 +244,17 @@ PERFORMANCE_VARS = {
 
 SCHEMA_VARS = {'information_schema_size': ('mysql.info.schema.size', GAUGE)}
 
+
+# Vars found in "show slave status" or "show replication status" (depending on mysql version)
 REPLICA_VARS = {
-    'Seconds_Behind_Master': ('mysql.replication.seconds_behind_master', GAUGE),
+    'Seconds_Behind_Source': [  # for 8 onwards
+        ('mysql.replication.seconds_behind_source', GAUGE),
+        ('mysql.replication.seconds_behind_master', GAUGE),  # for retrocompatibility
+    ],
+    'Seconds_Behind_Master': [  # before 8
+        ('mysql.replication.seconds_behind_source', GAUGE),
+        ('mysql.replication.seconds_behind_master', GAUGE),
+    ],
     'Replicas_connected': [
         ('mysql.replication.slaves_connected', GAUGE),
         ('mysql.replication.replicas_connected', GAUGE),

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -40,6 +40,7 @@ mysql.performance.threads_connected,gauge,,connection,,The number of currently o
 mysql.performance.threads_running,gauge,,thread,,The number of threads that are not sleeping.,0,mysql,threads running
 mysql.performance.user_time,gauge,,percent,,Percentage of CPU time spent in user space by MySQL.,-1,mysql,cpu user
 mysql.replication.seconds_behind_master,gauge,,second,,The lag in seconds between the master and the slave.,-1,mysql,replication lag
+mysql.replication.seconds_behind_source,gauge,,second,,The lag in seconds between the source and the replica.,-1,mysql,replication lag
 mysql.replication.slave_running,gauge,,,,Deprecated. Use service check mysql.replication.replica_running instead. A boolean showing if this server is a replication slave / master that is running.,0,mysql,slave running
 mysql.replication.slaves_connected,gauge,,,,Deprecated. Use mysql.replication.replicas_connected instead. Number of slaves connected to a replication master.,0,mysql,slaves connected
 mysql.replication.replicas_connected,gauge,,,,Number of replicas connected to a replication source.,0,mysql,replicas connected

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -91,6 +91,7 @@ SYSTEM_METRICS = ['mysql.performance.user_time', 'mysql.performance.kernel_time'
 OPTIONAL_REPLICATION_METRICS = [
     'mysql.replication.slave_running',
     'mysql.replication.seconds_behind_master',
+    'mysql.replication.seconds_behind_source',
     'mysql.replication.slaves_connected',
     'mysql.replication.replicas_connected',
 ]


### PR DESCRIPTION
When adding support for v8 API in https://github.com/DataDog/integrations-core/pull/8402 I missed this.
The test is not reliable because replication metrics are not always emitted, added a note about that.

Changes included:
* Ensuring seconds_behind_source/master is emited in all mysql versions
* Adding new metric to metadata csv and tests

Followup: https://github.com/DataDog/integrations-core/pull/9245