### PR TITLE
Change agent port for ddtrace

### DIFF
--- a/.azure-pipelines/all_master.yml
+++ b/.azure-pipelines/all_master.yml
@@ -14,11 +14,12 @@ resources:
     - container: dd_agent
       image: datadog/agent:latest
       ports:
-        - 8126:8126
+        - 8127:8127
       env:
         DD_API_KEY: $(DD_CI_API_KEY)
         DD_HOSTNAME: "none"
         DD_INSIDE_CI: "true"
+        DD_TRACE_AGENT_PORT: 8127
 
 jobs:
 - template: './templates/test-all-checks.yml'

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -194,7 +194,7 @@ class AgentCheck(object):
 
         logger = logging.getLogger('{}.{}'.format(__name__, self.name))
         self.log = CheckLoggingAdapter(logger, self)
-
+        self.log("hi")
         # TODO: Remove with Agent 5
         # Set proxy settings
         self.proxies = self._get_requests_proxy()

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -194,6 +194,7 @@ class AgentCheck(object):
 
         logger = logging.getLogger('{}.{}'.format(__name__, self.name))
         self.log = CheckLoggingAdapter(logger, self)
+
         # TODO: Remove with Agent 5
         # Set proxy settings
         self.proxies = self._get_requests_proxy()

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -194,7 +194,6 @@ class AgentCheck(object):
 
         logger = logging.getLogger('{}.{}'.format(__name__, self.name))
         self.log = CheckLoggingAdapter(logger, self)
-        self.log.debug("hi")
         # TODO: Remove with Agent 5
         # Set proxy settings
         self.proxies = self._get_requests_proxy()

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -194,7 +194,7 @@ class AgentCheck(object):
 
         logger = logging.getLogger('{}.{}'.format(__name__, self.name))
         self.log = CheckLoggingAdapter(logger, self)
-        self.log("hi")
+        self.log.debug("hi")
         # TODO: Remove with Agent 5
         # Set proxy settings
         self.proxies = self._get_requests_proxy()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
some services use the port 8126 we can encounter some checks failing because they are trying to access that port. Fixes CI for statsd.

### Motivation
<!-- What inspired you to submit this pull request? -->
statsd:
```
---------------------------- Captured stderr setup -----------------------------
Creating network "compose_default" with the default driver
Building statsd
Image for service statsd was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Creating compose_statsd_1 ... Host is already in use by another container
Creating compose_statsd_1 ... error

ERROR: for compose_statsd_1  
Cannot start service statsd: 
driver failed programming external connectivity on endpoint compose_statsd_1 (50f0c363a38cc6fec9a7cd6379d2b9280e1257a42d0e7e6bda8cda596f2352ad): 
Bind for 0.0.0.0:8126 failed: port is already allocated
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
