### PR TITLE
Fix collect_aggregates_only option type

### DIFF
--- a/haproxy/assets/configuration/spec.yaml
+++ b/haproxy/assets/configuration/spec.yaml
@@ -40,8 +40,8 @@ files:
         NOTE: This only takes effect when `use_prometheus` is set to `false`.
     - name: collect_aggregates_only
       value:
-        example: true
-        type: boolean
+        example: 'true'
+        type: string
       description: |
         This parameter instructs the check to collect metrics only from the aggregate frontend/backend
         status lines from the stats output instead of for each backend. With this parameter set to false the agent

--- a/haproxy/assets/configuration/spec.yaml
+++ b/haproxy/assets/configuration/spec.yaml
@@ -40,8 +40,10 @@ files:
         NOTE: This only takes effect when `use_prometheus` is set to `false`.
     - name: collect_aggregates_only
       value:
-        example: 'true'
-        type: string
+        anyOf:
+          - type: boolean
+          - type: string
+        example: true
       description: |
         This parameter instructs the check to collect metrics only from the aggregate frontend/backend
         status lines from the stats output instead of for each backend. With this parameter set to false the agent

--- a/haproxy/datadog_checks/haproxy/config_models/defaults.py
+++ b/haproxy/datadog_checks/haproxy/config_models/defaults.py
@@ -57,7 +57,7 @@ def instance_collate_status_tags_per_host(field, value):
 
 
 def instance_collect_aggregates_only(field, value):
-    return True
+    return 'true'
 
 
 def instance_collect_status_metrics(field, value):

--- a/haproxy/datadog_checks/haproxy/config_models/defaults.py
+++ b/haproxy/datadog_checks/haproxy/config_models/defaults.py
@@ -57,7 +57,7 @@ def instance_collate_status_tags_per_host(field, value):
 
 
 def instance_collect_aggregates_only(field, value):
-    return 'true'
+    return get_default_field_value(field, value)
 
 
 def instance_collect_status_metrics(field, value):

--- a/haproxy/datadog_checks/haproxy/config_models/instance.py
+++ b/haproxy/datadog_checks/haproxy/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional, Sequence, Union
 
-from pydantic import BaseModel, Extra, root_validator, validator
+from pydantic import BaseModel, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -42,14 +42,6 @@ class LabelJoins(BaseModel):
         allow_mutation = False
 
     target_metric: Optional[TargetMetric]
-
-
-class Metric(BaseModel):
-    pass
-
-    class Config:
-        extra = Extra.allow
-        allow_mutation = False
 
 
 class Proxy(BaseModel):
@@ -100,7 +92,7 @@ class InstanceConfig(BaseModel):
     label_to_hostname: Optional[str]
     labels_mapper: Optional[Mapping[str, Any]]
     log_requests: Optional[bool]
-    metrics: Optional[Sequence[Union[str, Metric]]]
+    metrics: Optional[Sequence[Union[str, Mapping[str, str]]]]
     min_collection_interval: Optional[float]
     namespace: Optional[str]
     ntlm_domain: Optional[str]

--- a/haproxy/datadog_checks/haproxy/config_models/instance.py
+++ b/haproxy/datadog_checks/haproxy/config_models/instance.py
@@ -74,7 +74,7 @@ class InstanceConfig(BaseModel):
     bearer_token_auth: Optional[bool]
     bearer_token_path: Optional[str]
     collate_status_tags_per_host: Optional[bool]
-    collect_aggregates_only: Optional[str]
+    collect_aggregates_only: Optional[Union[bool, str]]
     collect_status_metrics: Optional[bool]
     collect_status_metrics_by_host: Optional[bool]
     connect_timeout: Optional[float]

--- a/haproxy/datadog_checks/haproxy/config_models/instance.py
+++ b/haproxy/datadog_checks/haproxy/config_models/instance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional, Sequence, Union
 
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, Extra, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -44,6 +44,14 @@ class LabelJoins(BaseModel):
     target_metric: Optional[TargetMetric]
 
 
+class Metric(BaseModel):
+    pass
+
+    class Config:
+        extra = Extra.allow
+        allow_mutation = False
+
+
 class Proxy(BaseModel):
     class Config:
         allow_mutation = False
@@ -66,7 +74,7 @@ class InstanceConfig(BaseModel):
     bearer_token_auth: Optional[bool]
     bearer_token_path: Optional[str]
     collate_status_tags_per_host: Optional[bool]
-    collect_aggregates_only: Optional[bool]
+    collect_aggregates_only: Optional[str]
     collect_status_metrics: Optional[bool]
     collect_status_metrics_by_host: Optional[bool]
     connect_timeout: Optional[float]
@@ -92,7 +100,7 @@ class InstanceConfig(BaseModel):
     label_to_hostname: Optional[str]
     labels_mapper: Optional[Mapping[str, Any]]
     log_requests: Optional[bool]
-    metrics: Optional[Sequence[Union[str, Mapping[str, str]]]]
+    metrics: Optional[Sequence[Union[str, Metric]]]
     min_collection_interval: Optional[float]
     namespace: Optional[str]
     ntlm_domain: Optional[str]

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -72,7 +72,7 @@ instances:
     #
     # status_check: false
 
-    ## @param collect_aggregates_only - boolean or string - optional
+    ## @param collect_aggregates_only - boolean or string - optional - default: true
     ## This parameter instructs the check to collect metrics only from the aggregate frontend/backend
     ## status lines from the stats output instead of for each backend. With this parameter set to false the agent
     ## collects data for each backend but ignores the aggregated data for backends. Because some metrics are only
@@ -83,7 +83,7 @@ instances:
     ##
     ## NOTE: This only takes effect when `use_prometheus` is set to `false`.
     #
-    # collect_aggregates_only: <COLLECT_AGGREGATES_ONLY>
+    # collect_aggregates_only: true
 
     ## @param collect_status_metrics - boolean - optional - default: false
     ## This parameter instructs the check to collect metrics on status counts (e.g. haproxy.count_per_status)

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -72,7 +72,7 @@ instances:
     #
     # status_check: false
 
-    ## @param collect_aggregates_only - string - optional - default: true
+    ## @param collect_aggregates_only - boolean or string - optional
     ## This parameter instructs the check to collect metrics only from the aggregate frontend/backend
     ## status lines from the stats output instead of for each backend. With this parameter set to false the agent
     ## collects data for each backend but ignores the aggregated data for backends. Because some metrics are only
@@ -83,7 +83,7 @@ instances:
     ##
     ## NOTE: This only takes effect when `use_prometheus` is set to `false`.
     #
-    # collect_aggregates_only: 'true'
+    # collect_aggregates_only: <COLLECT_AGGREGATES_ONLY>
 
     ## @param collect_status_metrics - boolean - optional - default: false
     ## This parameter instructs the check to collect metrics on status counts (e.g. haproxy.count_per_status)

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -72,7 +72,7 @@ instances:
     #
     # status_check: false
 
-    ## @param collect_aggregates_only - boolean - optional - default: true
+    ## @param collect_aggregates_only - string - optional - default: true
     ## This parameter instructs the check to collect metrics only from the aggregate frontend/backend
     ## status lines from the stats output instead of for each backend. With this parameter set to false the agent
     ## collects data for each backend but ignores the aggregated data for backends. Because some metrics are only
@@ -83,7 +83,7 @@ instances:
     ##
     ## NOTE: This only takes effect when `use_prometheus` is set to `false`.
     #
-    # collect_aggregates_only: true
+    # collect_aggregates_only: 'true'
 
     ## @param collect_status_metrics - boolean - optional - default: false
     ## This parameter instructs the check to collect metrics on status counts (e.g. haproxy.count_per_status)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`collect_aggregates_only` option can be `true`, `false`, or `both`, so it's not a boolean.

### Motivation
<!-- What inspired you to submit this pull request? -->
QA #8924 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
