### PR TITLE
Provide a reason for not having an execution plan (MySQL)

### DIFF
--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -818,7 +818,7 @@ class MySQLStatementSamples(object):
     @staticmethod
     def _can_explain(obfuscated_statement):
         if obfuscated_statement.split(' ', 1)[0].lower() not in VALID_EXPLAIN_STATEMENTS:
-            return False, {'code': FailedExplainReason.no_plans_possible.value}
+            return False, {'code': FailedExplainReason.invalid_statement.value}
         return True, None
 
     @staticmethod

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -694,10 +694,9 @@ class MySQLStatementSamples(object):
 
         self._log.debug('explaining statement. schema=%s, statement="%s"', schema, statement)
 
-        ok, db_explain_error = self._can_explain(obfuscated_statement)
-        if not ok:
+        if not self._can_explain(obfuscated_statement):
             self._log.debug('Skipping statement which cannot be explained: %s', obfuscated_statement)
-            return None, db_explain_error, None
+            return None, DBExplainError.no_plans_possible, None
 
         strategy_cache = self._collection_strategy_cache.get(strategy_cache_key)
         if strategy_cache:
@@ -815,9 +814,7 @@ class MySQLStatementSamples(object):
 
     @staticmethod
     def _can_explain(obfuscated_statement):
-        if obfuscated_statement.split(' ', 1)[0].lower() not in SUPPORTED_EXPLAIN_STATEMENTS:
-            return False, DBExplainError.no_plans_possible
-        return True, None
+        return obfuscated_statement.split(' ', 1)[0].lower() in SUPPORTED_EXPLAIN_STATEMENTS
 
     @staticmethod
     def _parse_execution_plan_cost(execution_plan):

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -21,7 +21,7 @@ from datadog_checks.base.utils.db.sql import compute_exec_plan_signature, comput
 from datadog_checks.base.utils.db.utils import ConstantRateLimiter, default_json_event_encoding, resolve_db_host
 from datadog_checks.base.utils.serialization import json
 
-SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update'})
+SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update', 'with'})
 
 # unless a specific table is configured, we try all of the events_statements tables in descending order of
 # preference

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -21,7 +21,7 @@ from datadog_checks.base.utils.db.sql import compute_exec_plan_signature, comput
 from datadog_checks.base.utils.db.utils import ConstantRateLimiter, default_json_event_encoding, resolve_db_host
 from datadog_checks.base.utils.serialization import json
 
-VALID_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update'})
+SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update'})
 
 # unless a specific table is configured, we try all of the events_statements tables in descending order of
 # preference
@@ -815,7 +815,7 @@ class MySQLStatementSamples(object):
 
     @staticmethod
     def _can_explain(obfuscated_statement):
-        if obfuscated_statement.split(' ', 1)[0].lower() not in VALID_EXPLAIN_STATEMENTS:
+        if obfuscated_statement.split(' ', 1)[0].lower() not in SUPPORTED_EXPLAIN_STATEMENTS:
             return False, DBExplainError.no_plans_possible
         return True, None
 

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -509,7 +509,7 @@ class MySQLStatementSamples(object):
 
         collection_error = None
         if explain_err_code:
-            collection_error = {'code': explain_err_code.value, 'message': '{}'.format(type(err))}
+            collection_error = {'code': explain_err_code.value, 'message': '{}'.format(type(err)) if err else None}
 
         normalized_plan, obfuscated_plan, plan_signature, plan_cost = None, None, None, None
         if plan:

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -411,7 +411,7 @@ def test_statement_metrics_with_duplicates(aggregator, dbm_instance, datadog_age
         (
             None,
             'select name as nam from testdb.users',
-            {'code': 'invalid_schema', 'message': None},
+            {'code': 'procedure_strategy_requires_default_schema', 'message': None},
         ),
         (
             'information_schema',

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -486,6 +486,13 @@ def test_statement_samples_collect(
         assert 'query_block' in json.loads(event['db']['plan']['definition']), "invalid json execution plan"
         assert set(event['ddtags'].split(',')) == expected_tags
 
+    # validate the events to ensure we've provided an explanation for not providing an exec plan
+    for event in matching:
+        if event['db']['plan']['definition'] is None:
+            assert event['db']['plan']['collection_error'] != {}
+        else:
+            assert event['db']['plan']['collection_error'] is None
+
     # we avoid closing these in a try/finally block in order to maintain the connections in case we want to
     # debug the test with --pdb
     mysql_check._statement_samples._close_db_conn()

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -411,7 +411,7 @@ def test_statement_metrics_with_duplicates(aggregator, dbm_instance, datadog_age
         (
             None,
             'select name as nam from testdb.users',
-            {'code': 'invalid_schema', 'message': "<class 'NoneType'>"},
+            {'code': 'invalid_schema', 'message': None},
         ),
         (
             'information_schema',
@@ -502,13 +502,7 @@ def test_statement_samples_collect(
     # Validate the events to ensure we've provided an explanation for not providing an exec plan
     for event in matching:
         if event['db']['plan']['definition'] is None:
-            if schema == 'information_schema' and explain_strategy == 'PROCEDURE':
-                # Since we can't create an EXPLAIN statement procedure in performance_schema, the result of the
-                # collection_error is unreliable, making expected mocks difficult. The important thing here is
-                # to verify we have a collection_error.
-                assert event['db']['plan']['collection_error'] != {}
-            else:
-                assert event['db']['plan']['collection_error'] == expected_collection_error
+            assert event['db']['plan']['collection_error'] == expected_collection_error
         else:
             assert event['db']['plan']['collection_error'] is None
 

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -415,7 +415,7 @@ def test_statement_metrics_with_duplicates(aggregator, dbm_instance, datadog_age
         ),
         (
             'information_schema',
-            'select name as nam from testdb.users',
+            'select * from testdb.users',
             {'code': 'database_error', 'message': "<class 'pymysql.err.OperationalError'>"},
         ),
         (


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Provides a reason for not having a MySQL execution plan.

### Motivation
<!-- What inspired you to submit this pull request? -->
Currently in Database Monitoring, the UX is lacking when it comes to execution plans. There are cases where it's impossible to collect or something failed, so we should indicate the reason it could not be collected and actions to fix it, if any.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
