### PR TITLE
log execution plan collection failure at debug level

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -374,7 +374,7 @@ class PostgresStatementSamples(object):
         try:
             return self._run_explain(dbname, statement, obfuscated_statement)
         except psycopg2.errors.DatabaseError as e:
-            self._log.warning("Failed to collect execution plan: %s", repr(e))
+            self._log.debug("Failed to collect execution plan: %s", repr(e))
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 1,


### PR DESCRIPTION
### What does this PR do?

Execution plans collection is expected to fail in many cases, like if a client is using the extended query protocol meaning we won't get the original parameters from `pg_stat_activity`. To avoid spamming the logs, update this message to be logged only at the debug level.

This now matches what we do for mysql.

### Motivation

Reduce spammy logging. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
