### PR TITLE
Check for duplicate metrics in common metric assertion

### DIFF
--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -197,3 +197,4 @@ def assert_metrics(aggregator, expected_tags):
         aggregator.assert_metric(mname)
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK, tags=expected_tags)
     aggregator.assert_all_metrics_covered()
+    aggregator.assert_no_duplicate_metrics()


### PR DESCRIPTION
### What does this PR do?
- Checks for duplicate metrics in the SQL Server integration tests.

### Motivation
- Catch potential issues arising when duplicate metrics are submitted, which can result in unexpected values or the agent resetting the counter (AGENT-6021)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
