### PR TITLE
Do not use check inheritance

### DIFF
--- a/tls/datadog_checks/tls/tls.py
+++ b/tls/datadog_checks/tls/tls.py
@@ -1,13 +1,11 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import abc
 import socket
 import ssl
 from datetime import datetime
 
 import service_identity
-import six
 from six import text_type
 from six.moves.urllib.parse import urlparse
 
@@ -26,7 +24,6 @@ from .utils import days_to_seconds, get_protocol_versions, is_ip_address, second
 PROTOCOL_TLS_CLIENT = getattr(ssl, 'PROTOCOL_TLS_CLIENT', ssl.PROTOCOL_TLS)
 
 
-@six.add_metaclass(abc.ABCMeta)
 class TLSCheck(AgentCheck):
     # This remapper is used to support legacy TLS integration config values
     TLS_CONFIG_REMAPPER = {
@@ -36,19 +33,6 @@ class TLSCheck(AgentCheck):
         'validate_hostname': {'name': 'tls_validate_hostname'},
         'validate_cert': {'name': 'tls_verify'},
     }
-
-    def __new__(cls, name, init_config, instances):
-        local_cert_path = instances[0].get('local_cert_path', '')
-
-        # Decide the method of collection for this instance (local file vs remote connection)
-        if local_cert_path:
-            from .tls_local import TLSLocalCheck
-
-            return super(TLSCheck, TLSLocalCheck).__new__(TLSLocalCheck)
-        else:
-            from .tls_remote import TLSRemoteCheck
-
-            return super(TLSCheck, TLSRemoteCheck).__new__(TLSRemoteCheck)
 
     def __init__(self, name, init_config, instances):
         super(TLSCheck, self).__init__(name, init_config, instances)
@@ -121,6 +105,21 @@ class TLSCheck(AgentCheck):
 
         # Only load intermediate certs once
         self._intermediate_cert_id_cache = set()
+
+        local_cert_path = instances[0].get('local_cert_path', '')
+
+        # Decide the method of collection for this instance (local file vs remote connection)
+        if local_cert_path:
+            from .tls_local import TLSLocalCheck
+
+            self.checker = TLSLocalCheck(self)
+        else:
+            from .tls_remote import TLSRemoteCheck
+
+            self.checker = TLSRemoteCheck(self)
+
+    def check(self, _):
+        self.checker.check()
 
     def check_protocol_version(self, version):
         if version is None:

--- a/tls/datadog_checks/tls/tls_local.py
+++ b/tls/datadog_checks/tls/tls_local.py
@@ -5,29 +5,29 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import load_der_x509_certificate, load_pem_x509_certificate
 
 from datadog_checks.base import ConfigurationError
+from datadog_checks.base.log import get_check_logger
 from datadog_checks.tls.const import SERVICE_CHECK_VALIDATION
 
-from . import TLSCheck
 
-
-class TLSLocalCheck(TLSCheck):
-    def __init__(self, name, init_config, instances):
-        super(TLSLocalCheck, self).__init__(name, init_config, instances)
+class TLSLocalCheck(object):
+    def __init__(self, agent_check):
+        self.agent_check = agent_check
+        self.log = get_check_logger()
         self.log.debug('Selecting local connection for method of collection')
-        if self._tls_validate_hostname and self._server_hostname:
-            self._tags.append('server_hostname:{}'.format(self._server_hostname))
+        if self.agent_check._tls_validate_hostname and self.agent_check._server_hostname:
+            self.agent_check._tags.append('server_hostname:{}'.format(self.agent_check._server_hostname))
 
     def _get_local_cert(self):
         try:
-            with open(self._local_cert_path, 'rb') as f:
+            with open(self.agent_check._local_cert_path, 'rb') as f:
                 self.log.debug('Reading from local cert path')
                 cert = f.read()
         except Exception as e:
             self.log.debug('Error occurred while reading from local cert path: %s', str(e))
-            self.service_check(
+            self.agent_check.service_check(
                 SERVICE_CHECK_VALIDATION,
-                self.CRITICAL,
-                tags=self._tags,
+                self.agent_check.CRITICAL,
+                tags=self.agent_check._tags,
                 message='Unable to open the certificate: {}'.format(e),
             )
             return None
@@ -39,24 +39,24 @@ class TLSLocalCheck(TLSCheck):
         except Exception as e:
             message = 'Unable to parse the certificate: {}'.format(e)
             self.log.debug(message)
-            self.service_check(
+            self.agent_check.service_check(
                 SERVICE_CHECK_VALIDATION,
-                self.CRITICAL,
-                tags=self._tags,
+                self.agent_check.CRITICAL,
+                tags=self.agent_check._tags,
                 message='Unable to parse the certificate: {}'.format(e),
             )
             return None
         return cert
 
     def check(self, _):
-        if self._tls_validate_hostname and not self._server_hostname:
+        if self.agent_check._tls_validate_hostname and not self.agent_check._server_hostname:
             raise ConfigurationError(
                 'You must specify `server_hostname` in your configuration file, or disable `tls_validate_hostname`.'
             )
 
         cert = self._get_local_cert()
-        self.validate_certificate(cert)
-        self.check_age(cert)
+        self.agent_check.validate_certificate(cert)
+        self.agent_check.check_age(cert)
 
     @staticmethod
     def local_cert_loader(cert):

--- a/tls/datadog_checks/tls/tls_local.py
+++ b/tls/datadog_checks/tls/tls_local.py
@@ -48,7 +48,7 @@ class TLSLocalCheck(object):
             return None
         return cert
 
-    def check(self, _):
+    def check(self):
         if self.agent_check._tls_validate_hostname and not self.agent_check._server_hostname:
             raise ConfigurationError(
                 'You must specify `server_hostname` in your configuration file, or disable `tls_validate_hostname`.'

--- a/tls/datadog_checks/tls/tls_remote.py
+++ b/tls/datadog_checks/tls/tls_remote.py
@@ -37,7 +37,7 @@ class TLSRemoteCheck(object):
             * 60
         )
 
-    def check(self, _):
+    def check(self):
         if not self.agent_check._server:
             raise ConfigurationError('You must specify `server` in your configuration file.')
 

--- a/tls/datadog_checks/tls/tls_remote.py
+++ b/tls/datadog_checks/tls/tls_remote.py
@@ -10,32 +10,35 @@ from cryptography.x509.extensions import ExtensionNotFound
 from cryptography.x509.oid import AuthorityInformationAccessOID, ExtensionOID
 
 from datadog_checks.base import ConfigurationError, is_affirmative
+from datadog_checks.base.log import get_check_logger
 from datadog_checks.base.utils.time import get_timestamp
 
-from . import TLSCheck
 from .const import SERVICE_CHECK_CAN_CONNECT, SERVICE_CHECK_EXPIRATION, SERVICE_CHECK_VALIDATION
 from .utils import closing
 
 
-class TLSRemoteCheck(TLSCheck):
-    def __init__(self, name, init_config, instances):
-        super(TLSRemoteCheck, self).__init__(name, init_config, instances)
+class TLSRemoteCheck(object):
+    def __init__(self, agent_check):
+        self.agent_check = agent_check
+        self.log = get_check_logger()
         self.log.debug('Selecting remote connection for method of collection')
-        self._tags.append('server_hostname:{}'.format(self._server_hostname))
-        self._tags.append('server:{}'.format(self._server))
-        self._tags.append('port:{}'.format(self._port))
+        self.agent_check._tags.append('server_hostname:{}'.format(self.agent_check._server_hostname))
+        self.agent_check._tags.append('server:{}'.format(self.agent_check._server))
+        self.agent_check._tags.append('port:{}'.format(self.agent_check._port))
 
         self._fetch_intermediate_certs = is_affirmative(
-            self.instance.get('fetch_intermediate_certs', self.init_config.get('fetch_intermediate_certs', False))
+            self.agent_check.instance.get(
+                'fetch_intermediate_certs', self.agent_check.init_config.get('fetch_intermediate_certs', False)
+            )
         )
         self._intermediate_cert_refresh_interval = (
             # Convert minutes to seconds
-            float(self.instance.get('intermediate_cert_refresh_interval', 60))
+            float(self.agent_check.instance.get('intermediate_cert_refresh_interval', 60))
             * 60
         )
 
     def check(self, _):
-        if not self._server:
+        if not self.agent_check._server:
             raise ConfigurationError('You must specify `server` in your configuration file.')
 
         if self._fetch_intermediate_certs:
@@ -44,9 +47,9 @@ class TLSRemoteCheck(TLSCheck):
         sock = self._get_connection()
         cert, protocol_version = self._get_cert_and_protocol_version(sock)
 
-        self.check_protocol_version(protocol_version)
-        self.validate_certificate(cert)
-        self.check_age(cert)
+        self.agent_check.check_protocol_version(protocol_version)
+        self.agent_check.validate_certificate(cert)
+        self.agent_check.check_age(cert)
 
     def _get_cert_and_protocol_version(self, sock):
         if sock is None:
@@ -57,7 +60,9 @@ class TLSRemoteCheck(TLSCheck):
             self.log.debug('Getting cert and TLS protocol version')
             try:
                 with closing(
-                    self.get_tls_context().wrap_socket(sock, server_hostname=self._server_hostname)
+                    self.agent_check.get_tls_context().wrap_socket(
+                        sock, server_hostname=self.agent_check._server_hostname
+                    )
                 ) as secure_sock:
                     der_cert = secure_sock.getpeercert(binary_form=True)
                     protocol_version = secure_sock.version()
@@ -67,14 +72,19 @@ class TLSRemoteCheck(TLSCheck):
                 err_code = getattr(e, 'verify_code', None)
                 message = getattr(e, 'verify_message', str(e))
                 self.log.debug('Error occurred while getting cert and TLS version from connection: %s', str(e))
-                self.service_check(SERVICE_CHECK_VALIDATION, self.CRITICAL, tags=self._tags, message=message)
+                self.agent_check.service_check(
+                    SERVICE_CHECK_VALIDATION, self.agent_check.CRITICAL, tags=self.agent_check._tags, message=message
+                )
 
                 # There's no sane way to tell it to not validate just the expiration
                 # This only works on Python 3.7+, see: https://bugs.python.org/issue28182
                 # https://github.com/openssl/openssl/blob/0b45d8eec051fd9816b6bf46a975fa461ffc983d/include/openssl/x509_vfy.h#L109
                 if err_code == 10:
-                    self.service_check(
-                        SERVICE_CHECK_EXPIRATION, self.CRITICAL, tags=self._tags, message='Certificate has expired'
+                    self.agent_check.service_check(
+                        SERVICE_CHECK_EXPIRATION,
+                        self.agent_check.CRITICAL,
+                        tags=self.agent_check._tags,
+                        message='Certificate has expired',
                     )
 
                 return None, None
@@ -87,10 +97,10 @@ class TLSRemoteCheck(TLSCheck):
             return cert, protocol_version
         except Exception as e:
             self.log.debug('Error while deserializing peer certificate: %s', str(e))
-            self.service_check(
+            self.agent_check.service_check(
                 SERVICE_CHECK_VALIDATION,
-                self.CRITICAL,
-                tags=self._tags,
+                self.agent_check.CRITICAL,
+                tags=self.agent_check._tags,
                 message='Unable to parse the certificate: {}'.format(e),
             )
             return None, None
@@ -98,20 +108,22 @@ class TLSRemoteCheck(TLSCheck):
     def _get_connection(self):
         try:
             self.log.debug('Checking that TLS service check can connect')
-            sock = self.create_connection()
+            sock = self.agent_check.create_connection()
         except Exception as e:
             self.log.debug('Error occurred while connecting to socket: %s', str(e))
-            self.service_check(SERVICE_CHECK_CAN_CONNECT, self.CRITICAL, tags=self._tags, message=str(e))
+            self.agent_check.service_check(
+                SERVICE_CHECK_CAN_CONNECT, self.agent_check.CRITICAL, tags=self.agent_check._tags, message=str(e)
+            )
             return
         else:
             self.log.debug('TLS check able to connect')
-            self.service_check(SERVICE_CHECK_CAN_CONNECT, self.OK, tags=self._tags)
+            self.agent_check.service_check(SERVICE_CHECK_CAN_CONNECT, self.agent_check.OK, tags=self.agent_check._tags)
         return sock
 
     def fetch_intermediate_certs(self):
         # TODO: prefer stdlib implementation when available, see https://bugs.python.org/issue18617
         try:
-            sock = self.create_connection()
+            sock = self.agent_check.create_connection()
         except Exception as e:
             self.log.error('Error occurred while connecting to socket to discover intermediate certificates: %s', e)
             return
@@ -121,7 +133,9 @@ class TLSRemoteCheck(TLSCheck):
                 context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS)
                 context.verify_mode = ssl.CERT_NONE
 
-                with closing(context.wrap_socket(sock, server_hostname=self._server_hostname)) as secure_sock:
+                with closing(
+                    context.wrap_socket(sock, server_hostname=self.agent_check._server_hostname)
+                ) as secure_sock:
                     der_cert = secure_sock.getpeercert(binary_form=True)
             except Exception as e:
                 self.log.error('Error occurred while getting cert to discover intermediate certificates: %s', e)
@@ -154,14 +168,15 @@ class TLSRemoteCheck(TLSCheck):
 
             uri = access_description.access_location.value
             if (
-                uri in self._intermediate_cert_uri_cache
-                and get_timestamp() - self._intermediate_cert_uri_cache[uri] < self._intermediate_cert_refresh_interval
+                uri in self.agent_check._intermediate_cert_uri_cache
+                and get_timestamp() - self.agent_check._intermediate_cert_uri_cache[uri]
+                < self._intermediate_cert_refresh_interval
             ):
                 continue
 
             # Assume HTTP for now
             try:
-                response = self.http.get(uri)  # SKIP_HTTP_VALIDATION
+                response = self.agent_check.http.get(uri)  # SKIP_HTTP_VALIDATION
                 response.raise_for_status()
             except Exception as e:
                 self.log.error('Error fetching intermediate certificate from `%s`: %s', uri, e)
@@ -171,9 +186,9 @@ class TLSRemoteCheck(TLSCheck):
                 intermediate_cert = response.content
 
             cert_id = sha256(intermediate_cert).digest()
-            if cert_id not in self._intermediate_cert_id_cache:
-                self.get_tls_context().load_verify_locations(cadata=intermediate_cert)
-                self._intermediate_cert_id_cache.add(cert_id)
+            if cert_id not in self.agent_check._intermediate_cert_id_cache:
+                self.agent_check.get_tls_context().load_verify_locations(cadata=intermediate_cert)
+                self.agent_check._intermediate_cert_id_cache.add(cert_id)
 
-            self._intermediate_cert_uri_cache[uri] = access_time
+            self.agent_check._intermediate_cert_uri_cache[uri] = access_time
             self.load_intermediate_certs(intermediate_cert)

--- a/tls/tests/test_local.py
+++ b/tls/tests/test_local.py
@@ -40,6 +40,7 @@ def test_not_found(aggregator, instance_local_not_found):
 
 def test_ok(aggregator, instance_local_ok):
     c = TLSCheck('tls', {}, [instance_local_ok])
+
     c.check(None)
 
     aggregator.assert_service_check(SERVICE_CHECK_CAN_CONNECT, count=0)

--- a/tls/tests/test_local.py
+++ b/tls/tests/test_local.py
@@ -16,7 +16,7 @@ from datadog_checks.tls.tls_local import TLSLocalCheck
 
 def test_right_class(instance_local_no_server_hostname):
     c = TLSCheck('tls', {}, [instance_local_no_server_hostname])
-    assert isinstance(c, TLSLocalCheck)
+    assert isinstance(c.checker, TLSLocalCheck)
 
 
 def test_no_server_hostname(instance_local_no_server_hostname):

--- a/tls/tests/test_remote.py
+++ b/tls/tests/test_remote.py
@@ -18,7 +18,7 @@ from datadog_checks.tls.tls_remote import TLSRemoteCheck
 
 def test_right_class_is_instantiated(instance_remote_no_server):
     c = TLSCheck('tls', {}, [instance_remote_no_server])
-    assert isinstance(c, TLSRemoteCheck)
+    assert isinstance(c.checker, TLSRemoteCheck)
 
 
 def test_no_server(instance_remote_no_server):


### PR DESCRIPTION
Having inheritance on a check will cause the agent to not load it properly. The issue presents in this case when there is more than one instance of the check. The first instance will load the child class and the second instance will fail to find the parent class

The fix here (we can think of something more elegant for long term) is to pass the parent class to the now not children classes and explicitly call it instead of using self