### PR TITLE
Change check name in Kubernetes instruction from elasticsearch to elastic

### DIFF
--- a/elastic/README.md
+++ b/elastic/README.md
@@ -201,7 +201,7 @@ kind: Pod
 metadata:
   name: elasticsearch
   annotations:
-    ad.datadoghq.com/elasticsearch.check_names: '["elasticsearch"]'
+    ad.datadoghq.com/elasticsearch.check_names: '["elastic"]'
     ad.datadoghq.com/elasticsearch.init_configs: '[{}]'
     ad.datadoghq.com/elasticsearch.instances: |
       [


### PR DESCRIPTION
### What does this PR do?
Change check name in Kubernetes instruction from elasticsearch to elastic
https://docs.datadoghq.com/integrations/elastic/?tab=kubernetes#configuration

### Motivation
It's incorrect. Encountered by customer (ZD Ticket Number 491514)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
