### PR TITLE
Pin click to 7.1.2

### DIFF
--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -72,7 +72,8 @@ setup(
             'appdirs>=1.4.4',
             'atomicwrites',
             'beautifulsoup4>=4.9.3',
-            'click>7',
+            # click 8.0.0 breaks with ddev --version
+            'click==7.1.2',
             'colorama',
             'datamodel-code-generator~=0.11.4; python_version > "3.0"',
             'docker-compose>=1.25',


### PR DESCRIPTION
`click` recently released v8.0.0
For some unknown reason currently, `ddev --version` doesn't work anymore and this breaks our CI.