### PR TITLE
Update WMI check to include full sample

### DIFF
--- a/wmi_check/README.md
+++ b/wmi_check/README.md
@@ -64,6 +64,71 @@ The metrics definitions include three components:
 - Metric name as it appears in Datadog.
 - The metric type.
 
+Another sample configuration can be found below, which will populate many more metrics on a Windows 2012 server.
+```yaml
+init_config:
+
+instances:
+  # Fetch the number of processes and users.
+  - class: Win32_OperatingSystem
+    metrics:
+      - [NumberOfProcesses, system.proc.count, gauge]
+      - [NumberOfUsers, system.users.count, gauge]
+
+# Paging info
+  - class: Win32_PerfFormattedData_PerfOS_Memory
+    metrics:
+      - [PageFaultsPersec, system.mem.page.faults, gauge]
+      - [PageReadsPersec, system.mem.page.reads, gauge]
+      - [PagesInputPersec, system.mem.page.input, gauge]
+      - [AvailableMBytes, system.mem.avail, gauge]
+      - [CommitLimit, system.mem.limit, gauge]
+      # Cache bytes metric for disk info
+      - [CacheBytes, system.mem.fs_cache, gauge]
+
+# Paging file
+  - class: Win32_PerfFormattedData_PerfOS_PagingFile
+    metrics:
+      - [PercentUsage, system.mem.page.pct, gauge]
+    tag_by: Name
+  # Fetch the number of processes
+  - class: Win32_PerfFormattedData_PerfOS_System
+    metrics:
+      - [ProcessorQueueLength, system.proc.queue, gauge]
+
+  - class: Win32_PerfFormattedData_PerfOS_Processor
+    metrics:
+      - [PercentProcessorTime, system.cpu.pct, gauge]
+      - [PercentPrivilegedTime, system.cpu.priv.pct, gauge]
+      - [PercentDPCTime, system.cpu.dpc.pct, gauge]
+      - [PercentInterruptTime, system.cpu.interrupt.pct, gauge]
+      - [DPCsQueuedPersec, system.cpu.dpc.queue, gauge]
+    tag_by: Name
+
+# Context switches
+  - class: Win32_PerfFormattedData_PerfProc_Thread
+    metrics:
+      - [ContextSwitchesPersec, system.proc.context_switches, gauge]
+    filters:
+      - Name: _total/_total
+
+# Disk info
+  - class: Win32_PerfFormattedData_PerfDisk_LogicalDisk
+    metrics:
+      - [PercentFreeSpace, system.disk.free.pct, gauge]
+      - [PercentIdleTime, system.disk.idle, gauge]
+      - [AvgDisksecPerRead, system.disk.read_sec, gauge]
+      - [AvgDisksecPerWrite, system.disk.write_sec, gauge]
+      - [DiskWritesPersec, system.disk.writes, gauge]
+      - [DiskReadsPersec, system.disk.reads, gauge]
+      - [AvgDiskQueueLength, system.disk.queue, gauge]
+    tag_by: Name
+
+  - class: Win32_PerfFormattedData_Tcpip_TCPv4
+    metrics:
+      - [SegmentsRetransmittedPersec, system.net.tcp.retrans_seg, gauge]
+    tag_by: Name
+```
 #### Configuration Options
 
 _This feature is available starting with version 5.3 of the agent_

--- a/wmi_check/README.md
+++ b/wmi_check/README.md
@@ -64,7 +64,7 @@ The metrics definitions include three components:
 - Metric name as it appears in Datadog.
 - The metric type.
 
-Another sample configuration can be found below, which will populate many more metrics on a Windows 2012 server.
+The following sample configuration populates many more metrics on a Windows 2012 server.
 ```yaml
 init_config:
 


### PR DESCRIPTION
Default WMI dashboard does not fully populate with the sample shown, however, it does when using a sample config (third party) that can be found here:
https://github.com/vagelim/windows-server-2012/blob/master/wmi_check.yaml

### What does this PR do?
Update WMI documentation to include a full example

### Motivation
Customer had issue getting WMI going with all possible metrics, and found this PR linked from an escalation / blog article

### Additional Notes
This might be formatted in a better way, using this an example.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
