### PR TITLE
Use new REST API when possible

### DIFF
--- a/vsphere/datadog_checks/vsphere/api_rest.py
+++ b/vsphere/datadog_checks/vsphere/api_rest.py
@@ -32,11 +32,11 @@ class VSphereRestAPI(object):
     Abstraction class over the vSphere REST api
     """
 
-    def __init__(self, config, log):
-        # type: (VSphereConfig, CheckLoggingAdapter) -> None
+    def __init__(self, config, log, deprecated_api=True):
+        # type: (VSphereConfig, CheckLoggingAdapter, bool) -> None
         self.config = config
         self.log = log
-        self._client = VSphereRestClient(config, log)
+        self._client = VSphereRestClient(config, log, deprecated_api)
         self.smart_connect()
 
     def smart_connect(self):
@@ -136,12 +136,40 @@ class VSphereRestClient(object):
     """
 
     JSON_REQUEST_HEADERS = {'Content-Type': 'application/json'}
+    API_ENDPOINTS = {
+        'current': {
+            'tag-association-action': 'cis/tagging/tag-association?action=list-attached-tags-on-objects',
+            'tags-get': 'cis/tagging/tag/{}',
+            'category-get': 'cis/tagging/category/{}',
+            'session': 'session',
+        },
+        'deprecated': {
+            'tag-association-action': 'tagging/tag-association?~action=list-attached-tags-on-objects',
+            'tags-get': 'tagging/tag/id:{}',
+            'category-get': 'tagging/category/id:{}',
+            'session': 'session',
+        },
+    }
 
-    def __init__(self, config, log):
-        # type: (VSphereConfig, CheckLoggingAdapter) -> None
+    def __init__(self, config, log, deprecated_api):
+        # type: (VSphereConfig, CheckLoggingAdapter, bool) -> None
         self.log = log
-        self._api_base_url = "https://{}/rest/com/vmware/cis/".format(config.hostname)
-        self._http = RequestsWrapper(config.rest_api_options, config.shared_rest_api_options)
+        self.deprecated_api = deprecated_api
+        self._api_base_url = "https://{}/api/".format(config.hostname)
+        self.endpoints = self.API_ENDPOINTS['current']
+        if deprecated_api:
+            self._api_base_url = "https://{}/rest/com/vmware/cis/".format(config.hostname)
+            self.endpoints = self.API_ENDPOINTS['deprecated']
+        http_config = {
+            'username': config.username,
+            'password': config.password,
+            'tls_ca_cert': config.ssl_capath,
+            'tls_verify': config.ssl_verify,
+            'tls_ignore_warning': config.tls_ignore_warning,
+        }
+        self._http = RequestsWrapper(
+            http_config, {}
+        )  # self._http = RequestsWrapper(config.rest_api_options, config.shared_rest_api_options)
 
     def connect_session(self):
         # type: () -> None
@@ -159,7 +187,9 @@ class VSphereRestClient(object):
         Doc:
         https://vmware.github.io/vsphere-automation-sdk-rest/6.5/operations/com/vmware/cis/session.create-operation.html
         """
-        session_token = self._request_json("session", method="post", extra_headers=self.JSON_REQUEST_HEADERS)
+        session_token = self._request_json(
+            self.endpoints['session'], method="post", extra_headers=self.JSON_REQUEST_HEADERS
+        )
         return session_token
 
     def tagging_category_get(self, category_id):
@@ -169,7 +199,7 @@ class VSphereRestClient(object):
         Doc:
         https://vmware.github.io/vsphere-automation-sdk-rest/6.5/operations/com/vmware/cis/tagging/category.get-operation.html
         """
-        return self._request_json("tagging/category/id:{}".format(category_id))
+        return self._request_json(self.endpoints['category-get'].format(category_id))
 
     def tagging_tags_get(self, tag_id):
         # type: (str) -> Dict[str, Any]
@@ -178,7 +208,7 @@ class VSphereRestClient(object):
         Doc:
         https://vmware.github.io/vsphere-automation-sdk-rest/6.5/operations/com/vmware/cis/tagging/tag.get-operation.html
         """
-        return self._request_json("tagging/tag/id:{}".format(tag_id))
+        return self._request_json(self.endpoints['tags-get'].format(tag_id))
 
     def tagging_tag_association_list_attached_tags_on_objects(self, mors):
         # type: (List[vim.ManagedEntity]) -> List[TagAssociation]
@@ -191,7 +221,7 @@ class VSphereRestClient(object):
         """
         payload = {"object_ids": [{"id": mor._moId, "type": MOR_TYPE_MAPPING_TO_STRING[type(mor)]} for mor in mors]}
         tag_associations = self._request_json(
-            "tagging/tag-association?~action=list-attached-tags-on-objects",
+            self.endpoints['tag-association-action'],
             method="post",
             data=json.dumps(payload),
             extra_headers=self.JSON_REQUEST_HEADERS,
@@ -205,6 +235,9 @@ class VSphereRestClient(object):
         resp.raise_for_status()
 
         data = resp.json()
+        if not self.deprecated_api:
+            return data
+
         if 'value' not in data:
             raise APIResponseError("Missing `value` element in response for url: {}".format(url))
 

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -104,12 +104,17 @@ class VSphereCheck(AgentCheck):
 
         if self._config.should_collect_tags:
             try:
-                try:
-                    # Try to connect to REST API vSphere v7
-                    self.api_rest = VSphereRestAPI(self._config, self.log, False)
-                except Exception:
-                    self.log.debug("REST API of vSphere 7 not detected, falling back to the old API.")
-                    self.api_rest = VSphereRestAPI(self._config, self.log, True)
+                version_info = self.api.get_version()
+                major_version = int(version_info.version_str[0])
+
+                if major_version >= 7:
+                    try:
+                        # Try to connect to REST API vSphere v7
+                        self.api_rest = VSphereRestAPI(self._config, self.log, False)
+                        return
+                    except Exception:
+                        self.log.debug("REST API of vSphere 7 not detected, falling back to the old API.")
+                self.api_rest = VSphereRestAPI(self._config, self.log, True)
             except Exception as e:
                 self.log.error("Cannot connect to vCenter REST API. Tags won't be collected. Error: %s", e)
 

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -104,7 +104,12 @@ class VSphereCheck(AgentCheck):
 
         if self._config.should_collect_tags:
             try:
-                self.api_rest = VSphereRestAPI(self._config, self.log)
+                try:
+                    # Try to connect to REST API vSphere v7
+                    self.api_rest = VSphereRestAPI(self._config, self.log, False)
+                except Exception:
+                    self.log.debug("REST API of vSphere 7 not detected, falling back to the old API.")
+                    self.api_rest = VSphereRestAPI(self._config, self.log, True)
             except Exception as e:
                 self.log.error("Cannot connect to vCenter REST API. Tags won't be collected. Error: %s", e)
 

--- a/vsphere/tests/common.py
+++ b/vsphere/tests/common.py
@@ -3,7 +3,11 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import os
 
+from datadog_checks.vsphere.api_rest import VSphereRestAPI
+
 HERE = os.path.abspath(os.path.dirname(__file__))
+
+VSPHERE_VERSION = os.environ.get('VSPHERE_VERSION')
 
 LAB_USERNAME = os.environ.get('TEST_VSPHERE_USER')
 LAB_PASSWORD = os.environ.get('TEST_VSPHERE_PASS')
@@ -21,3 +25,9 @@ LAB_INSTANCE = {
     'collect_events': True,
     'use_collect_events_fallback': True,
 }
+
+
+def build_rest_api_client(config, logger):
+    if VSPHERE_VERSION.startswith('7.'):
+        return VSphereRestAPI(config, logger, False)
+    return VSphereRestAPI(config, logger, True)

--- a/vsphere/tests/conftest.py
+++ b/vsphere/tests/conftest.py
@@ -6,8 +6,8 @@ import os
 import pytest
 from mock import MagicMock, Mock, patch
 
-from .common import LAB_INSTANCE
-from .mocked_api import MockedAPI, mock_http_rest_api
+from .common import LAB_INSTANCE, VSPHERE_VERSION
+from .mocked_api import MockedAPI, mock_http_rest_api_v6, mock_http_rest_api_v7
 
 try:
     from contextlib import ExitStack
@@ -99,5 +99,9 @@ def mock_api():
 
 @pytest.fixture
 def mock_rest_api():
-    with patch('requests.api.request', mock_http_rest_api):
-        yield
+    if VSPHERE_VERSION.startswith('7.'):
+        with patch('requests.api.request', mock_http_rest_api_v7):
+            yield
+    else:
+        with patch('requests.api.request', mock_http_rest_api_v6):
+            yield

--- a/vsphere/tests/mocked_api.py
+++ b/vsphere/tests/mocked_api.py
@@ -10,7 +10,7 @@ from mock import MagicMock
 from pyVmomi import vim
 from requests import Response
 from six import iteritems
-from tests.common import HERE
+from tests.common import HERE, VSPHERE_VERSION
 
 from datadog_checks.vsphere.api import VersionInfo
 
@@ -36,9 +36,9 @@ class MockedAPI(object):
 
     def get_version(self):
         about = MagicMock(
-            version='6.7.0',
+            version=VSPHERE_VERSION,
             build='123456789',
-            fullName='VMware vCenter Server 6.7.0 build-14792544',
+            fullName='VMware vCenter Server {} build-14792544'.format(VSPHERE_VERSION),
             apiType='VirtualCenter',
         )
         return VersionInfo(about)

--- a/vsphere/tests/mocked_api.py
+++ b/vsphere/tests/mocked_api.py
@@ -133,7 +133,9 @@ class MockResponse(Response):
         return self.json_data
 
 
-def mock_http_rest_api(method, url, *args, **kwargs):
+def mock_http_rest_api_v6(method, url, *args, **kwargs):
+    if '/api/' in url:
+        return MockResponse({}, 404)
     if method == 'get':
         if re.match(r'.*/category/id:.*$', url):
             parts = url.split('_')
@@ -183,4 +185,53 @@ def mock_http_rest_api(method, url, *args, **kwargs):
                 },
                 200,
             )
+    raise Exception("Rest api mock request not matched: method={}, url={}".format(method, url))
+
+
+def mock_http_rest_api_v7(method, url, *args, **kwargs):
+    if method == 'get':
+        if re.match(r'.*/category/.*$', url):
+            parts = url.split('_')
+            num = parts[len(parts) - 1]
+            return MockResponse(
+                {
+                    'name': 'my_cat_name_{}'.format(num),
+                    'description': 'VM category description',
+                    'id': 'cat_id_{}'.format(num),
+                    'used_by': [],
+                    'cardinality': 'SINGLE',
+                },
+                200,
+            )
+
+        elif re.match(r'.*/tagging/tag/.*$', url):
+            parts = url.split('_')
+            num = parts[len(parts) - 1]
+            return MockResponse(
+                {
+                    'category_id': 'cat_id_{}'.format(num),
+                    'name': 'my_tag_name_{}'.format(num),
+                    'description': '',
+                    'id': 'tag_id_{}'.format(num),
+                    'used_by': [],
+                },
+                200,
+            )
+    elif method == 'post':
+        assert kwargs['headers']['Content-Type'] == 'application/json'
+        if re.match(r'.*/session$', url):
+            return MockResponse(
+                "dummy-token",
+                200,
+            )
+        elif re.match(r'.*/tagging/tag-association\?action=list-attached-tags-on-objects$', url):
+            return MockResponse(
+                [
+                    {'tag_ids': ['tag_id_1', 'tag_id_2'], 'object_id': {'id': 'VM4-4-1', 'type': 'VirtualMachine'}},
+                    {'tag_ids': ['tag_id_2'], 'object_id': {'id': 'NFS-Share-1', 'type': 'Datastore'}},
+                    {'tag_ids': ['tag_id_2'], 'object_id': {'id': '10.0.0.104-1', 'type': 'HostSystem'}},
+                ],
+                200,
+            )
+
     raise Exception("Rest api mock request not matched: method={}, url={}".format(method, url))

--- a/vsphere/tests/test_api_rest.py
+++ b/vsphere/tests/test_api_rest.py
@@ -11,13 +11,15 @@ from datadog_checks.vsphere import VSphereCheck
 from datadog_checks.vsphere.api_rest import VSphereRestAPI
 from datadog_checks.vsphere.config import VSphereConfig
 
+from .common import build_rest_api_client
+
 logger = logging.getLogger()
 
 
 @pytest.mark.usefixtures("mock_rest_api", "mock_type")
 def test_get_resource_tags(realtime_instance):
     config = VSphereConfig(realtime_instance, {}, logger)
-    mock_api = VSphereRestAPI(config, log=logger)
+    mock_api = build_rest_api_client(config, logger)
     mock_mors = [MagicMock(spec=vim.VirtualMachine, _moId="foo")]
 
     resource_tags = mock_api.get_resource_tags_for_mors(mock_mors)
@@ -176,7 +178,7 @@ def test_rest_api_config(init_config, instance_config, expected_shared_rest_api_
 @pytest.mark.usefixtures("mock_rest_api")
 def test_create_session(realtime_instance):
     config = VSphereConfig(realtime_instance, {}, logger)
-    mock_api = VSphereRestAPI(config, log=logger)
+    mock_api = build_rest_api_client(config, logger)
 
     assert mock_api._client._http.options['headers']['vmware-api-session-id'] == "dummy-token"
 
@@ -186,7 +188,7 @@ def test_create_session(realtime_instance):
 def test_make_batch(realtime_instance, batch_size, number_of_batches):
     realtime_instance['batch_tags_collector_size'] = batch_size
     config = VSphereConfig(realtime_instance, {}, logger)
-    mock_api = VSphereRestAPI(config, log=logger)
+    mock_api = build_rest_api_client(config, logger)
     data_to_batch = list(range(1000))
 
     batches = list(VSphereRestAPI.make_batch(mock_api, data_to_batch))

--- a/vsphere/tests/test_cache.py
+++ b/vsphere/tests/test_cache.py
@@ -8,10 +8,11 @@ from mock import MagicMock, patch
 from pyVmomi import vim
 from six import iteritems
 
-from datadog_checks.vsphere.api_rest import VSphereRestAPI
 from datadog_checks.vsphere.cache import InfrastructureCache, MetricsMetadataCache, VSphereCache
 from datadog_checks.vsphere.config import VSphereConfig
 from datadog_checks.vsphere.constants import ALL_RESOURCES_WITH_METRICS
+
+from .common import build_rest_api_client
 
 logger = logging.getLogger()
 
@@ -78,7 +79,7 @@ def test_metrics_metadata_cache():
 def test_infrastructure_cache(realtime_instance):
     cache = InfrastructureCache(float('inf'))
     config = VSphereConfig(realtime_instance, {}, logger)
-    mock_api = VSphereRestAPI(config, log=logger)
+    mock_api = build_rest_api_client(config, logger)
 
     mors = {MagicMock(spec=k, _moId="foo"): object() for k in ALL_RESOURCES_WITH_METRICS * 2}
     with cache.update():

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -14,10 +14,9 @@ from tests.legacy.utils import mock_alarm_event
 from datadog_checks.base import to_string
 from datadog_checks.vsphere import VSphereCheck
 from datadog_checks.vsphere.api import APIConnectionError
-from datadog_checks.vsphere.api_rest import VSphereRestAPI
 from datadog_checks.vsphere.config import VSphereConfig
 
-from .common import HERE
+from .common import HERE, build_rest_api_client
 from .mocked_api import MockedAPI
 
 
@@ -100,7 +99,7 @@ def test_external_host_tags(aggregator, realtime_instance):
     check = VSphereCheck('vsphere', {}, [realtime_instance])
     config = VSphereConfig(realtime_instance, {}, MagicMock())
     check.api = MockedAPI(config)
-    check.api_rest = VSphereRestAPI(config, MagicMock())
+    check.api_rest = build_rest_api_client(config, MagicMock())
 
     with check.infrastructure_cache.update():
         check.refresh_infrastructure_cache()
@@ -303,7 +302,7 @@ def test_renew_rest_api_session_on_failure(aggregator, dd_run_check, realtime_in
     realtime_instance.update({'collect_tags': True})
     check = VSphereCheck('vsphere', {}, [realtime_instance])
     config = VSphereConfig(realtime_instance, {}, MagicMock())
-    check.api_rest = VSphereRestAPI(config, MagicMock())
+    check.api_rest = build_rest_api_client(config, MagicMock())
     check.api_rest.make_batch = MagicMock(side_effect=[Exception, []])
     check.api_rest.smart_connect = MagicMock()
 

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -16,7 +16,7 @@ from datadog_checks.vsphere import VSphereCheck
 from datadog_checks.vsphere.api import APIConnectionError
 from datadog_checks.vsphere.config import VSphereConfig
 
-from .common import HERE, build_rest_api_client
+from .common import HERE, VSPHERE_VERSION, build_rest_api_client
 from .mocked_api import MockedAPI
 
 
@@ -400,13 +400,15 @@ def test_version_metadata(aggregator, dd_run_check, realtime_instance, datadog_a
     check = VSphereCheck('vsphere', {}, [realtime_instance])
     check.check_id = 'test:123'
     dd_run_check(check)
+
+    major, minor, patch = VSPHERE_VERSION.split('.')
     version_metadata = {
         'version.scheme': 'semver',
-        'version.major': '6',
-        'version.minor': '7',
-        'version.patch': '0',
+        'version.major': major,
+        'version.minor': minor,
+        'version.patch': patch,
         'version.build': '123456789',
-        'version.raw': '6.7.0+123456789',
+        'version.raw': '{}+123456789'.format(VSPHERE_VERSION),
     }
 
     datadog_agent.assert_metadata('test:123', version_metadata)

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}
+    py{27,38}-{6.7.0,7.0.2}
 
 [testenv]
 ensure_default_envdir = true
@@ -33,3 +33,6 @@ deps =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
+setenv =
+    6.7.0: VSPHERE_VERSION=6.7.0
+    7.0.2: VSPHERE_VERSION=7.0.2


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
https://core.vmware.com/blog/vsphere-7-update-2-rest-api-modernization
A new REST API was introduced in vsphere 7, so we try to use it instead of the deprecated one when possible.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
The deprecated API should be maintained in the 2 next vsphere major releases

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
