### PR TITLE
Add missing metrics to network check metatada file

### DIFF
--- a/network/metadata.csv
+++ b/network/metadata.csv
@@ -73,14 +73,34 @@ system.net.tcp.send_q.avg,gauge,,byte,,The average TCP send queue size.,0,system
 system.net.tcp.send_q.count,rate,,connection,second,The rate of connections.,0,system,send-q count
 system.net.tcp.send_q.max,gauge,,byte,,The maximum TCP send queue size.,0,system,send-q max
 system.net.tcp.send_q.median,gauge,,byte,,The median TCP send queue size.,0,system,send-q median
+system.net.tcp4.close,gauge,,connection,,The number of closed TCP IPv4 connections.,0,system,tcp4 close
+system.net.tcp4.close_wait,gauge,,connection,,The number of TCP IPv4 connections waiting for termination.,0,system,tcp4 close_wait
 system.net.tcp4.closing,gauge,,connection,second,The number of TCP IPv4 closing connections. ,0,system,tcp4 closing
+system.net.tcp4.estab,gauge,,connection,,The number of open TCP IPv4 connections.,0,system,tcp4 estab
 system.net.tcp4.established,gauge,,connection,second,The number of TCP IPv4 established connections. ,0,system,tcp4 established
+system.net.tcp4.fin_wait_1,gauge,,connection,,The number of TCP IPv4 connections waiting for a connection termination request or an ack of a connection termination request sent previously.,0,system,tcp4 fin_wait_1
+system.net.tcp4.fin_wait_2,gauge,,connection,,The number of TCP IPv4 connections waiting for a connection termination request.,0,system,tcp4 fin_wait_2
+system.net.tcp4.listen,gauge,,connection,second,The number of TCP IPv4 listening connections.,0,system,tcp4 listen
 system.net.tcp4.listening,gauge,,connection,second,The number of TCP IPv4 listening connections. ,0,system,tcp4 listening
 system.net.tcp4.opening,gauge,,connection,second,The number of TCP IPv4 opening connections. ,0,system,tcp4 opening
+system.net.tcp4.syn_recv,gauge,,connection,,The number of TCP IPv4 connections waiting for confirming connection request.,0,system,tcp4 syn_recv
+system.net.tcp4.syn_sent,gauge,,connection,,The number of TCP IPv4 connections waiting for matching connection request.,0,system,tcp4 syn_sent
+system.net.tcp4.time_wait,gauge,,connection,,The number of TCP IPv4 closed connections waiting for delayed packets.,0,system,tcp4 time_wait
+system.net.tcp4.unconn,gauge,,connection,,The number of TCP IPv4 connections in unconnected state.,0,system,tcp4 unconn
+system.net.tcp6.close,gauge,,connection,,The number of closed TCP IPv6 connections.,0,system,tcp6 close
+system.net.tcp6.close_wait,gauge,,connection,,The number of TCP IPv6 connections waiting for termination.,0,system,tcp6 close_wait
 system.net.tcp6.closing,gauge,,connection,second,The number of TCP IPv6 closing connections. ,0,system,tcp6 closing
+system.net.tcp6.estab,gauge,,connection,,The number of open TCP IPv6 connections.,0,system,tcp6 estab
 system.net.tcp6.established,gauge,,connection,second,The number of TCP IPv6 established connections. ,0,system,tcp6 established
+system.net.tcp6.fin_wait_1,gauge,,connection,,The number of TCP IPv6 connections waiting for a connection termination request or an ack of a connection termination request sent previously.,0,system,tcp6 fin_wait_1
+system.net.tcp6.fin_wait_2,gauge,,connection,,The number of TCP IPv6 connections waiting for a connection termination request.,0,system,tcp6 fin_wait_2
+system.net.tcp6.listen,gauge,,connection,second,The number of TCP IPv6 listening connections.,0,system,tcp6 listen
 system.net.tcp6.listening,gauge,,connection,second,The number of TCP IPv6 listening connections. ,0,system,tcp6 listening
 system.net.tcp6.opening,gauge,,connection,second,The number of TCP IPv6 opening connections. ,0,system,tcp6 opening
+system.net.tcp6.syn_recv,gauge,,connection,,The number of TCP IPv6 connections waiting for confirming connection request.,0,system,tcp6 syn_recv
+system.net.tcp6.syn_sent,gauge,,connection,,The number of TCP IPv6 connections waiting for matching connection request.,0,system,tcp6 syn_sent
+system.net.tcp6.time_wait,gauge,,connection,,The number of TCP IPv6 closed connections waiting for delayed packets.,0,system,tcp6 time_wait
+system.net.tcp6.unconn,gauge,,connection,,The number of TCP IPv6 connections in unconnected state.,0,system,tcp6 unconn
 system.net.udp.in_datagrams,gauge,,datagram,second,The rate of UDP datagrams delivered to UDP users (Linux only).,0,system,udp in datagrams
 system.net.udp.in_datagrams.count,count,,datagram,,Total number of UDP datagrams delivered to UDP users (Linux only).,0,system,udp in datagrams
 system.net.udp.in_errors,gauge,,datagram,second,The rate of received UDP datagrams that could not be delivered for reasons other than the lack of an application at the destination port (Linux only).,-1,system,udp in errors
@@ -94,3 +114,5 @@ system.net.udp.rcv_buf_errors.count,count,,error,,Total number of UDP datagrams 
 system.net.udp.snd_buf_errors,gauge,,error,second,The rate of UDP datagrams lost because there was no room in the send buffer (Linux only).,-1,system,udp snd buf errs
 system.net.udp.snd_buf_errors.count,count,,error,,Total number of UDP datagrams lost because there was no room in the send buffer (Linux only).,-1,system,udp snd buf errs
 system.net.udp.in_csum_errors.count,count,,error,,Total number of UDP datagrams that failed checksum verification (Linux only).,-1,system,udp in csum errors
+system.net.udp4.connections,gauge,,connection,,The number of UDP IPv4 sockets currently opened.,0,system,udp4 connections
+system.net.udp6.connections,gauge,,connection,,The number of UDP IPv6 sockets currently opened.,0,system,udp6 connections

--- a/network/metadata.csv
+++ b/network/metadata.csv
@@ -80,7 +80,7 @@ system.net.tcp4.estab,gauge,,connection,,The number of open TCP IPv4 connections
 system.net.tcp4.established,gauge,,connection,second,The number of TCP IPv4 established connections. ,0,system,tcp4 established
 system.net.tcp4.fin_wait_1,gauge,,connection,,The number of TCP IPv4 connections waiting for a connection termination request or an ack of a connection termination request sent previously.,0,system,tcp4 fin_wait_1
 system.net.tcp4.fin_wait_2,gauge,,connection,,The number of TCP IPv4 connections waiting for a connection termination request.,0,system,tcp4 fin_wait_2
-system.net.tcp4.listen,gauge,,connection,second,The number of TCP IPv4 listening connections.,0,system,tcp4 listen
+system.net.tcp4.listen,gauge,,connection,,The number of TCP IPv4 listening connections.,0,system,tcp4 listen
 system.net.tcp4.listening,gauge,,connection,second,The number of TCP IPv4 listening connections. ,0,system,tcp4 listening
 system.net.tcp4.opening,gauge,,connection,second,The number of TCP IPv4 opening connections. ,0,system,tcp4 opening
 system.net.tcp4.syn_recv,gauge,,connection,,The number of TCP IPv4 connections waiting for confirming connection request.,0,system,tcp4 syn_recv
@@ -94,7 +94,7 @@ system.net.tcp6.estab,gauge,,connection,,The number of open TCP IPv6 connections
 system.net.tcp6.established,gauge,,connection,second,The number of TCP IPv6 established connections. ,0,system,tcp6 established
 system.net.tcp6.fin_wait_1,gauge,,connection,,The number of TCP IPv6 connections waiting for a connection termination request or an ack of a connection termination request sent previously.,0,system,tcp6 fin_wait_1
 system.net.tcp6.fin_wait_2,gauge,,connection,,The number of TCP IPv6 connections waiting for a connection termination request.,0,system,tcp6 fin_wait_2
-system.net.tcp6.listen,gauge,,connection,second,The number of TCP IPv6 listening connections.,0,system,tcp6 listen
+system.net.tcp6.listen,gauge,,connection,,The number of TCP IPv6 listening connections.,0,system,tcp6 listen
 system.net.tcp6.listening,gauge,,connection,second,The number of TCP IPv6 listening connections. ,0,system,tcp6 listening
 system.net.tcp6.opening,gauge,,connection,second,The number of TCP IPv6 opening connections. ,0,system,tcp6 opening
 system.net.tcp6.syn_recv,gauge,,connection,,The number of TCP IPv6 connections waiting for confirming connection request.,0,system,tcp6 syn_recv


### PR DESCRIPTION
### What does this PR do?
Adds bunch of metrics that were missing from network check `metadata.csv` file even though they're actually submitted when `combine_connection_states` is set to `false`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
