### PR TITLE
Notify author on agent build time out

### DIFF
--- a/.gitlab/validate-agent-build/validate_agent_build.py
+++ b/.gitlab/validate-agent-build/validate_agent_build.py
@@ -89,6 +89,11 @@ if __name__ == '__main__':
             sys.exit(1)
         print("Waiting 1 min before next check.")
         time.sleep(60)
+    else:
+        # The job has run for 55 minutes and there are still some pending jobs.
+        # Fail and notify the author
+        print("Job is timing out, please retry it.")
+        sys.exit(1)
 
 
 


### PR DESCRIPTION
I realized that when the job was timing out, it was considered a success by gitlab.
This PR adds a log line and exit the script with a non-zero exit code