### PR TITLE
Lower default `min_collection_interval` to 10s

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -352,7 +352,7 @@ files:
                   example: 300
           - template: instances/default
             overrides:
-              min_collection_interval.default: 10
+              min_collection_interval.enabled: true
               min_collection_interval.value.example: 10
 
       - template: logs

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -351,6 +351,9 @@ files:
                   type: integer
                   example: 300
           - template: instances/default
+            overrides:
+              min_collection_interval.default: 10
+              min_collection_interval.value.example: 10
 
       - template: logs
         example:

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -45,7 +45,7 @@ def instance_max_custom_queries(field, value):
 
 
 def instance_min_collection_interval(field, value):
-    return 15
+    return 10
 
 
 def instance_options(field, value):

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -338,11 +338,11 @@ instances:
     #
     # service: <SERVICE>
 
-    ## @param min_collection_interval - number - optional - default: 15
+    ## @param min_collection_interval - number - optional - default: 10
     ## This changes the collection interval of the check. For more information, see:
     ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
     #
-    # min_collection_interval: 15
+    # min_collection_interval: 10
 
     ## @param empty_default_hostname - boolean - optional - default: false
     ## This forces the check to send metrics with no hostname.

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -342,7 +342,7 @@ instances:
     ## This changes the collection interval of the check. For more information, see:
     ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
     #
-    # min_collection_interval: 10
+    min_collection_interval: 10
 
     ## @param empty_default_hostname - boolean - optional - default: false
     ## This forces the check to send metrics with no hostname.

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -294,6 +294,10 @@ files:
             type: integer
             example: 10000
     - template: instances/default
+      overrides:
+        min_collection_interval.default: 10
+        min_collection_interval.value.example: 10
+
   - template: logs
     example:
     - type: file

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -61,7 +61,7 @@ def instance_max_relations(field, value):
 
 
 def instance_min_collection_interval(field, value):
-    return 15
+    return 10
 
 
 def instance_password(field, value):

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -261,11 +261,11 @@ instances:
     #
     # service: <SERVICE>
 
-    ## @param min_collection_interval - number - optional - default: 15
+    ## @param min_collection_interval - number - optional - default: 10
     ## This changes the collection interval of the check. For more information, see:
     ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
     #
-    # min_collection_interval: 15
+    # min_collection_interval: 10
 
     ## @param empty_default_hostname - boolean - optional - default: false
     ## This forces the check to send metrics with no hostname.


### PR DESCRIPTION
### What does this PR do?

Lower the default `min_collection_interval` for postgres & mysql to bring the metric interval inline with the default interval that dogstatsd uses. 

### Motivation

This makes plotting the DBM query metrics (`postgresql.queries.*`, `mysql.queries.*`) less error prone because the interval lines up more closely with the default rollup windows currently used in the query engine.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
