### PR TITLE
[release scripting] Fix tag filtering for `ddev release stats` command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/common.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/common.py
@@ -159,6 +159,12 @@ class Release:
             tag for tag in Tag.list_from_github(ctx, repo) if version_re.match(tag.name) or tag.name == release_version
         ]
 
+        # Exclude any tags with "-dbm-beta-" in the name. DB APM recently have used
+        # similar tags (e.g. `7.28.0-rc.1-dbm-beta-0.1`) for beta builds for clients
+        # and for deploying to classic that need to be filtered out, otherwise the
+        # dependent scripts get confused about what constitutes an "rc" tag.
+        rc_tags = [tag for tag in rc_tags if '-dbm-beta-' not in tag.name]
+
         for rc_tag in rc_tags:
             # we are forced to reload tags as the github does not return the tag's commit's SHA
             # when we are using the tag list API


### PR DESCRIPTION
### What does this PR do?

Since in the last few releases, we've had some tags created on the agent
with rc-matching regex pattern, the 'merged-prs' stats were incorrectly
calculating the changes between RCs. This change applies a fix to
exclude these tag patterns from being evaluated by the release stats.


### Motivation

Erroneous output of `ddev release stats merged-prs` command

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
