### PR TITLE
Enable autocommit on all connections

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -273,9 +273,7 @@ class PostgreSql(AgentCheck):
             if self._config.query_timeout:
                 args['options'] = '-c statement_timeout=%s' % self._config.query_timeout
             conn = psycopg2.connect(**args)
-        # The integration runs a number of queries in a session but they are independent and should
-        # not execute in a transaction. Therefore autocommit is enabled by default for safety for
-        # all new connections (to prevent long-lived transactions).
+        # Autocommit is enabled by default for safety for all new connections (to prevent long-lived transactions).
         conn.set_session(autocommit=True)
         return conn
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -258,7 +258,7 @@ class PostgreSql(AgentCheck):
             )
             if self._config.query_timeout:
                 connection_string += " options='-c statement_timeout=%s'" % self._config.query_timeout
-            return psycopg2.connect(connection_string)
+            conn = psycopg2.connect(connection_string)
         else:
             args = {
                 'host': self._config.host,
@@ -272,7 +272,12 @@ class PostgreSql(AgentCheck):
                 args['port'] = self._config.port
             if self._config.query_timeout:
                 args['options'] = '-c statement_timeout=%s' % self._config.query_timeout
-            return psycopg2.connect(**args)
+            conn = psycopg2.connect(**args)
+        # The integration runs a number of queries in a session but they are independent and should
+        # not execute in a transaction. Therefore autocommit is enabled by default for safety for
+        # all new connections (to prevent long-lived transactions).
+        conn.set_session(autocommit=True)
+        return conn
 
     def _connect(self):
         """Get and memoize connections to instances"""


### PR DESCRIPTION
### What does this PR do?

As a follow-up to: https://github.com/DataDog/integrations-core/pull/9476 this PR enables autocommit on new connections.

### Motivation

This prevents the agent from opening and holding long-lived transactions, which can cause subtle performance problems.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
