### PR TITLE
ceph agent 8 signature

### DIFF
--- a/cacti/datadog_checks/cacti/cacti.py
+++ b/cacti/datadog_checks/cacti/cacti.py
@@ -10,7 +10,7 @@ from fnmatch import fnmatch
 
 import pymysql
 
-from datadog_checks.base import AgentCheck
+from datadog_checks.base import AgentCheck, ConfigurationError
 
 try:
     import rrdtool
@@ -40,7 +40,7 @@ class CactiCheck(AgentCheck):
         super(CactiCheck, self).__init__(name, init_config, instances)
         self.last_ts = {}
         # Load the instance config
-        self._config = self._get_config(instances[0])
+        self._config = self._get_config()
 
     @staticmethod
     def get_library_versions():
@@ -48,9 +48,9 @@ class CactiCheck(AgentCheck):
             return {"rrdtool": rrdtool.__version__}
         return {"rrdtool": "Not Found"}
 
-    def check(self, instance):
+    def check(self, _):
         if rrdtool is None:
-            raise Exception("Unable to import python rrdtool module")
+            raise ConfigurationError("Unable to import python rrdtool module")
 
         connection = self._get_connection()
 
@@ -91,22 +91,21 @@ class CactiCheck(AgentCheck):
 
         return patterns
 
-    @classmethod
-    def _get_config(cls, instance):
+    def _get_config(self):
         required = ['mysql_host', 'mysql_user', 'rrd_path']
         for param in required:
-            if not instance.get(param):
-                raise Exception("Cacti instance missing %s. Skipping." % (param))
+            if not self.instance.get(param):
+                raise ConfigurationError("Cacti instance missing %s. Skipping." % param)
 
-        host = instance.get('mysql_host')
-        user = instance.get('mysql_user')
-        password = instance.get('mysql_password', '') or ''
-        db = instance.get('mysql_db', 'cacti')
-        port = instance.get('mysql_port')
-        rrd_path = instance.get('rrd_path')
-        whitelist = instance.get('rrd_whitelist')
-        field_names = instance.get('field_names', ['ifName', 'dskDevice'])
-        tags = instance.get('tags', [])
+        host = self.instance.get('mysql_host')
+        user = self.instance.get('mysql_user')
+        password = self.instance.get('mysql_password', '') or ''
+        db = self.instance.get('mysql_db', 'cacti')
+        port = self.instance.get('mysql_port')
+        rrd_path = self.instance.get('rrd_path')
+        whitelist = self.instance.get('rrd_whitelist')
+        field_names = self.instance.get('field_names', ['ifName', 'dskDevice'])
+        tags = self.instance.get('tags', [])
 
         Config = namedtuple(
             'Config', ['host', 'user', 'password', 'db', 'port', 'rrd_path', 'whitelist', 'field_names', 'tags']

--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -7,6 +7,7 @@ import os
 import re
 
 import simplejson as json
+from datadog_checks.base.errors import CheckException
 from six import iteritems
 
 from datadog_checks.base import AgentCheck
@@ -50,7 +51,7 @@ class Ceph(AgentCheck):
         if use_sudo:
             test_sudo = os.system('setsid sudo -l < /dev/null')
             if test_sudo != 0:
-                raise Exception('The dd-agent user does not have sudo access')
+                raise CheckException('The dd-agent user does not have sudo access')
             ceph_args = 'sudo {}'.format(ceph_cmd)
         else:
             ceph_args = ceph_cmd
@@ -348,12 +349,12 @@ class Ceph(AgentCheck):
                             status = AgentCheck.CRITICAL
                     self.service_check(self.NAMESPACE + '.' + check.lower(), status, tags=tags)
 
-    def check(self, instance):
-        ceph_cmd = instance.get('ceph_cmd') or self.DEFAULT_CEPH_CMD
-        ceph_cluster = instance.get('ceph_cluster') or self.DEFAULT_CEPH_CLUSTER
-        ceph_health_checks = instance.get('collect_service_check_for') or self.DEFAULT_HEALTH_CHECKS
-        custom_tags = instance.get('tags', [])
-        raw = self._collect_raw(ceph_cmd, ceph_cluster, instance)
+    def check(self, _):
+        ceph_cmd = self.instance.get('ceph_cmd') or self.DEFAULT_CEPH_CMD
+        ceph_cluster = self.instance.get('ceph_cluster') or self.DEFAULT_CEPH_CLUSTER
+        ceph_health_checks = self.instance.get('collect_service_check_for') or self.DEFAULT_HEALTH_CHECKS
+        custom_tags = self.instance.get('tags', [])
+        raw = self._collect_raw(ceph_cmd, ceph_cluster, self.instance)
         self._perform_service_checks(raw, custom_tags, ceph_health_checks)
-        tags = self._extract_tags(raw, instance)
+        tags = self._extract_tags(raw, self.instance)
         self._extract_metrics(raw, tags)

--- a/ceph/datadog_checks/ceph/ceph.py
+++ b/ceph/datadog_checks/ceph/ceph.py
@@ -7,11 +7,11 @@ import os
 import re
 
 import simplejson as json
-from datadog_checks.base.errors import CheckException
 from six import iteritems
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.config import _is_affirmative
+from datadog_checks.base.errors import CheckException
 from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 

--- a/ceph/tests/test_integration.py
+++ b/ceph/tests/test_integration.py
@@ -14,8 +14,8 @@ from .common import BASIC_CONFIG, CHECK_NAME, EXPECTED_METRICS, EXPECTED_SERVICE
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
 def test_check(aggregator):
-    ceph_check = Ceph(CHECK_NAME, {}, {})
-    ceph_check.check(copy.deepcopy(BASIC_CONFIG))
+    ceph_check = Ceph(CHECK_NAME, {}, [copy.deepcopy(BASIC_CONFIG)])
+    ceph_check.check({})
 
     for metric in EXPECTED_METRICS:
         aggregator.assert_metric(metric, at_least=1)

--- a/ceph/tests/test_unit.py
+++ b/ceph/tests/test_unit.py
@@ -36,8 +36,8 @@ pytestmark = pytest.mark.unit
 
 @mock.patch("datadog_checks.ceph.Ceph._collect_raw", return_value=mock_data("raw.json"))
 def test_simple_metrics(_, aggregator):
-    ceph_check = Ceph(CHECK_NAME, {}, {})
-    ceph_check.check(copy.deepcopy(BASIC_CONFIG))
+    ceph_check = Ceph(CHECK_NAME, {}, [copy.deepcopy(BASIC_CONFIG)])
+    ceph_check.check({})
 
     for metric in EXPECTED_METRICS:
         aggregator.assert_metric(metric, count=1, tags=EXPECTED_TAGS)
@@ -47,8 +47,8 @@ def test_simple_metrics(_, aggregator):
 
 @mock.patch("datadog_checks.ceph.Ceph._collect_raw", return_value=mock_data("warn.json"))
 def test_warn_health(_, aggregator):
-    ceph_check = Ceph(CHECK_NAME, {}, {})
-    ceph_check.check(copy.deepcopy(BASIC_CONFIG))
+    ceph_check = Ceph(CHECK_NAME, {}, [copy.deepcopy(BASIC_CONFIG)])
+    ceph_check.check({})
 
     for metric in EXPECTED_METRICS:
         aggregator.assert_metric(metric, count=1, tags=EXPECTED_TAGS)
@@ -58,10 +58,10 @@ def test_warn_health(_, aggregator):
 
 @mock.patch("datadog_checks.ceph.Ceph._collect_raw", return_value=mock_data("ceph_luminous_warn.json"))
 def test_luminous_warn_health(_, aggregator):
-    ceph_check = Ceph(CHECK_NAME, {}, {})
     config = copy.deepcopy(BASIC_CONFIG)
     config["collect_service_check_for"] = ['OSD_NEARFULL', 'OSD_FULL']
-    ceph_check.check(config)
+    ceph_check = Ceph(CHECK_NAME, {}, [config])
+    ceph_check.check({})
 
     aggregator.assert_service_check('ceph.overall_status', status=Ceph.CRITICAL, tags=EXPECTED_SERVICE_TAGS)
     aggregator.assert_service_check('ceph.osd_nearfull', status=Ceph.WARNING, tags=EXPECTED_SERVICE_TAGS)
@@ -70,11 +70,10 @@ def test_luminous_warn_health(_, aggregator):
 
 @mock.patch("datadog_checks.ceph.Ceph._collect_raw", return_value=mock_data("ceph_luminous_ok.json"))
 def test_luminous_ok_health(_, aggregator):
-
-    ceph_check = Ceph(CHECK_NAME, {}, {})
     config = copy.deepcopy(BASIC_CONFIG)
     config["collect_service_check_for"] = ['OSD_NEARFULL']
-    ceph_check.check(config)
+    ceph_check = Ceph(CHECK_NAME, {}, [config])
+    ceph_check.check({})
 
     aggregator.assert_service_check('ceph.overall_status', status=Ceph.OK)
     aggregator.assert_service_check('ceph.osd_nearfull', status=Ceph.OK)
@@ -83,9 +82,8 @@ def test_luminous_ok_health(_, aggregator):
 
 @mock.patch("datadog_checks.ceph.Ceph._collect_raw", return_value=mock_data("ceph_luminous_warn.json"))
 def test_luminous_osd_full_metrics(_, aggregator):
-
-    ceph_check = Ceph(CHECK_NAME, {}, {})
-    ceph_check.check(copy.deepcopy(BASIC_CONFIG))
+    ceph_check = Ceph(CHECK_NAME, {}, [copy.deepcopy(BASIC_CONFIG)])
+    ceph_check.check({})
 
     aggregator.assert_metric('ceph.num_full_osds', value=1)
     aggregator.assert_metric('ceph.num_near_full_osds', value=1)
@@ -94,8 +92,8 @@ def test_luminous_osd_full_metrics(_, aggregator):
 @mock.patch("datadog_checks.ceph.Ceph._collect_raw", return_value=mock_data("raw.json"))
 def test_tagged_metrics(_, aggregator):
 
-    ceph_check = Ceph(CHECK_NAME, {}, {})
-    ceph_check.check(copy.deepcopy(BASIC_CONFIG))
+    ceph_check = Ceph(CHECK_NAME, {}, [copy.deepcopy(BASIC_CONFIG)])
+    ceph_check.check({})
 
     for osd in ['osd0', 'osd1', 'osd2']:
         expected_tags = EXPECTED_TAGS + ['ceph_osd:%s' % osd]
@@ -113,8 +111,8 @@ def test_tagged_metrics(_, aggregator):
 @mock.patch("datadog_checks.ceph.Ceph._collect_raw", return_value=mock_data("raw2.json"))
 def test_osd_perf_with_osdstats(_, aggregator):
 
-    ceph_check = Ceph(CHECK_NAME, {}, {})
-    ceph_check.check(copy.deepcopy(BASIC_CONFIG))
+    ceph_check = Ceph(CHECK_NAME, {}, [copy.deepcopy(BASIC_CONFIG)])
+    ceph_check.check({})
 
     for osd in ['osd0', 'osd1', 'osd2']:
         expected_tags = EXPECTED_TAGS + ['ceph_osd:%s' % osd]
@@ -126,8 +124,8 @@ def test_osd_perf_with_osdstats(_, aggregator):
 @mock.patch("datadog_checks.ceph.Ceph._collect_raw", return_value=mock_data("ceph_10.2.2.json"))
 def test_osd_status_metrics(_, aggregator):
 
-    ceph_check = Ceph(CHECK_NAME, {}, {})
-    ceph_check.check(copy.deepcopy(BASIC_CONFIG))
+    ceph_check = Ceph(CHECK_NAME, {}, [copy.deepcopy(BASIC_CONFIG)])
+    ceph_check.check({})
 
     expected_metrics = ['ceph.read_op_per_sec', 'ceph.write_op_per_sec', 'ceph.op_per_sec']
 
@@ -151,8 +149,8 @@ def test_osd_status_metrics_non_osd_health(_, aggregator):
     shouldn't make the check fail
     """
 
-    ceph_check = Ceph(CHECK_NAME, {}, {})
-    ceph_check.check(copy.deepcopy(BASIC_CONFIG))
+    ceph_check = Ceph(CHECK_NAME, {}, [copy.deepcopy(BASIC_CONFIG)])
+    ceph_check.check({})
 
     aggregator.assert_metric('ceph.num_full_osds', value=0, count=1, tags=EXPECTED_TAGS)
     aggregator.assert_metric('ceph.num_near_full_osds', value=0, count=1, tags=EXPECTED_TAGS)


### PR DESCRIPTION
Update to use agent 8 signature (do not use instance in check method) and throws agent exceptions instead of a generic one