### PR TITLE
Remove redis_role tag from service check

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -198,6 +198,7 @@ class Redis(AgentCheck):
         # Ping the database for info, and track the latency.
         # Process the service check: the check passes if we can connect to Redis
         start = time.time()
+        tags = list(self.tags)
         try:
             info = conn.info()
             latency_ms = round_value((time.time() - start) * 1000, 2)
@@ -212,7 +213,6 @@ class Redis(AgentCheck):
         else:
             self.service_check('redis.can_connect', AgentCheck.OK, tags=tags)
 
-        tags = list(self.tags)
         if info.get("role"):
             tags.append("redis_role:{}".format(info["role"]))
         else:

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -202,13 +202,6 @@ class Redis(AgentCheck):
             info = conn.info()
             latency_ms = round_value((time.time() - start) * 1000, 2)
 
-            tags = list(self.tags)
-            if info.get("role"):
-                tags.append("redis_role:{}".format(info["role"]))
-            else:
-                self.log.debug("Redis role was not found")
-
-            self.gauge('redis.info.latency_ms', latency_ms, tags=tags)
             self._collect_metadata(info)
         except ValueError as e:
             self.service_check('redis.can_connect', AgentCheck.CRITICAL, message=str(e), tags=self.tags)
@@ -218,6 +211,14 @@ class Redis(AgentCheck):
             raise
         else:
             self.service_check('redis.can_connect', AgentCheck.OK, tags=tags)
+
+        tags = list(self.tags)
+        if info.get("role"):
+            tags.append("redis_role:{}".format(info["role"]))
+        else:
+            self.log.debug("Redis role was not found")
+
+        self.gauge('redis.info.latency_ms', latency_ms, tags=tags)
 
         try:
             config = conn.config_get("maxclients")

--- a/redisdb/tests/test_default.py
+++ b/redisdb/tests/test_default.py
@@ -104,7 +104,7 @@ def test_service_check(aggregator, redis_auth, redis_instance):
 
     assert len(aggregator.service_checks('redis.can_connect')) == 1
     sc = aggregator.service_checks('redis.can_connect')[0]
-    assert sc.tags == ['foo:bar', 'redis_host:{}'.format(HOST), 'redis_port:6379', 'redis_role:master']
+    assert sc.tags == ['foo:bar', 'redis_host:{}'.format(HOST), 'redis_port:6379']
 
 
 def test_disabled_config_get(aggregator, redis_auth, redis_instance):
@@ -115,7 +115,7 @@ def test_disabled_config_get(aggregator, redis_auth, redis_instance):
 
     assert len(aggregator.service_checks('redis.can_connect')) == 1
     sc = aggregator.service_checks('redis.can_connect')[0]
-    assert sc.tags == ['foo:bar', 'redis_host:{}'.format(HOST), 'redis_port:6379', 'redis_role:master']
+    assert sc.tags == ['foo:bar', 'redis_host:{}'.format(HOST), 'redis_port:6379']
 
 
 @requires_static_version

--- a/redisdb/tests/test_e2e.py
+++ b/redisdb/tests/test_e2e.py
@@ -14,10 +14,10 @@ pytestmark = pytest.mark.e2e
 
 
 def assert_common_metrics(aggregator):
-    tags = ['redis_host:{}'.format(common.HOST), 'redis_port:6382', 'redis_role:master']
+    base_tags = ['redis_host:{}'.format(common.HOST), 'redis_port:6382']
 
-    aggregator.assert_service_check('redis.can_connect', status=Redis.OK, tags=tags)
-
+    aggregator.assert_service_check('redis.can_connect', status=Redis.OK, tags=base_tags)
+    tags = base_tags + ['redis_role:master']
     aggregator.assert_metric('redis.mem.fragmentation_ratio', count=2, tags=tags)
     aggregator.assert_metric('redis.rdb.bgsave', count=2, tags=tags)
     aggregator.assert_metric('redis.aof.last_rewrite_time', count=2, tags=tags)


### PR DESCRIPTION
### What does this PR do?
This is a breaking change.
The PR removes the redis_role tag from service checks and updates tests accordingly. 
### Motivation
`redis_role` is only successfully tagged when the connection is successful. This results in a context mismatch between `OK` and `CRITICAL`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
