### PR TITLE
Fix AttributeError in AIA chasing

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -440,7 +440,7 @@ class RequestsWrapper(object):
                 ExtensionOID.AUTHORITY_INFORMATION_ACCESS
             )
         except ExtensionNotFound:
-            self.log.debug(
+            self.logger.debug(
                 'No Authority Information Access extension found, skipping discovery of intermediate certificates'
             )
             return


### PR DESCRIPTION
Otherwise the ExtensionNotFound is raised by the AttributeError call.

This will also make sure that the cant_connect service check is correctly emitted in case something goes wrong