### PR TITLE
Use cilium-agent and cilium as autodiscover identifiers

### DIFF
--- a/cilium/assets/configuration/spec.yaml
+++ b/cilium/assets/configuration/spec.yaml
@@ -35,6 +35,7 @@ files:
     overrides:
       value.example:
       - cilium-agent
+      - cilium
   - template: init_config
     options: []
   - template: instances

--- a/cilium/datadog_checks/cilium/data/auto_conf.yaml
+++ b/cilium/datadog_checks/cilium/data/auto_conf.yaml
@@ -5,6 +5,7 @@
 #
 ad_identifiers:
   - cilium-agent
+  - cilium
 
 ## All options defined here are available to all instances.
 #


### PR DESCRIPTION
### What does this PR do?
Uses both identifiers to ensure compatibility.

### Motivation
https://github.com/DataDog/integrations-core/pull/9512#discussion_r651526461
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
