### PR TITLE
update `DatadogAgentStub.obfuscate_sql` to trim whitespace

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -67,7 +67,7 @@ class DatadogAgentStub(object):
 
     def obfuscate_sql(self, query):
         # This is only whitespace cleanup, NOT obfuscation. Full obfuscation implementation is in go code.
-        return re.sub(r'\s+', ' ', query or '')
+        return re.sub(r'\s+', ' ', query or '').strip()
 
     def obfuscate_sql_exec_plan(self, plan, normalize=False):
         # Passthrough stub: obfuscation implementation is in Go code.


### PR DESCRIPTION
### What does this PR do?

Update the stub `obfuscate_sql` whitespace trimming behavior to match that of the go implementation.

See also https://github.com/DataDog/datadog-agent/pull/8218

### Motivation

Update the stub behavior to better match the core implementation behavior. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
