### PR TITLE
Fix required values in vertica

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/spec.py
@@ -394,7 +394,7 @@ def value_validator(value, loader, file_name, sections_display, option_name, dep
 
             value_validator(type_data, loader, file_name, sections_display, option_name, depth=depth + 1)
 
-        if not depth:
+        if not depth and value.get('example') is None:
             value['example'] = default_option_example(option_name)
 
         return

--- a/vertica/assets/configuration/spec.yaml
+++ b/vertica/assets/configuration/spec.yaml
@@ -16,11 +16,10 @@ files:
       - template: instances
         options:
           - name: db
-            description: The name of the database to establish a connection with.
+            description: The name of the database to establish a connection with defaults to the username.
             value:
               type: string
               example: <DATABASE_NAME>
-              display_default: username
           - name: server
             description: The hostname used to connect to the database.
             value:

--- a/vertica/assets/configuration/spec.yaml
+++ b/vertica/assets/configuration/spec.yaml
@@ -20,7 +20,7 @@ files:
             value:
               type: string
               example: <DATABASE_NAME>
-              default: username
+              display_default: username
           - name: server
             description: The hostname used to connect to the database.
             value:

--- a/vertica/assets/configuration/spec.yaml
+++ b/vertica/assets/configuration/spec.yaml
@@ -16,19 +16,17 @@ files:
       - template: instances
         options:
           - name: db
-            required: true
             description: The name of the database to establish a connection with.
             value:
               type: string
               example: <DATABASE_NAME>
+              default: username
           - name: server
-            required: true
             description: The hostname used to connect to the database.
             value:
               type: string
-              example: <SERVER>
+              example: localhost
           - name: port
-            required: true
             description: The port used to connect to the database.
             value:
               type: integer
@@ -55,7 +53,6 @@ files:
                 - disk_storage
                 - resource_usage
           - name: username
-            required: true
             description: The database user to authenticate as.
             value:
               type: string

--- a/vertica/datadog_checks/vertica/config_models/defaults.py
+++ b/vertica/datadog_checks/vertica/config_models/defaults.py
@@ -29,7 +29,7 @@ def instance_custom_queries(field, value):
 
 
 def instance_db(field, value):
-    return 'username'
+    return get_default_field_value(field, value)
 
 
 def instance_empty_default_hostname(field, value):

--- a/vertica/datadog_checks/vertica/config_models/defaults.py
+++ b/vertica/datadog_checks/vertica/config_models/defaults.py
@@ -28,6 +28,10 @@ def instance_custom_queries(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_db(field, value):
+    return 'username'
+
+
 def instance_empty_default_hostname(field, value):
     return False
 
@@ -42,6 +46,14 @@ def instance_min_collection_interval(field, value):
 
 def instance_password(field, value):
     return get_default_field_value(field, value)
+
+
+def instance_port(field, value):
+    return 5433
+
+
+def instance_server(field, value):
+    return 'localhost'
 
 
 def instance_service(field, value):
@@ -86,3 +98,7 @@ def instance_use_global_custom_queries(field, value):
 
 def instance_use_tls(field, value):
     return False
+
+
+def instance_username(field, value):
+    return get_default_field_value(field, value)

--- a/vertica/datadog_checks/vertica/config_models/instance.py
+++ b/vertica/datadog_checks/vertica/config_models/instance.py
@@ -30,13 +30,13 @@ class InstanceConfig(BaseModel):
     client_lib_log_level: Optional[str]
     connection_load_balance: Optional[bool]
     custom_queries: Optional[Sequence[CustomQuery]]
-    db: str
+    db: Optional[str]
     empty_default_hostname: Optional[bool]
     metric_groups: Optional[Sequence[str]]
     min_collection_interval: Optional[float]
     password: Optional[str]
-    port: int
-    server: str
+    port: Optional[int]
+    server: Optional[str]
     service: Optional[str]
     tags: Optional[Sequence[str]]
     timeout: Optional[int]
@@ -48,7 +48,7 @@ class InstanceConfig(BaseModel):
     tls_verify: Optional[bool]
     use_global_custom_queries: Optional[str]
     use_tls: Optional[bool]
-    username: str
+    username: Optional[str]
 
     @root_validator(pre=True)
     def _initial_validation(cls, values):

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -26,7 +26,7 @@ init_config:
 instances:
 
   -
-    ## @param db - string - optional
+    ## @param db - string - optional - default: username
     ## The name of the database to establish a connection with.
     #
     # db: <DATABASE_NAME>

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -25,20 +25,21 @@ init_config:
 #
 instances:
 
-    ## @param db - string - required
+  -
+    ## @param db - string - optional
     ## The name of the database to establish a connection with.
     #
-  - db: <DATABASE_NAME>
+    # db: <DATABASE_NAME>
 
-    ## @param server - string - required
+    ## @param server - string - optional - default: localhost
     ## The hostname used to connect to the database.
     #
-    server: <SERVER>
+    # server: localhost
 
-    ## @param port - integer - required
+    ## @param port - integer - optional - default: 5433
     ## The port used to connect to the database.
     #
-    port: 5433
+    # port: 5433
 
     ## @param metric_groups - list of strings - optional
     ## Enable metric groups for metric collection. Metric groups are based on Vertica tables.
@@ -58,10 +59,10 @@ instances:
     #   - disk_storage
     #   - resource_usage
 
-    ## @param username - string - required
+    ## @param username - string - optional
     ## The database user to authenticate as.
     #
-    username: <USERNAME>
+    # username: <USERNAME>
 
     ## @param password - string - optional
     ## The password of `username`.

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -26,8 +26,8 @@ init_config:
 instances:
 
   -
-    ## @param db - string - optional - default: username
-    ## The name of the database to establish a connection with.
+    ## @param db - string - optional
+    ## The name of the database to establish a connection with defaults to the username.
     #
     # db: <DATABASE_NAME>
 

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from itertools import chain
 
 import vertica_python as vertica
+from datadog_checks.base.utils.common import exclude_undefined_keys
 from six import iteritems
 from vertica_python.vertica.column import timestamp_tz_parse
 
@@ -580,8 +581,7 @@ class VerticaCheck(AgentCheck):
             connection_options['ssl'] = tls_context
 
         try:
-            connection_options = {k: v for k, v in connection_options.items() if v is not None}
-            connection = vertica.connect(**connection_options)
+            connection = vertica.connect(**exclude_undefined_keys(connection_options))
         except Exception as e:
             self.log.error('Unable to connect to database `%s` as user `%s`: %s', self._db, self._username, e)
             self.service_check(self.SERVICE_CHECK_CONNECT, self.CRITICAL, tags=self._tags)

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -10,11 +10,11 @@ from datetime import datetime
 from itertools import chain
 
 import vertica_python as vertica
-from datadog_checks.base.utils.common import exclude_undefined_keys
 from six import iteritems
 from vertica_python.vertica.column import timestamp_tz_parse
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
+from datadog_checks.base.utils.common import exclude_undefined_keys
 from datadog_checks.base.utils.containers import iter_unique
 
 from . import views


### PR DESCRIPTION
These values were not actually required before:
* There was no config option thrown
* They were set to '' if missing
* vertica lib assigned them actual default values

So I've updated the check to reflect what vertica is doing in case it changes in an update.