### PR TITLE
Fix auto-discovery for latest versions on Kubernetes

### DIFF
--- a/kube_scheduler/assets/configuration/spec.yaml
+++ b/kube_scheduler/assets/configuration/spec.yaml
@@ -40,12 +40,12 @@ files:
     options: []
   - template: instances
     options:
-    - name: prometheus_possible_urls
+    - name: possible_prometheus_urls
       required: true
       description: |
         The URLs to try to get your application metrics that are exposed by Prometheus.
         The check will try each URLs in the list and will use the first working one.
-        One of prometheus_possible_urls or prometheus_url parameter is required.
+        One of possible_prometheus_urls or prometheus_url parameter is required.
       value:
         type: array
         items:
@@ -59,7 +59,7 @@ files:
       required: false
       description: |
         The URL where your application metrics are exposed by Prometheus.
-        One of prometheus_possible_urls or prometheus_url parameter is required.
+        One of possible_prometheus_urls or prometheus_url parameter is required.
       value:
         example: http://%%host%%:10251/metrics
         type: string

--- a/kube_scheduler/assets/configuration/spec.yaml
+++ b/kube_scheduler/assets/configuration/spec.yaml
@@ -40,13 +40,31 @@ files:
     options: []
   - template: instances
     options:
-    - name: prometheus_url
+    - name: prometheus_possible_urls
       required: true
-      description: The URL where your application metrics are exposed by Prometheus.
+      description: |
+        The URLs to try to get your application metrics that are exposed by Prometheus.
+        The check will try each URLs in the list and will use the first working one.
+        One of prometheus_possible_urls or prometheus_url parameter is required.
+      value:
+        type: array
+        items:
+          type: string
+        example:
+          - https://%%host%%:10259/metrics
+          - https://localhost:10259/metrics
+          - http://%%host%%:10251/metrics
+          - http://localhost:10251/metrics
+    - name: prometheus_url
+      required: false
+      description: |
+        The URL where your application metrics are exposed by Prometheus.
+        One of prometheus_possible_urls or prometheus_url parameter is required.
       value:
         example: http://%%host%%:10251/metrics
         type: string
     - name: bearer_token_auth
+      required: true
       description: |
         Used if you are using RBACs and need the Agent to authenticate
         against the APIServer to retrieve metrics. Default to true.
@@ -59,6 +77,7 @@ files:
         type: string
         example: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: ssl_verify
+      required: true
       description: Used to verify self signed certificates.
       value:
         type: boolean

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
@@ -14,12 +14,12 @@ init_config:
 #
 instances:
 
-    ## @param prometheus_possible_urls - list of strings - required
+    ## @param possible_prometheus_urls - list of strings - required
     ## The URLs to try to get your application metrics that are exposed by Prometheus.
     ## The check will try each URLs in the list and will use the first working one.
-    ## One of prometheus_possible_urls or prometheus_url parameter is required.
+    ## One of possible_prometheus_urls or prometheus_url parameter is required.
     #
-  - prometheus_possible_urls:
+  - possible_prometheus_urls:
       - https://%%host%%:10259/metrics
       - https://localhost:10259/metrics
       - http://%%host%%:10251/metrics
@@ -27,7 +27,7 @@ instances:
 
     ## @param prometheus_url - string - optional - default: http://%%host%%:10251/metrics
     ## The URL where your application metrics are exposed by Prometheus.
-    ## One of prometheus_possible_urls or prometheus_url parameter is required.
+    ## One of possible_prometheus_urls or prometheus_url parameter is required.
     #
     # prometheus_url: http://%%host%%:10251/metrics
 

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
@@ -14,23 +14,35 @@ init_config:
 #
 instances:
 
-    ## @param prometheus_url - string - required
-    ## The URL where your application metrics are exposed by Prometheus.
+    ## @param prometheus_possible_urls - list(string) - optional
+    ## The URLs to try to get your application metrics that are exposed by Prometheus.
+    ## The check will try each URLs in the list and will use the first working one.
+    ## One of prometheus_possible_urls or prometheus_url parameter is required.
     #
-  - prometheus_url: http://%%host%%:10251/metrics
+  - prometheus_possible_urls:
+      - https://%%host%%:10259/metrics
+      - https://localhost:10259/metrics
+      - http://%%host%%:10251/metrics
+      - http://localhost:10251/metrics
 
-    ## @param bearer_token_auth - boolean - optional - default: true
+    ## @param prometheus_url - string - optional
+    ## The URL where your application metrics are exposed by Prometheus.
+    ## One of prometheus_possible_urls or prometheus_url parameter is required.
+    #
+    # prometheus_url: http://%%host%%:10251/metrics
+
+    ## @param bearer_token_auth - boolean - optional - default: false
     ## Used if you are using RBACs and need the Agent to authenticate
     ## against the APIServer to retrieve metrics. Default to true.
     #
-    # bearer_token_auth: true
+    bearer_token_auth: true
 
     ## @param bearer_token_path - string - optional - default: /var/run/secrets/kubernetes.io/serviceaccount/token
     ## Used to specify the path where the service account token is located.
     #
     # bearer_token_path: /var/run/secrets/kubernetes.io/serviceaccount/token
 
-    ## @param ssl_verify - boolean - optional - default: false
+    ## @param ssl_verify - boolean - optional - default: true
     ## Used to verify self signed certificates.
     #
-    # ssl_verify: false
+    ssl_verify: false

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
@@ -14,7 +14,7 @@ init_config:
 #
 instances:
 
-    ## @param prometheus_possible_urls - list(string) - optional
+    ## @param prometheus_possible_urls - list of strings - required
     ## The URLs to try to get your application metrics that are exposed by Prometheus.
     ## The check will try each URLs in the list and will use the first working one.
     ## One of prometheus_possible_urls or prometheus_url parameter is required.
@@ -25,13 +25,13 @@ instances:
       - http://%%host%%:10251/metrics
       - http://localhost:10251/metrics
 
-    ## @param prometheus_url - string - optional
+    ## @param prometheus_url - string - optional - default: http://%%host%%:10251/metrics
     ## The URL where your application metrics are exposed by Prometheus.
     ## One of prometheus_possible_urls or prometheus_url parameter is required.
     #
     # prometheus_url: http://%%host%%:10251/metrics
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean - required
     ## Used if you are using RBACs and need the Agent to authenticate
     ## against the APIServer to retrieve metrics. Default to true.
     #
@@ -42,7 +42,7 @@ instances:
     #
     # bearer_token_path: /var/run/secrets/kubernetes.io/serviceaccount/token
 
-    ## @param ssl_verify - boolean - optional - default: true
+    ## @param ssl_verify - boolean - required
     ## Used to verify self signed certificates.
     #
     ssl_verify: false


### PR DESCRIPTION
### What does this PR do?

Leverages the `possible_prometheus_urls` parameter introduced by #9573 in the auto-discovery configuration file.

### Motivation

Make the agent able to automatically monitor the Kube scheduler on most recent versions of Kubernetes without requiring too much user setup.
The goad is to simplify the Kubernetes control plane monitoring setup described in DataDog/documentation#10828.

### Additional Notes

On older versions of Kubernetes, the Kube scheduler metrics were available at `http://%%host%%:10251/metrics` where `%%host%%` is the node IP.
On most recent version of Kubernetes,
* only the secure `https` endpoint is available by default. The plain `http` endpoint is disabled by default.
* the port is bound on the loopback interface on `127.0.0.1` instead of being remotely available.

The new auto-discovery configuration will try the combination of different settings to find a usable Kube scheduler metrics endpoint.
The only thing that the end-user will still need to do to get this check working is:
* either enabling `hostNetwork: true` on its agent to be able to use the `127.0.0.1` IP, or
* to configure its control plane components to expose their metrics endpoint on `0.0.0.0` as already described in DataDog/documentation#10828.

Kubernetes exposes in the pods only the certificates needed to talk to the API server.
There is no reliable way to get the CA certificate used by the Kube scheduler that would work on every distribution. In particular, at least `minikube` and `kubeadm` are using self-signed certificates.
That’s why `ssl_verify: false` is required.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
