### PR TITLE
[doc] Removed  **Note** for Spark Structured Streaming metrics

### DIFF
--- a/spark/README.md
+++ b/spark/README.md
@@ -11,8 +11,6 @@ This check monitors [Spark][13] through the Datadog Agent. Collect Spark metrics
 - Tasks: number of tasks active, skipped, failed, and total.
 - Job state: number of jobs active, completed, skipped, and failed.
 
-**Note**: Spark Structured Streaming metrics are not supported.
-
 ## Setup
 
 ### Installation


### PR DESCRIPTION
Removed the below note because there are now 5 Spark Structured Streaming metrics in the metrics section.
**Note**: Spark Structured Streaming metrics are not supported.

### What does this PR do?
Removes **Note**: Spark Structured Streaming metrics are not supported.

### Motivation
Zendesk ticket: https://datadog.zendesk.com/agent/tickets/485593

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
