### PR TITLE
Fix version compatibility

### DIFF
--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This check monitors [IBM MQ][1] versions 5 to 9.0.
+This check monitors [IBM MQ][1] versions 8 to 9.0.
 
 ## Setup
 


### PR DESCRIPTION
MQ 5, was released on October 1997. The integration was developed in 2018 and version 8 came out in 2014.
Since we depend on IBM provided libraries is not possible for us to support eoled versions