### PR TITLE
Stop using a deprecated method to support newer versions of Aerospike

### DIFF
--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -106,6 +106,9 @@ class AerospikeCheck(AgentCheck):
         # We'll connect on the first check run
         self._client = None
 
+        # Cache for the entirety of each check run
+        self._node_name = None
+
     def check(self, _):
         if self._client is None:
             client = self.get_client()
@@ -113,6 +116,8 @@ class AerospikeCheck(AgentCheck):
                 return
 
             self._client = client
+
+        self._node_name = None
 
         # https://www.aerospike.com/docs/reference/info/#statistics
         self.collect_info('statistics', CLUSTER_METRIC_TYPE, required_keys=self._metrics, tags=self._tags)
@@ -289,12 +294,33 @@ class AerospikeCheck(AgentCheck):
             self.service_check(SERVICE_CHECK_CONNECT, self.OK, tags=self._tags)
             return client
 
+    @property
+    def node_name(self):
+        if self._node_name is None:
+            host, port = self._host[:2]
+            node_data = self._client.get_node_names()
+            for data in node_data:
+                if data['address'] == host and data['port'] == port:
+                    self._node_name = data['node_name']
+                    break
+            else:
+                raise Exception('Could not find node name for {}:{} among: {}'.format(host, port, node_data))
+
+        return self._node_name
+
+    def get_node_info(self, command):
+        # Aerospike deprecated `info_node` as of v6.0
+        if hasattr(self._client, 'get_node_names'):
+            return self._client.info_single_node(command, self.node_name, self._info_policies)
+        else:
+            return self._client.info_node(command, self._host, self._info_policies)
+
     def get_info(self, command, separator=';'):
         # type: (str, str) -> List[str]
         # See https://www.aerospike.com/docs/reference/info/
         # Example output: command\tKEY=VALUE;KEY=VALUE;...
         try:
-            data = self._client.info_node(command, self._host, self._info_policies)
+            data = self.get_node_info(command)
             self.log.debug(
                 "Get info results for command=`%s`, host=`%s`, policies=`%s`: %s",
                 command,

--- a/aerospike/metadata.csv
+++ b/aerospike/metadata.csv
@@ -709,8 +709,11 @@ aerospike.set.objects,gauge,,record,,The total number of objects (master and all
 aerospike.set.stop_writes_count,gauge,,,,The total count this set has hit stop_writes,0,aerospike,
 aerospike.set.device_data_bytes,gauge,,byte,,The device storage used by data (master and proles) excluding primary index.,0,aerospike,
 aerospike.set.disable_eviction,gauge,,,,Whether or not this set is protected from evictions,0,aerospike,
+aerospike.set.enable_index,gauge,,,,Whether or not this set has its own index,0,aerospike,
+aerospike.set.index_populating,gauge,,,,,0,aerospike,
+aerospike.set.sindexes,gauge,,,,,0,aerospike,
 aerospike.sindex.keys,gauge,,,,The number of secondary keys for this secondary index.,0,aerospike,
-aerospike.sindex.entries,gauge,,,,Th number of secondary index entries for this secondary index. This is the number of records that have been indexed by this secondary index.,0,aerospike,
+aerospike.sindex.entries,gauge,,,,The number of secondary index entries for this secondary index. This is the number of records that have been indexed by this secondary index.,0,aerospike,
 aerospike.sindex.ibtr_memory_used,gauge,,byte,,The amount of memory the secondary index is consuming for the keys,0,aerospike,Sindex Index Memory Used
 aerospike.sindex.nbtr_memory_used,gauge,,byte,,The amount of memory the secondary index is consuming for the entries,0,aerospike,Sindex Entry Memory Used
 aerospike.sindex.si_accounted_memory,gauge,,byte,,The amount of memory the secondary index is consuming. This is the sum of ibtr_memory_used and nbtr_memory_used.,0,aerospike,Sindex Total Memory Used

--- a/aerospike/tests/common.py
+++ b/aerospike/tests/common.py
@@ -31,9 +31,19 @@ TPS_METRICS = [
     'tps.read',
 ]
 
-SET_METRICS = ['tombstones', 'memory_data_bytes', 'truncate_lut', 'objects', 'stop_writes_count', 'disable_eviction']
+LEGACY_SET_METRICS = [
+    'tombstones',
+    'memory_data_bytes',
+    'truncate_lut',
+    'objects',
+    'stop_writes_count',
+    'disable_eviction',
+]
 
-ALL_METRICS = NAMESPACE_METRICS + SET_METRICS
+SET_METRICS = ['enable_index', 'index_populating', 'sindexes']
+SET_METRICS.extend(LEGACY_SET_METRICS)
+
+ALL_METRICS = NAMESPACE_METRICS + LEGACY_SET_METRICS
 
 STATS_METRICS = [
     'cluster_size',

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -27,6 +27,9 @@ def test_datacenter_metrics(aggregator):
 
     check.get_info = mock_get_info
     check._client = mock.MagicMock()
+    check._client.get_node_names = mock.MagicMock(
+        side_effect=lambda: [{'address': common.HOST, 'port': common.PORT, 'node_name': 'test'}]
+    )
     check.get_namespaces = mock.MagicMock()
     check.collect_info = mock.MagicMock()
     check.collect_throughput = mock.MagicMock()
@@ -151,7 +154,7 @@ def test_collect_empty_data(aggregator):
     check = AerospikeCheck('aerospike', {}, [common.INSTANCE])
 
     check._client = mock.MagicMock()
-    check._client.info_node.return_value = 'sets/test/ci	'  # from real data, there is a tab after the command
+    check._client.info_single_node.return_value = 'sets/test/ci	'  # from real data, there is a tab after the command
     check.log = mock.MagicMock()
     assert [] == check.get_info('sets/test/ci')
 

--- a/aerospike/tox.ini
+++ b/aerospike/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py{27,38}-{4.9,5.0,5.3}
+    py{27,38}-{4.9,5.0,5.3,5.6}
 
 [testenv]
 ensure_default_envdir = true
@@ -19,7 +19,7 @@ dd_mypy_args =
     --follow-imports silent
     datadog_checks/aerospike
 usedevelop = true
-platform = linux|darwin
+platform = linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
@@ -33,3 +33,4 @@ setenv =
     4.9: AEROSPIKE_VERSION=4.9.0.11
     5.0: AEROSPIKE_VERSION=5.0.0.10
     5.3: AEROSPIKE_VERSION=5.3.0.6
+    5.6: AEROSPIKE_VERSION=5.6.0.5


### PR DESCRIPTION
### Motivation

- https://docs.aerospike.com/apidocs/python/client.html#aerospike.Client.info_node
- https://docs.aerospike.com/docs/client/python/usage/incompatible.html#version-6-0-0

> Because of changes in client authentication internals in C client 5.2.0, info_node() will fail if used when authentication is enabled. Checkout info_single_node() for a replacement.