### PR TITLE
Allow strings in relations

### DIFF
--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -175,7 +175,7 @@ class RelationsManager(object):
 
     @staticmethod
     def validate_relations_config(yamlconfig):
-        # type: (Dict) -> None
+        # type: (List[Union[str, Dict]]) -> None
         for element in yamlconfig:
             if isinstance(element, dict):
                 if not (RELATION_NAME in element or RELATION_REGEX in element):
@@ -196,7 +196,7 @@ class RelationsManager(object):
                     raise ConfigurationError("Expected '%s' to be a list for %s", SCHEMAS, element)
                 if not isinstance(element.get(RELKIND, []), list):
                     raise ConfigurationError("Expected '%s' to be a list for %s", RELKIND, element)
-            else:
+            elif not isinstance(element, str):
                 raise ConfigurationError('Unhandled relations config type: %s', element)
 
     @staticmethod

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -4,6 +4,9 @@
 import psycopg2
 import pytest
 
+from datadog_checks.base import ConfigurationError
+from datadog_checks.postgres.relationsmanager import RelationsManager
+
 from .common import DB_NAME, HOST, PORT
 
 RELATION_METRICS = [
@@ -36,9 +39,8 @@ RELATION_INDEX_METRICS = [
 IDX_METRICS = ['postgresql.index_scans', 'postgresql.index_rows_read', 'postgresql.index_rows_fetched']
 
 
-pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
-
-
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 def test_relations_metrics(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = ['persons']
 
@@ -72,6 +74,8 @@ def test_relations_metrics(aggregator, integration_check, pg_instance):
         aggregator.assert_metric(name, count=1, tags=expected_size_tags)
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 def test_relations_metrics_regex(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = [
         {'relation_regex': '.*', 'schemas': ['hello', 'hello2']},
@@ -104,6 +108,8 @@ def test_relations_metrics_regex(aggregator, integration_check, pg_instance):
             aggregator.assert_metric(name, count=1, tags=expected_tags[relation])
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 def test_max_relations(aggregator, integration_check, pg_instance):
     pg_instance.update({'relations': [{'relation_regex': '.*'}], 'max_relations': 1})
     posgres_check = integration_check(pg_instance)
@@ -124,6 +130,8 @@ def test_max_relations(aggregator, integration_check, pg_instance):
         assert len(relation_metrics) == 1
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 def test_index_metrics(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = ['breed']
     pg_instance['dbname'] = 'dogs'
@@ -144,6 +152,8 @@ def test_index_metrics(aggregator, integration_check, pg_instance):
         aggregator.assert_metric(name, count=1, tags=expected_tags)
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 def test_locks_metrics(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = ['persons']
     pg_instance['query_timeout'] = 1000  # One of the relation queries waits for the table to not be locked
@@ -164,6 +174,8 @@ def test_locks_metrics(aggregator, integration_check, pg_instance):
     aggregator.assert_metric('postgresql.locks', count=1, tags=expected_tags)
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 def test_locks_relkind_match(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = [{'relation_regex': 'perso.*', 'relkind': ['r']}]
     pg_instance['query_timeout'] = 1000  # One of the relation queries waits for the table to not be locked
@@ -174,6 +186,8 @@ def test_locks_relkind_match(aggregator, integration_check, pg_instance):
     aggregator.assert_metric('postgresql.locks', count=1)
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 def test_locks_metrics_no_relkind_match(aggregator, integration_check, pg_instance):
     pg_instance['relations'] = [{'relation_regex': 'perso.*', 'relkind': ['i']}]
     pg_instance['query_timeout'] = 1000  # One of the relation queries waits for the table to not be locked
@@ -183,8 +197,41 @@ def test_locks_metrics_no_relkind_match(aggregator, integration_check, pg_instan
     aggregator.assert_metric('postgresql.locks', count=0)
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 def check_with_lock(check, instance):
     with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres", password="datad0g") as conn:
         with conn.cursor() as cur:
             cur.execute('LOCK persons')
             check.check(instance)
+
+
+@pytest.mark.unit
+def test_relations_validation_accepts_list_of_str_and_dict():
+    RelationsManager.validate_relations_config(
+        [
+            'alert_cycle_keys_aggregate',
+            'api_keys',
+            {'relation_regex': 'perso.*', 'relkind': ['i']},
+            {'relation_name': 'person', 'relkind': ['i']},
+            {'relation_name': 'person', 'schemas': ['foo']},
+        ]
+    )
+
+
+@pytest.mark.unit
+def test_relations_validation_fails_if_no_relname_or_regex():
+    with pytest.raises(ConfigurationError):
+        RelationsManager.validate_relations_config([{'relkind': ['i']}])
+
+
+@pytest.mark.unit
+def test_relations_validation_fails_if_schemas_is_wrong_type():
+    with pytest.raises(ConfigurationError):
+        RelationsManager.validate_relations_config([{'relation_name': 'person', 'schemas': 'foo'}])
+
+
+@pytest.mark.unit
+def test_relations_validation_fails_if_relkind_is_wrong_type():
+    with pytest.raises(ConfigurationError):
+        RelationsManager.validate_relations_config([{'relation_name': 'person', 'relkind': 'foo'}])


### PR DESCRIPTION
Fixes bug introduced in https://github.com/DataDog/integrations-core/pull/9322 where strings would not be allowed in relations