### PR TITLE
Fix zk_connect_str type

### DIFF
--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -227,10 +227,10 @@ files:
             - server2:2181
         value:
           anyOf:
+          - type: string
           - type: array
             items:
               type: string
-          - type: string
       - name: zk_prefix
         description: |
           DEPRECATION NOTICE: This option is only used for fetching consumer offsets

--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -216,12 +216,11 @@ files:
           KafkaClient / KazooClient tries contacting the next host.
           Details: https://github.com/DataDog/dd-agent/issues/2943
         value:
-          type: array
-          items:
-            type: object
-          example:
-            - localhost:2181
-            - <ZOOKEEPER_ENDPOINT>:2181
+          anyOf:
+          - type: array
+            items:
+              type: string
+          - type: string
       - name: zk_prefix
         description: |
           DEPRECATION NOTICE: This option is only used for fetching consumer offsets

--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -215,6 +215,16 @@ files:
           only generate a single check process, but if one host goes down,
           KafkaClient / KazooClient tries contacting the next host.
           Details: https://github.com/DataDog/dd-agent/issues/2943
+
+          You may specify a single server like:
+
+            zk_connect_str: localhost:2181
+
+          or multiple servers like:
+
+            zk_connect_str:
+            - server1:2181
+            - server2:2181
         value:
           anyOf:
           - type: array

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
@@ -41,7 +41,7 @@ class InstanceConfig(BaseModel):
     ssl_keyfile: Optional[str]
     ssl_password: Optional[str]
     tags: Optional[Sequence[str]]
-    zk_connect_str: Optional[Sequence[Mapping[str, Any]]]
+    zk_connect_str: Optional[Union[Sequence[str], str]]
     zk_prefix: Optional[str]
 
     @root_validator(pre=True)

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
@@ -41,7 +41,7 @@ class InstanceConfig(BaseModel):
     ssl_keyfile: Optional[str]
     ssl_password: Optional[str]
     tags: Optional[Sequence[str]]
-    zk_connect_str: Optional[Union[Sequence[str], str]]
+    zk_connect_str: Optional[Union[str, Sequence[str]]]
     zk_prefix: Optional[str]
 
     @root_validator(pre=True)

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -224,6 +224,16 @@ instances:
     ## only generate a single check process, but if one host goes down,
     ## KafkaClient / KazooClient tries contacting the next host.
     ## Details: https://github.com/DataDog/dd-agent/issues/2943
+    ##
+    ## You may specify a single server like:
+    ##
+    ##   zk_connect_str: localhost:2181
+    ##
+    ## or multiple servers like:
+    ##
+    ##   zk_connect_str:
+    ##   - server1:2181
+    ##   - server2:2181
     #
     # zk_connect_str: <ZK_CONNECT_STR>
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -215,7 +215,7 @@ instances:
     #
     # broker_requests_batch_size: 30
 
-    ## @param zk_connect_str - list of strings or string - optional
+    ## @param zk_connect_str - string or list of strings - optional
     ## DEPRECATION NOTICE: This option is only used for fetching consumer offsets
     ## from Zookeeper and is deprecated.
     ## Zookeeper endpoints and port to connect to.

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -215,7 +215,7 @@ instances:
     #
     # broker_requests_batch_size: 30
 
-    ## @param zk_connect_str - list of mappings - optional
+    ## @param zk_connect_str - list of strings or string - optional
     ## DEPRECATION NOTICE: This option is only used for fetching consumer offsets
     ## from Zookeeper and is deprecated.
     ## Zookeeper endpoints and port to connect to.
@@ -225,9 +225,7 @@ instances:
     ## KafkaClient / KazooClient tries contacting the next host.
     ## Details: https://github.com/DataDog/dd-agent/issues/2943
     #
-    # zk_connect_str:
-    #   - localhost:2181
-    #   - <ZOOKEEPER_ENDPOINT>:2181
+    # zk_connect_str: <ZK_CONNECT_STR>
 
     ## @param zk_prefix - string - optional
     ## DEPRECATION NOTICE: This option is only used for fetching consumer offsets

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -11,7 +11,7 @@ envdir =
     py27: {toxworkdir}/py27
     py38: {toxworkdir}/py38
 description =
-    py{27,38}-{0.9,latest}-kafka: e2e ready
+    py{27,38}-{0.9,latest}-{kafka,zk}: e2e ready
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`zk_connect_str` was an array of object, but we actually support it as `string` or `array of string` https://github.com/DataDog/integrations-core/blob/4dcb5e6acd2c3607e694f2d45114ef1b07880496/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py#L56-L59 

### Motivation
<!-- What inspired you to submit this pull request? -->
Our default environment configuration does not pass the model validation
It will break some of our customer config that we actually support

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
