### PR TITLE
Fix version parsing

### DIFF
--- a/glusterfs/datadog_checks/glusterfs/check.py
+++ b/glusterfs/datadog_checks/glusterfs/check.py
@@ -104,24 +104,29 @@ class GlusterfsCheck(AgentCheck):
     def submit_version_metadata(self, data):
         raw_version = data.get(GLUSTER_VERSION)
         if raw_version:
-            major, minor = self.parse_version(raw_version)
+            major, minor, patch = self.parse_version(raw_version)
             version_parts = {'major': str(int(major)), 'minor': str(int(minor))}
+            if patch:
+                version_parts['patch'] = patch
             self.set_metadata('version', raw_version, scheme='parts', part_map=version_parts)
             self.log.debug('Found GlusterFS version: %s', raw_version)
         else:
             self.log.warning('Could not retrieve GlusterFS version info: %s', raw_version)
 
     def parse_version(self, version):
-        # type (str) -> str, str
+        # type (str) -> str, str, str
         """
         GlusterFS versions are in format <major>.<minor>
         """
-        major, minor = None, None
+        major, minor, patch = None, None, None
         try:
-            major, minor = version.split('.')[0:2]
+            split_version = version.split('.')
+            major, minor = split_version[0:2]
+            if len(split_version) > 2:
+                patch = split_version[2]
         except ValueError as e:
             self.log.debug("Unable to parse GlusterFS version %s: %s", str(version), str(e))
-        return major, minor
+        return major, minor, patch
 
     def parse_volume_summary(self, output):
         for volume in output:

--- a/glusterfs/datadog_checks/glusterfs/check.py
+++ b/glusterfs/datadog_checks/glusterfs/check.py
@@ -102,11 +102,7 @@ class GlusterfsCheck(AgentCheck):
 
     @AgentCheck.metadata_entrypoint
     def submit_version_metadata(self, data):
-        try:
-            raw_version = data[GLUSTER_VERSION]
-        except KeyError as e:
-            self.log.debug("Could not retrieve GlusterFS version: %s", str(e))
-
+        raw_version = data.get(GLUSTER_VERSION)
         if raw_version:
             major, minor = self.parse_version(raw_version)
             version_parts = {'major': str(int(major)), 'minor': str(int(minor))}
@@ -116,15 +112,16 @@ class GlusterfsCheck(AgentCheck):
             self.log.warning('Could not retrieve GlusterFS version info: %s', raw_version)
 
     def parse_version(self, version):
+        # type (str) -> str, str
         """
         GlusterFS versions are in format <major>.<minor>
         """
+        major, minor = None, None
         try:
-            major, minor = version.split('.')
+            major, minor = version.split('.')[0:2]
         except ValueError as e:
-            self.log.debug("Unable to parse GlusterFS version: %s", str(e))
-        else:
-            return major, minor
+            self.log.debug("Unable to parse GlusterFS version %s: %s", str(version), str(e))
+        return major, minor
 
     def parse_volume_summary(self, output):
         for volume in output:

--- a/glusterfs/datadog_checks/glusterfs/check.py
+++ b/glusterfs/datadog_checks/glusterfs/check.py
@@ -4,13 +4,13 @@
 import json
 
 try:
-    from json import JSONDecodeError
+    from json.decoder import JSONDecodeError
 except ImportError:
     from simplejson import JSONDecodeError
 
 import os
 import shlex
-from typing import Any
+from typing import Dict, List
 
 from six import iteritems
 
@@ -34,7 +34,7 @@ class GlusterfsCheck(AgentCheck):
     BRICK_SC = "brick.health"
 
     def __init__(self, name, init_config, instances):
-        # type: (*Any, **Any) -> None
+        # type: (str, Dict, List[Dict]) -> None
         super(GlusterfsCheck, self).__init__(name, init_config, instances)
         self._tags = self.instance.get('tags', [])
 

--- a/glusterfs/tests/test_glusterfs.py
+++ b/glusterfs/tests/test_glusterfs.py
@@ -14,7 +14,7 @@ from .common import CHECK, E2E_INIT_CONFIG, EXPECTED_METRICS, GLUSTER_VERSION
 
 @pytest.mark.unit
 def test_check(aggregator, instance, mock_gstatus_data):
-    # type: (AggregatorStub, Dict[str, Any]) -> None
+    # type: (AggregatorStub, Dict[str, Any], str) -> None
     check = GlusterfsCheck(CHECK, E2E_INIT_CONFIG, [instance])
     check.check(instance)
 
@@ -30,7 +30,6 @@ def test_version_metadata(aggregator, datadog_agent, instance):
     c = GlusterfsCheck(CHECK, E2E_INIT_CONFIG, [instance])
     c.check_id = 'test:123'
     c.check(instance)
-
     major, minor = c.parse_version(GLUSTER_VERSION)
 
     version_metadata = {
@@ -42,3 +41,11 @@ def test_version_metadata(aggregator, datadog_agent, instance):
 
     datadog_agent.assert_metadata('test:123', version_metadata)
     datadog_agent.assert_metadata_count(4)
+
+
+@pytest.mark.unit
+def test_parse_version(instance):
+    c = GlusterfsCheck(CHECK, E2E_INIT_CONFIG, [instance])
+    major, minor = c.parse_version('3.13.2')
+    assert major == 3
+    assert minor == 13

--- a/glusterfs/tests/test_glusterfs.py
+++ b/glusterfs/tests/test_glusterfs.py
@@ -30,7 +30,7 @@ def test_version_metadata(aggregator, datadog_agent, instance):
     c = GlusterfsCheck(CHECK, E2E_INIT_CONFIG, [instance])
     c.check_id = 'test:123'
     c.check(instance)
-    major, minor = c.parse_version(GLUSTER_VERSION)
+    major, minor, patch = c.parse_version(GLUSTER_VERSION)
 
     version_metadata = {
         'version.raw': GLUSTER_VERSION,
@@ -46,6 +46,7 @@ def test_version_metadata(aggregator, datadog_agent, instance):
 @pytest.mark.unit
 def test_parse_version(instance):
     c = GlusterfsCheck(CHECK, E2E_INIT_CONFIG, [instance])
-    major, minor = c.parse_version('3.13.2')
+    major, minor, patch = c.parse_version('3.13.2')
     assert major == 3
     assert minor == 13
+    assert patch == 2

--- a/glusterfs/tests/test_glusterfs.py
+++ b/glusterfs/tests/test_glusterfs.py
@@ -47,6 +47,6 @@ def test_version_metadata(aggregator, datadog_agent, instance):
 def test_parse_version(instance):
     c = GlusterfsCheck(CHECK, E2E_INIT_CONFIG, [instance])
     major, minor, patch = c.parse_version('3.13.2')
-    assert major == 3
-    assert minor == 13
-    assert patch == 2
+    assert major == '3'
+    assert minor == '13'
+    assert patch == '2'

--- a/glusterfs/tox.ini
+++ b/glusterfs/tox.ini
@@ -13,6 +13,8 @@ envdir =
     py27: {toxworkdir}/py27
     py38: {toxworkdir}/py38
 dd_check_style = true
+dd_check_types = true
+dd_mypy_args = --py2 datadog_checks/ tests/ --exclude '.*/config_models/.*\.py$'
 usedevelop = true
 platform = linux|darwin|win32
 deps =


### PR DESCRIPTION
A customer is getting this error
```
glusterfs (1.1.2)
    -----------------
     ...
      Error: cannot unpack non-iterable NoneType object
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 897, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/glusterfs/check.py", line 82, in check
          self.submit_version_metadata(data)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 696, in entrypoint
          method(self, *args, **kwargs)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/glusterfs/check.py", line 111, in submit_version_metadata
          major, minor = self.parse_version(raw_version)
      TypeError: cannot unpack non-iterable NoneType object
```
It seems some times gluster version may have a patch although we're testing against latest and havent seen it on CI