### PR TITLE
Document containerd and docker uptime metrics in metadata

### DIFF
--- a/containerd/metadata.csv
+++ b/containerd/metadata.csv
@@ -36,3 +36,4 @@ containerd.blkio.wait_time_recursive,rate,,nanosecond,,The blkio io wait time re
 containerd.blkio.service_time_recursive,rate,,,,The blkio io service time recursive,0,containerd,io service time recursive
 containerd.image.size,gauge,,byte,,The size of the container image,0,containerd,image size
 containerd.proc.open_fds,gauge,,file,,The number of open file descriptors,0,containerd,open_fds
+containerd.uptime,gauge,,second,,Time since the container was started,0,containerd,uptime

--- a/docker_daemon/metadata.csv
+++ b/docker_daemon/metadata.csv
@@ -118,3 +118,4 @@ docker.metadata.total,gauge,,byte,,Storage pool metadata space total,0,docker,me
 docker.metadata.percent,gauge,,percent,,The percent of storage pool metadata used,0,docker,percent of metadata space total
 docker.thread.count,gauge,,thread,,"Current thread count for the container",0,docker,thread.count
 docker.thread.limit,gauge,,thread,,"Thread count limit for the container, if set",0,docker,thread.limit
+docker.uptime,gauge,,second,,Time since the container was started,0,docker,uptime


### PR DESCRIPTION
### What does this PR do?
Document `docker.uptime` and `containerd.uptime` in the checks' metadata.

### Motivation
User noticed the docker uptime metric missing in our public docs.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
