### PR TITLE
Bump minimum base package requirement

### DIFF
--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=18.1.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=18.3.0'
 
 setup(
     name='datadog-mysql',

--- a/postgres/setup.py
+++ b/postgres/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=18.1.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=18.3.0'
 
 setup(
     name='datadog-postgres',

--- a/voltdb/setup.py
+++ b/voltdb/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.7.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=18.1.0'
 
 
 setup(

--- a/win32_event_log/setup.py
+++ b/win32_event_log/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=16.5.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=16.9.0'
 
 setup(
     name='datadog-win32_event_log',

--- a/win32_event_log/setup.py
+++ b/win32_event_log/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.11.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=16.5.0'
 
 setup(
     name='datadog-win32_event_log',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Bump minimum base package requirement for integration failing on master CI

`win32_event_log`: failing when adding configuration model
`postgres`, `mysql`: probably failing after `#9227` and `#9253`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
