### PR TITLE
Send database monitoring "full query text" events

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -67,7 +67,7 @@ class DatadogAgentStub(object):
 
     def obfuscate_sql(self, query):
         # This is only whitespace cleanup, NOT obfuscation. Full obfuscation implementation is in go code.
-        return re.sub(r'\s+', ' ', query or '')
+        return re.sub(r'\s+', ' ', query or '').strip()
 
     def obfuscate_sql_exec_plan(self, plan, normalize=False):
         # Passthrough stub: obfuscation implementation is in Go code.

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -67,7 +67,7 @@ class DatadogAgentStub(object):
 
     def obfuscate_sql(self, query):
         # This is only whitespace cleanup, NOT obfuscation. Full obfuscation implementation is in go code.
-        return re.sub(r'\s+', ' ', query or '').strip()
+        return re.sub(r'\s+', ' ', query or '')
 
     def obfuscate_sql_exec_plan(self, plan, normalize=False):
         # Passthrough stub: obfuscation implementation is in Go code.

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -30,6 +30,10 @@ class MySQLConfig(object):
         self.charset = instance.get('charset')
         self.deep_database_monitoring = is_affirmative(instance.get('deep_database_monitoring', False))
         self.statement_metrics_limits = instance.get('statement_metrics_limits', None)
+        self.full_statement_text_cache_max_size = instance.get('full_statement_text_cache_max_size', 10000)
+        self.full_statement_text_samples_per_hour_per_query = instance.get(
+            'full_statement_text_samples_per_hour_per_query', 1
+        )
         self.statement_samples_config = instance.get('statement_samples', {}) or {}
         self.min_collection_interval = instance.get('min_collection_interval', 15)
         self.configuration_checks()

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import copy
 import logging
+import re
 import subprocess
 import time
 from collections import Counter
@@ -10,7 +11,6 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from contextlib import closing
 from os import environ
 
-import re
 import mock
 import psutil
 import pymysql


### PR DESCRIPTION
### What does this PR do?

When collecting mysql query metrics, send the full length query text in separate "full query text" events. These events are rate limited to a low default rate limit of one event per hour.

Sending the full query text separately enables us to significantly reduce the size of the query metrics payload by sending only the first 200 characters of each query.

### Motivation

* Enable full text search for all queries including those for which we don't capture any samples 
* Reduce size of DBM metrics payload 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
