### PR TITLE
Rename cluster_name tag to envoy_cluster

### DIFF
--- a/envoy/assets/configuration/spec.yaml
+++ b/envoy/assets/configuration/spec.yaml
@@ -77,6 +77,14 @@ files:
       value:
         type: boolean
         example: true
+    - name: disable_legacy_cluster_tag
+      description: |
+        Enable to stop submitting the tag `cluster_name` and `virtual_cluster_name`,
+        which has been renamed to `envoy_cluster` and `virtual_envoy_cluster`.
+      value:
+        type: boolean
+        display_default: false
+        example: true
     - template: instances/default
     - template: instances/http
       overrides:

--- a/envoy/assets/configuration/spec.yaml
+++ b/envoy/assets/configuration/spec.yaml
@@ -79,7 +79,7 @@ files:
         example: true
     - name: disable_legacy_cluster_tag
       description: |
-        Enable to stop submitting the tag `cluster_name` and `virtual_cluster_name`,
+        Enable to stop submitting the tags `cluster_name` and `virtual_cluster_name`,
         which has been renamed to `envoy_cluster` and `virtual_envoy_cluster`.
       value:
         type: boolean

--- a/envoy/assets/configuration/spec.yaml
+++ b/envoy/assets/configuration/spec.yaml
@@ -81,6 +81,7 @@ files:
       description: |
         Enable to stop submitting the tags `cluster_name` and `virtual_cluster_name`,
         which has been renamed to `envoy_cluster` and `virtual_envoy_cluster`.
+      enabled: true
       value:
         type: boolean
         display_default: false

--- a/envoy/datadog_checks/envoy/config_models/defaults.py
+++ b/envoy/datadog_checks/envoy/config_models/defaults.py
@@ -52,6 +52,10 @@ def instance_connect_timeout(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_disable_legacy_cluster_tag(field, value):
+    return True
+
+
 def instance_empty_default_hostname(field, value):
     return False
 

--- a/envoy/datadog_checks/envoy/config_models/instance.py
+++ b/envoy/datadog_checks/envoy/config_models/instance.py
@@ -42,6 +42,7 @@ class InstanceConfig(BaseModel):
     cache_metrics: Optional[bool]
     collect_server_info: Optional[bool]
     connect_timeout: Optional[float]
+    disable_legacy_cluster_tag: Optional[bool]
     empty_default_hostname: Optional[bool]
     excluded_metrics: Optional[Sequence[str]]
     extra_headers: Optional[Mapping[str, Any]]

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -120,6 +120,12 @@ instances:
     #
     # collect_server_info: true
 
+    ## @param disable_legacy_cluster_tag - boolean - optional - default: false
+    ## Enable to stop submitting the tag `cluster_name` and `virtual_cluster_name`,
+    ## which has been renamed to `envoy_cluster` and `virtual_envoy_cluster`.
+    #
+    # disable_legacy_cluster_tag: true
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -124,7 +124,7 @@ instances:
     ## Enable to stop submitting the tags `cluster_name` and `virtual_cluster_name`,
     ## which has been renamed to `envoy_cluster` and `virtual_envoy_cluster`.
     #
-    # disable_legacy_cluster_tag: true
+    disable_legacy_cluster_tag: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -121,7 +121,7 @@ instances:
     # collect_server_info: true
 
     ## @param disable_legacy_cluster_tag - boolean - optional - default: false
-    ## Enable to stop submitting the tag `cluster_name` and `virtual_cluster_name`,
+    ## Enable to stop submitting the tags `cluster_name` and `virtual_cluster_name`,
     ## which has been renamed to `envoy_cluster` and `virtual_envoy_cluster`.
     #
     # disable_legacy_cluster_tag: true

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -51,6 +51,7 @@ class Envoy(AgentCheck):
 
         self.caching_metrics = None
         self.parse_unknown_metrics = is_affirmative(self.instance.get('parse_unknown_metrics', False))
+        self.disable_legacy_cluster_tag = is_affirmative(self.instance.get('disable_legacy_cluster_tag', False))
 
     def check(self, _):
         self._collect_metadata()
@@ -88,7 +89,11 @@ class Envoy(AgentCheck):
                 continue
 
             try:
-                metric, tags, method = parse_metric(envoy_metric, retry=self.parse_unknown_metrics)
+                metric, tags, method = parse_metric(
+                    envoy_metric,
+                    retry=self.parse_unknown_metrics,
+                    disable_legacy_cluster_tag=self.disable_legacy_cluster_tag,
+                )
             except UnknownMetric:
                 if envoy_metric not in self.unknown_metrics:
                     self.log.debug('Unknown metric `%s`', envoy_metric)

--- a/envoy/datadog_checks/envoy/metrics.py
+++ b/envoy/datadog_checks/envoy/metrics.py
@@ -337,7 +337,7 @@ METRICS = {
     'vhost.vcluster.upstream_rq_1xx': {
         'tags': (
             ('virtual_host_name', ),
-            ('virtual_cluster_name', ),
+            ('virtual_envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -345,7 +345,7 @@ METRICS = {
     'vhost.vcluster.upstream_rq_2xx': {
         'tags': (
             ('virtual_host_name', ),
-            ('virtual_cluster_name', ),
+            ('virtual_envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -353,7 +353,7 @@ METRICS = {
     'vhost.vcluster.upstream_rq_3xx': {
         'tags': (
             ('virtual_host_name', ),
-            ('virtual_cluster_name', ),
+            ('virtual_envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -361,7 +361,7 @@ METRICS = {
     'vhost.vcluster.upstream_rq_4xx': {
         'tags': (
             ('virtual_host_name', ),
-            ('virtual_cluster_name', ),
+            ('virtual_envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -369,7 +369,7 @@ METRICS = {
     'vhost.vcluster.upstream_rq_5xx': {
         'tags': (
             ('virtual_host_name', ),
-            ('virtual_cluster_name', ),
+            ('virtual_envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -377,7 +377,7 @@ METRICS = {
     'vhost.vcluster.upstream_rq_retry': {
         'tags': (
             ('virtual_host_name', ),
-            ('virtual_cluster_name', ),
+            ('virtual_envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -385,7 +385,7 @@ METRICS = {
     'vhost.vcluster.upstream_rq_retry_limit_exceeded': {
         'tags': (
             ('virtual_host_name', ),
-            ('virtual_cluster_name', ),
+            ('virtual_envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -393,7 +393,7 @@ METRICS = {
     'vhost.vcluster.upstream_rq_retry_overflow': {
         'tags': (
             ('virtual_host_name', ),
-            ('virtual_cluster_name', ),
+            ('virtual_envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -401,7 +401,7 @@ METRICS = {
     'vhost.vcluster.upstream_rq_retry_success': {
         'tags': (
             ('virtual_host_name', ),
-            ('virtual_cluster_name', ),
+            ('virtual_envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -409,7 +409,7 @@ METRICS = {
     'vhost.vcluster.upstream_rq_time': {
         'tags': (
             ('virtual_host_name', ),
-            ('virtual_cluster_name', ),
+            ('virtual_envoy_cluster', ),
             (),
         ),
         'method': 'histogram',
@@ -417,7 +417,7 @@ METRICS = {
     'vhost.vcluster.upstream_rq_timeout': {
         'tags': (
             ('virtual_host_name', ),
-            ('virtual_cluster_name', ),
+            ('virtual_envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -425,14 +425,14 @@ METRICS = {
     'vhost.vcluster.upstream_rq_total': {
         'tags': (
             ('virtual_host_name', ),
-            ('virtual_cluster_name', ),
+            ('virtual_envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.ratelimit.ok': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -440,7 +440,7 @@ METRICS = {
     },
     'cluster.ratelimit.error': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -448,7 +448,7 @@ METRICS = {
     },
     'cluster.ratelimit.over_limit': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -480,7 +480,7 @@ METRICS = {
     },
     'cluster.grpc.success': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('grpc_service', 'grpc_method', ),
             (),
         ),
@@ -488,7 +488,7 @@ METRICS = {
     },
     'cluster.grpc.failure': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('grpc_service', 'grpc_method', ),
             (),
         ),
@@ -496,7 +496,7 @@ METRICS = {
     },
     'cluster.grpc.total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('grpc_service', 'grpc_method', ),
             (),
         ),
@@ -2023,308 +2023,308 @@ METRICS = {
     },
     'cluster.assignment_stale': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.assignment_timeout_received': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_active': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'gauge',
     },
     'cluster.upstream_cx_http1_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_http2_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_connect_fail': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_connect_timeout': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_connect_attempts_exceeded': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_overflow': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_connect_ms': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'histogram',
     },
     'cluster.upstream_cx_length_ms': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'histogram',
     },
     'cluster.upstream_cx_destroy': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_destroy_local': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_destroy_remote': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_destroy_with_active_rq': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_destroy_local_with_active_rq': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_destroy_remote_with_active_rq': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_close_notify': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_rx_bytes_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_rx_bytes_buffered': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'gauge',
     },
     'cluster.upstream_cx_tx_bytes_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_tx_bytes_buffered': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'gauge',
     },
     'cluster.upstream_cx_protocol_error': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_max_requests': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_none_healthy': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_cx_idle_timeout': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count'
     },
     'cluster.upstream_cx_pool_overflow': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count'
     },
     'cluster.upstream_rq_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_active': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'gauge',
     },
     'cluster.upstream_rq_pending_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_pending_overflow': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_pending_failure_eject': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_pending_active': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'gauge',
     },
     'cluster.upstream_rq_cancelled': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_maintenance_mode': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_timeout': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_per_try_timeout': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_rx_reset': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_tx_reset': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_retry': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_retry_success': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_retry_overflow': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.client_ssl_socket_factory.ssl_context_update_by_sds': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2332,7 +2332,7 @@ METRICS = {
     },
     'cluster.client_ssl_socket_factory.upstream_context_secrets_not_ready': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2340,7 +2340,7 @@ METRICS = {
     },
     'cluster.ssl.connection_error': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2348,7 +2348,7 @@ METRICS = {
     },
     'cluster.ssl.handshake': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2356,7 +2356,7 @@ METRICS = {
     },
     'cluster.ssl.session_reused': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2364,7 +2364,7 @@ METRICS = {
     },
     'cluster.ssl.no_certificate': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2372,7 +2372,7 @@ METRICS = {
     },
     'cluster.ssl.fail_no_sni_match': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2380,7 +2380,7 @@ METRICS = {
     },
     'cluster.ssl.fail_verify_no_cert': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2388,7 +2388,7 @@ METRICS = {
     },
     'cluster.ssl.fail_verify_error': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2396,7 +2396,7 @@ METRICS = {
     },
     'cluster.ssl.fail_verify_san': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2404,7 +2404,7 @@ METRICS = {
     },
     'cluster.ssl.fail_verify_cert_hash': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2412,7 +2412,7 @@ METRICS = {
     },
     'cluster.ssl.ciphers': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             ('cipher', ),
         ),
@@ -2420,7 +2420,7 @@ METRICS = {
     },
     'cluster.ssl.curves': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             ('curve', ),
         ),
@@ -2428,7 +2428,7 @@ METRICS = {
     },
     'cluster.ssl.sigalgs': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             ('sigalg', ),
         ),
@@ -2436,7 +2436,7 @@ METRICS = {
     },
     'cluster.ssl.versions': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             ('version', ),
         ),
@@ -2444,161 +2444,161 @@ METRICS = {
     },
     'cluster.upstream_flow_control_paused_reading_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_flow_control_resumed_reading_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_flow_control_backed_up_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_flow_control_drained_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_internal_redirect_failed_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count'
     },
     'cluster.upstream_internal_redirect_succeeded_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count'
     },
     'cluster.membership_change': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.membership_degraded': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'gauge',
     },
     'cluster.membership_excluded': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'gauge',
     },
     'cluster.membership_healthy': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'gauge',
     },
     'cluster.membership_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'gauge',
     },
     'cluster.retry_or_shadow_abandoned': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.config_reload': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.update_attempt': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.update_success': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.update_failure': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.update_empty': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.update_no_rebuild': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.version': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'gauge',
     },
     'cluster.max_host_weight': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'gauge',
     },
     'cluster.bind_errors': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.original_dst_host_invalid': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.health_check.attempt': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2606,7 +2606,7 @@ METRICS = {
     },
     'cluster.health_check.success': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2614,7 +2614,7 @@ METRICS = {
     },
     'cluster.health_check.failure': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2622,7 +2622,7 @@ METRICS = {
     },
     'cluster.health_check.passive_failure': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2630,7 +2630,7 @@ METRICS = {
     },
     'cluster.health_check.network_failure': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2638,7 +2638,7 @@ METRICS = {
     },
     'cluster.health_check.verify_cluster': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2646,7 +2646,7 @@ METRICS = {
     },
     'cluster.health_check.healthy': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2654,7 +2654,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_enforced_total': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2662,7 +2662,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_active': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2670,7 +2670,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_overflow': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2678,7 +2678,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_enforced_consecutive_5xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2686,7 +2686,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_detected_consecutive_5xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2694,7 +2694,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_enforced_success_rate': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2702,7 +2702,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_detected_success_rate': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2710,7 +2710,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_enforced_consecutive_gateway_failure': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2718,7 +2718,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_detected_consecutive_gateway_failure': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2726,7 +2726,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_enforced_consecutive_local_origin_failure': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2734,7 +2734,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_detected_consecutive_local_origin_failure': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2742,7 +2742,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_enforced_local_origin_success_rate': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2750,7 +2750,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_detected_local_origin_success_rate': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2758,7 +2758,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_enforced_failure_percentage': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2766,7 +2766,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_detected_failure_percentage': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2774,7 +2774,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_enforced_failure_percentage_local_origin': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2782,7 +2782,7 @@ METRICS = {
     },
     'cluster.outlier_detection.ejections_detected_failure_percentage_local_origin': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2790,7 +2790,7 @@ METRICS = {
     },
     'cluster.circuit_breakers.cx_open': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('priority', ),
             (),
         ),
@@ -2798,7 +2798,7 @@ METRICS = {
     },
     'cluster.circuit_breakers.cx_pool_open': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('priority', ),
             (),
         ),
@@ -2806,7 +2806,7 @@ METRICS = {
     },
     'cluster.circuit_breakers.rq_open': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('priority', ),
             (),
         ),
@@ -2814,7 +2814,7 @@ METRICS = {
     },
     'cluster.circuit_breakers.rq_pending_open': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('priority', ),
             (),
         ),
@@ -2822,7 +2822,7 @@ METRICS = {
     },
     'cluster.circuit_breakers.rq_retry_open': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('priority', ),
             (),
         ),
@@ -2830,7 +2830,7 @@ METRICS = {
     },
     'cluster.circuit_breakers.remaining_cx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('priority', ),
             (),
         ),
@@ -2838,7 +2838,7 @@ METRICS = {
     },
     'cluster.circuit_breakers.remaining_pending': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('priority', ),
             (),
         ),
@@ -2846,7 +2846,7 @@ METRICS = {
     },
     'cluster.circuit_breakers.remaining_rq': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('priority', ),
             (),
         ),
@@ -2854,7 +2854,7 @@ METRICS = {
     },
     'cluster.circuit_breakers.remaining_retries': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('priority', ),
             (),
         ),
@@ -2862,56 +2862,56 @@ METRICS = {
     },
     'cluster.upstream_rq_completed': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_1xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_2xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_3xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_4xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_5xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.upstream_rq_time': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'histogram',
     },
     'cluster.canary.upstream_rq_completed': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2919,7 +2919,7 @@ METRICS = {
     },
     'cluster.canary.upstream_rq_1xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2927,7 +2927,7 @@ METRICS = {
     },
     'cluster.canary.upstream_rq_2xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2935,7 +2935,7 @@ METRICS = {
     },
     'cluster.canary.upstream_rq_3xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2943,7 +2943,7 @@ METRICS = {
     },
     'cluster.canary.upstream_rq_4xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2951,7 +2951,7 @@ METRICS = {
     },
     'cluster.canary.upstream_rq_5xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2959,7 +2959,7 @@ METRICS = {
     },
     'cluster.canary.upstream_rq_time': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2967,7 +2967,7 @@ METRICS = {
     },
     'cluster.internal.upstream_rq_completed': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2975,7 +2975,7 @@ METRICS = {
     },
     'cluster.internal.upstream_rq_1xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2983,7 +2983,7 @@ METRICS = {
     },
     'cluster.internal.upstream_rq_2xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2991,7 +2991,7 @@ METRICS = {
     },
     'cluster.internal.upstream_rq_3xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -2999,7 +2999,7 @@ METRICS = {
     },
     'cluster.internal.upstream_rq_4xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3007,7 +3007,7 @@ METRICS = {
     },
     'cluster.internal.upstream_rq_5xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3015,7 +3015,7 @@ METRICS = {
     },
     'cluster.internal.upstream_rq_time': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3023,7 +3023,7 @@ METRICS = {
     },
     'cluster.external.upstream_rq_completed': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3031,7 +3031,7 @@ METRICS = {
     },
     'cluster.external.upstream_rq_1xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3039,7 +3039,7 @@ METRICS = {
     },
     'cluster.external.upstream_rq_2xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3047,7 +3047,7 @@ METRICS = {
     },
     'cluster.external.upstream_rq_3xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3055,7 +3055,7 @@ METRICS = {
     },
     'cluster.external.upstream_rq_4xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3063,7 +3063,7 @@ METRICS = {
     },
     'cluster.external.upstream_rq_5xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3071,7 +3071,7 @@ METRICS = {
     },
     'cluster.external.upstream_rq_time': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3079,7 +3079,7 @@ METRICS = {
     },
     'cluster.zone.upstream_rq_1xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('from_zone', 'to_zone', ),
             (),
         ),
@@ -3087,7 +3087,7 @@ METRICS = {
     },
     'cluster.zone.upstream_rq_2xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('from_zone', 'to_zone', ),
             (),
         ),
@@ -3095,7 +3095,7 @@ METRICS = {
     },
     'cluster.zone.upstream_rq_3xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('from_zone', 'to_zone', ),
             (),
         ),
@@ -3103,7 +3103,7 @@ METRICS = {
     },
     'cluster.zone.upstream_rq_4xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('from_zone', 'to_zone', ),
             (),
         ),
@@ -3111,7 +3111,7 @@ METRICS = {
     },
     'cluster.zone.upstream_rq_5xx': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('from_zone', 'to_zone', ),
             (),
         ),
@@ -3119,7 +3119,7 @@ METRICS = {
     },
     'cluster.zone.upstream_rq_time': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             ('from_zone', 'to_zone', ),
             (),
         ),
@@ -3127,112 +3127,112 @@ METRICS = {
     },
     'cluster.lb_recalculate_zone_structures': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.lb_healthy_panic': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.lb_zone_cluster_too_small': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.lb_zone_routing_all_directly': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.lb_zone_routing_sampled': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.lb_zone_routing_cross_zone': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.lb_local_cluster_not_ok': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.lb_zone_number_differs': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.lb_zone_no_capacity_left': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.lb_subsets_active': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'gauge',
     },
     'cluster.lb_subsets_created': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.lb_subsets_removed': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.lb_subsets_selected': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.lb_subsets_fallback': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.lb_subsets_fallback_panic': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
         ),
         'method': 'monotonic_count',
     },
     'cluster.http1.dropped_headers_with_underscores': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3240,7 +3240,7 @@ METRICS = {
     },
     'cluster.http1.metadata_not_supported_error': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3248,7 +3248,7 @@ METRICS = {
     },
     'cluster.http1.response_flood': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3256,7 +3256,7 @@ METRICS = {
     },
     'cluster.http1.requests_rejected_with_underscores_in_headers': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3264,7 +3264,7 @@ METRICS = {
     },
     'cluster.http2.header_overflow': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3272,7 +3272,7 @@ METRICS = {
     },
     'cluster.http2.headers_cb_no_stream': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3280,7 +3280,7 @@ METRICS = {
     },
     'cluster.http2.inbound_empty_frames_flood': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3288,7 +3288,7 @@ METRICS = {
     },
     'cluster.http2.inbound_priority_frames_flood': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3296,7 +3296,7 @@ METRICS = {
     },
     'cluster.http2.inbound_window_update_frames_flood': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3304,7 +3304,7 @@ METRICS = {
     },
     'cluster.http2.outbound_control_flood': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3312,7 +3312,7 @@ METRICS = {
     },
     'cluster.http2.outbound_flood': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3320,7 +3320,7 @@ METRICS = {
     },
     'cluster.http2.rx_messaging_error': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3328,7 +3328,7 @@ METRICS = {
     },
     'cluster.http2.rx_reset': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3336,7 +3336,7 @@ METRICS = {
     },
     'cluster.http2.too_many_header_frames': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3344,7 +3344,7 @@ METRICS = {
     },
     'cluster.http2.trailers': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),
@@ -3352,7 +3352,7 @@ METRICS = {
     },
     'cluster.http2.tx_reset': {
         'tags': (
-            ('cluster_name', ),
+            ('envoy_cluster', ),
             (),
             (),
         ),

--- a/envoy/tests/test_parser.py
+++ b/envoy/tests/test_parser.py
@@ -35,7 +35,7 @@ def test_retry_metric():
     tags = [tag for tags in METRICS[untagged_metric]['tags'] for tag in tags]
     tag0 = 'service-foo.default.eu-west-3-prd.internal.a4d363d6-a669-b02c-a274-52c1df12bd41.consul'
     tagged_metric = metric.format('.{}'.format(tag0))
-    assert parse_metric(tagged_metric, retry=True) == (
+    assert parse_metric(tagged_metric, retry=True, disable_legacy_cluster_tag=True) == (
         METRIC_PREFIX + untagged_metric,
         ['{}:{}'.format(tags[0], tag0)],
         METRICS[untagged_metric]['method'],
@@ -73,9 +73,16 @@ def test_http_router_filter_vhost():
     tag1 = 'some_vcluster_name'
     tagged_metric = metric.format('.{}'.format(tag0), '.{}'.format(tag1))
 
-    assert parse_metric(tagged_metric) == (
+    assert parse_metric(tagged_metric, disable_legacy_cluster_tag=True) == (
         METRIC_PREFIX + untagged_metric,
         ['{}:{}'.format(tags[0], tag0), '{}:{}'.format(tags[1], tag1)],
+        METRICS[untagged_metric]['method'],
+    )
+
+    # Legacy tag
+    assert parse_metric(tagged_metric) == (
+        METRIC_PREFIX + untagged_metric,
+        ['{}:{}'.format(tags[0], tag0), '{}:{}'.format(tags[1], tag1), 'virtual_cluster_name:{}'.format(tag1)],
         METRICS[untagged_metric]['method'],
     )
 
@@ -87,7 +94,7 @@ def test_http_rate_limit():
     tag0 = 'some_route_target_cluster'
     tagged_metric = metric.format('.{}'.format(tag0))
 
-    assert parse_metric(tagged_metric) == (
+    assert parse_metric(tagged_metric, disable_legacy_cluster_tag=True) == (
         METRIC_PREFIX + untagged_metric,
         ['{}:{}'.format(tags[0], tag0)],
         METRICS[untagged_metric]['method'],
@@ -118,7 +125,7 @@ def test_grpc():
     tag2 = 'some_grpc_method'
     tagged_metric = metric.format('.{}'.format(tag0), '.{}'.format(tag1), '.{}'.format(tag2))
 
-    assert parse_metric(tagged_metric) == (
+    assert parse_metric(tagged_metric, disable_legacy_cluster_tag=True) == (
         METRIC_PREFIX + untagged_metric,
         ['{}:{}'.format(tags[0], tag0), '{}:{}'.format(tags[1], tag1), '{}:{}'.format(tags[2], tag2)],
         METRICS[untagged_metric]['method'],
@@ -461,9 +468,16 @@ def test_cluster():
     tag0 = 'some_name'
     tagged_metric = metric.format('.{}'.format(tag0))
 
-    assert parse_metric(tagged_metric) == (
+    assert parse_metric(tagged_metric, disable_legacy_cluster_tag=True) == (
         METRIC_PREFIX + untagged_metric,
         ['{}:{}'.format(tags[0], tag0)],
+        METRICS[untagged_metric]['method'],
+    )
+
+    # Legacy tag
+    assert parse_metric(tagged_metric) == (
+        METRIC_PREFIX + untagged_metric,
+        ['{}:{}'.format(tags[0], tag0), 'cluster_name:{}'.format(tag0)],
         METRICS[untagged_metric]['method'],
     )
 
@@ -475,7 +489,7 @@ def test_cluster_health_check():
     tag0 = 'some_name'
     tagged_metric = metric.format('.{}'.format(tag0))
 
-    assert parse_metric(tagged_metric) == (
+    assert parse_metric(tagged_metric, disable_legacy_cluster_tag=True) == (
         METRIC_PREFIX + untagged_metric,
         ['{}:{}'.format(tags[0], tag0)],
         METRICS[untagged_metric]['method'],
@@ -489,7 +503,7 @@ def test_cluster_outlier_detection():
     tag0 = 'some_name'
     tagged_metric = metric.format('.{}'.format(tag0))
 
-    assert parse_metric(tagged_metric) == (
+    assert parse_metric(tagged_metric, disable_legacy_cluster_tag=True) == (
         METRIC_PREFIX + untagged_metric,
         ['{}:{}'.format(tags[0], tag0)],
         METRICS[untagged_metric]['method'],
@@ -503,7 +517,7 @@ def test_cluster_dynamic_http():
     tag0 = 'some_name'
     tagged_metric = metric.format('.{}'.format(tag0))
 
-    assert parse_metric(tagged_metric) == (
+    assert parse_metric(tagged_metric, disable_legacy_cluster_tag=True) == (
         METRIC_PREFIX + untagged_metric,
         ['{}:{}'.format(tags[0], tag0)],
         METRICS[untagged_metric]['method'],
@@ -519,7 +533,7 @@ def test_cluster_dynamic_http_zones():
     tag2 = 'some_to_zone'
     tagged_metric = metric.format('.{}'.format(tag0), '.{}'.format(tag1), '.{}'.format(tag2))
 
-    assert parse_metric(tagged_metric) == (
+    assert parse_metric(tagged_metric, disable_legacy_cluster_tag=True) == (
         METRIC_PREFIX + untagged_metric,
         ['{}:{}'.format(tags[0], tag0), '{}:{}'.format(tags[1], tag1), '{}:{}'.format(tags[2], tag2)],
         METRICS[untagged_metric]['method'],
@@ -533,7 +547,7 @@ def test_cluster_load_balancer():
     tag0 = 'some_name'
     tagged_metric = metric.format('.{}'.format(tag0))
 
-    assert parse_metric(tagged_metric) == (
+    assert parse_metric(tagged_metric, disable_legacy_cluster_tag=True) == (
         METRIC_PREFIX + untagged_metric,
         ['{}:{}'.format(tags[0], tag0)],
         METRICS[untagged_metric]['method'],
@@ -547,7 +561,7 @@ def test_cluster_load_balancer_subsets():
     tag0 = 'some_name'
     tagged_metric = metric.format('.{}'.format(tag0))
 
-    assert parse_metric(tagged_metric) == (
+    assert parse_metric(tagged_metric, disable_legacy_cluster_tag=True) == (
         METRIC_PREFIX + untagged_metric,
         ['{}:{}'.format(tags[0], tag0)],
         METRICS[untagged_metric]['method'],
@@ -561,7 +575,7 @@ def test_tag_with_dots():
     tag0 = 'out.alerting-event-evaluator-test.datadog.svc.cluster.local|iperf'
     tagged_metric = metric.format('.{}'.format(tag0))
 
-    assert parse_metric(tagged_metric) == (
+    assert parse_metric(tagged_metric, disable_legacy_cluster_tag=True) == (
         METRIC_PREFIX + untagged_metric,
         ['{}:{}'.format(tags[0], tag0)],
         METRICS[untagged_metric]['method'],


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Rename tags:
* `cluster_name` -> `envoy_cluster`
* `virtual_cluster_name` -> `virtual_envoy_cluster`

with a configuration option for backward compatibility.

Same name as in spark config https://github.com/DataDog/integrations-core/blob/51a570ae9f8824f1e53911e7bc01bf84a2f00094/spark/datadog_checks/spark/data/conf.yaml.example#L138

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
