### PR TITLE
Fix defaults for `collect_default_metrics` JMX config option

### DIFF
--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -7,10 +7,10 @@ init_config:
     #
     is_jmx: true
 
-    ## @param collect_default_metrics - boolean - optional - default: true
+    ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
     #
-    # collect_default_metrics: true
+    collect_default_metrics: true
 
     ## @param new_gc_metrics - boolean - optional - default: false
     ## Set to true to use better metric names for garbage collection metrics.

--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -7,10 +7,10 @@ init_config:
     #
     is_jmx: true
 
-    ## @param collect_default_metrics - boolean - optional - default: true
+    ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
     #
-    # collect_default_metrics: true
+    collect_default_metrics: true
 
     ## @param new_gc_metrics - boolean - optional - default: false
     ## Set to true to use better metric names for garbage collection metrics.

--- a/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+++ b/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
@@ -7,10 +7,10 @@ init_config:
     #
     is_jmx: true
 
-    ## @param collect_default_metrics - boolean - optional - default: true
+    ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
     #
-    # collect_default_metrics: true
+    collect_default_metrics: true
 
     ## @param new_gc_metrics - boolean - optional - default: false
     ## Set to true to use better metric names for garbage collection metrics.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
@@ -6,7 +6,9 @@
     type: boolean
 - name: collect_default_metrics
   description: Whether or not the check should collect all default metrics.
+  enabled: true
   value:
+    display_default: false
     example: true
     type: boolean
 - name: new_gc_metrics

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -7,10 +7,10 @@ init_config:
     #
     is_jmx: false
 
-    ## @param collect_default_metrics - boolean - optional - default: true
+    ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
     #
-    # collect_default_metrics: true
+    collect_default_metrics: true
 
     ## @param new_gc_metrics - boolean - optional - default: false
     ## Set to true to use better metric names for garbage collection metrics.

--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -7,10 +7,10 @@ init_config:
     #
     is_jmx: true
 
-    ## @param collect_default_metrics - boolean - optional - default: true
+    ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
     #
-    # collect_default_metrics: true
+    collect_default_metrics: true
 
     ## @param new_gc_metrics - boolean - optional - default: false
     ## Set to true to use better metric names for garbage collection metrics.

--- a/hivemq/datadog_checks/hivemq/data/conf.yaml.example
+++ b/hivemq/datadog_checks/hivemq/data/conf.yaml.example
@@ -7,10 +7,10 @@ init_config:
     #
     is_jmx: true
 
-    ## @param collect_default_metrics - boolean - optional - default: true
+    ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
     #
-    # collect_default_metrics: true
+    collect_default_metrics: true
 
     ## @param new_gc_metrics - boolean - optional - default: false
     ## Set to true to use better metric names for garbage collection metrics.

--- a/ignite/datadog_checks/ignite/data/conf.yaml.example
+++ b/ignite/datadog_checks/ignite/data/conf.yaml.example
@@ -7,10 +7,10 @@ init_config:
     #
     is_jmx: true
 
-    ## @param collect_default_metrics - boolean - optional - default: true
+    ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
     #
-    # collect_default_metrics: true
+    collect_default_metrics: true
 
     ## @param new_gc_metrics - boolean - optional - default: false
     ## Set to true to use better metric names for garbage collection metrics.

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -7,10 +7,10 @@ init_config:
     #
     is_jmx: true
 
-    ## @param collect_default_metrics - boolean - optional - default: true
+    ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
     #
-    # collect_default_metrics: true
+    collect_default_metrics: true
 
     ## @param new_gc_metrics - boolean - optional - default: false
     ## Set to true to use better metric names for garbage collection metrics.

--- a/kafka/datadog_checks/kafka/data/conf.yaml.example
+++ b/kafka/datadog_checks/kafka/data/conf.yaml.example
@@ -7,10 +7,10 @@ init_config:
     #
     is_jmx: true
 
-    ## @param collect_default_metrics - boolean - optional - default: true
+    ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
     #
-    # collect_default_metrics: true
+    collect_default_metrics: true
 
     ## @param new_gc_metrics - boolean - optional - default: false
     ## Set to true to use better metric names for garbage collection metrics.

--- a/presto/datadog_checks/presto/data/conf.yaml.example
+++ b/presto/datadog_checks/presto/data/conf.yaml.example
@@ -7,10 +7,10 @@ init_config:
     #
     is_jmx: true
 
-    ## @param collect_default_metrics - boolean - optional - default: true
+    ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
     #
-    # collect_default_metrics: true
+    collect_default_metrics: true
 
     ## @param new_gc_metrics - boolean - optional - default: false
     ## Set to true to use better metric names for garbage collection metrics.

--- a/solr/datadog_checks/solr/data/conf.yaml.example
+++ b/solr/datadog_checks/solr/data/conf.yaml.example
@@ -7,10 +7,10 @@ init_config:
     #
     is_jmx: true
 
-    ## @param collect_default_metrics - boolean - optional - default: true
+    ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
     #
-    # collect_default_metrics: true
+    collect_default_metrics: true
 
     ## @param new_gc_metrics - boolean - optional - default: false
     ## Set to true to use better metric names for garbage collection metrics.

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -7,10 +7,10 @@ init_config:
     #
     # is_jmx: false
 
-    ## @param collect_default_metrics - boolean - optional - default: true
+    ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
     #
-    # collect_default_metrics: true
+    collect_default_metrics: true
 
     ## @param new_gc_metrics - boolean - optional - default: false
     ## Set to true to use better metric names for garbage collection metrics.

--- a/tomcat/datadog_checks/tomcat/data/conf.yaml.example
+++ b/tomcat/datadog_checks/tomcat/data/conf.yaml.example
@@ -7,10 +7,10 @@ init_config:
     #
     is_jmx: true
 
-    ## @param collect_default_metrics - boolean - optional - default: true
+    ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
     #
-    # collect_default_metrics: true
+    collect_default_metrics: true
 
     ## @param new_gc_metrics - boolean - optional - default: false
     ## Set to true to use better metric names for garbage collection metrics.


### PR DESCRIPTION
### What does this PR do?

Fix https://github.com/DataDog/integrations-core/pull/9364

### Motivation

https://github.com/DataDog/datadog-agent/blob/8081b2ba06ac5e4275c1bc0011cfabb19d26053d/pkg/collector/check/jmx.go#L93-L96