### PR TITLE
Remove unused query metric limit configuration refs in mysql integration

### DIFF
--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -232,25 +232,6 @@ instances:
     #
     # deep_database_monitoring: false
 
-    ## @param statement_metrics_limits - mapping - optional - default: false
-    ## Defines the top and bottom limits on queries to track for each metric. These limits apply only to the
-    ## ALPHA features of Deep Database Monitoring. It is recommended to leave these settings at their default
-    ## values unless instructed otherwise. This API may change in the future.
-    ##
-    ## If you would like to hear more about Deep Database Monitoring, please reach out to your customer
-    ## success manager or Datadog support.
-    #
-    # statement_metrics_limits:
-    #   calls:
-    #   - 100
-    #   - 0
-    #   time:
-    #   - 100
-    #   - 0
-    #   <METRIC_COLUMN>:
-    #   - <TOP_K_LIMIT>
-    #   - <BOTTOM_K_LIMIT>
-
     ## Configure collection of statement samples
     #
     statement_samples:

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -41,25 +41,6 @@ METRICS_COLUMNS = {
     'sum_no_good_index_used',
 }
 
-# These limits define the top K and bottom K unique query rows for each metric. For each check run the
-# max metrics sent will be sum of all numbers below (in practice, much less due to overlap in rows).
-DEFAULT_STATEMENT_METRICS_LIMITS = {
-    'count': (400, 0),
-    'errors': (100, 0),
-    'time': (400, 0),
-    'select_scan': (50, 0),
-    'select_full_join': (50, 0),
-    'no_index_used': (50, 0),
-    'no_good_index_used': (50, 0),
-    'lock_time': (50, 0),
-    'rows_affected': (100, 0),
-    'rows_sent': (100, 0),
-    'rows_examined': (100, 0),
-    # Synthetic column limits
-    'avg_time': (400, 0),
-    'rows_sent_ratio': (0, 50),
-}
-
 
 class MySQLStatementMetrics(object):
     """


### PR DESCRIPTION
### What does this PR do?
The statement metric limits have been removed in [this commit](https://github.com/DataDog/integrations-core/commit/d4f422c7bce0833dc427e18392553b2e7d13a817#diff-17584d7d2fd6b787e9e92a852f881f84c5dee3af11aa571549593a0a4d2b55e2) but there were a few leftovers. This PR cleans up the map of default config values as well as the references in the configuration example. 

### Motivation
Cleaning up to avoid confusion by users that might see the metric limit configs and try to use them. 

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
