### PR TITLE
update mysql test grant permission

### DIFF
--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -158,6 +158,7 @@ def _init_datadog_sample_collection(conn):
     cur = conn.cursor()
     cur.execute("CREATE DATABASE datadog")
     cur.execute("GRANT CREATE TEMPORARY TABLES ON `datadog`.* TO 'dog'@'%'")
+    cur.execute("GRANT EXECUTE on `datadog`.*  TO 'dog'@'%'")
     _create_explain_procedure(conn, "datadog")
     _create_explain_procedure(conn, "mysql")
     _create_enable_consumers_procedure(conn)
@@ -180,7 +181,8 @@ def _create_explain_procedure(conn, schema):
             schema=schema
         )
     )
-    cur.execute("GRANT EXECUTE ON PROCEDURE {schema}.explain_statement to 'dog'@'%'".format(schema=schema))
+    if schema != 'datadog':
+        cur.execute("GRANT EXECUTE ON PROCEDURE {schema}.explain_statement to 'dog'@'%'".format(schema=schema))
     cur.close()
 
 
@@ -196,7 +198,6 @@ def _create_enable_consumers_procedure(conn):
         END;
     """
     )
-    cur.execute("GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers to 'dog'@'%'")
     cur.close()
 
 


### PR DESCRIPTION
### What does this PR do?

Update the mysql test grant permission statement to use one grant to grant the agent full execute permissions within the `datadog` schema. This matches instructions the will be in the setup documentation.

### Motivation

Make tests match docs. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
