### PR TITLE
Revert "Update pycryptodome to 3.10.1"

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -47,7 +47,7 @@ protobuf==3.7.0
 psutil==5.7.2
 psycopg2-binary==2.8.4
 pyasn1==0.4.6
-pycryptodomex==3.10.1
+pycryptodomex==3.9.4
 pydantic==1.8.1; python_version > "3.0"
 pyhdb==0.3.4
 pyjwt==1.7.1; python_version < "3.0"


### PR DESCRIPTION
Reverts DataDog/integrations-core#9348