### PR TITLE
Support "ignore_tags" configuration

### DIFF
--- a/amazon_msk/datadog_checks/amazon_msk/config_models/defaults.py
+++ b/amazon_msk/datadog_checks/amazon_msk/config_models/defaults.py
@@ -84,6 +84,10 @@ def instance_ignore_metrics_by_labels(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_ignore_tags(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_jmx_exporter_port(field, value):
     return 11001
 

--- a/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
+++ b/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
@@ -74,6 +74,7 @@ class InstanceConfig(BaseModel):
     health_service_check: Optional[bool]
     ignore_metrics: Optional[Sequence[str]]
     ignore_metrics_by_labels: Optional[IgnoreMetricsByLabels]
+    ignore_tags: Optional[Sequence[str]]
     jmx_exporter_port: Optional[int]
     kerberos_auth: Optional[str]
     kerberos_cache: Optional[str]

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -194,6 +194,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -195,13 +195,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
@@ -162,6 +162,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
@@ -163,13 +163,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/cilium/datadog_checks/cilium/data/conf.yaml.example
+++ b/cilium/datadog_checks/cilium/data/conf.yaml.example
@@ -165,6 +165,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/cilium/datadog_checks/cilium/data/conf.yaml.example
+++ b/cilium/datadog_checks/cilium/data/conf.yaml.example
@@ -166,13 +166,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -157,6 +157,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -158,13 +158,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -176,6 +176,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -177,13 +177,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/crio/datadog_checks/crio/data/conf.yaml.example
+++ b/crio/datadog_checks/crio/data/conf.yaml.example
@@ -157,6 +157,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/crio/datadog_checks/crio/data/conf.yaml.example
+++ b/crio/datadog_checks/crio/data/conf.yaml.example
@@ -158,13 +158,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -318,6 +318,21 @@ class OpenMetricsScraperMixin(object):
         # Custom tags that will be sent with each metric
         config['custom_tags'] = instance.get('tags', [])
 
+        # Some tags can be ignored to reduce the cardinality.
+        # This can be useful for cost optimization in containerized environments
+        # when the openmetrics check is configured to collect custom metrics.
+        # Even when the Agent's Tagger is configured to add low-cardinality tags only,
+        # some tags can still generate unwanted metric contexts (e.g pod annotations as tags).
+        ignore_tags = instance.get('ignore_tags', default_instance.get('ignore_tags', []))
+        if ignore_tags:
+            ignored_tag_patterns = set()
+            for ignored_tag in ignore_tags:
+                ignored_tag_patterns.add(translate(ignored_tag))
+
+            if ignored_tag_patterns:
+                ignored_tags_re = compile('|'.join(ignored_tag_patterns))
+                config['custom_tags'] = [tag for tag in config['custom_tags'] if not ignored_tags_re.search(tag)]
+
         # Additional tags to be sent with each metric
         config['_metric_tags'] = []
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -325,13 +325,8 @@ class OpenMetricsScraperMixin(object):
         # some tags can still generate unwanted metric contexts (e.g pod annotations as tags).
         ignore_tags = instance.get('ignore_tags', default_instance.get('ignore_tags', []))
         if ignore_tags:
-            ignored_tag_patterns = set()
-            for ignored_tag in ignore_tags:
-                ignored_tag_patterns.add(translate(ignored_tag))
-
-            if ignored_tag_patterns:
-                ignored_tags_re = compile('|'.join(ignored_tag_patterns))
-                config['custom_tags'] = [tag for tag in config['custom_tags'] if not ignored_tags_re.search(tag)]
+            ignored_tags_re = compile('|'.join(set(ignore_tags)))
+            config['custom_tags'] = [tag for tag in config['custom_tags'] if not ignored_tags_re.search(tag)]
 
         # Additional tags to be sent with each metric
         config['_metric_tags'] = []

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -151,13 +151,8 @@ class OpenMetricsScraper:
         # some tags can still generate unwanted metric contexts (e.g pod annotations as tags).
         ignore_tags = config.get('ignore_tags', [])
         if ignore_tags:
-            ignored_tag_patterns = set()
-            for ignored_tag in ignore_tags:
-                ignored_tag_patterns.add(fnmatch.translate(ignored_tag))
-
-            if ignored_tag_patterns:
-                ignored_tags_re = re.compile('|'.join(ignored_tag_patterns))
-                custom_tags = [tag for tag in custom_tags if not ignored_tags_re.search(tag)]
+            ignored_tags_re = re.compile('|'.join(set(ignore_tags)))
+            custom_tags = [tag for tag in custom_tags if not ignored_tags_re.search(tag)]
 
         # 16 KiB seems optimal, and is also the standard chunk size of the Bittorrent protocol:
         # https://www.bittorrent.org/beps/bep_0003.html

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -144,6 +144,21 @@ class OpenMetricsScraper:
             if not isinstance(entry, str):
                 raise ConfigurationError(f'Entry #{i} of setting `tags` must be a string')
 
+        # Some tags can be ignored to reduce the cardinality.
+        # This can be useful for cost optimization in containerized environments
+        # when the openmetrics check is configured to collect custom metrics.
+        # Even when the Agent's Tagger is configured to add low-cardinality tags only,
+        # some tags can still generate unwanted metric contexts (e.g pod annotations as tags).
+        ignore_tags = config.get('ignore_tags', [])
+        if ignore_tags:
+            ignored_tag_patterns = set()
+            for ignored_tag in ignore_tags:
+                ignored_tag_patterns.add(fnmatch.translate(ignored_tag))
+
+            if ignored_tag_patterns:
+                ignored_tags_re = re.compile('|'.join(ignored_tag_patterns))
+                custom_tags = [tag for tag in custom_tags if not ignored_tags_re.search(tag)]
+
         # 16 KiB seems optimal, and is also the standard chunk size of the Bittorrent protocol:
         # https://www.bittorrent.org/beps/bep_0003.html
         self.request_size = int(float(config.get('request_size') or 16) * KIBIBYTE)

--- a/datadog_checks_base/tests/openmetrics/test_options.py
+++ b/datadog_checks_base/tests/openmetrics/test_options.py
@@ -550,3 +550,25 @@ class TestShareLabels:
         )
 
         aggregator.assert_all_metrics_covered()
+
+
+class TestIgnoreTags:
+    def test(self, aggregator, dd_run_check, mock_http_response):
+        mock_http_response(
+            """
+            # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+            # TYPE go_memstats_alloc_bytes gauge
+            go_memstats_alloc_bytes 6.396288e+06
+            """
+        )
+
+        all_tags = ['foo', 'foofoo', 'bar', 'bar:baz']
+        ignored_tags = ['foo*', 'bar:baz']
+        check = get_check({'metrics': ['go_memstats_alloc_bytes'], 'tags': all_tags, 'ignore_tags': ignored_tags})
+        dd_run_check(check)
+
+        aggregator.assert_metric(
+            'test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['endpoint:test', 'bar']
+        )
+
+        aggregator.assert_all_metrics_covered()

--- a/datadog_checks_base/tests/openmetrics/test_options.py
+++ b/datadog_checks_base/tests/openmetrics/test_options.py
@@ -553,7 +553,7 @@ class TestShareLabels:
 
 
 class TestIgnoreTags:
-    def test(self, aggregator, dd_run_check, mock_http_response):
+    def test_simple_match(self, aggregator, dd_run_check, mock_http_response):
         mock_http_response(
             """
             # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
@@ -561,14 +561,54 @@ class TestIgnoreTags:
             go_memstats_alloc_bytes 6.396288e+06
             """
         )
-
-        all_tags = ['foo', 'foofoo', 'bar', 'bar:baz']
-        ignored_tags = ['foo*', 'bar:baz']
+        all_tags = ['foo', 'foobar', 'bar', 'bar:baz', 'bar:bar']
+        ignored_tags = ['foo', 'bar:baz']
+        wanted_tags = ['bar', 'bar:bar']
         check = get_check({'metrics': ['go_memstats_alloc_bytes'], 'tags': all_tags, 'ignore_tags': ignored_tags})
         dd_run_check(check)
 
         aggregator.assert_metric(
-            'test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['endpoint:test', 'bar']
+            'test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['endpoint:test'] + wanted_tags
+        )
+
+        aggregator.assert_all_metrics_covered()
+
+    def test_simple_wildcard(self, aggregator, dd_run_check, mock_http_response):
+        mock_http_response(
+            """
+            # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+            # TYPE go_memstats_alloc_bytes gauge
+            go_memstats_alloc_bytes 6.396288e+06
+            """
+        )
+        all_tags = ['foo', 'foobar', 'bar', 'bar:baz', 'bar:bar']
+        ignored_tags = ['foo*', '.*baz']
+        wanted_tags = ['bar', 'bar:bar']
+        check = get_check({'metrics': ['go_memstats_alloc_bytes'], 'tags': all_tags, 'ignore_tags': ignored_tags})
+        dd_run_check(check)
+
+        aggregator.assert_metric(
+            'test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['endpoint:test'] + wanted_tags
+        )
+
+        aggregator.assert_all_metrics_covered()
+
+    def test_regex(self, aggregator, dd_run_check, mock_http_response):
+        mock_http_response(
+            """
+            # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+            # TYPE go_memstats_alloc_bytes gauge
+            go_memstats_alloc_bytes 6.396288e+06
+            """
+        )
+        all_tags = ['foo', 'foobar', 'bar:baz', 'bar:bar']
+        ignored_tags = ['^foo', '.+:bar$']
+        wanted_tags = ['bar:baz']
+        check = get_check({'metrics': ['go_memstats_alloc_bytes'], 'tags': all_tags, 'ignore_tags': ignored_tags})
+        dd_run_check(check)
+
+        aggregator.assert_metric(
+            'test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['endpoint:test'] + wanted_tags
         )
 
         aggregator.assert_all_metrics_covered()

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -2781,3 +2781,20 @@ def test_empty_namespace(aggregator, mocked_prometheus_check, text_data, ref_gau
     check.process_metric(ref_gauge, config)
 
     aggregator.assert_metric('process.vm.bytes', count=1)
+
+
+def test_ignore_tags(aggregator, mocked_prometheus_check, ref_gauge):
+    """
+    Test that tags matching ignored tag patterns are properly discarded.
+    """
+    check = mocked_prometheus_check
+    instance = copy.deepcopy(PROMETHEUS_CHECK_INSTANCE)
+    instance['tags'] = ['foo', 'foofoo', 'bar', 'bar:baz']
+    instance['ignore_tags'] = ['foo*', 'bar:baz']
+
+    config = check.get_scraper_config(instance)
+    config['_dry_run'] = False
+
+    check.process_metric(ref_gauge, config)
+
+    aggregator.assert_metric('prometheus.process.vm.bytes', tags=['bar'], count=1)

--- a/datadog_checks_base/tests/test_openmetrics.py
+++ b/datadog_checks_base/tests/test_openmetrics.py
@@ -2783,18 +2783,61 @@ def test_empty_namespace(aggregator, mocked_prometheus_check, text_data, ref_gau
     aggregator.assert_metric('process.vm.bytes', count=1)
 
 
-def test_ignore_tags(aggregator, mocked_prometheus_check, ref_gauge):
+def test_ignore_tags_match(aggregator, mocked_prometheus_check, ref_gauge):
     """
     Test that tags matching ignored tag patterns are properly discarded.
     """
     check = mocked_prometheus_check
     instance = copy.deepcopy(PROMETHEUS_CHECK_INSTANCE)
-    instance['tags'] = ['foo', 'foofoo', 'bar', 'bar:baz']
-    instance['ignore_tags'] = ['foo*', 'bar:baz']
+    all_tags = ['foo', 'foobar', 'bar', 'bar:baz', 'bar:bar']
+    ignored_tags = ['foo', 'bar:baz']
+    wanted_tags = ['bar', 'bar:bar']
+    instance['tags'] = all_tags
+    instance['ignore_tags'] = ignored_tags
 
     config = check.get_scraper_config(instance)
     config['_dry_run'] = False
 
     check.process_metric(ref_gauge, config)
 
-    aggregator.assert_metric('prometheus.process.vm.bytes', tags=['bar'], count=1)
+    aggregator.assert_metric('prometheus.process.vm.bytes', tags=wanted_tags, count=1)
+
+
+def test_ignore_tags_wildcard(aggregator, mocked_prometheus_check, ref_gauge):
+    """
+    Test that tags matching ignored tag patters with wildcards are properly discarded.
+    """
+    check = mocked_prometheus_check
+    instance = copy.deepcopy(PROMETHEUS_CHECK_INSTANCE)
+    all_tags = ['foo', 'foobar', 'bar', 'bar:baz', 'bar:bar']
+    ignored_tags = ['foo*', '.*baz']
+    wanted_tags = ['bar', 'bar:bar']
+    instance['tags'] = all_tags
+    instance['ignore_tags'] = ignored_tags
+
+    config = check.get_scraper_config(instance)
+    config['_dry_run'] = False
+
+    check.process_metric(ref_gauge, config)
+
+    aggregator.assert_metric('prometheus.process.vm.bytes', tags=wanted_tags, count=1)
+
+
+def test_ignore_tags_regex(aggregator, mocked_prometheus_check, ref_gauge):
+    """
+    Test that tags matching ignored tag patters with regex are properly discarded.
+    """
+    check = mocked_prometheus_check
+    instance = copy.deepcopy(PROMETHEUS_CHECK_INSTANCE)
+    all_tags = ['foo', 'foobar', 'bar:baz', 'bar:bar']
+    ignored_tags = ['^foo', '.+:bar$']
+    wanted_tags = ['bar:baz']
+    instance['tags'] = all_tags
+    instance['ignore_tags'] = ignored_tags
+
+    config = check.get_scraper_config(instance)
+    config['_dry_run'] = False
+
+    check.process_metric(ref_gauge, config)
+
+    aggregator.assert_metric('prometheus.process.vm.bytes', tags=wanted_tags, count=1)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -300,5 +300,16 @@
   value:
     example: false
     type: boolean
+- name: ignore_tags
+  description: A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+  value:
+    type: array
+    items:
+      type: string
+    example:
+      - <FULL:TAG>
+      - <TAG_PREFIX*>
+      - <*TAG_SUFFIX>
+      - <*SUBSTRING*>
 - template: instances/http
 - template: instances/default

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -301,15 +301,14 @@
     example: false
     type: boolean
 - name: ignore_tags
-  description: A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+  description: A list of tags to ignore, regular expressions can be used to match multiple tag strings.
   value:
     type: array
     items:
       type: string
     example:
       - <FULL:TAG>
-      - <TAG_PREFIX*>
-      - <*TAG_SUFFIX>
-      - <*SUBSTRING*>
+      - <TAG_PREFIX:.*>
+      - <TAG_SUFFIX$>
 - template: instances/http
 - template: instances/default

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy.yaml
@@ -167,5 +167,16 @@
     example:
       <KEY_1>: [<LABEL_1>, <LABEL_2>]
       <KEY_2>: ['*']
+- name: ignore_tags
+  description: A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+  value:
+    type: array
+    items:
+      type: string
+    example:
+      - <FULL:TAG>
+      - <TAG_PREFIX*>
+      - <*TAG_SUFFIX>
+      - <*SUBSTRING*>
 - template: instances/http
 - template: instances/default

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy.yaml
@@ -168,15 +168,14 @@
       <KEY_1>: [<LABEL_1>, <LABEL_2>]
       <KEY_2>: ['*']
 - name: ignore_tags
-  description: A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+  description: A list of tags to ignore, regular expressions can be used to match multiple tag strings.
   value:
     type: array
     items:
       type: string
     example:
       - <FULL:TAG>
-      - <TAG_PREFIX*>
-      - <*TAG_SUFFIX>
-      - <*SUBSTRING*>
+      - <TAG_PREFIX:.*>
+      - <TAG_SUFFIX$>
 - template: instances/http
 - template: instances/default

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -163,6 +163,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -164,13 +164,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/external_dns/datadog_checks/external_dns/data/conf.yaml.example
+++ b/external_dns/datadog_checks/external_dns/data/conf.yaml.example
@@ -157,6 +157,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/external_dns/datadog_checks/external_dns/data/conf.yaml.example
+++ b/external_dns/datadog_checks/external_dns/data/conf.yaml.example
@@ -158,13 +158,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -127,6 +127,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -128,13 +128,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/gitlab_runner/datadog_checks/gitlab_runner/config_models/defaults.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/config_models/defaults.py
@@ -80,6 +80,10 @@ def instance_ignore_metrics_by_labels(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_ignore_tags(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_kerberos_auth(field, value):
     return 'disabled'
 

--- a/gitlab_runner/datadog_checks/gitlab_runner/config_models/instance.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/config_models/instance.py
@@ -73,6 +73,7 @@ class InstanceConfig(BaseModel):
     health_service_check: Optional[bool]
     ignore_metrics: Optional[Sequence[str]]
     ignore_metrics_by_labels: Optional[IgnoreMetricsByLabels]
+    ignore_tags: Optional[Sequence[str]]
     kerberos_auth: Optional[str]
     kerberos_cache: Optional[str]
     kerberos_delegate: Optional[bool]

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -211,6 +211,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -212,13 +212,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/haproxy/datadog_checks/haproxy/config_models/defaults.py
+++ b/haproxy/datadog_checks/haproxy/config_models/defaults.py
@@ -112,6 +112,10 @@ def instance_ignore_metrics_by_labels(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_ignore_tags(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_kerberos_auth(field, value):
     return 'disabled'
 

--- a/haproxy/datadog_checks/haproxy/config_models/instance.py
+++ b/haproxy/datadog_checks/haproxy/config_models/instance.py
@@ -80,6 +80,7 @@ class InstanceConfig(BaseModel):
     health_service_check: Optional[bool]
     ignore_metrics: Optional[Sequence[str]]
     ignore_metrics_by_labels: Optional[IgnoreMetricsByLabels]
+    ignore_tags: Optional[Sequence[str]]
     kerberos_auth: Optional[str]
     kerberos_cache: Optional[str]
     kerberos_delegate: Optional[bool]

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -304,6 +304,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -305,13 +305,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/istio/datadog_checks/istio/config_models/defaults.py
+++ b/istio/datadog_checks/istio/config_models/defaults.py
@@ -88,6 +88,10 @@ def instance_ignore_metrics_by_labels(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_ignore_tags(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_istio_mesh_endpoint(field, value):
     return 'http://istio-proxy.istio-system:15090/stats/prometheus'
 

--- a/istio/datadog_checks/istio/config_models/instance.py
+++ b/istio/datadog_checks/istio/config_models/instance.py
@@ -74,6 +74,7 @@ class InstanceConfig(BaseModel):
     health_service_check: Optional[bool]
     ignore_metrics: Optional[Sequence[str]]
     ignore_metrics_by_labels: Optional[IgnoreMetricsByLabels]
+    ignore_tags: Optional[Sequence[str]]
     istio_mesh_endpoint: Optional[str]
     istiod_endpoint: Optional[str]
     kerberos_auth: Optional[str]

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -196,6 +196,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -197,13 +197,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -237,6 +237,15 @@ instances:
     #
     # telemetry: false
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -238,13 +238,12 @@ instances:
     # telemetry: false
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -164,6 +164,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -165,13 +165,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -173,6 +173,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -174,13 +174,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/linkerd/datadog_checks/linkerd/data/conf.yaml.example
+++ b/linkerd/datadog_checks/linkerd/data/conf.yaml.example
@@ -157,6 +157,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/linkerd/datadog_checks/linkerd/data/conf.yaml.example
+++ b/linkerd/datadog_checks/linkerd/data/conf.yaml.example
@@ -158,13 +158,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -165,6 +165,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -166,13 +166,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -171,6 +171,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -172,13 +172,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -174,6 +174,15 @@ instances:
     #   <KEY_2>:
     #   - '*'
 
+    ## @param ignore_tags - list of strings - optional
+    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX*>
+    #   - <*TAG_SUFFIX>
+    #   - <*SUBSTRING*>
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -175,13 +175,12 @@ instances:
     #   - '*'
 
     ## @param ignore_tags - list of strings - optional
-    ## A list of tags to ignore, the "*" wildcard can be used to match multiple tag strings.
+    ## A list of tags to ignore, regular expressions can be used to match multiple tag strings.
     #
     # ignore_tags:
     #   - <FULL:TAG>
-    #   - <TAG_PREFIX*>
-    #   - <*TAG_SUFFIX>
-    #   - <*SUBSTRING*>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.


### PR DESCRIPTION
### What does this PR do?
Introduce a new config `ignore_tags` in the `openmetrics` check.

### Motivation
- FR
- Useful for cost optimization when the `openmetrics` check is configured to collect custom metrics

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
