### PR TITLE
support username/password as alternative to user/pass

### DIFF
--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -21,7 +21,7 @@ class ClickhouseCheck(AgentCheck):
         self._server = self.instance.get('server', '')
         self._port = self.instance.get('port')
         self._db = self.instance.get('db', 'default')
-        self._user = self.instance.get('user', 'default')
+        self._user = self.instance.get('user', self.instance.get('username', 'default'))
         self._password = self.instance.get('password', '')
         self._connect_timeout = float(self.instance.get('connect_timeout', 10))
         self._read_timeout = float(self.instance.get('read_timeout', 10))

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -17,7 +17,7 @@ class MySQLConfig(object):
         self.mysql_sock = instance.get('sock', '')
         self.defaults_file = instance.get('defaults_file', '')
         self.user = instance.get('user', '')
-        self.password = str(instance.get('pass', ''))
+        self.password = str(instance.get('pass', instance.get('password', '')))
         self.tags = self._build_tags(instance.get('tags', []))
         self.options = instance.get('options', {}) or {}  # options could be None if empty in the YAML
         replication_channel = self.options.get('replication_channel')

--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -38,7 +38,7 @@ class Oracle(AgentCheck):
     def __init__(self, name, init_config, instances):
         super(Oracle, self).__init__(name, init_config, instances)
         self._server = self.instance.get('server')
-        self._user = self.instance.get('user')
+        self._user = self.instance.get('user') or self.instance.get('username')
         self._password = self.instance.get('password')
         self._service = self.instance.get('service_name')
         self._jdbc_driver = self.instance.get('jdbc_driver_path')

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -26,7 +26,7 @@ class Config(object):
             instance = {}
 
         account = instance.get('account')
-        user = instance.get('user')
+        user = instance.get('user') or instance.get('username')
         password = instance.get('password')
         role = instance.get('role')
         database = instance.get('database', 'SNOWFLAKE')

--- a/supervisord/datadog_checks/supervisord/supervisord.py
+++ b/supervisord/datadog_checks/supervisord/supervisord.py
@@ -163,7 +163,7 @@ class SupervisordCheck(AgentCheck):
     @staticmethod
     def _connect(instance):
         sock = instance.get('socket')
-        user = instance.get('user')
+        user = instance.get('user') or instance.get('username')
         password = instance.get('pass') or instance.get('password')
         if sock is not None:
             host = instance.get('host', DEFAULT_SOCKET_IP)

--- a/supervisord/datadog_checks/supervisord/supervisord.py
+++ b/supervisord/datadog_checks/supervisord/supervisord.py
@@ -164,7 +164,7 @@ class SupervisordCheck(AgentCheck):
     def _connect(instance):
         sock = instance.get('socket')
         user = instance.get('user')
-        password = instance.get('pass')
+        password = instance.get('pass') or instance.get('password')
         if sock is not None:
             host = instance.get('host', DEFAULT_SOCKET_IP)
             transport = supervisor.xmlrpc.SupervisorTransport(user, password, sock)


### PR DESCRIPTION
### What does this PR do?
- Support `password` as alternative to `pass` - 2 integrations affected
- Support `username` as alternative to `user`- 4 integrations affected

### Motivation
AGENT-6199

### Additional Notes
- I decided not to include `user` as alternative to `username`
- skipped Process check since `user` is more in line with `process_owner` than a `username` usually for logons.
- skipped SNMP since code appears to look for `user` specifically

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
