### PR TITLE
Fix metric type to match description

### DIFF
--- a/solr/metadata.csv
+++ b/solr/metadata.csv
@@ -15,12 +15,12 @@ solr.query_result_cache.evictions,gauge,10,eviction,second,The total number of c
 solr.query_result_cache.hits,gauge,10,hit,second,The number of cache hits per second.,1,solr,query result cache hits
 solr.query_result_cache.inserts,gauge,10,set,second,The total number of cache inserts per second.,0,solr,query result cache sets
 solr.query_result_cache.lookups,gauge,10,get,second,The total number of cache lookups per second.,0,solr,query result cache gets
-solr.search_handler.request_times.50percentile,gauge,10,request,second,Request processing time in milliseconds (50percentile).,-1,solr,search reqs proces time 50p
-solr.search_handler.request_times.75percentile,gauge,10,request,second,Request processing time in milliseconds (75percentile).,-1,solr,search reqs proces time 75p
-solr.search_handler.request_times.95percentile,gauge,10,request,second,Request processing time in milliseconds (95percentile).,-1,solr,search reqs proces time 95p
-solr.search_handler.request_times.98percentile,gauge,10,request,second,Request processing time in milliseconds (98percentile).,-1,solr,search reqs proces time 98p
-solr.search_handler.request_times.99percentile,gauge,10,request,second,Request processing time in milliseconds (99percentile).,-1,solr,search reqs proces time 99p
-solr.search_handler.request_times.999percentile,gauge,10,request,second,Request processing time in milliseconds (999percentile).,-1,solr,search reqs proces time 999p
+solr.search_handler.request_times.50percentile,gauge,10,millisecond,,Request processing time in milliseconds (50percentile).,-1,solr,search reqs proces time 50p
+solr.search_handler.request_times.75percentile,gauge,10,millisecond,,Request processing time in milliseconds (75percentile).,-1,solr,search reqs proces time 75p
+solr.search_handler.request_times.95percentile,gauge,10,millisecond,,Request processing time in milliseconds (95percentile).,-1,solr,search reqs proces time 95p
+solr.search_handler.request_times.98percentile,gauge,10,millisecond,,Request processing time in milliseconds (98percentile).,-1,solr,search reqs proces time 98p
+solr.search_handler.request_times.99percentile,gauge,10,millisecond,,Request processing time in milliseconds (99percentile).,-1,solr,search reqs proces time 99p
+solr.search_handler.request_times.999percentile,gauge,10,millisecond,,Request processing time in milliseconds (999percentile).,-1,solr,search reqs proces time 999p
 solr.search_handler.request_times.one_minute_rate,gauge,10,request,second,Requests per second received over the past minutes.,1,solr,search reqs proces time
 solr.search_handler.request_times.mean_rate,gauge,10,request,second,Average number of requests received per second since the Solr core was first created.,1,solr,search reqs mean rate
 solr.search_handler.request_times.mean,gauge,10,millisecond,request,The average time per request.,-1,solr,search time mean


### PR DESCRIPTION
### What does this PR do?
Some Solr request_times metrics should be in millisecond (not req/s).
https://solr.apache.org/guide/8_4/performance-statistics-reference.html#commonly-used-stats-for-request-handlers

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
