### PR TITLE
Add collect_server_info config option

### DIFF
--- a/envoy/assets/configuration/spec.yaml
+++ b/envoy/assets/configuration/spec.yaml
@@ -70,6 +70,13 @@ files:
       value:
         type: boolean
         example: false
+    - name: collect_server_info
+      description: |
+        Collect Envoy version by accessing the `/server_info` endpoint.
+        Disable this if this endpoint is not reachable by the agent.
+      value:
+        type: boolean
+        example: true
     - template: instances/default
     - template: instances/http
       overrides:

--- a/envoy/datadog_checks/envoy/config_models/defaults.py
+++ b/envoy/datadog_checks/envoy/config_models/defaults.py
@@ -44,6 +44,10 @@ def instance_cache_metrics(field, value):
     return True
 
 
+def instance_collect_server_info(field, value):
+    return True
+
+
 def instance_connect_timeout(field, value):
     return get_default_field_value(field, value)
 

--- a/envoy/datadog_checks/envoy/config_models/instance.py
+++ b/envoy/datadog_checks/envoy/config_models/instance.py
@@ -40,6 +40,7 @@ class InstanceConfig(BaseModel):
     aws_region: Optional[str]
     aws_service: Optional[str]
     cache_metrics: Optional[bool]
+    collect_server_info: Optional[bool]
     connect_timeout: Optional[float]
     empty_default_hostname: Optional[bool]
     excluded_metrics: Optional[Sequence[str]]

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -114,6 +114,12 @@ instances:
     #
     # parse_unknown_metrics: false
 
+    ## @param collect_server_info - boolean - optional - default: true
+    ## Collect Envoy version by accessing the `/server_info` endpoint.
+    ## Disable this if this endpoint is not reachable by the agent.
+    #
+    # collect_server_info: true
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -146,9 +146,7 @@ class Envoy(AgentCheck):
     @AgentCheck.metadata_entrypoint
     def _collect_metadata(self):
         if not self.collect_server_info:
-            self.log.debug(
-                "Skipping server info collection because collect_server_info was disabled"
-            )
+            self.log.debug("Skipping server info collection because collect_server_info was disabled")
             return
         # From http://domain/thing/stats to http://domain/thing/server_info
         server_info_url = urljoin(self.stats_url, 'server_info')

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -27,6 +27,7 @@ class Envoy(AgentCheck):
         self.custom_tags = self.instance.get('tags', [])
         self.caching_metrics = self.instance.get('cache_metrics', True)
 
+        self.collect_server_info = self.instance.get('collect_server_info', True)
         self.stats_url = self.instance.get('stats_url')
         if self.stats_url is None:
             raise ConfigurationError('Envoy configuration setting `stats_url` is required')
@@ -144,6 +145,8 @@ class Envoy(AgentCheck):
 
     @AgentCheck.metadata_entrypoint
     def _collect_metadata(self):
+        if not self.collect_server_info:
+            return
         # From http://domain/thing/stats to http://domain/thing/server_info
         server_info_url = urljoin(self.stats_url, 'server_info')
         raw_version = None

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -146,6 +146,9 @@ class Envoy(AgentCheck):
     @AgentCheck.metadata_entrypoint
     def _collect_metadata(self):
         if not self.collect_server_info:
+            self.log.debug(
+                "Skipping server info collection because collect_server_info was disabled"
+            )
             return
         # From http://domain/thing/stats to http://domain/thing/server_info
         server_info_url = urljoin(self.stats_url, 'server_info')

--- a/envoy/tests/common.py
+++ b/envoy/tests/common.py
@@ -29,6 +29,10 @@ INSTANCES = {
         'included_metrics': [r'envoy\.cluster\.'],
         'excluded_metrics': [r'envoy\.cluster\.out\.'],
     },
+    'collect_server_info': {
+        'stats_url': 'http://{}:{}/stats'.format(HOST, PORT),
+        'collect_server_info': 'false',
+    },
 }
 ENVOY_VERSION = os.getenv('ENVOY_VERSION')
 

--- a/envoy/tests/test_envoy.py
+++ b/envoy/tests/test_envoy.py
@@ -223,6 +223,18 @@ def test_metadata(datadog_agent):
         check.log.debug.assert_called_with('Version not matched.')
 
 
+@pytest.mark.unit
+def test_metadata_not_collected(datadog_agent):
+    instance = INSTANCES['collect_server_info']
+    check = Envoy(CHECK_NAME, {}, [instance])
+    check.check_id = 'test:123'
+    check.log = mock.MagicMock()
+
+    datadog_agent.assert_metadata('test:123', {})
+    datadog_agent.assert_metadata_count(0)
+    check.log.assert_not_called()
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_metadata_integration(aggregator, datadog_agent):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add a config option to Envoy check to  disable checking the `/server_info` endpoint to collect metadata. This cannot be accessed in some configurations of Envoy, like consul connect or kubernetes deployments that only expose the `/stats` endpoint. 
### Motivation
<!-- What inspired you to submit this pull request? -->
Users will be spammed with logs otherwise:

```text
2021-04-27 20:44:34 UTC | CORE | INFO | (pkg/collector/python/datadog_agent.go:124 in LogMessage) | envoy:706dc0e2f7ee4a62 | (envoy.py:156) | Envoy endpoint `http://172.17.0.9:90/server_info` responded with HTTP status code 404
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
