### PR TITLE
Fix init failure when auth_ticket is not provided

### DIFF
--- a/mapr/datadog_checks/mapr/mapr.py
+++ b/mapr/datadog_checks/mapr/mapr.py
@@ -70,8 +70,8 @@ class MaprCheck(AgentCheck):
                 "user. Please update the file permissions.",
                 self.auth_ticket,
             )
-
-        os.environ[TICKET_LOCATION_ENV_VAR] = self.auth_ticket
+        else:
+            os.environ[TICKET_LOCATION_ENV_VAR] = self.auth_ticket
 
     def check(self, _):
         if ck is None:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`auth_ticket` is not required for all environment, and assigning an environment variable with `None` raises an exception.

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
