### PR TITLE
Support new Synthetics `run` metric unit for validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -206,6 +206,7 @@ VALID_UNIT_NAMES = {
     'decidegree celsius',
     'span',
     'exception',
+    'run',
 }
 
 ALLOWED_PREFIXES = ['system', 'jvm', 'http', 'datadog', 'sftp']


### PR DESCRIPTION
### What does this PR do?
Adds the Synthetics `run` unit, that represents test runs.

### Motivation
We want to add support for this new unit, that will be first used for estimated metrics.
https://datadoghq.atlassian.net/browse/SSV-547

### Additional Notes
Linked to PR https://github.com/DataDog/dogweb/pull/60065

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
