### PR TITLE
Update query and name of 2 widgets

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_nodes.json
+++ b/kubernetes/assets/dashboards/kubernetes_nodes.json
@@ -555,7 +555,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}, avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}*100",
+                        "q": "avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}",
                         "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
@@ -574,7 +574,7 @@
                         "display_type": "error dashed"
                     }
                 ],
-                "title": "Memory utilization per node",
+                "title": "Memory utilization of pods per node",
                 "title_size": "16",
                 "title_align": "left",
                 "show_legend": false,
@@ -1399,7 +1399,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}, avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}*100",
+                        "q": "avg:kubernetes.memory.usage_pct{$cluster,$host} by {host}*100",
                         "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
@@ -1424,7 +1424,7 @@
                         "label": "y = 80"
                     }
                 ],
-                "title": "Memory utilization % per node",
+                "title": "Memory utilization % of pods per node",
                 "title_size": "16",
                 "title_align": "left",
                 "show_legend": false,


### PR DESCRIPTION
### What does this PR do?
For the Kubernetes Nodes Overview Dashboard, it was brought up that both widgets named Memory Utilization % Per Node and Memory Utilization Per Node utilized the same query, and that their names were unclear.

Queries and names were updated.

### Motivation
Customer escalation: https://datadoghq.atlassian.net/browse/CONS-3796

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
