### PR TITLE
Remove kubernetes_state.replicaset.replicas_ready from the IO by node widgets in the Kubernetes Dashboard

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_dashboard.json
+++ b/kubernetes/assets/dashboards/kubernetes_dashboard.json
@@ -962,7 +962,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes.io.read_bytes{$scope,$daemonset,$service,$namespace,$label,$cluster,$deployment,$node} by {replicaset,host}-avg:kubernetes_state.replicaset.replicas_ready{$scope,$daemonset,$service,$namespace,$label,$cluster,$deployment,$node} by {host}",
+                        "q": "sum:kubernetes.io.read_bytes{$scope,$daemonset,$service,$namespace,$label,$cluster,$deployment,$node} by {host}",
                         "display_type": "line",
                         "style": {
                             "palette": "grey",
@@ -994,7 +994,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes.io.write_bytes{$scope,$daemonset,$service,$namespace,$label,$cluster,$deployment,$node} by {replicaset,host}-avg:kubernetes_state.replicaset.replicas_ready{$scope,$daemonset,$service,$namespace,$label,$cluster,$deployment,$node} by {host}",
+                        "q": "sum:kubernetes.io.write_bytes{$scope,$daemonset,$service,$namespace,$label,$cluster,$deployment,$node} by {host}",
                         "display_type": "line",
                         "style": {
                             "palette": "grey",


### PR DESCRIPTION
### What does this PR do?
This removes the kubernetes_state.replicaset.replicas_ready from the IO by node widgets in the Kubernetes Dashboard because this metric is not tagged by host. In the widgets, this metric is averaged by host, which doesn't make sense.
This metric is tagged only by replicaset.
Only the host where the KSM pod runs will show up as a host. If KSM core or a cluster check is used, there will be no host.

### Motivation
A customer reported the widgets are broken when moving to KSM core, because of the reason explained above.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
