### PR TITLE
Add missing prometheus metrics

### DIFF
--- a/consul/datadog_checks/consul/metrics.py
+++ b/consul/datadog_checks/consul/metrics.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 METRIC_MAP = {
+    'consul_client_rpc': 'client.rpc',
+    'consul_client_rpc_failed': 'client.rpc.failed',
     'consul_memberlist_degraded': 'memberlist.degraded',
     'consul_memberlist_gossip': 'memberlist.gossip',
     'consul_memberlist_health_score': 'memberlist.health.score',
@@ -21,6 +23,7 @@ METRIC_MAP = {
     'consul_raft_commitTime': 'raft.commitTime',
     'consul_raft_leader_dispatchLog': 'raft.leader.dispatchLog',
     'consul_raft_leader_lastContact': 'raft.leader.lastContact',
+    'consul_runtime_gc_pause_ns': 'runtime.gc_pause_ns',
     'consul_serf_events': 'serf.events',
     'consul_serf_coordinate_adjustment_ms': 'serf.coordinate.adjustment_ms',
     'consul_serf_member_flap': 'serf.member.flap',

--- a/consul/tests/common.py
+++ b/consul/tests/common.py
@@ -25,6 +25,8 @@ PROMETHEUS_ENDPOINT_AVAILABLE = version.parse(CONSUL_VERSION) > version.parse('1
 # raft.replication.installSnapshot and raft.replication.appendEntries.logs are not tested
 # since our testing environment does not easily expose them.
 PROMETHEUS_METRICS = [
+    'consul.client.rpc',
+    'consul.client.rpc.failed',
     'consul.memberlist.msg.alive',
     'consul.memberlist.tcp.accept',
     'consul.memberlist.tcp.connect',
@@ -48,6 +50,7 @@ PROMETHEUS_HIST_METRICS = [
     'consul.raft.leader.dispatchLog.',
     'consul.raft.replication.appendEntries.rpc.',
     'consul.raft.replication.heartbeat.',
+    'consul.runtime.gc_pause_ns.',
     'consul.serf.coordinate.adjustment_ms.',
     'consul.serf.msgs.sent.',
     'consul.serf.msgs.received.',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adding prometheus support for some metrics available through dogstatsd
Metadata update in #9388 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
