### PR TITLE
Remove monotonic count from ignored types in no duplicate assertion

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -418,7 +418,7 @@ class AggregatorStub(object):
         - hostname
         """
         # metric types that intended to be called multiple times are ignored
-        ignored_types = [self.COUNT, self.MONOTONIC_COUNT, self.COUNTER]
+        ignored_types = [self.COUNT, self.COUNTER]
         metric_stubs = [m for metrics in self._metrics.values() for m in metrics if m.type not in ignored_types]
 
         def stub_to_key_fn(stub):

--- a/datadog_checks_base/tests/stubs/test_aggregator_no_duplicate.py
+++ b/datadog_checks_base/tests/stubs/test_aggregator_no_duplicate.py
@@ -83,10 +83,26 @@ Duplicate metrics found:
             False,
         ),
         (
-            'duplicate metric',
+            'duplicate gauge metric',
             [
                 dict(type='gauge', name='metric.a', value=1, tags=['aa'], hostname='1'),
                 dict(type='gauge', name='metric.a', value=1, tags=['aa'], hostname='1'),
+            ],
+            True,
+        ),
+        (
+            'duplicate rate metric',
+            [
+                dict(type='rate', name='metric.a', value=1, tags=['aa'], hostname='1'),
+                dict(type='rate', name='metric.a', value=1, tags=['aa'], hostname='1'),
+            ],
+            True,
+        ),
+        (
+            'duplicate monotonic_count metric',
+            [
+                dict(type='monotonic_count', name='metric.a', value=1, tags=['aa'], hostname='1'),
+                dict(type='monotonic_count', name='metric.a', value=1, tags=['aa'], hostname='1'),
             ],
             True,
         ),

--- a/datadog_checks_base/tests/stubs/test_aggregator_no_duplicate.py
+++ b/datadog_checks_base/tests/stubs/test_aggregator_no_duplicate.py
@@ -75,8 +75,6 @@ Duplicate metrics found:
             [
                 dict(type='count', name='metric.count', value=1, tags=['aa'], hostname='1'),
                 dict(type='count', name='metric.count', value=1, tags=['aa'], hostname='1'),
-                dict(type='monotonic_count', name='metric.monotonic_count', value=1, tags=['aa'], hostname='1'),
-                dict(type='monotonic_count', name='metric.monotonic_count', value=1, tags=['aa'], hostname='1'),
                 dict(type='increment', name='metric.increment', value=1, tags=['aa'], hostname='1'),
                 dict(type='increment', name='metric.increment', value=1, tags=['aa'], hostname='1'),
                 dict(type='decrement', name='metric.decrement', value=1, tags=['aa'], hostname='1'),


### PR DESCRIPTION
### What does this PR do?
- Updates the the aggregator's no duplicates assertion to check for duplicate monotonic count types
- Explores options for failing aggregator when duplicate metrics are submitted for metric types which should have one context per run, such as rate

### Motivation
- `AI-1553`
- Submitting duplicate rates or monotonic counts (when new sample is less than previous) can lead to unexpected values or the agent resetting the counter

### Additional Notes
Ideas explored to fail aggregator when this occurs:

1. Initial idea for catching the issue at metric submission:
```
    NON_DUPLICATE_TYPES = [RATE, MONOTONIC_COUNT]
    ...    
    def submit_metric(self, check, check_id, mtype, name, value, tags, hostname, flush_first_value):
        if mtype in self.NON_DUPLICATE_TYPES and self.is_duplicate_context(MetricStub(name, mtype, value, tags, hostname, None)):
            raise Exception("'{}' of type '{}' submitted twice with same context.".format(name, AggregatorStub.METRIC_ENUM_MAP_REV[mtype])
        
        if not self.ignore_metric(name):
            self._metrics[name].append(MetricStub(name, mtype, value, tags, hostname, None))

    def is_duplicate_context(self, new_metric):
        def format_stub(stub):
            return stub.name, stub.type, str(sorted(stub.tags)), stub.hostname

        contexts = self.metrics(new_metric.name)
        for context in contexts:
            return format_stub(context) == format_stub(new_metric)
```
2. Two ways to catch duplicates when calling `assert_metric` in tests:
```
    def assert_metric(
        self, name, value=None, tags=None, count=None, at_least=1, hostname=None, metric_type=None, device=None
    ):
        ...
        candidates = []
        ...
        # enforce a count of 1 for candidates with a non-duplicate type (when a count=0 is not used)
        if count != 0 and candidates and all(m.type in self.NON_DUPLICATE_TYPES for m in candidates):
            count = 1
        ...
        # set a condition that catches duplicates with a non-duplicate type
        if value is not None and candidates and all(self.is_aggregate(m.type) for m in candidates):
            got = sum(m.value for m in candidates)
            msg = "Expected count value for '{}': {}, got {}".format(name, value, got)
            condition = value == got
        elif count != 0 and candidates and all(m.type in self.NON_DUPLICATE_TYPES for m in candidates):
            msg = "Duplicate '{}' of non-duplicate type".format(name)
            condition = len(candidates) == 1
        elif count is not None:
            msg = "Needed exactly {} candidates for '{}', got {}".format(count, name, len(candidates))
            condition = len(candidates) == count
        else:
            msg = "Needed at least {} candidates for '{}', got {}".format(at_least, name, len(candidates))
            condition = len(candidates) >= at_least
        self._assert(condition, msg=msg, expected_stub=expected_metric, submitted_elements=self._metrics)    
        ...          
```
- Not exactly sure how to tell aggregator when `check` method is called twice in integration tests- maybe this can be asserted at the check level in tests through `assert_no_duplicate_*`?
- `dd_agent_check` fixture populates aggregator with json check output in `replay_check_run`, which would result in one rate value despite duplicates (when called with `rate`)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
