### PR TITLE
Remove second parameter definition

### DIFF
--- a/.azure-pipelines/templates/test-all.yml
+++ b/.azure-pipelines/templates/test-all.yml
@@ -28,4 +28,3 @@ jobs:
       # Avoid max step limits
       ${{ if eq(check.checkName, 'datadog_checks_base') }}:
         validate: true
-        validate_codeowners: false


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Github Actions doesn't allow setting a parameter twice, so remove the hard-coded value here to fix - https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=61089&view=results