### PR TITLE
Remove instance-level database tag from DBM metrics & events

### DIFF
--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -135,6 +135,10 @@ class PostgresStatementMetrics(object):
         return self._db_hostname
 
     def collect_per_statement_metrics(self, db, db_version, tags):
+        # exclude the default "db" tag from statement metrics & FQT events because this data is collected from
+        # all databases on the host. For metrics the "db" tag is added during ingestion based on which database
+        # each query came from.
+        tags = [t for t in tags if not t.startswith("db:")]
         try:
             rows = self._collect_metrics_rows(db)
             if not rows:

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -288,7 +288,8 @@ def test_statement_metrics(aggregator, integration_check, dbm_instance, dbstrict
     assert event['host'] == 'stubbed.hostname'
     assert event['timestamp'] > 0
     assert event['min_collection_interval'] == dbm_instance['min_collection_interval']
-    assert set(event['tags']) == {'foo:bar', 'server:{}'.format(HOST), 'port:{}'.format(PORT), 'db:datadog_test'}
+    expected_dbm_metrics_tags = {'foo:bar', 'server:{}'.format(HOST), 'port:{}'.format(PORT)}
+    assert set(event['tags']) == expected_dbm_metrics_tags
     obfuscated_param = '?' if POSTGRES_VERSION.split('.')[0] == "9" else '$1'
 
     dbm_samples = aggregator.get_event_platform_events("dbm-samples")
@@ -325,6 +326,10 @@ def test_statement_metrics(aggregator, integration_check, dbm_instance, dbstrict
         assert fqt_event['postgres']['rolname'] == username
         assert fqt_event['timestamp'] > 0
         assert fqt_event['host'] == 'stubbed.hostname'
+        assert set(fqt_event['ddtags'].split(',')) == expected_dbm_metrics_tags | {
+            "db:" + fqt_event['postgres']['datname'],
+            "rolname:" + fqt_event['postgres']['rolname'],
+        }
 
     for conn in connections.values():
         conn.close()


### PR DESCRIPTION
### What does this PR do?

Remove the incorrect `db` tag inherited from the check instance tags from postgres DBM statement metrics & FQT events. 

Also improve tests to clarify the expected tags for both metrics and FQT events.

### Motivation

This tag needs to be excluded because statement metrics & FQT events are collected from all databases on the host as of https://github.com/DataDog/integrations-core/pull/9252. DBM statement samples are already doing the right thing here.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
