### PR TITLE
Fix Redis slowlog parsing when no new slowlog entries

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -488,7 +488,8 @@ class Redis(AgentCheck):
             value = slowlog['duration']
             self.histogram('redis.slowlog.micros', value, tags=slowlog_tags)
 
-        self.last_timestamp_seen = max_ts
+        if max_ts != 0:
+            self.last_timestamp_seen = max_ts
 
     def _check_command_stats(self, conn, tags):
         """Get command-specific statistics from redis' INFO COMMANDSTATS command"""


### PR DESCRIPTION
### What does this PR do?
This fixes a bug where old slowlog entries could continually contribute to slowlog metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
If there were no new slowlog entries seen by the check, it would
reset the last seen timestamp to 0. This would cause the next run
to see all of the slowlog entries as new again. The next run after
that would find nothing new and again reset last seen to 0, etc.

Note that this doesn't prevent us from reparsing old slowlog entries if datadog agent restarts, but this should still be an improvement.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
