### PR TITLE
Update running metrics description

### DIFF
--- a/otel/metadata.csv
+++ b/otel/metadata.csv
@@ -26,5 +26,5 @@ otel.process.disk.io,count,,byte,,Disk bytes transferred per second,0,otel,proce
 otel.system.paging.usage,gauge,,byte,,Unix swap or windows pagefile usage,0,otel,paging in use
 otel.system.paging.faults,count,,occurrence,,The number of paging faults,0,otel,paging faults
 otel.system.paging.operations,count,,unit,,The number of paging operations,0,otel,paging ops
-otel.datadog_exporter.metrics.running,gauge,,unit,,Reports that metrics are being sent from an OpenTelemetry instrumented host,0,otel,metrics running
-otel.datadog_exporter.traces.running,gauge,,unit,,Reports that traces are being sent from an OpenTelemetry instrumented host,0,otel,traces running
+otel.datadog_exporter.metrics.running,gauge,,unit,,Reports that metrics are being sent from a host through the Collector Datadog exporter,0,otel,metrics running
+otel.datadog_exporter.traces.running,gauge,,unit,,Reports that traces are being sent from a host through the Collector Datadog exporter,0,otel,traces running

--- a/otel/metadata.csv
+++ b/otel/metadata.csv
@@ -26,5 +26,5 @@ otel.process.disk.io,count,,byte,,Disk bytes transferred per second,0,otel,proce
 otel.system.paging.usage,gauge,,byte,,Unix swap or windows pagefile usage,0,otel,paging in use
 otel.system.paging.faults,count,,occurrence,,The number of paging faults,0,otel,paging faults
 otel.system.paging.operations,count,,unit,,The number of paging operations,0,otel,paging ops
-otel.datadog_exporter.metrics.running,gauge,,unit,,Reports that metrics are being sent from a host through the Collector Datadog exporter,0,otel,metrics running
-otel.datadog_exporter.traces.running,gauge,,unit,,Reports that traces are being sent from a host through the Collector Datadog exporter,0,otel,traces running
+otel.datadog_exporter.metrics.running,gauge,,unit,,Reports that metrics are being sent from a host through the Datadog exporter for the OpenTelemetry Collector,0,otel,metrics running
+otel.datadog_exporter.traces.running,gauge,,unit,,Reports that traces are being sent from a host through the Datadog exporter for the OpenTelemetry Collector,0,otel,traces running

--- a/otel/metadata.csv
+++ b/otel/metadata.csv
@@ -26,5 +26,5 @@ otel.process.disk.io,count,,byte,,Disk bytes transferred per second,0,otel,proce
 otel.system.paging.usage,gauge,,byte,,Unix swap or windows pagefile usage,0,otel,paging in use
 otel.system.paging.faults,count,,occurrence,,The number of paging faults,0,otel,paging faults
 otel.system.paging.operations,count,,unit,,The number of paging operations,0,otel,paging ops
-otel.datadog_exporter.metrics.running,gauge,,unit,,Reports that the Datadog metrics exporter is successfully sending metrics,0,otel,metrics running
-otel.datadog_exporter.traces.running,gauge,,unit,,Reports that the Datadog traces exporter is successfully sending traces,0,otel,traces running
+otel.datadog_exporter.metrics.running,gauge,,unit,,Reports that metrics are being sent from an OpenTelemetry instrumented host,0,otel,metrics running
+otel.datadog_exporter.traces.running,gauge,,unit,,Reports that traces are being sent from an OpenTelemetry instrumented host,0,otel,traces running


### PR DESCRIPTION
### What does this PR do?

Fix metadata description for `otel.datadog_exporter.*.running`, stating that one metric is sent per instrumented host.

### Motivation

Originally this metric was reported only by the host where the Datadog exporter was running, but this was later extended in open-telemetry/opentelemetry-collector-contrib#2023 to account for situations where a metric was forwarded through multiple OpenTelemetry Collectors, which changed the meaning of the metric. 

The naming is confusing now, but we can't change it for backwards-compatibility reasons :(

### Additional Notes

Relates to open-telemetry/opentelemetry-collector-contrib#3293.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
