### PR TITLE
elasticsearch url default is http, not https

### DIFF
--- a/elastic/README.md
+++ b/elastic/README.md
@@ -153,7 +153,7 @@ Set [Autodiscovery Integrations Templates][22] as Docker labels on your applicat
 ```yaml
 LABEL "com.datadoghq.ad.check_names"='["elastic"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"url": "https://%%host%%:9200"}]'
+LABEL "com.datadoghq.ad.instances"='[{"url": "http://%%host%%:9200"}]'
 ```
 
 ##### Log collection
@@ -206,7 +206,7 @@ metadata:
     ad.datadoghq.com/elasticsearch.instances: |
       [
         {
-          "url": "https://%%host%%:9200"
+          "url": "http://%%host%%:9200"
         }
       ]
 spec:
@@ -268,7 +268,7 @@ Set [Autodiscovery Integrations Templates][30] as Docker labels on your applicat
     "dockerLabels": {
       "com.datadoghq.ad.check_names": "[\"elastic\"]",
       "com.datadoghq.ad.init_configs": "[{}]",
-      "com.datadoghq.ad.instances": "[{\"url\": \"https://%%host%%:9200\"}]"
+      "com.datadoghq.ad.instances": "[{\"url\": \"http://%%host%%:9200\"}]"
     }
   }]
 }


### PR DESCRIPTION
### What does this PR do?
Change Elasticsearch default url protocol to HTTP like in the setting in auto_conf.yaml
https://github.com/DataDog/integrations-core/blob/master/elastic/datadog_checks/elastic/data/auto_conf.yaml

### Motivation
Inconsistent doc

### Additional Notes
affects https://docs.datadoghq.com/integrations/elastic/?tab=docker#configuration

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
