### PR TITLE
Fix docs build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ skip_install = true
 
 [testenv:docs]
 ; for CLI & API auto-documentation of ddev
-sitepackages = true
 deps =
     mkdocs>=1.1.1
     ; theme
@@ -28,7 +27,6 @@ deps =
     ; Necessary to generate PDF
     WeasyPrint>=51
     ; for API auto-documentation
-    -e./datadog_checks_base[deps,http]
     -e./datadog_checks_dev[cli]
     ; for CLI auto-documentation of ddev
     mkdocs-click~=0.4
@@ -37,4 +35,5 @@ setenv =
     ; See https://reproducible-builds.org/specs/source-date-epoch/
     SOURCE_DATE_EPOCH=1580601600
 commands =
+    python -m pip install -e./datadog_checks_base[deps,http]
     python -m mkdocs {posargs}


### PR DESCRIPTION
### Motivation

The base package has strict pins which breaks the current version of pip's resolver so we should force those in a final install step