### PR TITLE
Provide a reason for not having an execution plan (MySQL & Postgres)

### DIFF
--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -486,6 +486,13 @@ def test_statement_samples_collect(
         assert 'query_block' in json.loads(event['db']['plan']['definition']), "invalid json execution plan"
         assert set(event['ddtags'].split(',')) == expected_tags
 
+    # validate the events (if applicable) to ensure we've provided an explanation for not providing an exec plan
+    for event in matching:
+        if event['db']['plan']['definition'] is None:
+            assert event['db']['no_plan_reason'] != {}
+        else:
+            assert 'no_plan_reason' not in event['db']
+
     # we avoid closing these in a try/finally block in order to maintain the connections in case we want to
     # debug the test with --pdb
     mysql_check._statement_samples._close_db_conn()

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -489,7 +489,7 @@ def test_statement_samples_collect(
     # validate the events (if applicable) to ensure we've provided an explanation for not providing an exec plan
     for event in matching:
         if event['db']['plan']['definition'] is None:
-            assert event['db']['no_plan_reason'] != {}
+            assert event['db']['no_plan_reason'] != ''
         else:
             assert 'no_plan_reason' not in event['db']
 

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -460,7 +460,7 @@ class PostgresStatementSamples(object):
                 'postgres': {k: v for k, v in row.items() if k not in pg_stat_activity_sample_exclude_keys},
             }
             if not obfuscated_plan:
-                # There are situations where a 'no plan reason' is provided even when a plan is generated.
+                # There could be a situation where a 'no plan reason' is provided even when a plan is generated.
                 # This is because some queries in a schema can fail while others succeed. This check
                 # prevents including a 'no plan reason' despite actually having a plan.
                 event['db']['no_plan_reason'] = self._no_explain_reason

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -100,6 +100,7 @@ class PostgresStatementSamples(object):
         self._explain_function = self._config.statement_samples_config.get(
             'explain_function', 'datadog.explain_statement'
         )
+        self._no_exec_plan_reason = {}
 
         self._collection_strategy_cache = TTLCache(
             maxsize=self._config.statement_samples_config.get('collection_strategy_cache_maxsize', 1000),
@@ -295,10 +296,20 @@ class PostgresStatementSamples(object):
 
     def _can_explain_statement(self, obfuscated_statement):
         if obfuscated_statement.startswith('SELECT {}'.format(self._explain_function)):
+            self._no_exec_plan_reason = {
+                'reason': 'There are no execution plans for the EXPLAIN function.'
+            }
             return False
         if obfuscated_statement.startswith('autovacuum:'):
+            self._no_exec_plan_reason = {
+                'reason': 'There are no execution plans for the AUTOVACUUM process.'
+            }
             return False
         if obfuscated_statement.split(' ', 1)[0].lower() not in VALID_EXPLAIN_STATEMENTS:
+            self._no_exec_plan_reason = {
+                'reason': 'This statement is not a valid EXPLAIN statement. Statements that' +
+                          ' can be explained: {}'.format(", ".join([s.upper() for s in VALID_EXPLAIN_STATEMENTS]))
+            }
             return False
         return True
 
@@ -307,6 +318,9 @@ class PostgresStatementSamples(object):
         try:
             self._get_db(dbname)
         except (psycopg2.DatabaseError, psycopg2.OperationalError) as e:
+            self._no_exec_plan_reason = {
+                'reason': 'Unable to explain statement due to a failed DB connection.'
+            }
             self._log.warning(
                 "cannot collect execution plans due to failed DB connection to dbname=%s: %s", dbname, repr(e)
             )
@@ -315,15 +329,25 @@ class PostgresStatementSamples(object):
         try:
             result = self._run_explain(dbname, EXPLAIN_VALIDATION_QUERY, EXPLAIN_VALIDATION_QUERY)
         except psycopg2.errors.InvalidSchemaName as e:
+            self._no_exec_plan_reason = {
+                'reason': 'Unable to explain statement due to an invalid schema.'
+            }
             self._log.warning("cannot collect execution plans due to invalid schema in dbname=%s: %s", dbname, repr(e))
             return DBExplainSetupState.invalid_schema
         except psycopg2.DatabaseError as e:
             # if the schema is valid then it's some problem with the function (missing, or invalid permissions,
             # incorrect definition)
+            self._no_exec_plan_reason = {
+                'reason': 'Unable to explain statement. There could be a problem with the EXPLAIN function (missing,'
+                          + ' invalid permissions, or incorrect definition).'
+            }
             self._log.warning("cannot collect execution plans in dbname=%s: %s", dbname, repr(e))
             return DBExplainSetupState.failed_function
 
         if not result:
+            self._no_exec_plan_reason = {
+                'reason': 'Received an invalid result when invoking the explain function.'
+            }
             return DBExplainSetupState.invalid_result
 
         return DBExplainSetupState.ok
@@ -374,6 +398,9 @@ class PostgresStatementSamples(object):
         try:
             return self._run_explain(dbname, statement, obfuscated_statement)
         except psycopg2.errors.DatabaseError as e:
+            self._no_exec_plan_reason = {
+                'reason': 'Unable to explain statement due to a database error.'
+            }
             self._log.warning("Failed to collect execution plan: %s", repr(e))
             self._check.count(
                 "dd.postgres.statement_samples.error",
@@ -398,6 +425,7 @@ class PostgresStatementSamples(object):
         if cache_key in self._explained_statements_cache:
             return None
         self._explained_statements_cache[cache_key] = True
+        self._no_exec_plan_reason.clear()
 
         # Plans have several important signatures to tag events with. Note that for postgres, the
         # query_signature and resource_hash will be the same value.
@@ -432,6 +460,7 @@ class PostgresStatementSamples(object):
                 "db": {
                     "instance": row.get('datname', None),
                     "plan": {"definition": obfuscated_plan, "cost": plan_cost, "signature": plan_signature},
+                    "no_plan_reason": self._no_exec_plan_reason,
                     "query_signature": query_signature,
                     "resource_hash": query_signature,
                     "application": row.get('application_name', None),

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -475,10 +475,12 @@ def test_statement_samples_collect(
 
         if expected_error_tag:
             assert event['db']['plan']['definition'] is None, "did not expect to collect an execution plan"
+            assert event['db']['no_plan_reason'] is not None
             aggregator.assert_metric("dd.postgres.statement_samples.error", tags=tags + [expected_error_tag])
         else:
             assert set(event['ddtags'].split(',')) == set(tags)
             assert event['db']['plan']['definition'] is not None, "missing execution plan"
+            assert event['db']['no_plan_reason'] == {}
             assert 'Plan' in json.loads(event['db']['plan']['definition']), "invalid json execution plan"
             # we expect to get a duration because the connections are in "idle" state
             assert event['duration']

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -475,15 +475,20 @@ def test_statement_samples_collect(
 
         if expected_error_tag:
             assert event['db']['plan']['definition'] is None, "did not expect to collect an execution plan"
-            assert event['db']['no_plan_reason'] is not None
             aggregator.assert_metric("dd.postgres.statement_samples.error", tags=tags + [expected_error_tag])
         else:
             assert set(event['ddtags'].split(',')) == set(tags)
             assert event['db']['plan']['definition'] is not None, "missing execution plan"
-            assert event['db']['no_plan_reason'] == {}
             assert 'Plan' in json.loads(event['db']['plan']['definition']), "invalid json execution plan"
             # we expect to get a duration because the connections are in "idle" state
             assert event['duration']
+
+        # validate the events (if applicable) to ensure we've provided an explanation for not providing an exec plan
+        for event in matching:
+            if event['db']['plan']['definition'] is None:
+                assert event['db']['no_plan_reason'] != {}
+            else:
+                assert 'no_plan_reason' not in event['db']
 
     finally:
         conn.close()

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -486,7 +486,7 @@ def test_statement_samples_collect(
         # validate the events (if applicable) to ensure we've provided an explanation for not providing an exec plan
         for event in matching:
             if event['db']['plan']['definition'] is None:
-                assert event['db']['no_plan_reason'] != {}
+                assert event['db']['no_plan_reason'] != ''
             else:
                 assert 'no_plan_reason' not in event['db']
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Provides a reason for not having a MySQL or PostgreSQL execution plan.

### Motivation
<!-- What inspired you to submit this pull request? -->
Currently in Database Monitoring, the UX is lacking when it comes to execution plans. There are cases where it's impossible to collect or something failed, so we should indicate the reason it could not be collected and actions to fix it, if any.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
