### PR TITLE
Make trello status command output be more usable

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/status.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/status.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import json
+from typing import List
 
 import click
 import pyperclip
@@ -10,12 +11,111 @@ import pyperclip
 from ....trello import TrelloClient
 from ...console import CONTEXT_SETTINGS, echo_info, echo_success
 
+ROW_FORMAT = {
+    'verbose': '{:19} | {:<8} | {:<8} | {:<8} | {:<8} | {:<8} | {}',
+    'summarized': '{:20} {:>4}',
+}
+
+HEADERS = {
+    'verbose': ('Total', 'Inbox', 'In Progress', 'Issues Found', 'Awaiting Build', 'Done'),
+    'summarized': ('Team', 'Done'),
+}
+
+
+ROW_DIVIDER = '-' * 4
+
+
+def _get_percent(completed: int, assigned: int) -> int:
+    return round((float(completed) / float(assigned)) * 100)
+
+
+def _verbose_status(counts: dict, as_json: bool) -> List[str]:
+    """Returns the Trello status output as a detailed table"""
+
+    row_format = ROW_FORMAT['verbose']
+    headers = HEADERS['verbose']
+
+    if as_json:
+        return [json.dumps(counts, indent=2)]
+
+    totals = dict(zip(headers, [0] * len(headers)))
+
+    output = []
+    output.append(row_format.format('', '', '', 'In', 'Issues', 'Awaiting', ''))
+    output.append(row_format.format('Team', 'Total', 'Inbox', 'Progress', 'Found', 'Build', 'Done'))
+    output.append(row_format.format(ROW_DIVIDER, *[ROW_DIVIDER for _ in headers]))
+
+    for team, data in counts.items():
+        for header in headers:
+            totals[header] += data[header]
+        row = row_format.format(team, *[data[header] for header in headers])
+        output.append(row)
+
+    output.append(row_format.format(ROW_DIVIDER, *[ROW_DIVIDER for _ in headers]))
+    row = row_format.format('TOTALS', *[totals[header] for header in headers])
+    output.append(row)
+
+    return output
+
+
+def _summary_status(counts: dict, as_json: bool) -> List[str]:
+    """Returns the Trello status output as a summarized table"""
+
+    row_format = ROW_FORMAT['summarized']
+
+    total_assigned = 0
+    total_completed = 0
+
+    computed_data = []
+    for team_name, data in counts.items():
+        completed = data['Done']
+        assigned = data['Total']
+
+        total_completed += completed
+        total_assigned += assigned
+
+        if assigned == 0:
+            computed_data.append((team_name, 100))
+            continue
+
+        computed_data.append((team_name, _get_percent(completed, assigned)))
+
+    computed_data.sort(key=lambda x: x[1])
+    total_percent_complete = _get_percent(total_completed, total_assigned)
+
+    if as_json:
+        json_data = {}
+        for team_name, pct_complete in computed_data:
+            json_data[team_name] = {
+                "PctComplete": pct_complete,
+            }
+
+        json_data['Total'] = {
+            "PctComplete": total_percent_complete,
+        }
+
+        return [json.dumps(json_data, indent=2)]
+
+    output = []
+    output.append(row_format.format(*HEADERS['summarized']))
+    output.append(row_format.format(ROW_DIVIDER * 5, ROW_DIVIDER))
+
+    for team_name, pct_complete in computed_data:
+        row = row_format.format(team_name, "{}%".format(pct_complete))
+        output.append(row)
+
+    output.append(row_format.format(ROW_DIVIDER * 5, ROW_DIVIDER))
+    output.append(row_format.format('TOTAL', "{}%".format(total_percent_complete)))
+
+    return output
+
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Gather statistics from the Trello release board')
+@click.option('--verbose', '-v', is_flag=True, help='Return the detailed results instead of the aggregates')
 @click.option('--json', '-j', 'as_json', is_flag=True, help='Return as raw JSON instead')
 @click.option('--clipboard', '-c', is_flag=True, help='Copy output to clipboard')
 @click.pass_context
-def status(ctx: click.Context, as_json: bool, clipboard: bool) -> None:
+def status(ctx: click.Context, verbose: bool, as_json: bool, clipboard: bool) -> None:
     """Print tabular status of Agent Release based on Trello columns.
 
     See trello subcommand for details on how to setup access:
@@ -28,29 +128,10 @@ def status(ctx: click.Context, as_json: bool, clipboard: bool) -> None:
 
     counts = trello.count_by_columns()
 
-    row_format = '{:19} | {:<8} | {:<8} | {:<8} | {:<8} | {:<8} | {}'
-    headers = ('Total', 'Inbox', 'In Progress', 'Issues Found', 'Awaiting Build', 'Done')
-
-    if as_json:
-        print(json.dumps(counts, indent=2))
-        return
-
-    totals = dict(zip(headers, [0] * len(headers)))
-
-    output = []
-    output.append(row_format.format('', '', '', 'In', 'Issues', 'Awaiting', ''))
-    output.append(row_format.format('Team', 'Total', 'Inbox', 'Progress', 'Found', 'Build', 'Done'))
-    output.append(row_format.format('--', *['--' for _ in headers]))
-
-    for team, data in counts.items():
-        for header in headers:
-            totals[header] += data[header]
-        row = row_format.format(team, *[data[header] for header in headers])
-        output.append(row)
-
-    output.append(row_format.format('--', *['--' for _ in headers]))
-    row = row_format.format('TOTALS', *[totals[header] for header in headers])
-    output.append(row)
+    if not verbose:
+        output = _summary_status(counts, as_json)
+    else:
+        output = _verbose_status(counts, as_json)
 
     out = '\n'.join(output)
 


### PR DESCRIPTION
Our old output was not really useful as the data density made it
difficult to quickly parse and as such it made it easy to ignore. The
new output only shows the most relevant datapoint (percentage complete)
which should increase signal-to-noise for this output. The old command
output can still be utilized with the addition of `--verbose` or `-v`
flag.

New Output:
```
Team                 Done
-------------------- ----
Core                  68%
Runtime-Security      70%
Platform              76%
Container App         78%
Networks              91%
Containers            93%
Integrations          97%
Logs                 100%
Processes            100%
Trace                100%
Tools and Libraries  100%
Infra-Integrations   100%
-------------------- ----
TOTAL                 89%
```

Old Output:
```
Team                | Total    | Inbox    | Progress | Found    | Build    | Done
----                | ----     | ----     | ----     | ----     | ----     | ----
Containers          | 43       | 2        | 0        | 1        | 0        | 40
Container App       | 9        | 2        | 0        | 0        | 0        | 7
Core                | 22       | 1        | 4        | 2        | 0        | 15
Integrations        | 102      | 0        | 1        | 0        | 2        | 99
Logs                | 0        | 0        | 0        | 0        | 0        | 0
Platform            | 29       | 6        | 0        | 1        | 0        | 22
Networks            | 11       | 0        | 0        | 1        | 0        | 10
Processes           | 15       | 0        | 0        | 0        | 0        | 15
Trace               | 7        | 0        | 0        | 0        | 0        | 7
Tools and Libraries | 1        | 0        | 0        | 0        | 0        | 1
Runtime-Security    | 23       | 4        | 0        | 3        | 0        | 16
Infra-Integrations  | 14       | 0        | 0        | 0        | 0        | 14
----                | ----     | ----     | ----     | ----     | ----     | ----
TOTALS              | 276      | 15       | 5        | 8        | 2        | 246
```

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
