### PR TITLE
Fix master leader detection after 307

### DIFF
--- a/mesos_master/assets/service_checks.json
+++ b/mesos_master/assets/service_checks.json
@@ -13,6 +13,6 @@
             "host",
             "url"
         ],
-        "description": "Returns CRITICAL if the Agent cannot connect to the Mesos Master API to collect metrics, UNKNWON if the master is not detected as the leader, otherwise OK."
+        "description": "Returns CRITICAL if the Agent cannot connect to the Mesos Master API to collect metrics, UNKNOWN if the master is not detected as the leader, otherwise OK."
     }
 ]

--- a/mesos_master/assets/service_checks.json
+++ b/mesos_master/assets/service_checks.json
@@ -5,13 +5,14 @@
         "check": "mesos_master.can_connect",
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "unknown"
         ],
         "name": "Can Connect",
         "groups": [
             "host",
             "url"
         ],
-        "description": "Returns CRITICAL if the Agent cannot connect to the Mesos Master API to collect metrics, otherwise OK."
+        "description": "Returns CRITICAL if the Agent cannot connect to the Mesos Master API to collect metrics, UNKNWON if the master is not detected as the leader, otherwise OK."
     }
 ]

--- a/mesos_master/datadog_checks/mesos_master/mesos_master.py
+++ b/mesos_master/datadog_checks/mesos_master/mesos_master.py
@@ -158,33 +158,39 @@ class MesosMaster(AgentCheck):
 
     def _get_json(self, url, failure_expected=False, tags=None):
         tags = tags + ["url:%s" % url] if tags else ["url:%s" % url]
-        msg = None
-        status = None
-        timeout = self.http.options['timeout']
-        response = None
-        try:
-            response = self.http.get(url)
-            if response.status_code != 200:
-                status = AgentCheck.CRITICAL
-                msg = "Got %s when hitting %s" % (response.status_code, url)
-            else:
-                status = AgentCheck.OK
-                msg = "Mesos master instance detected at %s " % url
-        except requests.exceptions.Timeout:
-            # If there's a timeout
-            msg = "%s seconds timeout when hitting %s" % (timeout, url)
-            status = AgentCheck.CRITICAL
-        except Exception as e:
-            msg = str(e)
-            status = AgentCheck.CRITICAL
-        finally:
-            self.log.debug('Request to url : %s, timeout: %s, message: %s', url, timeout, msg)
-            self._send_service_check(url, status, failure_expected=failure_expected, tags=tags, message=msg)
+
+        response, msg, status = self._make_request(url)
+
+        self.log.debug('Request to url : %s, timeout: %s, message: %s', url, self.http.options['timeout'], msg)
+        self._send_service_check(url, status, failure_expected=failure_expected, tags=tags, message=msg)
 
         if response.encoding is None:
             response.encoding = 'UTF8'
 
         return response.json()
+
+    def _make_request(self, url):
+        msg = None
+        status = None
+        response = None
+
+        try:
+            response = self.http.get(url)
+            if response.status_code != 200:
+                status = AgentCheck.CRITICAL
+                msg = "Got {} when hitting {}".format(response.status_code, url)
+            else:
+                status = AgentCheck.OK
+                msg = "Mesos master instance detected at {} ".format(url)
+        except requests.exceptions.Timeout:
+            # If there's a timeout
+            msg = "{} seconds timeout when hitting {}".format(self.http.options['timeout'], url)
+            status = AgentCheck.CRITICAL
+        except Exception as e:
+            msg = str(e)
+            status = AgentCheck.CRITICAL
+
+        return response, msg, status
 
     def _send_service_check(self, url, status, failure_expected=False, tags=None, message=None):
         skip_service_check = False
@@ -201,18 +207,50 @@ class MesosMaster(AgentCheck):
         if status is AgentCheck.CRITICAL:
             raise CheckException(message)
 
+    def _master_state_found_307(self, resp1, resp2):
+        history = []
+        if resp1 is not None:
+            history = resp1.history
+        if resp2 is not None:
+            history += resp2.history
+
+        for r in history:
+            if r is not None and r.status_code == 307:
+                return True
+        return False
+
     def _get_master_state(self, url, tags):
         # Mesos version >= 0.25
         endpoint = url + '/state'
-        try:
-            master_state = self._get_json(endpoint, failure_expected=True, tags=tags)
-        except CheckException:
+        url_tag = endpoint
+        master_state = None
+
+        response, msg, status = self._make_request(endpoint)
+        if response is None or response.status_code != 200:
             # Mesos version < 0.25
             old_endpoint = endpoint + '.json'
+            url_tag = old_endpoint
             self.log.info(
                 'Unable to fetch state from %s. Retrying with the deprecated endpoint: %s.', endpoint, old_endpoint
             )
-            master_state = self._get_json(old_endpoint, tags=tags)
+
+            old_response, msg, status = self._make_request(old_endpoint)
+            if old_response is not None and old_response.status_code == 200:
+                if old_response.encoding is None:
+                    old_response.encoding = 'UTF8'
+                master_state = old_response.json()
+
+            elif self._master_state_found_307(response, old_response):
+                # If there is a 401 after a 307, the master is not a leader
+                # http://mesos.apache.org/documentation/latest/endpoints/master/state/
+                self.log.debug('Url %s is not a leader master.', url)
+                status = AgentCheck.UNKNOWN
+        else:
+            if response.encoding is None:
+                response.encoding = 'UTF8'
+            master_state = response.json()
+
+        self._send_service_check(url, status, tags=tags + ["url:{}".format(url_tag)], message=msg)
         return master_state
 
     def _get_master_stats(self, url, tags):

--- a/mesos_master/tests/test_check.py
+++ b/mesos_master/tests/test_check.py
@@ -125,6 +125,26 @@ def test_instance_timeout(check, instance):
             ['my:tag', 'url:http://hello.com/state.json'],
             True,
         ),
+        (
+            'OK case with non-leader master on /state',
+            [
+                mock.MagicMock(status_code=401, history=[mock.MagicMock(status_code=307)]),
+                mock.MagicMock(content='{}', history=[], status_code=500),
+            ],
+            AgentCheck.UNKNOWN,
+            ['my:tag', 'url:http://hello.com/state.json'],
+            False,
+        ),
+        (
+            'OK case with non-leader master on /state.json',
+            [
+                mock.MagicMock(status_code=500, history=[]),
+                mock.MagicMock(content='{}', history=[mock.MagicMock(status_code=307)], status_code=401),
+            ],
+            AgentCheck.UNKNOWN,
+            ['my:tag', 'url:http://hello.com/state.json'],
+            False,
+        ),
     ],
 )
 @pytest.mark.integration


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
http://mesos.apache.org/documentation/latest/endpoints/master/state/

According to the doc, the `/state` endpoint returns `307` when the master is not the current leader, and redirect to the current leader. However, the `Authorization` headers are not passed after a 307 redirection, so we end up with a 401 for example.
If we fail to get the master state with both the legacy and the new method, we make sure there was no `307` in the history before failing.

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
