### PR TITLE
Fix missing replication_role tag on DBM metrics & events

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -109,8 +109,7 @@ class MySql(AgentCheck):
                 self._conn = db
 
                 if self._get_is_aurora(db):
-                    tags.extend(self._get_runtime_aurora_tags(db))
-                    tags = list(set(tags))
+                    tags = tags + self._get_runtime_aurora_tags(db)
 
                 # version collection
                 self.version = get_version(db)
@@ -120,8 +119,9 @@ class MySql(AgentCheck):
                 self._collect_metrics(db, tags=tags)
                 self._collect_system_metrics(self._config.host, db, tags)
                 if self._config.deep_database_monitoring:
-                    self._statement_metrics.collect_per_statement_metrics(db, self.service_check_tags)
-                    self._statement_samples.run_sampler(self.service_check_tags)
+                    dbm_tags = list(set(self.service_check_tags) | set(tags))
+                    self._statement_metrics.collect_per_statement_metrics(db, dbm_tags)
+                    self._statement_samples.run_sampler(dbm_tags)
 
                 # keeping track of these:
                 self._put_qcache_stats()


### PR DESCRIPTION
### What does this PR do?

Fixes a regression added in https://github.com/DataDog/integrations-core/pull/9223, ensuring that DBM metrics & samples receive the aurora `replication_role` tag.

### Motivation

Fix missing tag. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
