### PR TITLE
Remove `service` event facet

### DIFF
--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -216,7 +216,6 @@ class MySQLStatementSamples(object):
         self._db = None
         self._tags = None
         self._tags_str = None
-        self._service = "mysql"
         self._collection_loop_future = None
         self._cancel_event = threading.Event()
         self._rate_limiter = ConstantRateLimiter(1)
@@ -290,9 +289,6 @@ class MySQLStatementSamples(object):
             return
         self._tags = tags
         self._tags_str = ','.join(tags)
-        for t in self._tags:
-            if t.startswith('service:'):
-                self._service = t[len('service:') :]
         if not self._version_processed and self._check.version:
             self._has_window_functions = self._check.version.version_compatible((8, 0, 0))
             if self._check.version.flavor == "MariaDB" or not self._check.version.version_compatible((5, 7, 0)):
@@ -506,7 +502,6 @@ class MySQLStatementSamples(object):
             return {
                 "timestamp": row["timer_end_time_s"] * 1000,
                 "host": self._db_hostname,
-                "service": self._service,
                 "ddsource": "mysql",
                 "ddtags": self._tags_str,
                 "duration": row['timer_wait_ns'],

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -67,7 +67,6 @@ class PostgresStatementSamples(object):
         self._cancel_event = threading.Event()
         self._tags = None
         self._tags_str = None
-        self._service = "postgres"
         self._db_hostname = resolve_db_host(self._config.host)
         self._enabled = is_affirmative(self._config.statement_samples_config.get('enabled', False))
         self._run_sync = is_affirmative(self._config.statement_samples_config.get('run_sync', False))
@@ -106,9 +105,6 @@ class PostgresStatementSamples(object):
             return
         self._tags = tags
         self._tags_str = ','.join(self._tags)
-        for t in self._tags:
-            if t.startswith('service:'):
-                self._service = t[len('service:') :]
         self._last_check_run = time.time()
         if self._run_sync or is_affirmative(os.environ.get('DBM_STATEMENT_SAMPLER_RUN_SYNC', "false")):
             self._log.debug("Running statement sampler synchronously")
@@ -322,7 +318,6 @@ class PostgresStatementSamples(object):
             self._seen_samples_cache[statement_plan_sig] = True
             event = {
                 "host": self._db_hostname,
-                "service": self._service,
                 "ddsource": "postgres",
                 "ddtags": self._tags_str,
                 "network": {


### PR DESCRIPTION
### What does this PR do?

Deprecate the `service` event facet in favor of sending "service" only as a regular tag. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
