### PR TITLE
Don't emit any warnings if NO_MSG_AVAILABLE is received

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -94,7 +94,7 @@ class ChannelMetricCollector(object):
             self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.CRITICAL, search_channel_tags)
             if e.comp == pymqi.CMQC.MQCC_FAILED and e.reason == pymqi.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND:
                 self.log.debug("Channel status not found for channel %s: %s", search_channel_name, e)
-            else:
+            elif not (e.comp == pymqi.CMQC.MQCC_FAILED and e.reason == pymqi.CMQC.MQRC_NO_MSG_AVAILABLE):
                 self.log.warning("Error getting CHANNEL status for channel %s: %s", search_channel_name, e)
         else:
             for channel_info in response:


### PR DESCRIPTION
Follow up of https://github.com/DataDog/integrations-core/pull/9400/files

There was one place where the warning was still logged incorrectly