### PR TITLE
Set validate-agent-build job timeout to 2h

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,6 +81,7 @@ trigger-agent-build:
 validate-agent-build:
   stage: validate
   image: $VALIDATE_AGENT_BUILD
+  timeout: 2 hours
   script:
     - |
       if [[ -s ./pipeline_id.txt ]]; then


### PR DESCRIPTION
Didn't realize we could do it per-job like this. This job is usually times out too often