### PR TITLE
Fix codeowner for database-monitoring

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -97,10 +97,10 @@ assets/               @DataDog/agent-integrations
 
 
 # Database monitoring
-postgres/statements.py                    @DataDog/agent-integrations @DataDog/database-monitoring
-postgres/statement_samples.py             @DataDog/agent-integrations @DataDog/database-monitoring
-mysql/statements.py                       @DataDog/agent-integrations @DataDog/database-monitoring
-mysql/statement_samples.py                @DataDog/agent-integrations @DataDog/database-monitoring
+**/postgres/statements.py                    @DataDog/agent-integrations @DataDog/database-monitoring
+**/postgres/statement_samples.py             @DataDog/agent-integrations @DataDog/database-monitoring
+**/mysql/statements.py                       @DataDog/agent-integrations @DataDog/database-monitoring
+**/mysql/statement_samples.py                @DataDog/agent-integrations @DataDog/database-monitoring
 
 # Checks base
 /datadog_checks_base/                                          @DataDog/agent-core @DataDog/agent-integrations


### PR DESCRIPTION
### What does this PR do?
Fix codeowner pattern for `database-monitoring` team. 

Follow-up to https://github.com/DataDog/integrations-core/pull/9511

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
