### PR TITLE
Add Sqreen to ignored integrations for codeowners validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
@@ -24,6 +24,7 @@ IGNORE_TILES = {
     'rigor',
     'rookout',
     'rundeck',
+    'sqreen',
     'squadcast',
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Sqreen is a tile-only intg in `integrations-extra`. This PR is to fix the CI on the codeowners validation. 
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
