### PR TITLE
Fix `metrics` option type for legacy OpenMetrics config spec

### DIFF
--- a/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
+++ b/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence, Union
 
 from pydantic import BaseModel, root_validator, validator
 
@@ -86,7 +86,7 @@ class InstanceConfig(BaseModel):
     label_to_hostname: Optional[str]
     labels_mapper: Optional[Mapping[str, Any]]
     log_requests: Optional[bool]
-    metrics: Optional[Sequence[str]]
+    metrics: Optional[Sequence[Union[str, Mapping[str, str]]]]
     min_collection_interval: Optional[float]
     namespace: Optional[str]
     node_exporter_port: Optional[int]

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -60,7 +60,7 @@ instances:
     tags:
       - dns-pod:%%host%%
 
-    ## @param metrics - list of strings - optional
+    ## @param metrics - (list of string or mapping) - optional
     ## List of metrics to be fetched from the prometheus endpoint, if there's a
     ## value it'll be renamed. This list should contain at least one metric.
     #

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy.yaml
@@ -21,7 +21,11 @@
       - memory:mem
       - io
     items:
-      type: string
+      anyOf:
+      - type: string
+      - type: object
+        additionalProperties:
+          type: string
 - name: prometheus_metrics_prefix
   description: Removes a given <PREFIX> from exposed Prometheus metrics.
   value:

--- a/istio/datadog_checks/istio/config_models/instance.py
+++ b/istio/datadog_checks/istio/config_models/instance.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence, Union
 
 from pydantic import BaseModel, root_validator, validator
 
@@ -87,7 +87,7 @@ class InstanceConfig(BaseModel):
     label_to_hostname: Optional[str]
     labels_mapper: Optional[Mapping[str, Any]]
     log_requests: Optional[bool]
-    metrics: Optional[Sequence[Mapping[str, str]]]
+    metrics: Optional[Sequence[Union[str, Mapping[str, str]]]]
     min_collection_interval: Optional[float]
     mixer_endpoint: Optional[str]
     namespace: Optional[str]

--- a/istio/datadog_checks/istio/config_models/instance.py
+++ b/istio/datadog_checks/istio/config_models/instance.py
@@ -87,7 +87,7 @@ class InstanceConfig(BaseModel):
     label_to_hostname: Optional[str]
     labels_mapper: Optional[Mapping[str, Any]]
     log_requests: Optional[bool]
-    metrics: Optional[Sequence[str]]
+    metrics: Optional[Sequence[Mapping[str, str]]]
     min_collection_interval: Optional[float]
     mixer_endpoint: Optional[str]
     namespace: Optional[str]

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -55,7 +55,7 @@ instances:
     #
     namespace: service
 
-    ## @param metrics - list of strings - required
+    ## @param metrics - (list of string or mapping) - required
     ## List of metrics to be fetched from the prometheus endpoint, if there's a
     ## value it'll be renamed. This list should contain at least one metric.
     #


### PR DESCRIPTION
### What does this PR do?
Fix incorrect validation spec for istio integration.

### Motivation
The istio validation spec expects metrics to be a list of strings (Sequence[str]). It is in fact supposed to be a list of maps (Sequence[Mapping[str, str]]).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
