### PR TITLE
add a default dashboard for openLDAP

### DIFF
--- a/openldap/assets/dashboards/openldap_overview.json
+++ b/openldap/assets/dashboards/openldap_overview.json
@@ -1,0 +1,615 @@
+{
+    "title": "OpenLDAP - Overview",
+    "description": "This dashboard provides an overview of OpenLDAP metrics from the `cn=Monitor` backend of your OpenLDAP servers. \n\nFor more information, see:\n\n- Our [official OpenLDAP documentation](https://docs.datadoghq.com/integrations/openldap/)",
+    "widgets": [
+      {
+        "id": 0,
+        "definition": {
+          "title": "About OpenLDAP",
+          "title_align": "center",
+          "type": "group",
+          "banner_img": "https://static.datadoghq.com/static/images/logos/openldap_large.svg",
+          "show_title": false,
+          "layout_type": "ordered",
+          "widgets": [
+            {
+              "id": 8013519185925578,
+              "definition": {
+                "type": "note",
+                "content": "This dashboard shows you the status of your OpenLDAP server, as well as its connections, operations, threads, and logs to help you monitor and maintain the health of your database.\n\n##### [Official Datadog OpenLDAP documentation ↗](https://docs.datadoghq.com/integrations/openldap/)\n\nYou can clone this dashboard and modify its contents or copy and paste widgets to create your own visualizations for your OpenLDAP server",
+                "background_color": "transparent",
+                "font_size": "16",
+                "text_align": "left",
+                "vertical_align": "top",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "left",
+                "has_padding": true
+              },
+              "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 8,
+                "height": 3
+              }
+            }
+          ]
+        },
+        "layout": {
+          "x": 0,
+          "y": 0,
+          "width": 8,
+          "height": 6
+        }
+      },
+      {
+        "id": 1,
+        "definition": {
+          "title": "Server Status",
+          "title_align": "center",
+          "type": "group",
+          "show_title": true,
+          "layout_type": "ordered",
+          "widgets": [
+            {
+              "id": 5794216397682308,
+              "definition": {
+                "title": "OpenLDAP Service Check",
+                "title_size": "16",
+                "title_align": "left",
+                "time": {
+                  "live_span": "10m"
+                },
+                "type": "check_status",
+                "check": "openldap.can_connect",
+                "grouping": "cluster",
+                "group_by": [
+                  "host",
+                  "url"
+                ],
+                "tags": [
+                  "$host",
+                  "$url"
+                ]
+              },
+              "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 4,
+                "height": 2
+              }
+            },
+            {
+              "id": 6805529559452018,
+              "definition": {
+                "type": "note",
+                "content": "If the OpenLDAP cannot bind to the monitored server, this check returns **CRITICAL**, otherwise returns **OK**.\n\n",
+                "background_color": "gray",
+                "font_size": "14",
+                "text_align": "center",
+                "vertical_align": "top",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "top",
+                "has_padding": true
+              },
+              "layout": {
+                "x": 0,
+                "y": 2,
+                "width": 4,
+                "height": 2
+              }
+            }
+          ]
+        },
+        "layout": {
+          "x": 8,
+          "y": 0,
+          "width": 4,
+          "height": 6
+        }
+      },
+      {
+        "id": 5418366396402,
+        "definition": {
+          "title": "Threads Metrics",
+          "type": "group",
+          "show_title": true,
+          "layout_type": "ordered",
+          "widgets": [
+            {
+              "id": 1902084353892230,
+              "definition": {
+                "title": "Threads by Status",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "vertical",
+                "legend_columns": [
+                  "value",
+                  "avg"
+                ],
+                "type": "timeseries",
+                "requests": [
+                  {
+                    "q": "sum:openldap.threads{$host,$url} by {status}",
+                    "on_right_yaxis": false,
+                    "style": {
+                      "palette": "dog_classic",
+                      "line_type": "solid",
+                      "line_width": "normal"
+                    },
+                    "display_type": "area"
+                  }
+                ],
+                "yaxis": {
+                  "scale": "linear",
+                  "label": "",
+                  "include_zero": true,
+                  "min": "auto",
+                  "max": "auto"
+                },
+                "markers": []
+              },
+              "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 6,
+                "height": 5
+              }
+            },
+            {
+              "id": 6016125597671316,
+              "definition": {
+                "title": "Remaining Available Threads ",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                  "sum"
+                ],
+                "time": {},
+                "type": "timeseries",
+                "requests": [
+                  {
+                    "q": "sum:openldap.threads.max{$host,$url} by {host,url}-sum:openldap.threads{$host,$url} by {host,url}",
+                    "on_right_yaxis": false,
+                    "style": {
+                      "palette": "dog_classic",
+                      "line_type": "solid",
+                      "line_width": "normal"
+                    },
+                    "display_type": "line"
+                  }
+                ],
+                "yaxis": {
+                  "scale": "linear",
+                  "label": "",
+                  "include_zero": true,
+                  "min": "auto",
+                  "max": "auto"
+                },
+                "markers": [
+                  {
+                    "label": " 4 remaining threads available ",
+                    "value": "y = 4",
+                    "display_type": "warning dashed"
+                  }
+                ]
+              },
+              "layout": {
+                "x": 6,
+                "y": 0,
+                "width": 6,
+                "height": 5
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": 4089774572580756,
+        "definition": {
+          "title": "Statistics",
+          "type": "group",
+          "show_title": true,
+          "layout_type": "ordered",
+          "widgets": [
+            {
+              "id": 569430273145778,
+              "definition": {
+                "title": "PDU Packets by Server",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                  "avg",
+                  "min",
+                  "max",
+                  "value",
+                  "sum"
+                ],
+                "time": {},
+                "type": "timeseries",
+                "requests": [
+                  {
+                    "q": "sum:openldap.statistics.pdu{$url} by {host}.as_count()",
+                    "style": {
+                      "palette": "dog_classic",
+                      "line_type": "solid",
+                      "line_width": "normal"
+                    },
+                    "display_type": "line"
+                  }
+                ],
+                "yaxis": {
+                  "scale": "linear",
+                  "label": "",
+                  "include_zero": true,
+                  "min": "auto",
+                  "max": "auto"
+                },
+                "markers": []
+              },
+              "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 4,
+                "height": 3
+              }
+            },
+            {
+              "id": 4890120308859972,
+              "definition": {
+                "title": "Bytes Sent by Server",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                  "avg",
+                  "min",
+                  "max",
+                  "value",
+                  "sum"
+                ],
+                "time": {},
+                "type": "timeseries",
+                "requests": [
+                  {
+                    "q": "sum:openldap.statistics.bytes{$host,$url} by {host}.as_count()",
+                    "style": {
+                      "palette": "dog_classic",
+                      "line_type": "solid",
+                      "line_width": "normal"
+                    },
+                    "display_type": "line"
+                  }
+                ],
+                "yaxis": {
+                  "scale": "linear",
+                  "label": "",
+                  "include_zero": true,
+                  "min": "auto",
+                  "max": "auto"
+                },
+                "markers": []
+              },
+              "layout": {
+                "x": 4,
+                "y": 0,
+                "width": 4,
+                "height": 3
+              }
+            },
+            {
+              "id": 517747265586524,
+              "definition": {
+                "title": "Entries Sent by Server",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                  "avg",
+                  "min",
+                  "max",
+                  "value",
+                  "sum"
+                ],
+                "time": {},
+                "type": "timeseries",
+                "requests": [
+                  {
+                    "q": "sum:openldap.statistics.entries{$host,$url} by {host}.as_count()",
+                    "style": {
+                      "palette": "dog_classic",
+                      "line_type": "solid",
+                      "line_width": "normal"
+                    },
+                    "display_type": "line"
+                  }
+                ],
+                "yaxis": {
+                  "scale": "linear",
+                  "label": "",
+                  "include_zero": true,
+                  "min": "auto",
+                  "max": "auto"
+                },
+                "markers": []
+              },
+              "layout": {
+                "x": 8,
+                "y": 0,
+                "width": 4,
+                "height": 3
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": 4,
+        "definition": {
+          "title": "Operation Metrics",
+          "title_align": "center",
+          "type": "group",
+          "show_title": true,
+          "layout_type": "ordered",
+          "widgets": [
+            {
+              "id": 2205784706649616,
+              "definition": {
+                "title": "Completed Operations",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                  "avg",
+                  "min",
+                  "max",
+                  "value",
+                  "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                  {
+                    "q": "avg:openldap.operations.completed.total{$host,$url} by {host,url}.as_count()",
+                    "on_right_yaxis": false,
+                    "style": {
+                      "palette": "dog_classic",
+                      "line_type": "solid",
+                      "line_width": "normal"
+                    },
+                    "display_type": "bars"
+                  }
+                ],
+                "yaxis": {
+                  "scale": "linear",
+                  "label": "",
+                  "include_zero": true,
+                  "min": "auto",
+                  "max": "auto"
+                },
+                "markers": []
+              },
+              "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 6,
+                "height": 3
+              }
+            },
+            {
+              "id": 7619695970441178,
+              "definition": {
+                "title": "Incomplete Operations",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                  "avg",
+                  "min",
+                  "max",
+                  "value",
+                  "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                  {
+                    "q": "top(avg:openldap.operations.completed.total{$host,$url} by {host,url}.as_count(), 10, 'sum', 'desc')-top(avg:openldap.operations.initiated.total{$host,$url} by {host,url}.as_count(), 10, 'sum', 'desc')",
+                    "on_right_yaxis": false,
+                    "style": {
+                      "palette": "dog_classic",
+                      "line_type": "solid",
+                      "line_width": "normal"
+                    },
+                    "display_type": "bars"
+                  }
+                ],
+                "yaxis": {
+                  "scale": "linear",
+                  "label": "",
+                  "include_zero": true,
+                  "min": "auto",
+                  "max": "auto"
+                },
+                "markers": []
+              },
+              "layout": {
+                "x": 6,
+                "y": 0,
+                "width": 6,
+                "height": 3
+              }
+            }
+          ]
+        },
+        "layout": {
+          "is_column_break": true
+        }
+      },
+      {
+        "id": 3,
+        "definition": {
+          "title": "Connection Metrics",
+          "title_align": "center",
+          "type": "group",
+          "show_title": true,
+          "layout_type": "ordered",
+          "widgets": [
+            {
+              "id": 936573064721974,
+              "definition": {
+                "title": "Active Connections per Server",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                  "max"
+                ],
+                "time": {},
+                "type": "timeseries",
+                "requests": [
+                  {
+                    "q": "max:openldap.connections.current{$host,$url} by {host,url}",
+                    "on_right_yaxis": false,
+                    "style": {
+                      "palette": "dog_classic",
+                      "line_type": "solid",
+                      "line_width": "normal"
+                    },
+                    "display_type": "bars"
+                  }
+                ],
+                "yaxis": {
+                  "scale": "linear",
+                  "label": "",
+                  "include_zero": true,
+                  "min": "auto",
+                  "max": "auto"
+                },
+                "markers": []
+              },
+              "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 6,
+                "height": 3
+              }
+            },
+            {
+              "id": 3941916095677364,
+              "definition": {
+                "title": "Total Connections per Server",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                  "avg",
+                  "min",
+                  "max",
+                  "value",
+                  "sum"
+                ],
+                "time": {},
+                "type": "timeseries",
+                "requests": [
+                  {
+                    "q": "max:openldap.connections.total{$host,$url} by {host,url}.as_count()",
+                    "on_right_yaxis": false,
+                    "style": {
+                      "palette": "dog_classic",
+                      "line_type": "solid",
+                      "line_width": "normal"
+                    },
+                    "display_type": "bars"
+                  }
+                ],
+                "yaxis": {
+                  "scale": "linear",
+                  "label": "",
+                  "include_zero": true,
+                  "min": "auto",
+                  "max": "auto"
+                },
+                "markers": []
+              },
+              "layout": {
+                "x": 6,
+                "y": 0,
+                "width": 6,
+                "height": 3
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": 4468676229331770,
+        "definition": {
+          "title": "Logs",
+          "type": "group",
+          "show_title": true,
+          "layout_type": "ordered",
+          "widgets": [
+            {
+              "id": 3534096394864830,
+              "definition": {
+                "title": "",
+                "title_size": "16",
+                "title_align": "left",
+                "type": "log_stream",
+                "indexes": [],
+                "query": "source:openldap",
+                "sort": {
+                  "column": "time",
+                  "order": "desc"
+                },
+                "columns": [
+                  "status",
+                  "host",
+                  "@url",
+                  "service",
+                  "@op"
+                ],
+                "show_date_column": true,
+                "show_message_column": true,
+                "message_display": "expanded-md"
+              },
+              "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 12,
+                "height": 7
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "template_variables": [
+      {
+        "name": "host",
+        "default": "*",
+        "prefix": "host"
+      },
+      {
+        "name": "url",
+        "default": "*",
+        "prefix": "url"
+      }
+    ],
+    "layout_type": "ordered",
+    "is_read_only": true,
+    "notify_list": [],
+    "reflow_type": "fixed",
+    "id": "be8-8nz-b6u"
+  }

--- a/openldap/manifest.json
+++ b/openldap/manifest.json
@@ -29,7 +29,9 @@
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {},
-    "dashboards": {},
+    "dashboards": {
+      "OpenLDAP Overview": "assets/dashboards/openldap_overview.json"
+    },
     "service_checks": "assets/service_checks.json",
     "logs": {
       "source": "openldap"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds the OOTB OpenLDAP Overview Dashboard.

I can be viewed on ddev here: https://dddev.datadoghq.com/dashboard/be8-8nz-b6u/openldap---overview?from_ts=1619679656311&live=false&to_ts=1619740304779&tpl_var_host=%2A 

### Motivation
<!-- What inspired you to submit this pull request? -->
We have created an OpenLDAP integration, so we want to provide customers with an OOTB dashboard.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
