### PR TITLE
should be using sum, not average for counts

### DIFF
--- a/istio/assets/dashboards/istio_1_5_overview.json
+++ b/istio/assets/dashboards/istio_1_5_overview.json
@@ -46,7 +46,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "top(avg:istio.mesh.request.count{$cluster} by {host}, 10, 'mean', 'desc')",
+                        "q": "top(sum:istio.mesh.request.count{$cluster} by {host}, 10, 'mean', 'desc')",
                         "display_type": "area",
                         "style": {
                             "palette": "dog_classic",


### PR DESCRIPTION
### What does this PR do?
changes the top list of request count to sum

### Motivation
a customer complained about it on a call

"How did no one notice this? does no one use these out of the box dashboards"