### PR TITLE
[SNMP] Invert interactive logic in validate mib files

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_mib_filenames.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_mib_filenames.py
@@ -48,9 +48,9 @@ MibFile = namedtuple('MibFile', ['index', 'folder', 'base_filename', 'name', 'is
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate MIB file names')
 @click.argument('mib_files', nargs=-1)
-@click.option('--fix-silent', '-s', is_flag=False, help='Rename all invalid MIB files without prompting to confirm')
+@click.option('--interactive', '-i', is_flag=True, help='Prompt to confirm before renaming all invalid MIB files')
 @click.pass_context
-def validate_mib_filenames(ctx, mib_files, fix_silent):
+def validate_mib_filenames(ctx, mib_files, interactive):
     """
     Validate MIB file names. Frameworks used to load mib files expect MIB file names to match
     MIB name.
@@ -83,7 +83,7 @@ def validate_mib_filenames(ctx, mib_files, fix_silent):
         index += 1
 
     option = '*'
-    if not fix_silent:
+    if interactive:
         echo_info(
             tabulate(
                 [[mib.index, mib.base_filename, mib.name, mib.is_valid] for mib in mibs],


### PR DESCRIPTION
### What does this PR do?
Silent execution by default, prompt for user input if explicitly chosen

### Motivation
Review of https://github.com/DataDog/integrations-core/pull/9228

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
