### PR TITLE
remove unused mariadb parameter from test config

### DIFF
--- a/mysql/tests/compose/mariadb.conf
+++ b/mysql/tests/compose/mariadb.conf
@@ -8,7 +8,6 @@ slow_query_log_file = /opt/bitnami/mariadb/logs/mysql_slow.log
 long_query_time = 0.1  # Facilitates local slow query log testing.
 # log_short_format=ON  # Uncomment to simulate short log format.
 performance_schema = ON
-performance-schema-instrument='stage/%=ON'
 performance-schema-consumer-events-statements-current=ON
 performance-schema-consumer-events-statements-history=ON
 performance-schema-consumer-events-statements-history-long=ON


### PR DESCRIPTION
### What does this PR do?

Remove unused `performance-schema-instrument='stage/%=ON'` parameter from `mariadb.conf`.

### Motivation

Remove potentially confusing parameters from the test configuration. If we don't need it then it shouldn't be in there. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
