### PR TITLE
Change 'collision in cached query metrics' log from debug to error

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
@@ -57,7 +57,7 @@ class StatementMetrics:
         for row in rows:
             row_key = key(row)
             if row_key in new_cache:
-                logger.debug(
+                logger.error(
                     'Collision in cached query metrics. Dropping existing row, row_key=%s new=%s dropped=%s',
                     row_key,
                     row,

--- a/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
@@ -58,7 +58,7 @@ class StatementMetrics:
             row_key = key(row)
             if row_key in new_cache:
                 logger.error(
-                    'Collision in cached query metrics. Dropping existing row, row_key=%s new=%s dropped=%s',
+                    'Unexpected collision in cached query metrics. Dropping existing row, row_key=%s new=%s dropped=%s',
                     row_key,
                     row,
                     new_cache[row_key],


### PR DESCRIPTION
### What does this PR do?
With https://github.com/DataDog/integrations-core/pull/9227 which performs a merge of rows by key, we should never see any colliding rows when computing derivative rows. Because of this, the log showing the detection of a collision would be much more serious and an indicator of a bug so this increases the logging from `debug` to `error`. 

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
