### PR TITLE
Reenable agent build tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,6 @@ stages:
   - release
   - notify
 
-
 validate-log-integrations:
   stage: validate
   image: $VALIDATE_LOG_INTGS
@@ -48,34 +47,70 @@ validate-log-integrations:
     when: always
   tags: [ "runner:main", "size:large" ]
 
-# trigger-agent-build:
-#   stage: trigger
-#   image: $VALIDATE_AGENT_BUILD
-#   only:
-#     changes:
-#     - datadog_checks_base/datadog_checks/base/data/agent_requirements.in
-#   script:
-#     - DATADOG_AGENT_PIPELINE_URL=$(aws ssm get-parameter --region us-east-1 --name ci.integrations-core.datadog-agent-pipeline-url --with-decryption --query "Parameter.Value" --out text)
-#     - DATADOG_AGENT_PIPELINE_URL=$DATADOG_AGENT_PIPELINE_URL python -u /trigger_agent_build.py --output-file pipeline_id.txt
-#   artifacts:
-#     paths:
-#     - pipeline_id.txt
-#     expire_in: 1 day
-#     when: always
-#   tags: [ "runner:main", "size:large" ]
+trigger-agent-build:
+  stage: trigger
+  image: $VALIDATE_AGENT_BUILD
+  script:
+    - DATADOG_AGENT_PIPELINE_URL=$(aws ssm get-parameter --region us-east-1 --name ci.integrations-core.datadog-agent-pipeline-url --with-decryption --query "Parameter.Value" --out text)
+    - export AGENT_REQUIREMENTS_CHANGED="false"
+    - git fetch origin master
+    - git --no-pager diff --exit-code --name-only HEAD $(git merge-base HEAD FETCH_HEAD) -- datadog_checks_base/datadog_checks/base/data/agent_requirements.in || export AGENT_REQUIREMENTS_CHANGED="true" || true
+    - |
+      if [[ "$AGENT_REQUIREMENTS_CHANGED" = "true" ]]; then
+          echo "File agent_requirements.in has been modified, triggering an agent build pipeline."
+          DATADOG_AGENT_PIPELINE_URL=$DATADOG_AGENT_PIPELINE_URL python -u /trigger_agent_build.py --output-file pipeline_id.txt
+
+          # Get slack user
+          if [[ $GITLAB_USER_LOGIN = "gitsync" ]]; then EMAIL=$(git show -s --format="%ae" "$CI_COMMIT_SHA"); else EMAIL=$GITLAB_USER_EMAIL; fi
+          SLACK_AUTHOR=$(echo $EMAIL | email2slackid)
+          if [ -z "$SLACK_AUTHOR" ]; then echo "Author not found or unsubscribed"; SLACK_AUTHOR=$NOTIFICATIONS_SLACK_CHANNEL; fi
+
+          MESSAGE="Starting a build of the agent, watch ${CI_PIPELINE_URL}."
+          postmessage "$SLACK_AUTHOR" "$MESSAGE"
+      else
+          echo "Nothing to run, skipping job."
+      fi
+  artifacts:
+    paths:
+    - pipeline_id.txt
+    expire_in: 1 day
+    when: always
+  tags: [ "runner:main", "size:large" ]
 
 
-# validate-agent-build:
-#   stage: validate
-#   image: $VALIDATE_AGENT_BUILD
-#   only:
-#     changes:
-#     - datadog_checks_base/datadog_checks/base/data/agent_requirements.in
-#   script:
-#     - GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.integrations-core.temp_gitlab_token --with-decryption --query "Parameter.Value" --out text)
-#     - DATADOG_AGENT_PIPELINE_URL=$(aws ssm get-parameter --region us-east-1 --name ci.integrations-core.datadog-agent-pipeline-url --with-decryption --query "Parameter.Value" --out text)
-#     - GITLAB_TOKEN=$GITLAB_TOKEN DATADOG_AGENT_PIPELINE_URL=$DATADOG_AGENT_PIPELINE_URL python -u /validate_agent_build.py --pipeline-id $(cat pipeline_id.txt)
-#   tags: [ "runner:main", "size:large" ]
+validate-agent-build:
+  stage: validate
+  image: $VALIDATE_AGENT_BUILD
+  script:
+    - |
+      if [[ -s ./pipeline_id.txt ]]; then
+          # Fetch secrets from SCM
+          GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.integrations-core.temp_gitlab_token --with-decryption --query "Parameter.Value" --out text)
+          DATADOG_AGENT_PIPELINE_URL=$(aws ssm get-parameter --region us-east-1 --name ci.integrations-core.datadog-agent-pipeline-url --with-decryption --query "Parameter.Value" --out text)
+          PIPELINE_ID=$(cat pipeline_id.txt)
+
+          # Get slack user
+          if [[ $GITLAB_USER_LOGIN = "gitsync" ]]; then EMAIL=$(git show -s --format="%ae" "$CI_COMMIT_SHA"); else EMAIL=$GITLAB_USER_EMAIL; fi
+          SLACK_AUTHOR=$(echo $EMAIL | email2slackid)
+          if [ -z "$SLACK_AUTHOR" ]; then echo "Author not found or unsubscribed"; SLACK_AUTHOR=$NOTIFICATIONS_SLACK_CHANNEL; fi
+
+          # Wait for the agent build to complete
+          export BUILD_SUCCESS="true"
+          GITLAB_TOKEN=$GITLAB_TOKEN DATADOG_AGENT_PIPELINE_URL=$DATADOG_AGENT_PIPELINE_URL python -u /validate_agent_build.py --pipeline-id $(cat pipeline_id.txt) || export BUILD_SUCCESS="false" || true
+          echo $BUILD_SUCCESS
+          if [[ "$BUILD_SUCCESS" = "true" ]]; then
+              echo "Agent build was successful!"
+              postmessage "$SLACK_AUTHOR" "Build was successful, you can merge your PR!" success
+          else
+              echo "Agent build failed."
+              postmessage "$SLACK_AUTHOR" "The build failed, you might want to retry this job: ${CI_JOB_URL}" alert
+              exit 1
+          fi
+      else
+        echo "A pipeline was not triggered, skipping this job."
+      fi
+
+  tags: [ "runner:main", "size:large" ]
 
 notify-slack:
   stage: notify
@@ -98,6 +133,8 @@ notify-slack:
 notify-failed-pipeline:
   stage: notify
   image: $NOTIFIER_IMAGE
+  only:
+  - master
   when: on_failure
   script:
     - |
@@ -198,6 +235,7 @@ validate-agent-build-builder:
       - master
   script:
     - cd .gitlab/validate-agent-build/
+    - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/Datadog/devtools.git --depth 1
     - docker build --tag $VALIDATE_AGENT_BUILD .
     - docker images $VALIDATE_AGENT_BUILD
     - docker push $VALIDATE_AGENT_BUILD

--- a/.gitlab/validate-agent-build/Dockerfile
+++ b/.gitlab/validate-agent-build/Dockerfile
@@ -1,8 +1,14 @@
 FROM 486234852809.dkr.ecr.us-east-1.amazonaws.com/base-python3:focal
+USER root
 
-RUN clean-apt install python3-pip
-RUN pip3 install requests
-RUN pip3 install awscli
+COPY devtools/deb/slack-notifier/ /slack-notifier
+
+RUN clean-apt install python3.9-dev git gcc
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 -u get-pip.py && rm get-pip.py
+RUN pip install -r /slack-notifier/requirements.txt
+RUN pip install /slack-notifier
+RUN rm -Rf /slack-notifier
+
 COPY validate_agent_build.py /validate_agent_build.py
 COPY trigger_agent_build.py /trigger_agent_build.py
 

--- a/.gitlab/validate-agent-build/trigger_agent_build.py
+++ b/.gitlab/validate-agent-build/trigger_agent_build.py
@@ -18,6 +18,7 @@ def trigger_pipeline():
             "RELEASE_VERSION_7": "nightly-a7",
             "DEB_RPM_BUCKET_BRANCH": "none",
             "INTEGRATIONS_CORE_VERSION": os.environ['CI_COMMIT_REF_NAME'],
+            "RUN_KITCHEN_TESTS": "false",
         }
     }
 

--- a/.gitlab/validate-agent-build/validate_agent_build.py
+++ b/.gitlab/validate-agent-build/validate_agent_build.py
@@ -26,21 +26,19 @@ def _get_jobs(pipeline_id, scope=None):
     return all_jobs
 
 
-def get_pending_jobs(pipeline_id):
-    scopes = ['created', 'pending', 'running']
+def get_remaining_jobs(pipeline_id):
+    """Returns all gitlab job that are not yet successful"""
+    scopes = ['created', 'pending', 'running', 'failed', 'canceled']
     all_jobs = []
     for scope in scopes:
         all_jobs.extend(_get_jobs(pipeline_id, scope=scope))
 
-    jobs = [j for j in all_jobs if j['stage'] in STAGES_TO_CHECK]
+    jobs = [j for j in all_jobs if not j['allow_failure'] and j['stage'] in STAGES_TO_CHECK]
     return jobs
 
 
 def get_failed_jobs(pipeline_id):
-    scopes = ['failed', 'canceled']
-    jobs = []
-    for scope in scopes:
-        jobs.extend(_get_jobs(pipeline_id, scope=scope))
+    jobs = _get_jobs(pipeline_id, scope='failed')
 
     jobs = [j for j in jobs if not j['allow_failure'] and j['stage'] in STAGES_TO_CHECK]
     return jobs
@@ -48,6 +46,8 @@ def get_failed_jobs(pipeline_id):
 
 def retry_failed_jobs(pipeline_id):
     failed_jobs = get_failed_jobs(pipeline_id)
+    if not failed_jobs:
+        return
     print(f"Found {len(failed_jobs)} failed jobs. Retrying...")
     for job in failed_jobs:
         url = f"{DATADOG_AGENT_PIPELINE_URL}/jobs/{job['id']}/retry"
@@ -58,6 +58,7 @@ def retry_failed_jobs(pipeline_id):
 
 
 if __name__ == '__main__':
+    t0 = time.time()
     parser = argparse.ArgumentParser(description='Wait for (and retry if needed) a given agent build pipeline.')
     parser.add_argument('-p', '--pipeline-id', dest='pipeline_id', action='store',
                         help='The pipeline id to watch for.', required=True)
@@ -69,14 +70,19 @@ if __name__ == '__main__':
     retry_failed_jobs(pipeline_id)
 
     # Wait for jobs to end and exit immediately if any failure.
-    while True:
-        pending_jobs = get_pending_jobs(pipeline_id)
-        if not pending_jobs:
+    # If it takes more than 55 minutes, cancel the job. Otherwise gitlab will cancel the job on its own without
+    # notifying the author.
+    while (time.time() - t0) / 60 < 55:
+        remaining_jobs = get_remaining_jobs(pipeline_id)
+        if not remaining_jobs:
             print("Success, pipeline has built the agent correctly.")
             break
 
-        print(f"Still {len(pending_jobs)} are pending...")
-        failed_jobs = get_failed_jobs(pipeline_id)
+        print(f"Still {len(remaining_jobs)} are pending...")
+        failed_jobs = [
+            j for j in remaining_jobs if
+            j['status'] in ['failed', 'canceled']
+        ]
         if failed_jobs:
             for job in failed_jobs:
                 print(f"ERROR: Job {job['web_url']} has encountered a failure, exiting.")


### PR DESCRIPTION
1. Re-enable the trigger and validate job builds
2. These jobs are now run on every branch but are immediatly skipped unless the agent_requirements.in file has been modified. This comes from a gitlab limitation, we don't have a way to enable a specific job based on whether the branch is modifying a file against master.
3. If the file has been modified, the script triggers a build pipeline, sends a slack message and wait for completion.