### PR TITLE
Don't emit warnings if there are no messages

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -50,7 +50,10 @@ class ChannelMetricCollector(object):
             pcf = pymqi.PCFExecute(queue_manager, convert=self.config.convert_endianness)
             response = pcf.MQCMD_INQUIRE_CHANNEL(args)
         except pymqi.MQMIError as e:
-            self.log.warning("Error getting CHANNEL stats %s", e)
+            # Don't warn if no messages, see:
+            # https://github.com/dsuch/pymqi/blob/v1.12.0/docs/examples.rst#how-to-wait-for-multiple-messages
+            if not (e.comp == pymqi.CMQC.MQCC_FAILED and e.reason == pymqi.CMQC.MQRC_NO_MSG_AVAILABLE):
+                self.log.warning("Error getting CHANNEL stats %s", e)
         else:
             channels = len(response)
             mname = '{}.channel.channels'.format(metrics.METRIC_PREFIX)

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
@@ -86,7 +86,10 @@ class QueueMetricCollector(object):
                 pcf = pymqi.PCFExecute(queue_manager, convert=self.config.convert_endianness)
                 response = pcf.MQCMD_INQUIRE_Q(args)
             except pymqi.MQMIError as e:
-                self.warning("Error discovering queue: %s", e)
+                # Don't warn if no messages, see:
+                # https://github.com/dsuch/pymqi/blob/v1.12.0/docs/examples.rst#how-to-wait-for-multiple-messages
+                if not (e.comp == pymqi.CMQC.MQCC_FAILED and e.reason == pymqi.CMQC.MQRC_NO_MSG_AVAILABLE):
+                    self.warning("Error discovering queue: %s", e)
             else:
                 for queue_info in response:
                     queue = queue_info[pymqi.CMQC.MQCA_Q_NAME]
@@ -117,7 +120,10 @@ class QueueMetricCollector(object):
             pcf = pymqi.PCFExecute(queue_manager, convert=self.config.convert_endianness)
             response = pcf.MQCMD_INQUIRE_Q(args)
         except pymqi.MQMIError as e:
-            self.warning("Error getting queue stats for %s: %s", queue_name, e)
+            # Don't warn if no messages, see:
+            # https://github.com/dsuch/pymqi/blob/v1.12.0/docs/examples.rst#how-to-wait-for-multiple-messages
+            if not (e.comp == pymqi.CMQC.MQCC_FAILED and e.reason == pymqi.CMQC.MQRC_NO_MSG_AVAILABLE):
+                self.warning("Error getting queue stats for %s: %s", queue_name, e)
         else:
             # Response is a list. It likely has only one member in it.
             for queue_info in response:
@@ -149,7 +155,10 @@ class QueueMetricCollector(object):
             pcf = pymqi.PCFExecute(queue_manager, convert=self.config.convert_endianness)
             response = pcf.MQCMD_INQUIRE_Q_STATUS(args)
         except pymqi.MQMIError as e:
-            self.warning("Error getting pcf queue stats for %s: %s", queue_name, e)
+            # Don't warn if no messages, see:
+            # https://github.com/dsuch/pymqi/blob/v1.12.0/docs/examples.rst#how-to-wait-for-multiple-messages
+            if not (e.comp == pymqi.CMQC.MQCC_FAILED and e.reason == pymqi.CMQC.MQRC_NO_MSG_AVAILABLE):
+                self.warning("Error getting pcf queue stats for %s: %s", queue_name, e)
         else:
             # Response is a list. It likely has only one member in it.
             for queue_info in response:
@@ -172,7 +181,10 @@ class QueueMetricCollector(object):
             pcf = pymqi.PCFExecute(queue_manager, convert=self.config.convert_endianness)
             response = pcf.MQCMD_RESET_Q_STATS(args)
         except pymqi.MQMIError as e:
-            self.warning("Error getting pcf queue stats for %s: %s", queue_name, e)
+            # Don't warn if no messages, see:
+            # https://github.com/dsuch/pymqi/blob/v1.12.0/docs/examples.rst#how-to-wait-for-multiple-messages
+            if not (e.comp == pymqi.CMQC.MQCC_FAILED and e.reason == pymqi.CMQC.MQRC_NO_MSG_AVAILABLE):
+                self.warning("Error getting pcf queue stats for %s: %s", queue_name, e)
         else:
             # Response is a list. It likely has only one member in it.
             for queue_info in response:

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
@@ -66,10 +66,10 @@ class StatsCollector(object):
                     self._collect_queue_stats(stats)
                 else:
                     self.log.debug('Unknown/NotImplemented command: %s', header.Command)
-        except pymqi.MQMIError as err:
-            if err.reason == MQRC_NO_MSG_AVAILABLE:
-                pass
-            else:
+        except pymqi.MQMIError as e:
+            # Don't warn if no messages, see:
+            # https://github.com/dsuch/pymqi/blob/v1.12.0/docs/examples.rst#how-to-wait-for-multiple-messages
+            if not (e.comp == pymqi.CMQC.MQCC_FAILED and e.reason == pymqi.CMQC.MQRC_NO_MSG_AVAILABLE):
                 raise
         finally:
             queue.close()

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from pymqi.CMQC import MQRC_NO_MSG_AVAILABLE
 from pymqi.CMQCFC import MQCMD_STATISTICS_CHANNEL, MQCMD_STATISTICS_Q
 
 from datadog_checks.ibm_mq.stats.base_stats import BaseStats


### PR DESCRIPTION
### What does this PR do?

Ignores https://www.ibm.com/docs/en/ibm-mq/9.2?topic=codes-2033-07f1-rc2033-mqrc-no-msg-available as expressed in:

- https://github.com/dsuch/pymqi/blob/v1.12.0/docs/examples.rst#how-to-wait-for-multiple-messages
- https://stackoverflow.com/a/57352594/5854007

### Motivation

Feedback