### PR TITLE
Provide a reason for not having an execution plan (Postgres)

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -22,7 +22,7 @@ from datadog_checks.base.utils.db.utils import ConstantRateLimiter, default_json
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.time import get_timestamp
 
-SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update'})
+SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update', 'with'})
 
 # columns from pg_stat_activity which correspond to attributes common to all databases and are therefore stored in
 # under other standard keys

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -411,7 +411,7 @@ class PostgresStatementSamples(object):
         plan_dict, explain_err_code, err = self._run_explain_safe(row['datname'], row['query'], obfuscated_statement)
         collection_error = None
         if explain_err_code:
-            collection_error = {'code': explain_err_code.value, 'message': '{}'.format(type(err))}
+            collection_error = {'code': explain_err_code.value, 'message': '{}'.format(type(err)) if err else None}
 
         plan, normalized_plan, obfuscated_plan, plan_signature, plan_cost = None, None, None, None, None
         if plan_dict:

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -296,12 +296,12 @@ class PostgresStatementSamples(object):
 
     def _can_explain_statement(self, obfuscated_statement):
         if obfuscated_statement.startswith('SELECT {}'.format(self._explain_function)):
-            return False, DBExplainError.no_plans_possible
+            return False
         if obfuscated_statement.startswith('autovacuum:'):
-            return False, DBExplainError.no_plans_possible
+            return False
         if obfuscated_statement.split(' ', 1)[0].lower() not in SUPPORTED_EXPLAIN_STATEMENTS:
-            return False, DBExplainError.no_plans_possible
-        return True, None
+            return False
+        return True
 
     def _get_db_explain_setup_state(self, dbname):
         # type: (str) -> Tuple[Optional[DBExplainError], Optional[Exception]]
@@ -362,9 +362,8 @@ class PostgresStatementSamples(object):
 
     def _run_explain_safe(self, dbname, statement, obfuscated_statement):
         # type: (str, str, str) -> Tuple[Optional[Dict], Optional[DBExplainError], Optional[Exception]]
-        ok, db_explain_error = self._can_explain_statement(obfuscated_statement)
-        if not ok:
-            return None, db_explain_error, None
+        if not self._can_explain_statement(obfuscated_statement):
+            return None, DBExplainError.no_plans_possible, None
 
         db_explain_error, err = self._get_db_explain_setup_state_cached(dbname)
         if db_explain_error is not None:

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -60,9 +60,6 @@ class DBExplainError(Enum):
     # database error i.e connection error
     database_error = 'database_error'
 
-    # statements not in VALID_EXPLAIN_STATEMENTS are not valid
-    invalid_statement = 'invalid_statement'
-
     # this could be the result of a missing EXPLAIN function
     invalid_schema = 'invalid_schema'
 

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -407,7 +407,7 @@ def test_get_db_explain_setup_state(
     explain_setup_state, failed_explain_reason = check.statement_samples._get_db_explain_setup_state(dbname)
     assert explain_setup_state == expected_explain_setup_state
     if explain_setup_state != DBExplainSetupState.ok:
-        assert failed_explain_reason is not None
+        assert failed_explain_reason != {}
     else:
         assert failed_explain_reason is None
 

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -396,7 +396,7 @@ def dbm_instance(pg_instance):
         ("datadog_test", DBExplainSetupState.ok, None),
         ("dogs", DBExplainSetupState.ok, None),
         ("dogs_noschema", DBExplainSetupState.invalid_schema, {'code': 'invalid_schema', 'reason': 'dummy reason'}),
-        ("dogs_nofunc", DBExplainSetupState.failed_function, {'code': 'invalid_schema', 'reason': 'dummy reason'}),
+        ("dogs_nofunc", DBExplainSetupState.failed_function, {'code': 'failed_function', 'reason': 'dummy reason'}),
     ],
 )
 def test_get_db_explain_setup_state(

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -419,7 +419,7 @@ def test_get_db_explain_setup_state(integration_check, dbm_instance, dbname, exp
             "SELECT * FROM kennel WHERE id = %s",
             123,
             "error:explain-{}".format(DBExplainError.invalid_schema),
-            {'code': 'invalid_schema', 'reason': "<class 'psycopg2.errors.InvalidSchemaName'>"},
+            {'code': 'invalid_schema', 'message': "<class 'psycopg2.errors.InvalidSchemaName'>"},
         ),
         (
             "dd_admin",
@@ -428,7 +428,7 @@ def test_get_db_explain_setup_state(integration_check, dbm_instance, dbname, exp
             "SELECT * FROM kennel WHERE id = %s",
             123,
             "error:explain-{}".format(DBExplainError.failed_function),
-            {'code': 'failed_function', 'reason': "<class 'psycopg2.errors.UndefinedFunction'>"},
+            {'code': 'failed_function', 'message': "<class 'psycopg2.errors.UndefinedFunction'>"},
         ),
     ],
 )
@@ -492,7 +492,7 @@ def test_statement_samples_collect(
             if event['db']['plan']['definition'] is None:
                 assert event['db']['plan']['collection_error'] == expected_collection_error
             else:
-                assert event['db']['plan']['collection_error'] == {'code': None, 'reason': None}
+                assert event['db']['plan']['collection_error'] is None
 
     finally:
         conn.close()

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -391,7 +391,7 @@ def dbm_instance(pg_instance):
 
 
 @pytest.mark.parametrize(
-    "dbname,expected_explain_setup_state,expected_no_explain_reason",
+    "dbname,expected_explain_setup_state,expected_failed_explain_reason",
     [
         ("datadog_test", DBExplainSetupState.ok, None),
         ("dogs", DBExplainSetupState.ok, None),
@@ -400,16 +400,16 @@ def dbm_instance(pg_instance):
     ],
 )
 def test_get_db_explain_setup_state(
-    integration_check, dbm_instance, dbname, expected_explain_setup_state, expected_no_explain_reason
+    integration_check, dbm_instance, dbname, expected_explain_setup_state, expected_failed_explain_reason
 ):
     check = integration_check(dbm_instance)
     check._connect()
-    explain_setup_state, no_explain_reason = check.statement_samples._get_db_explain_setup_state(dbname)
+    explain_setup_state, failed_explain_reason = check.statement_samples._get_db_explain_setup_state(dbname)
     assert explain_setup_state == expected_explain_setup_state
     if explain_setup_state != DBExplainSetupState.ok:
-        assert no_explain_reason is not None
+        assert failed_explain_reason is not None
     else:
-        assert no_explain_reason is None
+        assert failed_explain_reason is None
 
 
 @pytest.mark.parametrize("pg_stat_activity_view", ["pg_stat_activity", "datadog.pg_stat_activity()"])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Provides a reason for not having a PostgreSQL execution plan.

### Motivation
<!-- What inspired you to submit this pull request? -->
Currently in Database Monitoring, the UX is lacking when it comes to execution plans. There are cases where it's impossible to collect or something failed, so we should indicate the reason it could not be collected and actions to fix it, if any.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
