### PR TITLE
Update base image to internal docker repository

### DIFF
--- a/.gitlab/reminder/Dockerfile
+++ b/.gitlab/reminder/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine3.9 AS reqs
+FROM registry.ddbuild.io/images/mirror/python:3.7.2-alpine3.9 AS reqs
 
 WORKDIR /
 
@@ -9,7 +9,7 @@ RUN pip install pip-tools
 RUN pip-compile --quiet --generate-hashes --output-file requirements.txt requirements.in
 
 # Our actual image
-FROM python:3.7-alpine3.9
+FROM registry.ddbuild.io/images/mirror/python:3.7.2-alpine3.9
 
 RUN apk add --update --no-cache bash
 

--- a/.gitlab/tagger/Dockerfile
+++ b/.gitlab/tagger/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM registry.ddbuild.io/images/mirror/ubuntu:20.04
 
 # Update sources and install required packages
 RUN apt-get update \

--- a/.gitlab/validate-logs-intgs/Dockerfile
+++ b/.gitlab/validate-logs-intgs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM registry.ddbuild.io/images/mirror/node:12-alpine
 RUN apk add git python3 --no-cache
 RUN pip3 install pyyaml
 RUN npm install -g ts-node


### PR DESCRIPTION
Pull from an internal repo instead of docker hub to prevent rate limiting