### PR TITLE
Test datadog connection for pgBouncer before connecting via agent

### DIFF
--- a/pgbouncer/README.md
+++ b/pgbouncer/README.md
@@ -24,6 +24,17 @@ This check needs an associated user to query your PgBouncer instance:
    "datadog" "<PASSWORD>"
    ```
 
+3. To verify the credentials, run the following command:
+
+   ```shell
+   psql -h localhost -U datadog -p 6432 pgbouncer -c \
+   "SHOW VERSION;" \
+   && echo -e "\e[0;32mpgBouncer connection - OK\e[0m" \
+   || echo -e "\e[0;31mCannot connect to pgBouncer\e[0m"
+   ```
+
+   When it prompts for a password, enter the password you added to the `userlist.txt`.
+
 ### Configuration
 
 <!-- xxx tabs xxx -->
@@ -42,12 +53,12 @@ To configure this check for an Agent running on a host:
 
    instances:
      ## @param database_url - string - required
-     ## `database_url` parameter should point to PgBouncer stats database url
+     ## `database_url` parameter should point to PgBouncer stats database url (ie. "pgbouncer")
      #
      - database_url: "postgresql://datadog:<PASSWORD>@<HOSTNAME>:<PORT>/<DATABASE_URL>?sslmode=require"
    ```
 
-  **Note**: If your instance of PgBouncer does not have SSL support, replace `sslmode=require` with `sslmode=allow` to avoid server errors. For more information on SSL support, see the [Postgres documentation][10].
+   **Note**: If your instance of PgBouncer does not have SSL support, replace `sslmode=require` with `sslmode=allow` to avoid server errors. For more information on SSL support, see the [Postgres documentation][10].
 
 2. [Restart the Agent][4].
 
@@ -71,7 +82,7 @@ _Available for Agent versions >6.0_
        service: "<SERVICE_NAME>"
    ```
 
-    Change the `path` and `service` parameter values and configure them for your environment. See the [sample pgbouncer.d/conf.yaml][3] for all available configuration options.
+   Change the `path` and `service` parameter values and configure them for your environment. See the [sample pgbouncer.d/conf.yaml][3] for all available configuration options.
 
 3. [Restart the Agent][5].
 
@@ -86,7 +97,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 
 | Parameter            | Value                                                                                                  |
 | -------------------- | ------------------------------------------------------------------------------------------------------ |
-| `<INTEGRATION_NAME>` | `pgbouncer`                                                                                               |
+| `<INTEGRATION_NAME>` | `pgbouncer`                                                                                            |
 | `<INIT_CONFIG>`      | blank or `{}`                                                                                          |
 | `<INSTANCE_CONFIG>`  | `{"database_url": "postgresql://datadog:<PASSWORD>@%%host%%:%%port%%/<DATABASE_URL>?sslmode=require"}` |
 


### PR DESCRIPTION
Request user test their connection is setup correctly before adding to datadog agent

### What does this PR do?
The user should test their connection with the datadog user _before_ attempting to connect via the agent.

### Motivation
When the connection fails, the datadog agent status reports an issue with 'show version'. Ensuring that the user can run this command beforehand prevents the user from seeing this vague error.

### Review checklist (to be filled by reviewers)

- [N/A] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [Y] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [Y] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [Y] PR must have `changelog/` and `integration/` labels attached
