### PR TITLE
Added metrics from the apache scoreboard

### DIFF
--- a/apache/assets/dashboards/apache_dashboard.json
+++ b/apache/assets/dashboards/apache_dashboard.json
@@ -132,9 +132,55 @@
                 "requests": [
                     {
                         "display_type": "area",
-                        "q": "sum:apache.performance.idle_workers{$host,$scope}, sum:apache.performance.busy_workers{$host,$scope}",
+                        "q": "sum:apache.scoreboard.disabled{$host,$scope}, sum:apache.scoreboard.starting_up{$host,$scope}, sum:apache.scoreboard.reading_request{$host,$scope}, sum:apache.scoreboard.sending_reply{$host,$scope}, sum:apache.scoreboard.keepalive{$host,$scope}, sum:apache.scoreboard.dns_lookup{$host,$scope}, sum:apache.scoreboard.closing_connection{$host,$scope}, sum:apache.scoreboard.logging{$host,$scope}, sum:apache.scoreboard.gracefully_finishing{$host,$scope}, sum:apache.scoreboard.waiting_for_connection{$host,$scope}, sum:apache.scoreboard.idle_cleanup{$host,$scope}",
+                        "metadata": [
+                            {
+                                "expression": "sum:apache.scoreboard.disabled{$host,$scope}",
+                                "alias_name": "Disabled"
+                            },
+                            {
+                                "expression": "sum:apache.scoreboard.starting_up{$host,$scope}",
+                                "alias_name": "Starting up"
+                            },
+                            {
+                                "expression": "sum:apache.scoreboard.reading_request{$host,$scope}",
+                                "alias_name": "Reading Request"
+                            },
+                            {
+                                "expression": "sum:apache.scoreboard.sending_reply{$host,$scope}",
+                                "alias_name": "Sending Reply"
+                            },
+                            {
+                                "expression": "sum:apache.scoreboard.keepalive{$host,$scope}",
+                                "alias_name": "Keepalive (read)"
+                            },
+                            {
+                                "expression": "sum:apache.scoreboard.dns_lookup{$host,$scope}",
+                                "alias_name": "DNS Lookup"
+                            },
+                            {
+                                "expression": "sum:apache.scoreboard.closing_connection{$host,$scope}",
+                                "alias_name": "Closing connection"
+                            },
+                            {
+                                "expression": "sum:apache.scoreboard.logging{$host,$scope}",
+                                "alias_name": "Logging"
+                            },
+                            {
+                                "expression": "sum:apache.scoreboard.gracefully_finishing{$host,$scope}",
+                                "alias_name": "Gracefully finishing"
+                            },
+                            {
+                                "expression": "sum:apache.scoreboard.waiting_for_connection{$host,$scope}",
+                                "alias_name": "Waiting for Connection"
+                            },
+                            {
+                                "expression": "sum:apache.scoreboard.idle_cleanup{$host,$scope}",
+                                "alias_name": "Idle cleanup of worker"
+                            }
+                        ],
                         "style": {
-                            "palette": "cool"
+                            "palette": "dog_classic"
                         }
                     }
                 ],
@@ -142,7 +188,7 @@
                 "time": {
                     "live_span": "4h"
                 },
-                "title": "Busy vs. idle worker threads",
+                "title": "Status of worker threads",
                 "title_align": "left",
                 "title_size": "16",
                 "type": "timeseries"
@@ -451,7 +497,7 @@
         {
             "definition": {
                 "background_color": "gray",
-                "content": "A worker is considered \u201cbusy\u201d if it is in any of the following states: reading, writing, keep-alive, logging, closing, or gracefully finishing.\n\nAn \u201cidle\u201d worker is not in any of the busy states; the number of idle workers is shown on Apache\u2019s mod_status page.",
+                "content": "A worker is considered \u201cbusy\u201d if it is in any of the following states: Reading request, Sending reply, Keep-alive, Logging, Closing connection, or DNS lookup.\n\nAn worker in the \u2019Waiting for connection\u2019 state is considered \u201cidle\u201d.\n\n; The \u2019Gracefully finishing\u2019 state counts as \u201cidle\u201d when you are in async mode (you see the async metrics) but as \u201cbusy\u201d in any other mode.\n\n Workers in the \u2019Idle cleanup\u2109 state are moving from a idle state to a open/unused slot. \n\n A \u2109Disabled\u2109 worker can never be used in any of the other states, check your mpm worker config to allow them to be used.",
                 "font_size": "14",
                 "show_tick": true,
                 "text_align": "left",

--- a/apache/assets/dashboards/apache_dashboard.json
+++ b/apache/assets/dashboards/apache_dashboard.json
@@ -497,7 +497,7 @@
         {
             "definition": {
                 "background_color": "gray",
-                "content": "A worker is considered \u201cbusy\u201d if it is in any of the following states: Reading request, Sending reply, Keep-alive, Logging, Closing connection, or DNS lookup.\n\nAn worker in the \u2019Waiting for connection\u2019 state is considered \u201cidle\u201d.\n\n; The \u2019Gracefully finishing\u2019 state counts as \u201cidle\u201d when you are in async mode (you see the async metrics) but as \u201cbusy\u201d in any other mode.\n\n Workers in the \u2019Idle cleanup\u2109 state are moving from a idle state to a open/unused slot. \n\n A \u2109Disabled\u2109 worker can never be used in any of the other states, check your mpm worker config to allow them to be used.",
+                "content": "A worker is considered \u201cbusy\u201d if it is in any of the following states: Reading request, Sending reply, Keep-alive, Logging, Closing connection, or DNS lookup.\n\nA worker in the \u2019Waiting for connection\u2019 state is considered \u201cidle\u201d.\n\n; The \u2019Gracefully finishing\u2019 state counts as \u201cidle\u201d when you are in async mode (you see the async metrics) but as \u201cbusy\u201d in any other mode.\n\n Workers in the \u2019Idle cleanup\u2109 state are moving from an idle state to an open/unused slot. \n\n A \u2109Disabled\u2109 worker can never be used in any of the other states, check your mpm worker config to allow them to be used.",
                 "font_size": "14",
                 "show_tick": true,
                 "text_align": "left",

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -17,6 +17,7 @@ class Apache(AgentCheck):
     GAUGES = {
         'IdleWorkers': 'apache.performance.idle_workers',
         'BusyWorkers': 'apache.performance.busy_workers',
+        'MaxWorkers': 'apache.performance.max_workers',
         'CPULoad': 'apache.performance.cpu_load',
         'Uptime': 'apache.performance.uptime',
         'Total kBytes': 'apache.net.bytes',
@@ -28,6 +29,21 @@ class Apache(AgentCheck):
     }
 
     RATES = {'Total kBytes': 'apache.net.bytes_per_s', 'Total Accesses': 'apache.net.request_per_s'}
+
+    SCOREBOARD_KEYS = {
+        '_': 'apache.scoreboard.waiting_for_connection',
+        'S': 'apache.scoreboard.starting_up',
+        'R': 'apache.scoreboard.reading_request',
+        'W': 'apache.scoreboard.sending_reply',
+        'K': 'apache.scoreboard.keepalive',
+        'D': 'apache.scoreboard.dns_lookup',
+        'C': 'apache.scoreboard.closing_connection',
+        'L': 'apache.scoreboard.logging',
+        'G': 'apache.scoreboard.gracefully_finishing',
+        'I': 'apache.scoreboard.idle_cleanup',
+        '.': 'apache.scoreboard.open_slot',
+        ' ': 'apache.scoreboard.disabled',
+    }
 
     HTTP_CONFIG_REMAPPER = {
         'apache_user': {'name': 'username'},
@@ -81,6 +97,12 @@ class Apache(AgentCheck):
             values = line.split(': ')
             if len(values) == 2:  # match
                 metric, value = values
+
+                # Special case
+                if metric == 'Scoreboard':
+                    self._submit_scoreboard(value, tags)
+                    continue
+
                 # Special case: fetch and submit the version
                 if metric == 'ServerVersion':
                     self._submit_metadata(value)
@@ -141,3 +163,19 @@ class Apache(AgentCheck):
         version_parts = {name: part for name, part in zip(('major', 'minor', 'patch'), version.split('.'))}
         self.set_metadata('version', version, scheme='parts', final_scheme='semver', part_map=version_parts)
         self.log.debug("found apache version %s", version)
+
+    def _submit_scoreboard(self, value, tags):
+        max_workers = 0
+        metrics = {}
+        for _key, metric in self.SCOREBOARD_KEYS.items():
+            metrics[metric] = 0
+
+        for i in value:
+            max_workers += 1
+            metrics[self.SCOREBOARD_KEYS[i]] += 1
+
+        for _key, metric in self.SCOREBOARD_KEYS.items():
+            self.gauge(metric, metrics[metric], tags=tags)
+
+        self.gauge(self.GAUGES['MaxWorkers'], max_workers, tags=tags)
+        self.log.debug("Scoreboard: %s", value)

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -167,17 +167,8 @@ class Apache(AgentCheck):
     def _submit_scoreboard(self, value, tags):
         """The scoreboard is a long string where each character represents the status of a given worker.
         This method parses that string and emits the corresponding metrics"""
-        max_workers = 0
-        metrics = {}
         for _key, metric in self.SCOREBOARD_KEYS.items():
-            metrics[metric] = 0
+            self.gauge(metric, value.count(_key), tags=tags)
 
-        for i in value:
-            max_workers += 1
-            metrics[self.SCOREBOARD_KEYS[i]] += 1
-
-        for _key, metric in self.SCOREBOARD_KEYS.items():
-            self.gauge(metric, metrics[metric], tags=tags)
-
-        self.gauge(self.GAUGES['MaxWorkers'], max_workers, tags=tags)
+        self.gauge(self.GAUGES['MaxWorkers'], len(value), tags=tags)
         self.log.debug("Scoreboard: %s", value)

--- a/apache/datadog_checks/apache/apache.py
+++ b/apache/datadog_checks/apache/apache.py
@@ -98,7 +98,7 @@ class Apache(AgentCheck):
             if len(values) == 2:  # match
                 metric, value = values
 
-                # Special case
+                # Special case: Report the status of the workers
                 if metric == 'Scoreboard':
                     self._submit_scoreboard(value, tags)
                     continue
@@ -165,6 +165,8 @@ class Apache(AgentCheck):
         self.log.debug("found apache version %s", version)
 
     def _submit_scoreboard(self, value, tags):
+        """The scoreboard is a long string where each character represents the status of a given worker.
+        This method parses that string and emits the corresponding metrics"""
         max_workers = 0
         metrics = {}
         for _key, metric in self.SCOREBOARD_KEYS.items():

--- a/apache/metadata.csv
+++ b/apache/metadata.csv
@@ -14,13 +14,13 @@ apache.performance.max_workers,gauge,,thread,,The maximum number of workers apac
 apache.performance.uptime,gauge,,second,,The amount of time the server has been running.,0,apache,uptime
 apache.scoreboard.waiting_for_connection,gauge,,thread,,The number of workers that can immediately process an incoming request.,0,apache,waiting for connection
 apache.scoreboard.starting_up,gauge,,thread,,The workers that are still starting up and not yet able to handle a request.,0,apache,starting up
-apache.scoreboard.reading_request,gauge,,thread,,The workers that are reading the incoming request.,0,apache,reading request
-apache.scoreboard.sending_reply,gauge,,thread,,The number of workers that are sending a reply/response or waiting on a script (like php) to finish so it can send a reply.,0,apache,sending reply
-apache.scoreboard.keepalive,gauge,,thread,,"These workers are for a new request from the same client, because it asked to keep the connection alive.",0,apache,keepalive
-apache.scoreboard.dns_lookup,gauge,,thread,,The workers that wait on a DNS lookup.,0,apache,dns lookup
+apache.scoreboard.reading_request,gauge,,thread,,The workers reading the incoming request.,0,apache,reading request
+apache.scoreboard.sending_reply,gauge,,thread,,The number of workers sending a reply/response or waiting on a script (like php) to finish so it can send a reply.,0,apache,sending reply
+apache.scoreboard.keepalive,gauge,,thread,,"The workers intended for a new request from the same client, because it asked to keep the connection alive.",0,apache,keepalive
+apache.scoreboard.dns_lookup,gauge,,thread,,The workers waiting on a DNS lookup.,0,apache,dns lookup
 apache.scoreboard.closing_connection,gauge,,thread,,The amount of workers that are currently closing a connection.,0,apache,closing connection
-apache.scoreboard.logging,gauge,,thread,,The workers that are writing something to the apache logs.,0,apache,logging
-apache.scoreboard.gracefully_finishing,gauge,,thread,,The number of workers that are gracefully finishing their request.,0,apache,gracefully finishing
+apache.scoreboard.logging,gauge,,thread,,The workers writing something to the apache logs.,0,apache,logging
+apache.scoreboard.gracefully_finishing,gauge,,thread,,The number of workers finishing their request.,0,apache,gracefully finishing
 apache.scoreboard.idle_cleanup,gauge,,thread,,These workers were idle and their process is being stopped.,0,apache,idle cleanup
 apache.scoreboard.open_slot,gauge,,thread,,The amount of workers that apache can still start before hitting the maximum number of workers.,0,apache,open slots
 apache.scoreboard.disabled,gauge,,thread,,"These slots will never be able to handle any requests, indicates a misconfiguration.",0,apache,disabled workers

--- a/apache/metadata.csv
+++ b/apache/metadata.csv
@@ -10,4 +10,17 @@ apache.net.request_per_s,gauge,,request,second,The number of requests performed 
 apache.performance.cpu_load,gauge,,percent,,The percent of CPU used.,0,apache,cpu load
 apache.performance.busy_workers,gauge,,thread,,The number of workers serving requests.,0,apache,busy workers
 apache.performance.idle_workers,gauge,,thread,,The number of idle workers.,0,apache,idle workers
+apache.performance.max_workers,gauge,,thread,,The maximum number of workers apache can start.,0,apache,max workers
 apache.performance.uptime,gauge,,second,,The amount of time the server has been running.,0,apache,uptime
+apache.scoreboard.waiting_for_connection,gauge,,thread,,The number of workers that can immediately process an incoming request.,0,apache,waiting for connection
+apache.scoreboard.starting_up,gauge,,thread,,The workers that are still starting up and not yet able to handle a request.,0,apache,starting up
+apache.scoreboard.reading_request,gauge,,thread,,The workers that are reading the incoming request.,0,apache,reading request
+apache.scoreboard.sending_reply,gauge,,thread,,The number of workers that are sending a reply/response or waiting on a script (like php) to finish so it can send a reply.,0,apache,sending reply
+apache.scoreboard.keepalive,gauge,,thread,,"These workers are for a new request from the same client, because it asked to keep the connection alive.",0,apache,keepalive
+apache.scoreboard.dns_lookup,gauge,,thread,,The workers that wait on a DNS lookup.,0,apache,dns lookup
+apache.scoreboard.closing_connection,gauge,,thread,,The amount of workers that are currently closing a connection.,0,apache,closing connection
+apache.scoreboard.logging,gauge,,thread,,The workers that are writing something to the apache logs.,0,apache,logging
+apache.scoreboard.gracefully_finishing,gauge,,thread,,The number of workers that are gracefully finishing their request.,0,apache,gracefully finishing
+apache.scoreboard.idle_cleanup,gauge,,thread,,These workers were idle and their process is being stopped.,0,apache,idle cleanup
+apache.scoreboard.open_slot,gauge,,thread,,The amount of workers that apache can still start before hitting the maximum number of workers.,0,apache,open slots
+apache.scoreboard.disabled,gauge,,thread,,"These slots will never be able to handle any requests, indicates a misconfiguration.",0,apache,disabled workers

--- a/apache/metadata.csv
+++ b/apache/metadata.csv
@@ -15,12 +15,12 @@ apache.performance.uptime,gauge,,second,,The amount of time the server has been 
 apache.scoreboard.waiting_for_connection,gauge,,thread,,The number of workers that can immediately process an incoming request.,0,apache,waiting for connection
 apache.scoreboard.starting_up,gauge,,thread,,The workers that are still starting up and not yet able to handle a request.,0,apache,starting up
 apache.scoreboard.reading_request,gauge,,thread,,The workers reading the incoming request.,0,apache,reading request
-apache.scoreboard.sending_reply,gauge,,thread,,The number of workers sending a reply/response or waiting on a script (like php) to finish so it can send a reply.,0,apache,sending reply
+apache.scoreboard.sending_reply,gauge,,thread,,The number of workers sending a reply/response or waiting on a script (like PHP) to finish so they can send a reply.,0,apache,sending reply
 apache.scoreboard.keepalive,gauge,,thread,,"The workers intended for a new request from the same client, because it asked to keep the connection alive.",0,apache,keepalive
 apache.scoreboard.dns_lookup,gauge,,thread,,The workers waiting on a DNS lookup.,0,apache,dns lookup
 apache.scoreboard.closing_connection,gauge,,thread,,The amount of workers that are currently closing a connection.,0,apache,closing connection
-apache.scoreboard.logging,gauge,,thread,,The workers writing something to the apache logs.,0,apache,logging
+apache.scoreboard.logging,gauge,,thread,,The workers writing something to the Apache logs.,0,apache,logging
 apache.scoreboard.gracefully_finishing,gauge,,thread,,The number of workers finishing their request.,0,apache,gracefully finishing
 apache.scoreboard.idle_cleanup,gauge,,thread,,These workers were idle and their process is being stopped.,0,apache,idle cleanup
-apache.scoreboard.open_slot,gauge,,thread,,The amount of workers that apache can still start before hitting the maximum number of workers.,0,apache,open slots
+apache.scoreboard.open_slot,gauge,,thread,,The amount of workers that Apache can still start before hitting the maximum number of workers.,0,apache,open slots
 apache.scoreboard.disabled,gauge,,thread,,"These slots will never be able to handle any requests, indicates a misconfiguration.",0,apache,disabled workers

--- a/apache/tests/common.py
+++ b/apache/tests/common.py
@@ -26,6 +26,7 @@ NO_METRIC_CONFIG = {'apache_status_url': BASE_URL}
 APACHE_GAUGES = [
     'apache.performance.idle_workers',
     'apache.performance.busy_workers',
+    'apache.performance.max_workers',
     'apache.performance.cpu_load',
     'apache.performance.uptime',
     'apache.net.bytes',
@@ -34,6 +35,18 @@ APACHE_GAUGES = [
     'apache.conns_async_writing',
     'apache.conns_async_keep_alive',
     'apache.conns_async_closing',
+    'apache.scoreboard.waiting_for_connection',
+    'apache.scoreboard.starting_up',
+    'apache.scoreboard.reading_request',
+    'apache.scoreboard.sending_reply',
+    'apache.scoreboard.keepalive',
+    'apache.scoreboard.dns_lookup',
+    'apache.scoreboard.closing_connection',
+    'apache.scoreboard.logging',
+    'apache.scoreboard.gracefully_finishing',
+    'apache.scoreboard.idle_cleanup',
+    'apache.scoreboard.open_slot',
+    'apache.scoreboard.disabled',
 ]
 
 APACHE_RATES = ['apache.net.bytes_per_s', 'apache.net.request_per_s']

--- a/apache/tests/compose/httpd.conf
+++ b/apache/tests/compose/httpd.conf
@@ -28,6 +28,10 @@ ServerAdmin you@example.com
 User daemon
 Group daemon
 
+# Make sure we have max 400 workers for test_scoreboard in test_apache.py
+# This is the default but explicitly set to prevent regression when upgrading apache
+MaxRequestWorkers 400
+
 <Directory />
     AllowOverride none
     Order Allow,Deny

--- a/apache/tests/test_apache.py
+++ b/apache/tests/test_apache.py
@@ -177,3 +177,99 @@ def test_full_version_regex(check, version, expected_parts, datadog_agent):
         version_metadata['version.scheme'] = 'semver'
 
     datadog_agent.assert_metadata('test:123', version_metadata)
+
+
+@pytest.mark.usefixtures("dd_environment")
+def test_scoreboard(aggregator, check):
+    check = check(AUTO_CONFIG)
+    check.check(AUTO_CONFIG)
+
+    tags = AUTO_CONFIG['tags']
+    aggregator.assert_metric('apache.performance.max_workers', tags=tags, value=400)
+    # 'MaxClients 400' is set in httpd.conf
+
+
+@pytest.mark.parametrize(
+    'scoreboard, expected_metrics',
+    [
+        pytest.param(
+            '..._W',
+            {
+                'apache.performance.max_workers': 5,
+                'apache.scoreboard.open_slot': 3,
+                'apache.scoreboard.waiting_for_connection': 1,
+                'apache.scoreboard.sending_reply': 1,
+            },
+            id='simple_scoreboard',
+        ),
+        pytest.param(
+            '_SRWKDCLGI. ',
+            {
+                'apache.performance.max_workers': 12,
+                'apache.scoreboard.waiting_for_connection': 1,
+                'apache.scoreboard.starting_up': 1,
+                'apache.scoreboard.reading_request': 1,
+                'apache.scoreboard.sending_reply': 1,
+                'apache.scoreboard.keepalive': 1,
+                'apache.scoreboard.dns_lookup': 1,
+                'apache.scoreboard.closing_connection': 1,
+                'apache.scoreboard.logging': 1,
+                'apache.scoreboard.gracefully_finishing': 1,
+                'apache.scoreboard.idle_cleanup': 1,
+                'apache.scoreboard.open_slot': 1,
+                'apache.scoreboard.disabled': 1,
+            },
+            id='every_option',
+        ),
+        pytest.param(
+            '',
+            {
+                'apache.performance.max_workers': 0,
+                'apache.scoreboard.waiting_for_connection': 0,
+                'apache.scoreboard.starting_up': 0,
+                'apache.scoreboard.reading_request': 0,
+                'apache.scoreboard.sending_reply': 0,
+                'apache.scoreboard.keepalive': 0,
+                'apache.scoreboard.dns_lookup': 0,
+                'apache.scoreboard.closing_connection': 0,
+                'apache.scoreboard.logging': 0,
+                'apache.scoreboard.gracefully_finishing': 0,
+                'apache.scoreboard.idle_cleanup': 0,
+                'apache.scoreboard.open_slot': 0,
+                'apache.scoreboard.disabled': 0,
+            },
+            id='empty_scoreboard',
+        ),
+        pytest.param(
+            'WWWWWWWWWW__WWWWWWWWWW_WW_WWWWWWW.WWWWW_WW_W_.WW.W........G'
+            '.....................................................................',
+            {
+                'apache.performance.max_workers': 128,
+                'apache.scoreboard.waiting_for_connection': 7,
+                'apache.scoreboard.starting_up': 0,
+                'apache.scoreboard.reading_request': 0,
+                'apache.scoreboard.sending_reply': 40,
+                'apache.scoreboard.keepalive': 0,
+                'apache.scoreboard.dns_lookup': 0,
+                'apache.scoreboard.closing_connection': 0,
+                'apache.scoreboard.logging': 0,
+                'apache.scoreboard.gracefully_finishing': 1,
+                'apache.scoreboard.idle_cleanup': 0,
+                'apache.scoreboard.open_slot': 80,
+                'apache.scoreboard.disabled': 0,
+            },
+            id='real_scoreboard',
+        ),
+    ],
+)
+def test_scoreboard_values(aggregator, check, scoreboard, expected_metrics, datadog_agent):
+    """The default server token is Full. Full results in server info that can include
+    multiple non-Apache version specific information.
+    """
+    check = check({})
+    tags = []
+
+    check._submit_scoreboard(scoreboard, tags)
+
+    for metric, expectedValue in expected_metrics.items():
+        aggregator.assert_metric(metric, tags=tags, value=expectedValue)


### PR DESCRIPTION
### What does this PR do?

The PR adds metrics that can be derived from the Apache scoreboard. Mainly the maximum of workers available and a count of workers for each state a worker can be in. This is an expansion on the existing `idle_workers` and `busy_workers` metrics that are currently available. 

### Motivation
Currently datadog reports the busy and idle workers but those metrics are most usefull in the context of the maximum workers that can be started on a server. For example, you could have 100 Busy workers but if you have a heavy webserver that can easily handle 500 workers you are fine. But when you run with 100 max workers your apache is full and putting requests in a queue or maybe even dropping requests. The idle workers will then be 0 and you can set-up an alert on that but there are cases where the idle_workers will be 0 but the max workers aren't reached. A monitor of busy workers as a percentage of the max workers would be a more robuste metric and that was the initial motivation to expand the check. 

When I was investigating the way to find this metric on the `mod_status` page it became clear that I would need to check the scoreboard for this. The scoreboard gives us a detailed look at al the (possible) workers and I thought it wouldn't be that difficult to add all the different states in the scoreboard as separate metrics. 

This is very usefull because it allows you to write more precise monitor messages. If you know you have too many busy workers you will always instruct someone to go look at the scoreboard to see if your workers are all busy sending replies or maybe all waiting with a keepalive. These two have very different causes and need different steps to resolve. It would be awesome if the monitor would already detect this and have the title and message reflect this. 

And the different states could also make for a awesome timeseries where the different states would be displayed in a stacked area. This would allow you to quickly spot i which state the bulk of your workers are and see this over time. The latter is lacking from the apache status page since it will only show you the scoreboard at the moment you load/refresh the page, but you won't know what it looked like minutes/seconds ago. 

### Additional Notes

Example of a scoreboard. Each character represents a (potential) worker. 
```
WWWWWWWWW_WW_WWW_.WW..WWWW_W...WWWW.._WWWW...W.WW.W.......G.....
................................................................

Scoreboard Key:
"_" Waiting for Connection, "S" Starting up, "R" Reading Request,
"W" Sending Reply, "K" Keepalive (read), "D" DNS Lookup,
"C" Closing connection, "L" Logging, "G" Gracefully finishing,
"I" Idle cleanup of worker, "." Open slot with no current process
```

I checked the source code of `mod_status` to see when a status counts in the existing `idle_workers` and `busy_workers` metrics and you can see that there are statusses where apache won't be able to utilize/create a worker but it won't be counted as `busy` or `ready` yet. I think it would also help to use this to inform people in the documentation how these new metrics compare to the existing ones. 

Scoreboard key | Explanation on status page | ?notable text | Source code constant | Counted as idle (ready) | Counted as busy (busy)
-- | -- | -- | -- | -- | --
_ | Waiting for Connection | Ready | SERVER_READY | 1 | 0
S | Starting up | Starting | SERVER_STARTING | 0 | 0
R | Reading request | Read | SERVER_BUSY_READ | 0 | 1
W | Sending Reply | Write | SERVER_BUSY_WRITE | 0 | 1
K | Keepalive (read) | Keepalive | SERVER_BUSY_KEEPALIVE | 0 | 1
D | DNS Lookup | DNS lookup | SERVER_BUSY_DNS | 0 | 1
C | Closing connection | Closing | SERVER_CLOSING | 0 | 1
L | Logging | Logging | SERVER_BUSY_LOG | 0 | 1
G | Gracefully finishing | Graceful | SERVER_GRACEFUL | 1 _(when async)_ | 1 _(when not async)_
I | Idle cleanup of worker | Dying | SERVER_IDLE_KILL | 0 | 0
. | Open slot with no current process | Dead | SERVER_DEAD | 0 | 0
" " | not mentioned | omitted | SERVER_DISABLED | 0 | 0

_source: http://svn.apache.org/viewvc/httpd/httpd/trunk/modules/generators/mod_status.c?view=markup#l327 , http://svn.apache.org/viewvc/httpd/httpd/trunk/modules/generators/mod_status.c?view=markup#l777 & http://svn.apache.org/viewvc/httpd/httpd/trunk/modules/generators/mod_status.c?view=markup#l1002_

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
