### PR TITLE
Do not use deprecated API

### DIFF
--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -32,7 +32,7 @@ class DNSCheck(AgentCheck):
         if not hostname:
             raise BadConfException('A valid "hostname" must be specified')
 
-        resolver = dns.resolver.Resolver().resolve()
+        resolver = dns.resolver.Resolver()
 
         # If a specific DNS server was defined use it, else use the system default
         nameserver = instance.get('nameserver')

--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -32,7 +32,7 @@ class DNSCheck(AgentCheck):
         if not hostname:
             raise BadConfException('A valid "hostname" must be specified')
 
-        resolver = dns.resolver.Resolver.resolve()
+        resolver = dns.resolver.Resolver().resolve()
 
         # If a specific DNS server was defined use it, else use the system default
         nameserver = instance.get('nameserver')

--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -32,7 +32,7 @@ class DNSCheck(AgentCheck):
         if not hostname:
             raise BadConfException('A valid "hostname" must be specified')
 
-        resolver = dns.resolver.Resolver()
+        resolver = dns.resolver.Resolver.resolve()
 
         # If a specific DNS server was defined use it, else use the system default
         nameserver = instance.get('nameserver')
@@ -67,7 +67,7 @@ class DNSCheck(AgentCheck):
                 else:
                     raise AssertionError("Expected an NXDOMAIN, got a result.")
             else:
-                answer = resolver.query(hostname, rdtype=record_type)
+                answer = resolver.resolve(hostname, rdtype=record_type, search=True)
                 assert answer.rrset.items[0].to_text()
                 if resolves_as:
                     self._check_answer(answer, resolves_as)


### PR DESCRIPTION
change usage of deprecated method
```
def query(self, qname, rdtype=dns.rdatatype.A, rdclass=dns.rdataclass.IN,
              tcp=False, source=None, raise_on_no_answer=True, source_port=0,
              lifetime=None):  # pragma: no cover
        """Query nameservers to find the answer to the question.

        This method calls resolve() with ``search=True``, and is
        provided for backwards compatbility with prior versions of
        dnspython.  See the documentation for the resolve() method for
        further details.
        """
        warnings.warn('please use dns.resolver.Resolver.resolve() instead',
                      DeprecationWarning, stacklevel=2)
        return self.resolve(qname, rdtype, rdclass, tcp, source,
                            raise_on_no_answer, source_port, lifetime,
                            True)
```