### PR TITLE
Upgrade orjson to 3.5.2

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -38,7 +38,7 @@ lz4==3.1.3; python_version > "3.0"
 mmh3==2.5.1; python_version < "3.0"
 mmh3==3.0.0; python_version > "3.0"
 openstacksdk==0.24.0
-orjson==2.6.1; python_version > "3.0"
+orjson==3.5.2; python_version > "3.0"
 paramiko==2.6.0
 ply==3.10
 prometheus-client==0.9.0

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -12,7 +12,7 @@ ipaddress==1.0.22; python_version < '3.0'
 kubernetes==12.0.1
 mmh3==2.5.1; python_version < '3.0'
 mmh3==3.0.0; python_version > '3.0'
-orjson==2.6.1; python_version > '3.0'
+orjson==3.5.2; python_version > '3.0'
 prometheus-client==0.9.0
 protobuf==3.7.0
 pydantic==1.8.2; python_version > '3.0'


### PR DESCRIPTION
### What does this PR do?

Upgrade orjson to 3.5.2

### Motivation

This version adds binary wheels for Python 3.9 on Windows.

### Additional Notes

Version 3.0.0 accepts more types in `dumps`, otherwise should be backwards compatible.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
