### PR TITLE
Overrides 'SLOWLOG GET' response callback with fixed/upstream version of `parse_slowlog_get`

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -479,10 +479,7 @@ class Redis(AgentCheck):
 
             slowlog_tags = list(self.tags)
             command = slowlog['command'].split()
-            # When the "Garantia Data" custom Redis is used, redis-py returns
-            # an empty `command` field
-            # FIXME when https://github.com/andymccurdy/redis-py/pull/622 is released in redis-py
-            if command:
+            if len(command) > 0:
                 slowlog_tags.append('command:{}'.format(ensure_unicode(command[0])))
 
             value = slowlog['duration']
@@ -516,3 +513,27 @@ class Redis(AgentCheck):
     def _collect_metadata(self, info):
         if info and 'redis_version' in info:
             self.set_metadata('version', info['redis_version'])
+
+
+# Use fixed version of parse_slowlog_get from upstream/master since
+# it will not be released in redis==3.5.3
+# - https://github.com/andymccurdy/redis-py/issues/1428#issuecomment-749692873
+# - upstream/master: https://github.com/andymccurdy/redis-py/commit/bc5854217b4e94eb7a33e3da5738858a17135ca5
+def upstream_parse_slowlog_get(response, **options):
+    space = ' ' if options.get('decode_responses', False) else b' '
+    return [
+        {
+            'id': item[0],
+            'start_time': int(item[1]),
+            'duration': int(item[2]),
+            'command':
+            # Redis Enterprise injects another entry at index [3], which has
+            # the complexity info (i.e. the value N in case the command has
+            # an O(N) complexity) instead of the command.
+            space.join(item[3]) if isinstance(item[3], list) else space.join(item[4]),
+        }
+        for item in response
+    ]
+
+
+redis.client.Redis.RESPONSE_CALLBACKS['SLOWLOG GET'] = upstream_parse_slowlog_get


### PR DESCRIPTION
### What does this PR do?
Overrides 'SLOWLOG GET' response callback with fixed/upstream version of `parse_slowlog_get`

### Motivation
- fixed version not going to make it to redis==3.x.x
- https://github.com/andymccurdy/redis-py/blob/master/README.rst#response-callbacks

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
