### PR TITLE
KSM: fix `node.by_condition` metric

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -477,6 +477,17 @@ class KubernetesState(OpenMetricsBaseCheck):
         if bool(sample[self.SAMPLE_VALUE]) is False:
             return  # Ignore if gauge is not 1 and we are not processing the pod phase check
 
+        metric_name = scraper_config['namespace'] + '.node.by_condition'
+        metric_tags = []
+        for label_name, label_value in iteritems(sample[self.SAMPLE_LABELS]):
+            metric_tags += self._build_tags(label_name, label_value, scraper_config)
+        self.gauge(
+            metric_name,
+            sample[self.SAMPLE_VALUE],
+            tags=tags + metric_tags,
+            hostname=self.get_hostname_for_sample(sample, scraper_config),
+        )
+
         label_value, condition_map = self._get_metric_condition_map(base_sc_name, sample[self.SAMPLE_LABELS])
         service_check_name = condition_map['service_check_name']
         mapping = condition_map['mapping']
@@ -715,8 +726,7 @@ class KubernetesState(OpenMetricsBaseCheck):
     def kube_node_status_condition(self, metric, scraper_config):
         """ The ready status of a cluster node. v1.0+"""
         base_check_name = scraper_config['namespace'] + '.node'
-        aggregated_metric_name = scraper_config['namespace'] + '.nodes.by_condition'
-        individual_metric_name = scraper_config['namespace'] + '.node.by_condition'
+        metric_name = scraper_config['namespace'] + '.nodes.by_condition'
         by_condition_counter = Counter()
 
         for sample in metric.samples:
@@ -738,11 +748,8 @@ class KubernetesState(OpenMetricsBaseCheck):
             )
             by_condition_counter[tuple(sorted(tags))] += sample[self.SAMPLE_VALUE]
 
-            tags = list(tags) + self._label_to_tags("node", sample[self.SAMPLE_LABELS], scraper_config)
-            self.gauge(individual_metric_name, sample[self.SAMPLE_VALUE], tags=tags)
-
         for tags, count in iteritems(by_condition_counter):
-            self.gauge(aggregated_metric_name, count, tags=list(tags))
+            self.gauge(metric_name, count, tags=list(tags))
 
     def kube_node_status_ready(self, metric, scraper_config):
         """ The ready status of a cluster node (legacy)"""

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -140,8 +140,6 @@ TAGS = {
         'condition:ready',
         'status:true',
         'status:false',
-        'status:unknown',
-        'node:minikube',
     ],
     NAMESPACE
     + '.pod.status_phase': [


### PR DESCRIPTION
### What does this PR do?

Fix the `kubernetes.node.by_condition` metric introduced by #9311 to make it have the same behaviour as the `kubernetes_state_core` check.

### Motivation

* The `host` of the metric were always the host running the agent instead of node concerned by the metric
* Only the “active” (value == 1) metric must be taken into account.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
