### PR TITLE
Remove unused dependency

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -35,7 +35,6 @@ ldap3==2.5
 lxml==4.6.3
 lz4==2.2.1; python_version < "3.0"
 lz4==3.1.3; python_version > "3.0"
-meld3==1.0.2
 mmh3==2.5.1; python_version < "3.0"
 mmh3==3.0.0; python_version > "3.0"
 openstacksdk==0.24.0

--- a/supervisord/requirements.in
+++ b/supervisord/requirements.in
@@ -1,2 +1,1 @@
-meld3==1.0.2
 supervisor==4.1.0


### PR DESCRIPTION
### Motivation

https://github.com/supervisor/meld3

> No further development of the meld3 package is planned.  The meld3 package
  should be considered unmaintained as of April 2020.  Since 2007, meld3
  received only minimal updates to keep compatible with newer Python versions.
  It was only maintained because it was a dependency of the Supervisor package.
  Since Supervisor 4.1.0 (released in October 2019), the meld3 package is
  no longer a dependency of Supervisor.