### PR TITLE
[Gitlab] Replace `master` reference to `main`

### DIFF
--- a/.gitlab/validate-agent-build/trigger_agent_build.py
+++ b/.gitlab/validate-agent-build/trigger_agent_build.py
@@ -12,7 +12,7 @@ def trigger_pipeline():
     # TODO: Opt out of kitchen tests when the appropriate flag is implemented.
     data = {
         "token": CI_TOKEN,
-        "ref": "master",
+        "ref": "main",
         "variables": {
             "RELEASE_VERSION_6": "nightly",
             "RELEASE_VERSION_7": "nightly-a7",


### PR DESCRIPTION
### What does this PR do?

Replace `master` reference on Gitlab validator to `main`

### Motivation
<!-- What inspired you to submit this pull request? -->

Upcoming change from `master` to `main` on the `datadog-agent` repository.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- **This should be merged only after the renaming.**
- PRs need to be rebased to include this commit, otherwise they will point to the old `master` branch
- Reviewers should check that there are not other references to the `master` branch of the `datadog-agent` repository on this repository (links are okay; they will be redirected automatically).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
