### PR TITLE
Try SSL connection when host not found

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/connection.py
+++ b/ibm_mq/datadog_checks/ibm_mq/connection.py
@@ -28,7 +28,7 @@ def get_queue_manager_connection(config):
             get_normal_connection(config)
         except pymqi.MQMIError as e:
             log.debug("Tried normal connection before SSL connection. It failed with: %s", e)
-            if e.reason in [pymqi.CMQC.MQRC_HOST_NOT_AVAILABLE, pymqi.CMQC.MQRC_UNKNOWN_CHANNEL_NAME]:
+            if e.reason == pymqi.CMQC.MQRC_UNKNOWN_CHANNEL_NAME:
                 raise
         return get_ssl_connection(config)
     else:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
In some cases, pymqi can raise a `MQRC_HOST_NOT_AVAILABLE` exception due to a normal connection instead of an SSL connection.
If the normal connection raises a `MQRC_HOST_NOT_AVAILABLE` exception, we now try an SSL connection before failing (when SSL is configured)

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
