### PR TITLE
Upgrade pyvmomi to 7.0.2

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -64,7 +64,7 @@ python-binary-memcached==0.26.1; sys_platform != "win32" and python_version < "3
 python-binary-memcached==0.30.1; sys_platform != "win32" and python_version > "3.0"
 python-dateutil==2.8.0
 python3-gearman==0.1.0; sys_platform != "win32" and python_version > "3.0"
-pyvmomi==v6.5.0.2017.5-1
+pyvmomi==v7.0.2
 pywin32==228; sys_platform == "win32" and python_version < "3.0"
 pywin32==300; sys_platform == "win32" and python_version > "3.0"
 pyyaml==5.4.1

--- a/vsphere/requirements.in
+++ b/vsphere/requirements.in
@@ -1,2 +1,2 @@
 futures==3.3.0; python_version < '3.0'
-pyvmomi==v6.5.0.2017.5-1
+pyvmomi==v7.0.2


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Needed to support vSphere 7

### Motivation
<!-- What inspired you to submit this pull request? -->
First step for vsphere 7 support

### Additional Notes
<!-- Anything else we should know when reviewing? -->
`pyvmomi` is used to communicate with the SOAP API.
As they suggest in their doc https://github.com/vmware/pyvmomi
```
Pyvmomi maintains minimum backward compatibility with the previous _four_ releases of vSphere and it's own previous four releases. Compatibility with much older versions may continue to work but will not be actively supported.
```
So it should work from vSphere 6.0

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
