### PR TITLE
Update README.md

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -168,6 +168,9 @@ Metrics are collected with [DogStatsD][13] through UDP port 8125.
 
 To send custom metrics by listening to DogStatsD packets from other containers, set the environment variable `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` to `true` within the Datadog Agent container.
 
+**Note**: There is no provision for a host tag with Fargate, so in order to use a unique identifier for the submission of custom metrics set `DD_DOGSTATSD_TAGS` to inject the task_arn tag to all the dogstatsd metrics or set the agent dogstatsd tagger in orchestrator mode to automatically inject the `taks_arn` tag. This requires using origin detection(via UDS)to set the cardinality in the agent via `DD_DOGSTATSD_TAG_CARDINALITY`, see [DogStatsD over Unix Domain Socket][41]. (please note that implementing this setting can contribute to increased custom metric cardinality) 
+
+
 #### Other environment variables
 
 For environment variables available with the Docker Agent container, see the [Docker Agent][15] page. **Note**: Some variables are not be available for Fargate.
@@ -406,3 +409,5 @@ Need help? Contact [Datadog support][19].
 [38]: https://www.datadoghq.com/blog/aws-fargate-metrics/
 [39]: https://www.datadoghq.com/blog/tools-for-collecting-aws-fargate-metrics/
 [40]: https://www.datadoghq.com/blog/aws-fargate-monitoring-with-datadog/
+[41]: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/?tab=host
+


### PR DESCRIPTION
There are several open issues where this workaround is addressed but had not been made available in our public documentation. This has led some orgs to have vastly unexpected increases in custom metrics billing when migrating their DSD to Fargate - (ZD ticket 464631)

### What does this PR do?
Provides a workaround and emphasizes that a unique identifier may be needed in some custom metrics scenarios since the host has been abstracted in fargate.

### Motivation
Assurance and organization sending large volumes of custom metrics had unexpectedly seen a drop in their custom metrics count when migrating their DSD to Fargate.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
