### PR TITLE
Improve performance of latency metric computation

### DIFF
--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -590,17 +590,15 @@ class ConsulCheck(OpenMetricsBaseCheck):
 
         # Intra-datacenter
         nodes = self._get_coord_nodes()
-        if len(nodes) == 1:
+        num_nodes = len(nodes)
+        if num_nodes == 1:
             self.log.debug("Only 1 node in cluster, skipping network latency metrics.")
         else:
-            for node in nodes:
+            for i, node in enumerate(nodes):
                 node_name = node['Node']
-                latencies = []
-                for other in nodes:
-                    other_name = other['Node']
-                    if node_name == other_name:
-                        continue
-                    latencies.append(distance(node, other))
+                latencies = [distance(node, nodes[n]) for n in range(i + 1, num_nodes)]
+                if not latencies:
+                    continue
                 latencies.sort()
                 n = len(latencies)
                 half_n = n // 2

--- a/consul/tests/consul_mocks.py
+++ b/consul/tests/consul_mocks.py
@@ -281,6 +281,33 @@ def mock_get_coord_nodes():
     ]
 
 
+def mock_get_coord_nodes_benchmark(num_nodes):
+    nodes = []
+    for i in range(num_nodes):
+        nodes.append(
+            {
+                "Node": "host-{}".format(i),
+                "Coord": {
+                    "Vec": [
+                        0.007682993877165208,
+                        0.002411059340215172,
+                        0.0016420746641640123,
+                        0.0037411046929292906,
+                        0.004541946058965728,
+                        0.0032195622863890523,
+                        -0.0039447666794166095,
+                        -0.0021767019427297815,
+                    ],
+                    "Error": 0.28019529748212335,
+                    "Adjustment": -9.966407036439966e-05,
+                    "Height": 0.00011777098790169723,
+                },
+            }
+        )
+
+    return nodes
+
+
 def mock_get_health_check(_):
     return [
         {

--- a/consul/tests/test_bench.py
+++ b/consul/tests/test_bench.py
@@ -1,0 +1,26 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.consul import ConsulCheck
+
+from . import common, consul_mocks
+
+
+@pytest.mark.parametrize('num_nodes', [1000, 2000])
+def test_check_network_latency(benchmark, num_nodes):
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG_NETWORK_LATENCY_CHECKS])
+    my_mocks = consul_mocks._get_consul_mocks()
+    consul_mocks.mock_check(consul_check, my_mocks)
+
+    nodes = consul_mocks.mock_get_coord_nodes_benchmark(num_nodes)
+    consul_check._get_coord_nodes = lambda: nodes
+
+    # We start out as the leader, and stay that way
+    consul_check._last_known_leader = consul_mocks.mock_get_cluster_leader_A()
+
+    agent_dc = consul_check._get_agent_datacenter()
+    tags = ['consul_datacenter:{}'.format(agent_dc)]
+
+    benchmark(consul_check.check_network_latency, agent_dc, tags)

--- a/consul/tox.ini
+++ b/consul/tox.ini
@@ -3,6 +3,7 @@ minversion = 2.0
 basepython = py38
 envlist =
     py{27,38}-{0.6.4,0.7.2,1.0.0,1.9.0}
+    bench
 
 [testenv]
 ensure_default_envdir = true
@@ -28,3 +29,7 @@ setenv =
     0.7.2: CONSUL_VERSION=0.7.2
     1.0.0: CONSUL_VERSION=1.0.0
     1.9.0: CONSUL_VERSION=1.9.0
+
+[testenv:bench]
+setenv =
+    CONSUL_VERSION=1.9.0


### PR DESCRIPTION
### Motivation

Customer noticed that the method is slow b/c we perform redundant computation

This introduces caching to reduce the constant factor