### PR TITLE
Enable autocommit on all connections

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -167,6 +167,7 @@ class MySql(AgentCheck):
         connection_args = {
             'ssl': ssl,
             'connect_timeout': self._config.connect_timeout,
+            'autocommit': True,
         }
         if self._config.charset:
             connection_args['charset'] = self._config.charset

--- a/mysql/tests/test_connection.py
+++ b/mysql/tests/test_connection.py
@@ -21,7 +21,12 @@ def test_connection_with_defaults_file():
     }
     check = MySql(common.CHECK_NAME, {}, [file_instance])
     connection_args = check._get_connection_args()
-    assert connection_args == {'ssl': None, 'connect_timeout': 10, 'read_default_file': '/foo/bar'}
+    assert connection_args == {
+        'autocommit': True,
+        'ssl': None,
+        'connect_timeout': 10,
+        'read_default_file': '/foo/bar',
+    }
     assert 'host' not in connection_args
 
 
@@ -36,6 +41,7 @@ def test_connection_with_sock():
     check = MySql(common.CHECK_NAME, {}, [file_instance])
     connection_args = check._get_connection_args()
     assert connection_args == {
+        'autocommit': True,
         'ssl': None,
         'connect_timeout': 10,
         'unix_socket': '/foo/bar',
@@ -53,7 +59,14 @@ def test_connection_with_host():
     }
     check = MySql(common.CHECK_NAME, {}, [file_instance])
     connection_args = check._get_connection_args()
-    assert connection_args == {'ssl': None, 'connect_timeout': 10, 'user': 'ddog', 'passwd': 'pwd', 'host': 'localhost'}
+    assert connection_args == {
+        'autocommit': True,
+        'ssl': None,
+        'connect_timeout': 10,
+        'user': 'ddog',
+        'passwd': 'pwd',
+        'host': 'localhost',
+    }
 
 
 def test_connection_with_host_and_port():
@@ -61,6 +74,7 @@ def test_connection_with_host_and_port():
     check = MySql(common.CHECK_NAME, {}, [file_instance])
     connection_args = check._get_connection_args()
     assert connection_args == {
+        'autocommit': True,
         'ssl': None,
         'connect_timeout': 10,
         'user': 'ddog',
@@ -77,6 +91,7 @@ def test_connection_with_charset(instance_basic):
 
     connection_args = check._get_connection_args()
     assert connection_args == {
+        'autocommit': True,
         'host': common.HOST,
         'user': common.USER,
         'passwd': common.PASS,


### PR DESCRIPTION
### What does this PR do?

This PR enables autocommit on connections to ensure each query is executed as a separate transaction. The current behavior is to disable autocommit, which requires a `COMMIT` or `ROLLBACK` to be executed on connection close. But that cannot be guaranteed (network disruptions, hard shutdowns, etc.).

### Motivation

In the worst case, a transaction can remain open with uncommitted undo log actions on the InnoDB history. Since the agent does not require transaction isolation for any of its functionality, enabling autocommit should be the safest option.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
