### PR TITLE
Upgrade `aerospike` dependency on Python 3

### DIFF
--- a/aerospike/requirements.in
+++ b/aerospike/requirements.in
@@ -1,2 +1,2 @@
-aerospike==4.0.0; sys_platform != 'win32' and sys_platform != 'darwin'
-aerospike==4.0.0; sys_platform == 'darwin' and python_version < '3.0'
+aerospike==4.0.0; sys_platform != 'win32' and sys_platform != 'darwin' and python_version < '3.0'
+aerospike==6.0.0; sys_platform != 'win32' and sys_platform != 'darwin' and python_version > '3.0'

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -1,6 +1,6 @@
 adodbapi==2.6.0.7; sys_platform == "win32"
-aerospike==4.0.0; sys_platform != "win32" and sys_platform != "darwin"
-aerospike==4.0.0; sys_platform == "darwin" and python_version < "3.0"
+aerospike==4.0.0; sys_platform != "win32" and sys_platform != "darwin" and python_version < "3.0"
+aerospike==6.0.0; sys_platform != "win32" and sys_platform != "darwin" and python_version > "3.0"
 aws-requests-auth==0.4.2
 beautifulsoup4==4.5.1
 binary==1.0.0


### PR DESCRIPTION
### Motivation

Support Python 3.9