### PR TITLE
Provide a reason for not having an execution plan (MySQL)

### DIFF
--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -486,6 +486,13 @@ def test_statement_samples_collect(
         assert 'query_block' in json.loads(event['db']['plan']['definition']), "invalid json execution plan"
         assert set(event['ddtags'].split(',')) == expected_tags
 
+    # validate the events (if applicable) to ensure we've provided an explanation for not providing an exec plan
+    for event in matching:
+        if event['db']['plan']['definition'] is None:
+            assert event['db']['plan']['collection_error'] != {}
+        else:
+            assert event['db']['plan']['collection_error'] is None
+
     # we avoid closing these in a try/finally block in order to maintain the connections in case we want to
     # debug the test with --pdb
     mysql_check._statement_samples._close_db_conn()

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -396,7 +396,7 @@ def dbm_instance(pg_instance):
         ("datadog_test", DBExplainSetupState.ok, None),
         ("dogs", DBExplainSetupState.ok, None),
         ("dogs_noschema", DBExplainSetupState.invalid_schema, {'code': 'invalid_schema', 'reason': 'dummy reason'}),
-        ("dogs_nofunc", DBExplainSetupState.failed_function, {'code': 'invalid_schema', 'reason': 'dummy reason'}),
+        ("dogs_nofunc", DBExplainSetupState.failed_function, {'code': 'failed_function', 'reason': 'dummy reason'}),
     ],
 )
 def test_get_db_explain_setup_state(

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -391,7 +391,7 @@ def dbm_instance(pg_instance):
 
 
 @pytest.mark.parametrize(
-    "dbname,expected_explain_setup_state,expected_no_explain_reason",
+    "dbname,expected_explain_setup_state,expected_failed_explain_reason",
     [
         ("datadog_test", DBExplainSetupState.ok, None),
         ("dogs", DBExplainSetupState.ok, None),
@@ -400,16 +400,16 @@ def dbm_instance(pg_instance):
     ],
 )
 def test_get_db_explain_setup_state(
-    integration_check, dbm_instance, dbname, expected_explain_setup_state, expected_no_explain_reason
+    integration_check, dbm_instance, dbname, expected_explain_setup_state, expected_failed_explain_reason
 ):
     check = integration_check(dbm_instance)
     check._connect()
-    explain_setup_state, no_explain_reason = check.statement_samples._get_db_explain_setup_state(dbname)
+    explain_setup_state, failed_explain_reason = check.statement_samples._get_db_explain_setup_state(dbname)
     assert explain_setup_state == expected_explain_setup_state
     if explain_setup_state != DBExplainSetupState.ok:
-        assert no_explain_reason is not None
+        assert failed_explain_reason is not None
     else:
-        assert no_explain_reason is None
+        assert failed_explain_reason is None
 
 
 @pytest.mark.parametrize("pg_stat_activity_view", ["pg_stat_activity", "datadog.pg_stat_activity()"])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Provides a reason for not having a MySQL execution plan.

### Motivation
<!-- What inspired you to submit this pull request? -->
Currently in Database Monitoring, the UX is lacking when it comes to execution plans. There are cases where it's impossible to collect or something failed, so we should indicate the reason it could not be collected and actions to fix it, if any.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
