### PR TITLE
Add instance option for cluster_name in mesos_slave integration

### DIFF
--- a/mesos_slave/assets/configuration/spec.yaml
+++ b/mesos_slave/assets/configuration/spec.yaml
@@ -21,10 +21,9 @@ files:
               example: 5050
               type: integer
           - name: cluster_name
-            description: Specify the cluster name
+            description: This is used as the value of the `mesos_cluster` tag, avoiding potential network calls.
             value:
               type: string
-              example: <CLUSTER_NAME>
           - name: tasks
             description: Specify the tasks from which you want to send metrics to Datadog.
             value:

--- a/mesos_slave/assets/configuration/spec.yaml
+++ b/mesos_slave/assets/configuration/spec.yaml
@@ -24,7 +24,7 @@ files:
             description: Specify the cluster name
             value:
               type: string
-              example: my-cluster-name
+              example: <CLUSTER_NAME>
           - name: tasks
             description: Specify the tasks from which you want to send metrics to Datadog.
             value:

--- a/mesos_slave/assets/configuration/spec.yaml
+++ b/mesos_slave/assets/configuration/spec.yaml
@@ -20,6 +20,11 @@ files:
             value:
               example: 5050
               type: integer
+          - name: cluster_name
+            description: Specify the cluster name
+            value:
+              type: string
+              example: my-cluster-name
           - name: tasks
             description: Specify the tasks from which you want to send metrics to Datadog.
             value:

--- a/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
+++ b/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
@@ -55,10 +55,10 @@ instances:
     #
     # master_port: 5050
 
-    ## @param cluster_name - string - optional - default: my-cluster-name
+    ## @param cluster_name - string - optional
     ## Specify the cluster name
     #
-    # cluster_name: my-cluster-name
+    # cluster_name: <CLUSTER_NAME>
 
     ## @param tasks - list of strings - optional
     ## Specify the tasks from which you want to send metrics to Datadog.

--- a/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
+++ b/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
@@ -56,7 +56,7 @@ instances:
     # master_port: 5050
 
     ## @param cluster_name - string - optional
-    ## Specify the cluster name
+    ## This is used as the value of the `mesos_cluster` tag, avoiding potential network calls.
     #
     # cluster_name: <CLUSTER_NAME>
 

--- a/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
+++ b/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
@@ -55,8 +55,8 @@ instances:
     #
     # master_port: 5050
 
-    ## @param cluster_name - string - optional
-    ## Specify the cluster name, to optimize the check.
+    ## @param cluster_name - string - optional - default: my-cluster-name
+    ## Specify the cluster name
     #
     # cluster_name: my-cluster-name
 

--- a/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
+++ b/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
@@ -55,6 +55,11 @@ instances:
     #
     # master_port: 5050
 
+    ## @param cluster_name - string - optional
+    ## Specify the cluster name, to optimize the check.
+    #
+    # cluster_name: my-cluster-name
+
     ## @param tasks - list of strings - optional
     ## Specify the tasks from which you want to send metrics to Datadog.
     #

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -205,16 +205,13 @@ class MesosSlave(AgentCheck):
             self.set_metadata('version', version)
 
     def _set_cluster_name(self, url, master_port, state_metrics, tags):
-        if self.cluster_name:
-            tags.append('mesos_cluster:{}'.format(self.cluster_name))
-            return
-        if 'master_hostname' in state_metrics:
+        if 'master_hostname' in state_metrics and not self.cluster_name:
             master_url = '{}://{}:{}'.format(urlparse(url).scheme, state_metrics['master_hostname'], master_port)
             master_state = self._get_state_metrics(master_url, [], "-summary")
             if master_state:
                 self.cluster_name = master_state.get('cluster')
-                if self.cluster_name:
-                    tags.append('mesos_cluster:{}'.format(self.cluster_name))
+        if self.cluster_name:
+            tags.append('mesos_cluster:{}'.format(self.cluster_name))
 
     def _process_tasks(self, tasks, state_metrics, tags):
         for task in tasks:

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -95,7 +95,7 @@ class MesosSlave(AgentCheck):
 
     def __init__(self, name, init_config, instances):
         super(MesosSlave, self).__init__(name, init_config, instances)
-        self.cluster_name = None
+        self.cluster_name = self.instance.get('cluster_name', None)
         self.version = []
 
         url = self.instance.get('url', '')
@@ -165,12 +165,12 @@ class MesosSlave(AgentCheck):
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=stats_tags)
             raise
 
-    def _get_state_metrics(self, url, tags):
+    def _get_state_metrics(self, url, tags, suffix=''):
         # Mesos version >= 0.25
         endpoint = url + '/state'
         try:
-            state_metrics = self._get_json(endpoint)
-            tags.append("url:{}".format(endpoint))
+            state_metrics = self._get_json(endpoint + suffix)
+            tags.append("url:{}".format(endpoint + suffix))
         except Exception:
             # Mesos version < 0.25
             old_endpoint = endpoint + '.json'
@@ -205,9 +205,12 @@ class MesosSlave(AgentCheck):
             self.set_metadata('version', version)
 
     def _set_cluster_name(self, url, master_port, state_metrics, tags):
+        if self.cluster_name:
+            tags.append('mesos_cluster:{}'.format(self.cluster_name))
+            return
         if 'master_hostname' in state_metrics:
             master_url = '{}://{}:{}'.format(urlparse(url).scheme, state_metrics['master_hostname'], master_port)
-            master_state = self._get_state_metrics(master_url, [])
+            master_state = self._get_state_metrics(master_url, [], "-summary")
             if master_state:
                 self.cluster_name = master_state.get('cluster')
                 if self.cluster_name:

--- a/mesos_slave/tests/conftest.py
+++ b/mesos_slave/tests/conftest.py
@@ -40,6 +40,6 @@ def mock(init_config, instance):
     check = MesosSlave(common.CHECK_NAME, init_config, [instance])
 
     check._get_stats_metrics = lambda x, y: json.loads(read_fixture('stats.json'))
-    check._get_state_metrics = lambda x, y, z='': json.loads(read_fixture('state' + z +'.json'))
+    check._get_state_metrics = lambda x, y, z='': json.loads(read_fixture('state' + z + '.json'))
 
     return check

--- a/mesos_slave/tests/conftest.py
+++ b/mesos_slave/tests/conftest.py
@@ -40,6 +40,6 @@ def mock(init_config, instance):
     check = MesosSlave(common.CHECK_NAME, init_config, [instance])
 
     check._get_stats_metrics = lambda x, y: json.loads(read_fixture('stats.json'))
-    check._get_state_metrics = lambda x, y, z='': json.loads(read_fixture('state.json'))
+    check._get_state_metrics = lambda x, y, z='': json.loads(read_fixture('state' + z +'.json'))
 
     return check

--- a/mesos_slave/tests/conftest.py
+++ b/mesos_slave/tests/conftest.py
@@ -40,6 +40,6 @@ def mock(init_config, instance):
     check = MesosSlave(common.CHECK_NAME, init_config, [instance])
 
     check._get_stats_metrics = lambda x, y: json.loads(read_fixture('stats.json'))
-    check._get_state_metrics = lambda x, y: json.loads(read_fixture('state.json'))
+    check._get_state_metrics = lambda x, y, z='': json.loads(read_fixture('state.json'))
 
     return check

--- a/mesos_slave/tests/fixtures/state-summary.json
+++ b/mesos_slave/tests/fixtures/state-summary.json
@@ -1,0 +1,108 @@
+{
+  "frameworks": [
+    {
+      "slave_ids": [
+        "113c74e9-1c3f-4c7b-a2ac-0cbaa6a21d01-S2100"
+      ],
+      "TASK_UNREACHABLE": 85,
+      "TASK_ERROR": 0,
+      "TASK_LOST": 0,
+      "TASK_FAILED": 241,
+      "TASK_KILLED": 753,
+      "webui_url": "localhost:8080",
+      "hostname": "localhost",
+      "capabilities": [
+        "PARTITION_AWARE",
+        "REGION_AWARE",
+        "MULTI_ROLE"
+      ],
+      "offered_resources": {
+        "cpus": 0,
+        "gpus": 0,
+        "mem": 0,
+        "disk": 0
+      },
+      "used_resources": {
+        "ports": "[80-80]",
+        "cpus": 2732.63,
+        "gpus": 0,
+        "mem": 12606997,
+        "disk": 2000
+      },
+      "pid": "scheduler",
+      "name": "marathon",
+      "id": "113c74e9-1c3f-4c7b-a2ac-0cbaa6a21d01-0000",
+      "active": true,
+      "connected": true,
+      "recovered": false,
+      "TASK_STAGING": 0,
+      "TASK_STARTING": 0,
+      "TASK_RUNNING": 6616,
+      "TASK_KILLING": 0,
+      "TASK_FINISHED": 6
+    }
+  ],
+  "slaves": [
+    {
+      "framework_ids": [],
+      "TASK_UNREACHABLE": 0,
+      "TASK_ERROR": 0,
+      "TASK_LOST": 0,
+      "TASK_FAILED": 0,
+      "TASK_KILLED": 0,
+      "TASK_FINISHED": 0,
+      "TASK_KILLING": 0,
+      "TASK_RUNNING": 0,
+      "used_resources": {
+        "cpus": 0,
+        "gpus": 0,
+        "mem": 0,
+        "disk": 0
+      },
+      "resources": {
+        "ports": "[80-80, 2000-12000, 31000-32000]",
+        "cpus": 8,
+        "gpus": 0,
+        "mem": 28956,
+        "disk": 95536
+      },
+      "registered_time": 1623134184.212633,
+      "pid": "slave(1)@localhost:5051",
+      "attributes": {
+        "env": "prod",
+        "number": 29160,
+        "name": "agent",
+        "cluster": 48
+      },
+      "port": 5051,
+      "hostname": "localhost",
+      "id": "113c74e9-1c3f-4c7b-a2ac-0cbaa6a21d01-S2100",
+      "offered_resources": {
+        "cpus": 0,
+        "gpus": 0,
+        "mem": 0,
+        "disk": 0
+      },
+      "reserved_resources": {},
+      "unreserved_resources": {
+        "ports": "[80-80, 2000-12000, 31000-32000]",
+        "cpus": 8,
+        "gpus": 0,
+        "mem": 28956,
+        "disk": 95536
+      },
+      "active": true,
+      "version": "1.7.1",
+      "capabilities": [
+        "MULTI_ROLE",
+        "HIERARCHICAL_ROLE",
+        "RESERVATION_REFINEMENT",
+        "RESOURCE_PROVIDER",
+        "RESIZE_VOLUME"
+      ],
+      "TASK_STAGING": 0,
+      "TASK_STARTING": 0
+    }],
+  "cluster": "test-cluster",
+  "hostname": "localhost"
+}

--- a/mesos_slave/tests/test_unit.py
+++ b/mesos_slave/tests/test_unit.py
@@ -123,6 +123,8 @@ def test_config(check, instance, test_case, extra_config, expected_http_kwargs):
 
 additional_tags = ['instance:mytag1']
 cluster_name_tag = ['mesos_cluster:test-cluster']
+slave_attrs = {'json.return_value': {"master_hostname": "localhost", "frameworks": []}}
+master_attrs = {'json.return_value': {"cluster": "test-cluster"}}
 
 state_test_data = [
     (
@@ -145,6 +147,13 @@ state_test_data = [
         ['url:http://hello.com/state.json'] + additional_tags,
         True,
         AgentCheck.CRITICAL,
+    ),
+    (
+        'OK for /state, OK for /state-summary',
+        [mock.MagicMock(status_code=200, **slave_attrs), mock.MagicMock(status_code=200, **master_attrs)],
+        ['url:http://hello.com/state'] + additional_tags + cluster_name_tag,
+        False,
+        AgentCheck.OK,
     ),
 ]
 
@@ -179,25 +188,6 @@ def test_can_connect_service_check_state(
             assert not expect_exception
         except Exception:
             if not expect_exception:
-                raise
-
-    aggregator.assert_service_check('mesos_slave.can_connect', count=1, status=expected_status, tags=expected_tags)
-
-
-@pytest.mark.integration
-def test_can_connect_to_master_service_with_instance_cluster_name(instance, aggregator):
-    expected_tags = ['url:http://hello.com/state'] + cluster_name_tag + additional_tags
-    expected_status = AgentCheck.OK
-    check = MesosSlave('mesos_slave', {}, [instance])
-    with mock.patch('datadog_checks.base.utils.http.requests') as r:
-        mock_resp = mock.MagicMock(status_code=200)
-        mock_resp.json.return_value = {"master_hostname": "localhost", "frameworks":[]}
-        r.get.return_value = mock_resp
-        try:
-            check._process_state_info('http://hello.com', instance['tasks'], 5050, instance['tags'])
-            assert not False
-        except Exception:
-            if not False:
                 raise
 
     aggregator.assert_service_check('mesos_slave.can_connect', count=1, status=expected_status, tags=expected_tags)

--- a/mesos_slave/tests/test_unit.py
+++ b/mesos_slave/tests/test_unit.py
@@ -182,9 +182,10 @@ def test_can_connect_service_check_state(
 
     aggregator.assert_service_check('mesos_slave.can_connect', count=1, status=expected_status, tags=expected_tags)
 
+
 @pytest.mark.integration
 def test_can_connect_service_with_instance_cluster_name(instance, aggregator):
-    instance['cluster_name']='some-cluster-name'
+    instance['cluster_name'] = 'some-cluster-name'
     expected_tags = ['url:http://hello.com/state', 'instance:mytag1', 'mesos_cluster:some-cluster-name']
     expected_status = AgentCheck.OK
     check = MesosSlave('mesos_slave', {}, [instance])

--- a/mesos_slave/tests/test_unit.py
+++ b/mesos_slave/tests/test_unit.py
@@ -182,6 +182,23 @@ def test_can_connect_service_check_state(
 
     aggregator.assert_service_check('mesos_slave.can_connect', count=1, status=expected_status, tags=expected_tags)
 
+@pytest.mark.integration
+def test_can_connect_service_with_instance_cluster_name(instance, aggregator):
+    instance['cluster_name']='some-cluster-name'
+    expected_tags = ['url:http://hello.com/state', 'instance:mytag1', 'mesos_cluster:some-cluster-name']
+    expected_status = AgentCheck.OK
+    check = MesosSlave('mesos_slave', {}, [instance])
+    with mock.patch('datadog_checks.base.utils.http.requests') as r:
+        r.get.side_effect = [mock.MagicMock(status_code=200, content='{}')]
+        try:
+            check._process_state_info('http://hello.com', instance['tasks'], 5050, instance['tags'])
+            assert not False
+        except Exception:
+            if not False:
+                raise
+
+    aggregator.assert_service_check('mesos_slave.can_connect', count=1, status=expected_status, tags=expected_tags)
+
 
 @pytest.mark.parametrize(PARAMETERS, stats_test_data)
 @pytest.mark.integration

--- a/mesos_slave/tests/test_unit.py
+++ b/mesos_slave/tests/test_unit.py
@@ -33,7 +33,7 @@ def test_fixtures(check, instance, aggregator):
 
     service_check_tags = [
         'instance:mytag1',
-        'mesos_cluster:test',
+        'mesos_cluster:test-cluster',
         'mesos_node:slave',
         'mesos_pid:slave(1)@127.0.0.1:5051',
         'task_name:hello',
@@ -122,6 +122,7 @@ def test_config(check, instance, test_case, extra_config, expected_http_kwargs):
 
 
 additional_tags = ['instance:mytag1']
+cluster_name_tag = ['mesos_cluster:test-cluster']
 
 state_test_data = [
     (
@@ -184,9 +185,28 @@ def test_can_connect_service_check_state(
 
 
 @pytest.mark.integration
+def test_can_connect_to_master_service_with_instance_cluster_name(instance, aggregator):
+    expected_tags = ['url:http://hello.com/state'] + cluster_name_tag + additional_tags
+    expected_status = AgentCheck.OK
+    check = MesosSlave('mesos_slave', {}, [instance])
+    with mock.patch('datadog_checks.base.utils.http.requests') as r:
+        mock_resp = mock.MagicMock(status_code=200)
+        mock_resp.json.return_value = {"master_hostname": "localhost", "frameworks":[]}
+        r.get.return_value = mock_resp
+        try:
+            check._process_state_info('http://hello.com', instance['tasks'], 5050, instance['tags'])
+            assert not False
+        except Exception:
+            if not False:
+                raise
+
+    aggregator.assert_service_check('mesos_slave.can_connect', count=1, status=expected_status, tags=expected_tags)
+
+
+@pytest.mark.integration
 def test_can_connect_service_with_instance_cluster_name(instance, aggregator):
-    instance['cluster_name'] = 'some-cluster-name'
-    expected_tags = ['url:http://hello.com/state', 'instance:mytag1', 'mesos_cluster:some-cluster-name']
+    instance['cluster_name'] = 'test-cluster'
+    expected_tags = ['url:http://hello.com/state'] + cluster_name_tag + additional_tags
     expected_status = AgentCheck.OK
     check = MesosSlave('mesos_slave', {}, [instance])
     with mock.patch('datadog_checks.base.utils.http.requests') as r:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR mitigates the mesos_slave integration DDOSing the mesos master. 

### Motivation
<!-- What inspired you to submit this pull request? -->

When we tried adding in the mesos_slave integration into our system, the agents DDOS'd the master, by sending hundreds of requests every minute to the masters `/state` endpoint, all to get one piece of static information (the cluster name). That particular endpoint, `/state`, returned a JSON object around `85MB`, as it returned the entire history of the entire cluster to the agents, all to get one very small piece of static configuration - the `cluster_name`. 

This fix mitigates that in 3 ways:
1. It directs the master traffic to `/state-summary`, rather than `/state`, to get a significantly smaller response
2. It caches the `cluster_name` on the agent, assuming that in most cases the cluster name doesn't change, and the call is therefore just a meaningless call for static configuration.
3. It allows for a piece of instance configuration, where we provide the `cluster_name` ahead of time, in order to cut down the number of requests the agent has to make, and the load our master has to handle. This is useful for a situation where we know ahead of time what the `cluster_name` will be, and are confident that it won't change, as we are in our system.

Signed-off-by: David Freilich <david.freilich@appsflyer.com>

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
