### PR TITLE
Fix data configuration type

### DIFF
--- a/http_check/assets/configuration/spec.yaml
+++ b/http_check/assets/configuration/spec.yaml
@@ -33,7 +33,9 @@ files:
         request with the data parameter.
         SOAP requests are supported if you use the POST method and supply an XML string as the data parameter.
       value:
-        type: object
+        anyOf:
+        - type: object
+        - type: string
         enabled: false
         example:
           <KEY>: <VALUE>

--- a/http_check/datadog_checks/http_check/config_models/instance.py
+++ b/http_check/datadog_checks/http_check/config_models/instance.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence, Union
 
 from pydantic import BaseModel, root_validator, validator
 
@@ -45,7 +45,7 @@ class InstanceConfig(BaseModel):
     collect_response_time: Optional[bool]
     connect_timeout: Optional[float]
     content_match: Optional[str]
-    data: Optional[Mapping[str, Any]]
+    data: Optional[Union[Mapping[str, Any], str]]
     days_critical: Optional[int]
     days_warning: Optional[int]
     empty_default_hostname: Optional[bool]

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -61,7 +61,7 @@ instances:
     #
     # method: get
 
-    ## @param data - mapping - optional
+    ## @param data - mapping or string - optional
     ## If any one of the POST, PUT, DELETE, or PATCH method is specified, you can choose to send data in the body of the
     ## request with the data parameter.
     ## SOAP requests are supported if you use the POST method and supply an XML string as the data parameter.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We actually support `string` types https://github.com/DataDog/integrations-core/blob/e7c8157ecfd41136939d514d2df986a97015e93c/http_check/datadog_checks/http_check/http_check.py#L129 and we're testing that use case https://github.com/DataDog/integrations-core/blob/e7c8157ecfd41136939d514d2df986a97015e93c/http_check/tests/common.py#L225

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
