### PR TITLE
Exclude `EXPLAIN` queries from `pg_stat_statements`

### DIFF
--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -28,7 +28,7 @@ SELECT {cols}
   LEFT JOIN pg_database
          ON pg_stat_statements.dbid = pg_database.oid
   WHERE query != '<insufficient privilege>'
-  AND query NOT LIKE 'EXPLAIN %'
+  AND query NOT LIKE 'EXPLAIN %%'
   {filters}
   LIMIT {limit}
 """

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -28,6 +28,7 @@ SELECT {cols}
   LEFT JOIN pg_database
          ON pg_stat_statements.dbid = pg_database.oid
   WHERE query != '<insufficient privilege>'
+  AND query NOT LIKE 'EXPLAIN %'
   {filters}
   LIMIT {limit}
 """


### PR DESCRIPTION
### What does this PR do?

Update the collection of postgres query metrics to exclude `EXPLAIN` queries.

### Motivation

If deep database monitoring is enabled and we are collecting execution plans, then there will be at least one tracked EXPLAIN statement for every unique normalized query we encounter. Since these statements are not used in the product we exclude them from collection.

This updates postgres to have the same behavior as mysql, where we do the same exclusion for query metrics.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
