### PR TITLE
Resolve unexpected errors when statuses other than 'running' or 'idle' is received

### DIFF
--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
+import traceback
 from collections import defaultdict
 from contextlib import closing
 from itertools import chain
@@ -97,6 +98,7 @@ class SapHanaCheck(AgentCheck):
                     continue
                 except Exception as e:
                     self.log.error('Unexpected error running `%s`: %s', query_method.__name__, str(e))
+                    self.log.error(traceback.format_exc())
                     continue
         finally:
             if self._connection_lost:

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
-import traceback
 from collections import defaultdict
 from contextlib import closing
 from itertools import chain
@@ -97,8 +96,7 @@ class SapHanaCheck(AgentCheck):
                     self.log.error('Error querying %s: %s', e.source(), str(e))
                     continue
                 except Exception as e:
-                    self.log.error('Unexpected error running `%s`: %s', query_method.__name__, str(e))
-                    self.log.error(traceback.format_exc())
+                    self.log.exception('Unexpected error running `%s`: %s', query_method.__name__, str(e))
                     continue
         finally:
             if self._connection_lost:

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -199,13 +199,13 @@ class SapHanaCheck(AgentCheck):
             host = self.get_hana_hostname(host)
             running = counts['running']
             idle = counts['idle']
-            queueing = counts['queueing']
+            queuing = counts['queuing']
             empty = counts['empty']
 
             self.gauge('connection.running', running, tags=tags, hostname=host)
             self.gauge('connection.idle', idle, tags=tags, hostname=host)
             self.gauge('connection.open', running + idle, tags=tags, hostname=host)
-            self.gauge('connection.queueing', queueing, tags=tags, hostname=host)
+            self.gauge('connection.queuing', queuing, tags=tags, hostname=host)
             self.gauge('connection.empty', empty, tags=tags, hostname=host)
 
     def query_disk_usage(self):

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -185,8 +185,9 @@ class SapHanaCheck(AgentCheck):
             self.gauge('license.utilized', utilized, tags=tags, hostname=host)
 
     def query_connection_overview(self):
-        # https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.02/en-US/20abcf1f75191014a254a82b3d0f66bf.html
-        db_counts = defaultdict(lambda: {'running': 0, 'idle': 0})
+        # https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.05/en-US/20abcf1f75191014a254a82b3d0f66bf.html
+        # Documented statuses: RUNNING, IDLE, QUEUING, EMPTY
+        db_counts = defaultdict(lambda: defaultdict(int))
         for conn in self.iter_rows(queries.GlobalSystemConnectionsStatus):
             db_counts[(conn['db_name'], conn['host'], conn['port'])][conn['status'].lower()] += conn['total']
 
@@ -198,10 +199,14 @@ class SapHanaCheck(AgentCheck):
             host = self.get_hana_hostname(host)
             running = counts['running']
             idle = counts['idle']
+            queueing = counts['queueing']
+            empty = counts['empty']
 
             self.gauge('connection.running', running, tags=tags, hostname=host)
             self.gauge('connection.idle', idle, tags=tags, hostname=host)
             self.gauge('connection.open', running + idle, tags=tags, hostname=host)
+            self.gauge('connection.queueing', queueing, tags=tags, hostname=host)
+            self.gauge('connection.empty', empty, tags=tags, hostname=host)
 
     def query_disk_usage(self):
         # https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.02/en-US/a2aac2ee72b341699fa8eb3988d8cecb.html

--- a/sap_hana/metadata.csv
+++ b/sap_hana/metadata.csv
@@ -4,7 +4,7 @@ sap_hana.connection.idle,gauge,,connection,,The current number of idle connectio
 sap_hana.connection.open,gauge,,connection,,The current number of connections.,0,sap_hana,
 sap_hana.connection.running,gauge,,connection,,The current number of running connections.,0,sap_hana,
 sap_hana.connection.queuing,gauge,,connection,,The current number of queued connections.,0,sap_hana,
-sap_hana.connection.empty,gauge,,connection,,Historic connections that is removed after a period of time.,0,sap_hana,
+sap_hana.connection.empty,gauge,,connection,,Historic connections that are removed after a period of time.,0,sap_hana,
 sap_hana.cpu.service.utilized,gauge,,percent,,The CPU utilization of services as a percentage.,0,sap_hana,
 sap_hana.disk.free,gauge,,byte,,The total free size of the disk in bytes.,1,sap_hana,
 sap_hana.disk.size,gauge,,byte,,The total size of the disk in bytes.,0,sap_hana,

--- a/sap_hana/metadata.csv
+++ b/sap_hana/metadata.csv
@@ -3,6 +3,8 @@ sap_hana.backup.latest,gauge,,second,,The time elapsed since the latest database
 sap_hana.connection.idle,gauge,,connection,,The current number of idle connections.,0,sap_hana,
 sap_hana.connection.open,gauge,,connection,,The current number of connections.,0,sap_hana,
 sap_hana.connection.running,gauge,,connection,,The current number of running connections.,0,sap_hana,
+sap_hana.connection.queuing,gauge,,connection,,The current number of queued connections.,0,sap_hana,
+sap_hana.connection.empty,gauge,,connection,,Historic connections that is removed after a period of time.,0,sap_hana,
 sap_hana.cpu.service.utilized,gauge,,percent,,The CPU utilization of services as a percentage.,0,sap_hana,
 sap_hana.disk.free,gauge,,byte,,The total free size of the disk in bytes.,1,sap_hana,
 sap_hana.disk.size,gauge,,byte,,The total size of the disk in bytes.,0,sap_hana,

--- a/sap_hana/tests/metrics.py
+++ b/sap_hana/tests/metrics.py
@@ -6,6 +6,8 @@ STANDARD = [
     'sap_hana.connection.idle',
     'sap_hana.connection.open',
     'sap_hana.connection.running',
+    'sap_hana.connection.queuing',
+    'sap_hana.connection.empty',
     'sap_hana.cpu.service.utilized',
     'sap_hana.disk.free',
     'sap_hana.disk.size',

--- a/sap_hana/tests/test_unit.py
+++ b/sap_hana/tests/test_unit.py
@@ -44,7 +44,7 @@ def test_error_unknown(instance):
     check.query_master_database = query_master_database
 
     check.check(None)
-    check.log.error.assert_any_call('Unexpected error running `%s`: %s', 'query_master_database', 'test')
+    check.log.exception.assert_any_call('Unexpected error running `%s`: %s', 'query_master_database', 'test')
 
 
 def test_custom_query_configuration(instance):


### PR DESCRIPTION
### What does this PR do?
Resolves following errors:
```
Unexpected error running `query_connection_overview`: 'receiving'
Unexpected error running `query_connection_overview`: 'sending'
```

### Motivation
AGENT-6213

### Additional Notes
traceback added to the code for troubleshooting. Original error did not mention `KeyError`

```
Traceback (most recent call last):

File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sap_hana/sap_hana.py", line 95, in check
   query_method()
File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sap_hana/sap_hana.py", line 191, in query_connection_overview

db_counts[(conn['db_name'], conn['host'], conn['port'])][conn['status'].lower()] += conn['total']

KeyError: 'receiving'
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
