### PR TITLE
Look for mariadbd process for MariaDB 10.5+

### DIFF
--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -232,6 +232,9 @@ def _add_dog_user(conn):
     cur.execute("GRANT SELECT ON performance_schema.* TO 'dog'@'%'")
     if MYSQL_FLAVOR == 'mysql' and MYSQL_VERSION == '8.0':
         cur.execute("ALTER USER 'dog'@'%' WITH MAX_USER_CONNECTIONS 0")
+    elif MYSQL_FLAVOR == 'mariadb' and MYSQL_VERSION == '10.5':
+        cur.execute("GRANT SLAVE MONITOR ON *.* TO 'dog'@'%'")
+        cur.execute("ALTER USER 'dog'@'%' WITH MAX_USER_CONNECTIONS 0")
     else:
         cur.execute("UPDATE mysql.user SET max_user_connections = 0 WHERE user='dog' AND host='%'")
         cur.execute("FLUSH PRIVILEGES")

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{5.6,5.7,8.0,maria}
+    py{27,38}-{5.7,8.0,maria10.2,maria10.5}
 
 [testenv]
 ensure_default_envdir = true
@@ -32,14 +32,14 @@ commands =
 setenv =
     COMPOSE_FILE=mysql.yaml
     MYSQL_FLAVOR=mysql
-    # EOL February 5, 2021
-    5.6: MYSQL_VERSION=5.6
     # EOL October 21, 2023
     5.7: MYSQL_VERSION=5.7
     8.0: COMPOSE_FILE=mysql8.yaml
     # EOL April, 2026
     8.0: MYSQL_VERSION=8.0
-    maria: COMPOSE_FILE=mariadb.yaml
-    maria: MYSQL_FLAVOR=mariadb
+    maria{10.2,10.5}: COMPOSE_FILE=mariadb.yaml
+    maria{10.2,10.5}: MYSQL_FLAVOR=mariadb
     # EOL 23 May 2022
-    maria: MYSQL_VERSION=10.2.27
+    maria10.2: MYSQL_VERSION=10.2
+    # EOL 24 June 2025
+    maria10.5: MYSQL_VERSION=10.5


### PR DESCRIPTION
### What does this PR do?
Looks for `mariadbd` process instead of `mysqld` for MariaDB 10.5+

### Motivation
AGENT-6383

Missing mysql.performance.cpu_time metric for MariaDB 10.5 hosts, though is is working for MariaDB 5.5 hosts.
It appears in version 10.4 the executable name was changed from mysql to mariadb. 

### Additional Notes
- https://mariadb.com/docs/features/whats-new/whats-new-in-community-server-105/

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
