### PR TITLE
Fix twemproxy tests

### DIFF
--- a/twemproxy/tests/compose/Dockerfile
+++ b/twemproxy/tests/compose/Dockerfile
@@ -9,7 +9,7 @@
 # etcdctl set /services/redis/01 10.10.100.11:6001
 # etcdctl set /services/redis/02 10.10.100.12:6002
 
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 ARG TWEMPROXY_VERSION
 ENV DEBIAN_FRONTEND noninteractive

--- a/twemproxy/tox.ini
+++ b/twemproxy/tox.ini
@@ -10,7 +10,7 @@ envdir =
     py27: {toxworkdir}/py27
     py38: {toxworkdir}/py38
 description =
-    py27,py37: e2e ready
+    py{27,38}: e2e ready
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin


### PR DESCRIPTION
ubuntu 14 is too old, pip doesn't work anymore on it