### PR TITLE
Fix auto-discovery for latest versions on Kubernetes

### DIFF
--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/auto_conf.yaml
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/auto_conf.yaml
@@ -4,13 +4,30 @@ ad_identifiers:
 init_config:
 
 instances:
-    ## @param prometheus_url - string - required
-    ## The URL where your application metrics are exposed by Prometheus.
+    ## @param prometheus_possible_urls - list(string) - optional
+    ## The URLs to try to get your application metrics that are exposed by Prometheus.
+    ## The check will try each URLs in the list and will use the first working one.
+    ## One of prometheus_possible_urls or prometheus_url parameter is required.
     #
-  - prometheus_url: "http://%%host%%:10252/metrics"
+  - prometheus_possible_urls:
+      - https://%%host%%:10257/metrics
+      - https://localhost:10257/metrics
+      - http://%%host%%:10252/metrics
+      - http://localhost:10252/metrics
+
+    ## @param prometheus_url - string - optional
+    ## The URL where your application metrics are exposed by Prometheus.
+    ## One of prometheus_possible_urls or prometheus_url parameter is required.
+    #
+    # prometheus_url: http://%%host%%:10252/metrics
 
     ## @param bearer_token_auth - string - optional
     ## Used if you are using RBACs and need the Agent to authenticate
     ## against the APIServer to retrieve metrics. Default to true.
     #
     bearer_token_auth: true
+
+    ## @param ssl_verify - boolean - optional - default: true
+    ## Used to verify self signed certificates.
+    #
+    ssl_verify: false

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/auto_conf.yaml
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/auto_conf.yaml
@@ -4,12 +4,12 @@ ad_identifiers:
 init_config:
 
 instances:
-    ## @param prometheus_possible_urls - list(string) - optional
+    ## @param possible_prometheus_urls - list(string) - optional
     ## The URLs to try to get your application metrics that are exposed by Prometheus.
     ## The check will try each URLs in the list and will use the first working one.
-    ## One of prometheus_possible_urls or prometheus_url parameter is required.
+    ## One of possible_prometheus_urls or prometheus_url parameter is required.
     #
-  - prometheus_possible_urls:
+  - possible_prometheus_urls:
       - https://%%host%%:10257/metrics
       - https://localhost:10257/metrics
       - http://%%host%%:10252/metrics
@@ -17,7 +17,7 @@ instances:
 
     ## @param prometheus_url - string - optional
     ## The URL where your application metrics are exposed by Prometheus.
-    ## One of prometheus_possible_urls or prometheus_url parameter is required.
+    ## One of possible_prometheus_urls or prometheus_url parameter is required.
     #
     # prometheus_url: http://%%host%%:10252/metrics
 


### PR DESCRIPTION
### What does this PR do?

Leverages the `possible_prometheus_urls` parameter introduced by #9573 in the auto-discovery configuration file.

### Motivation

Make the agent able to automatically monitor the Kube controller manager on most recent versions of Kubernetes without requiring too much user setup.
The goad is to simplify the Kubernetes control plane monitoring setup described in DataDog/documentation#10828.

### Additional Notes

On older versions of Kubernetes, the Kube controller manager metrics were available at `http://%%host%%:10252/metrics` where `%%host%%` is the node IP.
On most recent version of Kubernetes,
* only the secure `https` endpoint is available by default. The plain `http` endpoint is disabled by default.
* the port is bound on the loopback interface on `127.0.0.1` instead of being remotely available.

The new auto-discovery configuration will try the combination of different settings to find a usable Kube controller manager metrics endpoint.
The only thing that the end-user will still need to do to get this check working is:
* either enabling `hostNetwork: true` on its agent to be able to use the `127.0.0.1` IP, or
* to configure its control plane components to expose their metrics endpoint on `0.0.0.0` as already described in DataDog/documentation#10828.

Kubernetes exposes in the pods only the certificates needed to talk to the API server.
There is no reliable way to get the CA certificate used by the Kube controller manager that would work on every distribution. In particular, at least `minikube` and `kubeadm` are using self-signed certificates.
That’s why `ssl_verify: false` is required.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
