### PR TITLE
Update version supported for Cat Allocation metrics

### DIFF
--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -75,7 +75,7 @@ files:
         example: true
     - name: cat_allocation_stats
       description: |
-        Enable to collect Elastic Cat Allocation metrics. Available only for Elasticsearch 7.2 or higher.
+        Enable to collect Elastic Cat Allocation metrics. Available only for Elasticsearch 5.0 or higher.
         Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html.
       value:
         type: boolean

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -104,7 +104,7 @@ instances:
     # pending_task_stats: true
 
     ## @param cat_allocation_stats - boolean - optional - default: false
-    ## Enable to collect Elastic Cat Allocation metrics. Available only for Elasticsearch 7.2 or higher.
+    ## Enable to collect Elastic Cat Allocation metrics. Available only for Elasticsearch 5.0 or higher.
     ## Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html.
     #
     # cat_allocation_stats: false

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -387,7 +387,7 @@ class ESCheck(AgentCheck):
                 self._process_metric(policy_data, metric, *desc, tags=tags)
 
     def _process_cat_allocation_data(self, admin_forwarder, version, base_tags):
-        if version < [7, 2, 0]:
+        if version < [5, 0, 0]:
             self.log.debug(
                 "Collecting cat allocation metrics is not supported in version %s. Skipping", '.'.join(version)
             )


### PR DESCRIPTION
### What does this PR do?
Update version supported for Elasticsearch Cat Allocation metrics

`disk.indices` available from 5.0.0
https://www.elastic.co/guide/en/elasticsearch/reference/5.0/cat-allocation.html

### Motivation
AGENT-6188

### Additional Notes
Oldest es version I was able to test this on is 5.3

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
