### PR TITLE
Upgrade psycopg2-binary to 2.8.6

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -44,7 +44,7 @@ ply==3.10
 prometheus-client==0.9.0
 protobuf==3.7.0
 psutil==5.7.2
-psycopg2-binary==2.8.4
+psycopg2-binary==2.8.6
 pyasn1==0.4.6
 pycryptodomex==3.10.1
 pydantic==1.8.2; python_version > "3.0"

--- a/pgbouncer/requirements.in
+++ b/pgbouncer/requirements.in
@@ -1,1 +1,1 @@
-psycopg2-binary==2.8.4
+psycopg2-binary==2.8.6

--- a/postgres/requirements.in
+++ b/postgres/requirements.in
@@ -1,4 +1,4 @@
 cachetools==3.1.1
-psycopg2-binary==2.8.4
+psycopg2-binary==2.8.6
 semver==2.9.0
 futures==3.3.0; python_version < '3.0'


### PR DESCRIPTION
### What does this PR do?

Upgrade psycopg2-binary to 2.8.6

### Motivation

This version adds support for Python 3.9.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
