### PR TITLE
Fix replication link metric test

### DIFF
--- a/redisdb/tests/test_replication.py
+++ b/redisdb/tests/test_replication.py
@@ -32,7 +32,7 @@ def test_redis_replication_link_metric(aggregator, replica_instance, dd_environm
     redis_check.check(replica_instance)
     metrics = aggregator.metrics(metric_name)
     assert len(metrics) == 1
-    assert metrics[0].value > 0
+    assert metrics[0].value != 0
 
 
 def test_redis_replication_service_check(aggregator, replica_instance, dd_environment):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
With `redis:latest`, there is now different behavior for `master_link_down_since_seconds`: https://github.com/redis/redis/pull/8785

> When replica never successfully connect to master, server.repl_down_since
will be initialized to 0, therefore, the info master_link_down_since_seconds
was showing the current unix timestamp, which does not make much sense.
This commit fixes the issue by showing master_link_down_since_seconds to -1.
means the replica never connect to master before.

So now need to check that the metric value is not equal to zero.


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
