### PR TITLE
Handle command output with erroneous trailing separators

### DIFF
--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -315,6 +315,8 @@ class AerospikeCheck(AgentCheck):
         if not data:
             return []
 
+        # Get rid of any trailing separators before splitting
+        data = data.rstrip(';')
         return data.split(separator)
 
     def collect_datacenter(self, datacenter):

--- a/aerospike/metadata.csv
+++ b/aerospike/metadata.csv
@@ -708,6 +708,7 @@ aerospike.set.memory_data_bytes,gauge,,byte,,The memory used by this set for the
 aerospike.set.objects,gauge,,record,,The total number of objects (master and all replicas) in this set on this node.,0,aerospike,Set Objects
 aerospike.set.stop_writes_count,gauge,,,,The total count this set has hit stop_writes,0,aerospike,
 aerospike.set.device_data_bytes,gauge,,byte,,The device storage used by data (master and proles) excluding primary index.,0,aerospike,
+aerospike.set.disable_eviction,gauge,,,,Whether or not this set is protected from evictions,0,aerospike,
 aerospike.sindex.keys,gauge,,,,The number of secondary keys for this secondary index.,0,aerospike,
 aerospike.sindex.entries,gauge,,,,Th number of secondary index entries for this secondary index. This is the number of records that have been indexed by this secondary index.,0,aerospike,
 aerospike.sindex.ibtr_memory_used,gauge,,byte,,The amount of memory the secondary index is consuming for the keys,0,aerospike,Sindex Index Memory Used

--- a/aerospike/tests/common.py
+++ b/aerospike/tests/common.py
@@ -31,7 +31,7 @@ TPS_METRICS = [
     'tps.read',
 ]
 
-SET_METRICS = ['tombstones', 'memory_data_bytes', 'truncate_lut', 'objects', 'stop_writes_count']
+SET_METRICS = ['tombstones', 'memory_data_bytes', 'truncate_lut', 'objects', 'stop_writes_count', 'disable_eviction']
 
 ALL_METRICS = NAMESPACE_METRICS + SET_METRICS
 


### PR DESCRIPTION
### What does this PR do?

For such commands, we would silently ignore the last result https://github.com/DataDog/integrations-core/blob/21a90b00f603b00250c4baa6534e47ee5529ed3c/aerospike/datadog_checks/aerospike/aerospike.py#L519-L521

### Motivation

See e.g. `sets/NAMESPACE/SET` of https://docs.aerospike.com/docs/reference/info#sets