### PR TITLE
Reflect default port in docs

### DIFF
--- a/twemproxy/README.md
+++ b/twemproxy/README.md
@@ -26,7 +26,7 @@ To configure this check for an Agent running on a host:
 
    instances:
      - host: localhost
-       port: 22222
+       port: 2222
    ```
 
 2. [Restart the Agent][5] to begin sending Twemproxy metrics to Datadog.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The port default is 2222 as of #9217. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
