### PR TITLE
Upgrade pydantic to 1.8.2

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -47,7 +47,7 @@ psutil==5.7.2
 psycopg2-binary==2.8.4
 pyasn1==0.4.6
 pycryptodomex==3.10.1
-pydantic==1.8.1; python_version > "3.0"
+pydantic==1.8.2; python_version > "3.0"
 pyhdb==0.3.4
 pyjwt==1.7.1; python_version < "3.0"
 pyjwt==2.0.1; python_version > "3.0"

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -15,7 +15,7 @@ mmh3==3.0.0; python_version > '3.0'
 orjson==2.6.1; python_version > '3.0'
 prometheus-client==0.9.0
 protobuf==3.7.0
-pydantic==1.8.1; python_version > '3.0'
+pydantic==1.8.2; python_version > '3.0'
 pyjwt==1.7.1; python_version < '3.0'
 pyjwt==2.0.1; python_version > '3.0'
 pysocks==1.7.0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
https://nvd.nist.gov/vuln/detail/CVE-2021-29510

> In affected versions passing either `'infinity'`, `'inf'` or `float('inf')` (or their negatives) to `datetime` or `date` fields causes validation to run forever with 100% CPU usage (on one CPU). Pydantic has been patched with fixes available in the following versions: v1.8.2, v1.7.4, v1.6.2.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
