### PR TITLE
Remove unused query metric limit configuration refs in postgres integration

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -235,21 +235,6 @@ files:
         type: boolean
         example: false
         display_default: false
-    - name: statement_metrics_limits
-      description: |
-        Defines the top and bottom limits on queries to track for each metric. These limits apply only to the
-        ALPHA features of Deep Database Monitoring. It is recommended to leave these settings at their default
-        values unless instructed otherwise. This API may change in the future.
-
-        If you would like to hear more about Deep Database Monitoring, please reach out to your customer
-        success manager or Datadog support.
-      value:
-        type: object
-        example:
-          calls: [100, 0]
-          time: [100, 0]
-          <METRIC_COLUMN>: [<TOP_K_LIMIT>, <BOTTOM_K_LIMIT>]
-        display_default: false
     - name: pg_stat_statements_view
       description: |
         Set this value if you want to define a custom view or function to allow the datadog user to query the

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -92,10 +92,6 @@ def instance_ssl(field, value):
     return 'false'
 
 
-def instance_statement_metrics_limits(field, value):
-    return get_default_field_value(field, value)
-
-
 def instance_statement_samples(field, value):
     return get_default_field_value(field, value)
 

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -63,7 +63,6 @@ class InstanceConfig(BaseModel):
     relations: Optional[Sequence[Union[str, Relation]]]
     service: Optional[str]
     ssl: Optional[str]
-    statement_metrics_limits: Optional[Mapping[str, Any]]
     statement_samples: Optional[StatementSamples]
     table_count_limit: Optional[int]
     tag_replication_role: Optional[bool]

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -194,25 +194,6 @@ instances:
     #
     # deep_database_monitoring: false
 
-    ## @param statement_metrics_limits - mapping - optional - default: false
-    ## Defines the top and bottom limits on queries to track for each metric. These limits apply only to the
-    ## ALPHA features of Deep Database Monitoring. It is recommended to leave these settings at their default
-    ## values unless instructed otherwise. This API may change in the future.
-    ##
-    ## If you would like to hear more about Deep Database Monitoring, please reach out to your customer
-    ## success manager or Datadog support.
-    #
-    # statement_metrics_limits:
-    #   calls:
-    #   - 100
-    #   - 0
-    #   time:
-    #   - 100
-    #   - 0
-    #   <METRIC_COLUMN>:
-    #   - <TOP_K_LIMIT>
-    #   - <BOTTOM_K_LIMIT>
-
     ## @param pg_stat_statements_view - string - optional - default: show_pg_stat_statements()
     ## Set this value if you want to define a custom view or function to allow the datadog user to query the
     ## `pg_stat_statements` table, which is useful for restricting the permissions given to the datadog agent.


### PR DESCRIPTION
### What does this PR do?
The statement metric limits have been removed in [this commit](https://github.com/DataDog/integrations-core/commit/26d90d6e73c135e3bc0c590ec195d459165dc89f#diff-157c2960ae5c7408275369d11207e5635cb0515cdc0b898396c4d043df08576d) but there were a few leftovers. This PR cleans up the map of default config values as well as the references in the configuration example.

### Motivation
Cleaning up to avoid confusion by users that might see the metric limit configs and try to use them.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
