### PR TITLE
Enable `new_gc_metrics` JMX config option for new installations

### DIFF
--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -20,7 +20,7 @@ init_config:
     ##                       jvm.gc.major_collection_time
     ## The default value is false to ensure backward compatibility.
     #
-    # new_gc_metrics: false
+    new_gc_metrics: true
 
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/cassandra/datadog_checks/cassandra/config_models/defaults.py
+++ b/cassandra/datadog_checks/cassandra/config_models/defaults.py
@@ -13,7 +13,7 @@ def shared_conf(field, value):
 
 
 def shared_new_gc_metrics(field, value):
-    return False
+    return True
 
 
 def shared_service(field, value):

--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -20,7 +20,7 @@ init_config:
     ##                       jvm.gc.major_collection_time
     ## The default value is false to ensure backward compatibility.
     #
-    # new_gc_metrics: false
+    new_gc_metrics: true
 
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+++ b/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
@@ -20,7 +20,7 @@ init_config:
     ##                       jvm.gc.major_collection_time
     ## The default value is false to ensure backward compatibility.
     #
-    # new_gc_metrics: false
+    new_gc_metrics: true
 
     ## @param service_check_prefix - string - required
     ## Service check prefix to use.

--- a/datadog_checks_dev/datadog_checks/dev/jmx.py
+++ b/datadog_checks_dev/datadog_checks/dev/jmx.py
@@ -36,3 +36,8 @@ JMX_E2E_METRICS = [
     'jmx.gc.minor_collection_count',
     'jmx.gc.minor_collection_time',
 ]
+
+JVM_E2E_METRICS_NEW = list(JVM_E2E_METRICS)
+JVM_E2E_METRICS_NEW.remove('jvm.gc.cms.count')
+JVM_E2E_METRICS_NEW.remove('jvm.gc.parnew.time')
+JVM_E2E_METRICS_NEW.extend(m.replace('jmx.', 'jvm.', 1) for m in JMX_E2E_METRICS)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config/jmx.yaml
@@ -19,9 +19,11 @@
     jvm.gc.parnew.time => jvm.gc.minor_collection_time
                           jvm.gc.major_collection_time
     The default value is false to ensure backward compatibility.
+  enabled: true
   value:
+    display_default: false
+    example: true
     type: boolean
-    example: false
 - name: service_check_prefix
   description: |
     Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -20,7 +20,7 @@ init_config:
     ##                       jvm.gc.major_collection_time
     ## The default value is false to ensure backward compatibility.
     #
-    # new_gc_metrics: false
+    new_gc_metrics: true
 
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -20,7 +20,7 @@ init_config:
     ##                       jvm.gc.major_collection_time
     ## The default value is false to ensure backward compatibility.
     #
-    # new_gc_metrics: false
+    new_gc_metrics: true
 
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/hivemq/datadog_checks/hivemq/data/conf.yaml.example
+++ b/hivemq/datadog_checks/hivemq/data/conf.yaml.example
@@ -20,7 +20,7 @@ init_config:
     ##                       jvm.gc.major_collection_time
     ## The default value is false to ensure backward compatibility.
     #
-    # new_gc_metrics: false
+    new_gc_metrics: true
 
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/ignite/datadog_checks/ignite/data/conf.yaml.example
+++ b/ignite/datadog_checks/ignite/data/conf.yaml.example
@@ -20,7 +20,7 @@ init_config:
     ##                       jvm.gc.major_collection_time
     ## The default value is false to ensure backward compatibility.
     #
-    # new_gc_metrics: false
+    new_gc_metrics: true
 
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -20,7 +20,7 @@ init_config:
     ##                       jvm.gc.major_collection_time
     ## The default value is false to ensure backward compatibility.
     #
-    # new_gc_metrics: false
+    new_gc_metrics: true
 
     ## @param service_check_prefix - string - required
     ## Service check prefix to use.

--- a/kafka/datadog_checks/kafka/config_models/defaults.py
+++ b/kafka/datadog_checks/kafka/config_models/defaults.py
@@ -13,7 +13,7 @@ def shared_conf(field, value):
 
 
 def shared_new_gc_metrics(field, value):
-    return False
+    return True
 
 
 def shared_service(field, value):

--- a/kafka/datadog_checks/kafka/data/conf.yaml.example
+++ b/kafka/datadog_checks/kafka/data/conf.yaml.example
@@ -20,7 +20,7 @@ init_config:
     ##                       jvm.gc.major_collection_time
     ## The default value is false to ensure backward compatibility.
     #
-    # new_gc_metrics: false
+    new_gc_metrics: true
 
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/kafka/tests/test_check.py
+++ b/kafka/tests/test_check.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from datadog_checks.dev.jmx import JVM_E2E_METRICS
+from datadog_checks.dev.jmx import JVM_E2E_METRICS_NEW
 from datadog_checks.dev.utils import get_metadata_metrics
 
 from .common import KAFKA_E2E_METRICS
@@ -15,8 +15,8 @@ def test(dd_agent_check):
     instance = {}
     aggregator = dd_agent_check(instance, rate=True)
 
-    for metric in KAFKA_E2E_METRICS + JVM_E2E_METRICS:
+    for metric in KAFKA_E2E_METRICS + JVM_E2E_METRICS_NEW:
         aggregator.assert_metric(metric)
 
     aggregator.assert_all_metrics_covered()
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=JVM_E2E_METRICS)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=JVM_E2E_METRICS_NEW)

--- a/presto/datadog_checks/presto/data/conf.yaml.example
+++ b/presto/datadog_checks/presto/data/conf.yaml.example
@@ -20,7 +20,7 @@ init_config:
     ##                       jvm.gc.major_collection_time
     ## The default value is false to ensure backward compatibility.
     #
-    # new_gc_metrics: false
+    new_gc_metrics: true
 
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/presto/tests/test_presto.py
+++ b/presto/tests/test_presto.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
-from datadog_checks.dev.jmx import JVM_E2E_METRICS
+from datadog_checks.dev.jmx import JVM_E2E_METRICS_NEW
 from datadog_checks.dev.utils import get_metadata_metrics
 
 from .common import METRICS
@@ -15,8 +15,8 @@ def test(dd_agent_check):
     instance = {}
     aggregator = dd_agent_check(instance, rate=True)
 
-    for metric in METRICS + JVM_E2E_METRICS:
+    for metric in METRICS + JVM_E2E_METRICS_NEW:
         aggregator.assert_metric(metric)
 
     aggregator.assert_all_metrics_covered()
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=JVM_E2E_METRICS)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=JVM_E2E_METRICS_NEW)

--- a/solr/datadog_checks/solr/data/conf.yaml.example
+++ b/solr/datadog_checks/solr/data/conf.yaml.example
@@ -20,7 +20,7 @@ init_config:
     ##                       jvm.gc.major_collection_time
     ## The default value is false to ensure backward compatibility.
     #
-    # new_gc_metrics: false
+    new_gc_metrics: true
 
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/solr/tests/test_check.py
+++ b/solr/tests/test_check.py
@@ -5,7 +5,7 @@
 import pytest
 
 from datadog_checks.base.stubs.aggregator import AggregatorStub
-from datadog_checks.dev.jmx import JVM_E2E_METRICS
+from datadog_checks.dev.jmx import JVM_E2E_METRICS_NEW
 from datadog_checks.dev.utils import get_metadata_metrics
 
 from .common import SOLR_METRICS
@@ -16,9 +16,9 @@ def test_e2e(dd_agent_check):
     instance = {}
     aggregator = dd_agent_check(instance, rate=True)  # type: AggregatorStub
 
-    for metric in SOLR_METRICS + JVM_E2E_METRICS:
+    for metric in SOLR_METRICS + JVM_E2E_METRICS_NEW:
         aggregator.assert_metric(metric)
 
     aggregator.assert_all_metrics_covered()
 
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=JVM_E2E_METRICS)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=JVM_E2E_METRICS_NEW)

--- a/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
+++ b/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
@@ -17,7 +17,7 @@ def shared_is_jmx(field, value):
 
 
 def shared_new_gc_metrics(field, value):
-    return False
+    return True
 
 
 def shared_proxy(field, value):

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -20,7 +20,7 @@ init_config:
     ##                       jvm.gc.major_collection_time
     ## The default value is false to ensure backward compatibility.
     #
-    # new_gc_metrics: false
+    new_gc_metrics: true
 
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/sonarqube/tests/metrics.py
+++ b/sonarqube/tests/metrics.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.dev.jmx import JVM_E2E_METRICS
+from datadog_checks.dev.jmx import JVM_E2E_METRICS_NEW
 
 JMX_METRICS = [
     'sonarqube.server.async_execution.largest_worker_count',
@@ -23,7 +23,7 @@ JMX_METRICS = [
     'sonarqube.server.database.pool_max_wait_millis',
     'sonarqube.server.database.pool_remove_abandoned_timeout_seconds',
 ]
-JMX_METRICS.extend(JVM_E2E_METRICS)
+JMX_METRICS.extend(JVM_E2E_METRICS_NEW)
 
 WEB_METRICS = [
     'sonarqube.complexity.cognitive_complexity',

--- a/tomcat/datadog_checks/tomcat/config_models/defaults.py
+++ b/tomcat/datadog_checks/tomcat/config_models/defaults.py
@@ -13,7 +13,7 @@ def shared_conf(field, value):
 
 
 def shared_new_gc_metrics(field, value):
-    return False
+    return True
 
 
 def shared_service(field, value):

--- a/tomcat/datadog_checks/tomcat/data/conf.yaml.example
+++ b/tomcat/datadog_checks/tomcat/data/conf.yaml.example
@@ -20,7 +20,7 @@ init_config:
     ##                       jvm.gc.major_collection_time
     ## The default value is false to ensure backward compatibility.
     #
-    # new_gc_metrics: false
+    new_gc_metrics: true
 
     ## @param service_check_prefix - string - optional
     ## Custom service check prefix. e.g. `my_prefix` to get a service check called `my_prefix.can_connect`.

--- a/tomcat/tests/common.py
+++ b/tomcat/tests/common.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 from datadog_checks.dev import get_here
-from datadog_checks.dev.jmx import JVM_E2E_METRICS
+from datadog_checks.dev.jmx import JVM_E2E_METRICS_NEW
 
 CHECK_NAME = "tomcat"
 
@@ -29,4 +29,4 @@ TOMCAT_E2E_METRICS = [
     "tomcat.string_cache.hit_count",
     "tomcat.web.cache.hit_count",
     "tomcat.web.cache.lookup_count",
-] + JVM_E2E_METRICS
+] + JVM_E2E_METRICS_NEW

--- a/tomcat/tests/test_check.py
+++ b/tomcat/tests/test_check.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from datadog_checks.dev.jmx import JVM_E2E_METRICS
+from datadog_checks.dev.jmx import JVM_E2E_METRICS_NEW
 from datadog_checks.dev.utils import get_metadata_metrics
 
 from .common import TOMCAT_E2E_METRICS
@@ -39,4 +39,4 @@ def test(dd_agent_check):
 
     aggregator.assert_all_metrics_covered()
 
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=JVM_E2E_METRICS + COUNTER_METRICS)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=JVM_E2E_METRICS_NEW + COUNTER_METRICS)


### PR DESCRIPTION
### Motivation

Match behavior of `collect_default_metrics` (see https://github.com/DataDog/integrations-core/pull/9441) as we plan on changing the default value of both to `true` in a major version update