### PR TITLE
Fix detection of E2E environments

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -35,7 +35,12 @@ JMX_TO_INAPP_TYPES = {
 
 
 def e2e_active():
-    return any(ev.startswith(E2E_PREFIX) for ev in os.environ)
+    return (
+        E2E_SET_UP in os.environ
+        or E2E_TEAR_DOWN in os.environ
+        or E2E_PARENT_PYTHON in os.environ
+        or any(ev.startswith(E2E_ENV_VAR_PREFIX) for ev in os.environ)
+    )
 
 
 def e2e_testing():


### PR DESCRIPTION
### What does this PR do?

Be more exact

### Motivation

This line https://github.com/DataDog/integrations-core/blob/0009096519d109b8a0dc93e96c170a55c8a82e33/.azure-pipelines/templates/test-single-windows.yml#L31 introduced in https://github.com/DataDog/integrations-core/pull/9140 made it so environments were always spun up on Windows CI

See `sqlserver` https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=60559&view=results